### PR TITLE
Overhaul AI chat: add Claude, Ollama, OpenRouter; streaming, persiste…

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "play-dl": "^1.9.7",
     "openai": "^4.24.1",
     "@google/generative-ai": "^0.2.1",
+    "@anthropic-ai/sdk": "^0.32.1",
     "canvas": "^2.11.2",
     "moment": "^2.30.1",
     "validator": "^13.11.0",

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -278,7 +278,7 @@
                 <section id="ai" class="panel">
                     <div class="panel-head">
                         <h2>AI Chat</h2>
-                        <p>Plug in OpenAI or Google Gemini for intelligent chat in a designated channel.</p>
+                        <p>Connect OpenAI, Gemini, Anthropic Claude, OpenRouter, or a self-hosted Ollama instance for chat in a designated channel.</p>
                     </div>
                     <label class="toggle">
                         <span class="toggle-text"><strong>Enable AI chat</strong><span>Respond to messages in the AI channel</span></span>
@@ -286,20 +286,43 @@
                     </label>
                     <div class="field">
                         <label class="field-label" for="ai-provider">Provider</label>
-                        <select id="ai-provider">
-                            <option value="openai" <%= settings.ai.provider === 'openai' || !settings.ai.provider ? 'selected' : '' %>>OpenAI (GPT-3.5 / GPT-4)</option>
+                        <select id="ai-provider" onchange="updateAiProviderUI()">
+                            <option value="openai" <%= settings.ai.provider === 'openai' || !settings.ai.provider ? 'selected' : '' %>>OpenAI</option>
+                            <option value="anthropic" <%= settings.ai.provider === 'anthropic' ? 'selected' : '' %>>Anthropic (Claude)</option>
                             <option value="gemini" <%= settings.ai.provider === 'gemini' ? 'selected' : '' %>>Google Gemini</option>
+                            <option value="openrouter" <%= settings.ai.provider === 'openrouter' ? 'selected' : '' %>>OpenRouter</option>
+                            <option value="ollama" <%= settings.ai.provider === 'ollama' ? 'selected' : '' %>>Ollama (self-hosted)</option>
                         </select>
                     </div>
                     <div class="field">
+                        <label class="field-label" for="ai-model">Model</label>
+                        <input type="text" id="ai-model" value="<%= settings.ai.model || '' %>" placeholder="Leave empty for provider default">
+                        <small id="ai-model-hint">Default: gpt-4o-mini</small>
+                    </div>
+                    <div class="field ai-key-field" data-provider="openai">
                         <label class="field-label" for="ai-openai-key">OpenAI API key</label>
                         <input type="password" id="ai-openai-key" value="<%= settings.ai.openaiKey || '' %>" placeholder="sk-…">
                         <small>Leave empty to use the bot's default key</small>
                     </div>
-                    <div class="field">
+                    <div class="field ai-key-field" data-provider="anthropic">
+                        <label class="field-label" for="ai-anthropic-key">Anthropic API key</label>
+                        <input type="password" id="ai-anthropic-key" value="<%= settings.ai.anthropicKey || '' %>" placeholder="sk-ant-…">
+                        <small>Leave empty to use the bot's default key</small>
+                    </div>
+                    <div class="field ai-key-field" data-provider="gemini">
                         <label class="field-label" for="ai-gemini-key">Gemini API key</label>
                         <input type="password" id="ai-gemini-key" value="<%= settings.ai.geminiKey || '' %>" placeholder="AIza…">
                         <small>Leave empty to use the bot's default key</small>
+                    </div>
+                    <div class="field ai-key-field" data-provider="openrouter">
+                        <label class="field-label" for="ai-openrouter-key">OpenRouter API key</label>
+                        <input type="password" id="ai-openrouter-key" value="<%= settings.ai.openrouterKey || '' %>" placeholder="sk-or-…">
+                        <small>Get a key at openrouter.ai. Use any model OpenRouter supports (e.g. <code>anthropic/claude-3.5-sonnet</code>, <code>meta-llama/llama-3.1-70b-instruct</code>).</small>
+                    </div>
+                    <div class="field ai-key-field" data-provider="ollama">
+                        <label class="field-label" for="ai-ollama-url">Ollama base URL</label>
+                        <input type="text" id="ai-ollama-url" value="<%= settings.ai.ollamaBaseUrl || 'http://localhost:11434' %>" placeholder="http://localhost:11434">
+                        <small>Point this at the host running <code>ollama serve</code>. Set the model field above to a tag you've pulled (e.g. <code>llama3.2</code>, <code>qwen2.5</code>, <code>mistral</code>).</small>
                     </div>
                     <div class="field">
                         <label class="field-label" for="ai-channel">AI chat channel</label>
@@ -313,6 +336,32 @@
                     <div class="field">
                         <label class="field-label" for="ai-prompt">System prompt</label>
                         <textarea id="ai-prompt" rows="3"><%= settings.ai.systemPrompt %></textarea>
+                    </div>
+                    <div class="field">
+                        <label class="field-label" for="ai-temperature">Temperature (<span id="ai-temp-display"><%= settings.ai.temperature ?? 0.7 %></span>)</label>
+                        <input type="range" id="ai-temperature" min="0" max="2" step="0.1" value="<%= settings.ai.temperature ?? 0.7 %>" oninput="document.getElementById('ai-temp-display').textContent = this.value">
+                    </div>
+                    <div class="field">
+                        <label class="field-label" for="ai-max-tokens">Max output tokens</label>
+                        <input type="number" id="ai-max-tokens" min="32" max="8192" value="<%= settings.ai.maxTokens ?? 1024 %>">
+                    </div>
+                    <div class="field">
+                        <label class="field-label" for="ai-max-history">Conversation history length</label>
+                        <input type="number" id="ai-max-history" min="0" max="100" value="<%= settings.ai.maxHistory ?? 20 %>">
+                        <small>Number of past messages remembered per user. 0 disables history.</small>
+                    </div>
+                    <label class="toggle">
+                        <span class="toggle-text"><strong>Stream responses</strong><span>Edit messages in real-time as the model generates them</span></span>
+                        <span class="switch"><input type="checkbox" id="ai-streaming" <%= settings.ai.streaming !== false ? 'checked' : '' %>><span class="slider"></span></span>
+                    </label>
+                    <div class="field">
+                        <label class="field-label" for="ai-rate-limit">Rate limit (requests per user)</label>
+                        <input type="number" id="ai-rate-limit" min="0" value="<%= settings.ai.rateLimitPerUser ?? 20 %>">
+                        <small>0 disables rate limiting.</small>
+                    </div>
+                    <div class="field">
+                        <label class="field-label" for="ai-rate-window">Rate-limit window (minutes)</label>
+                        <input type="number" id="ai-rate-window" min="1" value="<%= settings.ai.rateLimitWindowMin ?? 10 %>">
                     </div>
                     <div class="actions-row">
                         <button class="btn btn-primary" onclick="saveSettings('ai')">Save changes</button>
@@ -352,6 +401,24 @@
             clearTimeout(toastTimer);
             toastTimer = setTimeout(() => toastEl.classList.remove('show'), 2800);
         }
+
+        const AI_MODEL_DEFAULTS = {
+            openai: 'gpt-4o-mini',
+            anthropic: 'claude-haiku-4-5-20251001',
+            gemini: 'gemini-1.5-flash',
+            openrouter: 'openai/gpt-4o-mini',
+            ollama: 'llama3.2'
+        };
+
+        function updateAiProviderUI() {
+            const provider = document.getElementById('ai-provider').value;
+            document.querySelectorAll('.ai-key-field').forEach(el => {
+                el.style.display = el.dataset.provider === provider ? '' : 'none';
+            });
+            const hint = document.getElementById('ai-model-hint');
+            if (hint) hint.textContent = 'Default: ' + (AI_MODEL_DEFAULTS[provider] || '');
+        }
+        if (document.getElementById('ai-provider')) updateAiProviderUI();
 
         async function saveSettings(section) {
             const guildId = '<%= guild.id %>';
@@ -396,10 +463,20 @@
                 data = {
                     'ai.enabled': document.getElementById('ai-enabled').checked,
                     'ai.provider': document.getElementById('ai-provider').value,
+                    'ai.model': document.getElementById('ai-model').value.trim(),
                     'ai.openaiKey': document.getElementById('ai-openai-key').value,
+                    'ai.anthropicKey': document.getElementById('ai-anthropic-key').value,
                     'ai.geminiKey': document.getElementById('ai-gemini-key').value,
+                    'ai.openrouterKey': document.getElementById('ai-openrouter-key').value,
+                    'ai.ollamaBaseUrl': document.getElementById('ai-ollama-url').value.trim(),
                     'ai.channelId': document.getElementById('ai-channel').value,
-                    'ai.systemPrompt': document.getElementById('ai-prompt').value
+                    'ai.systemPrompt': document.getElementById('ai-prompt').value,
+                    'ai.temperature': parseFloat(document.getElementById('ai-temperature').value),
+                    'ai.maxTokens': parseInt(document.getElementById('ai-max-tokens').value, 10),
+                    'ai.maxHistory': parseInt(document.getElementById('ai-max-history').value, 10),
+                    'ai.streaming': document.getElementById('ai-streaming').checked,
+                    'ai.rateLimitPerUser': parseInt(document.getElementById('ai-rate-limit').value, 10),
+                    'ai.rateLimitWindowMin': parseInt(document.getElementById('ai-rate-window').value, 10)
                 };
             } else if (section === 'dailynews') {
                 const feedsText = document.getElementById('dailynews-feeds').value;

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -35,9 +35,7 @@ module.exports = {
             }
 
             if (guildSettings?.ai.enabled && message.channel.id === guildSettings.ai.channelId) {
-                const provider = guildSettings.ai.provider || 'openai';
-                const apiKey = provider === 'openai' ? guildSettings.ai.openaiKey : guildSettings.ai.geminiKey;
-                await handleAIChat(message, guildSettings.ai.systemPrompt, provider, apiKey);
+                await handleAIChat(message, guildSettings.ai);
                 return;
             }
 

--- a/src/models/Conversation.js
+++ b/src/models/Conversation.js
@@ -1,0 +1,22 @@
+const { Schema, model } = require('mongoose');
+
+const conversationSchema = new Schema({
+    guildId: { type: String, required: true, index: true },
+    channelId: { type: String, required: true, index: true },
+    userId: { type: String, required: true, index: true },
+    messages: [{
+        role: { type: String, enum: ['user', 'assistant'], required: true },
+        content: { type: String, required: true },
+        createdAt: { type: Date, default: Date.now }
+    }],
+    updatedAt: { type: Date, default: Date.now }
+});
+
+conversationSchema.index({ guildId: 1, channelId: 1, userId: 1 }, { unique: true });
+
+conversationSchema.pre('save', function(next) {
+    this.updatedAt = Date.now();
+    next();
+});
+
+module.exports = model('Conversation', conversationSchema);

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -105,11 +105,25 @@ const guildSchema = new Schema({
     
     ai: {
         enabled: { type: Boolean, default: false },
-        provider: { type: String, enum: ['openai', 'gemini'], default: 'openai' },
+        provider: {
+            type: String,
+            enum: ['openai', 'gemini', 'anthropic', 'ollama', 'openrouter'],
+            default: 'openai'
+        },
+        model: { type: String, default: null },
         openaiKey: { type: String, default: null },
         geminiKey: { type: String, default: null },
+        anthropicKey: { type: String, default: null },
+        openrouterKey: { type: String, default: null },
+        ollamaBaseUrl: { type: String, default: 'http://localhost:11434' },
         channelId: { type: String, default: null },
-        systemPrompt: { type: String, default: 'You are a helpful Discord bot assistant.' }
+        systemPrompt: { type: String, default: 'You are a helpful Discord bot assistant.' },
+        temperature: { type: Number, default: 0.7, min: 0, max: 2 },
+        maxTokens: { type: Number, default: 1024, min: 32, max: 8192 },
+        maxHistory: { type: Number, default: 20, min: 0, max: 100 },
+        streaming: { type: Boolean, default: true },
+        rateLimitPerUser: { type: Number, default: 20 },
+        rateLimitWindowMin: { type: Number, default: 10 }
     },
     
     customCommands: [{

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -1,122 +1,380 @@
 const OpenAI = require('openai');
 const { GoogleGenerativeAI } = require('@google/generative-ai');
+const Anthropic = require('@anthropic-ai/sdk');
+const axios = require('axios');
+const Conversation = require('../models/Conversation');
 
-let openai;
-let genAI;
+const DEFAULT_MODELS = {
+    openai: 'gpt-4o-mini',
+    gemini: 'gemini-1.5-flash',
+    anthropic: 'claude-haiku-4-5-20251001',
+    ollama: 'llama3.2',
+    openrouter: 'openai/gpt-4o-mini'
+};
 
-if (process.env.OPENAI_API_KEY) {
-    openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const DISCORD_MAX_LEN = 2000;
+const STREAM_EDIT_INTERVAL_MS = 1200;
+
+// userId -> [timestamps] for sliding-window rate limiting (in-memory)
+const rateLimits = new Map();
+
+function checkRateLimit(userId, limit, windowMin) {
+    if (!limit || limit <= 0) return true;
+    const now = Date.now();
+    const windowMs = (windowMin || 10) * 60 * 1000;
+    const arr = (rateLimits.get(userId) || []).filter(t => now - t < windowMs);
+    if (arr.length >= limit) {
+        rateLimits.set(userId, arr);
+        return false;
+    }
+    arr.push(now);
+    rateLimits.set(userId, arr);
+    return true;
 }
 
-if (process.env.GEMINI_API_KEY) {
-    genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+async function loadHistory(guildId, channelId, userId, max) {
+    if (!max || max <= 0) return { doc: null, messages: [] };
+    const doc = await Conversation.findOne({ guildId, channelId, userId });
+    if (!doc) return { doc: null, messages: [] };
+    const msgs = doc.messages.slice(-max).map(m => ({ role: m.role, content: m.content }));
+    return { doc, messages: msgs };
 }
 
-// channelId -> Map<userId, Array<{role, content}>>
-const conversationHistory = new Map();
-const MAX_HISTORY = 20;
-
-function getHistory(channelId, userId) {
-    if (!conversationHistory.has(channelId)) conversationHistory.set(channelId, new Map());
-    const channelMap = conversationHistory.get(channelId);
-    if (!channelMap.has(userId)) channelMap.set(userId, []);
-    return channelMap.get(userId);
+async function appendHistory(guildId, channelId, userId, userText, assistantText, max) {
+    if (!max || max <= 0) return;
+    let doc = await Conversation.findOne({ guildId, channelId, userId });
+    if (!doc) {
+        doc = new Conversation({ guildId, channelId, userId, messages: [] });
+    }
+    doc.messages.push({ role: 'user', content: userText });
+    doc.messages.push({ role: 'assistant', content: assistantText });
+    if (doc.messages.length > max * 2) {
+        doc.messages = doc.messages.slice(-max * 2);
+    }
+    await doc.save();
 }
 
-function appendHistory(channelId, userId, role, content) {
-    const history = getHistory(channelId, userId);
-    history.push({ role, content });
-    if (history.length > MAX_HISTORY) history.splice(0, history.length - MAX_HISTORY);
+async function clearHistory(guildId, channelId, userId) {
+    await Conversation.deleteOne({ guildId, channelId, userId });
 }
 
-function clearHistory(channelId, userId) {
-    conversationHistory.get(channelId)?.delete(userId);
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+async function withRetry(fn, { retries = 2, baseDelayMs = 800 } = {}) {
+    let lastErr;
+    for (let i = 0; i <= retries; i++) {
+        try {
+            return await fn();
+        } catch (err) {
+            lastErr = err;
+            const status = err?.status || err?.response?.status;
+            const retryable = !status || status === 408 || status === 429 || status >= 500;
+            if (!retryable || i === retries) throw err;
+            await sleep(baseDelayMs * Math.pow(2, i));
+        }
+    }
+    throw lastErr;
 }
 
-async function getChatCompletion(prompt, systemPrompt = 'You are a helpful Discord bot assistant.', provider = 'openai', apiKey = null, history = []) {
-    if (provider === 'openai') {
-        const client = apiKey ? new OpenAI({ apiKey }) : openai;
+function chunkText(text, size = DISCORD_MAX_LEN) {
+    if (text.length <= size) return [text];
+    const chunks = [];
+    let remaining = text;
+    while (remaining.length > size) {
+        let cut = remaining.lastIndexOf('\n', size);
+        if (cut < size * 0.5) cut = remaining.lastIndexOf(' ', size);
+        if (cut < size * 0.5) cut = size;
+        chunks.push(remaining.slice(0, cut));
+        remaining = remaining.slice(cut).trimStart();
+    }
+    if (remaining) chunks.push(remaining);
+    return chunks;
+}
 
-        if (!client) throw new Error('OpenAI API key not configured');
+// ---------- Provider implementations ----------
 
-        const messages = [
-            { role: 'system', content: systemPrompt },
-            ...history,
-            { role: 'user', content: prompt }
-        ];
+async function* streamOpenAI({ apiKey, model, systemPrompt, history, prompt, temperature, maxTokens, baseURL, defaultHeaders }) {
+    const client = new OpenAI({ apiKey, baseURL, defaultHeaders });
+    const messages = [
+        { role: 'system', content: systemPrompt },
+        ...history,
+        { role: 'user', content: prompt }
+    ];
+    const stream = await client.chat.completions.create({
+        model, messages, temperature, max_tokens: maxTokens, stream: true
+    });
+    for await (const chunk of stream) {
+        const delta = chunk.choices?.[0]?.delta?.content;
+        if (delta) yield delta;
+    }
+}
 
-        const completion = await client.chat.completions.create({
-            model: 'gpt-3.5-turbo',
-            messages,
-            max_tokens: 500,
-            temperature: 0.7
-        });
+async function callOpenAINonStream({ apiKey, model, systemPrompt, history, prompt, temperature, maxTokens, baseURL, defaultHeaders }) {
+    const client = new OpenAI({ apiKey, baseURL, defaultHeaders });
+    const messages = [
+        { role: 'system', content: systemPrompt },
+        ...history,
+        { role: 'user', content: prompt }
+    ];
+    const completion = await client.chat.completions.create({
+        model, messages, temperature, max_tokens: maxTokens
+    });
+    return completion.choices[0].message.content || '';
+}
 
-        return completion.choices[0].message.content;
-
-    } else if (provider === 'gemini') {
-        const client = apiKey ? new GoogleGenerativeAI(apiKey) : genAI;
-
-        if (!client) throw new Error('Gemini API key not configured');
-
-        const model = client.getGenerativeModel({ model: 'gemini-pro' });
-
-        const historyForGemini = history.map(h => ({
+async function* streamGemini({ apiKey, model, systemPrompt, history, prompt, temperature, maxTokens }) {
+    const client = new GoogleGenerativeAI(apiKey);
+    const generative = client.getGenerativeModel({
+        model,
+        systemInstruction: systemPrompt,
+        generationConfig: { temperature, maxOutputTokens: maxTokens }
+    });
+    const chat = generative.startChat({
+        history: history.map(h => ({
             role: h.role === 'assistant' ? 'model' : 'user',
             parts: [{ text: h.content }]
-        }));
-
-        const chat = model.startChat({
-            history: [
-                { role: 'user', parts: [{ text: systemPrompt }] },
-                { role: 'model', parts: [{ text: 'Understood. I will follow those instructions.' }] },
-                ...historyForGemini
-            ]
-        });
-
-        const result = await chat.sendMessage(prompt);
-        return result.response.text();
-
-    } else {
-        throw new Error('Invalid AI provider specified');
+        }))
+    });
+    const result = await chat.sendMessageStream(prompt);
+    for await (const chunk of result.stream) {
+        const text = chunk.text();
+        if (text) yield text;
     }
 }
 
-async function handleAIChat(message, systemPrompt, provider = 'openai', apiKey = null) {
-    const providerName = provider === 'openai' ? 'OpenAI' : 'Gemini';
+async function callGeminiNonStream(args) {
+    let out = '';
+    for await (const piece of streamGemini(args)) out += piece;
+    return out;
+}
 
-    if (provider === 'openai' && !openai && !apiKey) {
-        return message.reply('OpenAI is not configured. Please add your OpenAI API key in the dashboard.');
+async function* streamAnthropic({ apiKey, model, systemPrompt, history, prompt, temperature, maxTokens }) {
+    const client = new Anthropic({ apiKey });
+    const messages = [
+        ...history.map(h => ({ role: h.role, content: h.content })),
+        { role: 'user', content: prompt }
+    ];
+    const stream = await client.messages.stream({
+        model,
+        max_tokens: maxTokens,
+        temperature,
+        system: [
+            { type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }
+        ],
+        messages
+    });
+    for await (const event of stream) {
+        if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
+            yield event.delta.text;
+        }
+    }
+}
+
+async function callAnthropicNonStream(args) {
+    let out = '';
+    for await (const piece of streamAnthropic(args)) out += piece;
+    return out;
+}
+
+async function* streamOllama({ baseUrl, model, systemPrompt, history, prompt, temperature, maxTokens }) {
+    const url = `${(baseUrl || 'http://localhost:11434').replace(/\/$/, '')}/api/chat`;
+    const messages = [
+        { role: 'system', content: systemPrompt },
+        ...history,
+        { role: 'user', content: prompt }
+    ];
+    const response = await axios.post(url, {
+        model,
+        messages,
+        stream: true,
+        options: { temperature, num_predict: maxTokens }
+    }, { responseType: 'stream', timeout: 120000 });
+
+    let buf = '';
+    for await (const chunk of response.data) {
+        buf += chunk.toString('utf8');
+        let idx;
+        while ((idx = buf.indexOf('\n')) >= 0) {
+            const line = buf.slice(0, idx).trim();
+            buf = buf.slice(idx + 1);
+            if (!line) continue;
+            try {
+                const json = JSON.parse(line);
+                if (json.message?.content) yield json.message.content;
+                if (json.done) return;
+            } catch { /* skip malformed line */ }
+        }
+    }
+}
+
+async function callOllamaNonStream(args) {
+    let out = '';
+    for await (const piece of streamOllama(args)) out += piece;
+    return out;
+}
+
+// OpenRouter is OpenAI-compatible
+function openRouterArgs(base) {
+    return {
+        ...base,
+        baseURL: 'https://openrouter.ai/api/v1',
+        defaultHeaders: {
+            'HTTP-Referer': process.env.OPENROUTER_REFERER || 'https://github.com/theshield2594/ultrabot',
+            'X-Title': 'Ultrabot'
+        }
+    };
+}
+
+// ---------- Public API ----------
+
+function resolveProviderConfig(aiSettings) {
+    const provider = aiSettings.provider || 'openai';
+    const model = aiSettings.model || DEFAULT_MODELS[provider];
+    const temperature = aiSettings.temperature ?? 0.7;
+    const maxTokens = aiSettings.maxTokens ?? 1024;
+
+    let apiKey = null;
+    let baseUrl = null;
+
+    switch (provider) {
+        case 'openai':
+            apiKey = aiSettings.openaiKey || process.env.OPENAI_API_KEY;
+            break;
+        case 'gemini':
+            apiKey = aiSettings.geminiKey || process.env.GEMINI_API_KEY;
+            break;
+        case 'anthropic':
+            apiKey = aiSettings.anthropicKey || process.env.ANTHROPIC_API_KEY;
+            break;
+        case 'openrouter':
+            apiKey = aiSettings.openrouterKey || process.env.OPENROUTER_API_KEY;
+            break;
+        case 'ollama':
+            baseUrl = aiSettings.ollamaBaseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
+            break;
     }
 
-    if (provider === 'gemini' && !genAI && !apiKey) {
-        return message.reply('Gemini is not configured. Please add your Gemini API key in the dashboard.');
+    return { provider, model, temperature, maxTokens, apiKey, baseUrl };
+}
+
+async function* streamCompletion({ provider, model, apiKey, baseUrl, systemPrompt, history, prompt, temperature, maxTokens }) {
+    const common = { model, systemPrompt, history, prompt, temperature, maxTokens };
+    if (provider === 'openai') {
+        yield* streamOpenAI({ apiKey, ...common });
+    } else if (provider === 'gemini') {
+        yield* streamGemini({ apiKey, ...common });
+    } else if (provider === 'anthropic') {
+        yield* streamAnthropic({ apiKey, ...common });
+    } else if (provider === 'ollama') {
+        yield* streamOllama({ baseUrl, ...common });
+    } else if (provider === 'openrouter') {
+        yield* streamOpenAI(openRouterArgs({ apiKey, ...common }));
+    } else {
+        throw new Error(`Unknown provider: ${provider}`);
+    }
+}
+
+async function getCompletion({ provider, model, apiKey, baseUrl, systemPrompt, history, prompt, temperature, maxTokens }) {
+    const common = { model, systemPrompt, history, prompt, temperature, maxTokens };
+    if (provider === 'openai') return callOpenAINonStream({ apiKey, ...common });
+    if (provider === 'gemini') return callGeminiNonStream({ apiKey, ...common });
+    if (provider === 'anthropic') return callAnthropicNonStream({ apiKey, ...common });
+    if (provider === 'ollama') return callOllamaNonStream({ baseUrl, ...common });
+    if (provider === 'openrouter') return callOpenAINonStream(openRouterArgs({ apiKey, ...common }));
+    throw new Error(`Unknown provider: ${provider}`);
+}
+
+async function handleAIChat(message, aiSettings) {
+    const { provider, model, temperature, maxTokens, apiKey, baseUrl } = resolveProviderConfig(aiSettings);
+    const providerLabel = {
+        openai: 'OpenAI', gemini: 'Gemini', anthropic: 'Claude',
+        ollama: 'Ollama', openrouter: 'OpenRouter'
+    }[provider] || provider;
+
+    if (provider !== 'ollama' && !apiKey) {
+        return message.reply(`${providerLabel} is not configured. Add an API key in the dashboard.`);
     }
 
-    if (message.content.trim().toLowerCase() === '!reset') {
-        clearHistory(message.channel.id, message.author.id);
-        return message.reply('Conversation history cleared!');
+    const content = message.content.trim();
+    if (content.toLowerCase() === '!reset') {
+        await clearHistory(message.guild.id, message.channel.id, message.author.id);
+        return message.reply('Conversation history cleared.');
     }
 
-    const history = getHistory(message.channel.id, message.author.id);
+    if (!checkRateLimit(message.author.id, aiSettings.rateLimitPerUser, aiSettings.rateLimitWindowMin)) {
+        return message.reply(`Rate limit reached (${aiSettings.rateLimitPerUser} per ${aiSettings.rateLimitWindowMin}m). Please slow down.`);
+    }
+
+    const systemPrompt = aiSettings.systemPrompt || 'You are a helpful Discord bot assistant.';
+    const maxHistory = aiSettings.maxHistory ?? 20;
+    const useStreaming = aiSettings.streaming !== false;
 
     try {
         await message.channel.sendTyping();
+        const { messages: history } = await loadHistory(
+            message.guild.id, message.channel.id, message.author.id, maxHistory
+        );
 
-        const response = await getChatCompletion(message.content, systemPrompt, provider, apiKey, history);
+        const callArgs = { provider, model, apiKey, baseUrl, systemPrompt, history, prompt: content, temperature, maxTokens };
 
-        appendHistory(message.channel.id, message.author.id, 'user', message.content);
-        appendHistory(message.channel.id, message.author.id, 'assistant', response);
+        let fullResponse = '';
 
-        if (response.length > 2000) {
-            await message.reply(response.substring(0, 1997) + '...');
+        if (useStreaming) {
+            const placeholder = await message.reply('…');
+            let lastEdit = 0;
+            let currentMsg = placeholder;
+            let currentBuf = '';
+
+            await withRetry(async () => {
+                fullResponse = '';
+                currentBuf = '';
+                for await (const piece of streamCompletion(callArgs)) {
+                    fullResponse += piece;
+                    currentBuf += piece;
+                    if (currentBuf.length >= DISCORD_MAX_LEN - 50) {
+                        await currentMsg.edit(currentBuf.slice(0, DISCORD_MAX_LEN));
+                        const overflow = currentBuf.slice(DISCORD_MAX_LEN);
+                        currentMsg = await message.channel.send(overflow || '…');
+                        currentBuf = overflow;
+                        lastEdit = Date.now();
+                        continue;
+                    }
+                    const now = Date.now();
+                    if (now - lastEdit >= STREAM_EDIT_INTERVAL_MS) {
+                        await currentMsg.edit(currentBuf || '…').catch(() => {});
+                        lastEdit = now;
+                    }
+                }
+                if (currentBuf) await currentMsg.edit(currentBuf).catch(() => {});
+            });
         } else {
-            await message.reply(response);
+            const response = await withRetry(() => getCompletion(callArgs));
+            fullResponse = response || '(empty response)';
+            const chunks = chunkText(fullResponse);
+            await message.reply(chunks[0]);
+            for (let i = 1; i < chunks.length; i++) {
+                await message.channel.send(chunks[i]);
+            }
+        }
+
+        if (fullResponse.trim()) {
+            await appendHistory(
+                message.guild.id, message.channel.id, message.author.id,
+                content, fullResponse, maxHistory
+            );
         }
     } catch (error) {
-        console.error(`${providerName} chat error:`, error);
-        await message.reply(`Sorry, I encountered an error processing your message with ${providerName}.`);
+        console.error(`[AI:${provider}] error:`, error?.message || error);
+        const detail = error?.status ? ` (HTTP ${error.status})` : '';
+        await message.reply(`Sorry, I hit an error talking to ${providerLabel}${detail}.`).catch(() => {});
     }
 }
 
-module.exports = { getChatCompletion, handleAIChat, clearHistory };
+module.exports = {
+    handleAIChat,
+    clearHistory,
+    getCompletion,
+    streamCompletion,
+    resolveProviderConfig,
+    DEFAULT_MODELS
+};


### PR DESCRIPTION
…nce, rate limits

- Add Anthropic, Ollama, and OpenRouter as providers alongside OpenAI and Gemini
- Persist conversation history in MongoDB (new Conversation model) so context survives bot restarts
- Stream responses by editing the reply message in real-time, with overflow spilled into follow-up messages instead of a hard truncate
- Per-guild model, temperature, max_tokens, history depth, streaming toggle, and per-user sliding-window rate limits
- Upgrade defaults: gpt-4o-mini, claude-haiku-4-5, gemini-1.5-flash
- Use Gemini systemInstruction properly instead of faking it as the first turn
- Anthropic system prompt is sent with prompt caching enabled
- Retry with exponential backoff on transient/5xx errors
- Dashboard: provider-aware key fields, model field, advanced controls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended AI provider support to include Anthropic Claude, OpenRouter, and self-hosted Ollama alongside OpenAI and Gemini.
  * Added configurable AI model selection per provider with intelligent defaults.
  * Introduced tunable AI parameters: temperature, max output tokens, streaming toggle, and conversation history length limits.
  * Added per-user rate limiting controls with configurable time windows.
  * Implemented persistent conversation history and `!reset` command for chat management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->