### PR TITLE
feat: add Bible verse feature with daily posting and auto-response

### DIFF
--- a/src/commands/utility/bible.js
+++ b/src/commands/utility/bible.js
@@ -1,0 +1,63 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { lookupVerse, getDailyVerse, createVerseEmbed } = require('../../services/bibleService');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('bible')
+        .setDescription('Look up a Bible verse or get today\'s daily verse')
+        .addSubcommand(sub =>
+            sub.setName('verse')
+                .setDescription('Look up a specific Bible verse')
+                .addStringOption(opt =>
+                    opt.setName('reference')
+                        .setDescription('Verse reference, e.g. John 3:16 or Romans 8:28')
+                        .setRequired(true)
+                )
+                .addStringOption(opt =>
+                    opt.setName('translation')
+                        .setDescription('Bible translation (default: KJV)')
+                        .addChoices(
+                            { name: 'King James Version (KJV)', value: 'kjv' },
+                            { name: 'American Standard Version (ASV)', value: 'asv' },
+                            { name: 'World English Bible (WEB)', value: 'web' },
+                            { name: "Young's Literal Translation (YLT)", value: 'ylt' },
+                            { name: 'Darby', value: 'darby' }
+                        )
+                )
+        )
+        .addSubcommand(sub =>
+            sub.setName('daily')
+                .setDescription("Get today's daily Bible verse")
+        ),
+
+    async execute(interaction) {
+        await interaction.deferReply();
+        const sub = interaction.options.getSubcommand();
+
+        if (sub === 'verse') {
+            const reference = interaction.options.getString('reference');
+            const translation = interaction.options.getString('translation') || 'kjv';
+
+            const verseData = await lookupVerse(reference, translation);
+            if (!verseData?.text) {
+                return interaction.editReply({
+                    content: `Could not find **${reference}**. Please check the reference and try again.\nExample: \`John 3:16\`, \`Romans 8:28\`, \`Psalms 23:1-6\``
+                });
+            }
+
+            const embed = createVerseEmbed(verseData);
+            await interaction.editReply({ embeds: [embed] });
+
+        } else if (sub === 'daily') {
+            const verseData = await getDailyVerse();
+            if (!verseData) {
+                return interaction.editReply({
+                    content: 'Could not fetch today\'s daily verse. Please try again later.'
+                });
+            }
+
+            const embed = createVerseEmbed(verseData, '📖 Daily Bible Verse');
+            await interaction.editReply({ embeds: [embed] });
+        }
+    }
+};

--- a/src/dashboard/routes/api.js
+++ b/src/dashboard/routes/api.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const Guild = require('../../models/Guild');
 const { rescheduleDailyNews } = require('../../services/rssService');
+const { rescheduleBibleVerse } = require('../../services/dailyBibleService');
 
 function checkAuth(req, res, next) {
     if (req.isAuthenticated()) return next();
@@ -51,6 +52,11 @@ router.post('/guild/:guildId/settings', checkAuth, checkGuildAccess, async (req,
         const shouldRescheduleDailyNews = Object.keys(updates).some(key => key.startsWith('dailyNews.') || key === 'dailyNewsProfiles');
         if (shouldRescheduleDailyNews) {
             rescheduleDailyNews(req.client, guildId);
+        }
+
+        const shouldRescheduleBible = Object.keys(updates).some(key => key.startsWith('bibleVerse.'));
+        if (shouldRescheduleBible) {
+            rescheduleBibleVerse(req.client, guildId);
         }
         
         res.json({ success: true, settings: guildSettings });

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -45,6 +45,7 @@
                 <button class="nav-item" data-tab="analytics"><span class="nav-emoji">📊</span> Analytics</button>
                 <button class="nav-item" data-tab="ai"><span class="nav-emoji">🧠</span> AI Chat</button>
                 <button class="nav-item" data-tab="tempvoice"><span class="nav-emoji">🔊</span> Temp Voice</button>
+                <button class="nav-item" data-tab="bibleverses"><span class="nav-emoji">📖</span> Bible Verses</button>
             </aside>
 
             <div class="settings-content">
@@ -825,6 +826,61 @@
                         <p>Loading analytics...</p>
                     </div>
                 </section>
+
+                <!-- Bible Verses -->
+                <section id="bibleverses" class="panel">
+                    <div class="panel-head">
+                        <h2>Bible Verses</h2>
+                        <p>Post a daily Bible verse to a channel and auto-respond when members mention a verse reference like <code>John 3:16</code>.</p>
+                    </div>
+
+                    <div class="panel-head" style="margin-top:1rem"><h3>Daily Verse</h3></div>
+                    <label class="toggle">
+                        <span class="toggle-text"><strong>Enable daily Bible verse</strong><span>Post a verse automatically at the scheduled time</span></span>
+                        <span class="switch"><input type="checkbox" id="bv-enabled" <%= (settings.bibleVerse && settings.bibleVerse.enabled) ? 'checked' : '' %>><span class="slider"></span></span>
+                    </label>
+                    <div class="field">
+                        <label class="field-label" for="bv-channel">Post to channel</label>
+                        <select id="bv-channel">
+                            <option value="">Select a channel</option>
+                            <% channels.forEach(channel => { %>
+                                <option value="<%= channel.id %>" <%= (settings.bibleVerse && settings.bibleVerse.channelId === channel.id) ? 'selected' : '' %>>#<%= channel.name %></option>
+                            <% }); %>
+                        </select>
+                    </div>
+                    <div class="field" style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;">
+                        <div>
+                            <label class="field-label" for="bv-time">Post time (24h)</label>
+                            <input type="text" id="bv-time" placeholder="08:00" value="<%= (settings.bibleVerse && settings.bibleVerse.time) || '08:00' %>">
+                        </div>
+                        <div>
+                            <label class="field-label" for="bv-timezone">Timezone</label>
+                            <input type="text" id="bv-timezone" placeholder="UTC" value="<%= (settings.bibleVerse && settings.bibleVerse.timezone) || 'UTC' %>">
+                            <small>e.g. America/New_York, Europe/London, UTC</small>
+                        </div>
+                    </div>
+
+                    <div class="panel-head" style="margin-top:1rem"><h3>Auto-Response</h3></div>
+                    <label class="toggle">
+                        <span class="toggle-text"><strong>Auto-respond to verse references</strong><span>When a member types a reference like <code>John 3:16</code> the bot replies with the verse</span></span>
+                        <span class="switch"><input type="checkbox" id="bv-autorespond" <%= (!settings.bibleVerse || settings.bibleVerse.autoRespond !== false) ? 'checked' : '' %>><span class="slider"></span></span>
+                    </label>
+                    <div class="field">
+                        <label class="field-label" for="bv-translation">Default translation</label>
+                        <select id="bv-translation">
+                            <option value="kjv" <%= (!settings.bibleVerse || settings.bibleVerse.translation === 'kjv') ? 'selected' : '' %>>King James Version (KJV)</option>
+                            <option value="asv" <%= (settings.bibleVerse && settings.bibleVerse.translation === 'asv') ? 'selected' : '' %>>American Standard Version (ASV)</option>
+                            <option value="web" <%= (settings.bibleVerse && settings.bibleVerse.translation === 'web') ? 'selected' : '' %>>World English Bible (WEB)</option>
+                            <option value="ylt" <%= (settings.bibleVerse && settings.bibleVerse.translation === 'ylt') ? 'selected' : '' %>>Young's Literal Translation (YLT)</option>
+                            <option value="darby" <%= (settings.bibleVerse && settings.bibleVerse.translation === 'darby') ? 'selected' : '' %>>Darby</option>
+                        </select>
+                        <small>Used for both the daily verse and auto-responses. No API key required.</small>
+                    </div>
+
+                    <div class="actions-row">
+                        <button class="btn btn-primary" onclick="saveSettings('bibleverses')">Save changes</button>
+                    </div>
+                </section>
             </div>
         </div>
     </main>
@@ -1141,6 +1197,15 @@
                     'tempVoice.channelName': document.getElementById('tv-channel-name').value.trim() || "{username}'s VC",
                     'tempVoice.userLimit': parseInt(document.getElementById('tv-user-limit').value, 10) || 0,
                     'tempVoice.bitrate': parseInt(document.getElementById('tv-bitrate').value, 10) || 64
+                };
+            } else if (section === 'bibleverses') {
+                data = {
+                    'bibleVerse.enabled': document.getElementById('bv-enabled').checked,
+                    'bibleVerse.channelId': document.getElementById('bv-channel').value || null,
+                    'bibleVerse.time': document.getElementById('bv-time').value.trim() || '08:00',
+                    'bibleVerse.timezone': document.getElementById('bv-timezone').value.trim() || 'UTC',
+                    'bibleVerse.translation': document.getElementById('bv-translation').value,
+                    'bibleVerse.autoRespond': document.getElementById('bv-autorespond').checked
                 };
             } else if (section === 'dailynews') {
                 const feedsText = document.getElementById('dailynews-feeds').value;

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -100,6 +100,10 @@ module.exports = {
 
             await handleSuggestions(message, guildSettings);
 
+            if (guildSettings?.bibleVerse?.autoRespond) {
+                await handleBibleVerseDetection(message, guildSettings);
+            }
+
             // Streak + quests (only for non-blocked messages)
             await handleStreakAndQuests(message, guildSettings);
 
@@ -477,6 +481,18 @@ async function applyAutoModAction(message, guildSettings, reason, scoreWeight = 
     } catch (err) {
         console.error('AutoMod action error:', err);
     }
+}
+
+async function handleBibleVerseDetection(message, guildSettings) {
+    const { detectVerseReferences, lookupVerse, createVerseEmbed } = require('../services/bibleService');
+    const refs = detectVerseReferences(message.content);
+    if (!refs.length) return;
+
+    const translation = guildSettings.bibleVerse?.translation || 'kjv';
+    const verseData = await lookupVerse(refs[0], translation);
+    if (!verseData?.text) return;
+
+    await message.reply({ embeds: [createVerseEmbed(verseData)] }).catch(() => {});
 }
 
 async function handleCustomCommands(message, guildSettings) {

--- a/src/index.js
+++ b/src/index.js
@@ -86,6 +86,11 @@ async function startBot() {
     await startDashboard();
 
     client.once('ready', () => {
+        const { deployCommands } = require('./utils/commandDeployer');
+        deployCommands(process.env.CLIENT_ID, process.env.DISCORD_TOKEN)
+            .then(count => console.log(`[COMMANDS] Deployed ${count} slash commands`))
+            .catch(err => console.error('[COMMANDS] Failed to deploy slash commands:', err));
+
         const { startSummaryService } = require('./services/summaryService');
         startSummaryService(client);
 

--- a/src/index.js
+++ b/src/index.js
@@ -97,6 +97,9 @@ async function startBot() {
 
         const { scheduleActivePollExpirations } = require('./commands/utility/poll');
         scheduleActivePollExpirations(client);
+
+        const { startDailyBibleService } = require('./services/dailyBibleService');
+        startDailyBibleService(client);
     });
 
     client.login(process.env.DISCORD_TOKEN);

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -319,6 +319,15 @@ const guildSchema = new Schema({
         downvoteEmoji: { type: String, default: '👎' }
     },
 
+    bibleVerse: {
+        enabled: { type: Boolean, default: false },
+        channelId: { type: String, default: null },
+        time: { type: String, default: '08:00' },
+        timezone: { type: String, default: 'UTC' },
+        translation: { type: String, default: 'kjv' },
+        autoRespond: { type: Boolean, default: true }
+    },
+
     analytics: {
         memberEvents: [{
             date: { type: String, required: true },

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -324,7 +324,14 @@ const guildSchema = new Schema({
         channelId: { type: String, default: null },
         time: { type: String, default: '08:00' },
         timezone: { type: String, default: 'UTC' },
-        translation: { type: String, default: 'kjv' },
+        translation: {
+            type: String,
+            default: 'kjv',
+            enum: {
+                values: ['kjv', 'asv', 'web', 'ylt', 'darby'],
+                message: 'bibleVerse.translation must be one of: kjv, asv, web, ylt, darby'
+            }
+        },
         autoRespond: { type: Boolean, default: true }
     },
 

--- a/src/services/bibleService.js
+++ b/src/services/bibleService.js
@@ -1,0 +1,106 @@
+const axios = require('axios');
+const { EmbedBuilder } = require('discord.js');
+
+// All recognised book names and abbreviations, sorted longest-first so the
+// regex alternation matches greedily (e.g. "1 Samuel" before "Samuel").
+const BOOK_NAMES = [
+    'song of solomon', 'song of songs', '1 thessalonians', '2 thessalonians',
+    '1 corinthians', '2 corinthians', '1 chronicles', '2 chronicles',
+    'deuteronomy', 'lamentations', 'philippians', 'ecclesiastes',
+    'revelation', 'habakkuk', 'zephaniah', 'zechariah', 'galatians',
+    'ephesians', 'colossians', 'philemon', 'proverbs', 'hebrews',
+    'nehemiah', '1 timothy', '2 timothy', 'obadiah', 'malachi',
+    'isaiah', 'ezekiel', 'matthew', '1 samuel', '2 samuel',
+    'genesis', 'ezra', 'joshua', 'leviticus', 'numbers',
+    '1 peter', '2 peter', '1 kings', '2 kings', '1 john', '2 john', '3 john',
+    'jeremiah', 'daniel', 'haggai', 'romans', 'exodus', 'psalms', 'psalm',
+    'judges', 'nahum', 'titus', 'james', 'hosea', 'jonah', 'micah',
+    'joel', 'amos', 'acts', 'mark', 'luke', 'john', 'ruth', 'jude',
+    // common abbreviations
+    '1thess', '2thess', '1cor', '2cor', '1chr', '2chr', '1sam', '2sam',
+    '1tim', '2tim', '1pet', '2pet', '1kgs', '2kgs', '1jn', '2jn', '3jn',
+    'deut', 'phil', 'eccl', 'rev', 'hab', 'zeph', 'zech', 'gal', 'eph',
+    'col', 'phm', 'prov', 'heb', 'neh', 'obad', 'mal', 'isa', 'ezek',
+    'matt', 'gen', 'josh', 'lev', 'num', 'jer', 'dan', 'hag', 'rom',
+    'exo', 'psa', 'judg', 'nah', 'tit', 'jas', 'hos', 'jon', 'mic',
+    '1th', '2th', '1co', '2co', '1ch', '2ch', '1sa', '2sa', '1ti', '2ti',
+    '1pe', '2pe', '1ki', '2ki', 'lam', 'act', 'luk', 'joh', 'ru',
+    'ps', 'ex', 'mk', 'lk', 'jn', 'mt', 'ac', 'ro',
+];
+
+const PATTERN = BOOK_NAMES
+    .map(b => b.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|');
+
+const VERSE_REGEX = new RegExp(
+    `\\b(${PATTERN})\\.?\\s+(\\d+):(\\d+)(?:-(\\d+))?\\b`,
+    'gi'
+);
+
+async function lookupVerse(reference, translation = 'kjv') {
+    try {
+        const encoded = encodeURIComponent(reference);
+        const url = `https://bible-api.com/${encoded}?translation=${translation}`;
+        const { data } = await axios.get(url, { timeout: 8000 });
+        if (data.error) return null;
+        return data;
+    } catch {
+        return null;
+    }
+}
+
+async function getDailyVerse() {
+    try {
+        const { data } = await axios.get(
+            'https://beta.ourmanna.com/api/v1/get/?format=json&order=daily',
+            { timeout: 8000 }
+        );
+        const details = data?.verse?.details;
+        if (details?.text && details?.reference) {
+            return {
+                reference: details.reference,
+                text: details.text.trim(),
+                translation_name: details.version || 'KJV'
+            };
+        }
+    } catch {}
+    return null;
+}
+
+function createVerseEmbed(verseData, title = '📖 Bible Verse') {
+    const text = (verseData.text || '').trim().replace(/\s+/g, ' ');
+    const reference = verseData.reference || '';
+    const translation = verseData.translation_name || verseData.translation_id?.toUpperCase() || 'KJV';
+
+    return new EmbedBuilder()
+        .setColor(0xF5C518)
+        .setTitle(title)
+        .setDescription(`*"${text}"*`)
+        .setFooter({ text: `${reference}  ·  ${translation}` })
+        .setTimestamp();
+}
+
+function detectVerseReferences(content) {
+    const refs = [];
+    const seen = new Set();
+
+    VERSE_REGEX.lastIndex = 0;
+    let match;
+    while ((match = VERSE_REGEX.exec(content)) !== null) {
+        const book = match[1];
+        const chapter = match[2];
+        const verseStart = match[3];
+        const verseEnd = match[4];
+        const ref = verseEnd
+            ? `${book} ${chapter}:${verseStart}-${verseEnd}`
+            : `${book} ${chapter}:${verseStart}`;
+        const key = ref.toLowerCase();
+        if (!seen.has(key)) {
+            seen.add(key);
+            refs.push(ref);
+        }
+    }
+    return refs;
+}
+
+module.exports = { lookupVerse, getDailyVerse, createVerseEmbed, detectVerseReferences };

--- a/src/services/dailyBibleService.js
+++ b/src/services/dailyBibleService.js
@@ -1,0 +1,76 @@
+const cron = require('node-cron');
+const Guild = require('../models/Guild');
+const { getDailyVerse, createVerseEmbed } = require('./bibleService');
+
+const bibleJobs = new Map();
+
+function timeToCron(time) {
+    const [hour, minute] = (time || '08:00').split(':').map(Number);
+    return `${minute ?? 0} ${hour ?? 8} * * *`;
+}
+
+async function postDailyVerse(client, guildId, channelId) {
+    try {
+        const verseData = await getDailyVerse();
+        if (!verseData) return;
+
+        let channel = client.channels.cache.get(channelId);
+        if (!channel) channel = await client.channels.fetch(channelId).catch(() => null);
+        if (!channel || typeof channel.send !== 'function') return;
+
+        const embed = createVerseEmbed(verseData, '📖 Daily Bible Verse');
+        await channel.send({ embeds: [embed] });
+    } catch (err) {
+        console.error(`[BibleService] Failed to post daily verse for guild ${guildId}:`, err);
+    }
+}
+
+function scheduleBibleVerse(client, guildId, bv) {
+    const key = guildId;
+
+    if (bibleJobs.has(key)) {
+        bibleJobs.get(key).stop();
+        bibleJobs.delete(key);
+    }
+
+    if (!bv?.enabled || !bv?.channelId) return;
+
+    const cronExpr = timeToCron(bv.time);
+    const tz = bv.timezone || 'UTC';
+
+    const job = cron.schedule(
+        cronExpr,
+        () => postDailyVerse(client, guildId, bv.channelId),
+        { timezone: tz }
+    );
+    bibleJobs.set(key, job);
+    console.log(`[BibleService] Scheduled daily verse for guild ${guildId} at ${bv.time} (${tz})`);
+}
+
+async function startDailyBibleService(client) {
+    try {
+        const guilds = await Guild.find({
+            'bibleVerse.enabled': true,
+            'bibleVerse.channelId': { $ne: null }
+        });
+
+        for (const guild of guilds) {
+            scheduleBibleVerse(client, guild.guildId, guild.bibleVerse);
+        }
+
+        console.log(`[BibleService] Started daily verse scheduler for ${guilds.length} guild(s)`);
+    } catch (err) {
+        console.error('[BibleService] Failed to start daily Bible service:', err);
+    }
+}
+
+function rescheduleBibleVerse(client, guildId) {
+    Guild.findOne({ guildId })
+        .then(guild => {
+            if (!guild) return;
+            scheduleBibleVerse(client, guildId, guild.bibleVerse);
+        })
+        .catch(console.error);
+}
+
+module.exports = { startDailyBibleService, rescheduleBibleVerse };

--- a/src/services/dailyBibleService.js
+++ b/src/services/dailyBibleService.js
@@ -1,24 +1,50 @@
 const cron = require('node-cron');
 const Guild = require('../models/Guild');
-const { getDailyVerse, createVerseEmbed } = require('./bibleService');
+const { getDailyVerse, lookupVerse, createVerseEmbed } = require('./bibleService');
 
 const bibleJobs = new Map();
 
-function timeToCron(time) {
-    const [hour, minute] = (time || '08:00').split(':').map(Number);
-    return `${minute ?? 0} ${hour ?? 8} * * *`;
+function validateTime(time) {
+    const match = /^(\d{1,2}):(\d{2})$/.exec(time || '');
+    if (!match) return '08:00';
+    const h = parseInt(match[1], 10);
+    const m = parseInt(match[2], 10);
+    if (h < 0 || h > 23 || m < 0 || m > 59) return '08:00';
+    return time;
 }
 
-async function postDailyVerse(client, guildId, channelId) {
+function validateTimezone(tz) {
+    if (!tz) return 'UTC';
+    try {
+        Intl.DateTimeFormat(undefined, { timeZone: tz });
+        return tz;
+    } catch {
+        return 'UTC';
+    }
+}
+
+function timeToCron(time) {
+    const [hour, minute] = validateTime(time).split(':').map(Number);
+    return `${minute} ${hour} * * *`;
+}
+
+async function postDailyVerse(client, guildId, channelId, translation) {
     try {
         const verseData = await getDailyVerse();
         if (!verseData) return;
+
+        // Re-fetch in the guild's configured translation when it isn't the default KJV
+        let displayVerse = verseData;
+        if (translation && translation !== 'kjv' && verseData.reference) {
+            const translated = await lookupVerse(verseData.reference, translation);
+            if (translated?.text) displayVerse = translated;
+        }
 
         let channel = client.channels.cache.get(channelId);
         if (!channel) channel = await client.channels.fetch(channelId).catch(() => null);
         if (!channel || typeof channel.send !== 'function') return;
 
-        const embed = createVerseEmbed(verseData, '📖 Daily Bible Verse');
+        const embed = createVerseEmbed(displayVerse, '📖 Daily Bible Verse');
         await channel.send({ embeds: [embed] });
     } catch (err) {
         console.error(`[BibleService] Failed to post daily verse for guild ${guildId}:`, err);
@@ -35,16 +61,25 @@ function scheduleBibleVerse(client, guildId, bv) {
 
     if (!bv?.enabled || !bv?.channelId) return;
 
-    const cronExpr = timeToCron(bv.time);
-    const tz = bv.timezone || 'UTC';
+    const safeTime = validateTime(bv.time);
+    const safeTz = validateTimezone(bv.timezone);
+
+    if (safeTime !== bv.time) {
+        console.warn(`[BibleService] Invalid time "${bv.time}" for guild ${guildId}, falling back to ${safeTime}`);
+    }
+    if (safeTz !== bv.timezone) {
+        console.warn(`[BibleService] Invalid timezone "${bv.timezone}" for guild ${guildId}, falling back to UTC`);
+    }
+
+    const cronExpr = timeToCron(safeTime);
 
     const job = cron.schedule(
         cronExpr,
-        () => postDailyVerse(client, guildId, bv.channelId),
-        { timezone: tz }
+        () => postDailyVerse(client, guildId, bv.channelId, bv.translation),
+        { timezone: safeTz }
     );
     bibleJobs.set(key, job);
-    console.log(`[BibleService] Scheduled daily verse for guild ${guildId} at ${bv.time} (${tz})`);
+    console.log(`[BibleService] Scheduled daily verse for guild ${guildId} at ${safeTime} (${safeTz})`);
 }
 
 async function startDailyBibleService(client) {


### PR DESCRIPTION
- Adds /bible verse and /bible daily slash commands
- Auto-detects verse references (e.g. "John 3:16") in messages and replies with
  the verse in a rich embed when bibleVerse.autoRespond is enabled
- Schedules daily verse posts to a configured channel via node-cron (ourmanna.com API)
- Specific verse lookups powered by bible-api.com (free, no API key required)
- Supports KJV, ASV, WEB, YLT, and Darby translations
- Full dashboard UI under the new "Bible Verses" tab: enable/disable daily verse,
  channel, post time, timezone, translation, and auto-respond toggle
- Settings saved via existing /api/guild/:id/settings endpoint with live reschedule

https://claude.ai/code/session_013dqjBy5SuVvU4MUPkJK7z1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/bible` slash command for verse lookup and daily verse retrieval
  * Introduced scheduled daily Bible verse posting to a configured guild channel with customizable time and timezone settings
  * Added auto-response feature that detects Bible verse references in chat messages and replies with the full verse text
  * Added Bible verse configuration panel to guild settings enabling channel selection, scheduling, translation preference, and auto-response toggle

<!-- end of auto-generated comment: release notes by coderabbit.ai -->