### PR TITLE
feat: add service reliability — health checks, DLQ, migrations, backup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,14 +29,51 @@ services:
         condition: service_healthy
     volumes:
       - ultrabot_logs:/app/logs
+      - ./backups:/app/backups
     networks:
       - ultrabot-network
+    # Dedicated JSON health endpoint; 503 when mongo is down
     healthcheck:
-      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000', (r) => { process.exit(r.statusCode === 200 ? 0 : 1) }).on('error', () => process.exit(1))"]
+      test: ["CMD", "node", "-e",
+        "require('http').get('http://localhost:3000/health', (r) => { let b=''; r.on('data', d => b+=d); r.on('end', () => { try { const s = JSON.parse(b).status; process.exit(s === 'unhealthy' ? 1 : 0); } catch { process.exit(1); } }); }).on('error', () => process.exit(1))"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 60s
+      start_period: 90s
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+        reservations:
+          memory: 256m
+    stop_grace_period: 30s
+
+  # Optional scheduled backup (runs mongodump once a day at 03:00 UTC)
+  backup:
+    image: mongo:7
+    container_name: ultrabot-backup
+    profiles:
+      - backup
+    restart: unless-stopped
+    env_file:
+      - .env
+    volumes:
+      - ./backups:/backups
+    networks:
+      - ultrabot-network
+    depends_on:
+      mongodb:
+        condition: service_healthy
+    entrypoint: >
+      sh -c 'while true; do
+        TIMESTAMP=$$(date -u +"%Y%m%dT%H%M%SZ");
+        echo "[backup] Starting backup at $$TIMESTAMP";
+        mongodump --uri="$$MONGODB_URI" --gzip --archive="/backups/ultrabot-$$TIMESTAMP.gz" &&
+          echo "[backup] Done: /backups/ultrabot-$$TIMESTAMP.gz" ||
+          echo "[backup] FAILED";
+        find /backups -name "ultrabot-*.gz" -mtime +30 -delete;
+        sleep 86400;
+      done'
 
 volumes:
   mongodb_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,15 +65,23 @@ services:
       mongodb:
         condition: service_healthy
     entrypoint: >
-      sh -c 'while true; do
-        TIMESTAMP=$$(date -u +"%Y%m%dT%H%M%SZ");
-        echo "[backup] Starting backup at $$TIMESTAMP";
-        mongodump --uri="$$MONGODB_URI" --gzip --archive="/backups/ultrabot-$$TIMESTAMP.gz" &&
-          echo "[backup] Done: /backups/ultrabot-$$TIMESTAMP.gz" ||
-          echo "[backup] FAILED";
-        find /backups -name "ultrabot-*.gz" -mtime +30 -delete;
-        sleep 86400;
-      done'
+      sh -c '
+        NOW=$$(date -u +%s);
+        MIDNIGHT=$$(( ($$NOW / 86400) * 86400 ));
+        TARGET=$$(( $$MIDNIGHT + 10800 ));
+        if [ $$NOW -ge $$TARGET ]; then TARGET=$$(( $$TARGET + 86400 )); fi;
+        SLEEP=$$(( $$TARGET - $$NOW ));
+        echo "[backup] Sleeping $${SLEEP}s until next 03:00 UTC";
+        sleep $$SLEEP;
+        while true; do
+          TIMESTAMP=$$(date -u +"%Y%m%dT%H%M%SZ");
+          echo "[backup] Starting backup at $$TIMESTAMP";
+          mongodump --uri="$$MONGODB_URI" --gzip --archive="/backups/ultrabot-$$TIMESTAMP.gz" &&
+            echo "[backup] Done: /backups/ultrabot-$$TIMESTAMP.gz" ||
+            echo "[backup] FAILED";
+          find /backups -name "ultrabot-*.gz" -mtime +30 -delete;
+          sleep 86400;
+        done'
 
 volumes:
   mongodb_data:

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Backup UltraBot MongoDB data to a timestamped archive.
+# Usage: ./scripts/backup.sh [output-dir]
+# Requires: mongodump on PATH, or runs inside the ultrabot-mongodb container.
+set -euo pipefail
+
+BACKUP_DIR="${1:-./backups}"
+TIMESTAMP=$(date -u +"%Y%m%dT%H%M%SZ")
+ARCHIVE="${BACKUP_DIR}/ultrabot-${TIMESTAMP}.gz"
+
+# Load .env if present and MONGODB_URI is not already set
+if [ -z "${MONGODB_URI:-}" ] && [ -f "$(dirname "$0")/../.env" ]; then
+    # shellcheck disable=SC1090
+    set -a; source "$(dirname "$0")/../.env"; set +a
+fi
+
+MONGO_URI="${MONGODB_URI:-mongodb://localhost:27017/ultrabot}"
+
+mkdir -p "${BACKUP_DIR}"
+
+echo "[backup] Starting backup → ${ARCHIVE}"
+echo "[backup] URI: ${MONGO_URI}"
+
+if command -v mongodump &>/dev/null; then
+    mongodump --uri="${MONGO_URI}" --gzip --archive="${ARCHIVE}"
+else
+    # Fall back to running mongodump inside the Docker container
+    echo "[backup] mongodump not found locally; attempting via Docker container 'ultrabot-mongodb'"
+    docker exec ultrabot-mongodb \
+        mongodump --uri="${MONGO_URI}" --gzip --archive=/tmp/ultrabot-backup.gz
+    docker cp ultrabot-mongodb:/tmp/ultrabot-backup.gz "${ARCHIVE}"
+    docker exec ultrabot-mongodb rm /tmp/ultrabot-backup.gz
+fi
+
+SIZE=$(du -sh "${ARCHIVE}" | cut -f1)
+echo "[backup] Done. Archive size: ${SIZE} → ${ARCHIVE}"
+
+# Prune archives older than 30 days
+find "${BACKUP_DIR}" -name 'ultrabot-*.gz' -mtime +30 -print -delete \
+    && echo "[backup] Pruned backups older than 30 days"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -18,16 +18,20 @@ MONGO_URI="${MONGODB_URI:-mongodb://localhost:27017/ultrabot}"
 
 mkdir -p "${BACKUP_DIR}"
 
+MONGO_URI_MASKED=$(echo "${MONGO_URI}" | sed 's|://[^@]*@|://***@|')
 echo "[backup] Starting backup → ${ARCHIVE}"
-echo "[backup] URI: ${MONGO_URI}"
+echo "[backup] URI: ${MONGO_URI_MASKED}"
 
 if command -v mongodump &>/dev/null; then
     mongodump --uri="${MONGO_URI}" --gzip --archive="${ARCHIVE}"
 else
-    # Fall back to running mongodump inside the Docker container
+    # Fall back to running mongodump inside the Docker container.
+    # Replace 'localhost' with '127.0.0.1' so the URI points to the container's
+    # own loopback interface (the service hostname is not reachable from within).
     echo "[backup] mongodump not found locally; attempting via Docker container 'ultrabot-mongodb'"
+    CONTAINER_URI="${MONGO_URI/localhost/127.0.0.1}"
     docker exec ultrabot-mongodb \
-        mongodump --uri="${MONGO_URI}" --gzip --archive=/tmp/ultrabot-backup.gz
+        mongodump --uri="${CONTAINER_URI}" --gzip --archive=/tmp/ultrabot-backup.gz
     docker cp ultrabot-mongodb:/tmp/ultrabot-backup.gz "${ARCHIVE}"
     docker exec ultrabot-mongodb rm /tmp/ultrabot-backup.gz
 fi

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Restore UltraBot MongoDB data from a backup archive.
+# Usage: ./scripts/restore.sh <path-to-archive.gz> [--drop]
+#   --drop  Drop existing collections before restoring (clean restore)
+set -euo pipefail
+
+ARCHIVE="${1:-}"
+DROP_FLAG=""
+
+if [ -z "${ARCHIVE}" ]; then
+    echo "Usage: $0 <path-to-archive.gz> [--drop]" >&2
+    exit 1
+fi
+
+if [ ! -f "${ARCHIVE}" ]; then
+    echo "[restore] ERROR: Archive not found: ${ARCHIVE}" >&2
+    exit 1
+fi
+
+if [[ "${2:-}" == "--drop" ]]; then
+    DROP_FLAG="--drop"
+    echo "[restore] WARNING: --drop specified. Existing collections will be dropped before restore."
+fi
+
+# Load .env if present and MONGODB_URI is not already set
+if [ -z "${MONGODB_URI:-}" ] && [ -f "$(dirname "$0")/../.env" ]; then
+    # shellcheck disable=SC1090
+    set -a; source "$(dirname "$0")/../.env"; set +a
+fi
+
+MONGO_URI="${MONGODB_URI:-mongodb://localhost:27017/ultrabot}"
+
+echo "[restore] Archive:  ${ARCHIVE}"
+echo "[restore] URI:      ${MONGO_URI}"
+
+read -rp "[restore] Confirm restore? This will overwrite data. (yes/no): " CONFIRM
+if [[ "${CONFIRM}" != "yes" ]]; then
+    echo "[restore] Aborted."
+    exit 0
+fi
+
+if command -v mongorestore &>/dev/null; then
+    # shellcheck disable=SC2086
+    mongorestore --uri="${MONGO_URI}" --gzip --archive="${ARCHIVE}" ${DROP_FLAG}
+else
+    echo "[restore] mongorestore not found locally; attempting via Docker container 'ultrabot-mongodb'"
+    docker cp "${ARCHIVE}" ultrabot-mongodb:/tmp/ultrabot-restore.gz
+    # shellcheck disable=SC2086
+    docker exec ultrabot-mongodb \
+        mongorestore --uri="${MONGO_URI}" --gzip --archive=/tmp/ultrabot-restore.gz ${DROP_FLAG}
+    docker exec ultrabot-mongodb rm /tmp/ultrabot-restore.gz
+fi
+
+echo "[restore] Restore complete."

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -30,8 +30,9 @@ fi
 
 MONGO_URI="${MONGODB_URI:-mongodb://localhost:27017/ultrabot}"
 
+MONGO_URI_MASKED=$(echo "${MONGO_URI}" | sed 's|://[^@]*@|://***@|')
 echo "[restore] Archive:  ${ARCHIVE}"
-echo "[restore] URI:      ${MONGO_URI}"
+echo "[restore] URI:      ${MONGO_URI_MASKED}"
 
 read -rp "[restore] Confirm restore? This will overwrite data. (yes/no): " CONFIRM
 if [[ "${CONFIRM}" != "yes" ]]; then
@@ -45,9 +46,11 @@ if command -v mongorestore &>/dev/null; then
 else
     echo "[restore] mongorestore not found locally; attempting via Docker container 'ultrabot-mongodb'"
     docker cp "${ARCHIVE}" ultrabot-mongodb:/tmp/ultrabot-restore.gz
+    # Replace 'localhost' with '127.0.0.1' so the URI resolves inside the container.
+    SAFE_URI="${MONGO_URI/localhost/127.0.0.1}"
     # shellcheck disable=SC2086
     docker exec ultrabot-mongodb \
-        mongorestore --uri="${MONGO_URI}" --gzip --archive=/tmp/ultrabot-restore.gz ${DROP_FLAG}
+        mongorestore --uri="${SAFE_URI}" --gzip --archive=/tmp/ultrabot-restore.gz ${DROP_FLAG}
     docker exec ultrabot-mongodb rm /tmp/ultrabot-restore.gz
 fi
 

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -3,6 +3,7 @@ const session = require('express-session');
 const passport = require('passport');
 const DiscordStrategy = require('passport-discord').Strategy;
 const path = require('path');
+const { getStatus } = require('../health');
 
 const app = express();
 
@@ -80,7 +81,6 @@ function start(client) {
     app.use('/api', apiRoutes);
 
     app.get('/health', (req, res) => {
-        const { getStatus } = require('../health');
         const status = getStatus();
         res.status(status.status === 'unhealthy' ? 503 : 200).json(status);
     });

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -79,8 +79,19 @@ function start(client) {
     app.use('/dashboard', dashboardRoutes);
     app.use('/api', apiRoutes);
 
+    app.get('/health', (req, res) => {
+        const { getStatus } = require('../health');
+        const status = getStatus();
+        res.status(status.status === 'unhealthy' ? 503 : 200).json(status);
+    });
+
     app.get('/', (req, res) => {
         res.render('index', { user: req.user });
+    });
+
+    app.use((err, req, res, next) => {
+        console.error('[DASHBOARD] Unhandled error:', err);
+        res.status(500).json({ error: 'Internal server error' });
     });
 
     const PORT = process.env.DASHBOARD_PORT || 3000;

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -4,6 +4,7 @@ const { checkRssFeeds, scheduleDailyNews } = require('../services/rssService');
 const { checkReminders } = require('../services/reminderService');
 const { checkGiveaways } = require('../services/giveawayService');
 const { checkTempVoice } = require('../services/tempVoiceService');
+const { runJob } = require('../utils/jobRunner');
 
 module.exports = {
     name: 'ready',
@@ -24,23 +25,23 @@ module.exports = {
             status: 'online'
         });
 
-        cron.schedule('*/5 * * * *', async () => {
-            await checkRssFeeds(client);
-        });
+        cron.schedule('*/5 * * * *', () =>
+            runJob('rssService', 'checkRssFeeds', () => checkRssFeeds(client))
+        );
 
-        cron.schedule('* * * * *', async () => {
-            await checkReminders(client);
-        });
+        cron.schedule('* * * * *', () =>
+            runJob('reminderService', 'checkReminders', () => checkReminders(client))
+        );
 
         scheduleDailyNews(client);
 
-        cron.schedule('* * * * *', async () => {
-            await checkGiveaways(client);
-        });
+        cron.schedule('* * * * *', () =>
+            runJob('giveawayService', 'checkGiveaways', () => checkGiveaways(client))
+        );
 
-        cron.schedule('*/2 * * * *', async () => {
-            await checkTempVoice(client);
-        });
+        cron.schedule('*/2 * * * *', () =>
+            runJob('tempVoiceService', 'checkTempVoice', () => checkTempVoice(client))
+        );
 
         console.log('[READY] Background services started');
     }

--- a/src/health.js
+++ b/src/health.js
@@ -1,0 +1,67 @@
+const mongoose = require('mongoose');
+
+const state = {
+    startedAt: new Date(),
+    services: {},
+    unhandledRejections: 0,
+    uncaughtExceptions: 0,
+};
+
+function recordServiceRun(serviceName, { success, error = null, durationMs = null } = {}) {
+    const prev = state.services[serviceName] || { successCount: 0, errorCount: 0 };
+    state.services[serviceName] = {
+        ...prev,
+        lastRunAt: new Date().toISOString(),
+        lastSuccess: success,
+        lastError: error ? String(error) : null,
+        lastDurationMs: durationMs,
+        successCount: success ? prev.successCount + 1 : prev.successCount,
+        errorCount: success ? prev.errorCount : prev.errorCount + 1,
+    };
+}
+
+function getStatus() {
+    const mongoState = mongoose.connection.readyState;
+    // 0=disconnected, 1=connected, 2=connecting, 3=disconnecting
+    const mongoLabels = ['disconnected', 'connected', 'connecting', 'disconnecting'];
+    const mongoHealthy = mongoState === 1;
+
+    const uptimeSeconds = Math.floor((Date.now() - state.startedAt.getTime()) / 1000);
+    const mem = process.memoryUsage();
+
+    const serviceStatuses = {};
+    for (const [name, svc] of Object.entries(state.services)) {
+        serviceStatuses[name] = {
+            ...svc,
+            healthy: svc.lastSuccess !== false,
+        };
+    }
+
+    const allServicesHealthy = Object.values(serviceStatuses).every(s => s.healthy);
+    const overall = mongoHealthy && allServicesHealthy ? 'healthy' : !mongoHealthy ? 'unhealthy' : 'degraded';
+
+    return {
+        status: overall,
+        uptime: uptimeSeconds,
+        startedAt: state.startedAt.toISOString(),
+        mongo: {
+            status: mongoLabels[mongoState] || 'unknown',
+            healthy: mongoHealthy,
+        },
+        memory: {
+            heapUsedMb: Math.round(mem.heapUsed / 1024 / 1024),
+            heapTotalMb: Math.round(mem.heapTotal / 1024 / 1024),
+            rssMb: Math.round(mem.rss / 1024 / 1024),
+        },
+        process: {
+            unhandledRejections: state.unhandledRejections,
+            uncaughtExceptions: state.uncaughtExceptions,
+        },
+        services: serviceStatuses,
+    };
+}
+
+function incrementUnhandledRejections() { state.unhandledRejections++; }
+function incrementUncaughtExceptions() { state.uncaughtExceptions++; }
+
+module.exports = { recordServiceRun, getStatus, incrementUnhandledRejections, incrementUncaughtExceptions };

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
 const { Client, GatewayIntentBits, Collection, Partials } = require('discord.js');
-const { connect } = require('mongoose');
+const { connect, connection } = require('mongoose');
 const fs = require('fs');
 const path = require('path');
 require('dotenv').config();
+
+const health = require('./health');
 
 const client = new Client({
     intents: [
@@ -65,13 +67,18 @@ async function connectDatabase() {
     try {
         await connect(process.env.MONGODB_URI, {
             useNewUrlParser: true,
-            useUnifiedTopology: true
+            useUnifiedTopology: true,
+            serverSelectionTimeoutMS: 10000,
         });
         console.log('[DATABASE] Connected to MongoDB');
     } catch (error) {
         console.error('[DATABASE] Failed to connect:', error);
         process.exit(1);
     }
+
+    connection.on('disconnected', () => console.warn('[DATABASE] Disconnected from MongoDB'));
+    connection.on('reconnected', () => console.log('[DATABASE] Reconnected to MongoDB'));
+    connection.on('error', err => console.error('[DATABASE] Connection error:', err));
 }
 
 async function startDashboard() {
@@ -79,8 +86,26 @@ async function startDashboard() {
     dashboard.start(client);
 }
 
+// Graceful shutdown: close DB and destroy Discord client before exiting
+async function shutdown(signal) {
+    console.log(`[SHUTDOWN] Received ${signal}. Shutting down gracefully...`);
+    try {
+        client.destroy();
+        await connection.close();
+        console.log('[SHUTDOWN] Clean exit.');
+    } catch (err) {
+        console.error('[SHUTDOWN] Error during shutdown:', err);
+    }
+    process.exit(0);
+}
+
 async function startBot() {
     await connectDatabase();
+
+    // Run pending schema migrations before the bot starts accepting traffic
+    const { runMigrations } = require('./migrations/runner');
+    await runMigrations();
+
     await loadCommands();
     await loadEvents();
     await startDashboard();
@@ -110,8 +135,40 @@ async function startBot() {
     client.login(process.env.DISCORD_TOKEN);
 }
 
-startBot().catch(console.error);
+// --- Process-level reliability guards ---
 
-process.on('unhandledRejection', error => {
-    console.error('Unhandled promise rejection:', error);
+// Track repeated unhandled rejections; exit if they spike (indicates a stuck state)
+const REJECTION_WINDOW_MS = 60_000;
+const REJECTION_LIMIT = 10;
+const recentRejections = [];
+
+process.on('unhandledRejection', (error) => {
+    health.incrementUnhandledRejections();
+    console.error('[PROCESS] Unhandled promise rejection:', error);
+
+    const now = Date.now();
+    recentRejections.push(now);
+    // Evict entries outside the window
+    while (recentRejections.length && recentRejections[0] < now - REJECTION_WINDOW_MS) {
+        recentRejections.shift();
+    }
+    if (recentRejections.length >= REJECTION_LIMIT) {
+        console.error(`[PROCESS] ${REJECTION_LIMIT} unhandled rejections in ${REJECTION_WINDOW_MS / 1000}s — forcing exit.`);
+        process.exit(1);
+    }
+});
+
+process.on('uncaughtException', (error) => {
+    health.incrementUncaughtExceptions();
+    console.error('[PROCESS] Uncaught exception:', error);
+    // uncaughtException leaves the process in an undefined state; always exit
+    process.exit(1);
+});
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));
+
+startBot().catch(err => {
+    console.error('[STARTUP] Fatal error during bot startup:', err);
+    process.exit(1);
 });

--- a/src/migrations/001_add_indexes.js
+++ b/src/migrations/001_add_indexes.js
@@ -9,37 +9,37 @@ module.exports = {
         // Reminder lookups: due reminders that are not yet completed
         await db.collection('reminders').createIndex(
             { remindAt: 1, completed: 1 },
-            { background: true, name: 'idx_remind_due' }
+            { name: 'idx_remind_due' }
         );
 
         // Giveaway lookups: active (not ended) giveaways
         await db.collection('guilds').createIndex(
             { 'giveaways.ended': 1, 'giveaways.endsAt': 1 },
-            { background: true, name: 'idx_giveaways_active', sparse: true }
+            { name: 'idx_giveaways_active', sparse: true }
         );
 
         // SLA monitor: open cases with a deadline
         await db.collection('cases').createIndex(
             { status: 1, slaDeadline: 1 },
-            { background: true, name: 'idx_cases_sla' }
+            { name: 'idx_cases_sla' }
         );
 
         // Summary jobs: jobs that are enabled and due at a specific UTC hour/minute
         await db.collection('summaryjobs').createIndex(
             { enabled: 1, hour: 1, minute: 1 },
-            { background: true, name: 'idx_summaryjobs_schedule' }
+            { name: 'idx_summaryjobs_schedule' }
         );
 
         // RSS feeds: guilds with at least one feed
         await db.collection('guilds').createIndex(
             { 'rssFeeds.0': 1 },
-            { background: true, name: 'idx_guilds_rssfeeds', sparse: true }
+            { name: 'idx_guilds_rssfeeds', sparse: true }
         );
 
         // FailedJob querying by status + service
         await db.collection('failedjobs').createIndex(
             { status: 1, service: 1, createdAt: -1 },
-            { background: true, name: 'idx_failedjobs_status_service' }
+            { name: 'idx_failedjobs_status_service' }
         );
     },
 };

--- a/src/migrations/001_add_indexes.js
+++ b/src/migrations/001_add_indexes.js
@@ -1,0 +1,45 @@
+const mongoose = require('mongoose');
+
+module.exports = {
+    name: '001_add_indexes',
+
+    async up() {
+        const db = mongoose.connection.db;
+
+        // Reminder lookups: due reminders that are not yet completed
+        await db.collection('reminders').createIndex(
+            { remindAt: 1, completed: 1 },
+            { background: true, name: 'idx_remind_due' }
+        );
+
+        // Giveaway lookups: active (not ended) giveaways
+        await db.collection('guilds').createIndex(
+            { 'giveaways.ended': 1, 'giveaways.endsAt': 1 },
+            { background: true, name: 'idx_giveaways_active', sparse: true }
+        );
+
+        // SLA monitor: open cases with a deadline
+        await db.collection('cases').createIndex(
+            { status: 1, slaDeadline: 1 },
+            { background: true, name: 'idx_cases_sla' }
+        );
+
+        // Summary jobs: jobs that are enabled and due at a specific UTC hour/minute
+        await db.collection('summaryjobs').createIndex(
+            { enabled: 1, hour: 1, minute: 1 },
+            { background: true, name: 'idx_summaryjobs_schedule' }
+        );
+
+        // RSS feeds: guilds with at least one feed
+        await db.collection('guilds').createIndex(
+            { 'rssFeeds.0': 1 },
+            { background: true, name: 'idx_guilds_rssfeeds', sparse: true }
+        );
+
+        // FailedJob querying by status + service
+        await db.collection('failedjobs').createIndex(
+            { status: 1, service: 1, createdAt: -1 },
+            { background: true, name: 'idx_failedjobs_status_service' }
+        );
+    },
+};

--- a/src/migrations/runner.js
+++ b/src/migrations/runner.js
@@ -1,0 +1,63 @@
+const fs = require('fs');
+const path = require('path');
+const MigrationRecord = require('../models/MigrationRecord');
+
+/**
+ * Discovers and applies any pending migrations in this directory.
+ * Migrations are .js files (excluding runner.js itself) sorted by filename.
+ * Each migration file must export: { name: string, up: async function }.
+ * Already-applied migrations are skipped (tracked in the MigrationRecord collection).
+ */
+async function runMigrations() {
+    const migrationsDir = __dirname;
+    const files = fs.readdirSync(migrationsDir)
+        .filter(f => f.endsWith('.js') && f !== 'runner.js')
+        .sort();
+
+    if (files.length === 0) {
+        console.log('[MIGRATIONS] No migration files found.');
+        return;
+    }
+
+    const applied = new Set(
+        (await MigrationRecord.find({}, 'name').lean()).map(r => r.name)
+    );
+
+    let count = 0;
+    for (const file of files) {
+        const migration = require(path.join(migrationsDir, file));
+        const { name, up } = migration;
+
+        if (!name || typeof up !== 'function') {
+            console.warn(`[MIGRATIONS] Skipping ${file}: must export { name, up }`);
+            continue;
+        }
+
+        if (applied.has(name)) {
+            console.log(`[MIGRATIONS] Already applied: ${name}`);
+            continue;
+        }
+
+        console.log(`[MIGRATIONS] Applying: ${name}`);
+        const start = Date.now();
+        try {
+            await up();
+            const durationMs = Date.now() - start;
+            await MigrationRecord.create({ name, durationMs });
+            console.log(`[MIGRATIONS] Applied ${name} in ${durationMs}ms`);
+            count++;
+        } catch (err) {
+            console.error(`[MIGRATIONS] FAILED: ${name}`, err);
+            // Re-throw so startup aborts — running with a partially-applied schema is unsafe.
+            throw err;
+        }
+    }
+
+    if (count === 0) {
+        console.log('[MIGRATIONS] All migrations already applied. Nothing to do.');
+    } else {
+        console.log(`[MIGRATIONS] Applied ${count} migration(s).`);
+    }
+}
+
+module.exports = { runMigrations };

--- a/src/models/FailedJob.js
+++ b/src/models/FailedJob.js
@@ -1,0 +1,26 @@
+const { Schema, model } = require('mongoose');
+
+const FailedJobSchema = new Schema({
+    service: { type: String, required: true, index: true },
+    jobName: { type: String, required: true },
+    guildId: { type: String, default: null, index: true },
+    payload: { type: Schema.Types.Mixed, default: null },
+    errorMessage: { type: String, required: true },
+    errorStack: { type: String, default: null },
+    attempts: { type: Number, default: 1 },
+    maxAttempts: { type: Number, default: 3 },
+    status: {
+        type: String,
+        enum: ['pending', 'retrying', 'exhausted', 'resolved'],
+        default: 'pending',
+        index: true,
+    },
+    resolvedAt: { type: Date, default: null },
+    resolvedBy: { type: String, default: null },
+    lastAttemptAt: { type: Date, default: Date.now },
+}, { timestamps: true });
+
+// Auto-expire resolved/exhausted records after 30 days
+FailedJobSchema.index({ updatedAt: 1 }, { expireAfterSeconds: 30 * 24 * 60 * 60, partialFilterExpression: { status: { $in: ['resolved', 'exhausted'] } } });
+
+module.exports = model('FailedJob', FailedJobSchema);

--- a/src/models/MigrationRecord.js
+++ b/src/models/MigrationRecord.js
@@ -1,0 +1,9 @@
+const { Schema, model } = require('mongoose');
+
+const MigrationRecordSchema = new Schema({
+    name: { type: String, required: true, unique: true },
+    appliedAt: { type: Date, default: Date.now },
+    durationMs: { type: Number, default: null },
+});
+
+module.exports = model('MigrationRecord', MigrationRecordSchema);

--- a/src/services/caseService.js
+++ b/src/services/caseService.js
@@ -2,6 +2,7 @@ const cron = require('node-cron');
 const { EmbedBuilder } = require('discord.js');
 const Case = require('../models/Case');
 const Guild = require('../models/Guild');
+const { runJob } = require('../utils/jobRunner');
 
 async function getNextCaseId(guildId) {
     const result = await Guild.findOneAndUpdate(
@@ -76,9 +77,9 @@ async function getCasesForUser(guildId, targetUserId, limit = 10) {
 
 function startSlaMonitor(client) {
     // Check every 30 minutes for overdue open cases
-    cron.schedule('*/30 * * * *', async () => {
-        try {
-            const now = new Date();
+    cron.schedule('*/30 * * * *', () =>
+        runJob('caseService', 'slaMonitor', async () => {
+        const now = new Date();
             const overdueCases = await Case.find({
                 status: 'open',
                 slaDeadline: { $lte: now }
@@ -121,10 +122,8 @@ function startSlaMonitor(client) {
                     { slaDeadline: new Date(Date.now() + slaHours * 3600000) }
                 );
             }
-        } catch (err) {
-            console.error('SLA monitor error:', err);
-        }
-    });
+        })
+    );
 }
 
 module.exports = { createCase, addNote, closeCase, getCase, getCasesForUser, startSlaMonitor };

--- a/src/services/summaryService.js
+++ b/src/services/summaryService.js
@@ -2,6 +2,7 @@ const cron = require('node-cron');
 const SummaryJob = require('../models/SummaryJob');
 const Guild = require('../models/Guild');
 const { getCompletion, resolveProviderConfig } = require('./aiService');
+const { runJob } = require('../utils/jobRunner');
 
 const MAX_TRANSCRIPT_CHARS = 6000;
 
@@ -60,8 +61,8 @@ async function runSummaryJob(job, client) {
 
 function startSummaryService(client) {
     // Check every minute whether any daily job is due
-    cron.schedule('* * * * *', async () => {
-        try {
+    cron.schedule('* * * * *', () =>
+        runJob('summaryService', 'scheduler', async () => {
             const now = new Date();
             const utcHour = now.getUTCHours();
             const utcMinute = now.getUTCMinutes();
@@ -71,16 +72,13 @@ function startSummaryService(client) {
                 // Skip if already ran within the last 23 hours
                 if (job.lastRun && now - job.lastRun < 23 * 60 * 60 * 1000) continue;
 
-                try {
-                    await runSummaryJob(job, client);
-                } catch (err) {
-                    console.error(`[SummaryService] Job ${job._id} failed:`, err.message);
-                }
+                await runJob('summaryService', 'runSummaryJob', () => runSummaryJob(job, client), {
+                    guildId: job.guildId,
+                    payload: { jobId: String(job._id), label: job.label },
+                });
             }
-        } catch (err) {
-            console.error('[SummaryService] Scheduler error:', err.message);
-        }
-    });
+        })
+    );
 
     console.log('[SummaryService] Started');
 }

--- a/src/utils/jobRunner.js
+++ b/src/utils/jobRunner.js
@@ -1,0 +1,77 @@
+const FailedJob = require('../models/FailedJob');
+const { recordServiceRun } = require('../health');
+
+/**
+ * Wraps a cron job function with error recording (dead-letter queue) and health tracking.
+ *
+ * @param {string} service  - human-readable service name, e.g. "reminderService"
+ * @param {string} jobName  - specific job name, e.g. "checkReminders"
+ * @param {Function} fn     - async job function to run
+ * @param {object} [opts]
+ * @param {string}  [opts.guildId]      - guild this job is scoped to
+ * @param {object}  [opts.payload]      - extra context stored on failure
+ * @param {number}  [opts.maxAttempts]  - max DLQ retry count (default 3)
+ */
+async function runJob(service, jobName, fn, { guildId = null, payload = null, maxAttempts = 3 } = {}) {
+    const start = Date.now();
+    try {
+        await fn();
+        recordServiceRun(service, { success: true, durationMs: Date.now() - start });
+    } catch (error) {
+        const durationMs = Date.now() - start;
+        recordServiceRun(service, { success: false, error: error.message, durationMs });
+
+        console.error(`[JobRunner] ${service}/${jobName} failed:`, error.message);
+
+        try {
+            await FailedJob.create({
+                service,
+                jobName,
+                guildId,
+                payload,
+                errorMessage: error.message,
+                errorStack: error.stack,
+                maxAttempts,
+                lastAttemptAt: new Date(),
+            });
+        } catch (dbErr) {
+            // DLQ write failure must never crash the process
+            console.error(`[JobRunner] Failed to write DLQ entry for ${service}/${jobName}:`, dbErr.message);
+        }
+    }
+}
+
+/**
+ * Retry a pending FailedJob by its _id.
+ * Runs the supplied handler with the stored payload and updates the DLQ record.
+ *
+ * @param {string}   failedJobId  - FailedJob._id
+ * @param {Function} handler      - async fn(payload) to call
+ * @param {string}   resolvedBy   - userId or label for audit trail
+ */
+async function retryJob(failedJobId, handler, resolvedBy = 'system') {
+    const record = await FailedJob.findById(failedJobId);
+    if (!record) throw new Error('FailedJob not found');
+    if (record.status === 'resolved') throw new Error('Job already resolved');
+
+    record.attempts += 1;
+    record.lastAttemptAt = new Date();
+    record.status = 'retrying';
+    await record.save();
+
+    try {
+        await handler(record.payload);
+        record.status = 'resolved';
+        record.resolvedAt = new Date();
+        record.resolvedBy = resolvedBy;
+    } catch (error) {
+        record.errorMessage = error.message;
+        record.errorStack = error.stack;
+        record.status = record.attempts >= record.maxAttempts ? 'exhausted' : 'pending';
+    }
+
+    await record.save();
+    return record;
+}
+
+module.exports = { runJob, retryJob };

--- a/src/utils/jobRunner.js
+++ b/src/utils/jobRunner.js
@@ -53,6 +53,7 @@ async function retryJob(failedJobId, handler, resolvedBy = 'system') {
     const record = await FailedJob.findById(failedJobId);
     if (!record) throw new Error('FailedJob not found');
     if (record.status === 'resolved') throw new Error('Job already resolved');
+    if (record.status === 'exhausted') throw new Error('Job exhausted');
 
     record.attempts += 1;
     record.lastAttemptAt = new Date();


### PR DESCRIPTION
Health checks
- src/health.js: in-process state tracker (mongo status, per-service
  run counts, memory, unhandled-rejection tally)
- GET /health endpoint (200/503) with JSON body; used by the improved
  Docker healthcheck which now reads the status field instead of just
  checking for an HTTP 200

Dead-letter queue (DLQ)
- src/models/FailedJob.js: stores every cron-job failure with service,
  jobName, guildId, error, attempt count, and status
  (pending → retrying → exhausted/resolved)
- src/utils/jobRunner.js: runJob() wraps any async fn, records health,
  and writes to FailedJob on error; retryJob() re-runs a failed entry
  and updates its record; DLQ writes never crash the caller
- All cron handlers (ready.js, summaryService, caseService) now route
  through runJob so every failure is durably recorded

Migration safety rails
- src/models/MigrationRecord.js: tracks which migrations have run
- src/migrations/runner.js: discovers .js files in the migrations dir,
  skips already-applied ones, aborts startup on any failure so a
  partial migration never goes unnoticed
- src/migrations/001_add_indexes.js: adds the indexes that the hot
  cron paths need (reminders, cases, giveaways, summaryjobs, rssfeeds,
  failedjobs)
- runMigrations() is called in startBot() after DB connect, before the
  bot goes online

Process hardening (src/index.js)
- uncaughtException handler: logs and exits (undefined state is unsafe)
- unhandledRejection handler: rate-limited — exits if ≥10 rejections
  occur within 60 s to avoid silent stuck processes
- Graceful SIGTERM/SIGINT shutdown: destroys Discord client, closes
  Mongoose connection
- MongoDB reconnect/disconnect events logged

Backup/restore tooling
- scripts/backup.sh: mongodump to timestamped .gz; falls back to
  docker exec if mongodump isn't local; prunes archives > 30 days
- scripts/restore.sh: mongorestore with interactive confirmation and
  optional --drop flag; same local-or-docker fallback

Docker Compose
- Improved bot healthcheck reads /health JSON status field
- Memory limits (1 GB limit / 256 MB reservation) on bot container
- stop_grace_period: 30s for clean shutdown
- Optional backup service (docker compose --profile backup up)
- Backups volume mounted into bot container for script access

https://claude.ai/code/session_01ButyyxzTQbZQHsWHDqNM7m

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated daily MongoDB backups with 30-day retention
  * Introduced command-line utilities for manual backup and restore operations
  * Added health monitoring endpoint to check system status
  * Implemented failed job tracking for improved visibility into background task execution

* **Bug Fixes**
  * Improved error handling and logging for background jobs and system processes

* **Chores**
  * Enhanced container configuration with resource limits and improved health checks
  * Added database migration system for schema management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->