### PR TITLE
Add tiered /work progression with shift-based promotions

### DIFF
--- a/src/commands/economy/work.js
+++ b/src/commands/economy/work.js
@@ -34,29 +34,56 @@ module.exports = {
 
             const workMin = guildSettings?.economy.workMin || 50;
             const workMax = guildSettings?.economy.workMax || 150;
-            const earned = Math.floor(Math.random() * (workMax - workMin + 1)) + workMin;
 
-            const defaultJobs = [
-                'developer', 'designer', 'teacher', 'chef', 'driver',
-                'doctor', 'engineer', 'artist', 'musician', 'writer'
+            const jobTiers = [
+                { name: 'Intern', minShifts: 0, payMultiplier: 1, jobs: ['assistant', 'cashier', 'dishwasher', 'courier'] },
+                { name: 'Skilled Worker', minShifts: 10, payMultiplier: 1.2, jobs: ['developer', 'designer', 'teacher', 'chef', 'driver'] },
+                { name: 'Senior Specialist', minShifts: 25, payMultiplier: 1.45, jobs: ['engineer', 'artist', 'musician', 'writer', 'analyst'] },
+                { name: 'Executive', minShifts: 50, payMultiplier: 1.8, jobs: ['director', 'architect', 'surgeon', 'producer', 'founder'] }
             ];
+
+            const currentShifts = user.shiftsWorked || 0;
+            const activeTier = [...jobTiers].reverse().find(tier => currentShifts >= tier.minShifts) || jobTiers[0];
+            const nextTier = jobTiers.find(tier => tier.minShifts > currentShifts);
+
+            const tierMin = Math.floor(workMin * activeTier.payMultiplier);
+            const tierMax = Math.floor(workMax * activeTier.payMultiplier);
+            const earned = Math.floor(Math.random() * (tierMax - tierMin + 1)) + tierMin;
+
             const guildJobs = guildSettings?.jobs?.length > 0
                 ? guildSettings.jobs.map(j => j.emoji ? `${j.emoji} ${j.name}` : j.name)
-                : defaultJobs;
+                : activeTier.jobs;
             const job = guildJobs[Math.floor(Math.random() * guildJobs.length)];
 
             user.balance += earned;
+            user.shiftsWorked = currentShifts + 1;
             user.lastWork = new Date();
             await user.save();
+
+            const leveledUpTier = jobTiers.find(tier => tier.minShifts === user.shiftsWorked);
 
             const embed = new EmbedBuilder()
                 .setColor('#00ff00')
                 .setTitle('Work Complete!')
                 .setDescription(`You worked as a **${job}** and earned **${earned}** coins!`)
                 .addFields(
-                    { name: 'New Balance', value: `${user.balance.toLocaleString()} coins` }
+                    { name: 'Career Tier', value: `${activeTier.name} (${user.shiftsWorked.toLocaleString()} shifts worked)` },
+                    { name: 'New Balance', value: `${user.balance.toLocaleString()} coins` },
+                    {
+                        name: 'Next Promotion',
+                        value: nextTier
+                            ? `${nextTier.name} in **${(nextTier.minShifts - user.shiftsWorked).toLocaleString()}** shifts`
+                            : 'You have reached the highest career tier!'
+                    }
                 )
                 .setTimestamp();
+
+            if (leveledUpTier && leveledUpTier.minShifts > 0) {
+                embed.addFields({
+                    name: '🎉 Promotion Unlocked!',
+                    value: `You advanced to **${leveledUpTier.name}** and now earn higher pay per shift!`
+                });
+            }
 
             await interaction.reply({ embeds: [embed] });
         } catch (error) {

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -14,6 +14,7 @@ const userSchema = new Schema({
     lastDaily: { type: Date, default: null },
     lastWork: { type: Date, default: null },
     lastWheelSpin: { type: Date, default: null },
+    shiftsWorked: { type: Number, default: 0 },
 
     inventory: [{
         itemId: { type: String, required: true },


### PR DESCRIPTION
### Motivation

- Replace the purely-random `/work` job selection with a repeatable progression so users unlock better-paying jobs by working multiple shifts.
- Give players visible career progression and clear promotion milestones to encourage continued engagement.

### Description

- Add `shiftsWorked` to the `User` schema to persist per-user shift counts (`src/models/User.js`).
- Implement job tiers in `/work` with thresholds (0/10/25/50), tier-specific job pools, and pay multipliers that scale `workMin`/`workMax` (`src/commands/economy/work.js`).
- Preserve guild-custom job lists when configured, increment `shiftsWorked` on each successful work, detect promotions and compute the next promotion distance.
- Enhance the result embed to display current career tier, shifts worked, next promotion progress, new balance, and a promotion-unlocked message when a tier is reached.

### Testing

- Ran `node --check src/commands/economy/work.js` and it completed successfully. 
- Ran `node --check src/models/User.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f05da0cc8325afd734fef70e62a5)