### PR TITLE
Only trigger AI chat when bot is mentioned or replied to

### DIFF
--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -60,15 +60,28 @@ module.exports = {
                 const persona = ai.channelPersonas?.find(p => p.channelId === message.channel.id);
 
                 if (isDefaultChannel || persona) {
-                    const effectiveSettings = persona
-                        ? Object.assign({}, ai.toObject ? ai.toObject() : ai, { systemPrompt: persona.systemPrompt })
-                        : ai;
-                    if (guildSettings.moderation?.enabled) {
-                        const blocked = await handleAutoModeration(message, guildSettings);
-                        if (blocked) return;
+                    const isBotMentioned = message.mentions.has(client.user.id, { ignoreEveryone: true, ignoreRoles: true });
+                    let isReplyToBot = false;
+                    if (message.reference?.messageId) {
+                        try {
+                            const replied = await message.channel.messages.fetch(message.reference.messageId);
+                            isReplyToBot = replied.author.id === client.user.id;
+                        } catch {}
                     }
-                    await handleAIChat(message, effectiveSettings);
-                    return;
+
+                    if (!isBotMentioned && !isReplyToBot) {
+                        // Fall through to non-AI handlers (leveling, moderation, etc.)
+                    } else {
+                        const effectiveSettings = persona
+                            ? Object.assign({}, ai.toObject ? ai.toObject() : ai, { systemPrompt: persona.systemPrompt })
+                            : ai;
+                        if (guildSettings.moderation?.enabled) {
+                            const blocked = await handleAutoModeration(message, guildSettings);
+                            if (blocked) return;
+                        }
+                        await handleAIChat(message, effectiveSettings);
+                        return;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
Modified the message handling logic to only invoke AI chat when the bot is explicitly mentioned or when a user replies to one of the bot's messages. This prevents the bot from responding to every message in configured channels unless directly engaged.

## Key Changes
- Added detection for bot mentions using `message.mentions.has()` with appropriate filters
- Added logic to check if a message is a reply to a bot message by fetching the referenced message
- Wrapped AI chat invocation in a conditional block that only executes when the bot is mentioned or replied to
- Messages that don't meet these criteria now fall through to other handlers (leveling, moderation, etc.)

## Implementation Details
- The mention check uses `ignoreEveryone: true` and `ignoreRoles: true` to only detect direct bot mentions
- Reply detection safely handles cases where the referenced message cannot be fetched (wrapped in try-catch)
- The moderation check and AI chat handler remain unchanged, but are now only executed when engagement criteria are met
- Non-engagement messages can still be processed by other event handlers in the chain

https://claude.ai/code/session_01V7HKpPZtMGqNViLEhmw7WC