### PR TITLE
fix: resolve 4 reliability issues for self-hosted deployment

### DIFF
--- a/src/commands/economy/deposit.js
+++ b/src/commands/economy/deposit.js
@@ -37,7 +37,13 @@ module.exports = {
 
         userData.balance -= amount;
         userData.bank += amount;
-        await userData.save();
+
+        try {
+            await userData.save();
+        } catch (err) {
+            console.error('[deposit] save error:', err);
+            return interaction.reply({ content: 'Failed to save your deposit. Please try again.', ephemeral: true });
+        }
 
         const embed = new EmbedBuilder()
             .setColor('#00ff00')

--- a/src/commands/economy/withdraw.js
+++ b/src/commands/economy/withdraw.js
@@ -37,7 +37,13 @@ module.exports = {
 
         userData.bank -= amount;
         userData.balance += amount;
-        await userData.save();
+
+        try {
+            await userData.save();
+        } catch (err) {
+            console.error('[withdraw] save error:', err);
+            return interaction.reply({ content: 'Failed to save your withdrawal. Please try again.', ephemeral: true });
+        }
 
         const embed = new EmbedBuilder()
             .setColor('#00ff00')

--- a/src/commands/utility/poll.js
+++ b/src/commands/utility/poll.js
@@ -1,7 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
-
-// messageId -> Map<userId, optionIndex>
-const pollVotes = new Map();
+const Poll = require('../../models/Poll');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -30,25 +28,25 @@ module.exports = {
         }
 
         const counts = new Array(options.length).fill(0);
-
         const embed = buildPollEmbed(question, options, counts, endsAt, interaction.user);
-
-        const rows = buildPollRows(options, new Map());
+        const rows = buildPollRows(options);
 
         await interaction.reply({ embeds: [embed], components: rows });
         const msg = await interaction.fetchReply();
 
-        pollVotes.set(msg.id, new Map());
+        await Poll.create({
+            messageId: msg.id,
+            guildId: interaction.guild.id,
+            channelId: interaction.channel.id,
+            question,
+            options,
+            votes: new Map(),
+            endsAt,
+            createdBy: interaction.user.tag
+        });
 
         if (endsAt) {
-            const delay = endsAt.getTime() - Date.now();
-            setTimeout(async () => {
-                const votes = pollVotes.get(msg.id) ?? new Map();
-                const finalCounts = tallyVotes(votes, options.length);
-                const closedEmbed = buildPollEmbed(question, options, finalCounts, endsAt, interaction.user, true);
-                await msg.edit({ embeds: [closedEmbed], components: [] }).catch(console.error);
-                pollVotes.delete(msg.id);
-            }, delay);
+            scheduleExpiry(msg, question, options, endsAt, interaction.user.tag);
         }
     }
 };
@@ -75,12 +73,14 @@ function buildPollEmbed(question, options, counts, endsAt, author, closed = fals
         return `**${i + 1}. ${opt}**\n${bar} ${pct}% (${counts[i]} vote${counts[i] !== 1 ? 's' : ''})`;
     });
 
+    const authorTag = typeof author === 'string' ? author : author.tag;
+
     const embed = new EmbedBuilder()
         .setColor(closed ? '#ff0000' : '#5865F2')
         .setTitle(`${closed ? '🔒 ' : '📊 '}${question}`)
         .setDescription(lines.join('\n\n'))
         .addFields({ name: 'Total votes', value: total.toString(), inline: true })
-        .setFooter({ text: `Created by ${author.tag}${closed ? ' • Poll closed' : ''}` });
+        .setFooter({ text: `Created by ${authorTag}${closed ? ' • Poll closed' : ''}` });
 
     if (endsAt && !closed) {
         embed.addFields({ name: 'Ends', value: `<t:${Math.floor(endsAt.getTime() / 1000)}:R>`, inline: true });
@@ -89,7 +89,7 @@ function buildPollEmbed(question, options, counts, endsAt, author, closed = fals
     return embed;
 }
 
-function buildPollRows(options, voteMap) {
+function buildPollRows(options) {
     const rows = [];
     for (let i = 0; i < options.length; i += 5) {
         const row = new ActionRowBuilder();
@@ -106,47 +106,79 @@ function buildPollRows(options, voteMap) {
     return rows;
 }
 
+function scheduleExpiry(msg, question, options, endsAt, createdBy) {
+    const delay = endsAt.getTime() - Date.now();
+    if (delay <= 0) return;
+    setTimeout(async () => {
+        try {
+            const poll = await Poll.findOne({ messageId: msg.id });
+            if (!poll || poll.closed) return;
+
+            const counts = tallyVotes(poll.votes, options.length);
+            const closedEmbed = buildPollEmbed(question, options, counts, endsAt, createdBy, true);
+            await msg.edit({ embeds: [closedEmbed], components: [] }).catch(() => {});
+
+            poll.closed = true;
+            await poll.save();
+        } catch (err) {
+            console.error('[poll] expiry error:', err);
+        }
+    }, delay);
+}
+
 async function handlePollVote(interaction) {
     const optionIndex = parseInt(interaction.customId.split('_')[1]);
     const messageId = interaction.message.id;
 
-    if (!pollVotes.has(messageId)) {
+    const poll = await Poll.findOne({ messageId });
+    if (!poll) {
         return interaction.reply({ content: 'This poll is no longer active.', ephemeral: true });
     }
-
-    const votes = pollVotes.get(messageId);
-    const existing = votes.get(interaction.user.id);
-
-    if (existing === optionIndex) {
-        votes.delete(interaction.user.id);
-        await interaction.reply({ content: 'Your vote has been removed.', ephemeral: true });
-    } else {
-        votes.set(interaction.user.id, optionIndex);
-        await interaction.reply({ content: `You voted for option **${optionIndex + 1}**.`, ephemeral: true });
+    if (poll.closed) {
+        return interaction.reply({ content: 'This poll is closed.', ephemeral: true });
     }
 
-    const embed = interaction.message.embeds[0];
-    if (!embed) return;
+    const existing = poll.votes.get(interaction.user.id);
+    if (existing === optionIndex) {
+        poll.votes.delete(interaction.user.id);
+        await interaction.reply({ content: 'Your vote has been removed.', ephemeral: true });
+    } else {
+        poll.votes.set(interaction.user.id, optionIndex);
+        await interaction.reply({ content: `You voted for option **${optionIndex + 1}**.`, ephemeral: true });
+    }
+    poll.markModified('votes');
+    await poll.save();
 
-    const question = embed.title.replace(/^[🔒📊] /, '');
-    const options = embed.description.split('\n\n').map(block => {
-        const match = block.match(/^\*\*\d+\. (.+)\*\*/);
-        return match ? match[1] : '';
-    }).filter(Boolean);
+    const counts = tallyVotes(poll.votes, poll.options.length);
+    const newEmbed = buildPollEmbed(poll.question, poll.options, counts, poll.endsAt, poll.createdBy);
+    const rows = buildPollRows(poll.options);
+    await interaction.message.edit({ embeds: [newEmbed], components: rows }).catch(() => {});
+}
 
-    const counts = tallyVotes(votes, options.length);
-    const author = { tag: embed.footer.text.replace('Created by ', '').replace(/ • Poll closed$/, '') };
-    const endsAtField = interaction.message.embeds[0].fields.find(f => f.name === 'Ends');
-    const endsAt = endsAtField ? new Date(parseInt(endsAtField.value.match(/\d+/)[0]) * 1000) : null;
-
-    const newEmbed = buildPollEmbed(question, options, counts, endsAt, author);
-    const rows = buildPollRows(options, votes);
-
-    await interaction.message.edit({ embeds: [newEmbed], components: rows }).catch(console.error);
+async function scheduleActivePollExpirations(client) {
+    try {
+        const active = await Poll.find({ closed: false, endsAt: { $gt: new Date() } });
+        for (const poll of active) {
+            try {
+                const guild = client.guilds.cache.get(poll.guildId);
+                if (!guild) continue;
+                const channel = guild.channels.cache.get(poll.channelId);
+                if (!channel) continue;
+                const msg = await channel.messages.fetch(poll.messageId).catch(() => null);
+                if (!msg) continue;
+                scheduleExpiry(msg, poll.question, poll.options, poll.endsAt, poll.createdBy);
+            } catch (err) {
+                console.error('[poll] failed to reschedule poll', poll.messageId, err);
+            }
+        }
+        if (active.length) console.log(`[POLL] Rescheduled ${active.length} active poll(s).`);
+    } catch (err) {
+        console.error('[poll] scheduleActivePollExpirations error:', err);
+    }
 }
 
 module.exports.handlePollVote = handlePollVote;
-module.exports.pollVotes = pollVotes;
 module.exports.buildPollEmbed = buildPollEmbed;
 module.exports.buildPollRows = buildPollRows;
 module.exports.tallyVotes = tallyVotes;
+module.exports.scheduleActivePollExpirations = scheduleActivePollExpirations;

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -52,8 +52,12 @@ function start(client) {
     app.use(express.json());
     app.use(express.urlencoded({ extended: true }));
 
+    if (!process.env.SESSION_SECRET) {
+        throw new Error('[DASHBOARD] SESSION_SECRET is not set. Add a strong random value to your .env file.');
+    }
+
     app.use(session({
-        secret: process.env.SESSION_SECRET || 'your-secret-key',
+        secret: process.env.SESSION_SECRET,
         resave: false,
         saveUninitialized: false,
         cookie: { maxAge: 86400000 }

--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,9 @@ async function startBot() {
 
         const { startQuestService } = require('./services/questService');
         startQuestService();
+
+        const { scheduleActivePollExpirations } = require('./commands/utility/poll');
+        scheduleActivePollExpirations(client);
     });
 
     client.login(process.env.DISCORD_TOKEN);

--- a/src/models/Poll.js
+++ b/src/models/Poll.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+
+const pollSchema = new mongoose.Schema({
+    messageId: { type: String, required: true, unique: true },
+    guildId: { type: String, required: true },
+    channelId: { type: String, required: true },
+    question: { type: String, required: true },
+    options: [String],
+    votes: { type: Map, of: Number, default: () => new Map() },
+    endsAt: Date,
+    closed: { type: Boolean, default: false },
+    createdBy: String
+});
+
+module.exports = mongoose.model('Poll', pollSchema);

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -21,6 +21,14 @@ const STREAM_EDIT_INTERVAL_MS = 1200;
 // userId -> [timestamps] for sliding-window rate limiting (in-memory)
 const rateLimits = new Map();
 
+// Periodically remove entries whose timestamps have all expired (2-hour max window)
+setInterval(() => {
+    const cutoff = Date.now() - 2 * 60 * 60 * 1000;
+    for (const [userId, timestamps] of rateLimits) {
+        if (timestamps.every(t => t < cutoff)) rateLimits.delete(userId);
+    }
+}, 15 * 60 * 1000).unref();
+
 function checkRateLimit(userId, limit, windowMin) {
     if (!limit || limit <= 0) return true;
     const now = Date.now();
@@ -171,33 +179,23 @@ async function executeAction(action, message) {
                 const options = (action.options || []).slice(0, 5);
                 if (!action.question || options.length < 2) break;
 
-                const EMOJIS = ['1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣'];
+                const { buildPollEmbed, buildPollRows } = require('../commands/utility/poll');
+                const Poll = require('../models/Poll');
+
                 const counts = new Array(options.length).fill(0);
-                const total = 0;
+                const embed = buildPollEmbed(action.question, options, counts, null, 'AI', false);
+                const rows = buildPollRows(options);
 
-                const lines = options.map((opt, i) => {
-                    const bar = '░'.repeat(10);
-                    return `**${i + 1}. ${opt}**\n${bar} 0% (0 votes)`;
+                const pollMsg = await message.channel.send({ embeds: [embed], components: rows });
+                await Poll.create({
+                    messageId: pollMsg.id,
+                    guildId: message.guild.id,
+                    channelId: message.channel.id,
+                    question: action.question,
+                    options,
+                    votes: new Map(),
+                    createdBy: 'AI'
                 });
-
-                const embed = new EmbedBuilder()
-                    .setColor('#5865F2')
-                    .setTitle(`📊 ${action.question}`)
-                    .setDescription(lines.join('\n\n'))
-                    .addFields({ name: 'Total votes', value: '0', inline: true })
-                    .setFooter({ text: `Poll suggested by AI • React to vote` });
-
-                const row = new ActionRowBuilder();
-                options.forEach((opt, i) => {
-                    row.addComponents(
-                        new ButtonBuilder()
-                            .setCustomId(`poll_${i}`)
-                            .setLabel(`${i + 1}. ${opt.substring(0, 77)}`)
-                            .setStyle(ButtonStyle.Secondary)
-                    );
-                });
-
-                await message.channel.send({ embeds: [embed], components: [row] });
                 break;
             }
 


### PR DESCRIPTION
- Throw at startup if SESSION_SECRET is unset rather than silently using
  the insecure default, preventing cookie-forgery on any real deployment
- Wrap userData.save() in deposit/withdraw with try/catch so a DB hiccup
  can't silently corrupt a user's balance without an error reply
- Add a 15-min cleanup interval for the AI rate-limit Map so it no longer
  grows unboundedly over long uptimes (.unref() keeps it from blocking exit)
- Persist poll votes to MongoDB (new Poll model) so button votes survive
  bot restarts; re-schedules timed-expiry polls on ready event; AI-created
  polls are also persisted via executeAction

https://claude.ai/code/session_01J8rRorZw7tua6NY5jQTFCm