### PR TITLE
Add birthdays feature: models, service, slash command and dashboard UI

### DIFF
--- a/src/commands/utility/birthday.js
+++ b/src/commands/utility/birthday.js
@@ -1,0 +1,120 @@
+const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const User = require('../../models/User');
+
+function isValidDate(month, day, year) {
+    const d = new Date(Date.UTC(year || 2000, month - 1, day));
+    return d.getUTCMonth() + 1 === month && d.getUTCDate() === day;
+}
+
+function formatBirthday(birthday) {
+    if (!birthday?.month || !birthday?.day) return 'Not set';
+    return `${birthday.month}/${birthday.day}${birthday.year ? `/${birthday.year}` : ''}`;
+}
+
+function daysUntilBirthday(month, day, now) {
+    const current = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+    let next = new Date(Date.UTC(now.getUTCFullYear(), month - 1, day));
+    if (next < current) next = new Date(Date.UTC(now.getUTCFullYear() + 1, month - 1, day));
+    return Math.round((next - current) / 86400000);
+}
+
+async function upsertBirthday(guildId, userId, month, day, year) {
+    let user = await User.findOne({ guildId, userId });
+    if (!user) user = await User.create({ guildId, userId });
+    user.birthday = {
+        ...(user.birthday || {}),
+        month,
+        day,
+        year: year || null,
+        lastCelebratedYear: null
+    };
+    await user.save();
+}
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('birthday')
+        .setDescription('Manage birthdays')
+        .addSubcommand(sub => sub
+            .setName('add')
+            .setDescription('Add your birthday')
+            .addIntegerOption(o => o.setName('month').setDescription('Month (1-12)').setRequired(true).setMinValue(1).setMaxValue(12))
+            .addIntegerOption(o => o.setName('day').setDescription('Day').setRequired(true).setMinValue(1).setMaxValue(31))
+            .addIntegerOption(o => o.setName('year').setDescription('Birth year (optional)').setMinValue(1900).setMaxValue(2100)))
+        .addSubcommand(sub => sub
+            .setName('set')
+            .setDescription('Set another member birthday')
+            .addUserOption(o => o.setName('user').setDescription('Member').setRequired(true))
+            .addIntegerOption(o => o.setName('month').setDescription('Month (1-12)').setRequired(true).setMinValue(1).setMaxValue(12))
+            .addIntegerOption(o => o.setName('day').setDescription('Day').setRequired(true).setMinValue(1).setMaxValue(31))
+            .addIntegerOption(o => o.setName('year').setDescription('Birth year (optional)').setMinValue(1900).setMaxValue(2100)))
+        .addSubcommand(sub => sub
+            .setName('remove')
+            .setDescription('Remove your birthday'))
+        .addSubcommand(sub => sub
+            .setName('removeuser')
+            .setDescription('Remove another member birthday')
+            .addUserOption(o => o.setName('user').setDescription('Member').setRequired(true)))
+        .addSubcommand(sub => sub
+            .setName('show')
+            .setDescription('Show birthday for yourself or another member')
+            .addUserOption(o => o.setName('user').setDescription('Member').setRequired(false)))
+        .addSubcommand(sub => sub
+            .setName('next')
+            .setDescription('Show next 5 upcoming birthdays')),
+
+    async execute(interaction) {
+        const sub = interaction.options.getSubcommand();
+
+        if (sub === 'add' || sub === 'set') {
+            const target = sub === 'set' ? interaction.options.getUser('user', true) : interaction.user;
+            if (sub === 'set' && !interaction.memberPermissions.has(PermissionFlagsBits.ManageGuild)) {
+                return interaction.reply({ content: 'You need Manage Server to set another member birthday.', ephemeral: true });
+            }
+
+            const month = interaction.options.getInteger('month', true);
+            const day = interaction.options.getInteger('day', true);
+            const year = interaction.options.getInteger('year');
+            if (!isValidDate(month, day, year || 2000)) {
+                return interaction.reply({ content: 'Invalid date provided.', ephemeral: true });
+            }
+
+            await upsertBirthday(interaction.guild.id, target.id, month, day, year);
+            return interaction.reply({ content: `✅ Birthday saved for ${target}: ${month}/${day}${year ? `/${year}` : ''}`, ephemeral: true });
+        }
+
+        if (sub === 'remove' || sub === 'removeuser') {
+            const target = sub === 'removeuser' ? interaction.options.getUser('user', true) : interaction.user;
+            if (sub === 'removeuser' && !interaction.memberPermissions.has(PermissionFlagsBits.ManageGuild)) {
+                return interaction.reply({ content: 'You need Manage Server to remove another member birthday.', ephemeral: true });
+            }
+
+            const user = await User.findOne({ userId: target.id, guildId: interaction.guild.id });
+            if (!user) return interaction.reply({ content: `No birthday found for ${target}.`, ephemeral: true });
+            user.birthday = { month: null, day: null, year: null, lastCelebratedYear: null };
+            await user.save();
+            return interaction.reply({ content: `✅ Birthday removed for ${target}.`, ephemeral: true });
+        }
+
+        if (sub === 'show') {
+            const target = interaction.options.getUser('user') || interaction.user;
+            const user = await User.findOne({ userId: target.id, guildId: interaction.guild.id });
+            if (!user?.birthday?.month || !user?.birthday?.day) {
+                return interaction.reply({ content: `No birthday is set for ${target}.`, ephemeral: true });
+            }
+            return interaction.reply({ content: `🎂 ${target}'s birthday: ${formatBirthday(user.birthday)}`, ephemeral: true });
+        }
+
+        const all = await User.find({ guildId: interaction.guild.id, 'birthday.month': { $ne: null }, 'birthday.day': { $ne: null } });
+        if (!all.length) return interaction.reply({ content: 'No birthdays have been set yet.', ephemeral: true });
+
+        const now = new Date();
+        const ranked = all
+            .map(u => ({ ...u.toObject(), daysLeft: daysUntilBirthday(u.birthday.month, u.birthday.day, now) }))
+            .sort((a, b) => a.daysLeft - b.daysLeft)
+            .slice(0, 5);
+
+        const lines = ranked.map((u, i) => `${i + 1}. <@${u.userId}> — ${formatBirthday(u.birthday)} (${u.daysLeft} day${u.daysLeft === 1 ? '' : 's'})`);
+        return interaction.reply({ content: `🎉 **Next 5 Birthdays**\n${lines.join('\n')}`, ephemeral: true });
+    }
+};

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -35,6 +35,10 @@
                 <button class="nav-item" data-tab="leveling"><span class="nav-emoji">📈</span> Leveling</button>
                 <button class="nav-item active" data-tab="welcome"><span class="nav-emoji">👋</span> Welcome</button>
 
+                
+
+                <button class="nav-item" data-tab="birthdays"><span class="nav-emoji">🎂</span> Birthdays</button>
+
                 <!-- Moderation -->
                 <div class="nav-section-header">Moderation</div>
                 <button class="nav-item" data-tab="moderation"><span class="nav-emoji">🛡️</span> Moderation</button>
@@ -158,6 +162,48 @@
                     </div>
                     <div class="actions-row">
                         <button class="btn btn-primary" onclick="saveSettings('farewell')">Save changes</button>
+                    </div>
+                </section>
+
+                <!-- Birthdays -->
+                <section id="birthdays" class="panel">
+                    <div class="panel-head">
+                        <h2>Birthday Settings</h2>
+                        <p>Configure automated birthday wishes and birthday role assignment.</p>
+                    </div>
+                    <label class="toggle">
+                        <span class="toggle-text"><strong>Enable birthday system</strong><span>Send automated birthday wishes</span></span>
+                        <span class="switch"><input type="checkbox" id="birthday-enabled" <%= settings.birthdays?.enabled ? 'checked' : '' %>><span class="slider"></span></span>
+                    </label>
+                    <div class="field">
+                        <label class="field-label" for="birthday-channel">Happy birthday wishing channel</label>
+                        <select id="birthday-channel">
+                            <option value="">Select a channel</option>
+                            <% channels.forEach(channel => { %>
+                                <option value="<%= channel.id %>" <%= settings.birthdays?.channelId === channel.id ? 'selected' : '' %>>#<%= channel.name %></option>
+                            <% }); %>
+                        </select>
+                    </div>
+                    <div class="field">
+                        <label class="field-label" for="birthday-hour">Happy birthday wishing hour (UTC)</label>
+                        <input type="number" id="birthday-hour" min="0" max="23" value="<%= settings.birthdays?.wishingHourUtc ?? 9 %>">
+                    </div>
+                    <div class="field">
+                        <label class="field-label" for="birthday-role">Birthday role</label>
+                        <select id="birthday-role">
+                            <option value="">No birthday role</option>
+                            <% roles.forEach(role => { %>
+                                <option value="<%= role.id %>" <%= settings.birthdays?.roleId === role.id ? 'selected' : '' %>>@<%= role.name %></option>
+                            <% }); %>
+                        </select>
+                    </div>
+                    <div class="field">
+                        <label class="field-label" for="birthday-message">Birthday message template</label>
+                        <textarea id="birthday-message" rows="2"><%= settings.birthdays?.message || "It's the birthday of {user} ({age}) ! 🎂" %></textarea>
+                        <small>Variables: <code>{user}</code> · <code>{age}</code></small>
+                    </div>
+                    <div class="actions-row">
+                        <button class="btn btn-primary" onclick="saveSettings('birthdays')">Save changes</button>
                     </div>
                 </section>
 
@@ -1236,6 +1282,14 @@
                     'farewell.enabled': document.getElementById('farewell-enabled').checked,
                     'farewell.channelId': document.getElementById('farewell-channel').value,
                     'farewell.message': document.getElementById('farewell-message').value
+                };
+            } else if (section === 'birthdays') {
+                data = {
+                    'birthdays.enabled': document.getElementById('birthday-enabled').checked,
+                    'birthdays.channelId': document.getElementById('birthday-channel').value || null,
+                    'birthdays.wishingHourUtc': parseInt(document.getElementById('birthday-hour').value, 10) || 9,
+                    'birthdays.roleId': document.getElementById('birthday-role').value || null,
+                    'birthdays.message': document.getElementById('birthday-message').value || "It's the birthday of {user} ({age}) ! 🎂"
                 };
             } else if (section === 'moderation') {
                 const immunityRoleIds = Array.from(document.getElementById('mod-immunity-roles').selectedOptions).map(o => o.value);

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -4,6 +4,7 @@ const { checkRssFeeds, scheduleDailyNews } = require('../services/rssService');
 const { checkReminders } = require('../services/reminderService');
 const { checkGiveaways } = require('../services/giveawayService');
 const { checkTempVoice } = require('../services/tempVoiceService');
+const { checkBirthdays } = require('../services/birthdayService');
 const { runJob } = require('../utils/jobRunner');
 
 module.exports = {
@@ -41,6 +42,10 @@ module.exports = {
 
         cron.schedule('*/2 * * * *', () =>
             runJob('tempVoiceService', 'checkTempVoice', () => checkTempVoice(client))
+        );
+
+        cron.schedule('0 * * * *', () =>
+            runJob('birthdayService', 'checkBirthdays', () => checkBirthdays(client))
         );
 
         console.log('[READY] Background services started');

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -46,6 +46,14 @@ const guildSchema = new Schema({
         channelId: { type: String, default: null },
         message: { type: String, default: 'Goodbye {user}!' }
     },
+
+    birthdays: {
+        enabled: { type: Boolean, default: false },
+        channelId: { type: String, default: null },
+        wishingHourUtc: { type: Number, default: 9, min: 0, max: 23 },
+        roleId: { type: String, default: null },
+        message: { type: String, default: "It's the birthday of {user} ({age}) ! 🎂" }
+    },
     
     moderation: {
         enabled: { type: Boolean, default: true },

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -63,6 +63,13 @@ const userSchema = new Schema({
     dailyMessages: { type: Number, default: 0 },
     lastDailyReset: { type: Date, default: null },
 
+    birthday: {
+        month: { type: Number, min: 1, max: 12, default: null },
+        day: { type: Number, min: 1, max: 31, default: null },
+        year: { type: Number, min: 1900, max: 2100, default: null },
+        lastCelebratedYear: { type: Number, default: null }
+    },
+
     createdAt: { type: Date, default: Date.now },
     updatedAt: { type: Date, default: Date.now }
 });

--- a/src/services/birthdayService.js
+++ b/src/services/birthdayService.js
@@ -1,0 +1,61 @@
+const Guild = require('../models/Guild');
+const User = require('../models/User');
+
+function calculateAge(year, now) {
+    if (!year) return null;
+    const age = now.getUTCFullYear() - year;
+    return age > 0 ? age : null;
+}
+
+async function checkBirthdays(client) {
+    const now = new Date();
+    const month = now.getUTCMonth() + 1;
+    const day = now.getUTCDate();
+    const hour = now.getUTCHours();
+
+    const guilds = await Guild.find({
+        'birthdays.enabled': true,
+        'birthdays.channelId': { $ne: null },
+        'birthdays.wishingHourUtc': hour
+    });
+
+    for (const settings of guilds) {
+        const guild = client.guilds.cache.get(settings.guildId);
+        if (!guild) continue;
+
+        const channel = guild.channels.cache.get(settings.birthdays.channelId);
+        if (!channel || !channel.isTextBased()) continue;
+
+        const users = await User.find({
+            guildId: settings.guildId,
+            'birthday.month': month,
+            'birthday.day': day,
+            $or: [
+                { 'birthday.lastCelebratedYear': { $ne: now.getUTCFullYear() } },
+                { 'birthday.lastCelebratedYear': { $exists: false } }
+            ]
+        });
+
+        for (const u of users) {
+            const member = await guild.members.fetch(u.userId).catch(() => null);
+            if (!member) continue;
+
+            const age = calculateAge(u.birthday?.year, now);
+            const template = settings.birthdays.message || "It's the birthday of {user} ({age}) ! 🎂";
+            const content = template
+                .replace(/{user}/g, `<@${u.userId}>`)
+                .replace(/{age}/g, age ? String(age) : '?');
+
+            await channel.send({ content }).catch(() => null);
+
+            if (settings.birthdays.roleId && member.roles.cache.has(settings.birthdays.roleId) === false) {
+                await member.roles.add(settings.birthdays.roleId).catch(() => null);
+            }
+
+            u.birthday.lastCelebratedYear = now.getUTCFullYear();
+            await u.save();
+        }
+    }
+}
+
+module.exports = { checkBirthdays };


### PR DESCRIPTION
### Motivation

- Add a birthday system to record user birthdays, send automated birthday wishes, and optionally assign a birthday role. 
- Provide server-level configuration for birthday messaging and scheduling via the dashboard and a slash command interface.

### Description

- Introduce a `birthday` field on the `User` model and a `birthdays` config block on the `Guild` model to persist birthday data and guild settings. 
- Add a new `birthdayService` with `checkBirthdays` to scan enabled guilds hourly and post birthday messages, assign a role, and mark `lastCelebratedYear`. 
- Register a new `/birthday` slash command (`src/commands/utility/birthday.js`) with subcommands to `add`, `set`, `remove`, `removeuser`, `show`, and `next` for managing and viewing birthdays. 
- Schedule the birthday job in `ready.js` to run hourly and update the dashboard view `guild-settings.ejs` to include a Birthdays settings panel and saving logic in `saveSettings` for `birthdays` options.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f2525ed083259dd6ec2d8f37f7d2)