### PR TITLE
Update Portainer stack deployment docs and change dashboard port to 7001

### DIFF
--- a/portainer-stack.yml
+++ b/portainer-stack.yml
@@ -42,7 +42,7 @@ services:
       - CLIENT_ID=${CLIENT_ID}
       - CLIENT_SECRET=${CLIENT_SECRET}
       - SESSION_SECRET=${SESSION_SECRET}
-      - DASHBOARD_URL=${DASHBOARD_URL}
+      - DASHBOARD_URL=${DASHBOARD_URL:-http://localhost:7001}
       # --- Optional: AI ---
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - GEMINI_API_KEY=${GEMINI_API_KEY}

--- a/portainer-stack.yml
+++ b/portainer-stack.yml
@@ -1,12 +1,20 @@
 version: '3.8'
 
 # Deploy this file via Portainer > Stacks > Add Stack > Web Editor.
-# Before deploying, build and push the bot image to a registry:
-#   docker build -t ghcr.io/theshield2594/ultrabot:latest .
-#   docker push ghcr.io/theshield2594/ultrabot:latest
 #
-# Then set all variables marked (required) in the "Environment variables"
-# section of the Portainer Stack form before clicking Deploy.
+# BEFORE DEPLOYING:
+#   1. Build and push the image to GHCR:
+#        docker build -t ghcr.io/theshield2594/ultrabot:latest .
+#        docker push ghcr.io/theshield2594/ultrabot:latest
+#
+#   2. If the GHCR package is private, add registry credentials in Portainer first:
+#        Portainer > Registries > Add registry > Custom registry
+#        URL: ghcr.io
+#        Username: your GitHub username
+#        Password: GitHub PAT with read:packages scope
+#
+#   3. Set all required variables in the Portainer Stack "Environment variables"
+#      section before clicking Deploy.
 
 services:
   mongodb:
@@ -25,7 +33,7 @@ services:
       start_period: 30s
 
   bot:
-    image: ghcr.io/theshield2594/ultrabot:latest  # change to your registry image
+    image: ghcr.io/theshield2594/ultrabot:latest
     container_name: ultrabot
     restart: unless-stopped
     environment:
@@ -42,10 +50,10 @@ services:
       - YOUTUBE_COOKIE=${YOUTUBE_COOKIE}
       # --- Defaults (override if needed) ---
       - MONGODB_URI=${MONGODB_URI:-mongodb://mongodb:27017/ultrabot}
-      - DASHBOARD_PORT=${DASHBOARD_PORT:-3000}
+      - DASHBOARD_PORT=7001
       - NODE_ENV=${NODE_ENV:-production}
     ports:
-      - "3000:3000"
+      - "7001:7001"
     depends_on:
       mongodb:
         condition: service_healthy
@@ -54,7 +62,7 @@ services:
     networks:
       - ultrabot-network
     healthcheck:
-      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000', (r) => { process.exit(r.statusCode === 200 ? 0 : 1) }).on('error', () => process.exit(1))"]
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:7001', (r) => { process.exit(r.statusCode === 200 ? 0 : 1) }).on('error', () => process.exit(1))"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
Improved the Portainer stack deployment documentation and updated the dashboard port from 3000 to 7001 for better clarity and consistency.

## Key Changes
- **Enhanced deployment instructions**: Restructured the pre-deployment checklist with clearer numbered steps and better formatting
- **Added registry credentials guidance**: Included instructions for configuring private GHCR registry access in Portainer with required GitHub PAT scope
- **Updated dashboard port**: Changed `DASHBOARD_PORT` from 3000 to 7001 (hardcoded value instead of environment variable with default)
- **Updated port mapping**: Changed exposed port from `3000:3000` to `7001:7001`
- **Updated healthcheck**: Modified the healthcheck endpoint from `localhost:3000` to `localhost:7001`
- **Removed redundant comment**: Removed "change to your registry image" comment from the bot image configuration as it's now clear from the documentation

## Implementation Details
The port change is applied consistently across:
- Environment variable default (`DASHBOARD_PORT=7001`)
- Container port mapping (`7001:7001`)
- Service healthcheck endpoint (`http://localhost:7001`)

The documentation improvements make the deployment process more accessible for users, particularly those working with private container registries.

https://claude.ai/code/session_01BmyPFjB3yXrFQosYHBUuGS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration**
  * Dashboard port changed from 3000 to 7001.

* **Documentation**
  * Enhanced deployment process documentation with clearer pre-deployment requirements, including image build/push and environment variable setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->