### PR TITLE
fix: enforce economy toggles and add missing blackjack command

### DIFF
--- a/src/commands/economy/blackjack.js
+++ b/src/commands/economy/blackjack.js
@@ -1,0 +1,204 @@
+const {
+    SlashCommandBuilder,
+    EmbedBuilder,
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+} = require('discord.js');
+const User  = require('../../models/User');
+const Guild = require('../../models/Guild');
+
+const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f0cf.png';
+const MIN_BET = 10;
+const MAX_BET = 5000;
+
+const SUITS  = ['♠', '♥', '♦', '♣'];
+const VALUES = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
+
+function buildDeck() {
+    const deck = [];
+    for (const suit of SUITS) {
+        for (const value of VALUES) deck.push({ suit, value });
+    }
+    // Fisher-Yates shuffle
+    for (let i = deck.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [deck[i], deck[j]] = [deck[j], deck[i]];
+    }
+    return deck;
+}
+
+function cardValue(card) {
+    if (['J', 'Q', 'K'].includes(card.value)) return 10;
+    if (card.value === 'A') return 11;
+    return parseInt(card.value, 10);
+}
+
+function handTotal(hand) {
+    let total = hand.reduce((sum, c) => sum + cardValue(c), 0);
+    let aces  = hand.filter(c => c.value === 'A').length;
+    while (total > 21 && aces > 0) { total -= 10; aces--; }
+    return total;
+}
+
+function displayHand(hand, hideSecond = false) {
+    return hand.map((c, i) => (hideSecond && i === 1) ? '🂠' : `${c.value}${c.suit}`).join('  ');
+}
+
+function embedAuthor(interaction) {
+    return {
+        name: interaction.member?.displayName || interaction.user.username,
+        iconURL: interaction.user.displayAvatarURL({ dynamic: true }),
+    };
+}
+
+function buildEmbed(interaction, playerHand, dealerHand, bet, currency, status, color, hideDealer) {
+    const playerTotal = handTotal(playerHand);
+    const dealerShown = hideDealer ? cardValue(dealerHand[0]) : handTotal(dealerHand);
+
+    return new EmbedBuilder()
+        .setAuthor(embedAuthor(interaction))
+        .setThumbnail(THUMB)
+        .setColor(color)
+        .setTitle('🃏 Blackjack')
+        .addFields(
+            { name: `Dealer's Hand (${hideDealer ? dealerShown : dealerShown})`, value: displayHand(dealerHand, hideDealer), inline: false },
+            { name: `Your Hand (${playerTotal})`, value: displayHand(playerHand), inline: false },
+            { name: 'Bet', value: `${currency}${bet.toLocaleString()}`, inline: true },
+            { name: 'Status', value: status, inline: true },
+        )
+        .setFooter({ text: 'Blackjack pays 3:2 · Dealer stands on 17' })
+        .setTimestamp();
+}
+
+function buildButtons(gameId, disabled = false) {
+    return new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+            .setCustomId(`bj_hit_${gameId}`)
+            .setLabel('Hit')
+            .setStyle(ButtonStyle.Primary)
+            .setDisabled(disabled),
+        new ButtonBuilder()
+            .setCustomId(`bj_stand_${gameId}`)
+            .setLabel('Stand')
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(disabled),
+    );
+}
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('blackjack')
+        .setDescription('Play blackjack against the dealer')
+        .addIntegerOption(opt =>
+            opt.setName('bet')
+                .setDescription(`Amount to bet (${MIN_BET}–${MAX_BET})`)
+                .setRequired(true)
+                .setMinValue(MIN_BET)
+                .setMaxValue(MAX_BET)),
+
+    async execute(interaction) {
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        if (guildSettings?.economy?.enabled === false || guildSettings?.economy?.gamesEnabled === false || guildSettings?.economy?.blackjackEnabled === false) {
+            return interaction.reply({ content: 'Blackjack is disabled on this server.', ephemeral: true });
+        }
+
+        const currency = guildSettings?.economy?.currency || '💰';
+        const bet      = interaction.options.getInteger('bet');
+
+        let user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+        if (!user) user = await User.create({ userId: interaction.user.id, guildId: interaction.guild.id });
+
+        if (user.balance < bet) {
+            return interaction.reply({ content: `You don't have enough ${currency}. Your balance: **${currency}${user.balance.toLocaleString()}**`, ephemeral: true });
+        }
+
+        // Deduct bet upfront
+        user.balance -= bet;
+        await user.save();
+
+        const deck       = buildDeck();
+        const playerHand = [deck.pop(), deck.pop()];
+        const dealerHand = [deck.pop(), deck.pop()];
+        const gameId     = `${interaction.user.id}_${Date.now()}`;
+
+        // Natural blackjack check
+        if (handTotal(playerHand) === 21) {
+            const payout = Math.floor(bet * 1.5);
+            user.balance += bet + payout;
+            await user.save();
+
+            const embed = buildEmbed(interaction, playerHand, dealerHand, bet, currency, `🎉 Blackjack! +${currency}${payout.toLocaleString()}`, '#2ecc71', false);
+            return interaction.reply({ embeds: [embed], components: [buildButtons(gameId, true)] });
+        }
+
+        await interaction.reply({
+            embeds:     [buildEmbed(interaction, playerHand, dealerHand, bet, currency, '🎲 Your turn', '#5865F2', true)],
+            components: [buildButtons(gameId)],
+        });
+
+        const msg       = await interaction.fetchReply();
+        const collector = msg.createMessageComponentCollector({
+            filter: i => i.user.id === interaction.user.id && (i.customId === `bj_hit_${gameId}` || i.customId === `bj_stand_${gameId}`),
+            time:   60_000,
+        });
+
+        collector.on('collect', async i => {
+            await i.deferUpdate();
+
+            if (i.customId === `bj_hit_${gameId}`) {
+                playerHand.push(deck.pop());
+                const total = handTotal(playerHand);
+
+                if (total > 21) {
+                    collector.stop('bust');
+                    const embed = buildEmbed(interaction, playerHand, dealerHand, bet, currency, `💥 Bust! -${currency}${bet.toLocaleString()}`, '#e74c3c', false);
+                    return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] });
+                }
+
+                if (total === 21) {
+                    collector.stop('stand');
+                } else {
+                    const embed = buildEmbed(interaction, playerHand, dealerHand, bet, currency, '🎲 Your turn', '#5865F2', true);
+                    return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId)] });
+                }
+            }
+
+            if (i.customId === `bj_stand_${gameId}` || handTotal(playerHand) === 21) {
+                collector.stop('stand');
+            }
+        });
+
+        collector.on('end', async (_, reason) => {
+            if (reason === 'bust') return; // already handled above
+
+            // Dealer draws to 17+
+            while (handTotal(dealerHand) < 17) dealerHand.push(deck.pop());
+
+            const playerTotal = handTotal(playerHand);
+            const dealerTotal = handTotal(dealerHand);
+
+            let color, status;
+            let freshUser = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+            if (!freshUser) freshUser = user;
+
+            if (dealerTotal > 21 || playerTotal > dealerTotal) {
+                freshUser.balance += bet * 2;
+                status = `✅ You win! +${currency}${bet.toLocaleString()}`;
+                color  = '#2ecc71';
+            } else if (playerTotal === dealerTotal) {
+                freshUser.balance += bet;
+                status = `🤝 Push — bet returned`;
+                color  = '#f39c12';
+            } else {
+                status = `❌ Dealer wins. -${currency}${bet.toLocaleString()}`;
+                color  = '#e74c3c';
+            }
+
+            await freshUser.save();
+
+            const embed = buildEmbed(interaction, playerHand, dealerHand, bet, currency, status, color, false);
+            await interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] }).catch(() => {});
+        });
+    },
+};

--- a/src/commands/economy/blackjack.js
+++ b/src/commands/economy/blackjack.js
@@ -48,7 +48,7 @@ function displayHand(hand, hideSecond = false) {
 function embedAuthor(interaction) {
     return {
         name: interaction.member?.displayName || interaction.user.username,
-        iconURL: interaction.user.displayAvatarURL({ dynamic: true }),
+        iconURL: interaction.user.displayAvatarURL(),
     };
 }
 
@@ -122,12 +122,17 @@ module.exports = {
         const dealerHand = [deck.pop(), deck.pop()];
         const gameId     = `${interaction.user.id}_${Date.now()}`;
 
-        // Natural blackjack check
+        // Natural blackjack check — push if dealer also has 21
         if (handTotal(playerHand) === 21) {
+            if (handTotal(dealerHand) === 21) {
+                user.balance += bet;
+                await user.save();
+                const embed = buildEmbed(interaction, playerHand, dealerHand, bet, currency, '🤝 Push — both got blackjack', '#f39c12', false);
+                return interaction.reply({ embeds: [embed], components: [buildButtons(gameId, true)] });
+            }
             const payout = Math.floor(bet * 1.5);
             user.balance += bet + payout;
             await user.save();
-
             const embed = buildEmbed(interaction, playerHand, dealerHand, bet, currency, `🎉 Blackjack! +${currency}${payout.toLocaleString()}`, '#2ecc71', false);
             return interaction.reply({ embeds: [embed], components: [buildButtons(gameId, true)] });
         }

--- a/src/commands/economy/crime.js
+++ b/src/commands/economy/crime.js
@@ -1,0 +1,88 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const User  = require('../../models/User');
+const Guild = require('../../models/Guild');
+
+const COOLDOWN_MS   = 4 * 3_600_000; // 4 hours
+const SUCCESS_CHANCE = 0.40;
+
+const CRIMES = [
+    { name: 'pickpocketing',       emoji: '🤏', minPayout: 80,   maxPayout: 200  },
+    { name: 'selling fake merch',  emoji: '🛍️', minPayout: 100,  maxPayout: 300  },
+    { name: 'hacking ATMs',        emoji: '💻', minPayout: 200,  maxPayout: 500  },
+    { name: 'art forgery',         emoji: '🖼️', minPayout: 300,  maxPayout: 700  },
+    { name: 'casino cheating',     emoji: '🎰', minPayout: 400,  maxPayout: 1000 },
+    { name: 'grand larceny',       emoji: '💎', minPayout: 600,  maxPayout: 1500 },
+];
+
+const FINES = [
+    'You were caught by an undercover officer.',
+    'A bystander called the police on you.',
+    'Security footage gave you away.',
+    'Your partner-in-crime ratted you out.',
+    'Your disguise fell off at the worst moment.',
+];
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('crime')
+        .setDescription('Attempt a crime for a big payout — or pay a heavy fine'),
+
+    async execute(interaction) {
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        if (guildSettings?.economy?.enabled === false) {
+            return interaction.reply({ content: 'The economy is disabled on this server.', ephemeral: true });
+        }
+
+        const currency = guildSettings?.economy?.currency || '💰';
+
+        let user = await User.findOneAndUpdate(
+            { userId: interaction.user.id, guildId: interaction.guild.id },
+            {},
+            { upsert: true, new: true }
+        );
+
+        const lastCrime = user.get('lastCrime');
+        if (lastCrime && Date.now() - new Date(lastCrime).getTime() < COOLDOWN_MS) {
+            const remaining = COOLDOWN_MS - (Date.now() - new Date(lastCrime).getTime());
+            const hrs = Math.ceil(remaining / 3_600_000);
+            return interaction.reply({ content: `You're still on the radar from last time. Lay low for **${hrs}h**.`, ephemeral: true });
+        }
+
+        const crime   = CRIMES[Math.floor(Math.random() * CRIMES.length)];
+        const success = Math.random() < SUCCESS_CHANCE;
+
+        user.set('lastCrime', new Date());
+
+        let embed;
+        if (success) {
+            const earned = Math.floor(crime.minPayout + Math.random() * (crime.maxPayout - crime.minPayout));
+            user.balance += earned;
+            await user.save();
+
+            embed = new EmbedBuilder()
+                .setColor('#f39c12')
+                .setTitle(`${crime.emoji} Crime Pays — This Time`)
+                .setDescription(`Your attempt at **${crime.name}** was a success! You pocketed **${currency}${earned.toLocaleString()}**.`)
+                .addFields({ name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true })
+                .setFooter({ text: 'Crimes can be committed every 4 hours' })
+                .setTimestamp();
+        } else {
+            const fine = Math.floor(50 + Math.random() * 200);
+            const paid = Math.min(fine, user.balance);
+            user.balance = Math.max(0, user.balance - paid);
+            await user.save();
+
+            const flavorText = FINES[Math.floor(Math.random() * FINES.length)];
+            embed = new EmbedBuilder()
+                .setColor('#e74c3c')
+                .setTitle(`${crime.emoji} Busted!`)
+                .setDescription(`Your attempt at **${crime.name}** went sideways. ${flavorText}\nYou were fined **${currency}${paid.toLocaleString()}**.`)
+                .addFields({ name: 'Fine Paid', value: `${currency}${paid.toLocaleString()}`, inline: true },
+                           { name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true })
+                .setFooter({ text: 'Crimes can be committed every 4 hours' })
+                .setTimestamp();
+        }
+
+        await interaction.reply({ embeds: [embed] });
+    }
+};

--- a/src/commands/economy/crime.js
+++ b/src/commands/economy/crime.js
@@ -41,9 +41,8 @@ module.exports = {
             { upsert: true, new: true }
         );
 
-        const lastCrime = user.get('lastCrime');
-        if (lastCrime && Date.now() - new Date(lastCrime).getTime() < COOLDOWN_MS) {
-            const remaining = COOLDOWN_MS - (Date.now() - new Date(lastCrime).getTime());
+        if (user.lastCrime && Date.now() - user.lastCrime.getTime() < COOLDOWN_MS) {
+            const remaining = COOLDOWN_MS - (Date.now() - user.lastCrime.getTime());
             const hrs = Math.ceil(remaining / 3_600_000);
             return interaction.reply({ content: `You're still on the radar from last time. Lay low for **${hrs}h**.`, ephemeral: true });
         }
@@ -51,38 +50,45 @@ module.exports = {
         const crime   = CRIMES[Math.floor(Math.random() * CRIMES.length)];
         const success = Math.random() < SUCCESS_CHANCE;
 
-        user.set('lastCrime', new Date());
+        user.lastCrime = new Date();
 
-        let embed;
-        if (success) {
-            const earned = Math.floor(crime.minPayout + Math.random() * (crime.maxPayout - crime.minPayout));
-            user.balance += earned;
-            await user.save();
+        try {
+            let embed;
+            if (success) {
+                const earned = Math.floor(crime.minPayout + Math.random() * (crime.maxPayout - crime.minPayout));
+                user.balance += earned;
+                await user.save();
 
-            embed = new EmbedBuilder()
-                .setColor('#f39c12')
-                .setTitle(`${crime.emoji} Crime Pays — This Time`)
-                .setDescription(`Your attempt at **${crime.name}** was a success! You pocketed **${currency}${earned.toLocaleString()}**.`)
-                .addFields({ name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true })
-                .setFooter({ text: 'Crimes can be committed every 4 hours' })
-                .setTimestamp();
-        } else {
-            const fine = Math.floor(50 + Math.random() * 200);
-            const paid = Math.min(fine, user.balance);
-            user.balance = Math.max(0, user.balance - paid);
-            await user.save();
+                embed = new EmbedBuilder()
+                    .setColor('#f39c12')
+                    .setTitle(`${crime.emoji} Crime Pays — This Time`)
+                    .setDescription(`Your attempt at **${crime.name}** was a success! You pocketed **${currency}${earned.toLocaleString()}**.`)
+                    .addFields({ name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true })
+                    .setFooter({ text: 'Crimes can be committed every 4 hours' })
+                    .setTimestamp();
+            } else {
+                const fine = Math.floor(50 + Math.random() * 200);
+                const paid = Math.min(fine, user.balance);
+                user.balance = Math.max(0, user.balance - paid);
+                await user.save();
 
-            const flavorText = FINES[Math.floor(Math.random() * FINES.length)];
-            embed = new EmbedBuilder()
-                .setColor('#e74c3c')
-                .setTitle(`${crime.emoji} Busted!`)
-                .setDescription(`Your attempt at **${crime.name}** went sideways. ${flavorText}\nYou were fined **${currency}${paid.toLocaleString()}**.`)
-                .addFields({ name: 'Fine Paid', value: `${currency}${paid.toLocaleString()}`, inline: true },
-                           { name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true })
-                .setFooter({ text: 'Crimes can be committed every 4 hours' })
-                .setTimestamp();
+                const flavorText = FINES[Math.floor(Math.random() * FINES.length)];
+                embed = new EmbedBuilder()
+                    .setColor('#e74c3c')
+                    .setTitle(`${crime.emoji} Busted!`)
+                    .setDescription(`Your attempt at **${crime.name}** went sideways. ${flavorText}\nYou were fined **${currency}${paid.toLocaleString()}**.`)
+                    .addFields({ name: 'Fine Paid', value: `${currency}${paid.toLocaleString()}`, inline: true },
+                               { name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true })
+                    .setFooter({ text: 'Crimes can be committed every 4 hours' })
+                    .setTimestamp();
+            }
+
+            await interaction.reply({ embeds: [embed] });
+        } catch (error) {
+            console.error('Crime command error:', error);
+            if (!interaction.replied) {
+                await interaction.reply({ content: 'Something went wrong.', ephemeral: true });
+            }
         }
-
-        await interaction.reply({ embeds: [embed] });
     }
 };

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -43,32 +43,36 @@ module.exports = {
             { upsert: true, new: true }
         );
 
-        const lastFish = user.get('lastFish');
-        if (lastFish && Date.now() - new Date(lastFish).getTime() < COOLDOWN_MS) {
-            const remaining = COOLDOWN_MS - (Date.now() - new Date(lastFish).getTime());
+        if (user.lastFish && Date.now() - user.lastFish.getTime() < COOLDOWN_MS) {
+            const remaining = COOLDOWN_MS - (Date.now() - user.lastFish.getTime());
             const mins = Math.ceil(remaining / 60000);
             return interaction.reply({ content: `Your fishing rod needs a rest. Try again in **${mins} min**.`, ephemeral: true });
         }
 
         await interaction.deferReply();
 
-        const catch_ = roll();
-        user.balance += catch_.payout;
-        user.set('lastFish', new Date());
-        await user.save();
+        try {
+            const catch_ = roll();
+            user.balance += catch_.payout;
+            user.lastFish = new Date();
+            await user.save();
 
-        const embed = new EmbedBuilder()
-            .setColor(catch_.payout === 0 ? '#95a5a6' : catch_.payout >= 350 ? '#f39c12' : '#3498db')
-            .setTitle(`${catch_.emoji} ${catch_.name}`)
-            .setDescription(
-                catch_.payout === 0
-                    ? `You reeled in a **${catch_.name}**. Better luck next time.`
-                    : `You caught a **${catch_.name}** and earned **${currency}${catch_.payout.toLocaleString()}**!`
-            )
-            .addFields({ name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true })
-            .setFooter({ text: 'Come back in 1 hour to fish again' })
-            .setTimestamp();
+            const embed = new EmbedBuilder()
+                .setColor(catch_.payout === 0 ? '#95a5a6' : catch_.payout >= 350 ? '#f39c12' : '#3498db')
+                .setTitle(`${catch_.emoji} ${catch_.name}`)
+                .setDescription(
+                    catch_.payout === 0
+                        ? `You reeled in a **${catch_.name}**. Better luck next time.`
+                        : `You caught a **${catch_.name}** and earned **${currency}${catch_.payout.toLocaleString()}**!`
+                )
+                .addFields({ name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true })
+                .setFooter({ text: 'Come back in 1 hour to fish again' })
+                .setTimestamp();
 
-        await interaction.editReply({ embeds: [embed] });
+            await interaction.editReply({ embeds: [embed] });
+        } catch (error) {
+            console.error('Fish command error:', error);
+            await interaction.editReply({ content: 'Something went wrong while fishing.' });
+        }
     }
 };

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -1,0 +1,74 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const User  = require('../../models/User');
+const Guild = require('../../models/Guild');
+
+const COOLDOWN_MS = 3_600_000; // 1 hour
+
+const CATCHES = [
+    { name: 'Old Boot',       emoji: '👢', payout: 0,    weight: 15 },
+    { name: 'Seaweed',        emoji: '🌿', payout: 5,    weight: 20 },
+    { name: 'Small Fish',     emoji: '🐟', payout: 25,   weight: 25 },
+    { name: 'Crab',           emoji: '🦀', payout: 50,   weight: 15 },
+    { name: 'Salmon',         emoji: '🐡', payout: 80,   weight: 10 },
+    { name: 'Lobster',        emoji: '🦞', payout: 120,  weight: 7  },
+    { name: 'Swordfish',      emoji: '🐬', payout: 200,  weight: 5  },
+    { name: 'Shark',          emoji: '🦈', payout: 350,  weight: 2  },
+    { name: 'Golden Fish',    emoji: '✨', payout: 750,  weight: 1  },
+];
+
+const TOTAL_WEIGHT = CATCHES.reduce((s, c) => s + c.weight, 0);
+
+function roll() {
+    let r = Math.random() * TOTAL_WEIGHT;
+    for (const c of CATCHES) { r -= c.weight; if (r <= 0) return c; }
+    return CATCHES[0];
+}
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('fish')
+        .setDescription('Cast your line and see what you catch'),
+
+    async execute(interaction) {
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        if (guildSettings?.economy?.enabled === false) {
+            return interaction.reply({ content: 'The economy is disabled on this server.', ephemeral: true });
+        }
+
+        const currency = guildSettings?.economy?.currency || '💰';
+
+        let user = await User.findOneAndUpdate(
+            { userId: interaction.user.id, guildId: interaction.guild.id },
+            {},
+            { upsert: true, new: true }
+        );
+
+        const lastFish = user.get('lastFish');
+        if (lastFish && Date.now() - new Date(lastFish).getTime() < COOLDOWN_MS) {
+            const remaining = COOLDOWN_MS - (Date.now() - new Date(lastFish).getTime());
+            const mins = Math.ceil(remaining / 60000);
+            return interaction.reply({ content: `Your fishing rod needs a rest. Try again in **${mins} min**.`, ephemeral: true });
+        }
+
+        await interaction.deferReply();
+
+        const catch_ = roll();
+        user.balance += catch_.payout;
+        user.set('lastFish', new Date());
+        await user.save();
+
+        const embed = new EmbedBuilder()
+            .setColor(catch_.payout === 0 ? '#95a5a6' : catch_.payout >= 350 ? '#f39c12' : '#3498db')
+            .setTitle(`${catch_.emoji} ${catch_.name}`)
+            .setDescription(
+                catch_.payout === 0
+                    ? `You reeled in a **${catch_.name}**. Better luck next time.`
+                    : `You caught a **${catch_.name}** and earned **${currency}${catch_.payout.toLocaleString()}**!`
+            )
+            .addFields({ name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true })
+            .setFooter({ text: 'Come back in 1 hour to fish again' })
+            .setTimestamp();
+
+        await interaction.editReply({ embeds: [embed] });
+    }
+};

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -50,39 +50,43 @@ module.exports = {
             { upsert: true, new: true }
         );
 
-        const lastMine = user.get('lastMine');
-        if (lastMine && Date.now() - new Date(lastMine).getTime() < COOLDOWN_MS) {
-            const remaining = COOLDOWN_MS - (Date.now() - new Date(lastMine).getTime());
+        if (user.lastMine && Date.now() - user.lastMine.getTime() < COOLDOWN_MS) {
+            const remaining = COOLDOWN_MS - (Date.now() - user.lastMine.getTime());
             const mins = Math.ceil(remaining / 60000);
             return interaction.reply({ content: `The mines are closed for maintenance. Come back in **${mins} min**.`, ephemeral: true });
         }
 
         await interaction.deferReply();
 
-        const ore = roll();
-        const qty = quantity();
-        const earned = ore.payout * qty;
+        try {
+            const ore = roll();
+            const qty = quantity();
+            const earned = ore.payout * qty;
 
-        user.balance += earned;
-        user.set('lastMine', new Date());
-        await user.save();
+            user.balance += earned;
+            user.lastMine = new Date();
+            await user.save();
 
-        const embed = new EmbedBuilder()
-            .setColor(ore.payout >= 600 ? '#f39c12' : ore.payout >= 200 ? '#2ecc71' : '#7f8c8d')
-            .setTitle(`${ore.emoji} Mining Results`)
-            .setDescription(
-                qty > 1
-                    ? `You struck **${qty}x ${ore.name}** and earned **${currency}${earned.toLocaleString()}**!`
-                    : `You found **${ore.name}** and earned **${currency}${earned.toLocaleString()}**!`
-            )
-            .addFields(
-                { name: 'Ore', value: `${ore.emoji} ${ore.name} ×${qty}`, inline: true },
-                { name: 'Earned', value: `${currency}${earned.toLocaleString()}`, inline: true },
-                { name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true }
-            )
-            .setFooter({ text: 'The mines reopen in 2 hours' })
-            .setTimestamp();
+            const embed = new EmbedBuilder()
+                .setColor(ore.payout >= 600 ? '#f39c12' : ore.payout >= 200 ? '#2ecc71' : '#7f8c8d')
+                .setTitle(`${ore.emoji} Mining Results`)
+                .setDescription(
+                    qty > 1
+                        ? `You struck **${qty}x ${ore.name}** and earned **${currency}${earned.toLocaleString()}**!`
+                        : `You found **${ore.name}** and earned **${currency}${earned.toLocaleString()}**!`
+                )
+                .addFields(
+                    { name: 'Ore', value: `${ore.emoji} ${ore.name} ×${qty}`, inline: true },
+                    { name: 'Earned', value: `${currency}${earned.toLocaleString()}`, inline: true },
+                    { name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true }
+                )
+                .setFooter({ text: 'The mines reopen in 2 hours' })
+                .setTimestamp();
 
-        await interaction.editReply({ embeds: [embed] });
+            await interaction.editReply({ embeds: [embed] });
+        } catch (error) {
+            console.error('Mine command error:', error);
+            await interaction.editReply({ content: 'Something went wrong while mining.' });
+        }
     }
 };

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -1,0 +1,88 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const User  = require('../../models/User');
+const Guild = require('../../models/Guild');
+
+const COOLDOWN_MS = 2 * 3_600_000; // 2 hours
+
+const ORES = [
+    { name: 'Stone',       emoji: '🪨', payout: 10,   weight: 30 },
+    { name: 'Coal',        emoji: '⬛', payout: 25,   weight: 25 },
+    { name: 'Iron',        emoji: '🔩', payout: 50,   weight: 18 },
+    { name: 'Gold',        emoji: '🟡', payout: 100,  weight: 12 },
+    { name: 'Emerald',     emoji: '💚', payout: 200,  weight: 8  },
+    { name: 'Ruby',        emoji: '🔴', payout: 350,  weight: 4  },
+    { name: 'Diamond',     emoji: '💎', payout: 600,  weight: 2  },
+    { name: 'Void Crystal',emoji: '🔮', payout: 1200, weight: 1  },
+];
+
+const TOTAL_WEIGHT = ORES.reduce((s, o) => s + o.weight, 0);
+
+function roll() {
+    let r = Math.random() * TOTAL_WEIGHT;
+    for (const o of ORES) { r -= o.weight; if (r <= 0) return o; }
+    return ORES[0];
+}
+
+// Occasionally find multiple pieces
+function quantity() {
+    const r = Math.random();
+    if (r < 0.05) return 3;
+    if (r < 0.20) return 2;
+    return 1;
+}
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('mine')
+        .setDescription('Head into the mines and dig for ore'),
+
+    async execute(interaction) {
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        if (guildSettings?.economy?.enabled === false) {
+            return interaction.reply({ content: 'The economy is disabled on this server.', ephemeral: true });
+        }
+
+        const currency = guildSettings?.economy?.currency || '💰';
+
+        let user = await User.findOneAndUpdate(
+            { userId: interaction.user.id, guildId: interaction.guild.id },
+            {},
+            { upsert: true, new: true }
+        );
+
+        const lastMine = user.get('lastMine');
+        if (lastMine && Date.now() - new Date(lastMine).getTime() < COOLDOWN_MS) {
+            const remaining = COOLDOWN_MS - (Date.now() - new Date(lastMine).getTime());
+            const mins = Math.ceil(remaining / 60000);
+            return interaction.reply({ content: `The mines are closed for maintenance. Come back in **${mins} min**.`, ephemeral: true });
+        }
+
+        await interaction.deferReply();
+
+        const ore = roll();
+        const qty = quantity();
+        const earned = ore.payout * qty;
+
+        user.balance += earned;
+        user.set('lastMine', new Date());
+        await user.save();
+
+        const embed = new EmbedBuilder()
+            .setColor(ore.payout >= 600 ? '#f39c12' : ore.payout >= 200 ? '#2ecc71' : '#7f8c8d')
+            .setTitle(`${ore.emoji} Mining Results`)
+            .setDescription(
+                qty > 1
+                    ? `You struck **${qty}x ${ore.name}** and earned **${currency}${earned.toLocaleString()}**!`
+                    : `You found **${ore.name}** and earned **${currency}${earned.toLocaleString()}**!`
+            )
+            .addFields(
+                { name: 'Ore', value: `${ore.emoji} ${ore.name} ×${qty}`, inline: true },
+                { name: 'Earned', value: `${currency}${earned.toLocaleString()}`, inline: true },
+                { name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true }
+            )
+            .setFooter({ text: 'The mines reopen in 2 hours' })
+            .setTimestamp();
+
+        await interaction.editReply({ embeds: [embed] });
+    }
+};

--- a/src/commands/economy/rob.js
+++ b/src/commands/economy/rob.js
@@ -1,0 +1,89 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const User  = require('../../models/User');
+const Guild = require('../../models/Guild');
+
+const COOLDOWN_MS   = 2 * 3_600_000; // 2 hours
+const SUCCESS_CHANCE = 0.45;
+const MIN_ROB_BALANCE = 50;
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('rob')
+        .setDescription('Attempt to steal coins from another member')
+        .addUserOption(o =>
+            o.setName('target')
+                .setDescription('The member to rob')
+                .setRequired(true)),
+
+    async execute(interaction) {
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        if (guildSettings?.economy?.enabled === false) {
+            return interaction.reply({ content: 'The economy is disabled on this server.', ephemeral: true });
+        }
+
+        const currency = guildSettings?.economy?.currency || '💰';
+        const target   = interaction.options.getUser('target');
+
+        if (target.id === interaction.user.id) {
+            return interaction.reply({ content: "You can't rob yourself.", ephemeral: true });
+        }
+        if (target.bot) {
+            return interaction.reply({ content: "You can't rob a bot.", ephemeral: true });
+        }
+
+        const [robber, victim] = await Promise.all([
+            User.findOneAndUpdate({ userId: interaction.user.id, guildId: interaction.guild.id }, {}, { upsert: true, new: true }),
+            User.findOne({ userId: target.id, guildId: interaction.guild.id })
+        ]);
+
+        // Cooldown
+        if (robber.lastWork && Date.now() - new Date(robber.lastWork).getTime() < COOLDOWN_MS) {
+            const remaining = COOLDOWN_MS - (Date.now() - new Date(robber.lastWork).getTime());
+            const mins = Math.ceil(remaining / 60000);
+            return interaction.reply({ content: `You're lying low after your last job. Try again in **${mins} min**.`, ephemeral: true });
+        }
+
+        if (!victim || victim.balance < MIN_ROB_BALANCE) {
+            return interaction.reply({ content: `${target.username} doesn't have enough ${currency} to be worth robbing (minimum ${currency}${MIN_ROB_BALANCE}).`, ephemeral: true });
+        }
+
+        const success = Math.random() < SUCCESS_CHANCE;
+        robber.lastWork = new Date();
+
+        let embed;
+        if (success) {
+            const stolen = Math.floor(victim.balance * (0.1 + Math.random() * 0.2));
+            robber.balance += stolen;
+            victim.balance -= stolen;
+            await Promise.all([robber.save(), victim.save()]);
+
+            embed = new EmbedBuilder()
+                .setColor('#f39c12')
+                .setTitle('🦹 Successful Heist!')
+                .setDescription(`You slipped into **${target.username}'s** wallet and made off with **${currency}${stolen.toLocaleString()}**!`)
+                .addFields(
+                    { name: 'Your Balance', value: `${currency}${robber.balance.toLocaleString()}`, inline: true },
+                    { name: 'Their Balance', value: `${currency}${victim.balance.toLocaleString()}`, inline: true }
+                )
+                .setTimestamp();
+        } else {
+            const fine = Math.floor(robber.balance * 0.1);
+            const paid = Math.min(fine, robber.balance);
+            robber.balance = Math.max(0, robber.balance - paid);
+            victim.balance += paid;
+            await Promise.all([robber.save(), victim.save()]);
+
+            embed = new EmbedBuilder()
+                .setColor('#e74c3c')
+                .setTitle('🚔 Caught Red-Handed!')
+                .setDescription(`**${target.username}** caught you and you were fined **${currency}${paid.toLocaleString()}**, which went straight to them.`)
+                .addFields(
+                    { name: 'Fine Paid', value: `${currency}${paid.toLocaleString()}`, inline: true },
+                    { name: 'Your Balance', value: `${currency}${robber.balance.toLocaleString()}`, inline: true }
+                )
+                .setTimestamp();
+        }
+
+        await interaction.reply({ embeds: [embed] });
+    }
+};

--- a/src/commands/economy/rob.js
+++ b/src/commands/economy/rob.js
@@ -47,43 +47,50 @@ module.exports = {
             return interaction.reply({ content: `${target.username} doesn't have enough ${currency} to be worth robbing (minimum ${currency}${MIN_ROB_BALANCE}).`, ephemeral: true });
         }
 
-        const success = Math.random() < SUCCESS_CHANCE;
-        robber.lastWork = new Date();
+        try {
+            const success = Math.random() < SUCCESS_CHANCE;
+            robber.lastWork = new Date();
 
-        let embed;
-        if (success) {
-            const stolen = Math.floor(victim.balance * (0.1 + Math.random() * 0.2));
-            robber.balance += stolen;
-            victim.balance -= stolen;
-            await Promise.all([robber.save(), victim.save()]);
+            let embed;
+            if (success) {
+                const stolen = Math.floor(victim.balance * (0.1 + Math.random() * 0.2));
+                robber.balance += stolen;
+                victim.balance -= stolen;
+                await Promise.all([robber.save(), victim.save()]);
 
-            embed = new EmbedBuilder()
-                .setColor('#f39c12')
-                .setTitle('🦹 Successful Heist!')
-                .setDescription(`You slipped into **${target.username}'s** wallet and made off with **${currency}${stolen.toLocaleString()}**!`)
-                .addFields(
-                    { name: 'Your Balance', value: `${currency}${robber.balance.toLocaleString()}`, inline: true },
-                    { name: 'Their Balance', value: `${currency}${victim.balance.toLocaleString()}`, inline: true }
-                )
-                .setTimestamp();
-        } else {
-            const fine = Math.floor(robber.balance * 0.1);
-            const paid = Math.min(fine, robber.balance);
-            robber.balance = Math.max(0, robber.balance - paid);
-            victim.balance += paid;
-            await Promise.all([robber.save(), victim.save()]);
+                embed = new EmbedBuilder()
+                    .setColor('#f39c12')
+                    .setTitle('🦹 Successful Heist!')
+                    .setDescription(`You slipped into **${target.username}'s** wallet and made off with **${currency}${stolen.toLocaleString()}**!`)
+                    .addFields(
+                        { name: 'Your Balance', value: `${currency}${robber.balance.toLocaleString()}`, inline: true },
+                        { name: 'Their Balance', value: `${currency}${victim.balance.toLocaleString()}`, inline: true }
+                    )
+                    .setTimestamp();
+            } else {
+                const fine = Math.floor(robber.balance * 0.1);
+                const paid = Math.min(fine, robber.balance);
+                robber.balance = Math.max(0, robber.balance - paid);
+                victim.balance += paid;
+                await Promise.all([robber.save(), victim.save()]);
 
-            embed = new EmbedBuilder()
-                .setColor('#e74c3c')
-                .setTitle('🚔 Caught Red-Handed!')
-                .setDescription(`**${target.username}** caught you and you were fined **${currency}${paid.toLocaleString()}**, which went straight to them.`)
-                .addFields(
-                    { name: 'Fine Paid', value: `${currency}${paid.toLocaleString()}`, inline: true },
-                    { name: 'Your Balance', value: `${currency}${robber.balance.toLocaleString()}`, inline: true }
-                )
-                .setTimestamp();
+                embed = new EmbedBuilder()
+                    .setColor('#e74c3c')
+                    .setTitle('🚔 Caught Red-Handed!')
+                    .setDescription(`**${target.username}** caught you and you were fined **${currency}${paid.toLocaleString()}**, which went straight to them.`)
+                    .addFields(
+                        { name: 'Fine Paid', value: `${currency}${paid.toLocaleString()}`, inline: true },
+                        { name: 'Your Balance', value: `${currency}${robber.balance.toLocaleString()}`, inline: true }
+                    )
+                    .setTimestamp();
+            }
+
+            await interaction.reply({ embeds: [embed] });
+        } catch (error) {
+            console.error('Rob command error:', error);
+            if (!interaction.replied) {
+                await interaction.reply({ content: 'Something went wrong.', ephemeral: true });
+            }
         }
-
-        await interaction.reply({ embeds: [embed] });
     }
 };

--- a/src/commands/economy/use.js
+++ b/src/commands/economy/use.js
@@ -1,0 +1,65 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const User  = require('../../models/User');
+const Guild = require('../../models/Guild');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('use')
+        .setDescription('Use an item from your inventory')
+        .addStringOption(o =>
+            o.setName('item')
+                .setDescription('Name of the item to use')
+                .setRequired(true)),
+
+    async execute(interaction) {
+        const itemName = interaction.options.getString('item').trim();
+
+        const [user, guildSettings] = await Promise.all([
+            User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }),
+            Guild.findOne({ guildId: interaction.guild.id })
+        ]);
+
+        if (!user || !user.inventory?.length) {
+            return interaction.reply({ content: "Your inventory is empty. Buy items with `/shop buy`.", ephemeral: true });
+        }
+
+        const invEntry = user.inventory.find(e => e.itemId.toLowerCase() === itemName.toLowerCase());
+        if (!invEntry || invEntry.quantity < 1) {
+            return interaction.reply({ content: `You don't have **${itemName}** in your inventory.`, ephemeral: true });
+        }
+
+        const shopItem = guildSettings?.shop?.find(s => s.name.toLowerCase() === itemName.toLowerCase());
+
+        // Consume one from inventory
+        invEntry.quantity -= 1;
+        if (invEntry.quantity <= 0) {
+            user.inventory = user.inventory.filter(e => e.itemId.toLowerCase() !== itemName.toLowerCase());
+        }
+
+        let roleGranted = false;
+        if (shopItem?.roleId) {
+            const member = await interaction.guild.members.fetch(interaction.user.id).catch(() => null);
+            if (member && !member.roles.cache.has(shopItem.roleId)) {
+                await member.roles.add(shopItem.roleId, `Used shop item: ${shopItem.name}`).catch(() => {});
+                roleGranted = true;
+            }
+        }
+
+        await user.save();
+
+        const embed = new EmbedBuilder()
+            .setColor('#2ecc71')
+            .setTitle(`✅ Used: ${shopItem?.name ?? itemName}`)
+            .setDescription(shopItem?.description || 'Item consumed from your inventory.')
+            .setTimestamp();
+
+        if (roleGranted) {
+            embed.addFields({ name: 'Role Granted', value: `<@&${shopItem.roleId}>` });
+        }
+
+        const remaining = user.inventory.find(e => e.itemId.toLowerCase() === itemName.toLowerCase())?.quantity ?? 0;
+        embed.addFields({ name: 'Remaining', value: `${remaining}x`, inline: true });
+
+        await interaction.reply({ embeds: [embed] });
+    }
+};

--- a/src/commands/economy/use.js
+++ b/src/commands/economy/use.js
@@ -30,21 +30,20 @@ module.exports = {
 
         const shopItem = guildSettings?.shop?.find(s => s.name.toLowerCase() === itemName.toLowerCase());
 
-        // Consume one from inventory
-        invEntry.quantity -= 1;
-        if (invEntry.quantity <= 0) {
-            user.inventory = user.inventory.filter(e => e.itemId.toLowerCase() !== itemName.toLowerCase());
-        }
-
         let roleGranted = false;
         if (shopItem?.roleId) {
             const member = await interaction.guild.members.fetch(interaction.user.id).catch(() => null);
             if (member && !member.roles.cache.has(shopItem.roleId)) {
-                await member.roles.add(shopItem.roleId, `Used shop item: ${shopItem.name}`).catch(() => {});
+                await member.roles.add(shopItem.roleId, `Used shop item: ${shopItem.name}`);
                 roleGranted = true;
             }
         }
 
+        // Consume from inventory only after successful effects
+        invEntry.quantity -= 1;
+        if (invEntry.quantity <= 0) {
+            user.inventory = user.inventory.filter(e => e.itemId.toLowerCase() !== itemName.toLowerCase());
+        }
         await user.save();
 
         const embed = new EmbedBuilder()

--- a/src/commands/fun/coinflip.js
+++ b/src/commands/fun/coinflip.js
@@ -5,6 +5,7 @@ const {
     ButtonBuilder,
     ButtonStyle,
 } = require('discord.js');
+const Guild = require('../../models/Guild');
 
 const HEADS_THUMB = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1fa99.png';
 
@@ -54,6 +55,10 @@ module.exports = {
         .setDescription('Flip a coin — heads or tails?'),
 
     async execute(interaction) {
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        if (guildSettings?.economy?.enabled === false || guildSettings?.economy?.coinflipEnabled === false) {
+            return interaction.reply({ content: 'Coinflip is disabled on this server.', ephemeral: true });
+        }
         await interaction.deferReply();
         await playCoinFlip(interaction);
     },

--- a/src/commands/fun/roll.js
+++ b/src/commands/fun/roll.js
@@ -5,6 +5,7 @@ const {
     ButtonBuilder,
     ButtonStyle,
 } = require('discord.js');
+const Guild = require('../../models/Guild');
 
 const THUMB = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3b2.png';
 
@@ -78,6 +79,10 @@ module.exports = {
                 .setMaxValue(100)),
 
     async execute(interaction) {
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        if (guildSettings?.economy?.enabled === false || guildSettings?.economy?.rollEnabled === false) {
+            return interaction.reply({ content: 'Dice roll is disabled on this server.', ephemeral: true });
+        }
         const sides = interaction.options.getInteger('sides') || 6;
         await interaction.deferReply();
         await playRoll(interaction, sides);

--- a/src/commands/moderation/ban.js
+++ b/src/commands/moderation/ban.js
@@ -72,23 +72,21 @@ module.exports = {
         let durationMs = null;
         if (durationStr) {
             durationMs = parseDuration(durationStr);
-            if (!durationMs) {
+            if (durationMs === null) {
                 return interaction.reply({ content: 'Invalid duration format. Use e.g. `30m`, `12h`, `7d`.', ephemeral: true });
             }
         }
 
         try {
-            await interaction.guild.members.ban(user, { deleteMessageSeconds: deleteDays * 86400, reason });
-
             if (durationMs) {
-                await TempBan.create({
-                    guildId:     interaction.guild.id,
-                    userId:      user.id,
-                    moderatorId: interaction.user.id,
-                    reason,
-                    expiresAt:   new Date(Date.now() + durationMs)
-                });
+                await TempBan.findOneAndUpdate(
+                    { guildId: interaction.guild.id, userId: user.id },
+                    { moderatorId: interaction.user.id, reason, expiresAt: new Date(Date.now() + durationMs) },
+                    { upsert: true }
+                );
             }
+
+            await interaction.guild.members.ban(user, { deleteMessageSeconds: deleteDays * 86400, reason });
 
             const embed = new EmbedBuilder()
                 .setColor('#ff0000')

--- a/src/commands/moderation/ban.js
+++ b/src/commands/moderation/ban.js
@@ -1,50 +1,98 @@
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
 const { logModeration } = require('../../utils/logger');
+const TempBan = require('../../models/TempBan');
+
+const DURATION_RE = /^(\d+)(m|h|d)$/i;
+
+function parseDuration(str) {
+    if (!str) return null;
+    const m = str.trim().match(DURATION_RE);
+    if (!m) return null;
+    const n = parseInt(m[1], 10);
+    const unit = m[2].toLowerCase();
+    if (unit === 'm') return n * 60_000;
+    if (unit === 'h') return n * 3_600_000;
+    if (unit === 'd') return n * 86_400_000;
+    return null;
+}
+
+function formatDuration(ms) {
+    const d = Math.floor(ms / 86_400_000);
+    const h = Math.floor((ms % 86_400_000) / 3_600_000);
+    const m = Math.floor((ms % 3_600_000) / 60_000);
+    const parts = [];
+    if (d) parts.push(`${d}d`);
+    if (h) parts.push(`${h}h`);
+    if (m) parts.push(`${m}m`);
+    return parts.join(' ') || '< 1m';
+}
 
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('ban')
         .setDescription('Ban a member from the server')
-        .addUserOption(option =>
-            option.setName('user')
+        .addUserOption(o =>
+            o.setName('user')
                 .setDescription('The user to ban')
                 .setRequired(true))
-        .addStringOption(option =>
-            option.setName('reason')
+        .addStringOption(o =>
+            o.setName('reason')
                 .setDescription('Reason for the ban')
                 .setRequired(false))
-        .addIntegerOption(option =>
-            option.setName('delete_days')
-                .setDescription('Delete messages from the last X days (0-7)')
+        .addStringOption(o =>
+            o.setName('duration')
+                .setDescription('Temporary ban duration e.g. 30m, 12h, 7d (omit for permanent)')
+                .setRequired(false))
+        .addIntegerOption(o =>
+            o.setName('delete_days')
+                .setDescription('Delete messages from the last X days (0–7)')
                 .setMinValue(0)
                 .setMaxValue(7)
                 .setRequired(false))
         .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers),
+
     async execute(interaction) {
-        const user = interaction.options.getUser('user');
-        const reason = interaction.options.getString('reason') || 'No reason provided';
-        const deleteDays = interaction.options.getInteger('delete_days') || 0;
+        const user        = interaction.options.getUser('user');
+        const reason      = interaction.options.getString('reason') || 'No reason provided';
+        const durationStr = interaction.options.getString('duration');
+        const deleteDays  = interaction.options.getInteger('delete_days') || 0;
 
         if (user.id === interaction.user.id) {
-            return interaction.reply({ content: 'You cannot ban yourself!', ephemeral: true });
+            return interaction.reply({ content: 'You cannot ban yourself.', ephemeral: true });
         }
-
         if (user.id === interaction.client.user.id) {
-            return interaction.reply({ content: 'I cannot ban myself!', ephemeral: true });
+            return interaction.reply({ content: 'I cannot ban myself.', ephemeral: true });
         }
 
         const member = interaction.guild.members.cache.get(user.id);
-        
         if (member && !member.bannable) {
-            return interaction.reply({ content: 'I cannot ban this user! They may have higher permissions.', ephemeral: true });
+            return interaction.reply({ content: 'I cannot ban this user — they may have higher permissions.', ephemeral: true });
+        }
+
+        let durationMs = null;
+        if (durationStr) {
+            durationMs = parseDuration(durationStr);
+            if (!durationMs) {
+                return interaction.reply({ content: 'Invalid duration format. Use e.g. `30m`, `12h`, `7d`.', ephemeral: true });
+            }
         }
 
         try {
             await interaction.guild.members.ban(user, { deleteMessageSeconds: deleteDays * 86400, reason });
 
+            if (durationMs) {
+                await TempBan.create({
+                    guildId:     interaction.guild.id,
+                    userId:      user.id,
+                    moderatorId: interaction.user.id,
+                    reason,
+                    expiresAt:   new Date(Date.now() + durationMs)
+                });
+            }
+
             const embed = new EmbedBuilder()
                 .setColor('#ff0000')
-                .setTitle('User Banned')
+                .setTitle(durationMs ? 'User Temporarily Banned' : 'User Banned')
                 .setDescription(`**${user.tag}** has been banned from the server.`)
                 .addFields(
                     { name: 'Reason', value: reason },
@@ -52,8 +100,16 @@ module.exports = {
                 )
                 .setTimestamp();
 
+            if (durationMs) {
+                embed.addFields(
+                    { name: 'Duration', value: formatDuration(durationMs), inline: true },
+                    { name: 'Expires', value: `<t:${Math.floor((Date.now() + durationMs) / 1000)}:R>`, inline: true }
+                );
+            }
+
             await interaction.reply({ embeds: [embed] });
-            await logModeration(interaction.guild.id, 'ban', user, interaction.user, reason);
+            await logModeration(interaction.guild.id, 'ban', user, interaction.user, reason,
+                durationMs ? { duration: Math.round(durationMs / 60000) } : {});
         } catch (error) {
             console.error('Ban error:', error);
             await interaction.reply({ content: 'Failed to ban the user.', ephemeral: true });

--- a/src/commands/moderation/massban.js
+++ b/src/commands/moderation/massban.js
@@ -12,6 +12,7 @@ module.exports = {
         .addStringOption(o =>
             o.setName('reason')
                 .setDescription('Reason applied to all bans')
+                .setMaxLength(1024)
                 .setRequired(false))
         .addIntegerOption(o =>
             o.setName('delete_days')
@@ -65,7 +66,7 @@ module.exports = {
             .addFields(
                 { name: 'Banned', value: `${succeeded.length} user(s)`, inline: true },
                 { name: 'Failed', value: `${failed.length} user(s)`, inline: true },
-                { name: 'Reason', value: reason }
+                { name: 'Reason', value: reason.slice(0, 1024) }
             )
             .setTimestamp();
 

--- a/src/commands/moderation/massban.js
+++ b/src/commands/moderation/massban.js
@@ -1,0 +1,78 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const { logModeration } = require('../../utils/logger');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('massban')
+        .setDescription('Ban multiple users by ID — useful for raid cleanup')
+        .addStringOption(o =>
+            o.setName('user_ids')
+                .setDescription('Space or comma-separated list of user IDs')
+                .setRequired(true))
+        .addStringOption(o =>
+            o.setName('reason')
+                .setDescription('Reason applied to all bans')
+                .setRequired(false))
+        .addIntegerOption(o =>
+            o.setName('delete_days')
+                .setDescription('Days of messages to delete per user (0–7)')
+                .setMinValue(0)
+                .setMaxValue(7)
+                .setRequired(false))
+        .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers | PermissionFlagsBits.ManageGuild),
+
+    async execute(interaction) {
+        await interaction.deferReply();
+
+        const raw        = interaction.options.getString('user_ids');
+        const reason     = interaction.options.getString('reason') || 'Mass ban';
+        const deleteDays = interaction.options.getInteger('delete_days') ?? 0;
+
+        const ids = [...new Set(raw.split(/[\s,]+/).filter(id => /^\d{17,20}$/.test(id)))];
+
+        if (ids.length === 0) {
+            return interaction.editReply('No valid user IDs found. Provide 17–20 digit Discord IDs.');
+        }
+        if (ids.length > 50) {
+            return interaction.editReply('Maximum 50 users per mass ban. Split into multiple calls if needed.');
+        }
+
+        const succeeded = [];
+        const failed    = [];
+
+        for (const userId of ids) {
+            if (userId === interaction.user.id || userId === interaction.client.user.id) {
+                failed.push(userId);
+                continue;
+            }
+            try {
+                await interaction.guild.members.ban(userId, {
+                    deleteMessageSeconds: deleteDays * 86400,
+                    reason: `[MassBan] ${reason}`
+                });
+                succeeded.push(userId);
+
+                const fetchedUser = await interaction.client.users.fetch(userId).catch(() => ({ id: userId, tag: userId }));
+                await logModeration(interaction.guild.id, 'ban', fetchedUser, interaction.user, `[MassBan] ${reason}`);
+            } catch {
+                failed.push(userId);
+            }
+        }
+
+        const embed = new EmbedBuilder()
+            .setColor(failed.length === 0 ? '#ff0000' : '#ff9900')
+            .setTitle('Mass Ban Complete')
+            .addFields(
+                { name: 'Banned', value: `${succeeded.length} user(s)`, inline: true },
+                { name: 'Failed', value: `${failed.length} user(s)`, inline: true },
+                { name: 'Reason', value: reason }
+            )
+            .setTimestamp();
+
+        if (failed.length > 0) {
+            embed.addFields({ name: 'Failed IDs', value: failed.slice(0, 20).join(', ') });
+        }
+
+        await interaction.editReply({ embeds: [embed] });
+    }
+};

--- a/src/commands/moderation/slowmode.js
+++ b/src/commands/moderation/slowmode.js
@@ -1,0 +1,47 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('slowmode')
+        .setDescription('Set or clear the slowmode for a channel')
+        .addIntegerOption(o =>
+            o.setName('seconds')
+                .setDescription('Cooldown in seconds (0 to disable, max 21600)')
+                .setRequired(true)
+                .setMinValue(0)
+                .setMaxValue(21600))
+        .addChannelOption(o =>
+            o.setName('channel')
+                .setDescription('Channel to apply slowmode to (defaults to current channel)')
+                .setRequired(false))
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels),
+
+    async execute(interaction) {
+        const seconds = interaction.options.getInteger('seconds');
+        const channel = interaction.options.getChannel('channel') ?? interaction.channel;
+
+        if (!channel.isTextBased()) {
+            return interaction.reply({ content: 'Slowmode can only be set on text channels.', ephemeral: true });
+        }
+
+        try {
+            await channel.setRateLimitPerUser(seconds, `Set by ${interaction.user.tag}`);
+
+            const embed = new EmbedBuilder()
+                .setColor(seconds === 0 ? '#00ff00' : '#ff9900')
+                .setTitle(seconds === 0 ? 'Slowmode Disabled' : 'Slowmode Enabled')
+                .setDescription(
+                    seconds === 0
+                        ? `Slowmode has been removed from ${channel}.`
+                        : `${channel} now has a **${seconds}s** slowmode.`
+                )
+                .addFields({ name: 'Set by', value: interaction.user.tag, inline: true })
+                .setTimestamp();
+
+            await interaction.reply({ embeds: [embed] });
+        } catch (error) {
+            console.error('Slowmode error:', error);
+            await interaction.reply({ content: 'Failed to update slowmode.', ephemeral: true });
+        }
+    }
+};

--- a/src/commands/moderation/softban.js
+++ b/src/commands/moderation/softban.js
@@ -1,0 +1,66 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const { logModeration } = require('../../utils/logger');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('softban')
+        .setDescription('Ban then immediately unban a member to purge their recent messages')
+        .addUserOption(o =>
+            o.setName('user')
+                .setDescription('The member to softban')
+                .setRequired(true))
+        .addStringOption(o =>
+            o.setName('reason')
+                .setDescription('Reason for the softban')
+                .setRequired(false))
+        .addIntegerOption(o =>
+            o.setName('delete_days')
+                .setDescription('Days of messages to delete (1–7, default 1)')
+                .setMinValue(1)
+                .setMaxValue(7)
+                .setRequired(false))
+        .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers),
+
+    async execute(interaction) {
+        const user       = interaction.options.getUser('user');
+        const reason     = interaction.options.getString('reason') || 'No reason provided';
+        const deleteDays = interaction.options.getInteger('delete_days') ?? 1;
+
+        if (user.id === interaction.user.id) {
+            return interaction.reply({ content: 'You cannot softban yourself.', ephemeral: true });
+        }
+        if (user.id === interaction.client.user.id) {
+            return interaction.reply({ content: 'I cannot softban myself.', ephemeral: true });
+        }
+
+        const member = interaction.guild.members.cache.get(user.id);
+        if (member && !member.bannable) {
+            return interaction.reply({ content: 'I cannot ban this user — they may have higher permissions.', ephemeral: true });
+        }
+
+        try {
+            await interaction.guild.members.ban(user, {
+                deleteMessageSeconds: deleteDays * 86400,
+                reason: `[Softban] ${reason}`
+            });
+            await interaction.guild.members.unban(user.id, `[Softban] Auto-unban after message purge`);
+
+            const embed = new EmbedBuilder()
+                .setColor('#ff9900')
+                .setTitle('User Softbanned')
+                .setDescription(`**${user.tag}** has been softbanned — their last ${deleteDays} day(s) of messages were removed and they may rejoin.`)
+                .addFields(
+                    { name: 'Reason', value: reason },
+                    { name: 'Messages Deleted', value: `${deleteDays} day(s)` },
+                    { name: 'Moderator', value: interaction.user.tag }
+                )
+                .setTimestamp();
+
+            await interaction.reply({ embeds: [embed] });
+            await logModeration(interaction.guild.id, 'kick', user, interaction.user, `[Softban] ${reason}`);
+        } catch (error) {
+            console.error('Softban error:', error);
+            await interaction.reply({ content: 'Failed to softban the user.', ephemeral: true });
+        }
+    }
+};

--- a/src/commands/moderation/softban.js
+++ b/src/commands/moderation/softban.js
@@ -43,24 +43,29 @@ module.exports = {
                 deleteMessageSeconds: deleteDays * 86400,
                 reason: `[Softban] ${reason}`
             });
-            await interaction.guild.members.unban(user.id, `[Softban] Auto-unban after message purge`);
-
-            const embed = new EmbedBuilder()
-                .setColor('#ff9900')
-                .setTitle('User Softbanned')
-                .setDescription(`**${user.tag}** has been softbanned — their last ${deleteDays} day(s) of messages were removed and they may rejoin.`)
-                .addFields(
-                    { name: 'Reason', value: reason },
-                    { name: 'Messages Deleted', value: `${deleteDays} day(s)` },
-                    { name: 'Moderator', value: interaction.user.tag }
-                )
-                .setTimestamp();
-
-            await interaction.reply({ embeds: [embed] });
-            await logModeration(interaction.guild.id, 'kick', user, interaction.user, `[Softban] ${reason}`);
         } catch (error) {
-            console.error('Softban error:', error);
-            await interaction.reply({ content: 'Failed to softban the user.', ephemeral: true });
+            console.error('Softban (ban step) error:', error);
+            return interaction.reply({ content: 'Failed to ban the user.', ephemeral: true });
         }
+
+        try {
+            await interaction.guild.members.unban(user.id, `[Softban] Auto-unban after message purge`);
+        } catch (error) {
+            console.error('Softban (unban step) error:', error);
+        }
+
+        const embed = new EmbedBuilder()
+            .setColor('#ff9900')
+            .setTitle('User Softbanned')
+            .setDescription(`**${user.tag}** has been softbanned — their last ${deleteDays} day(s) of messages were removed and they may rejoin.`)
+            .addFields(
+                { name: 'Reason', value: reason },
+                { name: 'Messages Deleted', value: `${deleteDays} day(s)` },
+                { name: 'Moderator', value: interaction.user.tag }
+            )
+            .setTimestamp();
+
+        await interaction.reply({ embeds: [embed] });
+        await logModeration(interaction.guild.id, 'ban', user, interaction.user, `[Softban] ${reason}`);
     }
 };

--- a/src/commands/moderation/unban.js
+++ b/src/commands/moderation/unban.js
@@ -1,0 +1,51 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const { logModeration } = require('../../utils/logger');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('unban')
+        .setDescription('Unban a user from the server')
+        .addStringOption(o =>
+            o.setName('user_id')
+                .setDescription('The user ID to unban')
+                .setRequired(true))
+        .addStringOption(o =>
+            o.setName('reason')
+                .setDescription('Reason for the unban')
+                .setRequired(false))
+        .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers),
+
+    async execute(interaction) {
+        const userId = interaction.options.getString('user_id').trim();
+        const reason = interaction.options.getString('reason') || 'No reason provided';
+
+        if (!/^\d{17,20}$/.test(userId)) {
+            return interaction.reply({ content: 'Invalid user ID. Provide a valid Discord user ID (17–20 digits).', ephemeral: true });
+        }
+
+        try {
+            const ban = await interaction.guild.bans.fetch(userId).catch(() => null);
+            if (!ban) {
+                return interaction.reply({ content: 'That user is not banned.', ephemeral: true });
+            }
+
+            await interaction.guild.members.unban(userId, reason);
+
+            const embed = new EmbedBuilder()
+                .setColor('#00ff00')
+                .setTitle('User Unbanned')
+                .setDescription(`**${ban.user.tag}** has been unbanned.`)
+                .addFields(
+                    { name: 'Reason', value: reason },
+                    { name: 'Moderator', value: interaction.user.tag }
+                )
+                .setTimestamp();
+
+            await interaction.reply({ embeds: [embed] });
+            await logModeration(interaction.guild.id, 'unban', ban.user, interaction.user, reason);
+        } catch (error) {
+            console.error('Unban error:', error);
+            await interaction.reply({ content: 'Failed to unban the user.', ephemeral: true });
+        }
+    }
+};

--- a/src/commands/moderation/unban.js
+++ b/src/commands/moderation/unban.js
@@ -12,6 +12,7 @@ module.exports = {
         .addStringOption(o =>
             o.setName('reason')
                 .setDescription('Reason for the unban')
+                .setMaxLength(1024)
                 .setRequired(false))
         .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers),
 

--- a/src/commands/moderation/warn.js
+++ b/src/commands/moderation/warn.js
@@ -5,54 +5,123 @@ const { logModeration } = require('../../utils/logger');
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('warn')
-        .setDescription('Warn a member')
-        .addUserOption(option =>
-            option.setName('user')
-                .setDescription('The user to warn')
-                .setRequired(true))
-        .addStringOption(option =>
-            option.setName('reason')
-                .setDescription('Reason for the warning')
-                .setRequired(true))
+        .setDescription('Manage member warnings')
+        .addSubcommand(sub =>
+            sub.setName('add')
+                .setDescription('Issue a warning to a member')
+                .addUserOption(o => o.setName('user').setDescription('The user to warn').setRequired(true))
+                .addStringOption(o => o.setName('reason').setDescription('Reason for the warning').setRequired(true)))
+        .addSubcommand(sub =>
+            sub.setName('list')
+                .setDescription('List all warnings for a member')
+                .addUserOption(o => o.setName('user').setDescription('The user to look up').setRequired(true)))
+        .addSubcommand(sub =>
+            sub.setName('remove')
+                .setDescription('Remove a warning by its case ID')
+                .addIntegerOption(o => o.setName('case_id').setDescription('The case ID of the warning to remove').setRequired(true).setMinValue(1)))
         .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
+
     async execute(interaction) {
-        const user = interaction.options.getUser('user');
-        const reason = interaction.options.getString('reason');
+        const sub = interaction.options.getSubcommand();
 
-        if (user.bot) {
-            return interaction.reply({ content: 'You cannot warn bots!', ephemeral: true });
-        }
+        if (sub === 'add') {
+            const user   = interaction.options.getUser('user');
+            const reason = interaction.options.getString('reason');
 
-        try {
-            await logModeration(interaction.guild.id, 'warn', user, interaction.user, reason);
-
-            const warningCount = await Case.countDocuments({
-                guildId: interaction.guild.id,
-                targetUserId: user.id,
-                type: 'warn'
-            });
-
-            const embed = new EmbedBuilder()
-                .setColor('#ffff00')
-                .setTitle('User Warned')
-                .setDescription(`**${user.tag}** has been warned.`)
-                .addFields(
-                    { name: 'Reason', value: reason },
-                    { name: 'Total Warnings', value: warningCount.toString() },
-                    { name: 'Moderator', value: interaction.user.tag }
-                )
-                .setTimestamp();
-
-            await interaction.reply({ embeds: [embed] });
+            if (user.bot) return interaction.reply({ content: 'You cannot warn bots.', ephemeral: true });
 
             try {
-                await user.send(`You have been warned in **${interaction.guild.name}** for: ${reason}`);
-            } catch {
-                console.log('Could not DM user');
+                await logModeration(interaction.guild.id, 'warn', user, interaction.user, reason);
+
+                const warningCount = await Case.countDocuments({
+                    guildId: interaction.guild.id,
+                    targetUserId: user.id,
+                    type: 'warn'
+                });
+
+                const embed = new EmbedBuilder()
+                    .setColor('#ffff00')
+                    .setTitle('User Warned')
+                    .setDescription(`**${user.tag}** has been warned.`)
+                    .addFields(
+                        { name: 'Reason', value: reason },
+                        { name: 'Total Warnings', value: warningCount.toString() },
+                        { name: 'Moderator', value: interaction.user.tag }
+                    )
+                    .setTimestamp();
+
+                await interaction.reply({ embeds: [embed] });
+                await user.send(`You have been warned in **${interaction.guild.name}** for: ${reason}`).catch(() => {});
+            } catch (error) {
+                console.error('Warn error:', error);
+                await interaction.reply({ content: 'Failed to warn the user.', ephemeral: true });
             }
-        } catch (error) {
-            console.error('Warn error:', error);
-            await interaction.reply({ content: 'Failed to warn the user.', ephemeral: true });
+        }
+
+        if (sub === 'list') {
+            const user = interaction.options.getUser('user');
+
+            try {
+                const warnings = await Case.find({
+                    guildId: interaction.guild.id,
+                    targetUserId: user.id,
+                    type: 'warn'
+                }).sort({ createdAt: -1 }).limit(20);
+
+                if (!warnings.length) {
+                    return interaction.reply({ content: `${user.tag} has no warnings.`, ephemeral: true });
+                }
+
+                const lines = warnings.map(w => {
+                    const date = w.createdAt.toISOString().slice(0, 10);
+                    return `**#${w.caseId}** \`${date}\` — ${w.reason}`;
+                });
+
+                const embed = new EmbedBuilder()
+                    .setColor('#ffff00')
+                    .setTitle(`Warnings for ${user.tag}`)
+                    .setDescription(lines.join('\n'))
+                    .setFooter({ text: `${warnings.length} warning(s) shown · use /warn remove <case_id> to clear one` })
+                    .setTimestamp();
+
+                await interaction.reply({ embeds: [embed] });
+            } catch (error) {
+                console.error('Warn list error:', error);
+                await interaction.reply({ content: 'Failed to fetch warnings.', ephemeral: true });
+            }
+        }
+
+        if (sub === 'remove') {
+            const caseId = interaction.options.getInteger('case_id');
+
+            try {
+                const warnCase = await Case.findOne({
+                    guildId: interaction.guild.id,
+                    caseId,
+                    type: 'warn'
+                });
+
+                if (!warnCase) {
+                    return interaction.reply({ content: `Warning case #${caseId} not found in this server.`, ephemeral: true });
+                }
+
+                await Case.deleteOne({ _id: warnCase._id });
+
+                const embed = new EmbedBuilder()
+                    .setColor('#00ff00')
+                    .setTitle('Warning Removed')
+                    .setDescription(`Case **#${caseId}** has been deleted.`)
+                    .addFields(
+                        { name: 'Original Reason', value: warnCase.reason },
+                        { name: 'Removed by', value: interaction.user.tag }
+                    )
+                    .setTimestamp();
+
+                await interaction.reply({ embeds: [embed] });
+            } catch (error) {
+                console.error('Warn remove error:', error);
+                await interaction.reply({ content: 'Failed to remove the warning.', ephemeral: true });
+            }
         }
     }
 };

--- a/src/commands/moderation/warn.js
+++ b/src/commands/moderation/warn.js
@@ -54,7 +54,9 @@ module.exports = {
                 await user.send(`You have been warned in **${interaction.guild.name}** for: ${reason}`).catch(() => {});
             } catch (error) {
                 console.error('Warn error:', error);
-                await interaction.reply({ content: 'Failed to warn the user.', ephemeral: true });
+                if (!interaction.replied) {
+                    await interaction.reply({ content: 'Failed to warn the user.', ephemeral: true });
+                }
             }
         }
 
@@ -87,7 +89,9 @@ module.exports = {
                 await interaction.reply({ embeds: [embed] });
             } catch (error) {
                 console.error('Warn list error:', error);
-                await interaction.reply({ content: 'Failed to fetch warnings.', ephemeral: true });
+                if (!interaction.replied) {
+                    await interaction.reply({ content: 'Failed to fetch warnings.', ephemeral: true });
+                }
             }
         }
 
@@ -120,7 +124,9 @@ module.exports = {
                 await interaction.reply({ embeds: [embed] });
             } catch (error) {
                 console.error('Warn remove error:', error);
-                await interaction.reply({ content: 'Failed to remove the warning.', ephemeral: true });
+                if (!interaction.replied) {
+                    await interaction.reply({ content: 'Failed to remove the warning.', ephemeral: true });
+                }
             }
         }
     }

--- a/src/commands/utility/role.js
+++ b/src/commands/utility/role.js
@@ -1,0 +1,68 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const Guild = require('../../models/Guild');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('role')
+        .setDescription('Self-assign or remove a role from the server reaction role panels')
+        .addSubcommand(sub =>
+            sub.setName('add')
+                .setDescription('Give yourself a self-assignable role')
+                .addRoleOption(o => o.setName('role').setDescription('Role to assign').setRequired(true)))
+        .addSubcommand(sub =>
+            sub.setName('remove')
+                .setDescription('Remove a self-assignable role from yourself')
+                .addRoleOption(o => o.setName('role').setDescription('Role to remove').setRequired(true)))
+        .addSubcommand(sub =>
+            sub.setName('list')
+                .setDescription('List all self-assignable roles')),
+
+    async execute(interaction) {
+        const sub           = interaction.options.getSubcommand();
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+
+        // Collect all unique roleIds from reaction role panels
+        const selfRoleIds = [...new Set((guildSettings?.reactionRoles || []).map(r => r.roleId))];
+
+        if (sub === 'list') {
+            if (!selfRoleIds.length) {
+                return interaction.reply({ content: 'No self-assignable roles have been configured. Admins can set them up via Reaction Roles in the dashboard.', ephemeral: true });
+            }
+
+            const lines = selfRoleIds.map(id => `<@&${id}>`).join('\n');
+            const embed = new EmbedBuilder()
+                .setColor('#5865F2')
+                .setTitle('Self-Assignable Roles')
+                .setDescription(lines)
+                .setFooter({ text: 'Use /role add <role> to assign one' });
+
+            return interaction.reply({ embeds: [embed], ephemeral: true });
+        }
+
+        const role = interaction.options.getRole('role');
+
+        if (!selfRoleIds.includes(role.id)) {
+            return interaction.reply({ content: `**${role.name}** is not a self-assignable role. Use \`/role list\` to see available roles.`, ephemeral: true });
+        }
+
+        const member = await interaction.guild.members.fetch(interaction.user.id);
+
+        if (sub === 'add') {
+            if (member.roles.cache.has(role.id)) {
+                return interaction.reply({ content: `You already have the **${role.name}** role.`, ephemeral: true });
+            }
+
+            await member.roles.add(role.id, 'Self-assigned via /role add');
+            return interaction.reply({ content: `You've been given the **${role.name}** role.`, ephemeral: true });
+        }
+
+        if (sub === 'remove') {
+            if (!member.roles.cache.has(role.id)) {
+                return interaction.reply({ content: `You don't have the **${role.name}** role.`, ephemeral: true });
+            }
+
+            await member.roles.remove(role.id, 'Self-removed via /role remove');
+            return interaction.reply({ content: `The **${role.name}** role has been removed.`, ephemeral: true });
+        }
+    }
+};

--- a/src/commands/utility/role.js
+++ b/src/commands/utility/role.js
@@ -52,8 +52,13 @@ module.exports = {
                 return interaction.reply({ content: `You already have the **${role.name}** role.`, ephemeral: true });
             }
 
-            await member.roles.add(role.id, 'Self-assigned via /role add');
-            return interaction.reply({ content: `You've been given the **${role.name}** role.`, ephemeral: true });
+            try {
+                await member.roles.add(role.id, 'Self-assigned via /role add');
+                return interaction.reply({ content: `You've been given the **${role.name}** role.`, ephemeral: true });
+            } catch (error) {
+                console.error('Role add error:', error);
+                return interaction.reply({ content: 'Failed to assign the role. I may not have permission.', ephemeral: true });
+            }
         }
 
         if (sub === 'remove') {
@@ -61,8 +66,13 @@ module.exports = {
                 return interaction.reply({ content: `You don't have the **${role.name}** role.`, ephemeral: true });
             }
 
-            await member.roles.remove(role.id, 'Self-removed via /role remove');
-            return interaction.reply({ content: `The **${role.name}** role has been removed.`, ephemeral: true });
+            try {
+                await member.roles.remove(role.id, 'Self-removed via /role remove');
+                return interaction.reply({ content: `The **${role.name}** role has been removed.`, ephemeral: true });
+            } catch (error) {
+                console.error('Role remove error:', error);
+                return interaction.reply({ content: 'Failed to remove the role. I may not have permission.', ephemeral: true });
+            }
         }
     }
 };

--- a/src/commands/utility/suggest.js
+++ b/src/commands/utility/suggest.js
@@ -28,18 +28,21 @@ module.exports = {
             .setColor('#5865F2')
             .setAuthor({
                 name: interaction.member?.displayName || interaction.user.username,
-                iconURL: interaction.user.displayAvatarURL({ dynamic: true })
+                iconURL: interaction.user.displayAvatarURL()
             })
             .setTitle('💡 New Suggestion')
             .setDescription(text)
             .setFooter({ text: `Submitted by ${interaction.user.tag}` })
             .setTimestamp();
 
-        const msg = await channel.send({ embeds: [embed] });
-
-        await msg.react(guildSettings.suggestions.upvoteEmoji || '👍').catch(() => {});
-        await msg.react(guildSettings.suggestions.downvoteEmoji || '👎').catch(() => {});
-
-        await interaction.reply({ content: `Your suggestion has been posted in ${channel}!`, ephemeral: true });
+        try {
+            const msg = await channel.send({ embeds: [embed] });
+            await msg.react(guildSettings.suggestions.upvoteEmoji || '👍').catch(() => {});
+            await msg.react(guildSettings.suggestions.downvoteEmoji || '👎').catch(() => {});
+            await interaction.reply({ content: `Your suggestion has been posted in ${channel}!`, ephemeral: true });
+        } catch (error) {
+            console.error('Suggest command error:', error);
+            await interaction.reply({ content: 'Failed to post your suggestion. I may not have permission to send messages in that channel.', ephemeral: true });
+        }
     }
 };

--- a/src/commands/utility/suggest.js
+++ b/src/commands/utility/suggest.js
@@ -1,0 +1,45 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const Guild = require('../../models/Guild');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('suggest')
+        .setDescription('Submit a suggestion to the server')
+        .addStringOption(o =>
+            o.setName('suggestion')
+                .setDescription('Your suggestion')
+                .setRequired(true)
+                .setMaxLength(1000)),
+
+    async execute(interaction) {
+        const text          = interaction.options.getString('suggestion');
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+
+        if (!guildSettings?.suggestions?.enabled || !guildSettings.suggestions.channelId) {
+            return interaction.reply({ content: 'Suggestions are not enabled on this server.', ephemeral: true });
+        }
+
+        const channel = interaction.guild.channels.cache.get(guildSettings.suggestions.channelId);
+        if (!channel) {
+            return interaction.reply({ content: 'The suggestions channel no longer exists. Contact a server admin.', ephemeral: true });
+        }
+
+        const embed = new EmbedBuilder()
+            .setColor('#5865F2')
+            .setAuthor({
+                name: interaction.member?.displayName || interaction.user.username,
+                iconURL: interaction.user.displayAvatarURL({ dynamic: true })
+            })
+            .setTitle('💡 New Suggestion')
+            .setDescription(text)
+            .setFooter({ text: `Submitted by ${interaction.user.tag}` })
+            .setTimestamp();
+
+        const msg = await channel.send({ embeds: [embed] });
+
+        await msg.react(guildSettings.suggestions.upvoteEmoji || '👍').catch(() => {});
+        await msg.react(guildSettings.suggestions.downvoteEmoji || '👎').catch(() => {});
+
+        await interaction.reply({ content: `Your suggestion has been posted in ${channel}!`, ephemeral: true });
+    }
+};

--- a/src/commands/utility/vc.js
+++ b/src/commands/utility/vc.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder, PermissionFlagsBits } = require('discord.js');
 const Guild = require('../../models/Guild');
 
 module.exports = {
@@ -44,8 +44,13 @@ module.exports = {
             return interaction.reply({ content: 'You must be in a voice channel to use this command.', ephemeral: true });
         }
 
-        if (!guildSettings.tempVoice.activeChannels.includes(voiceChannel.id)) {
+        if (!(guildSettings.tempVoice.activeChannels ?? []).includes(voiceChannel.id)) {
             return interaction.reply({ content: 'You must be in your own temporary voice channel to use this command.', ephemeral: true });
+        }
+
+        const overwrite = voiceChannel.permissionOverwrites.cache.get(interaction.user.id);
+        if (!overwrite?.allow.has(PermissionFlagsBits.ManageChannels)) {
+            return interaction.reply({ content: 'This is not your temporary voice channel.', ephemeral: true });
         }
 
         try {

--- a/src/commands/utility/vc.js
+++ b/src/commands/utility/vc.js
@@ -1,0 +1,83 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const Guild = require('../../models/Guild');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('vc')
+        .setDescription('Manage your temporary voice channel')
+        .addSubcommand(sub =>
+            sub.setName('rename')
+                .setDescription('Rename your temp voice channel')
+                .addStringOption(o =>
+                    o.setName('name')
+                        .setDescription('New channel name')
+                        .setRequired(true)
+                        .setMaxLength(100)))
+        .addSubcommand(sub =>
+            sub.setName('limit')
+                .setDescription('Set the user limit for your temp voice channel (0 = unlimited)')
+                .addIntegerOption(o =>
+                    o.setName('limit')
+                        .setDescription('Max users (0–99)')
+                        .setRequired(true)
+                        .setMinValue(0)
+                        .setMaxValue(99)))
+        .addSubcommand(sub =>
+            sub.setName('lock')
+                .setDescription('Lock your temp voice channel — only you can invite others'))
+        .addSubcommand(sub =>
+            sub.setName('unlock')
+                .setDescription('Unlock your temp voice channel so anyone can join')),
+
+    async execute(interaction) {
+        const sub           = interaction.options.getSubcommand();
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+
+        if (!guildSettings?.tempVoice?.enabled) {
+            return interaction.reply({ content: 'Temporary voice channels are not enabled on this server.', ephemeral: true });
+        }
+
+        const member = await interaction.guild.members.fetch(interaction.user.id);
+        const voiceChannel = member.voice?.channel;
+
+        if (!voiceChannel) {
+            return interaction.reply({ content: 'You must be in a voice channel to use this command.', ephemeral: true });
+        }
+
+        if (!guildSettings.tempVoice.activeChannels.includes(voiceChannel.id)) {
+            return interaction.reply({ content: 'You must be in your own temporary voice channel to use this command.', ephemeral: true });
+        }
+
+        try {
+            if (sub === 'rename') {
+                const name = interaction.options.getString('name');
+                await voiceChannel.setName(name);
+                return interaction.reply({ content: `Your channel has been renamed to **${name}**.`, ephemeral: true });
+            }
+
+            if (sub === 'limit') {
+                const limit = interaction.options.getInteger('limit');
+                await voiceChannel.setUserLimit(limit);
+                return interaction.reply({
+                    content: limit === 0
+                        ? 'User limit removed — anyone can join.'
+                        : `User limit set to **${limit}**.`,
+                    ephemeral: true
+                });
+            }
+
+            if (sub === 'lock') {
+                await voiceChannel.permissionOverwrites.edit(interaction.guild.roles.everyone, { Connect: false });
+                return interaction.reply({ content: 'Your channel is now **locked**. Only users you invite can join.', ephemeral: true });
+            }
+
+            if (sub === 'unlock') {
+                await voiceChannel.permissionOverwrites.edit(interaction.guild.roles.everyone, { Connect: null });
+                return interaction.reply({ content: 'Your channel is now **unlocked**. Anyone can join.', ephemeral: true });
+            }
+        } catch (error) {
+            console.error('VC command error:', error);
+            await interaction.reply({ content: 'Failed to update your voice channel.', ephemeral: true });
+        }
+    }
+};

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -1646,7 +1646,7 @@
                 data = {
                     'birthdays.enabled': document.getElementById('birthday-enabled').checked,
                     'birthdays.channelId': document.getElementById('birthday-channel').value || null,
-                    'birthdays.wishingHourUtc': parseInt(document.getElementById('birthday-hour').value, 10) || 9,
+                    'birthdays.wishingHourUtc': (() => { const v = parseInt(document.getElementById('birthday-hour').value, 10); return Number.isNaN(v) ? 9 : v; })(),
                     'birthdays.roleId': document.getElementById('birthday-role').value || null,
                     'birthdays.message': document.getElementById('birthday-message').value || "It's the birthday of {user} ({age}) ! 🎂"
                 };
@@ -2004,12 +2004,17 @@
         var _cpRuleIdx = -1;
         var _cpCdIdx   = -1;
 
+        function escHtml(s) {
+            return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+        }
+
         function renderCpRules() {
             var list = document.getElementById('cp-rules-list');
             if (!_cpRules.length) { list.innerHTML = '<p style="color:var(--text-dim);font-size:.88rem;">No rules — click <strong>+ Add rule</strong> to add one.</p>'; return; }
             list.innerHTML = _cpRules.map(function(r, i) {
+                var color = r.effect === 'allow' ? '#2ecc71' : '#e74c3c';
                 return '<div class="store-item-card" style="padding:.6rem .9rem;display:flex;align-items:center;gap:.75rem;">' +
-                    '<span style="flex:1"><strong>' + r.command + '</strong> — <span style="color:' + (r.effect==='allow'?'#2ecc71':'#e74c3c') + '">' + r.effect + '</span></span>' +
+                    '<span style="flex:1"><strong>' + escHtml(r.command) + '</strong> — <span style="color:' + color + '">' + escHtml(r.effect) + '</span></span>' +
                     '<button class="btn btn-sm" onclick="openCpRuleModal(' + i + ')">Edit</button>' +
                     '<button class="btn btn-sm" style="color:#e74c3c" onclick="_cpRules.splice(' + i + ',1);renderCpRules()">✕</button></div>';
             }).join('');
@@ -2019,7 +2024,7 @@
             if (!_cpCooldowns.length) { list.innerHTML = '<p style="color:var(--text-dim);font-size:.88rem;">No cooldown overrides — click <strong>+ Add override</strong>.</p>'; return; }
             list.innerHTML = _cpCooldowns.map(function(c, i) {
                 return '<div class="store-item-card" style="padding:.6rem .9rem;display:flex;align-items:center;gap:.75rem;">' +
-                    '<span style="flex:1"><strong>' + c.command + '</strong> — Role <code>' + c.roleId + '</code> → ' + c.cooldownSeconds + 's</span>' +
+                    '<span style="flex:1"><strong>' + escHtml(c.command) + '</strong> — Role <code>' + escHtml(c.roleId) + '</code> → ' + escHtml(c.cooldownSeconds) + 's</span>' +
                     '<button class="btn btn-sm" onclick="openCpCooldownModal(' + i + ')">Edit</button>' +
                     '<button class="btn btn-sm" style="color:#e74c3c" onclick="_cpCooldowns.splice(' + i + ',1);renderCpCooldowns()">✕</button></div>';
             }).join('');

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -43,17 +43,22 @@
                 <div class="nav-section-header">Moderation</div>
                 <button class="nav-item" data-tab="moderation"><span class="nav-emoji">🛡️</span> Moderation</button>
                 <button class="nav-item" data-tab="raiddetection"><span class="nav-emoji">🚨</span> Raid Detection</button>
+                <button class="nav-item" data-tab="antinuke"><span class="nav-emoji">🔒</span> Anti-Nuke</button>
+                <button class="nav-item" data-tab="casesettings"><span class="nav-emoji">📁</span> Case Settings</button>
 
                 <!-- Engagement -->
                 <div class="nav-section-header">Engagement</div>
                 <button class="nav-item" data-tab="music"><span class="nav-emoji">🎵</span> Music</button>
                 <button class="nav-item" data-tab="quests"><span class="nav-emoji">🗺️</span> Quests</button>
+                <button class="nav-item" data-tab="season"><span class="nav-emoji">🏆</span> Season Pass</button>
+                <button class="nav-item" data-tab="progressiontracks"><span class="nav-emoji">🧭</span> Progression Tracks</button>
                 <button class="nav-item" data-tab="starboard"><span class="nav-emoji">⭐</span> Starboard</button>
                 <button class="nav-item" data-tab="suggestions"><span class="nav-emoji">💡</span> Suggestions</button>
                 <button class="nav-item" data-tab="reactionroles"><span class="nav-emoji">🎭</span> Reaction Roles</button>
 
                 <!-- Tools & Support -->
                 <div class="nav-section-header">Tools &amp; Support</div>
+                <button class="nav-item" data-tab="commandpolicies"><span class="nav-emoji">⚙️</span> Command Policies</button>
                 <button class="nav-item" data-tab="ai"><span class="nav-emoji">🧠</span> AI Chat</button>
                 <button class="nav-item" data-tab="knowledgebase"><span class="nav-emoji">📚</span> Knowledge Base</button>
                 <button class="nav-item" data-tab="aisummaries"><span class="nav-emoji">📝</span> AI Summaries</button>
@@ -648,6 +653,85 @@
                     </div>
                 </section>
 
+                <!-- Anti-Nuke -->
+                <section id="antinuke" class="panel">
+                    <div class="panel-head">
+                        <h2>Anti-Nuke</h2>
+                        <p>Detect and punish coordinated destructive actions (mass channel/role deletion, mass bans, webhook spam) before they cause permanent damage.</p>
+                    </div>
+                    <label class="toggle">
+                        <span class="toggle-text"><strong>Enable anti-nuke</strong></span>
+                        <span class="switch"><input type="checkbox" id="an-enabled" <%= settings.antiNuke?.enabled ? 'checked' : '' %>><span class="slider"></span></span>
+                    </label>
+                    <div class="field">
+                        <label class="field-label" for="an-alert-channel">Alert channel</label>
+                        <select id="an-alert-channel">
+                            <option value="">None</option>
+                            <% channels.forEach(ch => { %><option value="<%= ch.id %>" <%= settings.antiNuke?.alertChannelId === ch.id ? 'selected' : '' %>>#<%= ch.name %></option><% }); %>
+                        </select>
+                    </div>
+                    <div class="field" style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;">
+                        <div>
+                            <label class="field-label" for="an-window">Detection window (seconds)</label>
+                            <input type="number" id="an-window" value="<%= settings.antiNuke?.windowSeconds ?? 30 %>" min="5">
+                        </div>
+                        <div>
+                            <label class="field-label" for="an-punishment">Punishment</label>
+                            <select id="an-punishment">
+                                <% ['alert','strip-roles','kick','ban'].forEach(p => { %><option value="<%= p %>" <%= settings.antiNuke?.punishment === p ? 'selected' : '' %>><%= p %></option><% }); %>
+                            </select>
+                        </div>
+                    </div>
+                    <label class="toggle">
+                        <span class="toggle-text"><strong>Auto-lockdown</strong><span>Lock all text channels when a nuke event fires</span></span>
+                        <span class="switch"><input type="checkbox" id="an-auto-lockdown" <%= settings.antiNuke?.autoLockdown ? 'checked' : '' %>><span class="slider"></span></span>
+                    </label>
+                    <div class="field-label" style="margin-top:1rem;margin-bottom:.4rem;font-weight:600;">Action Thresholds <small style="font-weight:400;color:var(--text-dim)">(per window)</small></div>
+                    <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(140px,1fr));gap:.6rem;">
+                        <% [['channelDelete','Channel Delete'],['channelCreate','Channel Create'],['roleDelete','Role Delete'],['roleCreate','Role Create'],['ban','Ban'],['kick','Kick'],['webhookCreate','Webhook Create']].forEach(([k,label]) => { %>
+                        <div><label class="field-label" for="an-t-<%= k %>"><%= label %></label><input type="number" id="an-t-<%= k %>" value="<%= settings.antiNuke?.thresholds?.[k] ?? 3 %>" min="1"></div>
+                        <% }); %>
+                    </div>
+                    <div class="field-label" style="margin-top:1rem;margin-bottom:.4rem;font-weight:600;">Join Gate</div>
+                    <label class="toggle">
+                        <span class="toggle-text"><strong>Enable join gate</strong><span>Reject accounts younger than a minimum age</span></span>
+                        <span class="switch"><input type="checkbox" id="an-jg-enabled" <%= settings.antiNuke?.joinGate?.enabled ? 'checked' : '' %>><span class="slider"></span></span>
+                    </label>
+                    <div style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;margin-top:.5rem;">
+                        <div><label class="field-label" for="an-jg-age">Min account age (days)</label><input type="number" id="an-jg-age" value="<%= settings.antiNuke?.joinGate?.minAccountAgeDays ?? 3 %>" min="0"></div>
+                        <div><label class="field-label" for="an-jg-action">Action</label><select id="an-jg-action"><option value="kick" <%= settings.antiNuke?.joinGate?.action === 'kick' ? 'selected' : '' %>>Kick</option><option value="ban" <%= settings.antiNuke?.joinGate?.action === 'ban' ? 'selected' : '' %>>Ban</option></select></div>
+                    </div>
+                    <div class="field-label" style="margin-top:1rem;margin-bottom:.4rem;font-weight:600;">Whitelist <small style="font-weight:400;color:var(--text-dim)">— one ID per line</small></div>
+                    <div style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;">
+                        <div><label class="field-label" for="an-whitelist-users">User IDs</label><textarea id="an-whitelist-users" rows="3" placeholder="One user ID per line"><%= (settings.antiNuke?.whitelistUserIds||[]).join('\n') %></textarea></div>
+                        <div><label class="field-label" for="an-whitelist-roles">Role IDs</label><textarea id="an-whitelist-roles" rows="3" placeholder="One role ID per line"><%= (settings.antiNuke?.whitelistRoleIds||[]).join('\n') %></textarea></div>
+                    </div>
+                    <div class="actions-row"><button class="btn btn-primary" onclick="saveSettings('antinuke')">Save changes</button></div>
+                </section>
+
+                <!-- Case Settings -->
+                <section id="casesettings" class="panel">
+                    <div class="panel-head">
+                        <h2>Case Settings</h2>
+                        <p>Configure SLA monitoring for open moderation cases.</p>
+                    </div>
+                    <div style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;">
+                        <div>
+                            <label class="field-label" for="cs-sla-hours">SLA deadline (hours)</label>
+                            <input type="number" id="cs-sla-hours" value="<%= settings.caseSettings?.slaHours ?? 48 %>" min="1">
+                            <small>Cases open longer than this trigger an alert</small>
+                        </div>
+                        <div>
+                            <label class="field-label" for="cs-sla-channel">SLA alert channel</label>
+                            <select id="cs-sla-channel">
+                                <option value="">None</option>
+                                <% channels.forEach(ch => { %><option value="<%= ch.id %>" <%= settings.caseSettings?.slaChannelId === ch.id ? 'selected' : '' %>>#<%= ch.name %></option><% }); %>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="actions-row"><button class="btn btn-primary" onclick="saveSettings('casesettings')">Save changes</button></div>
+                </section>
+
                 <!-- Starboard -->
                 <section id="starboard" class="panel">
                     <div class="panel-head">
@@ -738,6 +822,56 @@
                     <div class="actions-row">
                         <button class="btn btn-primary" onclick="saveSettings('quests')">Save changes</button>
                     </div>
+                </section>
+
+                <!-- Season Pass -->
+                <section id="season" class="panel">
+                    <div class="panel-head">
+                        <h2>Season Pass</h2>
+                        <p>Run a seasonal progression system. Members earn season XP through quests and activity, unlocking tier rewards.</p>
+                    </div>
+                    <label class="toggle">
+                        <span class="toggle-text"><strong>Enable season pass</strong></span>
+                        <span class="switch"><input type="checkbox" id="season-enabled" <%= settings.season?.enabled ? 'checked' : '' %>><span class="slider"></span></span>
+                    </label>
+                    <div style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;margin-top:.75rem;">
+                        <div><label class="field-label" for="season-name">Season name</label><input type="text" id="season-name" value="<%= settings.season?.name || 'Season 1' %>"></div>
+                        <div><label class="field-label" for="season-id">Season ID <small>(unique slug)</small></label><input type="text" id="season-id" value="<%= settings.season?.seasonId || '' %>" placeholder="e.g. s1-2025"></div>
+                        <div><label class="field-label" for="season-start">Start date</label><input type="date" id="season-start" value="<%= settings.season?.startDate ? new Date(settings.season.startDate).toISOString().slice(0,10) : '' %>"></div>
+                        <div><label class="field-label" for="season-end">End date</label><input type="date" id="season-end" value="<%= settings.season?.endDate ? new Date(settings.season.endDate).toISOString().slice(0,10) : '' %>"></div>
+                        <div><label class="field-label" for="season-xp-per-tier">XP per tier</label><input type="number" id="season-xp-per-tier" value="<%= settings.season?.xpPerTier ?? 100 %>" min="1"></div>
+                        <div><label class="field-label" for="season-max-tiers">Max tiers</label><input type="number" id="season-max-tiers" value="<%= settings.season?.maxTiers ?? 50 %>" min="1"></div>
+                    </div>
+                    <div class="field" style="margin-top:.75rem;">
+                        <label class="field-label" for="season-tier-rewards">Tier rewards <small>— format: <code>tier|coins|roleId|label</code>, one per line (roleId and label optional)</small></label>
+                        <textarea id="season-tier-rewards" rows="6" placeholder="5|100||Bronze Tier&#10;10|250|ROLE_ID|Silver Tier&#10;25|500|ROLE_ID|Gold Tier"><%= (settings.season?.tierRewards || []).map(r => `${r.tier}|${r.coins}|${r.roleId||''}|${r.label||''}`).join('\n') %></textarea>
+                    </div>
+                    <div class="actions-row"><button class="btn btn-primary" onclick="saveSettings('season')">Save changes</button></div>
+                </section>
+
+                <!-- Progression Tracks -->
+                <section id="progressiontracks" class="panel">
+                    <div class="panel-head">
+                        <h2>Progression Tracks</h2>
+                        <p>Members choose a track (Creator, Helper, or Raider) that gives them a bonus XP multiplier for activity matching their role.</p>
+                    </div>
+                    <label class="toggle">
+                        <span class="toggle-text"><strong>Enable progression tracks</strong></span>
+                        <span class="switch"><input type="checkbox" id="pt-enabled" <%= settings.progressionTracks?.enabled ? 'checked' : '' %>><span class="slider"></span></span>
+                    </label>
+                    <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:.75rem;margin-top:.75rem;">
+                        <div><label class="field-label" for="pt-creator-bonus">Creator bonus %</label><input type="number" id="pt-creator-bonus" value="<%= settings.progressionTracks?.creatorBonus ?? 20 %>" min="0" max="200"><small>XP bonus for posts with attachments</small></div>
+                        <div><label class="field-label" for="pt-helper-bonus">Helper bonus %</label><input type="number" id="pt-helper-bonus" value="<%= settings.progressionTracks?.helperBonus ?? 20 %>" min="0" max="200"><small>XP bonus for activity in helper channels</small></div>
+                        <div><label class="field-label" for="pt-raider-bonus">Raider bonus %</label><input type="number" id="pt-raider-bonus" value="<%= settings.progressionTracks?.raiderBonus ?? 20 %>" min="0" max="200"><small>XP bonus for first 10 daily messages</small></div>
+                    </div>
+                    <div class="field" style="margin-top:.75rem;">
+                        <label class="field-label" for="pt-helper-channels">Helper channels <small>— select channels that count for the Helper track bonus</small></label>
+                        <select id="pt-helper-channels" multiple style="height:120px;">
+                            <% channels.forEach(ch => { %><option value="<%= ch.id %>" <%= (settings.progressionTracks?.helperChannels||[]).includes(ch.id) ? 'selected' : '' %>>#<%= ch.name %></option><% }); %>
+                        </select>
+                        <small>Hold Ctrl/Cmd to select multiple channels</small>
+                    </div>
+                    <div class="actions-row"><button class="btn btn-primary" onclick="saveSettings('progressiontracks')">Save changes</button></div>
                 </section>
 
                 <!-- Suggestions -->
@@ -986,6 +1120,65 @@
                         <button class="btn btn-primary" onclick="saveSettings('tempvoice')">Save changes</button>
                     </div>
                 </section>
+
+                <!-- Command Policies -->
+                <section id="commandpolicies" class="panel">
+                    <div class="panel-head">
+                        <h2>Command Policies</h2>
+                        <p>Restrict or allow commands by role, channel, or time of day. Also override per-role cooldowns.</p>
+                    </div>
+                    <label class="toggle">
+                        <span class="toggle-text"><strong>Enable command policies</strong></span>
+                        <span class="switch"><input type="checkbox" id="cp-enabled" <%= settings.commandPolicies?.enabled ? 'checked' : '' %>><span class="slider"></span></span>
+                    </label>
+                    <div class="field-label" style="margin-top:1rem;margin-bottom:.4rem;font-weight:600;">Global Exceptions <small style="font-weight:400;color:var(--text-dim)">— these users/roles bypass all rules</small></div>
+                    <div style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;">
+                        <div><label class="field-label" for="cp-exc-users">Exempt user IDs <small>(one per line)</small></label><textarea id="cp-exc-users" rows="3" placeholder="One user ID per line"><%= (settings.commandPolicies?.exceptions?.userIds||[]).join('\n') %></textarea></div>
+                        <div><label class="field-label" for="cp-exc-roles">Exempt role IDs <small>(one per line)</small></label><textarea id="cp-exc-roles" rows="3" placeholder="One role ID per line"><%= (settings.commandPolicies?.exceptions?.roleIds||[]).join('\n') %></textarea></div>
+                    </div>
+                    <div class="eco-section-head" style="margin-top:1.25rem;">
+                        <span style="font-weight:600;font-size:.95rem;">Allow / Deny Rules</span>
+                        <button class="btn btn-sm btn-primary" onclick="openCpRuleModal(-1)">+ Add rule</button>
+                    </div>
+                    <div id="cp-rules-list" style="margin-top:.6rem;"></div>
+                    <div class="eco-section-head" style="margin-top:1.25rem;">
+                        <span style="font-weight:600;font-size:.95rem;">Cooldown Overrides</span>
+                        <button class="btn btn-sm btn-primary" onclick="openCpCooldownModal(-1)">+ Add override</button>
+                    </div>
+                    <div id="cp-cooldowns-list" style="margin-top:.6rem;"></div>
+                    <div class="actions-row"><button class="btn btn-primary" onclick="saveSettings('commandpolicies')">Save changes</button></div>
+                </section>
+
+                <!-- Command Policies — Rule Modal -->
+                <div id="cp-rule-modal" class="modal-overlay" style="display:none;" onclick="if(event.target===this)closeCpRuleModal()">
+                    <div class="modal-box" style="max-width:520px;">
+                        <div class="modal-head"><span id="cp-rule-modal-title">Add Rule</span><button class="modal-close" onclick="closeCpRuleModal()">✕</button></div>
+                        <div style="display:flex;flex-direction:column;gap:.9rem;padding:1.25rem;">
+                            <div class="field"><label class="field-label">Command name</label><input type="text" id="cp-r-command" placeholder="e.g. ban"></div>
+                            <div class="field"><label class="field-label">Effect</label><select id="cp-r-effect"><option value="allow">Allow</option><option value="deny">Deny</option></select></div>
+                            <div class="field"><label class="field-label">Role IDs <small>(comma-separated)</small></label><input type="text" id="cp-r-roles" placeholder="Leave blank for all roles"></div>
+                            <div class="field"><label class="field-label">Channel IDs <small>(comma-separated)</small></label><input type="text" id="cp-r-channels" placeholder="Leave blank for all channels"></div>
+                            <div style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;">
+                                <div class="field"><label class="field-label">Start hour UTC (0–23)</label><input type="number" id="cp-r-start-hour" min="0" max="23" placeholder="Any"></div>
+                                <div class="field"><label class="field-label">End hour UTC (0–23)</label><input type="number" id="cp-r-end-hour" min="0" max="23" placeholder="Any"></div>
+                            </div>
+                        </div>
+                        <div class="modal-foot"><button class="btn" onclick="closeCpRuleModal()">Cancel</button><button class="btn btn-primary" onclick="saveCpRuleModal()">Save</button></div>
+                    </div>
+                </div>
+
+                <!-- Command Policies — Cooldown Modal -->
+                <div id="cp-cooldown-modal" class="modal-overlay" style="display:none;" onclick="if(event.target===this)closeCpCooldownModal()">
+                    <div class="modal-box" style="max-width:420px;">
+                        <div class="modal-head"><span>Cooldown Override</span><button class="modal-close" onclick="closeCpCooldownModal()">✕</button></div>
+                        <div style="display:flex;flex-direction:column;gap:.9rem;padding:1.25rem;">
+                            <div class="field"><label class="field-label">Command name</label><input type="text" id="cp-cd-command" placeholder="e.g. daily"></div>
+                            <div class="field"><label class="field-label">Role ID</label><input type="text" id="cp-cd-role" placeholder="Role ID"></div>
+                            <div class="field"><label class="field-label">Cooldown (seconds)</label><input type="number" id="cp-cd-seconds" min="0" placeholder="0 = no cooldown"></div>
+                        </div>
+                        <div class="modal-foot"><button class="btn" onclick="closeCpCooldownModal()">Cancel</button><button class="btn btn-primary" onclick="saveCpCooldownModal()">Save</button></div>
+                    </div>
+                </div>
 
                 <!-- AI -->
                 <section id="ai" class="panel">
@@ -1592,6 +1785,72 @@
                     'suggestions.upvoteEmoji': document.getElementById('suggestions-upvote').value || '👍',
                     'suggestions.downvoteEmoji': document.getElementById('suggestions-downvote').value || '👎'
                 };
+            } else if (section === 'antinuke') {
+                const splitIds = id => document.getElementById(id).value.split('\n').map(s => s.trim()).filter(Boolean);
+                data = {
+                    'antiNuke.enabled': document.getElementById('an-enabled').checked,
+                    'antiNuke.alertChannelId': document.getElementById('an-alert-channel').value || null,
+                    'antiNuke.windowSeconds': parseInt(document.getElementById('an-window').value, 10) || 30,
+                    'antiNuke.punishment': document.getElementById('an-punishment').value,
+                    'antiNuke.autoLockdown': document.getElementById('an-auto-lockdown').checked,
+                    'antiNuke.thresholds': {
+                        channelDelete: parseInt(document.getElementById('an-t-channelDelete').value, 10) || 3,
+                        channelCreate: parseInt(document.getElementById('an-t-channelCreate').value, 10) || 5,
+                        roleDelete:    parseInt(document.getElementById('an-t-roleDelete').value, 10) || 3,
+                        roleCreate:    parseInt(document.getElementById('an-t-roleCreate').value, 10) || 5,
+                        ban:           parseInt(document.getElementById('an-t-ban').value, 10) || 3,
+                        kick:          parseInt(document.getElementById('an-t-kick').value, 10) || 5,
+                        webhookCreate: parseInt(document.getElementById('an-t-webhookCreate').value, 10) || 2
+                    },
+                    'antiNuke.whitelistUserIds': splitIds('an-whitelist-users'),
+                    'antiNuke.whitelistRoleIds': splitIds('an-whitelist-roles'),
+                    'antiNuke.joinGate': {
+                        enabled:           document.getElementById('an-jg-enabled').checked,
+                        minAccountAgeDays: parseInt(document.getElementById('an-jg-age').value, 10) || 3,
+                        action:            document.getElementById('an-jg-action').value
+                    }
+                };
+            } else if (section === 'casesettings') {
+                data = {
+                    'caseSettings.slaHours':    parseInt(document.getElementById('cs-sla-hours').value, 10) || 48,
+                    'caseSettings.slaChannelId': document.getElementById('cs-sla-channel').value || null
+                };
+            } else if (section === 'season') {
+                const tierText = document.getElementById('season-tier-rewards').value;
+                const tierRewards = tierText.split('\n').map(l => l.trim()).filter(Boolean).map(l => {
+                    const [tier, coins, roleId, ...labelParts] = l.split('|');
+                    return { tier: parseInt(tier, 10), coins: parseInt(coins, 10) || 0, roleId: roleId || null, label: labelParts.join('|') || '' };
+                }).filter(r => !isNaN(r.tier));
+                data = {
+                    'season.enabled':    document.getElementById('season-enabled').checked,
+                    'season.name':       document.getElementById('season-name').value.trim() || 'Season 1',
+                    'season.seasonId':   document.getElementById('season-id').value.trim() || null,
+                    'season.startDate':  document.getElementById('season-start').value || null,
+                    'season.endDate':    document.getElementById('season-end').value || null,
+                    'season.xpPerTier':  parseInt(document.getElementById('season-xp-per-tier').value, 10) || 100,
+                    'season.maxTiers':   parseInt(document.getElementById('season-max-tiers').value, 10) || 50,
+                    'season.tierRewards': tierRewards
+                };
+            } else if (section === 'progressiontracks') {
+                const helperChannels = Array.from(document.getElementById('pt-helper-channels').selectedOptions).map(o => o.value);
+                data = {
+                    'progressionTracks.enabled':       document.getElementById('pt-enabled').checked,
+                    'progressionTracks.creatorBonus':  parseInt(document.getElementById('pt-creator-bonus').value, 10) || 20,
+                    'progressionTracks.helperBonus':   parseInt(document.getElementById('pt-helper-bonus').value, 10) || 20,
+                    'progressionTracks.raiderBonus':   parseInt(document.getElementById('pt-raider-bonus').value, 10) || 20,
+                    'progressionTracks.helperChannels': helperChannels
+                };
+            } else if (section === 'commandpolicies') {
+                const splitIds = id => document.getElementById(id).value.split('\n').map(s => s.trim()).filter(Boolean);
+                data = {
+                    'commandPolicies.enabled': document.getElementById('cp-enabled').checked,
+                    'commandPolicies.exceptions': {
+                        userIds: splitIds('cp-exc-users'),
+                        roleIds: splitIds('cp-exc-roles')
+                    },
+                    'commandPolicies.rules':            _cpRules,
+                    'commandPolicies.cooldownOverrides': _cpCooldowns
+                };
             } else if (section === 'ai') {
                 data = {
                     'ai.enabled': document.getElementById('ai-enabled').checked,
@@ -1739,6 +1998,85 @@
         }
 
         // ── Economy Store & Jobs ───────────────────────────────────────────────
+        // Command Policies state
+        var _cpRules     = <%- JSON.stringify(settings.commandPolicies?.rules || []) %>;
+        var _cpCooldowns = <%- JSON.stringify(settings.commandPolicies?.cooldownOverrides || []) %>;
+        var _cpRuleIdx = -1;
+        var _cpCdIdx   = -1;
+
+        function renderCpRules() {
+            var list = document.getElementById('cp-rules-list');
+            if (!_cpRules.length) { list.innerHTML = '<p style="color:var(--text-dim);font-size:.88rem;">No rules — click <strong>+ Add rule</strong> to add one.</p>'; return; }
+            list.innerHTML = _cpRules.map(function(r, i) {
+                return '<div class="store-item-card" style="padding:.6rem .9rem;display:flex;align-items:center;gap:.75rem;">' +
+                    '<span style="flex:1"><strong>' + r.command + '</strong> — <span style="color:' + (r.effect==='allow'?'#2ecc71':'#e74c3c') + '">' + r.effect + '</span></span>' +
+                    '<button class="btn btn-sm" onclick="openCpRuleModal(' + i + ')">Edit</button>' +
+                    '<button class="btn btn-sm" style="color:#e74c3c" onclick="_cpRules.splice(' + i + ',1);renderCpRules()">✕</button></div>';
+            }).join('');
+        }
+        function renderCpCooldowns() {
+            var list = document.getElementById('cp-cooldowns-list');
+            if (!_cpCooldowns.length) { list.innerHTML = '<p style="color:var(--text-dim);font-size:.88rem;">No cooldown overrides — click <strong>+ Add override</strong>.</p>'; return; }
+            list.innerHTML = _cpCooldowns.map(function(c, i) {
+                return '<div class="store-item-card" style="padding:.6rem .9rem;display:flex;align-items:center;gap:.75rem;">' +
+                    '<span style="flex:1"><strong>' + c.command + '</strong> — Role <code>' + c.roleId + '</code> → ' + c.cooldownSeconds + 's</span>' +
+                    '<button class="btn btn-sm" onclick="openCpCooldownModal(' + i + ')">Edit</button>' +
+                    '<button class="btn btn-sm" style="color:#e74c3c" onclick="_cpCooldowns.splice(' + i + ',1);renderCpCooldowns()">✕</button></div>';
+            }).join('');
+        }
+        function openCpRuleModal(idx) {
+            _cpRuleIdx = idx;
+            var r = idx === -1 ? {} : _cpRules[idx];
+            document.getElementById('cp-rule-modal-title').textContent = idx === -1 ? 'Add Rule' : 'Edit Rule';
+            document.getElementById('cp-r-command').value   = r.command || '';
+            document.getElementById('cp-r-effect').value    = r.effect || 'allow';
+            document.getElementById('cp-r-roles').value     = (r.roleIds || []).join(', ');
+            document.getElementById('cp-r-channels').value  = (r.channelIds || []).join(', ');
+            document.getElementById('cp-r-start-hour').value = r.startHourUtc != null ? r.startHourUtc : '';
+            document.getElementById('cp-r-end-hour').value   = r.endHourUtc   != null ? r.endHourUtc   : '';
+            document.getElementById('cp-rule-modal').style.display = 'flex';
+        }
+        function closeCpRuleModal() { document.getElementById('cp-rule-modal').style.display = 'none'; }
+        function saveCpRuleModal() {
+            var cmd = document.getElementById('cp-r-command').value.trim();
+            if (!cmd) { toast('Command name is required', 'error'); return; }
+            var splitCsv = function(s) { return s.split(',').map(function(x){return x.trim();}).filter(Boolean); };
+            var sh = document.getElementById('cp-r-start-hour').value;
+            var eh = document.getElementById('cp-r-end-hour').value;
+            var rule = {
+                command: cmd,
+                effect: document.getElementById('cp-r-effect').value,
+                roleIds: splitCsv(document.getElementById('cp-r-roles').value),
+                channelIds: splitCsv(document.getElementById('cp-r-channels').value),
+                startHourUtc: sh !== '' ? parseInt(sh, 10) : null,
+                endHourUtc:   eh !== '' ? parseInt(eh, 10) : null,
+                daysOfWeek: []
+            };
+            if (_cpRuleIdx === -1) _cpRules.push(rule); else _cpRules[_cpRuleIdx] = rule;
+            closeCpRuleModal(); renderCpRules();
+        }
+        function openCpCooldownModal(idx) {
+            _cpCdIdx = idx;
+            var c = idx === -1 ? {} : _cpCooldowns[idx];
+            document.getElementById('cp-cd-command').value = c.command || '';
+            document.getElementById('cp-cd-role').value    = c.roleId  || '';
+            document.getElementById('cp-cd-seconds').value = c.cooldownSeconds != null ? c.cooldownSeconds : '';
+            document.getElementById('cp-cooldown-modal').style.display = 'flex';
+        }
+        function closeCpCooldownModal() { document.getElementById('cp-cooldown-modal').style.display = 'none'; }
+        function saveCpCooldownModal() {
+            var cmd = document.getElementById('cp-cd-command').value.trim();
+            var role = document.getElementById('cp-cd-role').value.trim();
+            if (!cmd || !role) { toast('Command and role are required', 'error'); return; }
+            var entry = { command: cmd, roleId: role, cooldownSeconds: parseInt(document.getElementById('cp-cd-seconds').value, 10) || 0 };
+            if (_cpCdIdx === -1) _cpCooldowns.push(entry); else _cpCooldowns[_cpCdIdx] = entry;
+            closeCpCooldownModal(); renderCpCooldowns();
+        }
+
+        // Initialize CP lists
+        renderCpRules();
+        renderCpCooldowns();
+
         var storeItems = <%- JSON.stringify(settings.shop || []) %>;
         var _serverJobs = <%- JSON.stringify(settings.jobs || []) %>;
         var jobsList = _serverJobs.length > 0 ? _serverJobs : [

--- a/src/index.js
+++ b/src/index.js
@@ -130,6 +130,9 @@ async function startBot() {
 
         const { startDailyBibleService } = require('./services/dailyBibleService');
         startDailyBibleService(client);
+
+        const { startTempBanService } = require('./services/tempBanService');
+        startTempBanService(client);
     });
 
     client.login(process.env.DISCORD_TOKEN);

--- a/src/models/TempBan.js
+++ b/src/models/TempBan.js
@@ -1,0 +1,15 @@
+const { Schema, model } = require('mongoose');
+
+const tempBanSchema = new Schema({
+    guildId:     { type: String, required: true },
+    userId:      { type: String, required: true },
+    moderatorId: { type: String, required: true },
+    reason:      { type: String, default: 'Temporary ban' },
+    expiresAt:   { type: Date, required: true },
+    createdAt:   { type: Date, default: Date.now }
+});
+
+tempBanSchema.index({ expiresAt: 1 });
+tempBanSchema.index({ guildId: 1, userId: 1 });
+
+module.exports = model('TempBan', tempBanSchema);

--- a/src/models/TempBan.js
+++ b/src/models/TempBan.js
@@ -10,6 +10,6 @@ const tempBanSchema = new Schema({
 });
 
 tempBanSchema.index({ expiresAt: 1 });
-tempBanSchema.index({ guildId: 1, userId: 1 });
+tempBanSchema.index({ guildId: 1, userId: 1 }, { unique: true });
 
 module.exports = model('TempBan', tempBanSchema);

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -14,6 +14,9 @@ const userSchema = new Schema({
     lastDaily: { type: Date, default: null },
     lastWork: { type: Date, default: null },
     lastWheelSpin: { type: Date, default: null },
+    lastFish: { type: Date, default: null },
+    lastMine: { type: Date, default: null },
+    lastCrime: { type: Date, default: null },
     shiftsWorked: { type: Number, default: 0 },
 
     inventory: [{

--- a/src/services/tempBanService.js
+++ b/src/services/tempBanService.js
@@ -1,31 +1,41 @@
 const TempBan = require('../models/TempBan');
 const { logModeration } = require('../utils/logger');
 
+let processing = false;
+
 async function processExpiredBans(client) {
-    const now = new Date();
-    const expired = await TempBan.find({ expiresAt: { $lte: now } });
+    if (processing) return;
+    processing = true;
 
-    for (const entry of expired) {
-        try {
-            const guild = client.guilds.cache.get(entry.guildId);
-            if (!guild) { await TempBan.deleteOne({ _id: entry._id }); continue; }
+    try {
+        const now = new Date();
+        const expired = await TempBan.find({ expiresAt: { $lte: now } });
 
-            const bans = await guild.bans.fetch().catch(() => null);
-            if (bans?.has(entry.userId)) {
-                const bannedUser = bans.get(entry.userId).user;
-                await guild.members.unban(entry.userId, 'Temporary ban expired');
-                await logModeration(entry.guildId, 'unban', bannedUser, client.user, 'Temporary ban expired');
+        for (const entry of expired) {
+            try {
+                const guild = client.guilds.cache.get(entry.guildId);
+                if (!guild) {
+                    await TempBan.deleteOne({ _id: entry._id });
+                    continue;
+                }
+
+                const ban = await guild.bans.fetch(entry.userId).catch(() => null);
+                if (ban) {
+                    await guild.members.unban(entry.userId, 'Temporary ban expired');
+                    await logModeration(entry.guildId, 'unban', ban.user, client.user, 'Temporary ban expired');
+                }
+
+                await TempBan.deleteOne({ _id: entry._id });
+            } catch (err) {
+                console.error(`[TEMPBAN] Failed to unban ${entry.userId} in ${entry.guildId}:`, err);
             }
-        } catch (err) {
-            console.error(`[TEMPBAN] Failed to unban ${entry.userId} in ${entry.guildId}:`, err);
-        } finally {
-            await TempBan.deleteOne({ _id: entry._id }).catch(() => {});
         }
+    } finally {
+        processing = false;
     }
 }
 
 function startTempBanService(client) {
-    // Check immediately on startup, then every 60 seconds
     processExpiredBans(client).catch(console.error);
     setInterval(() => processExpiredBans(client).catch(console.error), 60_000);
 }

--- a/src/services/tempBanService.js
+++ b/src/services/tempBanService.js
@@ -1,0 +1,33 @@
+const TempBan = require('../models/TempBan');
+const { logModeration } = require('../utils/logger');
+
+async function processExpiredBans(client) {
+    const now = new Date();
+    const expired = await TempBan.find({ expiresAt: { $lte: now } });
+
+    for (const entry of expired) {
+        try {
+            const guild = client.guilds.cache.get(entry.guildId);
+            if (!guild) { await TempBan.deleteOne({ _id: entry._id }); continue; }
+
+            const bans = await guild.bans.fetch().catch(() => null);
+            if (bans?.has(entry.userId)) {
+                const bannedUser = bans.get(entry.userId).user;
+                await guild.members.unban(entry.userId, 'Temporary ban expired');
+                await logModeration(entry.guildId, 'unban', bannedUser, client.user, 'Temporary ban expired');
+            }
+        } catch (err) {
+            console.error(`[TEMPBAN] Failed to unban ${entry.userId} in ${entry.guildId}:`, err);
+        } finally {
+            await TempBan.deleteOne({ _id: entry._id }).catch(() => {});
+        }
+    }
+}
+
+function startTempBanService(client) {
+    // Check immediately on startup, then every 60 seconds
+    processExpiredBans(client).catch(console.error);
+    setInterval(() => processExpiredBans(client).catch(console.error), 60_000);
+}
+
+module.exports = { startTempBanService };


### PR DESCRIPTION
- /coinflip and /roll now check economy.enabled and their individual
  flags (coinflipEnabled, rollEnabled) — the dashboard toggles were
  silently ignored before
- Add /blackjack command with full hit/stand flow, natural blackjack
  (3:2 payout), dealer draw-to-17, push handling, and balance guard;
  respects economy.enabled, gamesEnabled, and blackjackEnabled flags

https://claude.ai/code/session_013QTfKmw7wz7qx3TgX3rT1F

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Economy mini-games: Blackjack, Crime, Fishing, Mining, Robbery, and item usage
  * Moderation commands: Mass ban, Slowmode, Softban, and Unban
  * Utility features: Self-assignable roles, suggestions channel, and temporary voice channel management
  * Dashboard expansions: Anti-Nuke, Case Settings, Season Pass, Progression Tracks, and Command Policies
  * Temporary ban system with configurable durations

* **Improvements**
  * Warn command now supports list and remove subcommands
  * Ban command supports configurable temporary durations
  * Server-level access control added for fun commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->