### PR TITLE
Sort dashboard sidebar into sections with A-Z ordering

### DIFF
--- a/src/dashboard/public/styles.css
+++ b/src/dashboard/public/styles.css
@@ -533,6 +533,16 @@ body {
     border: 1px solid var(--border-strong);
 }
 .nav-item .nav-emoji { font-size: 1.05rem; }
+.nav-section-header {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted, var(--text-dim));
+    padding: 0.9rem 0.85rem 0.25rem;
+    opacity: 0.6;
+}
+.nav-section-header:first-child { padding-top: 0.25rem; }
 
 .settings-content { min-width: 0; }
 .panel {

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -28,24 +28,41 @@
     <main class="container">
         <div class="settings-layout">
             <aside class="sidebar" role="tablist">
+                <!-- Members -->
+                <div class="nav-section-header">Members</div>
                 <button class="nav-item active" data-tab="welcome"><span class="nav-emoji">👋</span> Welcome</button>
                 <button class="nav-item" data-tab="farewell"><span class="nav-emoji">👋</span> Farewell</button>
-                <button class="nav-item" data-tab="moderation"><span class="nav-emoji">🛡️</span> Moderation</button>
                 <button class="nav-item" data-tab="leveling"><span class="nav-emoji">📈</span> Leveling</button>
                 <button class="nav-item" data-tab="economy"><span class="nav-emoji">💎</span> Economy</button>
-                <button class="nav-item" data-tab="music"><span class="nav-emoji">🎵</span> Music</button>
-                <button class="nav-item" data-tab="tickets"><span class="nav-emoji">🎫</span> Tickets</button>
+
+                <!-- Moderation -->
+                <div class="nav-section-header">Moderation</div>
+                <button class="nav-item" data-tab="moderation"><span class="nav-emoji">🛡️</span> Moderation</button>
                 <button class="nav-item" data-tab="raiddetection"><span class="nav-emoji">🚨</span> Raid Detection</button>
-                <button class="nav-item" data-tab="starboard"><span class="nav-emoji">⭐</span> Starboard</button>
-                <button class="nav-item" data-tab="eventlog"><span class="nav-emoji">📋</span> Event Log</button>
+
+                <!-- Engagement -->
+                <div class="nav-section-header">Engagement</div>
+                <button class="nav-item" data-tab="music"><span class="nav-emoji">🎵</span> Music</button>
                 <button class="nav-item" data-tab="quests"><span class="nav-emoji">🗺️</span> Quests</button>
+                <button class="nav-item" data-tab="starboard"><span class="nav-emoji">⭐</span> Starboard</button>
                 <button class="nav-item" data-tab="suggestions"><span class="nav-emoji">💡</span> Suggestions</button>
-                <button class="nav-item" data-tab="rss"><span class="nav-emoji">📰</span> RSS Feeds</button>
-                <button class="nav-item" data-tab="dailynews"><span class="nav-emoji">🗞️</span> Daily News</button>
-                <button class="nav-item" data-tab="analytics"><span class="nav-emoji">📊</span> Analytics</button>
+
+                <!-- Tools & Support -->
+                <div class="nav-section-header">Tools &amp; Support</div>
                 <button class="nav-item" data-tab="ai"><span class="nav-emoji">🧠</span> AI Chat</button>
                 <button class="nav-item" data-tab="tempvoice"><span class="nav-emoji">🔊</span> Temp Voice</button>
+                <button class="nav-item" data-tab="tickets"><span class="nav-emoji">🎫</span> Tickets</button>
+
+                <!-- Feeds & Automation -->
+                <div class="nav-section-header">Feeds &amp; Automation</div>
                 <button class="nav-item" data-tab="bibleverses"><span class="nav-emoji">📖</span> Bible Verses</button>
+                <button class="nav-item" data-tab="dailynews"><span class="nav-emoji">🗞️</span> Daily News</button>
+                <button class="nav-item" data-tab="rss"><span class="nav-emoji">📰</span> RSS Feeds</button>
+
+                <!-- Insights -->
+                <div class="nav-section-header">Insights</div>
+                <button class="nav-item" data-tab="analytics"><span class="nav-emoji">📊</span> Analytics</button>
+                <button class="nav-item" data-tab="eventlog"><span class="nav-emoji">📋</span> Event Log</button>
             </aside>
 
             <div class="settings-content">

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -30,10 +30,10 @@
             <aside class="sidebar" role="tablist">
                 <!-- Members -->
                 <div class="nav-section-header">Members</div>
-                <button class="nav-item active" data-tab="welcome"><span class="nav-emoji">👋</span> Welcome</button>
+                <button class="nav-item" data-tab="economy"><span class="nav-emoji">💎</span> Economy</button>
                 <button class="nav-item" data-tab="farewell"><span class="nav-emoji">👋</span> Farewell</button>
                 <button class="nav-item" data-tab="leveling"><span class="nav-emoji">📈</span> Leveling</button>
-                <button class="nav-item" data-tab="economy"><span class="nav-emoji">💎</span> Economy</button>
+                <button class="nav-item active" data-tab="welcome"><span class="nav-emoji">👋</span> Welcome</button>
 
                 <!-- Moderation -->
                 <div class="nav-section-header">Moderation</div>


### PR DESCRIPTION
Groups the 18 settings tabs into six logical sections (Members,
Moderation, Engagement, Tools & Support, Feeds & Automation,
Insights) and sorts items alphabetically within each section.
Adds .nav-section-header CSS for the subtle uppercase labels.

https://claude.ai/code/session_016eP4iR9UeThNLQLBgiXpsb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized settings sidebar navigation into grouped sections (Members, Moderation, Engagement, Tools & Support, Feeds & Automation, Insights) with improved visual hierarchy for easier access to settings features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->