### PR TITLE
Add Docker image build and publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,55 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow to automatically build and publish Docker images to GitHub Container Registry (GHCR).

## Key Changes
- Added `.github/workflows/docker-publish.yml` workflow that:
  - Triggers on pushes to `main` branch, version tags (`v*`), and manual workflow dispatch
  - Authenticates with GitHub Container Registry using GITHUB_TOKEN
  - Extracts Docker metadata including semantic versioning tags and branch references
  - Builds and pushes Docker images with optimized layer caching via GitHub Actions cache
  - Tags images with:
    - Branch name for branch pushes
    - Semantic version patterns (full version, major.minor)
    - `latest` tag for the default branch

## Implementation Details
- Uses Docker Buildx for enhanced build capabilities
- Implements GitHub Actions cache for faster builds (`type=gha`)
- Automatically generates appropriate image tags based on git refs and semantic versioning
- Requires `contents: read` and `packages: write` permissions for the workflow

https://claude.ai/code/session_01TkmKPfr9ZYb2bHtXmHU2b3