### PR TITLE
feat: improve knowledge base retrieval and add edit support

### DIFF
--- a/src/dashboard/routes/api.js
+++ b/src/dashboard/routes/api.js
@@ -632,6 +632,42 @@ router.delete('/guild/:guildId/knowledge-base/:entryId', checkAuth, checkGuildAc
     }
 });
 
+router.put('/guild/:guildId/knowledge-base/:entryId', checkAuth, checkGuildAccess, checkWriteRateLimit, async (req, res) => {
+    const { guildId, entryId } = req.params;
+    const { title, content, tags } = req.body;
+
+    if (!/^[0-9a-f]{24}$/i.test(entryId)) {
+        return res.status(400).json({ error: 'Invalid entry ID' });
+    }
+    if (!title || typeof title !== 'string' || !title.trim()) {
+        return res.status(400).json({ error: 'Title is required' });
+    }
+    if (!content || typeof content !== 'string' || !content.trim()) {
+        return res.status(400).json({ error: 'Content is required' });
+    }
+
+    const sanitizedTags = Array.isArray(tags) ? tags.map(t => String(t).trim()).filter(Boolean).slice(0, 10) : [];
+
+    try {
+        const entry = await KnowledgeBase.findOneAndUpdate(
+            { _id: entryId, guildId },
+            {
+                title: title.trim().slice(0, 200),
+                content: content.trim().slice(0, 4000),
+                tags: sanitizedTags
+            },
+            { new: true }
+        );
+        if (!entry) {
+            return res.status(404).json({ error: 'Entry not found' });
+        }
+        res.json({ success: true, entry });
+    } catch (error) {
+        console.error('Knowledge base update error:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
 // ── AI Summary Jobs ────────────────────────────────────────────────────────
 
 router.get('/guild/:guildId/summary-jobs', checkAuth, checkGuildAccess, async (req, res) => {

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -2449,21 +2449,77 @@
             }
             container.innerHTML = '';
             entries.forEach(function(entry) {
-                var div = document.createElement('div');
-                div.className = 'list-item';
-                var preview = entry.content.length > 120 ? entry.content.slice(0, 120) + '…' : entry.content;
-                var tagsHtml = (entry.tags && entry.tags.length)
-                    ? '<div style="margin-top:.3rem;">' + entry.tags.map(function(t) { return '<span style="background:var(--surface-2);border-radius:4px;padding:1px 6px;font-size:.76rem;margin-right:4px;">' + escHtml(t) + '</span>'; }).join('') + '</div>'
-                    : '';
-                div.innerHTML =
-                    '<div style="min-width:0;flex:1;">' +
-                        '<strong>' + escHtml(entry.title) + '</strong>' +
-                        '<div style="color:var(--text-mute);font-size:.82rem;margin-top:.2rem;">' + escHtml(preview) + '</div>' +
-                        tagsHtml +
-                    '</div>' +
-                    '<button class="btn btn-danger btn-sm" onclick="deleteKbEntry(\'' + entry._id + '\')">Remove</button>';
-                container.appendChild(div);
+                container.appendChild(buildKbRow(entry));
             });
+        }
+
+        function buildKbRow(entry) {
+            var div = document.createElement('div');
+            div.className = 'list-item';
+            div.id = 'kb-row-' + entry._id;
+            var preview = entry.content.length > 120 ? entry.content.slice(0, 120) + '…' : entry.content;
+            var tagsHtml = (entry.tags && entry.tags.length)
+                ? '<div style="margin-top:.3rem;">' + entry.tags.map(function(t) { return '<span style="background:var(--surface-2);border-radius:4px;padding:1px 6px;font-size:.76rem;margin-right:4px;">' + escHtml(t) + '</span>'; }).join('') + '</div>'
+                : '';
+            div.innerHTML =
+                '<div style="min-width:0;flex:1;">' +
+                    '<strong>' + escHtml(entry.title) + '</strong>' +
+                    '<div style="color:var(--text-mute);font-size:.82rem;margin-top:.2rem;">' + escHtml(preview) + '</div>' +
+                    tagsHtml +
+                '</div>' +
+                '<div style="display:flex;gap:.5rem;flex-shrink:0;">' +
+                    '<button class="btn btn-sm" onclick="editKbEntry(\'' + entry._id + '\',\'' + escHtml(entry.title).replace(/'/g,"&#39;") + '\',\'' + encodeURIComponent(entry.content) + '\',\'' + escHtml((entry.tags||[]).join(',')).replace(/'/g,"&#39;") + '\')">Edit</button>' +
+                    '<button class="btn btn-danger btn-sm" onclick="deleteKbEntry(\'' + entry._id + '\')">Remove</button>' +
+                '</div>';
+            return div;
+        }
+
+        function editKbEntry(id, title, encodedContent, tags) {
+            var row = document.getElementById('kb-row-' + id);
+            if (!row) return;
+            var content = decodeURIComponent(encodedContent);
+            row.innerHTML =
+                '<div style="flex:1;display:flex;flex-direction:column;gap:.5rem;">' +
+                    '<input id="kb-edit-title-' + id + '" class="field-input" value="' + escHtml(title) + '" placeholder="Title" style="width:100%;">' +
+                    '<textarea id="kb-edit-content-' + id + '" rows="4" style="width:100%;resize:vertical;" placeholder="Content">' + escHtml(content) + '</textarea>' +
+                    '<input id="kb-edit-tags-' + id + '" class="field-input" value="' + escHtml(tags) + '" placeholder="Tags (comma-separated)" style="width:100%;">' +
+                    '<div style="display:flex;gap:.5rem;">' +
+                        '<button class="btn btn-primary btn-sm" onclick="saveKbEntry(\'' + id + '\')">Save</button>' +
+                        '<button class="btn btn-sm" onclick="cancelKbEdit()">Cancel</button>' +
+                    '</div>' +
+                '</div>';
+        }
+
+        function cancelKbEdit() {
+            kbLoaded = false;
+            loadKnowledgeBase();
+        }
+
+        async function saveKbEntry(id) {
+            var guildId = '<%= guild.id %>';
+            var title = document.getElementById('kb-edit-title-' + id).value.trim();
+            var content = document.getElementById('kb-edit-content-' + id).value.trim();
+            var tagsRaw = document.getElementById('kb-edit-tags-' + id).value.trim();
+            var tags = tagsRaw ? tagsRaw.split(',').map(function(t) { return t.trim(); }).filter(Boolean) : [];
+            if (!title || !content) { toast('Title and content are required', 'error'); return; }
+            try {
+                var resp = await fetch('/api/guild/' + guildId + '/knowledge-base/' + id, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ title: title, content: content, tags: tags })
+                });
+                var data = await resp.json();
+                if (resp.ok) {
+                    toast('Entry updated ✓', 'success');
+                    kbLoaded = false;
+                    loadKnowledgeBase();
+                } else {
+                    toast(data.error || 'Failed to update entry', 'error');
+                }
+            } catch (e) {
+                console.error(e);
+                toast('An error occurred', 'error');
+            }
         }
 
         async function addKbEntry() {

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -2468,16 +2468,18 @@
                     tagsHtml +
                 '</div>' +
                 '<div style="display:flex;gap:.5rem;flex-shrink:0;">' +
-                    '<button class="btn btn-sm" onclick="editKbEntry(\'' + entry._id + '\',\'' + escHtml(entry.title).replace(/'/g,"&#39;") + '\',\'' + encodeURIComponent(entry.content) + '\',\'' + escHtml((entry.tags||[]).join(',')).replace(/'/g,"&#39;") + '\')">Edit</button>' +
+                    '<button class="btn btn-sm" onclick="editKbEntry(\'' + entry._id + '\',\'' + encodeURIComponent(entry.title) + '\',\'' + encodeURIComponent(entry.content) + '\',\'' + encodeURIComponent((entry.tags||[]).join(',')) + '\')">Edit</button>' +
                     '<button class="btn btn-danger btn-sm" onclick="deleteKbEntry(\'' + entry._id + '\')">Remove</button>' +
                 '</div>';
             return div;
         }
 
-        function editKbEntry(id, title, encodedContent, tags) {
+        function editKbEntry(id, encodedTitle, encodedContent, encodedTags) {
             var row = document.getElementById('kb-row-' + id);
             if (!row) return;
+            var title = decodeURIComponent(encodedTitle);
             var content = decodeURIComponent(encodedContent);
+            var tags = decodeURIComponent(encodedTags);
             row.innerHTML =
                 '<div style="flex:1;display:flex;flex-direction:column;gap:.5rem;">' +
                     '<input id="kb-edit-title-' + id + '" class="field-input" value="' + escHtml(title) + '" placeholder="Title" style="width:100%;">' +

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -126,14 +126,14 @@ const KB_CANDIDATE_LIMIT = 50;
 const KB_SMALL_THRESHOLD = 15; // include all entries when KB is this size or smaller
 
 async function retrieveKnowledge(guildId, query, limit = 5) {
-    const queryWords = query.toLowerCase().split(/\s+/).filter(w => w.length > 2);
-    if (!queryWords.length) return [];
-
     // For small knowledge bases, include every entry — no retrieval needed.
     const totalCount = await KnowledgeBase.countDocuments({ guildId });
     if (totalCount <= KB_SMALL_THRESHOLD) {
         return KnowledgeBase.find({ guildId }).sort({ createdAt: -1 }).lean();
     }
+
+    const queryWords = query.toLowerCase().split(/\s+/).filter(w => w.length > 2);
+    if (!queryWords.length) return [];
 
     // Use the MongoDB text index for a bounded candidate set; fall back to a
     // capped scan if the text index doesn't exist yet (e.g., fresh deployment).

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -123,10 +123,17 @@ function chunkText(text, size = DISCORD_MAX_LEN) {
 // ---------- Knowledge Base RAG ----------
 
 const KB_CANDIDATE_LIMIT = 50;
+const KB_SMALL_THRESHOLD = 15; // include all entries when KB is this size or smaller
 
-async function retrieveKnowledge(guildId, query, limit = 3) {
+async function retrieveKnowledge(guildId, query, limit = 5) {
     const queryWords = query.toLowerCase().split(/\s+/).filter(w => w.length > 2);
     if (!queryWords.length) return [];
+
+    // For small knowledge bases, include every entry — no retrieval needed.
+    const totalCount = await KnowledgeBase.countDocuments({ guildId });
+    if (totalCount <= KB_SMALL_THRESHOLD) {
+        return KnowledgeBase.find({ guildId }).sort({ createdAt: -1 }).lean();
+    }
 
     // Use the MongoDB text index for a bounded candidate set; fall back to a
     // capped scan if the text index doesn't exist yet (e.g., fresh deployment).
@@ -141,17 +148,20 @@ async function retrieveKnowledge(guildId, query, limit = 3) {
     }
     if (!candidates.length) return [];
 
+    // Combine MongoDB textScore (handles stemming) with exact keyword hit count
+    // for a more reliable relevance ranking.
     const scored = candidates.map(entry => {
         const text = `${entry.title} ${entry.content} ${(entry.tags || []).join(' ')}`.toLowerCase();
-        const score = queryWords.reduce((acc, word) => {
+        const keywordHits = queryWords.reduce((acc, word) => {
             return acc + (text.match(new RegExp(word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi')) || []).length;
         }, 0);
-        return { entry, score };
+        const combined = (entry.score || 0) * 2 + keywordHits;
+        return { entry, combined };
     });
 
     return scored
-        .filter(s => s.score > 0)
-        .sort((a, b) => b.score - a.score)
+        .filter(s => s.combined > 0)
+        .sort((a, b) => b.combined - a.combined)
         .slice(0, limit)
         .map(s => s.entry);
 }


### PR DESCRIPTION
- Increase retrieval limit from 3 to 5 entries per query
- Combine MongoDB textScore with keyword hit count for better ranking
- Auto-include all entries when KB has 15 or fewer items (no retrieval needed)
- Add PUT /api/guild/:guildId/knowledge-base/:entryId endpoint for editing
- Add inline edit UI to dashboard knowledge base list (Edit/Save/Cancel)

https://claude.ai/code/session_01W4dyKecpHFE52RRd6uookh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Knowledge base entries can now be edited directly within the list view using inline controls with save and cancel options.
  * Improved search relevance algorithm for knowledge base retrieval and query matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->