### PR TITLE
Auto-deploy slash commands on bot ready

### DIFF
--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -1,37 +1,11 @@
-const { REST, Routes } = require('discord.js');
-const fs = require('fs');
-const path = require('path');
 require('dotenv').config();
-
-const commands = [];
-const foldersPath = path.join(__dirname, 'commands');
-const commandFolders = fs.readdirSync(foldersPath);
-
-for (const folder of commandFolders) {
-    const commandsPath = path.join(foldersPath, folder);
-    const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
-
-    for (const file of commandFiles) {
-        const filePath = path.join(commandsPath, file);
-        const command = require(filePath);
-        if ('data' in command && 'execute' in command) {
-            commands.push(command.data.toJSON());
-        }
-    }
-}
-
-const rest = new REST().setToken(process.env.DISCORD_TOKEN);
+const { deployCommands } = require('./utils/commandDeployer');
 
 (async () => {
     try {
-        console.log(`Started refreshing ${commands.length} application (/) commands.`);
-
-        const data = await rest.put(
-            Routes.applicationCommands(process.env.CLIENT_ID),
-            { body: commands },
-        );
-
-        console.log(`Successfully reloaded ${data.length} application (/) commands.`);
+        console.log('Started refreshing application (/) commands.');
+        const count = await deployCommands(process.env.CLIENT_ID, process.env.DISCORD_TOKEN);
+        console.log(`Successfully reloaded ${count} application (/) commands.`);
     } catch (error) {
         console.error(error);
     }

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -1,30 +1,9 @@
-const { REST, Routes } = require('discord.js');
-const fs = require('fs');
-const path = require('path');
 const cron = require('node-cron');
+const { deployCommands } = require('../utils/commandDeployer');
 const { checkRssFeeds, scheduleDailyNews } = require('../services/rssService');
 const { checkReminders } = require('../services/reminderService');
 const { checkGiveaways } = require('../services/giveawayService');
 const { checkTempVoice } = require('../services/tempVoiceService');
-
-async function deployCommands(clientId) {
-    const commands = [];
-    const foldersPath = path.join(__dirname, '../commands');
-
-    for (const folder of fs.readdirSync(foldersPath)) {
-        const commandsPath = path.join(foldersPath, folder);
-        for (const file of fs.readdirSync(commandsPath).filter(f => f.endsWith('.js'))) {
-            const command = require(path.join(commandsPath, file));
-            if ('data' in command && 'execute' in command) {
-                commands.push(command.data.toJSON());
-            }
-        }
-    }
-
-    const rest = new REST().setToken(process.env.DISCORD_TOKEN);
-    await rest.put(Routes.applicationCommands(clientId), { body: commands });
-    return commands.length;
-}
 
 module.exports = {
     name: 'ready',
@@ -34,7 +13,7 @@ module.exports = {
         console.log(`[READY] Serving ${client.guilds.cache.size} guilds`);
 
         try {
-            const count = await deployCommands(client.user.id);
+            const count = await deployCommands(client.user.id, process.env.DISCORD_TOKEN);
             console.log(`[READY] Deployed ${count} slash commands`);
         } catch (error) {
             console.error('[READY] Failed to deploy slash commands:', error);

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -1,8 +1,30 @@
+const { REST, Routes } = require('discord.js');
+const fs = require('fs');
+const path = require('path');
 const cron = require('node-cron');
 const { checkRssFeeds, scheduleDailyNews } = require('../services/rssService');
 const { checkReminders } = require('../services/reminderService');
 const { checkGiveaways } = require('../services/giveawayService');
 const { checkTempVoice } = require('../services/tempVoiceService');
+
+async function deployCommands(clientId) {
+    const commands = [];
+    const foldersPath = path.join(__dirname, '../commands');
+
+    for (const folder of fs.readdirSync(foldersPath)) {
+        const commandsPath = path.join(foldersPath, folder);
+        for (const file of fs.readdirSync(commandsPath).filter(f => f.endsWith('.js'))) {
+            const command = require(path.join(commandsPath, file));
+            if ('data' in command && 'execute' in command) {
+                commands.push(command.data.toJSON());
+            }
+        }
+    }
+
+    const rest = new REST().setToken(process.env.DISCORD_TOKEN);
+    await rest.put(Routes.applicationCommands(clientId), { body: commands });
+    return commands.length;
+}
 
 module.exports = {
     name: 'ready',
@@ -10,20 +32,27 @@ module.exports = {
     async execute(client) {
         console.log(`[READY] Logged in as ${client.user.tag}`);
         console.log(`[READY] Serving ${client.guilds.cache.size} guilds`);
-        
+
+        try {
+            const count = await deployCommands(client.user.id);
+            console.log(`[READY] Deployed ${count} slash commands`);
+        } catch (error) {
+            console.error('[READY] Failed to deploy slash commands:', error);
+        }
+
         client.user.setPresence({
             activities: [{ name: '/help | UltraBot', type: 0 }],
             status: 'online'
         });
-        
+
         cron.schedule('*/5 * * * *', async () => {
             await checkRssFeeds(client);
         });
-        
+
         cron.schedule('* * * * *', async () => {
             await checkReminders(client);
         });
-        
+
         scheduleDailyNews(client);
 
         cron.schedule('* * * * *', async () => {

--- a/src/utils/commandDeployer.js
+++ b/src/utils/commandDeployer.js
@@ -1,0 +1,30 @@
+const { REST, Routes } = require('discord.js');
+const fs = require('fs');
+const path = require('path');
+
+async function deployCommands(clientId, token) {
+    const commands = [];
+    const foldersPath = path.join(__dirname, '../commands');
+
+    for (const entry of fs.readdirSync(foldersPath, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        const commandsPath = path.join(foldersPath, entry.name);
+
+        for (const file of fs.readdirSync(commandsPath).filter(f => f.endsWith('.js'))) {
+            try {
+                const command = require(path.join(commandsPath, file));
+                if ('data' in command && 'execute' in command && typeof command.data?.toJSON === 'function') {
+                    commands.push(command.data.toJSON());
+                }
+            } catch (error) {
+                console.error(`[DEPLOY] Failed to load command ${file}:`, error);
+            }
+        }
+    }
+
+    const rest = new REST().setToken(token);
+    await rest.put(Routes.applicationCommands(clientId), { body: commands });
+    return commands.length;
+}
+
+module.exports = { deployCommands };


### PR DESCRIPTION
The deploy-commands.js script was never called during startup, so
slash commands were loaded into memory but never registered with
Discord's API — making them invisible to users in servers.

The ready event now calls the Discord REST API to register all
slash commands automatically each time the bot starts, using
client.user.id to guarantee the correct application ID.

https://claude.ai/code/session_01WP3hhHsqbkV5NQ7MkxAQCY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Commands are now automatically deployed and synchronized with Discord's API when the bot initializes, ensuring all registered commands are available to users at startup.
  * Added comprehensive error handling and logging for command deployment to help diagnose issues and provide clear status updates during the initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->