### PR TITLE
feat(economy): implement active item effects system (Shield, Padlock, Lucky Charm, Lifesaver, Invisibility Cloak, Knife, Robbery Bag)

### DIFF
--- a/src/commands/economy/baccarat.js
+++ b/src/commands/economy/baccarat.js
@@ -7,6 +7,7 @@ const {
 } = require('discord.js');
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
+const { hasEffect } = require('../../services/effectsService');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3b4.png';
 const MIN_BET = 10;
@@ -265,11 +266,16 @@ async function playBaccarat(interaction, pick, bet) {
         // Resolve payout
         let credit = 0;
         let profit = -bet;
+        const isNaturalLoss = winner !== pick && !(winner === 'tie' && (pick === 'player' || pick === 'banker'));
+        const luckyActive   = hasEffect(debited, 'lucky_charm');
+        // Lucky Charm: on a loss, 20% chance to push (return bet)
+        const charmPush = isNaturalLoss && luckyActive && Math.random() < 0.20;
+        const effectiveWinner = charmPush ? 'tie' : winner;
 
-        if (winner === pick) {
+        if (effectiveWinner === pick) {
             profit = Math.floor(bet * PAYOUT[pick].profitMult);
             credit = bet + profit;
-        } else if (winner === 'tie' && (pick === 'player' || pick === 'banker')) {
+        } else if (effectiveWinner === 'tie' && (pick === 'player' || pick === 'banker')) {
             credit = bet;
             profit = 0;
         }
@@ -290,8 +296,13 @@ async function playBaccarat(interaction, pick, bet) {
             new ButtonBuilder().setCustomId(replayId).setLabel('🎴 Play Again').setStyle(ButtonStyle.Primary),
         );
 
+        const baccaratEmbed = resultEmbed({ pick, winner: effectiveWinner, player, banker, natural: charmPush ? false : natural, bet, profit, balance: updated.balance, interaction });
+        if (charmPush) {
+            const desc = baccaratEmbed.data.description ?? '';
+            baccaratEmbed.setDescription(desc + '\n> 🍀 *Lucky Charm saved your bet — push!*');
+        }
         await interaction.editReply({
-            embeds: [resultEmbed({ pick, winner, player, banker, natural, bet, profit, balance: updated.balance, interaction })],
+            embeds: [baccaratEmbed],
             components: [row],
         });
 

--- a/src/commands/economy/balance.js
+++ b/src/commands/economy/balance.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const User = require('../../models/User');
+const { pruneEffects, EFFECT_CONFIGS, timeRemaining } = require('../../services/effectsService');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -16,11 +17,11 @@ module.exports = {
             let user = await User.findOne({ userId: targetUser.id, guildId: interaction.guild.id });
 
             if (!user) {
-                user = await User.create({
-                    userId: targetUser.id,
-                    guildId: interaction.guild.id
-                });
+                user = await User.create({ userId: targetUser.id, guildId: interaction.guild.id });
             }
+
+            // Prune expired effects before displaying
+            pruneEffects(user);
 
             const embed = new EmbedBuilder()
                 .setColor('#00ff00')
@@ -28,10 +29,24 @@ module.exports = {
                 .setThumbnail(targetUser.displayAvatarURL({ dynamic: true }))
                 .addFields(
                     { name: '💰 Wallet', value: `${user.balance.toLocaleString()} coins`, inline: true },
-                    { name: '🏦 Bank', value: `${user.bank.toLocaleString()} coins`, inline: true },
-                    { name: '💎 Total', value: `${(user.balance + user.bank).toLocaleString()} coins`, inline: true }
+                    { name: '🏦 Bank',   value: `${user.bank.toLocaleString()} coins`,    inline: true },
+                    { name: '💎 Total',  value: `${(user.balance + user.bank).toLocaleString()} coins`, inline: true }
                 )
                 .setTimestamp();
+
+            // Show active protective effects as indicators
+            if (user.activeEffects?.length) {
+                const indicators = user.activeEffects.map(e => {
+                    const cfg = EFFECT_CONFIGS[e.type];
+                    if (!cfg) return null;
+                    const duration = e.expiresAt ? timeRemaining(e.expiresAt) : (e.charges === 1 ? '1 use left' : 'permanent');
+                    return `${cfg.emoji} **${cfg.label}** — ${duration}`;
+                }).filter(Boolean);
+
+                if (indicators.length) {
+                    embed.addFields({ name: '🔮 Active Effects', value: indicators.join('\n'), inline: false });
+                }
+            }
 
             await interaction.reply({ embeds: [embed] });
         } catch (error) {

--- a/src/commands/economy/blackjack.js
+++ b/src/commands/economy/blackjack.js
@@ -7,6 +7,7 @@ const {
 } = require('discord.js');
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
+const { hasEffect } = require('../../services/effectsService');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f0cf.png';
 const MIN_BET = 10;
@@ -187,6 +188,8 @@ module.exports = {
             let freshUser = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
             if (!freshUser) freshUser = user;
 
+            const luckyActive = hasEffect(freshUser, 'lucky_charm');
+
             if (dealerTotal > 21 || playerTotal > dealerTotal) {
                 freshUser.balance += bet * 2;
                 status = `✅ You win! +${currency}${bet.toLocaleString()}`;
@@ -194,6 +197,11 @@ module.exports = {
             } else if (playerTotal === dealerTotal) {
                 freshUser.balance += bet;
                 status = `🤝 Push — bet returned`;
+                color  = '#f39c12';
+            } else if (luckyActive && Math.random() < 0.20) {
+                // Lucky Charm: convert loss to push
+                freshUser.balance += bet;
+                status = `🍀 Lucky Charm! Push — bet returned (${currency}${bet.toLocaleString()})`;
                 color  = '#f39c12';
             } else {
                 status = `❌ Dealer wins. -${currency}${bet.toLocaleString()}`;

--- a/src/commands/economy/crash.js
+++ b/src/commands/economy/crash.js
@@ -6,6 +6,7 @@ const {
     ButtonStyle,
 } = require('discord.js');
 const User = require('../../models/User');
+const { hasEffect } = require('../../services/effectsService');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f4a5.png';
 const GROWTH  = 1.12;
@@ -197,7 +198,11 @@ async function playCrash(interaction, bet) {
             });
         }
 
-        const crash    = generateCrashPoint();
+        // Lucky Charm: boost crash point by 20% (higher crash = more time to cash out)
+        const luckyActive = hasEffect(debited, 'lucky_charm');
+        const crash    = luckyActive
+            ? Math.min(100.00, parseFloat((generateCrashPoint() * 1.2).toFixed(2)))
+            : generateCrashPoint();
         const cashOutId = `crash_co_${interaction.id}_${Date.now()}`;
 
         // Instant crash — no time to react

--- a/src/commands/economy/crime.js
+++ b/src/commands/economy/crime.js
@@ -1,9 +1,10 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
+const { hasEffect, consumeEffect } = require('../../services/effectsService');
 
-const COOLDOWN_MS   = 4 * 3_600_000; // 4 hours
-const SUCCESS_CHANCE = 0.40;
+const COOLDOWN_MS    = 4 * 3_600_000; // 4 hours
+const BASE_SUCCESS   = 0.40;
 
 const CRIMES = [
     { name: 'pickpocketing',       emoji: '🤏', minPayout: 80,   maxPayout: 200  },
@@ -47,9 +48,14 @@ module.exports = {
             return interaction.reply({ content: `You're still on the radar from last time. Lay low for **${hrs}h**.`, ephemeral: true });
         }
 
-        const crime   = CRIMES[Math.floor(Math.random() * CRIMES.length)];
-        const success = Math.random() < SUCCESS_CHANCE;
+        const crime = CRIMES[Math.floor(Math.random() * CRIMES.length)];
 
+        // Lucky Charm: +20% success rate on crime
+        let successChance = BASE_SUCCESS;
+        const luckyActive = hasEffect(user, 'lucky_charm');
+        if (luckyActive) successChance = Math.min(0.95, successChance + 0.20);
+
+        const success = Math.random() < successChance;
         user.lastCrime = new Date();
 
         try {
@@ -62,25 +68,44 @@ module.exports = {
                 embed = new EmbedBuilder()
                     .setColor('#f39c12')
                     .setTitle(`${crime.emoji} Crime Pays — This Time`)
-                    .setDescription(`Your attempt at **${crime.name}** was a success! You pocketed **${currency}${earned.toLocaleString()}**.`)
+                    .setDescription(`Your attempt at **${crime.name}** was a success! You pocketed **${currency}${earned.toLocaleString()}**.${luckyActive ? '\n> 🍀 *Lucky Charm boosted your success chance!*' : ''}`)
                     .addFields({ name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true })
                     .setFooter({ text: 'Crimes can be committed every 4 hours' })
                     .setTimestamp();
             } else {
                 const fine = Math.floor(50 + Math.random() * 200);
                 const paid = Math.min(fine, user.balance);
-                user.balance = Math.max(0, user.balance - paid);
-                await user.save();
 
-                const flavorText = FINES[Math.floor(Math.random() * FINES.length)];
-                embed = new EmbedBuilder()
-                    .setColor('#e74c3c')
-                    .setTitle(`${crime.emoji} Busted!`)
-                    .setDescription(`Your attempt at **${crime.name}** went sideways. ${flavorText}\nYou were fined **${currency}${paid.toLocaleString()}**.`)
-                    .addFields({ name: 'Fine Paid', value: `${currency}${paid.toLocaleString()}`, inline: true },
-                               { name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true })
-                    .setFooter({ text: 'Crimes can be committed every 4 hours' })
-                    .setTimestamp();
+                // Lifesaver: absorbs one failure — no fine paid
+                const lifesaverActive = hasEffect(user, 'lifesaver');
+                if (lifesaverActive) {
+                    consumeEffect(user, 'lifesaver');
+                    user.lastCrime = new Date();
+                    await user.save();
+
+                    const flavorText = FINES[Math.floor(Math.random() * FINES.length)];
+                    embed = new EmbedBuilder()
+                        .setColor('#e67e22')
+                        .setTitle(`${crime.emoji} Saved by the Lifesaver!`)
+                        .setDescription(`Your attempt at **${crime.name}** went sideways. ${flavorText}\n> 🛟 *Your Lifesaver absorbed the fine — no coins lost! (consumed)*`)
+                        .addFields({ name: 'Fine Absorbed', value: `${currency}${paid.toLocaleString()}`, inline: true },
+                                   { name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true })
+                        .setFooter({ text: 'Crimes can be committed every 4 hours' })
+                        .setTimestamp();
+                } else {
+                    user.balance = Math.max(0, user.balance - paid);
+                    await user.save();
+
+                    const flavorText = FINES[Math.floor(Math.random() * FINES.length)];
+                    embed = new EmbedBuilder()
+                        .setColor('#e74c3c')
+                        .setTitle(`${crime.emoji} Busted!`)
+                        .setDescription(`Your attempt at **${crime.name}** went sideways. ${flavorText}\nYou were fined **${currency}${paid.toLocaleString()}**.`)
+                        .addFields({ name: 'Fine Paid', value: `${currency}${paid.toLocaleString()}`, inline: true },
+                                   { name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true })
+                        .setFooter({ text: 'Crimes can be committed every 4 hours' })
+                        .setTimestamp();
+                }
             }
 
             await interaction.reply({ embeds: [embed] });

--- a/src/commands/economy/doubleornothing.js
+++ b/src/commands/economy/doubleornothing.js
@@ -7,6 +7,7 @@ const {
 } = require('discord.js');
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
+const { hasEffect } = require('../../services/effectsService');
 
 const THUMB          = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3b2.png';
 const MIN_BET        = 10;
@@ -43,7 +44,7 @@ function embedAuthor(interaction) {
     };
 }
 
-function liveEmbed(interaction, bet, round, pot, streak) {
+function liveEmbed(interaction, bet, round, pot, streak, luckyActive = false) {
     const nextPot    = pot * 2;
     const roundsLeft = MAX_ROUNDS - round;
     const atMax      = round >= MAX_ROUNDS;
@@ -68,7 +69,7 @@ function liveEmbed(interaction, bet, round, pot, streak) {
             { name: '📈 If Win',      value: `**${nextPot.toLocaleString()}** coins`, inline: true },
             { name: '🔥 Streak',      value: streak > 0 ? `**${streak}** win${streak === 1 ? '' : 's'}` : '*None yet*', inline: true },
             { name: '💸 Initial Bet', value: `${bet.toLocaleString()} coins`,       inline: true },
-            { name: '🎲 Win Chance',  value: '**50%** per flip',                    inline: true },
+            { name: '🎲 Win Chance',  value: luckyActive ? '**70%** per flip 🍀' : '**50%** per flip', inline: true },
         )
         .setFooter({ text: 'Green button = safe. Red button = risk everything.' });
 }
@@ -163,7 +164,8 @@ module.exports = {
                 });
             }
 
-            await playDoubleOrNothing(interaction, bet, userFilter, debited);
+            const luckyActive = hasEffect(debited, 'lucky_charm');
+            await playDoubleOrNothing(interaction, bet, userFilter, debited, luckyActive);
 
         } catch (err) {
             console.error('[DoubleOrNothing] error:', err);
@@ -173,7 +175,7 @@ module.exports = {
     },
 };
 
-async function playDoubleOrNothing(interaction, bet, userFilter, debited) {
+async function playDoubleOrNothing(interaction, bet, userFilter, debited, luckyActive = false) {
     const doubleId  = `don_double_${interaction.id}_${Date.now()}`;
     const cashOutId = `don_cash_${interaction.id}_${Date.now()}`;
 
@@ -183,7 +185,7 @@ async function playDoubleOrNothing(interaction, bet, userFilter, debited) {
     let settled = false;
 
     await interaction.editReply({
-        embeds:     [liveEmbed(interaction, bet, round, pot, streak)],
+        embeds:     [liveEmbed(interaction, bet, round, pot, streak, luckyActive)],
         components: [buildGameRow(doubleId, cashOutId)],
     });
 
@@ -232,7 +234,7 @@ async function playDoubleOrNothing(interaction, bet, userFilter, debited) {
                     });
                     return;
                 }
-                await playDoubleOrNothing(interaction, bet, userFilter, newDebited);
+                await playDoubleOrNothing(interaction, bet, userFilter, newDebited, luckyActive);
             });
             collector.on('end', (_, reason) => {
                 if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
@@ -256,8 +258,9 @@ async function playDoubleOrNothing(interaction, bet, userFilter, debited) {
                 return;
             }
 
-            // Double — flip the coin
-            const won = Math.random() < WIN_CHANCE;
+            // Double — flip the coin (Lucky Charm boosts win chance to 70%)
+            const effectiveWinChance = luckyActive ? Math.min(0.95, WIN_CHANCE + 0.20) : WIN_CHANCE;
+            const won = Math.random() < effectiveWinChance;
             if (!won) {
                 pot = 0;
                 await i.update({ components: [buildGameRow(doubleId, cashOutId, true)] }).catch(() => {});
@@ -276,7 +279,7 @@ async function playDoubleOrNothing(interaction, bet, userFilter, debited) {
             }
 
             await i.update({
-                embeds:     [liveEmbed(interaction, bet, round, pot, streak)],
+                embeds:     [liveEmbed(interaction, bet, round, pot, streak, luckyActive)],
                 components: [buildGameRow(doubleId, cashOutId)],
             }).catch(() => {});
 

--- a/src/commands/economy/higherlower.js
+++ b/src/commands/economy/higherlower.js
@@ -7,6 +7,7 @@ const {
 } = require('discord.js');
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
+const { hasEffect } = require('../../services/effectsService');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f0cf.png';
 const MIN_BET = 10;
@@ -180,7 +181,8 @@ module.exports = {
                 });
             }
 
-            await playHigherLower(interaction, bet, userFilter, []);
+            const luckyActive = hasEffect(debited, 'lucky_charm');
+            await playHigherLower(interaction, bet, userFilter, [], luckyActive);
 
         } catch (err) {
             console.error('[HigherLower] error:', err);
@@ -189,7 +191,7 @@ module.exports = {
     },
 };
 
-async function playHigherLower(interaction, bet, userFilter, history) {
+async function playHigherLower(interaction, bet, userFilter, history, luckyActive = false) {
     const current = rollCard();
     const upId    = `hl_up_${interaction.id}_${Date.now()}`;
     const downId  = `hl_down_${interaction.id}_${Date.now()}`;
@@ -222,8 +224,14 @@ async function playHigherLower(interaction, bet, userFilter, history) {
                 delta   = bet; // refund
             } else {
                 const won = pickedHigher ? next.value > current.value : next.value < current.value;
-                outcome   = won ? 'win' : 'loss';
-                delta     = won ? bet * 2 : 0;
+                // Lucky Charm: on loss, 20% chance to push (return bet)
+                if (!won && luckyActive && Math.random() < 0.20) {
+                    outcome = 'push';
+                    delta   = bet;
+                } else {
+                    outcome = won ? 'win' : 'loss';
+                    delta   = won ? bet * 2 : 0;
+                }
             }
 
             const updated = await User.findOneAndUpdate(
@@ -265,7 +273,7 @@ async function playHigherLower(interaction, bet, userFilter, history) {
                         return;
                     }
                     await ri.deferUpdate();
-                    await playHigherLower(interaction, bet, userFilter, newHistory.slice(-5));
+                    await playHigherLower(interaction, bet, userFilter, newHistory.slice(-5), luckyActive);
                 } catch (replayErr) {
                     console.error('[HigherLower] replay error:', replayErr);
                     await interaction.editReply({ content: 'Something went wrong on replay. Please try again.', embeds: [], components: [] }).catch(() => {});

--- a/src/commands/economy/inventory.js
+++ b/src/commands/economy/inventory.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const User = require('../../models/User');
 const Guild = require('../../models/Guild');
+const { pruneEffects, EFFECT_CONFIGS, timeRemaining } = require('../../services/effectsService');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -18,7 +19,7 @@ module.exports = {
 
         const currency = guildSettings?.economy?.currency ?? '💰';
 
-        if (!userData?.inventory?.length) {
+        if (!userData?.inventory?.length && !userData?.activeEffects?.length) {
             return interaction.reply({
                 content: target.id === interaction.user.id
                     ? "Your inventory is empty. Buy items from the `/shop`!"
@@ -27,20 +28,48 @@ module.exports = {
             });
         }
 
+        // Prune expired effects before displaying
+        if (userData) pruneEffects(userData);
+
         const shopItems = guildSettings?.shop ?? [];
-
-        const lines = userData.inventory.map(entry => {
-            const shopItem = shopItems.find(s => s.name.toLowerCase() === entry.itemId.toLowerCase());
-            const worth = shopItem ? `(worth ${currency}${shopItem.price} each)` : '';
-            return `**${entry.itemId}** ×${entry.quantity} ${worth}`;
-        });
-
         const embed = new EmbedBuilder()
             .setColor('#5865F2')
             .setTitle(`${target.username}'s Inventory`)
-            .setThumbnail(target.displayAvatarURL({ dynamic: true }))
-            .setDescription(lines.join('\n'))
-            .setFooter({ text: `${userData.inventory.reduce((sum, e) => sum + e.quantity, 0)} total items` });
+            .setThumbnail(target.displayAvatarURL({ dynamic: true }));
+
+        // ── Items in bag ──────────────────────────────────────────────────────
+        if (userData?.inventory?.length) {
+            const lines = userData.inventory.map(entry => {
+                const shopItem = shopItems.find(s => s.name.toLowerCase() === entry.itemId.toLowerCase());
+                const worth = shopItem ? ` (worth ${currency}${shopItem.price} each)` : '';
+                return `**${entry.itemId}** ×${entry.quantity}${worth}`;
+            });
+            embed.addFields({ name: '🎒 Items', value: lines.join('\n'), inline: false });
+        }
+
+        // ── Active effects ────────────────────────────────────────────────────
+        if (userData?.activeEffects?.length) {
+            const lines = userData.activeEffects.map(e => {
+                const cfg = EFFECT_CONFIGS[e.type];
+                if (!cfg) return null;
+                let durationStr;
+                if (e.expiresAt) {
+                    durationStr = `⏳ ${timeRemaining(e.expiresAt)} remaining`;
+                } else if (e.charges > 0) {
+                    durationStr = `${e.charges} use${e.charges !== 1 ? 's' : ''} left`;
+                } else {
+                    durationStr = 'permanent';
+                }
+                return `${cfg.emoji} **${cfg.label}** — ${durationStr}`;
+            }).filter(Boolean);
+
+            if (lines.length) {
+                embed.addFields({ name: '✨ Active Effects', value: lines.join('\n'), inline: false });
+            }
+        }
+
+        const totalItems = userData?.inventory?.reduce((sum, e) => sum + e.quantity, 0) ?? 0;
+        embed.setFooter({ text: `${totalItems} item${totalItems !== 1 ? 's' : ''} in bag` });
 
         await interaction.reply({ embeds: [embed] });
     }

--- a/src/commands/economy/plinko.js
+++ b/src/commands/economy/plinko.js
@@ -7,6 +7,7 @@ const {
 } = require('discord.js');
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
+const { hasEffect } = require('../../services/effectsService');
 
 const THUMB    = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3b1.png';
 const ROWS     = 8;
@@ -186,10 +187,17 @@ async function playPlinko(interaction, bet) {
             });
         }
 
-        const path       = generatePath();
-        const positions  = computePositions(path);
-        const bucket     = positions[ROWS];
-        const multiplier = MULTIPLIERS[bucket];
+        let path       = generatePath();
+        let positions  = computePositions(path);
+        let bucket     = positions[ROWS];
+        let multiplier = MULTIPLIERS[bucket];
+        // Lucky Charm: on lowest-tier bucket, 20% chance to re-roll the path
+        if (multiplier < 1.0 && hasEffect(debited, 'lucky_charm') && Math.random() < 0.20) {
+            path       = generatePath();
+            positions  = computePositions(path);
+            bucket     = positions[ROWS];
+            multiplier = MULTIPLIERS[bucket];
+        }
         const payout     = Math.floor(bet * multiplier);
         const delay      = ms => new Promise(r => setTimeout(r, ms));
 

--- a/src/commands/economy/rob.js
+++ b/src/commands/economy/rob.js
@@ -2,16 +2,13 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const mongoose = require('mongoose');
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
+const { hasEffect, consumeEffect, timeRemaining } = require('../../services/effectsService');
 
 const ROBBER_COOLDOWN_MS = 1 * 3_600_000; // 1 hour
 const VICTIM_IMMUNITY_MS = 30 * 60_000;   // 30 minutes
 const BASE_SUCCESS_CHANCE = 0.40;
 const ROB_STEAL_MIN = 0.10;
 const ROB_STEAL_MAX = 0.40;
-
-function hasItem(user, itemName) {
-    return user.inventory?.some(i => i.itemId?.toLowerCase() === itemName.toLowerCase() && i.quantity > 0);
-}
 
 async function saveRobState(robber, victim) {
     const session = await mongoose.startSession();
@@ -43,10 +40,10 @@ module.exports = {
             return interaction.reply({ content: 'Robbing is disabled on this server.', ephemeral: true });
         }
 
-        const currency = guildSettings?.economy?.currency || '💰';
+        const currency     = guildSettings?.economy?.currency || '💰';
         const minRobWallet = guildSettings?.economy?.robMinWallet ?? 100;
         const failFineRate = guildSettings?.economy?.robFailFineRate ?? 0.2;
-        const target   = interaction.options.getUser('target');
+        const target       = interaction.options.getUser('target');
 
         if (target.id === interaction.user.id) {
             return interaction.reply({ content: "You can't rob yourself.", ephemeral: true });
@@ -64,15 +61,15 @@ module.exports = {
             User.findOne({ userId: target.id, guildId: interaction.guild.id })
         ]);
 
-        // Cooldown
+        // Cooldown check
         if (robber.lastRob && Date.now() - new Date(robber.lastRob).getTime() < ROBBER_COOLDOWN_MS) {
             const remaining = ROBBER_COOLDOWN_MS - (Date.now() - new Date(robber.lastRob).getTime());
-            const mins = Math.ceil(remaining / 60000);
+            const mins = Math.ceil(remaining / 60_000);
             return interaction.reply({ content: `You're laying low after your last heist. Try again in **${mins} min**.`, ephemeral: true });
         }
         if (victim?.lastRobbedAt && Date.now() - new Date(victim.lastRobbedAt).getTime() < VICTIM_IMMUNITY_MS) {
             const remaining = VICTIM_IMMUNITY_MS - (Date.now() - new Date(victim.lastRobbedAt).getTime());
-            const mins = Math.ceil(remaining / 60000);
+            const mins = Math.ceil(remaining / 60_000);
             return interaction.reply({ content: `${target.username} is under rob immunity for **${mins} min**.`, ephemeral: true });
         }
 
@@ -81,30 +78,54 @@ module.exports = {
         }
 
         try {
-            let successChance = BASE_SUCCESS_CHANCE;
-            if (hasItem(robber, 'knife')) successChance += 0.15;
-            const victimHasShield = hasItem(victim, 'shield');
-            successChance = Math.max(0, Math.min(0.95, successChance));
             robber.lastRob = new Date();
 
-            if (victimHasShield) {
+            // ── Invisibility Cloak: victim cannot be targeted ─────────────────
+            if (victim && hasEffect(victim, 'invisibility_cloak')) {
+                const cloak = victim.activeEffects.find(e => e.type === 'invisibility_cloak');
                 await robber.save();
-                const embed = new EmbedBuilder()
-                    .setColor('#3498db')
-                    .setTitle('🛡️ Robbery Blocked!')
-                    .setDescription(`**${target.username}** blocked your robbery attempt with a shield.`)
-                    .setTimestamp();
-                return interaction.reply({ embeds: [embed] });
+                return interaction.reply({
+                    embeds: [new EmbedBuilder()
+                        .setColor('#9b59b6')
+                        .setTitle('🧥 Target Invisible!')
+                        .setDescription(`**${target.username}** is wearing an Invisibility Cloak. You can't find them! (${timeRemaining(cloak?.expiresAt)} remaining)`)
+                        .setTimestamp()]
+                });
             }
+
+            // ── Shield: blocks rob entirely ───────────────────────────────────
+            if (victim && hasEffect(victim, 'shield')) {
+                const shield = victim.activeEffects.find(e => e.type === 'shield');
+                await robber.save();
+                return interaction.reply({
+                    embeds: [new EmbedBuilder()
+                        .setColor('#3498db')
+                        .setTitle('🛡️ Robbery Blocked!')
+                        .setDescription(`**${target.username}** blocked your robbery attempt with a Shield. (${timeRemaining(shield?.expiresAt)} remaining)`)
+                        .setTimestamp()]
+                });
+            }
+
+            // ── Build success chance ──────────────────────────────────────────
+            let successChance = BASE_SUCCESS_CHANCE;
+            if (hasEffect(robber, 'knife'))       successChance += 0.15;  // Knife: +15%
+            successChance = Math.max(0, Math.min(0.95, successChance));
 
             const success = Math.random() < successChance;
 
             let embed;
             if (success) {
-                const maxRobbableWallet = hasItem(victim, 'padlock') ? victim.balance : (victim.balance + victim.bank);
-                const stolen = Math.floor(maxRobbableWallet * (ROB_STEAL_MIN + Math.random() * (ROB_STEAL_MAX - ROB_STEAL_MIN)));
+                // Padlock: only wallet accessible (bank protected)
+                const padlockActive = hasEffect(victim, 'padlock');
+                const stealablePool = padlockActive ? victim.balance : (victim.balance + victim.bank);
+                let stolen = Math.floor(stealablePool * (ROB_STEAL_MIN + Math.random() * (ROB_STEAL_MAX - ROB_STEAL_MIN)));
+
+                // Robbery Bag: +10% stolen
+                if (hasEffect(robber, 'robbery_bag')) stolen = Math.floor(stolen * 1.10);
+
                 robber.balance += stolen;
-                if (hasItem(victim, 'padlock')) {
+
+                if (padlockActive) {
                     victim.balance = Math.max(0, victim.balance - stolen);
                 } else {
                     const fromWallet = Math.min(victim.balance, stolen);
@@ -114,15 +135,20 @@ module.exports = {
                 victim.lastRobbedAt = new Date();
                 await saveRobState(robber, victim);
 
+                const bagNote = hasEffect(robber, 'robbery_bag') ? '\n> 💼 *Robbery Bag boosted your haul by 10%!*' : '';
                 embed = new EmbedBuilder()
                     .setColor('#f39c12')
                     .setTitle('🦹 Successful Heist!')
-                    .setDescription(`You slipped past **${target.username}** and stole **${currency}${stolen.toLocaleString()}**!`)
+                    .setDescription(`You slipped past **${target.username}** and stole **${currency}${stolen.toLocaleString()}**!${bagNote}`)
                     .addFields(
                         { name: 'Your Balance', value: `${currency}${robber.balance.toLocaleString()}`, inline: true },
                         { name: 'Their Balance', value: `${currency}${victim.balance.toLocaleString()}`, inline: true }
                     )
                     .setTimestamp();
+
+                if (padlockActive) {
+                    embed.addFields({ name: '🔒 Padlock Active', value: `${target.username}'s bank was protected!`, inline: false });
+                }
             } else {
                 const fine = Math.floor(robber.balance * failFineRate);
                 const paid = Math.min(fine, robber.balance);

--- a/src/commands/economy/roulette.js
+++ b/src/commands/economy/roulette.js
@@ -7,6 +7,7 @@ const {
 } = require('discord.js');
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
+const { hasEffect } = require('../../services/effectsService');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3a1.png';
 const MIN_BET = 10;
@@ -215,9 +216,16 @@ async function playRoulette(interaction, betKey, bet, target) {
             });
         }
 
-        const result   = spin();
+        let result   = spin();
         const betDef   = BETS[betKey];
-        const won      = betDef.matches(result, target);
+        let won        = betDef.matches(result, target);
+        // Lucky Charm: on loss, 20% chance to re-spin
+        let charmTriggered = false;
+        if (!won && hasEffect(debited, 'lucky_charm') && Math.random() < 0.20) {
+            result = spin();
+            won    = betDef.matches(result, target);
+            charmTriggered = true;
+        }
         const profit   = won ? bet * betDef.payout : -bet;
         const credit   = won ? bet + profit : 0;
         const delay    = ms => new Promise(r => setTimeout(r, ms));
@@ -256,8 +264,13 @@ async function playRoulette(interaction, betKey, bet, target) {
             new ButtonBuilder().setCustomId(replayId).setLabel('🎡 Spin Again').setStyle(ButtonStyle.Primary),
         );
 
+        const rouletteResultEmbed = resultEmbed({ result, won, betKey, target, bet, profit, balance: updated.balance, interaction });
+        if (charmTriggered) {
+            const desc = rouletteResultEmbed.data.description ?? '';
+            rouletteResultEmbed.setDescription(desc + (won ? '\n> 🍀 *Lucky Charm re-spun the wheel for you!*' : ''));
+        }
         await interaction.editReply({
-            embeds: [resultEmbed({ result, won, betKey, target, bet, profit, balance: updated.balance, interaction })],
+            embeds: [rouletteResultEmbed],
             components: [row],
         });
 

--- a/src/commands/economy/slots.js
+++ b/src/commands/economy/slots.js
@@ -6,6 +6,7 @@ const {
     ButtonStyle,
 } = require('discord.js');
 const User = require('../../models/User');
+const { hasEffect } = require('../../services/effectsService');
 
 const THUMB = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3b0.png';
 
@@ -171,14 +172,22 @@ module.exports = {
 async function playSlots(interaction, bet) {
     const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
     try {
-        await User.findOneAndUpdate(
+        const userDoc = await User.findOneAndUpdate(
             userFilter,
             { $setOnInsert: { ...userFilter, balance: 0 } },
             { upsert: true, new: true, setDefaultsOnInsert: true }
         );
+        const luckyActive = hasEffect(userDoc, 'lucky_charm');
 
-        const reels  = [spinReel(), spinReel(), spinReel()];
-        const result = evaluate(reels, bet);
+        let reels  = [spinReel(), spinReel(), spinReel()];
+        let result = evaluate(reels, bet);
+        // Lucky Charm: on loss, 20% chance to re-spin
+        let charmTriggered = false;
+        if (result.outcome === 'lose' && luckyActive && Math.random() < 0.20) {
+            reels  = [spinReel(), spinReel(), spinReel()];
+            result = evaluate(reels, bet);
+            charmTriggered = true;
+        }
         const net    = result.payout - bet;
 
         const user = await User.findOneAndUpdate(
@@ -212,8 +221,13 @@ async function playSlots(interaction, bet) {
             new ButtonBuilder().setCustomId(paytableId).setLabel('📊 Paytable').setStyle(ButtonStyle.Secondary),
         );
 
+        const finalEmbed = resultEmbed(reels, result, bet, user.balance, interaction);
+        if (charmTriggered) {
+            const desc = finalEmbed.data.description ?? '';
+            finalEmbed.setDescription(desc + '\n> 🍀 *Lucky Charm gave you a second chance!*');
+        }
         await interaction.editReply({
-            embeds: [resultEmbed(reels, result, bet, user.balance, interaction)],
+            embeds: [finalEmbed],
             components: [row],
         });
 

--- a/src/commands/economy/use.js
+++ b/src/commands/economy/use.js
@@ -1,6 +1,13 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
+const {
+    EFFECT_CONFIGS,
+    resolveEffectType,
+    addEffect,
+    hasEffect,
+    timeRemaining,
+} = require('../../services/effectsService');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -8,7 +15,7 @@ module.exports = {
         .setDescription('Use an item from your inventory')
         .addStringOption(o =>
             o.setName('item')
-                .setDescription('Exact name of the item to use (see /inventory for your items).')
+                .setDescription('Name of the item to use (see /inventory for your items).')
                 .setRequired(true)),
 
     async execute(interaction) {
@@ -28,6 +35,51 @@ module.exports = {
             return interaction.reply({ content: `You don't have **${itemName}** in your inventory.`, ephemeral: true });
         }
 
+        const effectType = resolveEffectType(itemName);
+        const cfg        = effectType ? EFFECT_CONFIGS[effectType] : null;
+
+        // ── Active-effect items ───────────────────────────────────────────────
+        if (cfg) {
+            if (hasEffect(user, effectType)) {
+                const existing = user.activeEffects.find(e => e.type === effectType);
+                return interaction.reply({
+                    content: `**${cfg.emoji} ${cfg.label}** is already active (${timeRemaining(existing?.expiresAt)} remaining). It will refresh when it expires.`,
+                    ephemeral: true
+                });
+            }
+
+            // Consume one from inventory
+            invEntry.quantity -= 1;
+            if (invEntry.quantity <= 0) {
+                user.inventory = user.inventory.filter(e => e.itemId.toLowerCase() !== itemName.toLowerCase());
+            }
+
+            const effect = addEffect(user, effectType);
+            await user.save();
+
+            const embed = new EmbedBuilder()
+                .setColor('#2ecc71')
+                .setTitle(`${cfg.emoji} Activated: ${cfg.label}`)
+                .setTimestamp();
+
+            if (effect.expiresAt) {
+                embed.setDescription(`Effect active for **${timeRemaining(effect.expiresAt)}**.`);
+            } else if (effect.charges === 1) {
+                embed.setDescription('Single-use effect is now ready. It will trigger automatically on the next qualifying event.');
+            } else {
+                embed.setDescription('Effect is permanently active until removed.');
+            }
+
+            embed.addFields({
+                name: 'Remaining in inventory',
+                value: `${user.inventory.find(e => e.itemId.toLowerCase() === itemName.toLowerCase())?.quantity ?? 0}x`,
+                inline: true
+            });
+
+            return interaction.reply({ embeds: [embed] });
+        }
+
+        // ── Generic (role-granting) items ─────────────────────────────────────
         const shopItem = guildSettings?.shop?.find(s => s.name.toLowerCase() === itemName.toLowerCase());
 
         let roleGranted = false;
@@ -39,7 +91,6 @@ module.exports = {
             }
         }
 
-        // Consume from inventory only after successful effects
         invEntry.quantity -= 1;
         if (invEntry.quantity <= 0) {
             user.inventory = user.inventory.filter(e => e.itemId.toLowerCase() !== itemName.toLowerCase());

--- a/src/commands/economy/wheel.js
+++ b/src/commands/economy/wheel.js
@@ -7,6 +7,7 @@ const {
 } = require('discord.js');
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
+const { hasEffect } = require('../../services/effectsService');
 
 const THUMB = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3a1.png';
 
@@ -227,7 +228,11 @@ function setupBuySpinCollector(interaction, buyCost, cooldownHours) {
 }
 
 async function performSpin(interaction, user, source, cost, buyCost, cooldownHours) {
-    const finalSegment = pickSegment();
+    let finalSegment = pickSegment();
+    // Lucky Charm: on Bust, 20% chance to re-spin
+    if (finalSegment.value === 0 && finalSegment.type === 'coins' && hasEffect(user, 'lucky_charm') && Math.random() < 0.20) {
+        finalSegment = pickSegment();
+    }
     const finalIndex   = SEGMENTS.indexOf(finalSegment);
     const len          = SEGMENTS.length;
     const totalSteps   = len * 2 + finalIndex;

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -278,6 +278,13 @@ const userSchema = new Schema({
     },
     // ─────────────────────────────────────────────────────────────────────────
 
+    // Active item effects (populated by /use; pruned on read)
+    activeEffects: [{
+        type:      { type: String, required: true },
+        expiresAt: { type: Date,   default: null },
+        charges:   { type: Number, default: -1 }
+    }],
+
     createdAt: { type: Date, default: Date.now },
     updatedAt: { type: Date, default: Date.now }
 });

--- a/src/services/effectsService.js
+++ b/src/services/effectsService.js
@@ -1,0 +1,99 @@
+// Configuration for every usable item effect
+const EFFECT_CONFIGS = {
+    shield:             { label: 'Shield',            emoji: '🛡️',  durationMs: 12 * 3_600_000, charges: -1 },
+    padlock:            { label: 'Padlock',            emoji: '🔒',  durationMs: null,            charges: -1 },
+    lucky_charm:        { label: 'Lucky Charm',        emoji: '🍀',  durationMs: 2  * 3_600_000, charges: -1 },
+    lifesaver:          { label: 'Lifesaver',          emoji: '🛟',  durationMs: null,            charges: 1  },
+    invisibility_cloak: { label: 'Invisibility Cloak', emoji: '🧥',  durationMs: 6  * 3_600_000, charges: -1 },
+    knife:              { label: 'Knife',              emoji: '🔪',  durationMs: null,            charges: -1 },
+    robbery_bag:        { label: 'Robbery Bag',        emoji: '💼',  durationMs: null,            charges: -1 },
+    finders_fee:        { label: "Finder's Fee",       emoji: '💸',  durationMs: null,            charges: -1 },
+};
+
+// Maps item names (as stored in inventory) to effect type keys
+const ITEM_TO_EFFECT = {
+    'shield':             'shield',
+    'padlock':            'padlock',
+    'lucky charm':        'lucky_charm',
+    'lifesaver':          'lifesaver',
+    'invisibility cloak': 'invisibility_cloak',
+    'knife':              'knife',
+    'robbery bag':        'robbery_bag',
+    "finder's fee":       'finders_fee',
+    'finders fee':        'finders_fee',
+};
+
+function resolveEffectType(itemName) {
+    return ITEM_TO_EFFECT[itemName.toLowerCase()] ?? null;
+}
+
+function pruneEffects(user) {
+    if (!user.activeEffects) { user.activeEffects = []; return; }
+    const now = Date.now();
+    user.activeEffects = user.activeEffects.filter(e => {
+        if (e.charges === 0) return false;
+        if (e.expiresAt && new Date(e.expiresAt).getTime() <= now) return false;
+        return true;
+    });
+}
+
+function hasEffect(user, type) {
+    pruneEffects(user);
+    return user.activeEffects.some(e => e.type === type);
+}
+
+function getEffect(user, type) {
+    pruneEffects(user);
+    return user.activeEffects.find(e => e.type === type) ?? null;
+}
+
+function addEffect(user, type) {
+    const cfg = EFFECT_CONFIGS[type];
+    if (!cfg) return null;
+    pruneEffects(user);
+    // Remove any existing effect of the same type before re-adding
+    user.activeEffects = user.activeEffects.filter(e => e.type !== type);
+    const effect = {
+        type,
+        expiresAt: cfg.durationMs ? new Date(Date.now() + cfg.durationMs) : null,
+        charges:   cfg.charges,
+    };
+    user.activeEffects.push(effect);
+    return effect;
+}
+
+// Consume one charge; removes effect if charges reach 0.
+// No-op for unlimited-charge effects (charges === -1).
+function consumeEffect(user, type) {
+    pruneEffects(user);
+    const idx = user.activeEffects.findIndex(e => e.type === type);
+    if (idx === -1) return false;
+    const effect = user.activeEffects[idx];
+    if (effect.charges > 0) {
+        effect.charges -= 1;
+        if (effect.charges === 0) user.activeEffects.splice(idx, 1);
+    }
+    return true;
+}
+
+// Returns a human-readable time-remaining string (e.g. "1h 23m")
+function timeRemaining(expiresAt) {
+    if (!expiresAt) return 'permanent';
+    const ms = new Date(expiresAt).getTime() - Date.now();
+    if (ms <= 0) return 'expired';
+    const h = Math.floor(ms / 3_600_000);
+    const m = Math.ceil((ms % 3_600_000) / 60_000);
+    if (h > 0) return `${h}h ${m}m`;
+    return `${m}m`;
+}
+
+module.exports = {
+    EFFECT_CONFIGS,
+    resolveEffectType,
+    pruneEffects,
+    hasEffect,
+    getEffect,
+    addEffect,
+    consumeEffect,
+    timeRemaining,
+};


### PR DESCRIPTION
Closes #104

- Add `activeEffects` array to User model with type, expiresAt, charges fields
- New `effectsService.js` with helpers: addEffect, hasEffect, consumeEffect, pruneEffects, timeRemaining
- `/use` now activates items into timed/charged activeEffects instead of just consuming inventory; re-uses old role-grant path for generic items
- `/rob`: Shield blocks rob entirely (12h), Invisibility Cloak hides victim (6h), Padlock protects bank, Knife +15% success, Robbery Bag +10% stolen amount
- `/crime`: Lucky Charm +20% success rate; Lifesaver absorbs one failure with no fine (single-use, consumed on trigger)
- `/balance`: shows active effect indicators with time remaining (🛡️🔒🍀 etc.)
- `/inventory`: new Active Effects section showing each effect with time/charges remaining
- All gambling commands (slots, blackjack, roulette, crash, plinko, baccarat, higherlower, doubleornothing, wheel) check for Lucky Charm and apply a 20% win-rate boost mechanic appropriate to each game

https://claude.ai/code/session_01A8iYR1HRgrwhXdDCbX757z