### PR TITLE
Align Welcome/Farewell with Mee6 feature parity

### DIFF
--- a/src/dashboard/public/styles.css
+++ b/src/dashboard/public/styles.css
@@ -201,6 +201,29 @@ body {
 .btn-ghost { background: transparent; }
 .btn-sm { padding: 0.45rem 0.85rem; font-size: 0.82rem; }
 
+.role-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.3rem 0.65rem;
+    background: rgba(88, 101, 242, 0.18);
+    border: 1px solid rgba(88, 101, 242, 0.4);
+    border-radius: 99px;
+    font-size: 0.85rem;
+    color: #c3c8ff;
+}
+.role-tag button {
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    font-size: 1rem;
+    line-height: 1;
+    opacity: 0.7;
+    padding: 0;
+}
+.role-tag button:hover { opacity: 1; }
+
 /* Layout */
 .container {
     max-width: 1200px;

--- a/src/dashboard/routes/api.js
+++ b/src/dashboard/routes/api.js
@@ -87,6 +87,45 @@ router.get('/guild/:guildId/stats', checkAuth, checkGuildAccess, async (req, res
     }
 });
 
+router.post('/guild/:guildId/autorole', checkAuth, checkGuildAccess, async (req, res) => {
+    const { guildId } = req.params;
+    const { roleId } = req.body;
+
+    if (!roleId) return res.status(400).json({ error: 'roleId required' });
+
+    try {
+        const guildSettings = await Guild.findOne({ guildId });
+        if (!guildSettings) return res.status(404).json({ error: 'Guild not found' });
+
+        if (!guildSettings.autoRoles.some(r => r.roleId === roleId)) {
+            guildSettings.autoRoles.push({ roleId });
+            await guildSettings.save();
+        }
+
+        res.json({ success: true });
+    } catch (error) {
+        console.error('Autorole add error:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
+router.delete('/guild/:guildId/autorole/:roleId', checkAuth, checkGuildAccess, async (req, res) => {
+    const { guildId, roleId } = req.params;
+
+    try {
+        const guildSettings = await Guild.findOne({ guildId });
+        if (!guildSettings) return res.status(404).json({ error: 'Guild not found' });
+
+        guildSettings.autoRoles = guildSettings.autoRoles.filter(r => r.roleId !== roleId);
+        await guildSettings.save();
+
+        res.json({ success: true });
+    } catch (error) {
+        console.error('Autorole remove error:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
 router.post('/guild/:guildId/rss/add', checkAuth, checkGuildAccess, async (req, res) => {
     const { guildId } = req.params;
     const { url, channelId } = req.body;

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -29,6 +29,7 @@
         <div class="settings-layout">
             <aside class="sidebar" role="tablist">
                 <button class="nav-item active" data-tab="welcome"><span class="nav-emoji">👋</span> Welcome</button>
+                <button class="nav-item" data-tab="farewell"><span class="nav-emoji">👋</span> Farewell</button>
                 <button class="nav-item" data-tab="moderation"><span class="nav-emoji">🛡️</span> Moderation</button>
                 <button class="nav-item" data-tab="leveling"><span class="nav-emoji">📈</span> Leveling</button>
                 <button class="nav-item" data-tab="economy"><span class="nav-emoji">💎</span> Economy</button>
@@ -61,14 +62,52 @@
                     <div class="field">
                         <label class="field-label" for="welcome-message">Welcome message</label>
                         <textarea id="welcome-message" rows="3"><%= settings.welcome.message %></textarea>
-                        <small>Variables: <code>{user}</code> · <code>{server}</code> · <code>{memberCount}</code></small>
+                        <small>Variables: <code>{user}</code> · <code>{username}</code> · <code>{tag}</code> · <code>{server}</code> · <code>{memberCount}</code></small>
                     </div>
                     <label class="toggle">
                         <span class="toggle-text"><strong>Enable welcome card</strong><span>Generate a rich image card for new members</span></span>
                         <span class="switch"><input type="checkbox" id="welcome-card" <%= settings.welcome.cardEnabled ? 'checked' : '' %>><span class="slider"></span></span>
                     </label>
+                    <label class="toggle">
+                        <span class="toggle-text"><strong>Send DM to new members</strong><span>Privately message each new member when they join</span></span>
+                        <span class="switch"><input type="checkbox" id="welcome-dm-enabled" <%= settings.welcome.dmEnabled ? 'checked' : '' %>><span class="slider"></span></span>
+                    </label>
+                    <div class="field">
+                        <label class="field-label" for="welcome-dm-message">DM message</label>
+                        <textarea id="welcome-dm-message" rows="3"><%= settings.welcome.dmMessage %></textarea>
+                        <small>Variables: <code>{username}</code> · <code>{tag}</code> · <code>{server}</code> · <code>{memberCount}</code></small>
+                    </div>
                     <div class="actions-row">
                         <button class="btn btn-primary" onclick="saveSettings('welcome')">Save changes</button>
+                    </div>
+                </section>
+
+                <!-- Farewell -->
+                <section id="farewell" class="panel">
+                    <div class="panel-head">
+                        <h2>Farewell Settings</h2>
+                        <p>Send a message when a member leaves the server.</p>
+                    </div>
+                    <label class="toggle">
+                        <span class="toggle-text"><strong>Enable farewell messages</strong><span>Send a message when someone leaves</span></span>
+                        <span class="switch"><input type="checkbox" id="farewell-enabled" <%= settings.farewell.enabled ? 'checked' : '' %>><span class="slider"></span></span>
+                    </label>
+                    <div class="field">
+                        <label class="field-label" for="farewell-channel">Farewell channel</label>
+                        <select id="farewell-channel">
+                            <option value="">Select a channel</option>
+                            <% channels.forEach(channel => { %>
+                                <option value="<%= channel.id %>" <%= settings.farewell.channelId === channel.id ? 'selected' : '' %>>#<%= channel.name %></option>
+                            <% }); %>
+                        </select>
+                    </div>
+                    <div class="field">
+                        <label class="field-label" for="farewell-message">Farewell message</label>
+                        <textarea id="farewell-message" rows="3"><%= settings.farewell.message %></textarea>
+                        <small>Variables: <code>{user}</code> · <code>{username}</code> · <code>{tag}</code> · <code>{server}</code> · <code>{memberCount}</code></small>
+                    </div>
+                    <div class="actions-row">
+                        <button class="btn btn-primary" onclick="saveSettings('farewell')">Save changes</button>
                     </div>
                 </section>
 
@@ -429,7 +468,15 @@
                     'welcome.enabled': document.getElementById('welcome-enabled').checked,
                     'welcome.channelId': document.getElementById('welcome-channel').value,
                     'welcome.message': document.getElementById('welcome-message').value,
-                    'welcome.cardEnabled': document.getElementById('welcome-card').checked
+                    'welcome.cardEnabled': document.getElementById('welcome-card').checked,
+                    'welcome.dmEnabled': document.getElementById('welcome-dm-enabled').checked,
+                    'welcome.dmMessage': document.getElementById('welcome-dm-message').value
+                };
+            } else if (section === 'farewell') {
+                data = {
+                    'farewell.enabled': document.getElementById('farewell-enabled').checked,
+                    'farewell.channelId': document.getElementById('farewell-channel').value,
+                    'farewell.message': document.getElementById('farewell-message').value
                 };
             } else if (section === 'moderation') {
                 data = {

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -77,6 +77,29 @@
                         <textarea id="welcome-dm-message" rows="3"><%= settings.welcome.dmMessage %></textarea>
                         <small>Variables: <code>{username}</code> · <code>{tag}</code> · <code>{server}</code> · <code>{memberCount}</code></small>
                     </div>
+                    <div class="panel-head" style="margin-top:1.5rem">
+                        <h3>Role to New Users</h3>
+                        <p>Automatically assign roles when a member joins.</p>
+                    </div>
+                    <div class="field">
+                        <div id="autorole-list" style="display:flex;flex-wrap:wrap;gap:.5rem;margin-bottom:.75rem">
+                            <% (settings.autoRoles || []).forEach(r => { %>
+                                <% const role = roles.find(ro => ro.id === r.roleId); %>
+                                <% if (role) { %>
+                                    <span class="role-tag" data-role-id="<%= r.roleId %>">@<%= role.name %> <button onclick="removeAutoRole('<%= r.roleId %>')" title="Remove">&times;</button></span>
+                                <% } %>
+                            <% }); %>
+                        </div>
+                        <div style="display:flex;gap:.5rem;align-items:center">
+                            <select id="autorole-select">
+                                <option value="">Select a role</option>
+                                <% roles.forEach(role => { %>
+                                    <option value="<%= role.id %>">@<%= role.name %></option>
+                                <% }); %>
+                            </select>
+                            <button class="btn btn-primary" onclick="addAutoRole()">Add role</button>
+                        </div>
+                    </div>
                     <div class="actions-row">
                         <button class="btn btn-primary" onclick="saveSettings('welcome')">Save changes</button>
                     </div>
@@ -547,6 +570,39 @@
                 });
                 if (response.ok) toast('Settings saved', 'success');
                 else toast('Failed to save settings', 'error');
+            } catch (error) {
+                console.error(error);
+                toast('An error occurred', 'error');
+            }
+        }
+
+        async function addAutoRole() {
+            const guildId = '<%= guild.id %>';
+            const roleId = document.getElementById('autorole-select').value;
+            if (!roleId) { toast('Please select a role', 'error'); return; }
+            if (document.querySelector(`#autorole-list [data-role-id="${roleId}"]`)) {
+                toast('Role already added', 'error'); return;
+            }
+            try {
+                const response = await fetch(`/api/guild/${guildId}/autorole`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ roleId })
+                });
+                if (response.ok) { toast('Role added', 'success'); setTimeout(() => location.reload(), 600); }
+                else toast('Failed to add role', 'error');
+            } catch (error) {
+                console.error(error);
+                toast('An error occurred', 'error');
+            }
+        }
+
+        async function removeAutoRole(roleId) {
+            const guildId = '<%= guild.id %>';
+            try {
+                const response = await fetch(`/api/guild/${guildId}/autorole/${roleId}`, { method: 'DELETE' });
+                if (response.ok) { toast('Role removed', 'success'); setTimeout(() => location.reload(), 600); }
+                else toast('Failed to remove role', 'error');
             } catch (error) {
                 console.error(error);
                 toast('An error occurred', 'error');

--- a/src/events/guildMemberAdd.js
+++ b/src/events/guildMemberAdd.js
@@ -2,44 +2,57 @@ const Guild = require('../models/Guild');
 const { EmbedBuilder, AttachmentBuilder } = require('discord.js');
 const { createWelcomeCard } = require('../utils/cardGenerator');
 
+function applyVariables(template, member) {
+    return template
+        .replace(/{user}/g, `<@${member.id}>`)
+        .replace(/{username}/g, member.user.displayName ?? member.user.username)
+        .replace(/{tag}/g, member.user.tag)
+        .replace(/{server}/g, member.guild.name)
+        .replace(/{memberCount}/g, member.guild.memberCount);
+}
+
 module.exports = {
     name: 'guildMemberAdd',
     async execute(member, client) {
         try {
             const guildSettings = await Guild.findOne({ guildId: member.guild.id });
-            
-            if (!guildSettings || !guildSettings.welcome.enabled) return;
-            
-            const channel = member.guild.channels.cache.get(guildSettings.welcome.channelId);
-            if (!channel) return;
-            
-            const message = guildSettings.welcome.message
-                .replace(/{user}/g, `<@${member.id}>`)
-                .replace(/{server}/g, member.guild.name)
-                .replace(/{memberCount}/g, member.guild.memberCount);
-            
-            if (guildSettings.welcome.cardEnabled) {
-                const card = await createWelcomeCard(member);
-                const attachment = new AttachmentBuilder(card, { name: 'welcome.png' });
-                
-                const embed = new EmbedBuilder()
-                    .setColor('#00ff00')
-                    .setDescription(message)
-                    .setImage('attachment://welcome.png')
-                    .setTimestamp();
-                
-                await channel.send({ embeds: [embed], files: [attachment] });
-            } else {
-                const embed = new EmbedBuilder()
-                    .setColor('#00ff00')
-                    .setTitle('Welcome!')
-                    .setDescription(message)
-                    .setThumbnail(member.user.displayAvatarURL({ dynamic: true }))
-                    .setTimestamp();
-                
-                await channel.send({ embeds: [embed] });
+
+            if (!guildSettings) return;
+
+            if (guildSettings.welcome.enabled) {
+                const channel = member.guild.channels.cache.get(guildSettings.welcome.channelId);
+                if (channel) {
+                    const message = applyVariables(guildSettings.welcome.message, member);
+
+                    if (guildSettings.welcome.cardEnabled) {
+                        const card = await createWelcomeCard(member);
+                        const attachment = new AttachmentBuilder(card, { name: 'welcome.png' });
+
+                        const embed = new EmbedBuilder()
+                            .setColor('#5865F2')
+                            .setDescription(message)
+                            .setImage('attachment://welcome.png')
+                            .setTimestamp();
+
+                        await channel.send({ embeds: [embed], files: [attachment] });
+                    } else {
+                        const embed = new EmbedBuilder()
+                            .setColor('#5865F2')
+                            .setTitle('Welcome!')
+                            .setDescription(message)
+                            .setThumbnail(member.user.displayAvatarURL({ dynamic: true }))
+                            .setTimestamp();
+
+                        await channel.send({ embeds: [embed] });
+                    }
+                }
             }
-            
+
+            if (guildSettings.welcome.dmEnabled) {
+                const dmMessage = applyVariables(guildSettings.welcome.dmMessage, member);
+                await member.send(dmMessage).catch(() => null);
+            }
+
             if (guildSettings.autoRoles.length > 0) {
                 for (const autoRole of guildSettings.autoRoles) {
                     const role = member.guild.roles.cache.get(autoRole.roleId);
@@ -53,7 +66,7 @@ module.exports = {
                 const logChannel = member.guild.channels.cache.get(guildSettings.eventLog.channelId);
                 if (logChannel) {
                     const logEmbed = new EmbedBuilder()
-                        .setColor('#00ff00')
+                        .setColor('#5865F2')
                         .setTitle('Member Joined')
                         .setAuthor({ name: member.user.tag, iconURL: member.user.displayAvatarURL({ dynamic: true }) })
                         .addFields(

--- a/src/events/guildMemberRemove.js
+++ b/src/events/guildMemberRemove.js
@@ -1,35 +1,42 @@
 const Guild = require('../models/Guild');
 const { EmbedBuilder } = require('discord.js');
 
+function applyVariables(template, member) {
+    return template
+        .replace(/{user}/g, member.user.tag)
+        .replace(/{username}/g, member.user.displayName ?? member.user.username)
+        .replace(/{tag}/g, member.user.tag)
+        .replace(/{server}/g, member.guild.name)
+        .replace(/{memberCount}/g, member.guild.memberCount);
+}
+
 module.exports = {
     name: 'guildMemberRemove',
     async execute(member, client) {
         try {
             const guildSettings = await Guild.findOne({ guildId: member.guild.id });
-            
+
             if (!guildSettings || !guildSettings.farewell.enabled) return;
-            
+
             const channel = member.guild.channels.cache.get(guildSettings.farewell.channelId);
             if (!channel) return;
-            
-            const message = guildSettings.farewell.message
-                .replace(/{user}/g, member.user.tag)
-                .replace(/{server}/g, member.guild.name)
-                .replace(/{memberCount}/g, member.guild.memberCount);
-            
+
+            const message = applyVariables(guildSettings.farewell.message, member);
+
             const embed = new EmbedBuilder()
-                .setColor('#ff0000')
+                .setColor('#ED4245')
                 .setTitle('Goodbye!')
                 .setDescription(message)
                 .setThumbnail(member.user.displayAvatarURL({ dynamic: true }))
                 .setTimestamp();
-            
+
             await channel.send({ embeds: [embed] });
+
             if (guildSettings.eventLog?.enabled && guildSettings.eventLog.logMemberLeave) {
                 const logChannel = member.guild.channels.cache.get(guildSettings.eventLog.channelId);
                 if (logChannel) {
                     const logEmbed = new EmbedBuilder()
-                        .setColor('#ff0000')
+                        .setColor('#ED4245')
                         .setTitle('Member Left')
                         .setAuthor({ name: member.user.tag, iconURL: member.user.displayAvatarURL({ dynamic: true }) })
                         .addFields(

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -23,7 +23,9 @@ const guildSchema = new Schema({
         enabled: { type: Boolean, default: false },
         channelId: { type: String, default: null },
         message: { type: String, default: 'Welcome {user} to {server}!' },
-        cardEnabled: { type: Boolean, default: true }
+        cardEnabled: { type: Boolean, default: true },
+        dmEnabled: { type: Boolean, default: false },
+        dmMessage: { type: String, default: 'Welcome to {server}! We\'re glad to have you here.' }
     },
     
     farewell: {


### PR DESCRIPTION
- Add DM welcome (dmEnabled + dmMessage) to schema, event handler, and dashboard
- Add Farewell section to dashboard with channel, message, and save handler
- Support {username} and {tag} template variables in both welcome and farewell
- Replace hardcoded lime-green/red embed colors with Discord blurple (#5865F2) and red (#ED4245)

https://claude.ai/code/session_01TWDp6a72WFbBs3SZxU92Dc