### PR TITLE
Add editable shop items and image support to economy /shop

### DIFF
--- a/src/commands/economy/shop.js
+++ b/src/commands/economy/shop.js
@@ -20,7 +20,18 @@ module.exports = {
                 .addIntegerOption(o => o.setName('price').setDescription('Price in coins').setRequired(true).setMinValue(1))
                 .addStringOption(o => o.setName('description').setDescription('Item description'))
                 .addRoleOption(o => o.setName('role').setDescription('Role to grant on purchase'))
-                .addIntegerOption(o => o.setName('stock').setDescription('Stock limit (-1 = unlimited)').setMinValue(-1)))
+                .addIntegerOption(o => o.setName('stock').setDescription('Stock limit (-1 = unlimited)').setMinValue(-1))
+                .addStringOption(o => o.setName('image_url').setDescription('Image URL shown for this item')))
+        .addSubcommand(sub =>
+            sub.setName('edit')
+                .setDescription('Edit an existing shop item (admin only)')
+                .addStringOption(o => o.setName('name').setDescription('Existing item name').setRequired(true))
+                .addStringOption(o => o.setName('new_name').setDescription('Updated item name'))
+                .addIntegerOption(o => o.setName('price').setDescription('Updated price in coins').setMinValue(1))
+                .addStringOption(o => o.setName('description').setDescription('Updated item description'))
+                .addRoleOption(o => o.setName('role').setDescription('Updated role to grant on purchase'))
+                .addIntegerOption(o => o.setName('stock').setDescription('Updated stock (-1 = unlimited)').setMinValue(-1))
+                .addStringOption(o => o.setName('image_url').setDescription('Updated image URL')))
         .addSubcommand(sub =>
             sub.setName('remove')
                 .setDescription('Remove an item from the shop (admin only)')
@@ -45,7 +56,8 @@ module.exports = {
             const lines = guildSettings.shop.map((item, i) => {
                 const stock = item.stock === -1 ? '∞' : item.stock;
                 const roleTag = item.roleId ? ` → <@&${item.roleId}>` : '';
-                return `**${i + 1}. ${item.name}** — ${currency}${item.price} (Stock: ${stock})${roleTag}\n${item.description || ''}`;
+                const imageTag = item.imageUrl ? `\nImage: ${item.imageUrl}` : '';
+                return `**${i + 1}. ${item.name}** — ${currency}${item.price} (Stock: ${stock})${roleTag}\n${item.description || ''}${imageTag}`;
             });
 
             const embed = new EmbedBuilder()
@@ -105,6 +117,10 @@ module.exports = {
                 .setDescription(`You bought **${item.name}** for ${currency}${item.price}.`)
                 .addFields({ name: 'New Balance', value: `${currency}${userData.balance}`, inline: true });
 
+            if (item.imageUrl) {
+                embed.setThumbnail(item.imageUrl);
+            }
+
             return interaction.reply({ embeds: [embed] });
         }
 
@@ -118,6 +134,7 @@ module.exports = {
             const description = interaction.options.getString('description') ?? '';
             const role = interaction.options.getRole('role');
             const stock = interaction.options.getInteger('stock') ?? -1;
+            const imageUrl = interaction.options.getString('image_url') ?? '';
 
             if (guildSettings.shop.find(i => i.name.toLowerCase() === name.toLowerCase())) {
                 return interaction.reply({ content: 'An item with that name already exists.', ephemeral: true });
@@ -128,11 +145,49 @@ module.exports = {
                 description,
                 price,
                 roleId: role?.id ?? null,
-                stock
+                stock,
+                imageUrl
             });
             await guildSettings.save();
 
             await interaction.reply({ content: `Added **${name}** to the shop for ${currency}${price}.` });
+        }
+
+        if (sub === 'edit') {
+            if (!interaction.member.permissions.has(PermissionFlagsBits.ManageGuild)) {
+                return interaction.reply({ content: 'You need Manage Server permission to edit the shop.', ephemeral: true });
+            }
+
+            const name = interaction.options.getString('name').toLowerCase();
+            const item = guildSettings.shop.find(i => i.name.toLowerCase() === name);
+
+            if (!item) {
+                return interaction.reply({ content: `Item \`${name}\` not found.`, ephemeral: true });
+            }
+
+            const newName = interaction.options.getString('new_name');
+            const price = interaction.options.getInteger('price');
+            const description = interaction.options.getString('description');
+            const role = interaction.options.getRole('role');
+            const stock = interaction.options.getInteger('stock');
+            const imageUrl = interaction.options.getString('image_url');
+
+            if (newName && newName.toLowerCase() !== name) {
+                const duplicate = guildSettings.shop.find(i => i.name.toLowerCase() === newName.toLowerCase());
+                if (duplicate) {
+                    return interaction.reply({ content: 'An item with that new name already exists.', ephemeral: true });
+                }
+                item.name = newName;
+            }
+
+            if (price !== null) item.price = price;
+            if (description !== null) item.description = description;
+            if (stock !== null) item.stock = stock;
+            if (imageUrl !== null) item.imageUrl = imageUrl;
+            if (role) item.roleId = role.id;
+
+            await guildSettings.save();
+            await interaction.reply({ content: `Updated **${item.name}**.` });
         }
 
         if (sub === 'remove') {

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -205,7 +205,8 @@ const guildSchema = new Schema({
         description: { type: String, default: '' },
         price: { type: Number, required: true },
         roleId: { type: String, default: null },
-        stock: { type: Number, default: -1 }
+        stock: { type: Number, default: -1 },
+        imageUrl: { type: String, default: '' }
     }],
 
     tickets: {


### PR DESCRIPTION
### Motivation
- Provide MEE6-style shop configurability so admins can set price, image, stock, role, and description per item and edit items after creation. 

### Description
- Added `imageUrl` to the guild shop item schema so items can persist an optional image via `src/models/Guild.js`.
- Extended `/shop add` to accept an `image_url` option and store it on the new item.
- Implemented a new admin-only `/shop edit` subcommand to update item `name`, `price`, `description`, `role`, `stock`, and `image_url`, including duplicate-name checks.
- Updated `/shop view` to show an item image URL when present and updated `/shop buy` to include the item image as a thumbnail on the purchase confirmation embed.

### Testing
- Ran `node --check src/commands/economy/shop.js` which completed successfully.
- Ran `node --check src/models/Guild.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4072417388325b6fa0482f51c9552)