### PR TITLE
Add command policy engine with contextual allow/deny and cooldown overrides

### DIFF
--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -55,6 +55,51 @@ async function trackQuestCommandUse(interaction) {
     }
 }
 
+function memberHasAnyRole(member, roleIds = []) {
+    if (!member || !Array.isArray(roleIds) || roleIds.length === 0) return false;
+    return roleIds.some(roleId => member.roles?.cache?.has(roleId));
+}
+
+function isWithinRuleWindow(rule, now) {
+    const day = now.getUTCDay();
+    const hour = now.getUTCHours();
+    if (Array.isArray(rule.daysOfWeek) && rule.daysOfWeek.length > 0 && !rule.daysOfWeek.includes(day)) {
+        return false;
+    }
+    if (rule.startHourUtc == null || rule.endHourUtc == null) return true;
+    if (rule.startHourUtc <= rule.endHourUtc) {
+        return hour >= rule.startHourUtc && hour <= rule.endHourUtc;
+    }
+    return hour >= rule.startHourUtc || hour <= rule.endHourUtc;
+}
+
+function getPolicyDecision(interaction, guildSettings) {
+    const policies = guildSettings?.commandPolicies;
+    if (!policies?.enabled) return { allowed: true };
+    if (policies.exceptions?.userIds?.includes(interaction.user.id)) return { allowed: true };
+    if (memberHasAnyRole(interaction.member, policies.exceptions?.roleIds)) return { allowed: true };
+
+    const cmd = interaction.commandName;
+    const now = new Date();
+    const applicableRules = (policies.rules || []).filter(rule => {
+        if (rule.command !== cmd && rule.command !== '*') return false;
+        if (Array.isArray(rule.roleIds) && rule.roleIds.length > 0 && !memberHasAnyRole(interaction.member, rule.roleIds)) return false;
+        if (Array.isArray(rule.channelIds) && rule.channelIds.length > 0 && !rule.channelIds.includes(interaction.channelId)) return false;
+        return isWithinRuleWindow(rule, now);
+    });
+    const denied = applicableRules.find(rule => rule.effect === 'deny');
+    if (denied) return { allowed: false, reason: 'This command is blocked by server policy for your context.' };
+    return { allowed: true };
+}
+
+function getCooldownSeconds(command, interaction, guildSettings) {
+    const defaultCooldownDuration = command.cooldown ?? 3;
+    const overrides = guildSettings?.commandPolicies?.cooldownOverrides || [];
+    const matches = overrides.filter(entry => entry.command === command.data.name && interaction.member?.roles?.cache?.has(entry.roleId));
+    if (!matches.length) return defaultCooldownDuration;
+    return Math.min(...matches.map(match => match.cooldownSeconds));
+}
+
 module.exports = {
     name: 'interactionCreate',
     async execute(interaction, client) {
@@ -85,6 +130,7 @@ module.exports = {
         }
 
         if (!interaction.isChatInputCommand()) return;
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
 
         const command = client.commands.get(interaction.commandName);
 
@@ -92,6 +138,12 @@ module.exports = {
             console.error(`No command matching ${interaction.commandName} was found.`);
             await logCommandMetric(interaction, false, 'unknown_command');
             return;
+        }
+
+        const policy = getPolicyDecision(interaction, guildSettings);
+        if (!policy.allowed) {
+            await logCommandMetric(interaction, false, 'policy_denied');
+            return interaction.reply({ content: policy.reason, ephemeral: true });
         }
 
         const { cooldowns } = client;
@@ -102,8 +154,7 @@ module.exports = {
 
         const now = Date.now();
         const timestamps = cooldowns.get(command.data.name);
-        const defaultCooldownDuration = 3;
-        const cooldownAmount = (command.cooldown ?? defaultCooldownDuration) * 1000;
+        const cooldownAmount = getCooldownSeconds(command, interaction, guildSettings) * 1000;
 
         if (timestamps.has(interaction.user.id)) {
             const expirationTime = timestamps.get(interaction.user.id) + cooldownAmount;

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -383,6 +383,28 @@ const guildSchema = new Schema({
         downvoteEmoji: { type: String, default: '👎' }
     },
 
+    commandPolicies: {
+        enabled: { type: Boolean, default: false },
+        exceptions: {
+            userIds: [{ type: String }],
+            roleIds: [{ type: String }]
+        },
+        rules: [{
+            command: { type: String, required: true },
+            effect: { type: String, enum: ['allow', 'deny'], default: 'allow' },
+            roleIds: [{ type: String }],
+            channelIds: [{ type: String }],
+            daysOfWeek: [{ type: Number, min: 0, max: 6 }],
+            startHourUtc: { type: Number, min: 0, max: 23, default: null },
+            endHourUtc: { type: Number, min: 0, max: 23, default: null }
+        }],
+        cooldownOverrides: [{
+            command: { type: String, required: true },
+            roleId: { type: String, required: true },
+            cooldownSeconds: { type: Number, min: 0, default: 3 }
+        }]
+    },
+
     bibleVerse: {
         enabled: { type: Boolean, default: false },
         channelId: { type: String, default: null },


### PR DESCRIPTION
### Motivation
- Provide a richer, server-configurable policy system to allow/deny commands by role/channel/time and to support per-role cooldown adjustments for better governance.
- Allow server admins to exempt specific users/roles from policy enforcement and to express simple rule-based policies without changing command code.

### Description
- Added a new `commandPolicies` section to the Guild schema in `src/models/Guild.js` with `enabled`, `exceptions` (`userIds`, `roleIds`), `rules` (per-command allow/deny with role/channel/day/hour windowing), and `cooldownOverrides` (per-command per-role cooldowns).
- Implemented helper functions in `src/events/interactionCreate.js`: `memberHasAnyRole`, `isWithinRuleWindow`, `getPolicyDecision`, and `getCooldownSeconds` to evaluate policies and role-based cooldowns at runtime.
- Integrated policy evaluation into the command dispatch flow so policy checks run before execution and rejected commands are logged with reason `policy_denied` via `logCommandMetric`.
- Replaced the fixed cooldown resolution with a role-aware lookup so the lowest matching override wins while preserving existing per-command cooldown map behavior.

### Testing
- Ran syntax checks with `node --check src/events/interactionCreate.js` and `node --check src/models/Guild.js`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ee5e0e94832587043ad6ea626e31)