### PR TITLE
Improve auto-moderation gating and filter precision

### DIFF
--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -116,6 +116,9 @@ async function handleLeveling(message, guildSettings) {
 async function handleAutoModeration(message, guildSettings) {
     const content = message.content.toLowerCase();
     const mod = guildSettings.moderation;
+    const isModerator = message.member.permissions.has('ManageMessages');
+
+    if (!mod.autoModEnabled) return;
 
     if (mod.spamProtection) {
         const guildId = message.guild.id;
@@ -142,7 +145,7 @@ async function handleAutoModeration(message, guildSettings) {
         }
     }
 
-    if (mod.inviteFilter && content.includes('discord.gg/')) {
+    if (mod.inviteFilter && !isModerator && /(discord\.gg\/|discord\.com\/invite\/)/i.test(content)) {
         await message.delete().catch(console.error);
         const warn = await message.channel.send(`${message.author}, invite links are not allowed!`);
         setTimeout(() => warn.delete().catch(() => {}), 5000);
@@ -151,7 +154,7 @@ async function handleAutoModeration(message, guildSettings) {
     }
 
     if (mod.linkFilter && (content.includes('http://') || content.includes('https://'))) {
-        if (!message.member.permissions.has('ManageMessages')) {
+        if (!isModerator) {
             await message.delete().catch(console.error);
             const warn = await message.channel.send(`${message.author}, links are not allowed!`);
             setTimeout(() => warn.delete().catch(() => {}), 5000);
@@ -160,9 +163,12 @@ async function handleAutoModeration(message, guildSettings) {
         }
     }
 
-    if (mod.profanityFilter) {
+    if (mod.profanityFilter && !isModerator) {
         const badWords = [...BASE_BAD_WORDS, ...(mod.customBadWords || [])];
-        const hasBadWord = badWords.some(word => content.includes(word.toLowerCase()));
+        const hasBadWord = badWords.some((word) => {
+            const escaped = word.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            return new RegExp(`\\b${escaped}\\b`, 'i').test(content);
+        });
 
         if (hasBadWord) {
             await message.delete().catch(console.error);


### PR DESCRIPTION
### Motivation
- Make auto-moderation behavior follow the dashboard toggle so rules don't run when `moderation.autoModEnabled` is off.
- Reduce false positives by avoiding enforcement on moderators performing legitimate actions.
- Improve pattern detection for invite links and profanity to lower accidental matches and increase coverage.

### Description
- Skip auto-moderation early when `mod.autoModEnabled` is false by returning from `handleAutoModeration` if the toggle is off.
- Add a single `isModerator` flag using `message.member.permissions.has('ManageMessages')` and use it to bypass staff from invite, link and profanity enforcement.
- Expand invite detection to match both `discord.gg` and `discord.com/invite` via a case-insensitive regex.
- Replace substring profanity checks with escaped, word-boundary regex matching to avoid partial-word matches and handle special characters in custom bad words.

### Testing
- Ran `node --check src/events/messageCreate.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2dc78cc308325886a55888c92d78d)