### PR TITLE
Add interactive /higherlower betting game using Discord buttons

### DIFF
--- a/src/commands/economy/higherlower.js
+++ b/src/commands/economy/higherlower.js
@@ -1,0 +1,131 @@
+const {
+    SlashCommandBuilder,
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+    EmbedBuilder
+} = require('discord.js');
+const User = require('../../models/User');
+const Guild = require('../../models/Guild');
+
+function rollCard() {
+    return Math.floor(Math.random() * 13) + 1;
+}
+
+function cardLabel(value) {
+    const labels = { 1: 'A', 11: 'J', 12: 'Q', 13: 'K' };
+    return labels[value] || String(value);
+}
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('higherlower')
+        .setDescription('Bet on whether the next card will be higher or lower')
+        .addIntegerOption(option =>
+            option
+                .setName('bet')
+                .setDescription('How many coins to wager')
+                .setMinValue(1)
+                .setRequired(true)
+        ),
+    async execute(interaction) {
+        try {
+            const bet = interaction.options.getInteger('bet');
+            const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+
+            if (guildSettings?.economy?.enabled === false || guildSettings?.economy?.gamesEnabled === false) {
+                return interaction.reply({ content: 'Economy games are disabled in this server.', ephemeral: true });
+            }
+
+            let user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+            if (!user) {
+                user = await User.create({ userId: interaction.user.id, guildId: interaction.guild.id });
+            }
+
+            if (user.balance < bet) {
+                return interaction.reply({ content: `You need ${bet.toLocaleString()} coins, but only have ${user.balance.toLocaleString()}.`, ephemeral: true });
+            }
+
+            const current = rollCard();
+            const upId = `hl_up_${interaction.id}`;
+            const downId = `hl_down_${interaction.id}`;
+
+            const row = new ActionRowBuilder().addComponents(
+                new ButtonBuilder().setCustomId(upId).setLabel('⬆️ Higher').setStyle(ButtonStyle.Success),
+                new ButtonBuilder().setCustomId(downId).setLabel('⬇️ Lower').setStyle(ButtonStyle.Danger)
+            );
+
+            const embed = new EmbedBuilder()
+                .setColor('#5865F2')
+                .setTitle('Higher or Lower')
+                .setDescription(`Current card: **${cardLabel(current)}**\nBet: **${bet.toLocaleString()}** coins\nChoose quickly: higher or lower?`)
+                .setFooter({ text: 'Equal cards are a push (your bet is returned).' });
+
+            await interaction.reply({ embeds: [embed], components: [row] });
+
+            const message = await interaction.fetchReply();
+            const collector = message.createMessageComponentCollector({
+                filter: i => i.user.id === interaction.user.id && [upId, downId].includes(i.customId),
+                max: 1,
+                time: 15000
+            });
+
+            collector.on('collect', async i => {
+                const next = rollCard();
+                const pickedHigher = i.customId === upId;
+
+                let resultText;
+                let delta = 0;
+                let color = '#f1c40f';
+
+                if (next === current) {
+                    resultText = 'Push! Same value — your coins are returned.';
+                } else {
+                    const won = pickedHigher ? next > current : next < current;
+                    if (won) {
+                        delta = bet;
+                        color = '#2ecc71';
+                        resultText = `You won **${bet.toLocaleString()}** coins!`;
+                    } else {
+                        delta = -bet;
+                        color = '#e74c3c';
+                        resultText = `You lost **${bet.toLocaleString()}** coins.`;
+                    }
+                }
+
+                user.balance += delta;
+                await user.save();
+
+                const resultEmbed = new EmbedBuilder()
+                    .setColor(color)
+                    .setTitle('Higher or Lower — Result')
+                    .setDescription(
+                        `Your pick: **${pickedHigher ? 'Higher' : 'Lower'}**\n` +
+                        `Current card: **${cardLabel(current)}**\n` +
+                        `Next card: **${cardLabel(next)}**\n\n` +
+                        `${resultText}`
+                    )
+                    .addFields({ name: 'New Balance', value: `${user.balance.toLocaleString()} coins` })
+                    .setTimestamp();
+
+                await i.update({ embeds: [resultEmbed], components: [] });
+            });
+
+            collector.on('end', async collected => {
+                if (collected.size === 0) {
+                    const timeoutEmbed = EmbedBuilder.from(embed)
+                        .setColor('#95a5a6')
+                        .setDescription(`Current card: **${cardLabel(current)}**\nBet: **${bet.toLocaleString()}** coins\n⏱️ Timed out. No coins were won or lost.`);
+                    await interaction.editReply({ embeds: [timeoutEmbed], components: [] }).catch(() => {});
+                }
+            });
+        } catch (error) {
+            console.error('HigherLower error:', error);
+            if (interaction.replied || interaction.deferred) {
+                await interaction.followUp({ content: 'Failed to run Higher or Lower.', ephemeral: true });
+            } else {
+                await interaction.reply({ content: 'Failed to run Higher or Lower.', ephemeral: true });
+            }
+        }
+    }
+};

--- a/src/commands/economy/higherlower.js
+++ b/src/commands/economy/higherlower.js
@@ -37,13 +37,36 @@ module.exports = {
                 return interaction.reply({ content: 'Economy games are disabled in this server.', ephemeral: true });
             }
 
-            let user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+            const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
+
+            await User.findOneAndUpdate(
+                userFilter,
+                { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id, balance: 0 } },
+                { upsert: true, new: true, setDefaultsOnInsert: true }
+            );
+
+            let user = await User.findOneAndUpdate(
+                { ...userFilter, balance: { $gte: bet } },
+                { $inc: { balance: -bet } },
+                { new: true }
+            );
+
             if (!user) {
-                user = await User.create({ userId: interaction.user.id, guildId: interaction.guild.id });
+                await User.findOneAndUpdate(
+                    userFilter,
+                    { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id, balance: 0 } },
+                    { upsert: true, new: true, setDefaultsOnInsert: true }
+                );
+
+                user = await User.findOneAndUpdate(
+                    { ...userFilter, balance: { $gte: bet } },
+                    { $inc: { balance: -bet } },
+                    { new: true }
+                );
             }
 
-            if (user.balance < bet) {
-                return interaction.reply({ content: `You need ${bet.toLocaleString()} coins, but only have ${user.balance.toLocaleString()}.`, ephemeral: true });
+            if (!user) {
+                return interaction.reply({ content: `Insufficient funds. You need ${bet.toLocaleString()} coins to place this bet.`, ephemeral: true });
             }
 
             const current = rollCard();
@@ -71,51 +94,75 @@ module.exports = {
             });
 
             collector.on('collect', async i => {
-                const next = rollCard();
-                const pickedHigher = i.customId === upId;
-
-                let resultText;
                 let delta = 0;
-                let color = '#f1c40f';
 
-                if (next === current) {
-                    resultText = 'Push! Same value — your coins are returned.';
-                } else {
-                    const won = pickedHigher ? next > current : next < current;
-                    if (won) {
+                try {
+                    const next = rollCard();
+                    const pickedHigher = i.customId === upId;
+
+                    let resultText;
+                    let color = '#f1c40f';
+
+                    if (next === current) {
                         delta = bet;
-                        color = '#2ecc71';
-                        resultText = `You won **${bet.toLocaleString()}** coins!`;
+                        resultText = 'Push! Same value — your coins are returned.';
                     } else {
-                        delta = -bet;
-                        color = '#e74c3c';
-                        resultText = `You lost **${bet.toLocaleString()}** coins.`;
+                        const won = pickedHigher ? next > current : next < current;
+                        if (won) {
+                            delta = bet * 2;
+                            color = '#2ecc71';
+                            resultText = `You won **${bet.toLocaleString()}** coins!`;
+                        } else {
+                            resultText = `You lost **${bet.toLocaleString()}** coins.`;
+                        }
+                    }
+
+                    user = await User.findOneAndUpdate(
+                        userFilter,
+                        { $inc: { balance: delta } },
+                        { new: true }
+                    );
+
+                    const resultEmbed = new EmbedBuilder()
+                        .setColor(color)
+                        .setTitle('Higher or Lower — Result')
+                        .setDescription(
+                            `Your pick: **${pickedHigher ? 'Higher' : 'Lower'}**\n` +
+                            `Current card: **${cardLabel(current)}**\n` +
+                            `Next card: **${cardLabel(next)}**\n\n` +
+                            `${resultText}`
+                        )
+                        .addFields({ name: 'New Balance', value: `${user.balance.toLocaleString()} coins` })
+                        .setTimestamp();
+
+                    await i.update({ embeds: [resultEmbed], components: [] });
+                } catch (collectError) {
+                    console.error('HigherLower collect error:', collectError);
+
+                    if (delta !== 0) {
+                        try {
+                            await User.findOneAndUpdate(userFilter, { $inc: { balance: -delta } });
+                        } catch (revertError) {
+                            console.error('HigherLower revert error:', revertError);
+                        }
+                    }
+
+                    try {
+                        await i.update({ content: 'Something went wrong while processing your pick. Your wager was refunded.', embeds: [], components: [] });
+                    } catch (updateError) {
+                        try {
+                            await i.reply({ content: 'Something went wrong while processing your pick. Your wager was refunded.', ephemeral: true });
+                        } catch (replyError) {}
                     }
                 }
-
-                user.balance += delta;
-                await user.save();
-
-                const resultEmbed = new EmbedBuilder()
-                    .setColor(color)
-                    .setTitle('Higher or Lower — Result')
-                    .setDescription(
-                        `Your pick: **${pickedHigher ? 'Higher' : 'Lower'}**\n` +
-                        `Current card: **${cardLabel(current)}**\n` +
-                        `Next card: **${cardLabel(next)}**\n\n` +
-                        `${resultText}`
-                    )
-                    .addFields({ name: 'New Balance', value: `${user.balance.toLocaleString()} coins` })
-                    .setTimestamp();
-
-                await i.update({ embeds: [resultEmbed], components: [] });
             });
 
             collector.on('end', async collected => {
                 if (collected.size === 0) {
                     const timeoutEmbed = EmbedBuilder.from(embed)
                         .setColor('#95a5a6')
-                        .setDescription(`Current card: **${cardLabel(current)}**\nBet: **${bet.toLocaleString()}** coins\n⏱️ Timed out. No coins were won or lost.`);
+                        .setDescription(`Current card: **${cardLabel(current)}**\nBet: **${bet.toLocaleString()}** coins\n⏱️ Timed out. Your wager was refunded.`);
+                    await User.findOneAndUpdate(userFilter, { $inc: { balance: bet } }).catch(() => {});
                     await interaction.editReply({ embeds: [timeoutEmbed], components: [] }).catch(() => {});
                 }
             });


### PR DESCRIPTION
### Motivation
- Provide a fast-paced, mobile-friendly mini-game that integrates with the server economy so users can wager coins on whether the next card will be higher or lower.
- Use Discord message buttons for quick interactions and keep gameplay simple and accessible on mobile devices.

### Description
- Added a new command at `src/commands/economy/higherlower.js` that registers the `/higherlower` slash command with a required `bet` integer option.
- Implements button-based play using two buttons (⬆️ Higher / ⬇️ Lower) with custom IDs scoped to the interaction and a 15s response window enforced by a component collector.
- Performs server gating via `guildSettings.economy.enabled` and `guildSettings.economy.gamesEnabled`, ensures the user exists (auto-creates a `User`), and verifies the user has sufficient `balance` before accepting a wager.
- Resolves outcomes with win/lose/push logic (equal cards are a push), updates and saves the user `balance`, and replaces buttons with a result embed or a timeout embed to prevent stale interactions.

### Testing
- Ran a syntax check: `node --check src/commands/economy/higherlower.js`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e11869688325a0a35d79f82f797e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/higherlower` economy game command: Users can bet coins and predict whether the next card will be higher or lower than the current card. Bets are limited to available balance, with win/loss outcomes and real-time coin balance updates. Each round has a 15-second timeout before the game closes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->