### PR TITLE
feat: add temp voice channel configuration to dashboard

### DIFF
--- a/src/dashboard/routes/dashboard.js
+++ b/src/dashboard/routes/dashboard.js
@@ -82,6 +82,14 @@ router.get('/guild/:guildId', checkAuth, async (req, res) => {
             .filter(c => c.type === 0)
             .map(c => ({ id: c.id, name: c.name }));
 
+        const voiceChannels = guild.channels.cache
+            .filter(c => c.type === 2)
+            .map(c => ({ id: c.id, name: c.name }));
+
+        const categories = guild.channels.cache
+            .filter(c => c.type === 4)
+            .map(c => ({ id: c.id, name: c.name }));
+
         const roles = guild.roles.cache
             .filter(r => r.name !== '@everyone')
             .map(r => ({ id: r.id, name: r.name }));
@@ -91,6 +99,8 @@ router.get('/guild/:guildId', checkAuth, async (req, res) => {
             guild: guild,
             settings: guildSettings,
             channels: channels,
+            voiceChannels: voiceChannels,
+            categories: categories,
             roles: roles
         });
     } catch (error) {

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -37,6 +37,7 @@
                 <button class="nav-item" data-tab="rss"><span class="nav-emoji">📰</span> RSS Feeds</button>
                 <button class="nav-item" data-tab="dailynews"><span class="nav-emoji">🗞️</span> Daily News</button>
                 <button class="nav-item" data-tab="ai"><span class="nav-emoji">🧠</span> AI Chat</button>
+                <button class="nav-item" data-tab="tempvoice"><span class="nav-emoji">🔊</span> Temp Voice</button>
             </aside>
 
             <div class="settings-content">
@@ -336,6 +337,55 @@
                     </div>
                 </section>
 
+                <!-- Temp Voice -->
+                <section id="tempvoice" class="panel">
+                    <div class="panel-head">
+                        <h2>Temporary Voice Channels</h2>
+                        <p>Members join a lobby channel and instantly get their own private voice channel. It's deleted automatically when empty.</p>
+                    </div>
+                    <label class="toggle">
+                        <span class="toggle-text"><strong>Enable temp voice channels</strong><span>Create a private VC for each member that joins the lobby</span></span>
+                        <span class="switch"><input type="checkbox" id="tv-enabled" <%= settings.tempVoice?.enabled ? 'checked' : '' %>><span class="slider"></span></span>
+                    </label>
+                    <div class="field">
+                        <label class="field-label" for="tv-lobby">Lobby voice channel</label>
+                        <select id="tv-lobby">
+                            <option value="">Select a voice channel</option>
+                            <% (voiceChannels || []).forEach(vc => { %>
+                                <option value="<%= vc.id %>" <%= settings.tempVoice?.lobbyChannelId === vc.id ? 'selected' : '' %>>🔊 <%= vc.name %></option>
+                            <% }); %>
+                        </select>
+                        <small>Members who join this channel will have a private VC created for them.</small>
+                    </div>
+                    <div class="field">
+                        <label class="field-label" for="tv-category">Category for new channels</label>
+                        <select id="tv-category">
+                            <option value="">Same as lobby (default)</option>
+                            <% (categories || []).forEach(cat => { %>
+                                <option value="<%= cat.id %>" <%= settings.tempVoice?.categoryId === cat.id ? 'selected' : '' %>><%= cat.name %></option>
+                            <% }); %>
+                        </select>
+                        <small>New temp channels are placed in this category.</small>
+                    </div>
+                    <div class="field">
+                        <label class="field-label" for="tv-channel-name">Channel name template</label>
+                        <input type="text" id="tv-channel-name" value="<%= settings.tempVoice?.channelName || '{username}\'s VC' %>" placeholder="{username}'s VC">
+                        <small>Variables: <code>{username}</code> · <code>{displayname}</code> · <code>{tag}</code></small>
+                    </div>
+                    <div class="field">
+                        <label class="field-label" for="tv-user-limit">User limit <span style="color:var(--text-mute);font-weight:400;">(0 = unlimited)</span></label>
+                        <input type="number" id="tv-user-limit" min="0" max="99" value="<%= settings.tempVoice?.userLimit ?? 0 %>">
+                    </div>
+                    <div class="field">
+                        <label class="field-label" for="tv-bitrate">Bitrate (kbps)</label>
+                        <input type="number" id="tv-bitrate" min="8" max="384" value="<%= settings.tempVoice?.bitrate ?? 64 %>">
+                        <small>Standard servers: up to 96 kbps · Boosted servers: up to 384 kbps.</small>
+                    </div>
+                    <div class="actions-row">
+                        <button class="btn btn-primary" onclick="saveSettings('tempvoice')">Save changes</button>
+                    </div>
+                </section>
+
                 <!-- AI -->
                 <section id="ai" class="panel">
                     <div class="panel-head">
@@ -547,6 +597,15 @@
                     'ai.streaming': document.getElementById('ai-streaming').checked,
                     'ai.rateLimitPerUser': parseInt(document.getElementById('ai-rate-limit').value, 10),
                     'ai.rateLimitWindowMin': parseInt(document.getElementById('ai-rate-window').value, 10)
+                };
+            } else if (section === 'tempvoice') {
+                data = {
+                    'tempVoice.enabled': document.getElementById('tv-enabled').checked,
+                    'tempVoice.lobbyChannelId': document.getElementById('tv-lobby').value || null,
+                    'tempVoice.categoryId': document.getElementById('tv-category').value || null,
+                    'tempVoice.channelName': document.getElementById('tv-channel-name').value.trim() || "{username}'s VC",
+                    'tempVoice.userLimit': parseInt(document.getElementById('tv-user-limit').value, 10) || 0,
+                    'tempVoice.bitrate': parseInt(document.getElementById('tv-bitrate').value, 10) || 64
                 };
             } else if (section === 'dailynews') {
                 const feedsText = document.getElementById('dailynews-feeds').value;

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -189,7 +189,10 @@ const guildSchema = new Schema({
         enabled: { type: Boolean, default: false },
         lobbyChannelId: { type: String, default: null },
         categoryId: { type: String, default: null },
-        activeChannels: [{ type: String }]
+        activeChannels: [{ type: String }],
+        channelName: { type: String, default: "{username}'s VC" },
+        userLimit: { type: Number, default: 0 },
+        bitrate: { type: Number, default: 64 }
     },
 
     eventLog: {

--- a/src/services/tempVoiceService.js
+++ b/src/services/tempVoiceService.js
@@ -8,15 +8,23 @@ async function handleVoiceStateUpdate(oldState, newState, client) {
     const guildSettings = await Guild.findOne({ guildId: guild.id });
     if (!guildSettings?.tempVoice?.enabled) return;
 
-    const { lobbyChannelId, categoryId } = guildSettings.tempVoice;
+    const { lobbyChannelId, categoryId, channelName, userLimit, bitrate } = guildSettings.tempVoice;
 
     // Member joined the lobby → create their channel
     if (newState.channelId === lobbyChannelId && newState.member) {
         const member = newState.member;
+        const nameTemplate = channelName || "{username}'s VC";
+        const resolvedName = nameTemplate
+            .replace(/{username}/gi, member.user.username)
+            .replace(/{displayname}/gi, member.displayName)
+            .replace(/{tag}/gi, member.user.tag ?? member.user.username);
+
         const channel = await guild.channels.create({
-            name: `${member.displayName}'s VC`,
+            name: resolvedName,
             type: ChannelType.GuildVoice,
             parent: categoryId ?? null,
+            userLimit: userLimit ?? 0,
+            bitrate: (bitrate ?? 64) * 1000,
             permissionOverwrites: [
                 { id: member.id, allow: [PermissionFlagsBits.ManageChannels, PermissionFlagsBits.MuteMembers, PermissionFlagsBits.DeafenMembers] }
             ]


### PR DESCRIPTION
- Add Temp Voice tab to the guild settings dashboard with lobby channel selector, category picker, channel name template, user limit, and bitrate controls
- Extend Guild model tempVoice schema with channelName, userLimit, and bitrate fields
- Pass voice channels and categories from dashboard route to template
- Apply name template ({username}/{displayname}/{tag}), user limit, and bitrate when creating temp channels in tempVoiceService

https://claude.ai/code/session_01PVnmi1jYRJXM2WmBMiEnHH