### PR TITLE
Improve shop command UX and fix dashboard image URL support

### DIFF
--- a/src/commands/economy/shop.js
+++ b/src/commands/economy/shop.js
@@ -1,6 +1,55 @@
-const { SlashCommandBuilder, EmbedBuilder, PermissionFlagsBits } = require('discord.js');
+const {
+    SlashCommandBuilder,
+    EmbedBuilder,
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+    ComponentType,
+    PermissionFlagsBits
+} = require('discord.js');
 const Guild = require('../../models/Guild');
 const User = require('../../models/User');
+
+const PAGE_SIZE = 5;
+const CONFIRM_THRESHOLD = 500;
+
+function buildViewEmbed(items, page, totalPages, guildName, currency, userBalance) {
+    const start = page * PAGE_SIZE;
+    const slice = items.slice(start, start + PAGE_SIZE);
+
+    const lines = slice.map((item, i) => {
+        const stock = item.stock === -1 ? '∞' : item.stock;
+        const roleTag = item.roleId ? ` → <@&${item.roleId}>` : '';
+        return `**${start + i + 1}. ${item.name}** — ${currency}${item.price.toLocaleString()} (Stock: ${stock})${roleTag}\n${item.description || '*No description*'}`;
+    });
+
+    const embed = new EmbedBuilder()
+        .setColor('#FFD700')
+        .setTitle(`${guildName} Shop`)
+        .setDescription(lines.join('\n\n'));
+
+    const footerParts = [`Use /shop buy <item name> to purchase`];
+    if (userBalance !== null) footerParts.push(`Your balance: ${currency}${userBalance.toLocaleString()}`);
+    if (totalPages > 1) footerParts.push(`Page ${page + 1}/${totalPages}`);
+    embed.setFooter({ text: footerParts.join(' · ') });
+
+    return embed;
+}
+
+function buildPageRow(page, totalPages) {
+    return new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+            .setCustomId('shop_prev')
+            .setLabel('◀ Previous')
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(page === 0),
+        new ButtonBuilder()
+            .setCustomId('shop_next')
+            .setLabel('Next ▶')
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(page >= totalPages - 1)
+    );
+}
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -30,8 +79,10 @@ module.exports = {
                 .addIntegerOption(o => o.setName('price').setDescription('Updated price in coins').setMinValue(1))
                 .addStringOption(o => o.setName('description').setDescription('Updated item description'))
                 .addRoleOption(o => o.setName('role').setDescription('Updated role to grant on purchase'))
+                .addBooleanOption(o => o.setName('clear_role').setDescription('Remove the role reward from this item'))
                 .addIntegerOption(o => o.setName('stock').setDescription('Updated stock (-1 = unlimited)').setMinValue(-1))
-                .addStringOption(o => o.setName('image_url').setDescription('Updated image URL')))
+                .addStringOption(o => o.setName('image_url').setDescription('Updated image URL'))
+                .addBooleanOption(o => o.setName('clear_image').setDescription('Remove the image from this item')))
         .addSubcommand(sub =>
             sub.setName('remove')
                 .setDescription('Remove an item from the shop (admin only)')
@@ -48,27 +99,51 @@ module.exports = {
 
         const currency = guildSettings.economy.currency;
 
+        // ── VIEW ──────────────────────────────────────────────────────────────
         if (sub === 'view') {
             if (!guildSettings.shop.length) {
                 return interaction.reply({ content: 'The shop is empty. Admins can add items with `/shop add`.', ephemeral: true });
             }
 
-            const lines = guildSettings.shop.map((item, i) => {
-                const stock = item.stock === -1 ? '∞' : item.stock;
-                const roleTag = item.roleId ? ` → <@&${item.roleId}>` : '';
-                const imageTag = item.imageUrl ? `\nImage: ${item.imageUrl}` : '';
-                return `**${i + 1}. ${item.name}** — ${currency}${item.price} (Stock: ${stock})${roleTag}\n${item.description || ''}${imageTag}`;
+            const userData = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+            const userBalance = userData?.balance ?? 0;
+            const items = guildSettings.shop;
+            const totalPages = Math.ceil(items.length / PAGE_SIZE);
+
+            let page = 0;
+            const embed = buildViewEmbed(items, page, totalPages, interaction.guild.name, currency, userBalance);
+
+            if (totalPages <= 1) {
+                return interaction.reply({ embeds: [embed] });
+            }
+
+            const row = buildPageRow(page, totalPages);
+            const msg = await interaction.reply({ embeds: [embed], components: [row], fetchReply: true });
+
+            const collector = msg.createMessageComponentCollector({
+                componentType: ComponentType.Button,
+                filter: i => i.user.id === interaction.user.id,
+                time: 120_000
             });
 
-            const embed = new EmbedBuilder()
-                .setColor('#FFD700')
-                .setTitle(`${interaction.guild.name} Shop`)
-                .setDescription(lines.join('\n\n'))
-                .setFooter({ text: 'Use /shop buy <item name> to purchase' });
+            collector.on('collect', async btn => {
+                if (btn.customId === 'shop_prev') page = Math.max(0, page - 1);
+                else page = Math.min(totalPages - 1, page + 1);
 
-            return interaction.reply({ embeds: [embed] });
+                await btn.update({
+                    embeds: [buildViewEmbed(items, page, totalPages, interaction.guild.name, currency, userBalance)],
+                    components: [buildPageRow(page, totalPages)]
+                });
+            });
+
+            collector.on('end', () => {
+                interaction.editReply({ components: [] }).catch(() => {});
+            });
+
+            return;
         }
 
+        // ── BUY ───────────────────────────────────────────────────────────────
         if (sub === 'buy') {
             const itemName = interaction.options.getString('item').toLowerCase();
             const item = guildSettings.shop.find(i => i.name.toLowerCase() === itemName);
@@ -89,41 +164,107 @@ module.exports = {
 
             if (userData.balance < item.price) {
                 return interaction.reply({
-                    content: `You need ${currency}${item.price} but only have ${currency}${userData.balance}.`,
+                    content: `You need ${currency}${item.price.toLocaleString()} but only have ${currency}${userData.balance.toLocaleString()}.`,
                     ephemeral: true
                 });
             }
 
-            userData.balance -= item.price;
+            const doPurchase = async (reply) => {
+                // Re-fetch to avoid race conditions on stock and balance
+                const [freshGuild, freshUser] = await Promise.all([
+                    Guild.findOne({ guildId: interaction.guild.id }),
+                    User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id })
+                ]);
 
-            const invEntry = userData.inventory.find(e => e.itemId === item.name);
-            if (invEntry) {
-                invEntry.quantity += 1;
-            } else {
-                userData.inventory.push({ itemId: item.name, quantity: 1 });
+                const freshItem = freshGuild.shop.find(i => i.name.toLowerCase() === itemName);
+                if (!freshItem || freshItem.stock === 0) {
+                    return reply({ content: 'That item is no longer available.', embeds: [], components: [] });
+                }
+                if (freshUser.balance < freshItem.price) {
+                    return reply({
+                        content: `You need ${currency}${freshItem.price.toLocaleString()} but only have ${currency}${freshUser.balance.toLocaleString()}.`,
+                        embeds: [], components: []
+                    });
+                }
+
+                freshUser.balance -= freshItem.price;
+                const invEntry = freshUser.inventory.find(e => e.itemId === freshItem.name);
+                if (invEntry) invEntry.quantity += 1;
+                else freshUser.inventory.push({ itemId: freshItem.name, quantity: 1 });
+
+                if (freshItem.stock > 0) freshItem.stock -= 1;
+                await Promise.all([freshUser.save(), freshGuild.save()]);
+
+                if (freshItem.roleId) {
+                    await interaction.member.roles.add(freshItem.roleId).catch(console.error);
+                }
+
+                const successEmbed = new EmbedBuilder()
+                    .setColor('#00ff00')
+                    .setTitle('Purchase Successful')
+                    .setDescription(`You bought **${freshItem.name}** for ${currency}${freshItem.price.toLocaleString()}.`)
+                    .addFields({ name: 'New Balance', value: `${currency}${freshUser.balance.toLocaleString()}`, inline: true });
+
+                if (freshItem.roleId) {
+                    successEmbed.addFields({ name: 'Role Granted', value: `<@&${freshItem.roleId}>`, inline: true });
+                }
+                if (freshItem.imageUrl) {
+                    successEmbed.setThumbnail(freshItem.imageUrl);
+                }
+
+                return reply({ embeds: [successEmbed], components: [] });
+            };
+
+            if (item.price >= CONFIRM_THRESHOLD) {
+                const row = new ActionRowBuilder().addComponents(
+                    new ButtonBuilder().setCustomId('shop_confirm').setLabel('Confirm Purchase').setStyle(ButtonStyle.Success),
+                    new ButtonBuilder().setCustomId('shop_cancel').setLabel('Cancel').setStyle(ButtonStyle.Secondary)
+                );
+
+                const confirmEmbed = new EmbedBuilder()
+                    .setColor('#f39c12')
+                    .setTitle('Confirm Purchase')
+                    .setDescription(`Buy **${item.name}** for **${currency}${item.price.toLocaleString()}**?`)
+                    .addFields(
+                        { name: 'Your Balance', value: `${currency}${userData.balance.toLocaleString()}`, inline: true },
+                        { name: 'After Purchase', value: `${currency}${(userData.balance - item.price).toLocaleString()}`, inline: true }
+                    )
+                    .setFooter({ text: 'This confirmation expires in 30 seconds' });
+
+                if (item.imageUrl) confirmEmbed.setThumbnail(item.imageUrl);
+
+                const msg = await interaction.reply({ embeds: [confirmEmbed], components: [row], fetchReply: true });
+
+                const collector = msg.createMessageComponentCollector({
+                    componentType: ComponentType.Button,
+                    filter: i => i.user.id === interaction.user.id,
+                    time: 30_000,
+                    max: 1
+                });
+
+                collector.on('collect', async btn => {
+                    if (btn.customId === 'shop_cancel') {
+                        return btn.update({ content: 'Purchase cancelled.', embeds: [], components: [] });
+                    }
+                    await btn.deferUpdate();
+                    await doPurchase(opts => interaction.editReply(opts));
+                });
+
+                collector.on('end', (collected, reason) => {
+                    if (reason === 'time' && collected.size === 0) {
+                        interaction.editReply({ content: 'Purchase timed out.', embeds: [], components: [] }).catch(() => {});
+                    }
+                });
+
+                return;
             }
 
-            if (item.stock > 0) item.stock -= 1;
-
-            await Promise.all([userData.save(), guildSettings.save()]);
-
-            if (item.roleId) {
-                await interaction.member.roles.add(item.roleId).catch(console.error);
-            }
-
-            const embed = new EmbedBuilder()
-                .setColor('#00ff00')
-                .setTitle('Purchase Successful')
-                .setDescription(`You bought **${item.name}** for ${currency}${item.price}.`)
-                .addFields({ name: 'New Balance', value: `${currency}${userData.balance}`, inline: true });
-
-            if (item.imageUrl) {
-                embed.setThumbnail(item.imageUrl);
-            }
-
-            return interaction.reply({ embeds: [embed] });
+            await interaction.deferReply();
+            await doPurchase(opts => interaction.editReply(opts));
+            return;
         }
 
+        // ── ADD ───────────────────────────────────────────────────────────────
         if (sub === 'add') {
             if (!interaction.member.permissions.has(PermissionFlagsBits.ManageGuild)) {
                 return interaction.reply({ content: 'You need Manage Server permission to edit the shop.', ephemeral: true });
@@ -140,19 +281,13 @@ module.exports = {
                 return interaction.reply({ content: 'An item with that name already exists.', ephemeral: true });
             }
 
-            guildSettings.shop.push({
-                name,
-                description,
-                price,
-                roleId: role?.id ?? null,
-                stock,
-                imageUrl
-            });
+            guildSettings.shop.push({ name, description, price, roleId: role?.id ?? null, stock, imageUrl });
             await guildSettings.save();
 
-            await interaction.reply({ content: `Added **${name}** to the shop for ${currency}${price}.` });
+            return interaction.reply({ content: `Added **${name}** to the shop for ${currency}${price.toLocaleString()}.` });
         }
 
+        // ── EDIT ──────────────────────────────────────────────────────────────
         if (sub === 'edit') {
             if (!interaction.member.permissions.has(PermissionFlagsBits.ManageGuild)) {
                 return interaction.reply({ content: 'You need Manage Server permission to edit the shop.', ephemeral: true });
@@ -169,12 +304,13 @@ module.exports = {
             const price = interaction.options.getInteger('price');
             const description = interaction.options.getString('description');
             const role = interaction.options.getRole('role');
+            const clearRole = interaction.options.getBoolean('clear_role');
             const stock = interaction.options.getInteger('stock');
             const imageUrl = interaction.options.getString('image_url');
+            const clearImage = interaction.options.getBoolean('clear_image');
 
             if (newName && newName.toLowerCase() !== name) {
-                const duplicate = guildSettings.shop.find(i => i.name.toLowerCase() === newName.toLowerCase());
-                if (duplicate) {
+                if (guildSettings.shop.find(i => i.name.toLowerCase() === newName.toLowerCase())) {
                     return interaction.reply({ content: 'An item with that new name already exists.', ephemeral: true });
                 }
                 item.name = newName;
@@ -183,13 +319,18 @@ module.exports = {
             if (price !== null) item.price = price;
             if (description !== null) item.description = description;
             if (stock !== null) item.stock = stock;
-            if (imageUrl !== null) item.imageUrl = imageUrl;
-            if (role) item.roleId = role.id;
+
+            if (clearRole) item.roleId = null;
+            else if (role) item.roleId = role.id;
+
+            if (clearImage) item.imageUrl = '';
+            else if (imageUrl !== null) item.imageUrl = imageUrl;
 
             await guildSettings.save();
-            await interaction.reply({ content: `Updated **${item.name}**.` });
+            return interaction.reply({ content: `Updated **${item.name}**.` });
         }
 
+        // ── REMOVE ────────────────────────────────────────────────────────────
         if (sub === 'remove') {
             if (!interaction.member.permissions.has(PermissionFlagsBits.ManageGuild)) {
                 return interaction.reply({ content: 'You need Manage Server permission to edit the shop.', ephemeral: true });
@@ -204,7 +345,7 @@ module.exports = {
             }
 
             await guildSettings.save();
-            await interaction.reply({ content: `Removed **${name}** from the shop.` });
+            return interaction.reply({ content: `Removed **${name}** from the shop.` });
         }
     }
 };

--- a/src/commands/economy/shop.js
+++ b/src/commands/economy/shop.js
@@ -170,49 +170,63 @@ module.exports = {
             }
 
             const doPurchase = async (reply) => {
-                // Re-fetch to avoid race conditions on stock and balance
-                const [freshGuild, freshUser] = await Promise.all([
-                    Guild.findOne({ guildId: interaction.guild.id }),
-                    User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id })
-                ]);
+                const session = await Guild.startSession();
+                session.startTransaction();
+                try {
+                    const [freshGuild, freshUser] = await Promise.all([
+                        Guild.findOne({ guildId: interaction.guild.id }).session(session),
+                        User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }).session(session)
+                    ]);
 
-                const freshItem = freshGuild.shop.find(i => i.name.toLowerCase() === itemName);
-                if (!freshItem || freshItem.stock === 0) {
-                    return reply({ content: 'That item is no longer available.', embeds: [], components: [] });
+                    const freshItem = freshGuild.shop.find(i => i.name.toLowerCase() === itemName);
+                    if (!freshItem || freshItem.stock === 0) {
+                        await session.abortTransaction();
+                        session.endSession();
+                        return reply({ content: 'That item is no longer available.', embeds: [], components: [] });
+                    }
+                    if (freshUser.balance < freshItem.price) {
+                        await session.abortTransaction();
+                        session.endSession();
+                        return reply({
+                            content: `You need ${currency}${freshItem.price.toLocaleString()} but only have ${currency}${freshUser.balance.toLocaleString()}.`,
+                            embeds: [], components: []
+                        });
+                    }
+
+                    freshUser.balance -= freshItem.price;
+                    const invEntry = freshUser.inventory.find(e => e.itemId === freshItem.name);
+                    if (invEntry) invEntry.quantity += 1;
+                    else freshUser.inventory.push({ itemId: freshItem.name, quantity: 1 });
+
+                    if (freshItem.stock > 0) freshItem.stock -= 1;
+                    await Promise.all([freshUser.save({ session }), freshGuild.save({ session })]);
+
+                    await session.commitTransaction();
+                    session.endSession();
+
+                    if (freshItem.roleId) {
+                        await interaction.member.roles.add(freshItem.roleId).catch(console.error);
+                    }
+
+                    const successEmbed = new EmbedBuilder()
+                        .setColor('#00ff00')
+                        .setTitle('Purchase Successful')
+                        .setDescription(`You bought **${freshItem.name}** for ${currency}${freshItem.price.toLocaleString()}.`)
+                        .addFields({ name: 'New Balance', value: `${currency}${freshUser.balance.toLocaleString()}`, inline: true });
+
+                    if (freshItem.roleId) {
+                        successEmbed.addFields({ name: 'Role Granted', value: `<@&${freshItem.roleId}>`, inline: true });
+                    }
+                    if (freshItem.imageUrl) {
+                        successEmbed.setThumbnail(freshItem.imageUrl);
+                    }
+
+                    return reply({ embeds: [successEmbed], components: [] });
+                } catch (err) {
+                    await session.abortTransaction().catch(() => {});
+                    session.endSession();
+                    throw err;
                 }
-                if (freshUser.balance < freshItem.price) {
-                    return reply({
-                        content: `You need ${currency}${freshItem.price.toLocaleString()} but only have ${currency}${freshUser.balance.toLocaleString()}.`,
-                        embeds: [], components: []
-                    });
-                }
-
-                freshUser.balance -= freshItem.price;
-                const invEntry = freshUser.inventory.find(e => e.itemId === freshItem.name);
-                if (invEntry) invEntry.quantity += 1;
-                else freshUser.inventory.push({ itemId: freshItem.name, quantity: 1 });
-
-                if (freshItem.stock > 0) freshItem.stock -= 1;
-                await Promise.all([freshUser.save(), freshGuild.save()]);
-
-                if (freshItem.roleId) {
-                    await interaction.member.roles.add(freshItem.roleId).catch(console.error);
-                }
-
-                const successEmbed = new EmbedBuilder()
-                    .setColor('#00ff00')
-                    .setTitle('Purchase Successful')
-                    .setDescription(`You bought **${freshItem.name}** for ${currency}${freshItem.price.toLocaleString()}.`)
-                    .addFields({ name: 'New Balance', value: `${currency}${freshUser.balance.toLocaleString()}`, inline: true });
-
-                if (freshItem.roleId) {
-                    successEmbed.addFields({ name: 'Role Granted', value: `<@&${freshItem.roleId}>`, inline: true });
-                }
-                if (freshItem.imageUrl) {
-                    successEmbed.setThumbnail(freshItem.imageUrl);
-                }
-
-                return reply({ embeds: [successEmbed], components: [] });
             };
 
             if (item.price >= CONFIRM_THRESHOLD) {
@@ -247,7 +261,12 @@ module.exports = {
                         return btn.update({ content: 'Purchase cancelled.', embeds: [], components: [] });
                     }
                     await btn.deferUpdate();
-                    await doPurchase(opts => interaction.editReply(opts));
+                    try {
+                        await doPurchase(opts => interaction.editReply(opts));
+                    } catch (err) {
+                        console.error(err);
+                        interaction.editReply({ content: 'Something went wrong processing your purchase. Please try again.', embeds: [], components: [] }).catch(() => {});
+                    }
                 });
 
                 collector.on('end', (collected, reason) => {
@@ -260,7 +279,12 @@ module.exports = {
             }
 
             await interaction.deferReply();
-            await doPurchase(opts => interaction.editReply(opts));
+            try {
+                await doPurchase(opts => interaction.editReply(opts));
+            } catch (err) {
+                console.error(err);
+                interaction.editReply({ content: 'Something went wrong processing your purchase. Please try again.', embeds: [], components: [] }).catch(() => {});
+            }
             return;
         }
 

--- a/src/dashboard/public/styles.css
+++ b/src/dashboard/public/styles.css
@@ -779,6 +779,8 @@ textarea { resize: vertical; min-height: 80px; }
 .store-meta-tag.price-tag { color: var(--warn); border-color: rgba(251,191,36,.3); background: rgba(251,191,36,.08); }
 .store-meta-tag.role-meta { color: #c3c8ff; border-color: rgba(88,101,242,.4); background: rgba(88,101,242,.1); }
 .store-card-actions { display: flex; gap: .4rem; }
+.store-card-thumb-wrap { display: flex; justify-content: center; margin-bottom: .25rem; }
+.store-card-thumb { width: 100%; max-height: 80px; object-fit: cover; border-radius: var(--radius-sm); }
 
 /* Games grid */
 .games-grid {

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -2208,12 +2208,13 @@
             var price = parseInt(document.getElementById('modal-item-price').value, 10);
             if (!name) { toast('Item name is required', 'error'); return; }
             if (!Number.isFinite(price) || price < 0) { toast('Enter a valid price', 'error'); return; }
+            var parsedStock = parseInt(document.getElementById('modal-item-stock').value, 10);
             var item = {
                 name: name,
                 description: document.getElementById('modal-item-desc').value.trim(),
                 price: price,
                 roleId: document.getElementById('modal-item-role').value || null,
-                stock: parseInt(document.getElementById('modal-item-stock').value, 10) || -1,
+                stock: Number.isNaN(parsedStock) ? -1 : parsedStock,
                 imageUrl: document.getElementById('modal-item-image').value.trim() || ''
             };
             if (editingItemIdx === -1) storeItems.push(item);

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -490,6 +490,11 @@
                                 <input type="number" id="modal-item-stock" value="-1">
                                 <small>-1 = unlimited stock</small>
                             </div>
+                            <div class="field">
+                                <label class="field-label">Image URL</label>
+                                <input type="url" id="modal-item-image" placeholder="https://example.com/image.png">
+                                <small>Shown as a thumbnail when viewing or buying this item</small>
+                            </div>
                         </div>
                         <div class="modal-actions">
                             <button class="btn" onclick="closeItemModal()">Cancel</button>
@@ -2163,7 +2168,9 @@
             grid.innerHTML = storeItems.map(function(item, i) {
                 var roleName = item.roleId ? (_roleMap[item.roleId] || item.roleId) : null;
                 var stockText = (item.stock === -1 || item.stock == null) ? '∞ Unlimited' : item.stock + ' left';
+                var thumbHtml = item.imageUrl ? '<img class="store-card-thumb" src="' + escHtml(item.imageUrl) + '" alt="" onerror="this.style.display=\'none\'">' : '';
                 return '<div class="store-card">' +
+                    (thumbHtml ? '<div class="store-card-thumb-wrap">' + thumbHtml + '</div>' : '') +
                     '<div class="store-card-body">' +
                         '<div class="store-card-name">' + escHtml(item.name) + '</div>' +
                         '<div class="store-card-desc">' + (item.description ? escHtml(item.description) : '<em style="color:var(--text-mute)">No description</em>') + '</div>' +
@@ -2190,6 +2197,7 @@
             document.getElementById('modal-item-price').value = item.price != null ? item.price : '';
             document.getElementById('modal-item-role').value = item.roleId || '';
             document.getElementById('modal-item-stock').value = (item.stock == null) ? -1 : item.stock;
+            document.getElementById('modal-item-image').value = item.imageUrl || '';
             document.getElementById('item-modal').style.display = 'flex';
         }
 
@@ -2205,7 +2213,8 @@
                 description: document.getElementById('modal-item-desc').value.trim(),
                 price: price,
                 roleId: document.getElementById('modal-item-role').value || null,
-                stock: parseInt(document.getElementById('modal-item-stock').value, 10) || -1
+                stock: parseInt(document.getElementById('modal-item-stock').value, 10) || -1,
+                imageUrl: document.getElementById('modal-item-image').value.trim() || ''
             };
             if (editingItemIdx === -1) storeItems.push(item);
             else storeItems[editingItemIdx] = item;


### PR DESCRIPTION
- /shop view: paginate large shops (5 items/page with Prev/Next buttons),
  show user's balance in footer, remove raw imageUrl from item text
- /shop buy: add confirmation dialog for purchases >= 500 coins (shows
  balance before/after), show role granted in success embed, re-fetch
  guild/user docs before writing to prevent race conditions on stock
- /shop edit: add clear_role and clear_image boolean options so admins
  can remove a previously set role reward or image without workarounds
- Dashboard: add missing Image URL field to the item modal (schema and
  command both support it but the dashboard form never exposed it),
  populate and save imageUrl through openItemModal/saveItemModal,
  render image thumbnail on store cards with graceful fallback

https://claude.ai/code/session_011QmB1PhQ5S241Zb3Rpyrkm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination controls to shop view for easier browsing
  * Purchase confirmation required for high-value items
  * Store items now display thumbnail images with dashboard management support

* **Improvements**
  * Enhanced purchase system reliability to prevent conflicts during concurrent transactions
  * Refined admin shop commands for better usability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->