### PR TITLE
Add knowledge base management to the dashboard

### DIFF
--- a/src/dashboard/routes/api.js
+++ b/src/dashboard/routes/api.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const Guild = require('../../models/Guild');
 const Case = require('../../models/Case');
 const User = require('../../models/User');
+const KnowledgeBase = require('../../models/KnowledgeBase');
 const { rescheduleDailyNews } = require('../../services/rssService');
 const { rescheduleBibleVerse } = require('../../services/dailyBibleService');
 const Parser = require('rss-parser');
@@ -566,6 +567,64 @@ router.delete('/guild/:guildId/rss/:index', checkAuth, checkGuildAccess, checkWr
         res.json({ success: true });
     } catch (error) {
         console.error('RSS delete error:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
+router.get('/guild/:guildId/knowledge-base', checkAuth, checkGuildAccess, async (req, res) => {
+    const { guildId } = req.params;
+    try {
+        const entries = await KnowledgeBase.find({ guildId }).sort({ createdAt: -1 }).limit(100);
+        res.json(entries);
+    } catch (error) {
+        console.error('Knowledge base list error:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
+router.post('/guild/:guildId/knowledge-base', checkAuth, checkGuildAccess, checkWriteRateLimit, async (req, res) => {
+    const { guildId } = req.params;
+    const { title, content, tags } = req.body;
+
+    if (!title || typeof title !== 'string' || !title.trim()) {
+        return res.status(400).json({ error: 'Title is required' });
+    }
+    if (!content || typeof content !== 'string' || !content.trim()) {
+        return res.status(400).json({ error: 'Content is required' });
+    }
+
+    const sanitizedTags = Array.isArray(tags) ? tags.map(t => String(t).trim()).filter(Boolean).slice(0, 10) : [];
+
+    try {
+        const entry = await KnowledgeBase.create({
+            guildId,
+            title: title.trim().slice(0, 200),
+            content: content.trim().slice(0, 4000),
+            tags: sanitizedTags,
+            addedBy: req.user.id
+        });
+        res.json({ success: true, entry });
+    } catch (error) {
+        console.error('Knowledge base add error:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
+router.delete('/guild/:guildId/knowledge-base/:entryId', checkAuth, checkGuildAccess, checkWriteRateLimit, async (req, res) => {
+    const { guildId, entryId } = req.params;
+
+    if (!/^[0-9a-f]{24}$/i.test(entryId)) {
+        return res.status(400).json({ error: 'Invalid entry ID' });
+    }
+
+    try {
+        const result = await KnowledgeBase.deleteOne({ _id: entryId, guildId });
+        if (result.deletedCount === 0) {
+            return res.status(404).json({ error: 'Entry not found' });
+        }
+        res.json({ success: true });
+    } catch (error) {
+        console.error('Knowledge base delete error:', error);
         res.status(500).json({ error: 'Internal server error' });
     }
 });

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -55,6 +55,7 @@
                 <!-- Tools & Support -->
                 <div class="nav-section-header">Tools &amp; Support</div>
                 <button class="nav-item" data-tab="ai"><span class="nav-emoji">🧠</span> AI Chat</button>
+                <button class="nav-item" data-tab="knowledgebase"><span class="nav-emoji">📚</span> Knowledge Base</button>
                 <button class="nav-item" data-tab="tempvoice"><span class="nav-emoji">🔊</span> Temp Voice</button>
                 <button class="nav-item" data-tab="tickets"><span class="nav-emoji">🎫</span> Tickets</button>
 
@@ -1068,6 +1069,34 @@
                     </div>
                 </section>
 
+                <section id="knowledgebase" class="panel">
+                    <div class="panel-head">
+                        <h2>Knowledge Base</h2>
+                        <p>Add context entries that the AI references when answering in this server. Changes take effect immediately — no commands needed.</p>
+                    </div>
+                    <div id="kb-list" style="margin-bottom:1.5rem;">
+                        <div class="empty-state" style="padding:2rem 1.5rem;">
+                            <p>Loading entries…</p>
+                        </div>
+                    </div>
+                    <div class="panel-head" style="margin-top:1rem"><h3>Add entry</h3></div>
+                    <div class="field">
+                        <label class="field-label" for="kb-title">Title</label>
+                        <input type="text" id="kb-title" placeholder="e.g. Server Rules">
+                    </div>
+                    <div class="field">
+                        <label class="field-label" for="kb-content">Content</label>
+                        <textarea id="kb-content" rows="5" placeholder="The information the AI should know…"></textarea>
+                    </div>
+                    <div class="field">
+                        <label class="field-label" for="kb-tags">Tags <small style="font-weight:normal;opacity:.7;">(comma-separated, optional)</small></label>
+                        <input type="text" id="kb-tags" placeholder="rules, faq, moderation">
+                    </div>
+                    <div class="actions-row">
+                        <button class="btn btn-primary" onclick="addKbEntry()">Add entry</button>
+                    </div>
+                </section>
+
                 <section id="analytics" class="panel">
                     <div class="panel-head">
                         <h2>Insights & Recommendations</h2>
@@ -1153,6 +1182,7 @@
                 item.classList.add('active');
                 document.getElementById(tab).classList.add('active');
                 if (tab === 'analytics') loadAnalytics();
+                if (tab === 'knowledgebase') loadKnowledgeBase();
                 if (history.replaceState) history.replaceState(null, '', '#' + tab);
             });
         });
@@ -1830,6 +1860,96 @@
                 }
             } catch (error) {
                 console.error(error);
+                toast('An error occurred', 'error');
+            }
+        }
+
+        // ── Knowledge Base ─────────────────────────────────────────────────────
+        var kbLoaded = false;
+
+        async function loadKnowledgeBase() {
+            if (kbLoaded) return;
+            var guildId = '<%= guild.id %>';
+            var container = document.getElementById('kb-list');
+            try {
+                var resp = await fetch('/api/guild/' + guildId + '/knowledge-base');
+                var entries = await resp.json();
+                kbLoaded = true;
+                renderKbEntries(entries);
+            } catch (e) {
+                container.innerHTML = '<div class="empty-state" style="padding:2rem 1.5rem;"><p>Failed to load entries.</p></div>';
+            }
+        }
+
+        function renderKbEntries(entries) {
+            var container = document.getElementById('kb-list');
+            if (!Array.isArray(entries) || !entries.length) {
+                container.innerHTML = '<div class="empty-state" style="padding:2rem 1.5rem;"><h3>No entries yet</h3><p>Add your first knowledge base entry below.</p></div>';
+                return;
+            }
+            container.innerHTML = '';
+            entries.forEach(function(entry) {
+                var div = document.createElement('div');
+                div.className = 'list-item';
+                var preview = entry.content.length > 120 ? entry.content.slice(0, 120) + '…' : entry.content;
+                var tagsHtml = (entry.tags && entry.tags.length)
+                    ? '<div style="margin-top:.3rem;">' + entry.tags.map(function(t) { return '<span style="background:var(--surface-2);border-radius:4px;padding:1px 6px;font-size:.76rem;margin-right:4px;">' + escHtml(t) + '</span>'; }).join('') + '</div>'
+                    : '';
+                div.innerHTML =
+                    '<div style="min-width:0;flex:1;">' +
+                        '<strong>' + escHtml(entry.title) + '</strong>' +
+                        '<div style="color:var(--text-mute);font-size:.82rem;margin-top:.2rem;">' + escHtml(preview) + '</div>' +
+                        tagsHtml +
+                    '</div>' +
+                    '<button class="btn btn-danger btn-sm" onclick="deleteKbEntry(\'' + entry._id + '\')">Remove</button>';
+                container.appendChild(div);
+            });
+        }
+
+        async function addKbEntry() {
+            var guildId = '<%= guild.id %>';
+            var title = document.getElementById('kb-title').value.trim();
+            var content = document.getElementById('kb-content').value.trim();
+            var tagsRaw = document.getElementById('kb-tags').value.trim();
+            var tags = tagsRaw ? tagsRaw.split(',').map(function(t) { return t.trim(); }).filter(Boolean) : [];
+            if (!title || !content) { toast('Title and content are required', 'error'); return; }
+            try {
+                var resp = await fetch('/api/guild/' + guildId + '/knowledge-base', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ title: title, content: content, tags: tags })
+                });
+                var data = await resp.json();
+                if (resp.ok) {
+                    toast('Entry added ✓', 'success');
+                    document.getElementById('kb-title').value = '';
+                    document.getElementById('kb-content').value = '';
+                    document.getElementById('kb-tags').value = '';
+                    kbLoaded = false;
+                    loadKnowledgeBase();
+                } else {
+                    toast(data.error || 'Failed to add entry', 'error');
+                }
+            } catch (e) {
+                console.error(e);
+                toast('An error occurred', 'error');
+            }
+        }
+
+        async function deleteKbEntry(id) {
+            if (!confirm('Remove this knowledge base entry?')) return;
+            var guildId = '<%= guild.id %>';
+            try {
+                var resp = await fetch('/api/guild/' + guildId + '/knowledge-base/' + id, { method: 'DELETE' });
+                if (resp.ok) {
+                    toast('Entry removed ✓', 'success');
+                    kbLoaded = false;
+                    loadKnowledgeBase();
+                } else {
+                    toast('Failed to remove entry', 'error');
+                }
+            } catch (e) {
+                console.error(e);
                 toast('An error occurred', 'error');
             }
         }


### PR DESCRIPTION
Moves knowledge base setup out of slash commands and into the web dashboard under Tools & Support > Knowledge Base. Admins can now add, view, and remove AI context entries directly from the guild settings page without typing any commands.

- New panel in guild-settings.ejs with entry list, add form (title/content/tags), and per-entry remove buttons
- Three new API routes: GET/POST/DELETE /api/guild/:guildId/knowledge-base
- Entries load lazily when the tab is first opened (same pattern as analytics)

https://claude.ai/code/session_01Ao2o36JsMDCtZGfKB8TFMf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Knowledge Base management to guild dashboard settings.
  * Create, view, and delete AI context entries with titles, content, and tags.
  * Includes input validation, rate limiting on modifications, and asynchronous loading with content previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->