### PR TITLE
Add Reaction Roles dashboard management

### DIFF
--- a/src/dashboard/routes/api.js
+++ b/src/dashboard/routes/api.js
@@ -188,6 +188,18 @@ router.post('/guild/:guildId/reactionrole/panel', checkAuth, checkGuildAccess, a
     if (!channelId) return res.status(400).json({ error: 'channelId is required' });
     if (!Array.isArray(mappings) || !mappings.length) return res.status(400).json({ error: 'At least one emoji/role mapping is required' });
 
+    for (const m of mappings) {
+        if (!m || typeof m.emoji !== 'string' || !m.emoji.trim() ||
+            typeof m.roleId !== 'string' || !m.roleId.trim()) {
+            return res.status(400).json({ error: 'Each mapping must have a non-empty emoji and roleId' });
+        }
+    }
+
+    const emojiValues = mappings.map(m => m.emoji.trim());
+    if (new Set(emojiValues).size !== emojiValues.length) {
+        return res.status(400).json({ error: 'Duplicate emoji values are not allowed within the same panel' });
+    }
+
     try {
         const guild = req.client.guilds.cache.get(guildId);
         if (!guild) return res.status(404).json({ error: 'Guild not found' });
@@ -195,42 +207,48 @@ router.post('/guild/:guildId/reactionrole/panel', checkAuth, checkGuildAccess, a
         const channel = guild.channels.cache.get(channelId);
         if (!channel) return res.status(404).json({ error: 'Channel not found' });
 
+        const guildSettings = await Guild.findOne({ guildId });
+        if (!guildSettings) return res.status(404).json({ error: 'Guild settings not found' });
+
         const { EmbedBuilder } = require('discord.js');
         const embed = new EmbedBuilder()
             .setColor(0x5865F2)
             .setTitle(title || 'React to get a role!')
             .setDescription(
                 (description ? description + '\n\n' : '') +
-                mappings.map(m => `${m.emoji} — <@&${m.roleId}>`).join('\n')
+                mappings.map(m => `${m.emoji.trim()} — <@&${m.roleId.trim()}>`).join('\n')
             )
             .setFooter({ text: 'React below to assign yourself a role' });
 
         const message = await channel.send({ embeds: [embed] });
 
-        for (const mapping of mappings) {
-            const reactArg = mapping.emoji.match(/^<a?:(\w+):(\d+)>$/)
-                ? mapping.emoji.match(/^<a?:(\w+):(\d+)>$/)[1] + ':' + mapping.emoji.match(/^<a?:(\w+):(\d+)>$/)[2]
-                : mapping.emoji;
-            await message.react(reactArg).catch(() => null);
+        try {
+            for (const mapping of mappings) {
+                const emojiStr = mapping.emoji.trim();
+                const match = emojiStr.match(/^<a?:(\w+):(\d+)>$/);
+                const reactArg = match ? `${match[1]}:${match[2]}` : emojiStr;
+                await message.react(reactArg);
+            }
+
+            for (const mapping of mappings) {
+                guildSettings.reactionRoles.push({
+                    messageId: message.id,
+                    channelId,
+                    emoji: mapping.emoji.trim(),
+                    roleId: mapping.roleId.trim()
+                });
+            }
+
+            await guildSettings.save();
+        } catch (innerError) {
+            await message.delete().catch(() => null);
+            throw innerError;
         }
 
-        const guildSettings = await Guild.findOne({ guildId });
-        if (!guildSettings) return res.status(404).json({ error: 'Guild settings not found' });
-
-        for (const mapping of mappings) {
-            guildSettings.reactionRoles.push({
-                messageId: message.id,
-                channelId,
-                emoji: mapping.emoji,
-                roleId: mapping.roleId
-            });
-        }
-
-        await guildSettings.save();
         res.json({ success: true, messageId: message.id });
     } catch (error) {
         console.error('Reaction role panel create error:', error);
-        res.status(500).json({ error: error.message || 'Internal server error' });
+        res.status(500).json({ error: 'Internal server error' });
     }
 });
 

--- a/src/dashboard/routes/api.js
+++ b/src/dashboard/routes/api.js
@@ -181,6 +181,87 @@ router.delete('/guild/:guildId/autorole/:roleId', checkAuth, checkGuildAccess, a
     }
 });
 
+router.post('/guild/:guildId/reactionrole/panel', checkAuth, checkGuildAccess, async (req, res) => {
+    const { guildId } = req.params;
+    const { channelId, title, description, mappings } = req.body;
+
+    if (!channelId) return res.status(400).json({ error: 'channelId is required' });
+    if (!Array.isArray(mappings) || !mappings.length) return res.status(400).json({ error: 'At least one emoji/role mapping is required' });
+
+    try {
+        const guild = req.client.guilds.cache.get(guildId);
+        if (!guild) return res.status(404).json({ error: 'Guild not found' });
+
+        const channel = guild.channels.cache.get(channelId);
+        if (!channel) return res.status(404).json({ error: 'Channel not found' });
+
+        const { EmbedBuilder } = require('discord.js');
+        const embed = new EmbedBuilder()
+            .setColor(0x5865F2)
+            .setTitle(title || 'React to get a role!')
+            .setDescription(
+                (description ? description + '\n\n' : '') +
+                mappings.map(m => `${m.emoji} — <@&${m.roleId}>`).join('\n')
+            )
+            .setFooter({ text: 'React below to assign yourself a role' });
+
+        const message = await channel.send({ embeds: [embed] });
+
+        for (const mapping of mappings) {
+            const reactArg = mapping.emoji.match(/^<a?:(\w+):(\d+)>$/)
+                ? mapping.emoji.match(/^<a?:(\w+):(\d+)>$/)[1] + ':' + mapping.emoji.match(/^<a?:(\w+):(\d+)>$/)[2]
+                : mapping.emoji;
+            await message.react(reactArg).catch(() => null);
+        }
+
+        const guildSettings = await Guild.findOne({ guildId });
+        if (!guildSettings) return res.status(404).json({ error: 'Guild settings not found' });
+
+        for (const mapping of mappings) {
+            guildSettings.reactionRoles.push({
+                messageId: message.id,
+                channelId,
+                emoji: mapping.emoji,
+                roleId: mapping.roleId
+            });
+        }
+
+        await guildSettings.save();
+        res.json({ success: true, messageId: message.id });
+    } catch (error) {
+        console.error('Reaction role panel create error:', error);
+        res.status(500).json({ error: error.message || 'Internal server error' });
+    }
+});
+
+router.delete('/guild/:guildId/reactionrole/panel/:messageId', checkAuth, checkGuildAccess, async (req, res) => {
+    const { guildId, messageId } = req.params;
+
+    try {
+        const guildSettings = await Guild.findOne({ guildId });
+        if (!guildSettings) return res.status(404).json({ error: 'Guild not found' });
+
+        const entry = guildSettings.reactionRoles.find(r => r.messageId === messageId);
+        if (entry) {
+            const guild = req.client.guilds.cache.get(guildId);
+            if (guild) {
+                const channel = guild.channels.cache.get(entry.channelId);
+                if (channel) {
+                    await channel.messages.fetch(messageId).then(m => m.delete()).catch(() => null);
+                }
+            }
+        }
+
+        guildSettings.reactionRoles = guildSettings.reactionRoles.filter(r => r.messageId !== messageId);
+        await guildSettings.save();
+
+        res.json({ success: true });
+    } catch (error) {
+        console.error('Reaction role panel delete error:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
 router.post('/guild/:guildId/rss/add', checkAuth, checkGuildAccess, async (req, res) => {
     const { guildId } = req.params;
     const { url, channelId } = req.body;

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -46,6 +46,7 @@
                 <button class="nav-item" data-tab="quests"><span class="nav-emoji">🗺️</span> Quests</button>
                 <button class="nav-item" data-tab="starboard"><span class="nav-emoji">⭐</span> Starboard</button>
                 <button class="nav-item" data-tab="suggestions"><span class="nav-emoji">💡</span> Suggestions</button>
+                <button class="nav-item" data-tab="reactionroles"><span class="nav-emoji">🎭</span> Reaction Roles</button>
 
                 <!-- Tools & Support -->
                 <div class="nav-section-header">Tools &amp; Support</div>
@@ -715,6 +716,80 @@
                     </div>
                     <div class="actions-row">
                         <button class="btn btn-primary" onclick="saveSettings('suggestions')">Save changes</button>
+                    </div>
+                </section>
+
+                <!-- Reaction Roles -->
+                <section id="reactionroles" class="panel">
+                    <div class="panel-head">
+                        <h2>Reaction Roles</h2>
+                        <p>Let members self-assign roles by reacting to a message you publish in any channel. No commands needed.</p>
+                    </div>
+
+                    <div class="panel-head" style="margin-top:.5rem"><h3>Active panels</h3></div>
+                    <div id="rr-panels-list">
+                        <%
+                        const rrMap = {};
+                        (settings.reactionRoles || []).forEach(function(rr) {
+                            if (!rrMap[rr.messageId]) rrMap[rr.messageId] = { channelId: rr.channelId, mappings: [] };
+                            rrMap[rr.messageId].mappings.push({ emoji: rr.emoji, roleId: rr.roleId });
+                        });
+                        const rrPanels = Object.entries(rrMap);
+                        %>
+                        <% if (!rrPanels.length) { %>
+                            <p style="color:var(--text-dim);font-size:.88rem;padding:.25rem 0">No reaction role panels yet — create one below.</p>
+                        <% } else { %>
+                            <% rrPanels.forEach(function([messageId, panel]) { %>
+                                <% const panelChannel = channels.find(function(c) { return c.id === panel.channelId; }); %>
+                                <div class="store-card">
+                                    <div class="store-card-body">
+                                        <div class="store-card-name">#<%= panelChannel ? panelChannel.name : panel.channelId %></div>
+                                        <div style="margin-top:.35rem;display:flex;flex-wrap:wrap;gap:.35rem;">
+                                            <% panel.mappings.forEach(function(m) { %>
+                                                <% const mappingRole = roles.find(function(r) { return r.id === m.roleId; }); %>
+                                                <span class="store-meta-tag role-meta"><%= m.emoji %> → @<%= mappingRole ? mappingRole.name : m.roleId %></span>
+                                            <% }); %>
+                                        </div>
+                                        <div style="margin-top:.4rem;font-size:.78rem;color:var(--text-dim)">Message ID: <%= messageId %></div>
+                                    </div>
+                                    <div class="store-card-actions">
+                                        <button class="btn btn-sm btn-danger" onclick="deleteRrPanel('<%= messageId %>')">Delete panel</button>
+                                    </div>
+                                </div>
+                            <% }); %>
+                        <% } %>
+                    </div>
+
+                    <div class="panel-head" style="margin-top:1.5rem">
+                        <h3>Create new panel</h3>
+                        <p>The bot will post an embed to your chosen channel and add the reactions automatically.</p>
+                    </div>
+                    <div class="field">
+                        <label class="field-label" for="rr-channel">Target channel</label>
+                        <select id="rr-channel">
+                            <option value="">Select a channel</option>
+                            <% channels.forEach(function(channel) { %>
+                                <option value="<%= channel.id %>">#<%= channel.name %></option>
+                            <% }); %>
+                        </select>
+                    </div>
+                    <div class="field">
+                        <label class="field-label" for="rr-title">Embed title</label>
+                        <input type="text" id="rr-title" placeholder="React to get a role!" maxlength="256">
+                    </div>
+                    <div class="field">
+                        <label class="field-label" for="rr-description">Embed description <small style="font-weight:400">(optional)</small></label>
+                        <textarea id="rr-description" rows="3" placeholder="Click a reaction below to assign yourself a role."></textarea>
+                        <small>The emoji → role list is appended automatically below your description.</small>
+                    </div>
+                    <div class="field">
+                        <label class="field-label">Emoji → Role mappings</label>
+                        <div id="rr-mappings-list" style="display:flex;flex-direction:column;gap:.5rem;margin-bottom:.5rem;"></div>
+                        <button class="btn btn-sm" type="button" onclick="addRrMapping()">+ Add mapping</button>
+                        <small style="display:block;margin-top:.4rem">Use a standard emoji (e.g. <code>👍</code>) or a custom Discord emoji (<code>&lt;:name:id&gt;</code>).</small>
+                    </div>
+                    <div class="actions-row">
+                        <button class="btn btn-primary" onclick="publishRrPanel()">Publish to channel</button>
                     </div>
                 </section>
 
@@ -1579,6 +1654,78 @@
             if (e.target.id === 'item-modal') closeItemModal();
             if (e.target.id === 'job-modal') closeJobModal();
         });
+
+        // ── Reaction Roles ─────────────────────────────────────────────────────────
+        var rrRoles = <%- JSON.stringify(roles || []) %>;
+
+        function addRrMapping() {
+            var list = document.getElementById('rr-mappings-list');
+            var row = document.createElement('div');
+            row.style.cssText = 'display:grid;grid-template-columns:1fr 2fr auto;gap:.5rem;align-items:center;';
+            row.innerHTML =
+                '<input type="text" placeholder="Emoji (e.g. 👍)" class="rr-emoji" style="font-size:1.1rem;">' +
+                '<select class="rr-role"><option value="">Select role</option>' +
+                rrRoles.map(function(r) { return '<option value="' + r.id + '">@' + escHtml(r.name) + '</option>'; }).join('') +
+                '</select>' +
+                '<button class="btn btn-sm btn-danger" type="button" onclick="this.parentElement.remove()">×</button>';
+            list.appendChild(row);
+        }
+
+        async function publishRrPanel() {
+            var channelId = document.getElementById('rr-channel').value;
+            if (!channelId) { toast('Select a target channel', 'error'); return; }
+
+            var rows = document.querySelectorAll('#rr-mappings-list > div');
+            var mappings = [];
+            rows.forEach(function(row) {
+                var emoji = row.querySelector('.rr-emoji').value.trim();
+                var roleId = row.querySelector('.rr-role').value;
+                if (emoji && roleId) mappings.push({ emoji: emoji, roleId: roleId });
+            });
+
+            if (!mappings.length) { toast('Add at least one emoji → role mapping', 'error'); return; }
+
+            var guildId = '<%= guild.id %>';
+            try {
+                var response = await fetch('/api/guild/' + guildId + '/reactionrole/panel', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        channelId: channelId,
+                        title: document.getElementById('rr-title').value.trim() || null,
+                        description: document.getElementById('rr-description').value.trim() || null,
+                        mappings: mappings
+                    })
+                });
+                var data = await response.json();
+                if (response.ok) {
+                    toast('Panel published ✓', 'success');
+                    setTimeout(function() { location.reload(); }, 800);
+                } else {
+                    toast(data.error || 'Failed to publish panel', 'error');
+                }
+            } catch (error) {
+                console.error(error);
+                toast('An error occurred', 'error');
+            }
+        }
+
+        async function deleteRrPanel(messageId) {
+            if (!confirm('Delete this reaction role panel? The Discord message will also be deleted.')) return;
+            var guildId = '<%= guild.id %>';
+            try {
+                var response = await fetch('/api/guild/' + guildId + '/reactionrole/panel/' + messageId, { method: 'DELETE' });
+                if (response.ok) {
+                    toast('Panel deleted ✓', 'success');
+                    setTimeout(function() { location.reload(); }, 600);
+                } else {
+                    toast('Failed to delete panel', 'error');
+                }
+            } catch (error) {
+                console.error(error);
+                toast('An error occurred', 'error');
+            }
+        }
 
         async function loadAnalytics() {
             const guildId = '<%= guild.id %>';

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -1656,7 +1656,7 @@
         });
 
         // ── Reaction Roles ─────────────────────────────────────────────────────────
-        var rrRoles = <%- JSON.stringify(roles || []) %>;
+        var rrRoles = <%- JSON.stringify(roles || []).replace(/</g, '\\u003c').replace(/>/g, '\\u003e') %>;
 
         function addRrMapping() {
             var list = document.getElementById('rr-mappings-list');


### PR DESCRIPTION
Admins can now create and manage reaction role panels entirely from
the dashboard — no slash commands required. The bot posts a branded
embed to the chosen channel, auto-adds the configured reactions, and
immediately starts assigning/removing roles when members react.

- POST /api/guild/:id/reactionrole/panel — send embed, react, save DB entries
- DELETE /api/guild/:id/reactionrole/panel/:messageId — remove panel + Discord message
- New "Reaction Roles" tab in guild settings sidebar (Engagement section)
- Active panels listed with channel, emoji→role mappings, and delete button
- Create form: channel picker, embed title/description, dynamic emoji→role rows

https://claude.ai/code/session_01WiSbeVPEv5ZEVNw1ihE7oe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Reaction-role panel creation now available in guild settings with flexible channel selection
* Configure custom emoji-to-role mappings and customize panels with titles and descriptions
* View all existing panels displaying their emoji-role associations and delete them as needed
* Robust validation and error handling throughout with user-friendly notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->