### PR TITLE
fix: prefix all hunt/fish commands with their game name

### DIFF
--- a/src/commands/economy/buygun.js
+++ b/src/commands/economy/buygun.js
@@ -12,7 +12,7 @@ module.exports = {
     cooldown: 5,
 
     data: new SlashCommandBuilder()
-        .setName('buygun')
+        .setName('huntbuygun')
         .setDescription('Purchase a weapon for hunting')
         .addSubcommand(sub =>
             sub.setName('list')
@@ -69,7 +69,7 @@ module.exports = {
                 .setTitle('🔫 Weapon Shop')
                 .setDescription(lines.join('\n\n'))
                 .addFields({ name: '🔧 Available Upgrades (one per weapon)', value: upgradeLines.join('\n') })
-                .setFooter({ text: 'Use /buygun buy <tier> to purchase • /buygun upgrade <module> for upgrades' });
+                .setFooter({ text: 'Use /huntbuygun buy <tier> to purchase • /huntbuygun upgrade <module> for upgrades' });
 
             return interaction.reply({ embeds: [embed] });
         }

--- a/src/commands/economy/buyrod.js
+++ b/src/commands/economy/buyrod.js
@@ -13,7 +13,7 @@ module.exports = {
     cooldown: 5,
 
     data: new SlashCommandBuilder()
-        .setName('buyrod')
+        .setName('fishbuyrod')
         .setDescription('Purchase a fishing rod or upgrade an existing one')
         .addSubcommand(sub =>
             sub.setName('rod')

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -65,11 +65,11 @@ module.exports = {
         const location     = LOCATIONS[locationId];
 
         if (!location) {
-            return interaction.reply({ content: `Unknown location. Use \`/location list\` to see available spots.`, ephemeral: true });
+            return interaction.reply({ content: `Unknown location. Use \`/fishlocation list\` to see available spots.`, ephemeral: true });
         }
         if (!f.unlockedLocations.includes(locationId)) {
             return interaction.reply({
-                content: `You haven't unlocked **${location.name}** yet. Use \`/location unlock ${locationId}\` to unlock it.`,
+                content: `You haven't unlocked **${location.name}** yet. Use \`/fishlocation unlock ${locationId}\` to unlock it.`,
                 ephemeral: true
             });
         }
@@ -110,7 +110,7 @@ module.exports = {
         // ── Rod check ─────────────────────────────────────────────────────
         if (f.equippedRodIndex < 0 || !f.rods[f.equippedRodIndex]) {
             return interaction.reply({
-                content: `You don't have a rod equipped! Buy one with \`/buyrod\` and equip it with \`/fishinv equip 1\`.`,
+                content: `You don't have a rod equipped! Buy one with \`/fishbuyrod\` and equip it with \`/fishinv equip 1\`.`,
                 ephemeral: true
             });
         }
@@ -119,7 +119,7 @@ module.exports = {
 
         if (rod.status === 'broken' || rod.currentDurability <= 0) {
             return interaction.reply({
-                content: `Your **${rod.name}** is broken! Repair it with \`/fishrepair\` or buy a new one with \`/buyrod\`.`,
+                content: `Your **${rod.name}** is broken! Repair it with \`/fishrepair\` or buy a new one with \`/fishbuyrod\`.`,
                 ephemeral: true
             });
         }

--- a/src/commands/economy/fishinv.js
+++ b/src/commands/economy/fishinv.js
@@ -66,7 +66,7 @@ async function showRods(interaction, user) {
     const f = user.fishing;
 
     if (!f.rods.length) {
-        return interaction.reply({ content: `You don't own any rods yet. Buy one with \`/buyrod\`.`, ephemeral: true });
+        return interaction.reply({ content: `You don't own any rods yet. Buy one with \`/fishbuyrod\`.`, ephemeral: true });
     }
 
     const { ROD_BY_TIER } = require('../../data/fishData');

--- a/src/commands/economy/fishprofile.js
+++ b/src/commands/economy/fishprofile.js
@@ -41,7 +41,7 @@ module.exports = {
         if (!userData) {
             return interaction.reply({
                 content: isSelf
-                    ? "You haven't started fishing yet! Buy a rod with `/buyrod` and use `/fish` to begin."
+                    ? "You haven't started fishing yet! Buy a rod with `/fishbuyrod` and use `/fish` to begin."
                     : `${target.username} hasn't started fishing yet.`,
                 ephemeral: true
             });

--- a/src/commands/economy/fishrepair.js
+++ b/src/commands/economy/fishrepair.js
@@ -50,7 +50,7 @@ module.exports = {
         const f = user.fishing;
 
         if (f.equippedRodIndex < 0 || !f.rods[f.equippedRodIndex]) {
-            return interaction.reply({ content: `You don't have a rod equipped. Buy one with \`/buyrod\`.`, ephemeral: true });
+            return interaction.reply({ content: `You don't have a rod equipped. Buy one with \`/fishbuyrod\`.`, ephemeral: true });
         }
 
         const rod = f.rods[f.equippedRodIndex];

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -69,11 +69,11 @@ module.exports = {
         const zone   = ZONES[zoneId];
 
         if (!zone) {
-            return interaction.reply({ content: `Unknown zone \`${zoneId}\`. Use \`/zone list\` to see available zones.`, ephemeral: true });
+            return interaction.reply({ content: `Unknown zone \`${zoneId}\`. Use \`/huntzone list\` to see available zones.`, ephemeral: true });
         }
         if (!h.unlockedZones.includes(zoneId)) {
             return interaction.reply({
-                content: `You haven't unlocked **${zone.name}** yet. Use \`/zone unlock ${zoneId}\` to unlock it.`,
+                content: `You haven't unlocked **${zone.name}** yet. Use \`/huntzone unlock ${zoneId}\` to unlock it.`,
                 ephemeral: true
             });
         }
@@ -114,7 +114,7 @@ module.exports = {
         // ── Weapon check ───────────────────────────────────────────────────
         if (h.equippedWeaponIndex < 0 || !h.weapons[h.equippedWeaponIndex]) {
             return interaction.reply({
-                content: `You don't have a weapon equipped! Buy one with \`/buygun\` and equip it with \`/huntinv equip 1\`.`,
+                content: `You don't have a weapon equipped! Buy one with \`/huntbuygun\` and equip it with \`/huntinv equip 1\`.`,
                 ephemeral: true
             });
         }
@@ -123,7 +123,7 @@ module.exports = {
 
         if (weapon.status === 'broken' || weapon.currentDurability <= 0) {
             return interaction.reply({
-                content: `Your **${weapon.name}** is broken! Repair it with \`/repair\` or buy a new one with \`/buygun\`.`,
+                content: `Your **${weapon.name}** is broken! Repair it with \`/huntrepair\` or buy a new one with \`/huntbuygun\`.`,
                 ephemeral: true
             });
         }
@@ -207,7 +207,7 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
         if (result.expiredCharm) embed.addFields({ name: '🍀 Charm Expired', value: `Your luck charm has worn off.`, inline: false });
 
         if (weapon.status === 'broken') {
-            embed.addFields({ name: '⚠️ Weapon Broke!', value: `Your **${weapon.name}** has broken! Use \`/repair\` before hunting again.`, inline: false });
+            embed.addFields({ name: '⚠️ Weapon Broke!', value: `Your **${weapon.name}** has broken! Use \`/huntrepair\` before hunting again.`, inline: false });
         } else if (weapon.currentDurability <= Math.floor(weapon.maxDurability * 0.20)) {
             embed.addFields({ name: '⚠️ Low Durability', value: `Your **${weapon.name}** is nearly worn out (${weapon.currentDurability}/${weapon.maxDurability}). Repair soon!`, inline: false });
         }
@@ -244,7 +244,7 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
     }
 
     if (weapon.status === 'broken') {
-        embed.addFields({ name: '❌ Weapon Broke!', value: `Your **${weapon.name}** has broken! Use \`/repair\` before hunting again.`, inline: false });
+        embed.addFields({ name: '❌ Weapon Broke!', value: `Your **${weapon.name}** has broken! Use \`/huntrepair\` before hunting again.`, inline: false });
     }
 
     embed.setFooter({ text: 'Tip: Use consumables from /huntshop to boost your success chance' });

--- a/src/commands/economy/huntinv.js
+++ b/src/commands/economy/huntinv.js
@@ -79,7 +79,7 @@ module.exports = {
         if (sub === 'weapons') {
             if (!h.weapons.length) {
                 return interaction.reply({
-                    content: "You don't own any weapons! Buy one with `/buygun buy <tier>`.",
+                    content: "You don't own any weapons! Buy one with `/huntbuygun buy <tier>`.",
                     ephemeral: true
                 });
             }
@@ -102,7 +102,7 @@ module.exports = {
                 .setColor('#3498db')
                 .setTitle('🔫 Your Weapons')
                 .setDescription(lines.join('\n\n'))
-                .setFooter({ text: 'Use /huntinv equip <#> to change weapon • /repair gun to restore durability • /buygun upgrade for modules' });
+                .setFooter({ text: 'Use /huntinv equip <#> to change weapon • /huntrepair gun to restore durability • /huntbuygun upgrade for modules' });
 
             return interaction.reply({ embeds: [embed] });
         }
@@ -118,7 +118,7 @@ module.exports = {
 
             const weapon = h.weapons[index];
             if (weapon.status === 'broken') {
-                return interaction.reply({ content: `**${weapon.name}** is broken and cannot be equipped. Repair it first with \`/repair gun\`.`, ephemeral: true });
+                return interaction.reply({ content: `**${weapon.name}** is broken and cannot be equipped. Repair it first with \`/huntrepair gun\`.`, ephemeral: true });
             }
 
             h.equippedWeaponIndex = index;
@@ -252,7 +252,7 @@ module.exports = {
                 .setColor('#e74c3c')
                 .setTitle('🗑️ Weapon Discarded')
                 .setDescription(`**${weapon.name}** has been discarded.`)
-                .setFooter({ text: h.weapons.length === 0 ? 'Buy a new weapon with /buygun' : 'Use /huntinv weapons to view remaining weapons' });
+                .setFooter({ text: h.weapons.length === 0 ? 'Buy a new weapon with /huntbuygun' : 'Use /huntinv weapons to view remaining weapons' });
 
             return interaction.reply({ embeds: [embed] });
         }

--- a/src/commands/economy/huntprofile.js
+++ b/src/commands/economy/huntprofile.js
@@ -41,7 +41,7 @@ module.exports = {
         if (!userData) {
             return interaction.reply({
                 content: isSelf
-                    ? "You haven't started hunting yet! Buy a weapon with `/buygun` and use `/hunt` to begin."
+                    ? "You haven't started hunting yet! Buy a weapon with `/huntbuygun` and use `/hunt` to begin."
                     : `${target.username} hasn't started hunting yet.`,
                 ephemeral: true
             });

--- a/src/commands/economy/huntprofile.js
+++ b/src/commands/economy/huntprofile.js
@@ -156,7 +156,7 @@ module.exports = {
         }
 
         if (prestige === 0 && h.level >= 50) {
-            embed.setFooter({ text: 'Max level reached! Use /prestige to reset and unlock new bonuses.' });
+            embed.setFooter({ text: 'Max level reached! Use /huntprestige to reset and unlock new bonuses.' });
         } else if (isSelf) {
             embed.setFooter({ text: `Daily: ${h.dailyHunts} hunts · ${currency}${h.dailyCoins.toLocaleString()} earned (cap: ${currency}${LIMITS.DAILY_HARD_CAP.toLocaleString()})` });
         }

--- a/src/commands/economy/location.js
+++ b/src/commands/economy/location.js
@@ -15,7 +15,7 @@ module.exports = {
     cooldown: 5,
 
     data: new SlashCommandBuilder()
-        .setName('location')
+        .setName('fishlocation')
         .setDescription('Manage your fishing locations')
         .addSubcommand(sub =>
             sub.setName('list')
@@ -83,7 +83,7 @@ async function showList(interaction, user, currency) {
         .setColor('#3498db')
         .setTitle('🗺️ Fishing Locations')
         .setDescription(locationLines.join('\n\n'))
-        .setFooter({ text: 'Use /location unlock <location> to unlock • /location set <location> to switch' })
+        .setFooter({ text: 'Use /fishlocation unlock <location> to unlock • /fishlocation set <location> to switch' })
         .setTimestamp();
 
     return interaction.reply({ embeds: [embed] });
@@ -101,7 +101,7 @@ async function setLocation(interaction, user) {
     }
     if (!f.unlockedLocations.includes(locationId)) {
         return interaction.reply({
-            content: `**${location.name}** is locked. Use \`/location unlock ${locationId}\` to unlock it first.`,
+            content: `**${location.name}** is locked. Use \`/fishlocation unlock ${locationId}\` to unlock it first.`,
             ephemeral: true
         });
     }

--- a/src/commands/economy/prestige.js
+++ b/src/commands/economy/prestige.js
@@ -36,7 +36,7 @@ module.exports = {
     cooldown: 10,
 
     data: new SlashCommandBuilder()
-        .setName('prestige')
+        .setName('huntprestige')
         .setDescription('Reset your hunter level for permanent prestige bonuses (requires Level 50)'),
 
     async execute(interaction) {

--- a/src/commands/economy/repair.js
+++ b/src/commands/economy/repair.js
@@ -10,7 +10,7 @@ module.exports = {
     cooldown: 3,
 
     data: new SlashCommandBuilder()
-        .setName('repair')
+        .setName('huntrepair')
         .setDescription('Repair your equipped weapon')
         .addSubcommand(sub =>
             sub.setName('gun')
@@ -50,7 +50,7 @@ module.exports = {
         const h = user.hunt;
 
         if (h.equippedWeaponIndex < 0 || !h.weapons[h.equippedWeaponIndex]) {
-            return interaction.reply({ content: 'No weapon equipped. Buy one with `/buygun` first.', ephemeral: true });
+            return interaction.reply({ content: 'No weapon equipped. Buy one with `/huntbuygun` first.', ephemeral: true });
         }
 
         const weapon = h.weapons[h.equippedWeaponIndex];
@@ -69,7 +69,7 @@ module.exports = {
             }
 
             if (weapon.status === 'condemned') {
-                return interaction.reply({ content: 'This weapon is condemned and cannot be repaired. Replace it with `/buygun`.', ephemeral: true });
+                return interaction.reply({ content: 'This weapon is condemned and cannot be repaired. Replace it with `/huntbuygun`.', ephemeral: true });
             }
 
             if (weapon.currentDurability >= weapon.maxDurability) {
@@ -101,7 +101,7 @@ module.exports = {
         // ── SHOP REPAIR ────────────────────────────────────────────────────
         if (sub === 'gun') {
             if (weapon.status === 'condemned') {
-                return interaction.reply({ content: 'This weapon is **condemned** and cannot be repaired. Replace it with `/buygun`.', ephemeral: true });
+                return interaction.reply({ content: 'This weapon is **condemned** and cannot be repaired. Replace it with `/huntbuygun`.', ephemeral: true });
             }
 
             if (weapon.currentDurability >= weapon.maxDurability && weapon.status !== 'broken') {
@@ -154,7 +154,7 @@ module.exports = {
                 embed.addFields({ name: '⚠️ Degraded', value: `Max durability is below 50% of original. Performance is reduced.` });
             }
 
-            embed.setFooter({ text: `Each shop repair permanently reduces max durability by 10% • Use repair kits (/repair kit) to avoid degradation` });
+            embed.setFooter({ text: `Each shop repair permanently reduces max durability by 10% • Use repair kits (/huntrepair kit) to avoid degradation` });
 
             return interaction.reply({ embeds: [embed] });
         }

--- a/src/commands/economy/zone.js
+++ b/src/commands/economy/zone.js
@@ -12,7 +12,7 @@ module.exports = {
     cooldown: 3,
 
     data: new SlashCommandBuilder()
-        .setName('zone')
+        .setName('huntzone')
         .setDescription('Manage your hunting zones')
         .addSubcommand(sub =>
             sub.setName('list')
@@ -95,7 +95,7 @@ module.exports = {
             if (!h.unlockedZones.includes(zoneId)) {
                 const costStr = zone.unlockCost > 0 ? ` for ${currency}${zone.unlockCost.toLocaleString()}` : '';
                 return interaction.reply({
-                    content: `**${zone.name}** is locked. Use \`/zone unlock ${zoneId}\`${costStr} to unlock it first.`,
+                    content: `**${zone.name}** is locked. Use \`/huntzone unlock ${zoneId}\`${costStr} to unlock it first.`,
                     ephemeral: true
                 });
             }
@@ -172,7 +172,7 @@ module.exports = {
                     { name: 'Unlock Cost',  value: `${currency}${zone.unlockCost.toLocaleString()}`,   inline: true },
                     { name: 'New Balance',  value: `${currency}${user.balance.toLocaleString()}`,      inline: true }
                 )
-                .setFooter({ text: `Switch to it with /zone set ${zoneId}` });
+                .setFooter({ text: `Switch to it with /huntzone set ${zoneId}` });
 
             return interaction.reply({ embeds: [embed] });
         }

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -525,7 +525,7 @@ function activateConsumable(user, consumableId) {
         h.staminaTonicsToday += 1;
     } else if (def.type === 'repair') {
         // Repair kit used from huntshop use — handled in repair command
-        return { success: false, error: `Use repair kits with \`/repair\`.` };
+        return { success: false, error: `Use repair kits with \`/huntrepair\`.` };
     } else {
         return { success: false, error: 'That item cannot be activated this way.' };
     }


### PR DESCRIPTION
Renamed command names so hunt commands start with "hunt" and fish
commands start with "fish":
- buygun → huntbuygun
- repair → huntrepair
- zone → huntzone
- buyrod → fishbuyrod
- location → fishlocation

Updated all in-game help text, error messages, and footer hints
across hunt.js, fish.js, huntinv.js, huntprofile.js, fishprofile.js,
fishinv.js, fishrepair.js, repair.js, zone.js, location.js,
buygun.js, and huntService.js to reference the new command names.

https://claude.ai/code/session_01KJKccD4wfUxe9pWtksuP6i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized command structure with updated namespacing: hunting commands now use `/hunt` prefix (`/huntbuygun`, `/huntrepair`, `/huntzone`, `/huntprestige`), and fishing commands use `/fish` prefix (`/fishbuyrod`, `/fishlocation`). Updated all user-facing help text and error messages across related commands to reference the new command names consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->