### PR TITLE
Add rate limiting, per-channel AI limits, and spam defense fixes

### DIFF
--- a/src/commands/ai/ai.js
+++ b/src/commands/ai/ai.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const { getChatCompletion } = require('../../services/aiService');
+const { getCompletion, resolveProviderConfig, checkRateLimit, checkChannelRateLimit } = require('../../services/aiService');
 const Guild = require('../../models/Guild');
 
 module.exports = {
@@ -18,19 +18,39 @@ module.exports = {
 
         try {
             const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
-            const provider = guildSettings?.ai.provider || 'openai';
-            const apiKey = provider === 'openai' ? guildSettings?.ai.openaiKey : guildSettings?.ai.geminiKey;
-            
-            const response = await getChatCompletion(prompt, 'You are a helpful Discord bot assistant.', provider, apiKey);
-            
-            if (response.length > 2000) {
-                await interaction.editReply(response.substring(0, 1997) + '...');
+            const ai = guildSettings?.ai || {};
+
+            if (!ai.enabled) {
+                return interaction.editReply('AI is not enabled for this server. Enable it in the dashboard.');
+            }
+
+            if (!checkRateLimit(interaction.user.id, ai.rateLimitPerUser, ai.rateLimitWindowMin)) {
+                return interaction.editReply(`Rate limit reached (${ai.rateLimitPerUser} per ${ai.rateLimitWindowMin}m). Please slow down.`);
+            }
+
+            if (!checkChannelRateLimit(interaction.channelId, ai.rateLimitPerChannel, ai.rateLimitWindowMin)) {
+                return interaction.editReply('This channel has reached the AI request limit. Please wait before sending more AI requests here.');
+            }
+
+            const { provider, model, apiKey, baseUrl, temperature, maxTokens } = resolveProviderConfig(ai);
+
+            if (provider !== 'ollama' && !apiKey) {
+                return interaction.editReply('AI API key is not configured. Add one in the dashboard.');
+            }
+
+            const systemPrompt = ai.systemPrompt || 'You are a helpful Discord bot assistant.';
+            const response = await getCompletion({ provider, model, apiKey, baseUrl, systemPrompt, history: [], prompt, temperature, maxTokens });
+
+            const reply = response?.trim() || '(empty response)';
+            if (reply.length > 2000) {
+                await interaction.editReply(reply.substring(0, 1997) + '...');
             } else {
-                await interaction.editReply(response);
+                await interaction.editReply(reply);
             }
         } catch (error) {
-            console.error('AI error:', error);
-            await interaction.editReply('Sorry, I encountered an error processing your request. Make sure the AI API key is configured in the dashboard.');
+            console.error('AI command error:', error);
+            const detail = error?.status ? ` (HTTP ${error.status})` : '';
+            await interaction.editReply(`Sorry, I encountered an error processing your request${detail}.`);
         }
     }
 };

--- a/src/commands/ai/aisummary.js
+++ b/src/commands/ai/aisummary.js
@@ -27,6 +27,7 @@ module.exports = {
             .setDescription('Run a summary job right now')
             .addStringOption(o => o.setName('id').setDescription('Job ID').setRequired(true))),
 
+    cooldown: 30,
     async execute(interaction) {
         const sub = interaction.options.getSubcommand();
 

--- a/src/commands/ai/remind.js
+++ b/src/commands/ai/remind.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder } = require('discord.js');
 const Reminder = require('../../models/Reminder');
 
 module.exports = {
+    cooldown: 5,
     data: new SlashCommandBuilder()
         .setName('remind')
         .setDescription('Set a reminder')

--- a/src/commands/economy/higherlower.js
+++ b/src/commands/economy/higherlower.js
@@ -18,6 +18,7 @@ function cardLabel(value) {
 }
 
 module.exports = {
+    cooldown: 5,
     data: new SlashCommandBuilder()
         .setName('higherlower')
         .setDescription('Bet on whether the next card will be higher or lower')

--- a/src/commands/economy/transfer.js
+++ b/src/commands/economy/transfer.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const User = require('../../models/User');
 
 module.exports = {
+    cooldown: 5,
     data: new SlashCommandBuilder()
         .setName('transfer')
         .setDescription('Transfer coins to another user')

--- a/src/commands/leveling/leaderboard.js
+++ b/src/commands/leveling/leaderboard.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const User = require('../../models/User');
 
 module.exports = {
+    cooldown: 10,
     data: new SlashCommandBuilder()
         .setName('leaderboard')
         .setDescription('View the server leaderboard')

--- a/src/commands/leveling/rank.js
+++ b/src/commands/leveling/rank.js
@@ -3,6 +3,7 @@ const User = require('../../models/User');
 const { createRankCard } = require('../../utils/cardGenerator');
 
 module.exports = {
+    cooldown: 5,
     data: new SlashCommandBuilder()
         .setName('rank')
         .setDescription('Check your or another user\'s rank')

--- a/src/commands/utility/bible.js
+++ b/src/commands/utility/bible.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder } = require('discord.js');
 const { lookupVerse, getDailyVerse, createVerseEmbed } = require('../../services/bibleService');
 
 module.exports = {
+    cooldown: 5,
     data: new SlashCommandBuilder()
         .setName('bible')
         .setDescription('Look up a Bible verse or get today\'s daily verse')

--- a/src/dashboard/routes/api.js
+++ b/src/dashboard/routes/api.js
@@ -26,18 +26,46 @@ function checkAuth(req, res, next) {
 
 function checkGuildAccess(req, res, next) {
     const { guildId } = req.params;
-    const userGuilds = req.user.guilds.filter(guild => 
+    const userGuilds = req.user.guilds.filter(guild =>
         (guild.permissions & 0x20) === 0x20 && req.client.guilds.cache.has(guild.id)
     );
-    
+
     if (!userGuilds.find(g => g.id === guildId)) {
         return res.status(403).json({ error: 'Forbidden' });
     }
-    
+
     next();
 }
 
-router.post('/guild/:guildId/settings', checkAuth, checkGuildAccess, async (req, res) => {
+// In-memory rate limiter for write operations: 60 requests per minute per user
+const writeRateLimits = new Map();
+setInterval(() => {
+    const cutoff = Date.now() - 60 * 1000;
+    for (const [userId, timestamps] of writeRateLimits) {
+        if (timestamps.every(t => t < cutoff)) writeRateLimits.delete(userId);
+    }
+}, 5 * 60 * 1000);
+
+function checkWriteRateLimit(req, res, next) {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+    const now = Date.now();
+    const windowMs = 60 * 1000;
+    const limit = 60;
+    const arr = (writeRateLimits.get(userId) || []).filter(t => now - t < windowMs);
+
+    if (arr.length >= limit) {
+        writeRateLimits.set(userId, arr);
+        return res.status(429).json({ error: 'Too many requests. Please slow down.' });
+    }
+
+    arr.push(now);
+    writeRateLimits.set(userId, arr);
+    next();
+}
+
+router.post('/guild/:guildId/settings', checkAuth, checkGuildAccess, checkWriteRateLimit, async (req, res) => {
     const { guildId } = req.params;
     const updates = req.body;
 
@@ -254,7 +282,7 @@ router.get('/guild/:guildId/insights', checkAuth, checkGuildAccess, async (req, 
     }
 });
 
-router.post('/guild/:guildId/autorole', checkAuth, checkGuildAccess, async (req, res) => {
+router.post('/guild/:guildId/autorole', checkAuth, checkGuildAccess, checkWriteRateLimit, async (req, res) => {
     const { guildId } = req.params;
     const { roleId } = req.body;
 
@@ -276,7 +304,7 @@ router.post('/guild/:guildId/autorole', checkAuth, checkGuildAccess, async (req,
     }
 });
 
-router.delete('/guild/:guildId/autorole/:roleId', checkAuth, checkGuildAccess, async (req, res) => {
+router.delete('/guild/:guildId/autorole/:roleId', checkAuth, checkGuildAccess, checkWriteRateLimit, async (req, res) => {
     const { guildId, roleId } = req.params;
 
     try {
@@ -293,7 +321,7 @@ router.delete('/guild/:guildId/autorole/:roleId', checkAuth, checkGuildAccess, a
     }
 });
 
-router.post('/guild/:guildId/reactionrole/panel', checkAuth, checkGuildAccess, async (req, res) => {
+router.post('/guild/:guildId/reactionrole/panel', checkAuth, checkGuildAccess, checkWriteRateLimit, async (req, res) => {
     const { guildId } = req.params;
     const { channelId, title, description, mappings } = req.body;
 
@@ -364,7 +392,7 @@ router.post('/guild/:guildId/reactionrole/panel', checkAuth, checkGuildAccess, a
     }
 });
 
-router.delete('/guild/:guildId/reactionrole/panel/:messageId', checkAuth, checkGuildAccess, async (req, res) => {
+router.delete('/guild/:guildId/reactionrole/panel/:messageId', checkAuth, checkGuildAccess, checkWriteRateLimit, async (req, res) => {
     const { guildId, messageId } = req.params;
 
     try {
@@ -392,7 +420,7 @@ router.delete('/guild/:guildId/reactionrole/panel/:messageId', checkAuth, checkG
     }
 });
 
-router.post('/guild/:guildId/rss/add', checkAuth, checkGuildAccess, async (req, res) => {
+router.post('/guild/:guildId/rss/add', checkAuth, checkGuildAccess, checkWriteRateLimit, async (req, res) => {
     const { guildId } = req.params;
     const { url, channelId } = req.body;
 
@@ -409,7 +437,7 @@ router.post('/guild/:guildId/rss/add', checkAuth, checkGuildAccess, async (req, 
     }
 });
 
-router.delete('/guild/:guildId/rss/:index', checkAuth, checkGuildAccess, async (req, res) => {
+router.delete('/guild/:guildId/rss/:index', checkAuth, checkGuildAccess, checkWriteRateLimit, async (req, res) => {
     const { guildId, index } = req.params;
 
     try {

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -260,8 +260,7 @@ async function handleAutoModeration(message, guildSettings) {
 
     if (!mod.autoModEnabled) return false;
 
-    if (mod.spamProtection) {
-        if (isModerator) return false;
+    if (mod.spamProtection && !isModerator) {
         const guildId = message.guild.id;
         const userId = message.author.id;
         const now = Date.now();

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -177,6 +177,7 @@ const guildSchema = new Schema({
         maxHistory: { type: Number, default: 20, min: 0, max: 100 },
         streaming: { type: Boolean, default: true },
         rateLimitPerUser: { type: Number, default: 20 },
+        rateLimitPerChannel: { type: Number, default: 0 },
         rateLimitWindowMin: { type: Number, default: 10 },
         // Per-channel personas: each entry overrides systemPrompt for that channel
         channelPersonas: {

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -18,14 +18,18 @@ const DEFAULT_MODELS = {
 const DISCORD_MAX_LEN = 2000;
 const STREAM_EDIT_INTERVAL_MS = 1200;
 
-// userId -> [timestamps] for sliding-window rate limiting (in-memory)
+// userId -> [timestamps] and channelId -> [timestamps] for sliding-window rate limiting (in-memory)
 const rateLimits = new Map();
+const channelRateLimits = new Map();
 
 // Periodically remove entries whose timestamps have all expired (2-hour max window)
 setInterval(() => {
     const cutoff = Date.now() - 2 * 60 * 60 * 1000;
     for (const [userId, timestamps] of rateLimits) {
         if (timestamps.every(t => t < cutoff)) rateLimits.delete(userId);
+    }
+    for (const [channelId, timestamps] of channelRateLimits) {
+        if (timestamps.every(t => t < cutoff)) channelRateLimits.delete(channelId);
     }
 }, 15 * 60 * 1000).unref();
 
@@ -40,6 +44,20 @@ function checkRateLimit(userId, limit, windowMin) {
     }
     arr.push(now);
     rateLimits.set(userId, arr);
+    return true;
+}
+
+function checkChannelRateLimit(channelId, limit, windowMin) {
+    if (!limit || limit <= 0) return true;
+    const now = Date.now();
+    const windowMs = (windowMin || 10) * 60 * 1000;
+    const arr = (channelRateLimits.get(channelId) || []).filter(t => now - t < windowMs);
+    if (arr.length >= limit) {
+        channelRateLimits.set(channelId, arr);
+        return false;
+    }
+    arr.push(now);
+    channelRateLimits.set(channelId, arr);
     return true;
 }
 
@@ -456,6 +474,10 @@ async function handleAIChat(message, aiSettings) {
         return message.reply(`Rate limit reached (${aiSettings.rateLimitPerUser} per ${aiSettings.rateLimitWindowMin}m). Please slow down.`);
     }
 
+    if (!checkChannelRateLimit(message.channel.id, aiSettings.rateLimitPerChannel, aiSettings.rateLimitWindowMin)) {
+        return message.reply(`This channel has reached the AI request limit. Please wait before sending more AI requests here.`);
+    }
+
     const maxHistory = aiSettings.maxHistory ?? 20;
     const useStreaming = aiSettings.streaming !== false;
 
@@ -572,5 +594,7 @@ module.exports = {
     streamCompletion,
     resolveProviderConfig,
     retrieveKnowledge,
+    checkRateLimit,
+    checkChannelRateLimit,
     DEFAULT_MODELS
 };


### PR DESCRIPTION
- Fix /ai command: replace nonexistent getChatCompletion with getCompletion,
  apply guild-configured per-user and per-channel rate limits
- Add per-channel AI rate limiting in aiService.js (channelRateLimits map +
  checkChannelRateLimit); expose via module.exports; add rateLimitPerChannel
  field to Guild schema (default 0 = disabled)
- Fix spam protection early-return bug in messageCreate.js: moderator check
  inside mod.spamProtection block used `return false` which bypassed all
  subsequent automod filters (invite, link, profanity, etc.); changed to
  `if (mod.spamProtection && !isModerator)` guard instead
- Add cooldowns to expensive commands without them: higherlower (5s),
  transfer (5s), aisummary (30s), leaderboard (10s), rank (5s),
  bible (5s), remind (5s)
- Add write-path rate limiting to dashboard API: 60 write ops/min per
  authenticated user applied to all POST and DELETE routes

https://claude.ai/code/session_01EfAjFHr3EBePu7QELQcA13