### PR TITLE
fix: four game correctness bugs across economy commands

### DIFF
--- a/src/commands/economy/crash.js
+++ b/src/commands/economy/crash.js
@@ -113,19 +113,27 @@ module.exports = {
         await interaction.deferReply();
 
         try {
-            // --- Load / create user ---
-            let user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
-            if (!user) user = await User.create({ userId: interaction.user.id, guildId: interaction.guild.id });
+            const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
 
-            if (user.balance < bet) {
+            await User.findOneAndUpdate(
+                userFilter,
+                { $setOnInsert: { ...userFilter, balance: 0 } },
+                { upsert: true, new: true, setDefaultsOnInsert: true }
+            );
+
+            // Atomic debit: only proceeds if balance covers the bet.
+            const debited = await User.findOneAndUpdate(
+                { ...userFilter, balance: { $gte: bet } },
+                { $inc: { balance: -bet } },
+                { new: true }
+            );
+
+            if (!debited) {
+                const fresh = await User.findOne(userFilter);
                 return interaction.editReply({
-                    content: `You don't have enough coins! Wallet: **${user.balance.toLocaleString()}** coins.`,
+                    content: `You don't have enough coins! Wallet: **${(fresh?.balance ?? 0).toLocaleString()}** coins.`,
                 });
             }
-
-            // Deduct bet up front; payout is credited on cash-out or withheld on crash.
-            user.balance -= bet;
-            await user.save();
 
             const crash     = generateCrashPoint();
             const username  = interaction.user.username;

--- a/src/commands/economy/higherlower.js
+++ b/src/commands/economy/higherlower.js
@@ -25,8 +25,9 @@ module.exports = {
         .addIntegerOption(option =>
             option
                 .setName('bet')
-                .setDescription('How many coins to wager')
-                .setMinValue(1)
+                .setDescription('How many coins to wager (10–5,000)')
+                .setMinValue(10)
+                .setMaxValue(5000)
                 .setRequired(true)
         ),
     async execute(interaction) {
@@ -40,31 +41,18 @@ module.exports = {
 
             const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
 
+            // Ensure the user document exists before the atomic debit.
             await User.findOneAndUpdate(
                 userFilter,
-                { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id, balance: 0 } },
+                { $setOnInsert: { ...userFilter, balance: 0 } },
                 { upsert: true, new: true, setDefaultsOnInsert: true }
             );
 
-            let user = await User.findOneAndUpdate(
+            const user = await User.findOneAndUpdate(
                 { ...userFilter, balance: { $gte: bet } },
                 { $inc: { balance: -bet } },
                 { new: true }
             );
-
-            if (!user) {
-                await User.findOneAndUpdate(
-                    userFilter,
-                    { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id, balance: 0 } },
-                    { upsert: true, new: true, setDefaultsOnInsert: true }
-                );
-
-                user = await User.findOneAndUpdate(
-                    { ...userFilter, balance: { $gte: bet } },
-                    { $inc: { balance: -bet } },
-                    { new: true }
-                );
-            }
 
             if (!user) {
                 return interaction.reply({ content: `Insufficient funds. You need ${bet.toLocaleString()} coins to place this bet.`, ephemeral: true });

--- a/src/commands/economy/quiz.js
+++ b/src/commands/economy/quiz.js
@@ -230,21 +230,29 @@ module.exports = {
             const chosenAnswer  = allAnswers[selectedIndex];
             const isCorrect     = chosenAnswer === correctAnswer;
 
-            const freshUser = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+            const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
+            let netChange, updated;
 
-            let netChange;
             if (isCorrect) {
                 netChange = rewards.win;
-                freshUser.balance += rewards.win;
+                updated   = await User.findOneAndUpdate(
+                    userFilter,
+                    { $inc: { balance: rewards.win } },
+                    { new: true }
+                );
             } else {
-                const actual = Math.min(rewards.lose, freshUser.balance);
-                netChange = -actual;
-                freshUser.balance = Math.max(0, freshUser.balance - rewards.lose);
+                const freshUser = await User.findOne(userFilter);
+                const penalty   = Math.min(rewards.lose, freshUser?.balance ?? 0);
+                netChange = -penalty;
+                updated   = await User.findOneAndUpdate(
+                    userFilter,
+                    { $inc: { balance: -penalty } },
+                    { new: true }
+                );
             }
-            await freshUser.save();
 
             await i.update({
-                embeds:     [resultEmbed(isCorrect, question, correctAnswer, chosenAnswer, difficulty, rewards, netChange, freshUser.balance, interaction.user.username)],
+                embeds:     [resultEmbed(isCorrect, question, correctAnswer, chosenAnswer, difficulty, rewards, netChange, updated?.balance ?? 0, interaction.user.username)],
                 components: [],
             });
         });
@@ -253,13 +261,17 @@ module.exports = {
         collector.on('end', async (collected, reason) => {
             if (reason === 'limit') return; // answered — handled above
 
-            const freshUser = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
-            const penalty   = Math.min(rewards.lose, freshUser.balance);
-            freshUser.balance = Math.max(0, freshUser.balance - rewards.lose);
-            await freshUser.save();
+            const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
+            const freshUser  = await User.findOne(userFilter);
+            const penalty    = Math.min(rewards.lose, freshUser?.balance ?? 0);
+            const updated    = await User.findOneAndUpdate(
+                userFilter,
+                { $inc: { balance: -penalty } },
+                { new: true }
+            );
 
             await interaction.editReply({
-                embeds:     [timeoutEmbed(question, correctAnswer, difficulty, penalty, freshUser.balance, interaction.user.username)],
+                embeds:     [timeoutEmbed(question, correctAnswer, difficulty, penalty, updated?.balance ?? 0, interaction.user.username)],
                 components: [],
             }).catch(() => {});
         });

--- a/src/commands/economy/slots.js
+++ b/src/commands/economy/slots.js
@@ -114,32 +114,44 @@ module.exports = {
         .setDescription('Spin the slot machine and try your luck!')
         .addIntegerOption(opt =>
             opt.setName('bet')
-                .setDescription('Amount of coins to bet (10–1000)')
+                .setDescription('Amount of coins to bet (10–5,000)')
                 .setMinValue(10)
-                .setMaxValue(1000)
+                .setMaxValue(5000)
                 .setRequired(true)),
     cooldown: 5,
     async execute(interaction) {
         const bet = interaction.options.getInteger('bet');
         await interaction.deferReply();
 
+        const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
+
         try {
-            let user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
-            if (!user) user = await User.create({ userId: interaction.user.id, guildId: interaction.guild.id });
+            await User.findOneAndUpdate(
+                userFilter,
+                { $setOnInsert: { ...userFilter, balance: 0 } },
+                { upsert: true, new: true, setDefaultsOnInsert: true }
+            );
 
-            if (user.balance < bet) {
-                return interaction.editReply({
-                    content: `You don't have enough coins! Wallet: **${user.balance.toLocaleString()}** coins.`,
-                });
-            }
-
-            // Determine result before animation so the balance is correct regardless of
-            // whether subsequent edits succeed.
+            // Determine result before touching the balance so the outcome is fixed
+            // regardless of whether subsequent DB/Discord calls succeed.
             const reels  = [spinReel(), spinReel(), spinReel()];
             const result = evaluate(reels, bet);
+            const net    = result.payout - bet;
 
-            user.balance = user.balance - bet + result.payout;
-            await user.save();
+            // Atomic: debit bet and credit payout in one step; only proceeds if the
+            // balance covers the wager.
+            const user = await User.findOneAndUpdate(
+                { ...userFilter, balance: { $gte: bet } },
+                { $inc: { balance: net } },
+                { new: true }
+            );
+
+            if (!user) {
+                const fresh = await User.findOne(userFilter);
+                return interaction.editReply({
+                    content: `You don't have enough coins! Wallet: **${(fresh?.balance ?? 0).toLocaleString()}** coins.`,
+                });
+            }
 
             const delay = ms => new Promise(r => setTimeout(r, ms));
             const u = interaction.user.username;


### PR DESCRIPTION
- higherlower: enforce 10–5,000 bet bounds (previously only had a min of
  1 with no maximum, letting players wager unlimited coins); also remove
  the redundant double-attempt debit pattern in favour of a single
  upsert-then-atomic-debit flow matching all other games

- slots: raise max bet from 1,000 to 5,000 coins to match every other
  economy game; replace the non-atomic findOne+save balance update with
  a single findOneAndUpdate that computes the net change (payout − bet)
  and applies it atomically, eliminating a TOCTOU race condition that
  could yield a negative balance under concurrent play

- crash: replace the non-atomic findOne+save debit with the same
  upsert-then-findOneAndUpdate pattern used by plinko/roulette/baccarat,
  closing the same race condition window

- quiz: replace Mongoose .save() calls in both the answer-collect and
  timeout handlers with findOneAndUpdate $inc operations; clamp the
  wrong/timeout penalty to the user's actual balance before the atomic
  update so the displayed loss matches what is really deducted

https://claude.ai/code/session_018kMKWB8qPzLquf6VEro3eA