### PR TITLE
Overhaul quest system with difficulty tiers, random pools, and notification channel

### DIFF
--- a/src/commands/community/quests.js
+++ b/src/commands/community/quests.js
@@ -1,7 +1,10 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const User = require('../../models/User');
 const Guild = require('../../models/Guild');
-const { ensureQuests, getQuestDefs } = require('../../services/questService');
+const { ensureQuests, getDailyPool, getWeeklyPool, getCategoryEmojis, getDifficultyColors } = require('../../services/questService');
+
+const DIFFICULTY_EMBED_COLORS = { easy: 0x57F287, medium: 0xFEE75C, hard: 0xED4245 };
+const DIFFICULTY_LABELS = { easy: 'Easy', medium: 'Medium', hard: 'Hard' };
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -23,54 +26,90 @@ module.exports = {
         await ensureQuests(user, guildSettings);
         await user.save();
 
-        const defs = getQuestDefs();
-        const now = new Date();
+        const catEmojis  = getCategoryEmojis();
+        const diffColors = getDifficultyColors();
+        const dailyPool  = getDailyPool();
+        const weeklyPool = getWeeklyPool();
+        const now        = new Date();
 
-        const dailyLines = [];
+        const dailyCoin   = guildSettings.quests.dailyCoinReward   ?? 25;
+        const dailyXp     = guildSettings.quests.dailyXpReward     ?? 50;
+        const weeklyCoin  = guildSettings.quests.weeklyCoinReward  ?? 150;
+        const weeklyXp    = guildSettings.quests.weeklyXpReward    ?? 300;
+
+        const dailyLines  = [];
         const weeklyLines = [];
 
-        for (const def of defs) {
-            const entry = user.quests.find(q => q.questId === def.questId && q.expiresAt > now);
-            if (!entry) continue;
+        const activeQuests = user.quests.filter(q => q.expiresAt > now);
 
-            const progress = entry.progress ?? 0;
-            const completed = !!entry.completedAt;
-            const bar = buildBar(progress, def.target);
-            const status = completed ? '✅' : '🔄';
-            const line = `${status} **${def.name}** — ${def.description}\n${bar} ${progress}/${def.target}`;
+        for (const entry of activeQuests) {
+            const def = [...dailyPool, ...weeklyPool].find(d => d.questId === entry.questId);
+            if (!def) continue;
 
-            if (def.type === 'daily') dailyLines.push(line);
-            else weeklyLines.push(line);
+            const isDaily    = dailyPool.some(d => d.questId === def.questId);
+            const progress   = entry.progress ?? 0;
+            const completed  = !!entry.completedAt;
+            const mult       = def.difficulty === 'hard' ? 3 : def.difficulty === 'medium' ? 1.75 : 1;
+            const rewardXp   = Math.round((isDaily ? dailyXp   : weeklyXp)   * mult);
+            const rewardCoin = Math.round((isDaily ? dailyCoin : weeklyCoin) * mult);
+
+            const bar        = buildBar(progress, def.target);
+            const catEmoji   = catEmojis[def.category] ?? '🗺️';
+            const diffDot    = diffColors[def.difficulty] ?? '🟢';
+            const diffLabel  = DIFFICULTY_LABELS[def.difficulty] ?? 'Easy';
+            const statusMark = completed ? '✅' : '🔄';
+
+            const line = [
+                `${statusMark} ${catEmoji} **${def.name}** ${diffDot} \`${diffLabel}\``,
+                `${def.description}`,
+                `${bar} **${progress}**/${def.target}`,
+                `Reward: **+${rewardXp} XP**, **+${rewardCoin} coins**`,
+            ].join('\n');
+
+            if (isDaily) dailyLines.push(line);
+            else         weeklyLines.push(line);
         }
 
-        const dailyCoin = guildSettings.quests.dailyCoinReward ?? 25;
-        const dailyXp = guildSettings.quests.dailyXpReward ?? 50;
-        const weeklyCoin = guildSettings.quests.weeklyCoinReward ?? 150;
-        const weeklyXp = guildSettings.quests.weeklyXpReward ?? 300;
+        const completedDailyCount  = activeQuests.filter(q => q.completedAt && dailyPool.some(d => d.questId === q.questId)).length;
+        const completedWeeklyCount = activeQuests.filter(q => q.completedAt && weeklyPool.some(d => d.questId === q.questId)).length;
+        const totalDaily  = dailyLines.length;
+        const totalWeekly = weeklyLines.length;
 
         const embed = new EmbedBuilder()
-            .setColor('#5865F2')
-            .setTitle(`${interaction.user.displayName}'s Quests`)
-            .setThumbnail(interaction.user.displayAvatarURL({ dynamic: true }))
+            .setColor(0x5865F2)
+            .setAuthor({
+                name: `${interaction.user.displayName}'s Quest Board`,
+                iconURL: interaction.user.displayAvatarURL({ dynamic: true })
+            })
+            .setDescription(
+                `Daily resets <t:${nextMidnightTs()}:R> · Weekly resets <t:${nextSundayTs()}:R>\n` +
+                `Progress: **${completedDailyCount}/${totalDaily}** daily · **${completedWeeklyCount}/${totalWeekly}** weekly`
+            )
             .addFields(
                 {
-                    name: `Daily Quests (resets in <t:${nextMidnightTs()}:R>) — +${dailyXp} XP, +${dailyCoin} coins each`,
-                    value: dailyLines.join('\n\n') || 'No daily quests active.'
+                    name: `📅 Daily Quests — base +${dailyXp} XP / +${dailyCoin} coins (scaled by difficulty)`,
+                    value: dailyLines.join('\n\n') || '_No daily quests active._'
                 },
                 {
-                    name: `Weekly Quests (resets <t:${nextSundayTs()}:R>) — +${weeklyXp} XP, +${weeklyCoin} coins each`,
-                    value: weeklyLines.join('\n\n') || 'No weekly quests active.'
+                    name: `📆 Weekly Quests — base +${weeklyXp} XP / +${weeklyCoin} coins (scaled by difficulty)`,
+                    value: weeklyLines.join('\n\n') || '_No weekly quests active._'
+                },
+                {
+                    name: 'Difficulty multipliers',
+                    value: '🟢 Easy ×1.0 · 🟡 Medium ×1.75 · 🔴 Hard ×3.0',
+                    inline: false
                 }
             )
+            .setFooter({ text: 'Complete quests to earn XP, coins, and season pass progress.' })
             .setTimestamp();
 
         await interaction.reply({ embeds: [embed], ephemeral: true });
     }
 };
 
-function buildBar(current, target, length = 10) {
-    const filled = Math.round((current / target) * length);
-    return '[' + '█'.repeat(Math.min(filled, length)) + '░'.repeat(Math.max(length - filled, 0)) + ']';
+function buildBar(current, target, length = 12) {
+    const filled = Math.min(Math.round((current / target) * length), length);
+    return '`[' + '█'.repeat(filled) + '░'.repeat(length - filled) + ']`';
 }
 
 function nextMidnightTs() {

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -830,21 +830,42 @@
                 <section id="quests" class="panel">
                     <div class="panel-head">
                         <h2>Quests</h2>
-                        <p>Daily and weekly quests keep members engaged. Use <code>/quests</code> to view progress.</p>
+                        <p>Daily and weekly quests keep members engaged with difficulty-scaled rewards. Use <code>/quests</code> to view progress.</p>
                     </div>
                     <label class="toggle">
                         <span class="toggle-text"><strong>Enable quests</strong></span>
                         <span class="switch"><input type="checkbox" id="quests-enabled" <%= settings.quests?.enabled ? 'checked' : '' %>><span class="slider"></span></span>
                     </label>
-                    <div class="panel-head" style="margin-top:1rem"><h3>Daily quest rewards</h3></div>
-                    <div class="field" style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;">
-                        <div><label class="field-label" for="quests-daily-xp">XP reward</label><input type="number" id="quests-daily-xp" value="<%= settings.quests?.dailyXpReward || 50 %>" min="0"></div>
-                        <div><label class="field-label" for="quests-daily-coins">Coin reward</label><input type="number" id="quests-daily-coins" value="<%= settings.quests?.dailyCoinReward || 25 %>" min="0"></div>
+
+                    <div class="panel-head" style="margin-top:1.25rem"><h3>Notifications</h3></div>
+                    <div class="field">
+                        <label class="field-label" for="quests-notif-channel">Quest completion channel <small>— post a rich embed here when a member finishes a quest (leave blank to post in the current channel)</small></label>
+                        <select id="quests-notif-channel">
+                            <option value="">— Same channel as activity —</option>
+                            <% channels.forEach(ch => { %><option value="<%= ch.id %>" <%= settings.quests?.notificationChannelId === ch.id ? 'selected' : '' %>>#<%= ch.name %></option><% }); %>
+                        </select>
                     </div>
-                    <div class="panel-head" style="margin-top:1rem"><h3>Weekly quest rewards</h3></div>
+
+                    <div class="panel-head" style="margin-top:1.25rem"><h3>Quest slots per reset</h3></div>
                     <div class="field" style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;">
-                        <div><label class="field-label" for="quests-weekly-xp">XP reward</label><input type="number" id="quests-weekly-xp" value="<%= settings.quests?.weeklyXpReward || 300 %>" min="0"></div>
-                        <div><label class="field-label" for="quests-weekly-coins">Coin reward</label><input type="number" id="quests-weekly-coins" value="<%= settings.quests?.weeklyCoinReward || 150 %>" min="0"></div>
+                        <div>
+                            <label class="field-label" for="quests-per-day">Daily quests assigned <small>(1–6)</small></label>
+                            <input type="number" id="quests-per-day" value="<%= settings.quests?.questsPerDay ?? 3 %>" min="1" max="6">
+                            <small>How many random daily quests each member receives per day.</small>
+                        </div>
+                        <div>
+                            <label class="field-label" for="quests-per-week">Weekly quests assigned <small>(1–4)</small></label>
+                            <input type="number" id="quests-per-week" value="<%= settings.quests?.questsPerWeek ?? 2 %>" min="1" max="4">
+                            <small>How many random weekly quests each member receives per week.</small>
+                        </div>
+                    </div>
+
+                    <div class="panel-head" style="margin-top:1.25rem"><h3>Base rewards <small>— scaled ×1.0 / ×1.75 / ×3.0 by difficulty</small></h3></div>
+                    <div class="field" style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;">
+                        <div><label class="field-label" for="quests-daily-xp">Daily XP (easy base)</label><input type="number" id="quests-daily-xp" value="<%= settings.quests?.dailyXpReward || 50 %>" min="0"></div>
+                        <div><label class="field-label" for="quests-daily-coins">Daily coins (easy base)</label><input type="number" id="quests-daily-coins" value="<%= settings.quests?.dailyCoinReward || 25 %>" min="0"></div>
+                        <div><label class="field-label" for="quests-weekly-xp">Weekly XP (easy base)</label><input type="number" id="quests-weekly-xp" value="<%= settings.quests?.weeklyXpReward || 300 %>" min="0"></div>
+                        <div><label class="field-label" for="quests-weekly-coins">Weekly coins (easy base)</label><input type="number" id="quests-weekly-coins" value="<%= settings.quests?.weeklyCoinReward || 150 %>" min="0"></div>
                     </div>
                     <div class="actions-row">
                         <button class="btn btn-primary" onclick="saveSettings('quests')">Save changes</button>
@@ -1799,8 +1820,12 @@
                 };
             } else if (section === 'quests') {
                 const safeReward = (id, fallback) => { const v = parseInt(document.getElementById(id).value, 10); return Number.isFinite(v) ? v : fallback; };
+                const safeSlot = (id, fallback, min, max) => { const v = parseInt(document.getElementById(id).value, 10); return Number.isFinite(v) ? Math.min(Math.max(v, min), max) : fallback; };
                 data = {
                     'quests.enabled': document.getElementById('quests-enabled').checked,
+                    'quests.notificationChannelId': document.getElementById('quests-notif-channel').value || null,
+                    'quests.questsPerDay': safeSlot('quests-per-day', 3, 1, 6),
+                    'quests.questsPerWeek': safeSlot('quests-per-week', 2, 1, 4),
                     'quests.dailyXpReward': safeReward('quests-daily-xp', 50),
                     'quests.dailyCoinReward': safeReward('quests-daily-coins', 25),
                     'quests.weeklyXpReward': safeReward('quests-weekly-xp', 300),

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -2,7 +2,7 @@ const Guild = require('../models/Guild');
 const User = require('../models/User');
 const { closeTicket } = require('../commands/moderation/ticket');
 const { handlePollVote } = require('../commands/utility/poll');
-const { ensureQuests, onCommandUse } = require('../services/questService');
+const { ensureQuests, onCommandUse, notifyQuestComplete } = require('../services/questService');
 async function logCommandMetric(interaction, success, reason = null) {
     try {
         const entry = {
@@ -46,13 +46,7 @@ async function trackQuestCommandUse(interaction) {
     const completed = await onCommandUse(user, guildSettings);
     await user.save();
 
-    for (const reward of completed) {
-        if (!reward) continue;
-        const ch = interaction.channel;
-        if (ch) {
-            await ch.send(`${interaction.user} completed a quest! **+${reward.xp} XP, +${reward.coins} coins**`).catch(() => {});
-        }
-    }
+    await notifyQuestComplete(guildSettings, interaction.member, completed, interaction.channel);
 }
 
 function memberHasAnyRole(member, roleIds = []) {

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -3,7 +3,7 @@ const Guild = require('../models/Guild');
 const Case = require('../models/Case');
 const { handleAIChat } = require('../services/aiService');
 const { logModeration } = require('../utils/logger');
-const { ensureQuests, onMessage } = require('../services/questService');
+const { ensureQuests, onMessage, notifyQuestComplete } = require('../services/questService');
 
 const BASE_BAD_WORDS = [
     'nigger', 'nigga', 'faggot', 'fag', 'retard', 'chink', 'spic', 'kike',
@@ -150,13 +150,7 @@ async function handleStreakAndQuests(message, guildSettings) {
 
         await user.save();
 
-        // Notify completed quests
-        for (const reward of completedQuests) {
-            if (!reward) continue;
-            await message.channel.send(
-                `${message.author} completed a quest! **+${reward.xp} XP, +${reward.coins} coins**`
-            ).catch(() => {});
-        }
+        await notifyQuestComplete(guildSettings, message.member, completedQuests, message.channel);
     } catch (err) {
         console.error('Streak/quest error:', err);
     }

--- a/src/events/messageReactionAdd.js
+++ b/src/events/messageReactionAdd.js
@@ -29,7 +29,11 @@ module.exports = {
 
 async function handleReactionQuests(reaction, discordUser, guild, guildSettings) {
     if (!guildSettings?.quests?.enabled) return;
-    let userDoc = await User.findOne({ userId: discordUser.id, guildId: guild.id });
+    let userDoc = await User.findOneAndUpdate(
+        { userId: discordUser.id, guildId: guild.id },
+        { $setOnInsert: { userId: discordUser.id, guildId: guild.id } },
+        { upsert: true, new: true }
+    );
     if (!userDoc) return;
     await ensureQuests(userDoc, guildSettings);
     const completed = await onReaction(userDoc, guildSettings);

--- a/src/events/messageReactionAdd.js
+++ b/src/events/messageReactionAdd.js
@@ -1,5 +1,7 @@
 const { EmbedBuilder } = require('discord.js');
 const Guild = require('../models/Guild');
+const User = require('../models/User');
+const { ensureQuests, onReaction, notifyQuestComplete } = require('../services/questService');
 
 module.exports = {
     name: 'messageReactionAdd',
@@ -21,8 +23,22 @@ module.exports = {
 
         await handleReactionRole(reaction, user, guild, guildSettings);
         await handleStarboard(reaction, user, guild, guildSettings);
+        await handleReactionQuests(reaction, user, guild, guildSettings);
     }
 };
+
+async function handleReactionQuests(reaction, discordUser, guild, guildSettings) {
+    if (!guildSettings?.quests?.enabled) return;
+    let userDoc = await User.findOne({ userId: discordUser.id, guildId: guild.id });
+    if (!userDoc) return;
+    await ensureQuests(userDoc, guildSettings);
+    const completed = await onReaction(userDoc, guildSettings);
+    await userDoc.save();
+    const member = await guild.members.fetch(discordUser.id).catch(() => null);
+    if (member) {
+        await notifyQuestComplete(guildSettings, member, completed, reaction.message.channel);
+    }
+}
 
 async function handleReactionRole(reaction, user, guild, guildSettings) {
     if (!guildSettings.reactionRoles?.length) return;

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -325,6 +325,9 @@ const guildSchema = new Schema({
 
     quests: {
         enabled: { type: Boolean, default: false },
+        notificationChannelId: { type: String, default: null },
+        questsPerDay: { type: Number, default: 3, min: 1, max: 6 },
+        questsPerWeek: { type: Number, default: 2, min: 1, max: 4 },
         dailyXpReward: { type: Number, default: 50 },
         dailyCoinReward: { type: Number, default: 25 },
         weeklyXpReward: { type: Number, default: 300 },

--- a/src/services/questService.js
+++ b/src/services/questService.js
@@ -96,9 +96,12 @@ async function ensureQuests(user, guildSettings) {
     const dailyExpiry  = getDailyExpiry();
     const weeklyExpiry = getWeeklyExpiry();
 
-    // Check how many of each type are still active
-    const activeDailyIds  = user.quests.filter(q => q.expiresAt.getTime() === dailyExpiry.getTime() || q.expiresAt < weeklyExpiry).map(q => q.questId);
-    const activeWeeklyIds = user.quests.filter(q => q.expiresAt.getTime() >= weeklyExpiry.getTime()).map(q => q.questId);
+    // Mutually exclusive by type: daily expires before the weekly cutoff, weekly at or after.
+    // Using getTime() avoids the Saturday edge case where dailyExpiry === weeklyExpiry.
+    const dailyExpiryMs  = dailyExpiry.getTime();
+    const weeklyExpiryMs = weeklyExpiry.getTime();
+    const activeDailyIds  = user.quests.filter(q => { const t = q.expiresAt.getTime(); return t === dailyExpiryMs && t < weeklyExpiryMs; }).map(q => q.questId);
+    const activeWeeklyIds = user.quests.filter(q => q.expiresAt.getTime() >= weeklyExpiryMs).map(q => q.questId);
 
     const dailyNeeded  = dailyCount  - activeDailyIds.length;
     const weeklyNeeded = weeklyCount - activeWeeklyIds.length;
@@ -259,7 +262,8 @@ async function onStreakUpdate(user, guildSettings) {
 async function notifyQuestComplete(guild, member, rewards, fallbackChannel) {
     if (!rewards?.length) return;
 
-    const notifChannelId = guild.settings?.quests?.notificationChannelId;
+    const settings = guild.settings ?? guild;
+    const notifChannelId = settings.quests?.notificationChannelId;
     const channel = notifChannelId
         ? (member.guild.channels.cache.get(notifChannelId) ?? fallbackChannel)
         : fallbackChannel;

--- a/src/services/questService.js
+++ b/src/services/questService.js
@@ -1,18 +1,65 @@
 const User = require('../models/User');
 const Guild = require('../models/Guild');
 
-// Built-in quest definitions
-const DAILY_QUESTS = [
-    { questId: 'daily_messages_10', name: 'Chatty', description: 'Send 10 messages', target: 10 },
-    { questId: 'daily_reactions_5', name: 'Reactor', description: 'React to 5 messages', target: 5 },
-    { questId: 'daily_commands_3', name: 'Explorer', description: 'Use 3 bot commands', target: 3 }
+// difficulty → reward multiplier
+const DIFFICULTY_MULTIPLIERS = { easy: 1, medium: 1.75, hard: 3 };
+
+const DAILY_QUEST_POOL = [
+    // Easy
+    { questId: 'daily_messages_5',      name: 'Icebreaker',        description: 'Send 5 messages',                   target: 5,   difficulty: 'easy',   category: 'social'   },
+    { questId: 'daily_reactions_3',     name: 'Hype Train',        description: 'React to 3 messages',               target: 3,   difficulty: 'easy',   category: 'social'   },
+    { questId: 'daily_commands_2',      name: 'First Steps',       description: 'Use 2 bot commands',                target: 2,   difficulty: 'easy',   category: 'explore'  },
+    { questId: 'daily_messages_10',     name: 'Chatty',            description: 'Send 10 messages',                  target: 10,  difficulty: 'easy',   category: 'social'   },
+    { questId: 'daily_reactions_5',     name: 'Reactor',           description: 'React to 5 messages',               target: 5,   difficulty: 'easy',   category: 'social'   },
+
+    // Medium
+    { questId: 'daily_commands_5',      name: 'Explorer',          description: 'Use 5 bot commands',                target: 5,   difficulty: 'medium', category: 'explore'  },
+    { questId: 'daily_messages_25',     name: 'Conversationalist', description: 'Send 25 messages',                  target: 25,  difficulty: 'medium', category: 'social'   },
+    { questId: 'daily_reactions_10',    name: 'Emote Master',      description: 'React to 10 messages',              target: 10,  difficulty: 'medium', category: 'social'   },
+    { questId: 'daily_economy_earn_50', name: 'Coin Collector',    description: 'Earn 50 coins through activities',  target: 50,  difficulty: 'medium', category: 'economy'  },
+    { questId: 'daily_hunt_1',          name: 'First Hunt',        description: 'Complete 1 hunt',                   target: 1,   difficulty: 'medium', category: 'hunt'     },
+    { questId: 'daily_fish_1',          name: 'Gone Fishin\'',     description: 'Make 1 fishing cast',               target: 1,   difficulty: 'medium', category: 'fishing'  },
+
+    // Hard
+    { questId: 'daily_messages_50',     name: 'Non-stop',          description: 'Send 50 messages',                  target: 50,  difficulty: 'hard',   category: 'social'   },
+    { questId: 'daily_commands_10',     name: 'Bot Addict',        description: 'Use 10 bot commands',               target: 10,  difficulty: 'hard',   category: 'explore'  },
+    { questId: 'daily_economy_earn_200','name': 'Money Grubber',   description: 'Earn 200 coins through activities', target: 200, difficulty: 'hard',   category: 'economy'  },
+    { questId: 'daily_hunt_5',          name: 'Hunt Frenzy',       description: 'Complete 5 hunts',                  target: 5,   difficulty: 'hard',   category: 'hunt'     },
+    { questId: 'daily_fish_5',          name: 'Cast Away',         description: 'Make 5 fishing casts',              target: 5,   difficulty: 'hard',   category: 'fishing'  },
+    { questId: 'daily_reactions_20',    name: 'Reaction God',      description: 'React to 20 messages',              target: 20,  difficulty: 'hard',   category: 'social'   },
 ];
 
-const WEEKLY_QUESTS = [
-    { questId: 'weekly_messages_50', name: 'Conversation Starter', description: 'Send 50 messages', target: 50 },
-    { questId: 'weekly_streak_5', name: 'Consistent', description: 'Maintain a 5-day streak', target: 5 },
-    { questId: 'weekly_commands_15', name: 'Bot Veteran', description: 'Use 15 bot commands', target: 15 }
+const WEEKLY_QUEST_POOL = [
+    // Easy
+    { questId: 'weekly_messages_50',    name: 'Conversation Starter', description: 'Send 50 messages this week',          target: 50,  difficulty: 'easy',   category: 'social'   },
+    { questId: 'weekly_commands_10',    name: 'Regular',              description: 'Use 10 bot commands this week',        target: 10,  difficulty: 'easy',   category: 'explore'  },
+
+    // Medium
+    { questId: 'weekly_messages_150',   name: 'Motormouth',           description: 'Send 150 messages this week',          target: 150, difficulty: 'medium', category: 'social'   },
+    { questId: 'weekly_streak_3',       name: 'Getting into It',      description: 'Maintain a 3-day activity streak',      target: 3,   difficulty: 'medium', category: 'streak'   },
+    { questId: 'weekly_commands_25',    name: 'Bot Veteran',          description: 'Use 25 bot commands this week',         target: 25,  difficulty: 'medium', category: 'explore'  },
+    { questId: 'weekly_economy_500',    name: 'Hustler',              description: 'Earn 500 coins this week',              target: 500, difficulty: 'medium', category: 'economy'  },
+    { questId: 'weekly_hunt_10',        name: 'Dedicated Hunter',     description: 'Complete 10 hunts this week',           target: 10,  difficulty: 'medium', category: 'hunt'     },
+    { questId: 'weekly_fish_10',        name: 'Weekend Angler',       description: 'Make 10 fishing casts this week',       target: 10,  difficulty: 'medium', category: 'fishing'  },
+
+    // Hard
+    { questId: 'weekly_streak_5',       name: 'Consistent',           description: 'Maintain a 5-day activity streak',      target: 5,   difficulty: 'hard',   category: 'streak'   },
+    { questId: 'weekly_messages_300',   name: 'Chatterbox',           description: 'Send 300 messages this week',           target: 300, difficulty: 'hard',   category: 'social'   },
+    { questId: 'weekly_economy_1500',   name: 'High Roller',          description: 'Earn 1500 coins this week',             target: 1500,difficulty: 'hard',   category: 'economy'  },
+    { questId: 'weekly_hunt_25',        name: 'Trophy Collector',     description: 'Complete 25 hunts this week',           target: 25,  difficulty: 'hard',   category: 'hunt'     },
+    { questId: 'weekly_fish_25',        name: 'Master Angler',        description: 'Make 25 fishing casts this week',       target: 25,  difficulty: 'hard',   category: 'fishing'  },
 ];
+
+const CATEGORY_EMOJIS = {
+    social:  '💬',
+    explore: '🔍',
+    economy: '💰',
+    hunt:    '🏹',
+    fishing: '🎣',
+    streak:  '🔥',
+};
+
+const DIFFICULTY_COLORS = { easy: '🟢', medium: '🟡', hard: '🔴' };
 
 function getDailyExpiry() {
     const d = new Date();
@@ -28,40 +75,66 @@ function getWeeklyExpiry() {
     return d;
 }
 
-function getAllQuestDefs() {
-    return [
-        ...DAILY_QUESTS.map(q => ({ ...q, type: 'daily', expiresAt: getDailyExpiry() })),
-        ...WEEKLY_QUESTS.map(q => ({ ...q, type: 'weekly', expiresAt: getWeeklyExpiry() }))
-    ];
+function pickRandom(pool, count) {
+    const shuffled = [...pool].sort(() => Math.random() - 0.5);
+    return shuffled.slice(0, Math.min(count, shuffled.length));
 }
 
-// Ensure active quest entries exist for the user, pruning expired ones.
-// NOTE: does not call user.save() — callers must persist after this.
+// Assign a fresh daily/weekly quest set for a user, keeping any still-active ones.
+// Does NOT call user.save() — callers must persist.
 async function ensureQuests(user, guildSettings) {
     if (!guildSettings?.quests?.enabled) return;
 
     const now = new Date();
-    // Remove expired
     user.quests = (user.quests || []).filter(q => q.expiresAt > now);
 
-    const existingIds = new Set(user.quests.map(q => q.questId));
-    for (const def of getAllQuestDefs()) {
-        if (!existingIds.has(def.questId)) {
-            user.quests.push({ questId: def.questId, progress: 0, completedAt: null, expiresAt: def.expiresAt });
+    const dailyCount  = guildSettings.quests.questsPerDay  ?? 3;
+    const weeklyCount = guildSettings.quests.questsPerWeek ?? 2;
+
+    const activeIds = new Set(user.quests.map(q => q.questId));
+
+    const dailyExpiry  = getDailyExpiry();
+    const weeklyExpiry = getWeeklyExpiry();
+
+    // Check how many of each type are still active
+    const activeDailyIds  = user.quests.filter(q => q.expiresAt.getTime() === dailyExpiry.getTime() || q.expiresAt < weeklyExpiry).map(q => q.questId);
+    const activeWeeklyIds = user.quests.filter(q => q.expiresAt.getTime() >= weeklyExpiry.getTime()).map(q => q.questId);
+
+    const dailyNeeded  = dailyCount  - activeDailyIds.length;
+    const weeklyNeeded = weeklyCount - activeWeeklyIds.length;
+
+    if (dailyNeeded > 0) {
+        const available = DAILY_QUEST_POOL.filter(q => !activeIds.has(q.questId));
+        const picked = pickRandom(available, dailyNeeded);
+        for (const def of picked) {
+            user.quests.push({ questId: def.questId, progress: 0, completedAt: null, expiresAt: dailyExpiry });
+        }
+    }
+
+    if (weeklyNeeded > 0) {
+        const available = WEEKLY_QUEST_POOL.filter(q => !activeIds.has(q.questId));
+        const picked = pickRandom(available, weeklyNeeded);
+        for (const def of picked) {
+            user.quests.push({ questId: def.questId, progress: 0, completedAt: null, expiresAt: weeklyExpiry });
         }
     }
 }
 
-// Increment progress on a quest and return reward info if just completed
+function getDefById(questId) {
+    return DAILY_QUEST_POOL.find(d => d.questId === questId)
+        || WEEKLY_QUEST_POOL.find(d => d.questId === questId)
+        || null;
+}
+
+// Increment progress on an active quest; returns the def if just completed
 async function incrementQuest(user, questId, amount = 1) {
     const entry = user.quests?.find(q => q.questId === questId && !q.completedAt && q.expiresAt > new Date());
     if (!entry) return null;
 
-    const def = getAllQuestDefs().find(d => d.questId === questId);
+    const def = getDefById(questId);
     if (!def) return null;
 
     entry.progress = Math.min((entry.progress || 0) + amount, def.target);
-
     if (entry.progress >= def.target) {
         entry.completedAt = new Date();
         return def;
@@ -69,104 +142,169 @@ async function incrementQuest(user, questId, amount = 1) {
     return null;
 }
 
-// Award quest rewards (XP + coins + season XP) when a quest completes
+// Award XP + coins scaled by difficulty; returns { xp, coins, def }
 async function awardQuest(user, questDef, guildSettings) {
-    const isDaily = DAILY_QUESTS.some(d => d.questId === questDef.questId);
-    const xp = isDaily
-        ? (guildSettings?.quests?.dailyXpReward ?? 50)
-        : (guildSettings?.quests?.weeklyXpReward ?? 300);
-    const coins = isDaily
-        ? (guildSettings?.quests?.dailyCoinReward ?? 25)
-        : (guildSettings?.quests?.weeklyCoinReward ?? 150);
+    const isDaily = DAILY_QUEST_POOL.some(d => d.questId === questDef.questId);
+    const mult = DIFFICULTY_MULTIPLIERS[questDef.difficulty] ?? 1;
 
-    user.xp += xp;
+    const baseXp    = isDaily ? (guildSettings?.quests?.dailyXpReward    ?? 50)  : (guildSettings?.quests?.weeklyXpReward    ?? 300);
+    const baseCoins = isDaily ? (guildSettings?.quests?.dailyCoinReward   ?? 25)  : (guildSettings?.quests?.weeklyCoinReward  ?? 150);
+
+    const xp    = Math.round(baseXp    * mult);
+    const coins = Math.round(baseCoins * mult);
+
+    user.xp      += xp;
     user.balance += coins;
     await awardSeasonXp(user, xp, guildSettings);
-    return { xp, coins };
+    return { xp, coins, def: questDef };
 }
 
-// Season XP and tier-up logic
 async function awardSeasonXp(user, xp, guildSettings) {
     const season = guildSettings?.season;
     if (!season?.enabled || !season.seasonId) return;
     if (user.season?.seasonId !== season.seasonId) {
         user.season = { seasonId: season.seasonId, xp: 0, tier: 0, claimedTiers: [] };
     }
-
     user.season.xp = (user.season.xp || 0) + xp;
     const xpPerTier = season.xpPerTier || 100;
-    const maxTiers = season.maxTiers || 50;
-    const newTier = Math.min(Math.floor(user.season.xp / xpPerTier), maxTiers);
-    user.season.tier = newTier;
+    const maxTiers  = season.maxTiers  || 50;
+    user.season.tier = Math.min(Math.floor(user.season.xp / xpPerTier), maxTiers);
 }
 
-// Called from messageCreate when user sends a message
+// ── Event hooks ──────────────────────────────────────────────────────────────
+
 async function onMessage(user, guildSettings) {
     if (!guildSettings?.quests?.enabled) return [];
     const completed = [];
-
-    const msg10 = await incrementQuest(user, 'daily_messages_10');
-    if (msg10) completed.push(await awardQuest(user, msg10, guildSettings));
-
-    const wk50 = await incrementQuest(user, 'weekly_messages_50');
-    if (wk50) completed.push(await awardQuest(user, wk50, guildSettings));
-
+    for (const questId of ['daily_messages_5', 'daily_messages_10', 'daily_messages_25', 'daily_messages_50',
+                           'weekly_messages_50', 'weekly_messages_150', 'weekly_messages_300']) {
+        const def = await incrementQuest(user, questId);
+        if (def) completed.push(await awardQuest(user, def, guildSettings));
+    }
     return completed;
 }
 
-// Called from messageReactionAdd when user adds a reaction
 async function onReaction(user, guildSettings) {
     if (!guildSettings?.quests?.enabled) return [];
     const completed = [];
-
-    const react5 = await incrementQuest(user, 'daily_reactions_5');
-    if (react5) completed.push(await awardQuest(user, react5, guildSettings));
-
+    for (const questId of ['daily_reactions_3', 'daily_reactions_5', 'daily_reactions_10', 'daily_reactions_20']) {
+        const def = await incrementQuest(user, questId);
+        if (def) completed.push(await awardQuest(user, def, guildSettings));
+    }
     return completed;
 }
 
-// Called from interactionCreate when user uses a command
 async function onCommandUse(user, guildSettings) {
     if (!guildSettings?.quests?.enabled) return [];
     const completed = [];
-
-    const cmd3 = await incrementQuest(user, 'daily_commands_3');
-    if (cmd3) completed.push(await awardQuest(user, cmd3, guildSettings));
-
-    const wkCmd15 = await incrementQuest(user, 'weekly_commands_15');
-    if (wkCmd15) completed.push(await awardQuest(user, wkCmd15, guildSettings));
-
+    for (const questId of ['daily_commands_2', 'daily_commands_5', 'daily_commands_10',
+                           'weekly_commands_10', 'weekly_commands_25']) {
+        const def = await incrementQuest(user, questId);
+        if (def) completed.push(await awardQuest(user, def, guildSettings));
+    }
     return completed;
 }
 
-// Called from streak updates in messageCreate
+async function onEconomyEarn(user, guildSettings, amount) {
+    if (!guildSettings?.quests?.enabled) return [];
+    const completed = [];
+    for (const questId of ['daily_economy_earn_50', 'daily_economy_earn_200',
+                           'weekly_economy_500', 'weekly_economy_1500']) {
+        const def = await incrementQuest(user, questId, amount);
+        if (def) completed.push(await awardQuest(user, def, guildSettings));
+    }
+    return completed;
+}
+
+async function onHunt(user, guildSettings) {
+    if (!guildSettings?.quests?.enabled) return [];
+    const completed = [];
+    for (const questId of ['daily_hunt_1', 'daily_hunt_5', 'weekly_hunt_10', 'weekly_hunt_25']) {
+        const def = await incrementQuest(user, questId);
+        if (def) completed.push(await awardQuest(user, def, guildSettings));
+    }
+    return completed;
+}
+
+async function onFish(user, guildSettings) {
+    if (!guildSettings?.quests?.enabled) return [];
+    const completed = [];
+    for (const questId of ['daily_fish_1', 'daily_fish_5', 'weekly_fish_10', 'weekly_fish_25']) {
+        const def = await incrementQuest(user, questId);
+        if (def) completed.push(await awardQuest(user, def, guildSettings));
+    }
+    return completed;
+}
+
 async function onStreakUpdate(user, guildSettings) {
     if (!guildSettings?.quests?.enabled) return [];
-    const streak = user.streak?.current || 0;
+    const streak    = user.streak?.current || 0;
     const completed = [];
-
-    if (streak >= 5) {
-        const entry = user.quests?.find(q => q.questId === 'weekly_streak_5' && !q.completedAt && q.expiresAt > new Date());
-        if (entry) {
-            const def = getAllQuestDefs().find(d => d.questId === 'weekly_streak_5');
-            if (def && entry.progress < def.target) {
-                entry.progress = def.target;
+    for (const questId of ['weekly_streak_3', 'weekly_streak_5']) {
+        const def = getDefById(questId);
+        if (!def) continue;
+        if (streak >= def.target) {
+            const entry = user.quests?.find(q => q.questId === questId && !q.completedAt && q.expiresAt > new Date());
+            if (entry && entry.progress < def.target) {
+                entry.progress    = def.target;
                 entry.completedAt = new Date();
                 completed.push(await awardQuest(user, def, guildSettings));
             }
         }
     }
-
     return completed;
 }
 
-function getQuestDefs() {
-    return getAllQuestDefs();
+// Send quest completion notification to the configured channel (or fallback channel)
+async function notifyQuestComplete(guild, member, rewards, fallbackChannel) {
+    if (!rewards?.length) return;
+
+    const notifChannelId = guild.settings?.quests?.notificationChannelId;
+    const channel = notifChannelId
+        ? (member.guild.channels.cache.get(notifChannelId) ?? fallbackChannel)
+        : fallbackChannel;
+    if (!channel) return;
+
+    const { EmbedBuilder } = require('discord.js');
+    for (const reward of rewards) {
+        if (!reward) continue;
+        const def        = reward.def;
+        const catEmoji   = CATEGORY_EMOJIS[def?.category] ?? '🗺️';
+        const diffColor  = DIFFICULTY_COLORS[def?.difficulty] ?? '🟢';
+        const diffName   = def?.difficulty ? (def.difficulty.charAt(0).toUpperCase() + def.difficulty.slice(1)) : 'Quest';
+        const embed = new EmbedBuilder()
+            .setColor(def?.difficulty === 'hard' ? 0xED4245 : def?.difficulty === 'medium' ? 0xFEE75C : 0x57F287)
+            .setAuthor({ name: `${member.displayName} completed a quest!`, iconURL: member.displayAvatarURL({ dynamic: true }) })
+            .setDescription(`${catEmoji} **${def?.name ?? 'Quest'}** ${diffColor} ${diffName}\n${def?.description ?? ''}`)
+            .addFields(
+                { name: 'XP Earned',    value: `+${reward.xp} XP`,      inline: true },
+                { name: 'Coins Earned', value: `+${reward.coins} coins`, inline: true }
+            )
+            .setTimestamp();
+        await channel.send({ embeds: [embed] }).catch(() => {});
+    }
 }
+
+function getQuestDefs() {
+    return [
+        ...DAILY_QUEST_POOL.map(q => ({ ...q, type: 'daily',  expiresAt: getDailyExpiry()  })),
+        ...WEEKLY_QUEST_POOL.map(q => ({ ...q, type: 'weekly', expiresAt: getWeeklyExpiry() })),
+    ];
+}
+
+function getDailyPool()  { return DAILY_QUEST_POOL;  }
+function getWeeklyPool() { return WEEKLY_QUEST_POOL; }
+function getCategoryEmojis()  { return CATEGORY_EMOJIS;  }
+function getDifficultyColors() { return DIFFICULTY_COLORS; }
 
 function startQuestService() {
-    // Placeholder: quest expiry/reset is handled per-user via ensureQuests on each interaction
-    console.log('[QUESTS] Quest service ready (per-user lazy expiry)');
+    console.log('[QUESTS] Quest service ready (per-user lazy expiry, randomised pool)');
 }
 
-module.exports = { ensureQuests, onMessage, onReaction, onCommandUse, onStreakUpdate, getQuestDefs, awardSeasonXp, startQuestService };
+module.exports = {
+    ensureQuests, getQuestDefs, getDailyPool, getWeeklyPool,
+    getCategoryEmojis, getDifficultyColors,
+    onMessage, onReaction, onCommandUse, onEconomyEarn, onHunt, onFish, onStreakUpdate,
+    awardSeasonXp, notifyQuestComplete,
+    startQuestService,
+};


### PR DESCRIPTION
- questService: replace 6 static quests with 30-quest pool (17 daily, 13 weekly)
  across 6 categories (social, explore, economy, hunt, fishing, streak);
  difficulty tiers (easy/medium/hard) with ×1/×1.75/×3 reward multipliers;
  random per-user assignment (questsPerDay/questsPerWeek slots) instead of
  giving every quest to every user; add onEconomyEarn, onHunt, onFish hooks;
  notifyQuestComplete posts a rich difficulty-coloured embed to the configured
  notification channel (falls back to current channel)
- Guild model: add quests.notificationChannelId, questsPerDay, questsPerWeek
- /quests command: full visual overhaul — category emojis, difficulty dots/labels,
  per-quest reward preview, progress summary header, styled progress bars
- messageCreate/interactionCreate: replace plain text completion message with
  notifyQuestComplete
- messageReactionAdd: wire in onReaction quest progress + notifyQuestComplete
- Dashboard quests panel: notification channel picker, quest slot controls,
  base-reward inputs labelled as easy-base with multiplier note

https://claude.ai/code/session_011qbhKXbfqtHEBye5J79Nat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Quests now track reaction interactions
  * Quest completion notification channel configuration added
  * Customizable daily and weekly quest assignment limits
  * Enhanced quest board display with improved formatting

* **Improvements**
  * Centralized quest completion notifications for better consistency
  * Updated quest settings panel organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->