### PR TITLE
fix: replace @discordjs/opus with opusscript to fix Alpine Docker build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@discordjs/opus": "^0.9.0",
         "@discordjs/voice": "^0.16.1",
         "@google/generative-ai": "^0.2.1",
         "axios": "^1.6.2",
@@ -24,6 +23,7 @@
         "mongoose": "^8.0.3",
         "node-cron": "^3.0.3",
         "openai": "^4.24.1",
+        "opusscript": "^0.0.8",
         "passport": "^0.7.0",
         "passport-discord": "^0.1.4",
         "play-dl": "^1.9.7",
@@ -102,6 +102,8 @@
       "resolved": "https://registry.npmjs.org/@discordjs/node-pre-gyp/-/node-pre-gyp-0.4.5.tgz",
       "integrity": "sha512-YJOVVZ545x24mHzANfYoy0BJX5PDyeZlpiJjDkUBM/V/Ao7TFX9lcUvCN4nr0tbr5ubeaXxtEBILUrHtTphVeQ==",
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -123,6 +125,8 @@
       "integrity": "sha512-NEE76A96FtQ5YuoAVlOlB3ryMPrkXbUCTQICHGKb8ShtjXyubGicjRMouHtP1RpuDdm16cDa+oI3aAMo1zQRUQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@discordjs/node-pre-gyp": "^0.4.5",
         "node-addon-api": "^5.0.0"
@@ -2100,7 +2104,9 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/node-cron": {
       "version": "3.0.3",
@@ -2382,6 +2388,12 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/opusscript": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
+      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
       "license": "MIT"
     },
     "node_modules/parseurl": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "rss-parser": "^3.13.0",
     "node-cron": "^3.0.3",
     "@discordjs/voice": "^0.16.1",
-    "@discordjs/opus": "^0.9.0",
+    "opusscript": "^0.0.8",
     "play-dl": "^1.9.7",
     "openai": "^4.24.1",
     "@google/generative-ai": "^0.2.1",


### PR DESCRIPTION
@discordjs/opus@0.9.0 has no pre-built binary for musl/Alpine and its bundled opus source fails to compile against gcc 14 (type mismatch in autocorr_FIX.c). opusscript is a pure-JS opus implementation that @discordjs/voice supports as a drop-in alternative with no native build.

https://claude.ai/code/session_01TkmKPfr9ZYb2bHtXmHU2b3