### PR TITLE
feat(daily-feed): profile rename, feed validation, dead-feed handling, timezone docs

### DIFF
--- a/src/dashboard/routes/api.js
+++ b/src/dashboard/routes/api.js
@@ -5,6 +5,7 @@ const Case = require('../../models/Case');
 const User = require('../../models/User');
 const { rescheduleDailyNews } = require('../../services/rssService');
 const { rescheduleBibleVerse } = require('../../services/dailyBibleService');
+const Parser = require('rss-parser');
 
 function median(nums) {
     if (!nums.length) return null;
@@ -417,6 +418,32 @@ router.delete('/guild/:guildId/reactionrole/panel/:messageId', checkAuth, checkG
     } catch (error) {
         console.error('Reaction role panel delete error:', error);
         res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
+router.post('/guild/:guildId/validate-feed', checkAuth, checkGuildAccess, async (req, res) => {
+    const { url } = req.body;
+    if (!url || typeof url !== 'string') {
+        return res.status(400).json({ valid: false, error: 'No URL provided.' });
+    }
+
+    let parsed;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return res.json({ valid: false, error: 'Invalid URL format.' });
+    }
+
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+        return res.json({ valid: false, error: 'URL must use http or https.' });
+    }
+
+    try {
+        const feedParser = new Parser({ timeout: 8000 });
+        const feed = await feedParser.parseURL(url);
+        return res.json({ valid: true, title: feed.title || '', itemCount: feed.items?.length ?? 0 });
+    } catch (err) {
+        return res.json({ valid: false, error: 'Could not fetch or parse feed. Check the URL and ensure it is a valid RSS/Atom feed.' });
     }
 });
 

--- a/src/dashboard/routes/api.js
+++ b/src/dashboard/routes/api.js
@@ -6,6 +6,95 @@ const User = require('../../models/User');
 const { rescheduleDailyNews } = require('../../services/rssService');
 const { rescheduleBibleVerse } = require('../../services/dailyBibleService');
 const Parser = require('rss-parser');
+const dns = require('dns');
+const net = require('net');
+const http = require('http');
+const https = require('https');
+
+// Returns true for any IP that must not be fetched (loopback, RFC1918, link-local, IPv6 ULA/LL).
+function isPrivateIp(ip) {
+    if (net.isIPv4(ip)) {
+        const [a, b] = ip.split('.').map(Number);
+        return (
+            a === 127 ||
+            a === 10 ||
+            (a === 172 && b >= 16 && b <= 31) ||
+            (a === 192 && b === 168) ||
+            (a === 169 && b === 254) ||
+            a === 0
+        );
+    }
+    if (net.isIPv6(ip)) {
+        const n = ip.toLowerCase();
+        return (
+            n === '::1' ||
+            n.startsWith('fc') ||
+            n.startsWith('fd') ||
+            /^fe[89ab]/i.test(n) ||
+            n === '::' ||
+            n.startsWith('::ffff:')
+        );
+    }
+    return true;
+}
+
+async function assertHostPublic(hostname) {
+    const addrs = await new Promise((resolve, reject) => {
+        dns.lookup(hostname, { all: true }, (err, results) => {
+            if (err) reject(new Error(`DNS lookup failed: ${err.message}`));
+            else resolve(results);
+        });
+    });
+    if (!addrs.length) throw new Error('Hostname resolved to no addresses.');
+    for (const { address } of addrs) {
+        if (isPrivateIp(address)) throw new Error('Feed URL resolves to a private or reserved IP address.');
+    }
+}
+
+// Fetches a feed URL safely: checks DNS on every hop, follows redirects up to maxRedirects.
+// Returns the response body as a string.
+async function safeFetchFeed(urlStr, maxRedirects = 5) {
+    let current = new URL(urlStr);
+
+    for (let hop = 0; hop <= maxRedirects; hop++) {
+        if (!['http:', 'https:'].includes(current.protocol)) {
+            throw new Error('Redirect to non-HTTP protocol rejected.');
+        }
+        await assertHostPublic(current.hostname);
+
+        const result = await new Promise((resolve, reject) => {
+            const mod = current.protocol === 'https:' ? https : http;
+            const port = current.port ? Number(current.port) : (current.protocol === 'https:' ? 443 : 80);
+            const req = mod.request(
+                { hostname: current.hostname, port, path: current.pathname + current.search, method: 'GET',
+                  headers: { 'User-Agent': 'UltraBot-FeedValidator/1.0', Accept: 'application/rss+xml,application/atom+xml,application/xml,text/xml,*/*' },
+                  timeout: 8000 },
+                (res) => {
+                    if ([301, 302, 303, 307, 308].includes(res.statusCode)) {
+                        const loc = res.headers.location;
+                        res.destroy();
+                        return resolve({ redirect: loc });
+                    }
+                    const chunks = [];
+                    res.on('data', c => chunks.push(c));
+                    res.on('end', () => resolve({ body: Buffer.concat(chunks).toString('utf8') }));
+                    res.on('error', reject);
+                }
+            );
+            req.on('timeout', () => { req.destroy(); reject(new Error('Feed request timed out.')); });
+            req.on('error', reject);
+            req.end();
+        });
+
+        if (result.redirect) {
+            if (!result.redirect) throw new Error('Redirect with empty Location header.');
+            current = new URL(result.redirect, current.href);
+            continue;
+        }
+        return result.body;
+    }
+    throw new Error('Too many redirects.');
+}
 
 function median(nums) {
     if (!nums.length) return null;
@@ -439,11 +528,12 @@ router.post('/guild/:guildId/validate-feed', checkAuth, checkGuildAccess, async 
     }
 
     try {
-        const feedParser = new Parser({ timeout: 8000 });
-        const feed = await feedParser.parseURL(url);
+        const body = await safeFetchFeed(url);
+        const feedParser = new Parser();
+        const feed = await feedParser.parseString(body);
         return res.json({ valid: true, title: feed.title || '', itemCount: feed.items?.length ?? 0 });
     } catch (err) {
-        return res.json({ valid: false, error: 'Could not fetch or parse feed. Check the URL and ensure it is a valid RSS/Atom feed.' });
+        return res.json({ valid: false, error: err.message || 'Could not fetch or parse feed. Check the URL and ensure it is a valid RSS/Atom feed.' });
     }
 });
 

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -1139,8 +1139,8 @@
     <div class="toast" id="toast"></div>
 
     <script>
-        const DAILY_NEWS_INITIAL_PROFILES = <%- JSON.stringify(settings.dailyNewsProfiles || []) %>;
-        const DAILY_NEWS_CHANNELS = <%- JSON.stringify(channels || []) %>;
+        const DAILY_NEWS_INITIAL_PROFILES = <%- JSON.stringify(settings.dailyNewsProfiles || []).replace(/</g, '\\u003c').replace(/>/g, '\\u003e') %>;
+        const DAILY_NEWS_CHANNELS = <%- JSON.stringify(channels || []).replace(/</g, '\\u003c').replace(/>/g, '\\u003e') %>;
 
         // Sidebar tab navigation
         const navItems = document.querySelectorAll('.nav-item');
@@ -1206,7 +1206,7 @@
                     enabled: p.enabled !== false,
                     channelId: p.channelId || '',
                     time: p.time || '09:00',
-                    timezone: p.timezone || 'UTC',
+                    timezone: p.timezone || '',
                     title: p.title || '📰 Daily News Digest',
                     feeds: Array.isArray(p.feeds) ? p.feeds : [],
                     maxItemsPerFeed: p.maxItemsPerFeed || 3
@@ -1229,18 +1229,18 @@
                             <strong>${escHtml(displayName)}</strong>
                             <button class="btn btn-danger btn-sm" type="button" onclick="removeDailyNewsProfile(${idx})">Remove</button>
                         </div>
-                        <label>Profile name</label>
-                        <input type="text" value="${escHtml(profile.name || '')}" placeholder="e.g. Tech News" oninput="updateDailyNewsProfile(${idx}, 'name', this.value); this.closest('.list-item').querySelector('strong').textContent = this.value || 'Profile ${idx + 1}';">
-                        <label>Channel</label>
-                        <select onchange="updateDailyNewsProfile(${idx}, 'channelId', this.value)">${dailyNewsChannelOptions(profile.channelId)}</select>
-                        <label>Time (24h)</label>
-                        <input type="text" value="${escHtml(profile.time || '09:00')}" onchange="updateDailyNewsProfile(${idx}, 'time', this.value)">
-                        <label>Timezone <small style="font-weight:normal;opacity:.7;">(IANA, e.g. UTC, America/New_York, Europe/London)</small></label>
-                        <input type="text" value="${escHtml(profile.timezone || 'UTC')}" placeholder="UTC" onchange="updateDailyNewsProfile(${idx}, 'timezone', this.value)">
-                        <label>Digest title</label>
-                        <input type="text" value="${escHtml(profile.title || '📰 Daily News Digest')}" onchange="updateDailyNewsProfile(${idx}, 'title', this.value)">
-                        <label>Feeds (one URL per line)</label>
-                        <textarea rows="3" onchange="updateDailyNewsProfile(${idx}, 'feeds', this.value)">${escHtml((profile.feeds || []).join('\n'))}</textarea>
+                        <label for="dn-${idx}-name">Profile name</label>
+                        <input id="dn-${idx}-name" type="text" value="${escHtml(profile.name || '')}" placeholder="e.g. Tech News" oninput="updateDailyNewsProfile(${idx}, 'name', this.value); this.closest('.list-item').querySelector('strong').textContent = this.value || 'Profile ${idx + 1}';">
+                        <label for="dn-${idx}-channel">Channel</label>
+                        <select id="dn-${idx}-channel" onchange="updateDailyNewsProfile(${idx}, 'channelId', this.value)">${dailyNewsChannelOptions(profile.channelId)}</select>
+                        <label for="dn-${idx}-time">Time (24h)</label>
+                        <input id="dn-${idx}-time" type="text" value="${escHtml(profile.time || '09:00')}" onchange="updateDailyNewsProfile(${idx}, 'time', this.value)">
+                        <label for="dn-${idx}-timezone">Timezone <small style="font-weight:normal;opacity:.7;">(IANA, e.g. UTC, America/New_York, Europe/London)</small></label>
+                        <input id="dn-${idx}-timezone" type="text" value="${escHtml(profile.timezone || '')}" placeholder="UTC" onchange="updateDailyNewsProfile(${idx}, 'timezone', this.value)">
+                        <label for="dn-${idx}-title">Digest title</label>
+                        <input id="dn-${idx}-title" type="text" value="${escHtml(profile.title || '📰 Daily News Digest')}" onchange="updateDailyNewsProfile(${idx}, 'title', this.value)">
+                        <label for="dn-${idx}-feeds">Feeds (one URL per line)</label>
+                        <textarea id="dn-${idx}-feeds" rows="3" onchange="updateDailyNewsProfile(${idx}, 'feeds', this.value)">${escHtml((profile.feeds || []).join('\n'))}</textarea>
                         <div id="feed-status-${idx}" style="font-size:.8rem;"></div>
                         <button class="btn btn-sm" type="button" onclick="validateProfileFeeds(${idx})">Validate feeds</button>
                     </div>
@@ -1256,7 +1256,7 @@
         function addDailyNewsProfile() {
             const container = document.getElementById('dailynews-profiles-list');
             const profiles = JSON.parse(container.dataset.profiles || '[]');
-            profiles.push({ profileId: `profile-${Date.now()}`, name: '', enabled: true, channelId: '', time: '09:00', timezone: 'UTC', title: '📰 Daily News Digest', feeds: [], maxItemsPerFeed: parseInt(document.getElementById('dailynews-max-items').value, 10) || 3 });
+            profiles.push({ profileId: `profile-${Date.now()}`, name: '', enabled: true, channelId: '', time: '09:00', timezone: '', title: '📰 Daily News Digest', feeds: [], maxItemsPerFeed: parseInt(document.getElementById('dailynews-max-items').value, 10) || 3 });
             container.dataset.profiles = JSON.stringify(profiles);
             renderDailyNewsProfiles();
         }
@@ -1525,7 +1525,7 @@
                         enabled: p.enabled !== false,
                         channelId: (p.channelId || '').trim(),
                         time: (p.time || '09:00').trim(),
-                        timezone: (p.timezone || 'UTC').trim(),
+                        timezone: (p.timezone || '').trim() || null,
                         title: (p.title || '📰 Daily News Digest').trim(),
                         feeds: (Array.isArray(p.feeds) ? p.feeds : []).map(f => f.trim()).filter(Boolean),
                         maxItemsPerFeed: parseInt(document.getElementById('dailynews-max-items').value, 10) || 3
@@ -1535,7 +1535,7 @@
                     'dailyNews.enabled': document.getElementById('dailynews-enabled').checked,
                     'dailyNews.channelId': document.getElementById('dailynews-channel').value,
                     'dailyNews.time': document.getElementById('dailynews-time').value,
-                    'dailyNews.timezone': document.getElementById('dailynews-timezone').value.trim() || 'UTC',
+                    'dailyNews.timezone': document.getElementById('dailynews-timezone').value.trim() || null,
                     'dailyNews.title': document.getElementById('dailynews-title').value,
                     'dailyNews.maxItemsPerFeed': parseInt(document.getElementById('dailynews-max-items').value),
                     'dailyNews.feeds': feeds,

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -907,6 +907,7 @@
                         <div>
                             <label class="field-label" for="dailynews-timezone">Timezone</label>
                             <input type="text" id="dailynews-timezone" value="<%= settings.dailyNews?.timezone || 'UTC' %>" placeholder="America/New_York">
+                            <small>IANA timezone name — e.g. <code>UTC</code>, <code>America/New_York</code>, <code>Europe/London</code>. Delivery time is interpreted in this timezone. Leave blank or use <code>UTC</code> to follow the bot server's clock.</small>
                         </div>
                     </div>
                     <div class="field">
@@ -920,6 +921,8 @@
                     <div class="field">
                         <label class="field-label" for="dailynews-feeds">RSS feed URLs (one per line)</label>
                         <textarea id="dailynews-feeds" rows="6" placeholder="https://example.com/feed1.xml&#10;https://example.com/feed2.xml"><%= settings.dailyNews?.feeds?.join('\n') || '' %></textarea>
+                        <div id="main-feed-status" style="font-size:.8rem;margin-top:.35rem;"></div>
+                        <button class="btn btn-sm" type="button" style="margin-top:.35rem;" onclick="validateMainFeeds()">Validate feeds</button>
                     </div>
                     <div class="field">
                         <label class="field-label">Additional delivery profiles</label>
@@ -1199,6 +1202,7 @@
             if (!container.dataset.initialized) {
                 const seed = (DAILY_NEWS_INITIAL_PROFILES.length ? DAILY_NEWS_INITIAL_PROFILES : []).map((p, idx) => ({
                     profileId: p.profileId || `profile-${Date.now()}-${idx + 1}`,
+                    name: p.name || '',
                     enabled: p.enabled !== false,
                     channelId: p.channelId || '',
                     time: p.time || '09:00',
@@ -1214,6 +1218,7 @@
             const profiles = JSON.parse(container.dataset.profiles || '[]');
             container.innerHTML = profiles.length ? '' : '<div class="empty-state" style="padding:1rem;"><p>No additional profiles yet.</p></div>';
             profiles.forEach((profile, idx) => {
+                const displayName = profile.name ? profile.name : `Profile ${idx + 1}`;
                 const card = document.createElement('div');
                 card.className = 'list-item';
                 card.style.display = 'block';
@@ -1221,29 +1226,37 @@
                 card.innerHTML = `
                     <div style="display:grid;gap:.5rem;">
                         <div style="display:flex;justify-content:space-between;align-items:center;">
-                            <strong>Profile ${idx + 1}</strong>
+                            <strong>${escHtml(displayName)}</strong>
                             <button class="btn btn-danger btn-sm" type="button" onclick="removeDailyNewsProfile(${idx})">Remove</button>
                         </div>
+                        <label>Profile name</label>
+                        <input type="text" value="${escHtml(profile.name || '')}" placeholder="e.g. Tech News" oninput="updateDailyNewsProfile(${idx}, 'name', this.value); this.closest('.list-item').querySelector('strong').textContent = this.value || 'Profile ${idx + 1}';">
                         <label>Channel</label>
                         <select onchange="updateDailyNewsProfile(${idx}, 'channelId', this.value)">${dailyNewsChannelOptions(profile.channelId)}</select>
                         <label>Time (24h)</label>
-                        <input type="text" value="${profile.time || '09:00'}" onchange="updateDailyNewsProfile(${idx}, 'time', this.value)">
-                        <label>Timezone</label>
-                        <input type="text" value="${profile.timezone || 'UTC'}" onchange="updateDailyNewsProfile(${idx}, 'timezone', this.value)">
-                        <label>Title</label>
-                        <input type="text" value="${profile.title || '📰 Daily News Digest'}" onchange="updateDailyNewsProfile(${idx}, 'title', this.value)">
+                        <input type="text" value="${escHtml(profile.time || '09:00')}" onchange="updateDailyNewsProfile(${idx}, 'time', this.value)">
+                        <label>Timezone <small style="font-weight:normal;opacity:.7;">(IANA, e.g. UTC, America/New_York, Europe/London)</small></label>
+                        <input type="text" value="${escHtml(profile.timezone || 'UTC')}" placeholder="UTC" onchange="updateDailyNewsProfile(${idx}, 'timezone', this.value)">
+                        <label>Digest title</label>
+                        <input type="text" value="${escHtml(profile.title || '📰 Daily News Digest')}" onchange="updateDailyNewsProfile(${idx}, 'title', this.value)">
                         <label>Feeds (one URL per line)</label>
-                        <textarea rows="3" onchange="updateDailyNewsProfile(${idx}, 'feeds', this.value)">${(profile.feeds || []).join('\n')}</textarea>
+                        <textarea rows="3" onchange="updateDailyNewsProfile(${idx}, 'feeds', this.value)">${escHtml((profile.feeds || []).join('\n'))}</textarea>
+                        <div id="feed-status-${idx}" style="font-size:.8rem;"></div>
+                        <button class="btn btn-sm" type="button" onclick="validateProfileFeeds(${idx})">Validate feeds</button>
                     </div>
                 `;
                 container.appendChild(card);
             });
         }
 
+        function escHtml(str) {
+            return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+        }
+
         function addDailyNewsProfile() {
             const container = document.getElementById('dailynews-profiles-list');
             const profiles = JSON.parse(container.dataset.profiles || '[]');
-            profiles.push({ profileId: `profile-${Date.now()}`, enabled: true, channelId: '', time: '09:00', timezone: 'UTC', title: '📰 Daily News Digest', feeds: [], maxItemsPerFeed: parseInt(document.getElementById('dailynews-max-items').value, 10) || 3 });
+            profiles.push({ profileId: `profile-${Date.now()}`, name: '', enabled: true, channelId: '', time: '09:00', timezone: 'UTC', title: '📰 Daily News Digest', feeds: [], maxItemsPerFeed: parseInt(document.getElementById('dailynews-max-items').value, 10) || 3 });
             container.dataset.profiles = JSON.stringify(profiles);
             renderDailyNewsProfiles();
         }
@@ -1262,6 +1275,45 @@
             if (!profiles[index]) return;
             profiles[index][key] = key === 'feeds' ? value.split('\n').map(f => f.trim()).filter(Boolean) : value;
             container.dataset.profiles = JSON.stringify(profiles);
+        }
+
+        async function validateFeedUrl(url, guildId) {
+            const resp = await fetch(`/api/guild/${guildId}/validate-feed`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ url })
+            });
+            return resp.json();
+        }
+
+        async function validateMainFeeds() {
+            const guildId = '<%= guild.id %>';
+            const statusEl = document.getElementById('main-feed-status');
+            const urls = document.getElementById('dailynews-feeds').value.split('\n').map(f => f.trim()).filter(Boolean);
+            if (!urls.length) { statusEl.textContent = 'No feed URLs to validate.'; return; }
+            statusEl.textContent = `Checking ${urls.length} feed(s)…`;
+            const results = await Promise.all(urls.map(url => validateFeedUrl(url, guildId).then(r => ({ url, ...r })).catch(() => ({ url, valid: false, error: 'Request failed' }))));
+            statusEl.innerHTML = results.map(r => r.valid
+                ? `<span style="color:var(--success,#3ba55d);">✓ ${escHtml(r.url)} — ${escHtml(r.title || 'untitled')} (${r.itemCount} items)</span>`
+                : `<span style="color:var(--danger,#ed4245);">✗ ${escHtml(r.url)} — ${escHtml(r.error)}</span>`
+            ).join('<br>');
+        }
+
+        async function validateProfileFeeds(index) {
+            const guildId = '<%= guild.id %>';
+            const container = document.getElementById('dailynews-profiles-list');
+            const profiles = JSON.parse(container.dataset.profiles || '[]');
+            const profile = profiles[index];
+            if (!profile) return;
+            const statusEl = document.getElementById(`feed-status-${index}`);
+            const urls = profile.feeds || [];
+            if (!urls.length) { statusEl.textContent = 'No feed URLs in this profile.'; return; }
+            statusEl.textContent = `Checking ${urls.length} feed(s)…`;
+            const results = await Promise.all(urls.map(url => validateFeedUrl(url, guildId).then(r => ({ url, ...r })).catch(() => ({ url, valid: false, error: 'Request failed' }))));
+            statusEl.innerHTML = results.map(r => r.valid
+                ? `<span style="color:var(--success,#3ba55d);">✓ ${escHtml(r.url)} — ${escHtml(r.title || 'untitled')} (${r.itemCount} items)</span>`
+                : `<span style="color:var(--danger,#ed4245);">✗ ${escHtml(r.url)} — ${escHtml(r.error)}</span>`
+            ).join('<br>');
         }
 
         async function saveSettings(section) {
@@ -1469,6 +1521,7 @@
                 const profiles = JSON.parse(document.getElementById('dailynews-profiles-list').dataset.profiles || '[]')
                     .map((p, index) => ({
                         profileId: p.profileId || `profile-${index + 1}`,
+                        name: (p.name || '').trim(),
                         enabled: p.enabled !== false,
                         channelId: (p.channelId || '').trim(),
                         time: (p.time || '09:00').trim(),

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -143,6 +143,7 @@ const guildSchema = new Schema({
     dailyNewsProfiles: {
         type: [{
             profileId: { type: String, required: true },
+            name: { type: String, default: '' },
             enabled: { type: Boolean, default: false },
             channelId: { type: String, default: null },
             time: { type: String, default: '09:00' },

--- a/src/services/rssService.js
+++ b/src/services/rssService.js
@@ -7,9 +7,12 @@ const parser = new Parser();
 let dailyNewsJobs = new Map();
 const runtimeTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-// Consecutive failure counts per feed URL. Feeds are skipped after DEAD_FEED_THRESHOLD failures.
+// Consecutive failure counts per feed URL. Feeds are skipped after DEAD_FEED_THRESHOLD failures,
+// but a retry is allowed once DEAD_FEED_COOLDOWN_MS has elapsed since the last failure.
 const feedFailCounts = new Map();
+const feedLastFailTime = new Map();
 const DEAD_FEED_THRESHOLD = 3;
+const DEAD_FEED_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
 
 function createLegacyProfile(guild) {
     const legacy = guild.dailyNews || {};
@@ -120,13 +123,18 @@ async function sendDailyNewsForProfile(client, guild, profile) {
     for (const feedUrl of profile.feeds) {
         const failCount = feedFailCounts.get(feedUrl) || 0;
         if (failCount >= DEAD_FEED_THRESHOLD) {
-            console.warn(`Skipping dead feed (${failCount} consecutive failures): ${feedUrl}`);
-            continue;
+            const lastFail = feedLastFailTime.get(feedUrl) || 0;
+            if (Date.now() - lastFail < DEAD_FEED_COOLDOWN_MS) {
+                console.warn(`Skipping dead feed (${failCount} consecutive failures): ${feedUrl}`);
+                continue;
+            }
+            console.log(`Retrying previously dead feed after cooldown: ${feedUrl}`);
         }
 
         try {
             const parsedFeed = await parser.parseURL(feedUrl);
             feedFailCounts.delete(feedUrl);
+            feedLastFailTime.delete(feedUrl);
             const feedItems = parsedFeed.items
                 .map(item => ({
                     title: item.title,
@@ -144,6 +152,7 @@ async function sendDailyNewsForProfile(client, guild, profile) {
         } catch (error) {
             const newCount = (feedFailCounts.get(feedUrl) || 0) + 1;
             feedFailCounts.set(feedUrl, newCount);
+            feedLastFailTime.set(feedUrl, Date.now());
             if (newCount >= DEAD_FEED_THRESHOLD) {
                 console.error(`Feed marked as dead after ${newCount} consecutive failures: ${feedUrl}`);
             } else {

--- a/src/services/rssService.js
+++ b/src/services/rssService.js
@@ -7,6 +7,10 @@ const parser = new Parser();
 let dailyNewsJobs = new Map();
 const runtimeTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
+// Consecutive failure counts per feed URL. Feeds are skipped after DEAD_FEED_THRESHOLD failures.
+const feedFailCounts = new Map();
+const DEAD_FEED_THRESHOLD = 3;
+
 function createLegacyProfile(guild) {
     const legacy = guild.dailyNews || {};
     return {
@@ -114,8 +118,15 @@ async function sendDailyNewsForProfile(client, guild, profile) {
     const cutoffMs = Date.now() - (24 * 60 * 60 * 1000);
 
     for (const feedUrl of profile.feeds) {
+        const failCount = feedFailCounts.get(feedUrl) || 0;
+        if (failCount >= DEAD_FEED_THRESHOLD) {
+            console.warn(`Skipping dead feed (${failCount} consecutive failures): ${feedUrl}`);
+            continue;
+        }
+
         try {
             const parsedFeed = await parser.parseURL(feedUrl);
+            feedFailCounts.delete(feedUrl);
             const feedItems = parsedFeed.items
                 .map(item => ({
                     title: item.title,
@@ -131,7 +142,13 @@ async function sendDailyNewsForProfile(client, guild, profile) {
 
             allItems.push(...feedItems);
         } catch (error) {
-            console.error(`Error parsing daily news feed ${feedUrl}:`, error);
+            const newCount = (feedFailCounts.get(feedUrl) || 0) + 1;
+            feedFailCounts.set(feedUrl, newCount);
+            if (newCount >= DEAD_FEED_THRESHOLD) {
+                console.error(`Feed marked as dead after ${newCount} consecutive failures: ${feedUrl}`);
+            } else {
+                console.error(`Error parsing daily news feed (failure ${newCount}/${DEAD_FEED_THRESHOLD}) ${feedUrl}:`, error.message);
+            }
         }
     }
 


### PR DESCRIPTION
- Add `name` field to dailyNewsProfiles schema so admins can label each
  profile (e.g. "Tech News", "Gaming Feed") independently of the embed title
- Dashboard profile cards now show an editable "Profile name" field and use
  it as the card heading; falls back to "Profile N" when blank
- Escape HTML in profile card template to prevent XSS via stored feed names
- Add POST /api/guild/:guildId/validate-feed endpoint that fetches and parses
  a candidate feed URL, returning { valid, title, itemCount } or { valid, error }
- "Validate feeds" button on main digest and each profile card calls this
  endpoint per URL and renders inline pass/fail results
- Track consecutive parse failures per feed URL in-memory (feedFailCounts);
  feeds are skipped once they reach DEAD_FEED_THRESHOLD (3) failures and a
  clear error is logged; counter resets to zero on the next successful fetch
- Add IANA timezone help text below both the main and profile timezone inputs
  explaining expected format and examples

https://claude.ai/code/session_01GqHUyjo6P3xEdt8wzXi38e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Feed validation controls for Daily News main feeds and profiles with real-time URL verification and item count feedback
  * Automatic dead feed detection: feeds failing three consecutive parse attempts are automatically skipped from future processing
  * Profile naming support for Daily News additional profiles
  * Enhanced Daily News settings with timezone guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->