### PR TITLE
feat(economy): add death/loss mechanic for high-risk activities (#108)

### DIFF
--- a/src/commands/economy/crime.js
+++ b/src/commands/economy/crime.js
@@ -92,7 +92,7 @@ module.exports = {
                     consumeEffect(user, 'lifesaver');
                     const wouldHaveLost = isCriticalFailure
                         ? Math.floor(user.balance * (DEATH_LOSS_MIN + Math.random() * (DEATH_LOSS_MAX - DEATH_LOSS_MIN)))
-                        : Math.floor(50 + Math.random() * 200);
+                        : Math.floor(Math.random() * 151) + 50;
                     user.lastCrime = new Date();
                     await user.save();
 
@@ -131,7 +131,7 @@ module.exports = {
                         .setFooter({ text: 'Purchase a Lifesaver from /shop to protect against death events' })
                         .setTimestamp();
                 } else {
-                    const fine = Math.floor(50 + Math.random() * 200);
+                    const fine = Math.floor(Math.random() * 151) + 50;
                     const paid = Math.min(fine, user.balance);
                     user.balance = Math.max(0, user.balance - paid);
                     user.lastCrime = new Date();

--- a/src/commands/economy/crime.js
+++ b/src/commands/economy/crime.js
@@ -3,8 +3,12 @@ const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { hasEffect, consumeEffect } = require('../../services/effectsService');
 
-const COOLDOWN_MS    = 4 * 3_600_000; // 4 hours
-const BASE_SUCCESS   = 0.40;
+const COOLDOWN_MS      = 4 * 3_600_000; // 4 hours
+const WANTED_MS        = 1 * 3_600_000; // 1 hour wanted cooldown after death
+const BASE_SUCCESS     = 0.40;
+const DEATH_RATE       = 0.08;          // 8% of failures trigger critical death
+const DEATH_LOSS_MIN   = 0.15;
+const DEATH_LOSS_MAX   = 0.30;
 
 const CRIMES = [
     { name: 'pickpocketing',       emoji: '🤏', minPayout: 80,   maxPayout: 200  },
@@ -42,6 +46,12 @@ module.exports = {
             { upsert: true, new: true }
         );
 
+        if (user.wantedUntil && Date.now() < user.wantedUntil.getTime()) {
+            const remaining = user.wantedUntil.getTime() - Date.now();
+            const mins = Math.ceil(remaining / 60_000);
+            return interaction.reply({ content: `🚨 You're still **wanted by the police**! Lay low for **${mins} min** before attempting another crime.`, ephemeral: true });
+        }
+
         if (user.lastCrime && Date.now() - user.lastCrime.getTime() < COOLDOWN_MS) {
             const remaining = COOLDOWN_MS - (Date.now() - user.lastCrime.getTime());
             const hrs = Math.ceil(remaining / 3_600_000);
@@ -73,36 +83,68 @@ module.exports = {
                     .setFooter({ text: 'Crimes can be committed every 4 hours' })
                     .setTimestamp();
             } else {
-                const fine = Math.floor(50 + Math.random() * 200);
-                const paid = Math.min(fine, user.balance);
+                const flavorText = FINES[Math.floor(Math.random() * FINES.length)];
+                const isCriticalFailure = Math.random() < DEATH_RATE;
 
-                // Lifesaver: absorbs one failure — no fine paid
+                // Lifesaver: absorbs any failure — no fine or death losses
                 const lifesaverActive = hasEffect(user, 'lifesaver');
                 if (lifesaverActive) {
                     consumeEffect(user, 'lifesaver');
+                    const wouldHaveLost = isCriticalFailure
+                        ? Math.floor(user.balance * (DEATH_LOSS_MIN + Math.random() * (DEATH_LOSS_MAX - DEATH_LOSS_MIN)))
+                        : Math.floor(50 + Math.random() * 200);
                     user.lastCrime = new Date();
                     await user.save();
 
-                    const flavorText = FINES[Math.floor(Math.random() * FINES.length)];
                     embed = new EmbedBuilder()
                         .setColor('#e67e22')
                         .setTitle(`${crime.emoji} Saved by the Lifesaver!`)
-                        .setDescription(`Your attempt at **${crime.name}** went sideways. ${flavorText}\n> 🛟 *Your Lifesaver absorbed the fine — no coins lost! (consumed)*`)
-                        .addFields({ name: 'Fine Absorbed', value: `${currency}${paid.toLocaleString()}`, inline: true },
-                                   { name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true })
+                        .setDescription(`Your attempt at **${crime.name}** went sideways. ${flavorText}\n> 🛟 *Your Lifesaver activated and saved you! No coins lost! (consumed)*`)
+                        .addFields(
+                            { name: isCriticalFailure ? 'Death Loss Absorbed' : 'Fine Absorbed', value: `${currency}${Math.min(wouldHaveLost, user.balance).toLocaleString()}`, inline: true },
+                            { name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true }
+                        )
                         .setFooter({ text: 'Crimes can be committed every 4 hours' })
                         .setTimestamp();
-                } else {
-                    user.balance = Math.max(0, user.balance - paid);
+                } else if (isCriticalFailure) {
+                    // Critical failure: lose 15–30% of wallet, enter "wanted" status
+                    const lossRate = DEATH_LOSS_MIN + Math.random() * (DEATH_LOSS_MAX - DEATH_LOSS_MIN);
+                    const lost = Math.floor(user.balance * lossRate);
+                    user.balance = Math.max(0, user.balance - lost);
+                    user.wantedUntil = new Date(Date.now() + WANTED_MS);
+                    user.lastCrime = new Date();
                     await user.save();
 
-                    const flavorText = FINES[Math.floor(Math.random() * FINES.length)];
+                    embed = new EmbedBuilder()
+                        .setColor('#8B0000')
+                        .setTitle(`💀 ${crime.emoji} Caught — You're Wanted!`)
+                        .setDescription(
+                            `Your attempt at **${crime.name}** ended catastrophically. ${flavorText}\n\n` +
+                            `**The police seized ${Math.round(lossRate * 100)}% of your wallet.**\n` +
+                            `> 🚨 You are now **wanted** — no crimes for 1 hour.`
+                        )
+                        .addFields(
+                            { name: '💸 Lost',           value: `${currency}${lost.toLocaleString()}`,          inline: true },
+                            { name: '💰 Remaining',      value: `${currency}${user.balance.toLocaleString()}`,  inline: true },
+                            { name: '⏳ Wanted For',     value: '1 hour',                                       inline: true }
+                        )
+                        .setFooter({ text: 'Purchase a Lifesaver from /shop to protect against death events' })
+                        .setTimestamp();
+                } else {
+                    const fine = Math.floor(50 + Math.random() * 200);
+                    const paid = Math.min(fine, user.balance);
+                    user.balance = Math.max(0, user.balance - paid);
+                    user.lastCrime = new Date();
+                    await user.save();
+
                     embed = new EmbedBuilder()
                         .setColor('#e74c3c')
                         .setTitle(`${crime.emoji} Busted!`)
                         .setDescription(`Your attempt at **${crime.name}** went sideways. ${flavorText}\nYou were fined **${currency}${paid.toLocaleString()}**.`)
-                        .addFields({ name: 'Fine Paid', value: `${currency}${paid.toLocaleString()}`, inline: true },
-                                   { name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true })
+                        .addFields(
+                            { name: 'Fine Paid', value: `${currency}${paid.toLocaleString()}`, inline: true },
+                            { name: 'Balance',   value: `${currency}${user.balance.toLocaleString()}`, inline: true }
+                        )
                         .setFooter({ text: 'Crimes can be committed every 4 hours' })
                         .setTimestamp();
                 }

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -238,12 +238,22 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
         embed.addFields({ name: '🤕 Injured', value: `Extra cooldown: **${formatMs(failure.severity.injuryMs)}**`, inline: true });
     }
 
+    if (result.deathEvent) {
+        if (result.deathEvent.saved) {
+            embed.setColor('#e67e22');
+            embed.addFields({ name: '🛟 Lifesaver Activated!', value: `A severe injury would have destroyed your **${result.deathEvent.weaponName}**, but your Lifesaver absorbed it! (consumed)`, inline: false });
+        } else {
+            embed.setColor('#8B0000');
+            embed.addFields({ name: '💀 Severe Injury!', value: `The encounter was catastrophic — your **${result.deathEvent.weaponName}** was completely destroyed! Use \`/huntrepair\` to fix it.`, inline: false });
+        }
+    }
+
     if (levelUp) {
         const ld = getLevelData(levelUp.newLevel);
         embed.addFields({ name: '⬆️ Level Up!', value: `Hunter Level **${levelUp.oldLevel}** → **${levelUp.newLevel}** (${ld.title})`, inline: false });
     }
 
-    if (weapon.status === 'broken') {
+    if (weapon.status === 'broken' && !result.deathEvent) {
         embed.addFields({ name: '❌ Weapon Broke!', value: `Your **${weapon.name}** has broken! Use \`/huntrepair\` before hunting again.`, inline: false });
     }
 

--- a/src/commands/economy/rob.js
+++ b/src/commands/economy/rob.js
@@ -152,19 +152,36 @@ module.exports = {
             } else {
                 const fine = Math.floor(robber.balance * failFineRate);
                 const paid = Math.min(fine, robber.balance);
-                robber.balance = Math.max(0, robber.balance - paid);
-                victim.balance += paid;
-                await saveRobState(robber, victim);
 
-                embed = new EmbedBuilder()
-                    .setColor('#e74c3c')
-                    .setTitle('🚔 Caught Red-Handed!')
-                    .setDescription(`**${target.username}** caught you and you were fined **${currency}${paid.toLocaleString()}**, which went straight to them.`)
-                    .addFields(
-                        { name: 'Fine Paid', value: `${currency}${paid.toLocaleString()}`, inline: true },
-                        { name: 'Your Balance', value: `${currency}${robber.balance.toLocaleString()}`, inline: true }
-                    )
-                    .setTimestamp();
+                // Lifesaver: absorbs the failure fine — no coins lost
+                if (hasEffect(robber, 'lifesaver')) {
+                    consumeEffect(robber, 'lifesaver');
+                    await robber.save();
+
+                    embed = new EmbedBuilder()
+                        .setColor('#e67e22')
+                        .setTitle('🛟 Lifesaver Activated!')
+                        .setDescription(`**${target.username}** caught you in the act, but your **Lifesaver** protected you from the **${currency}${paid.toLocaleString()}** fine! (consumed)`)
+                        .addFields(
+                            { name: 'Fine Absorbed', value: `${currency}${paid.toLocaleString()}`,        inline: true },
+                            { name: 'Your Balance',  value: `${currency}${robber.balance.toLocaleString()}`, inline: true }
+                        )
+                        .setTimestamp();
+                } else {
+                    robber.balance = Math.max(0, robber.balance - paid);
+                    victim.balance += paid;
+                    await saveRobState(robber, victim);
+
+                    embed = new EmbedBuilder()
+                        .setColor('#e74c3c')
+                        .setTitle('🚔 Caught Red-Handed!')
+                        .setDescription(`**${target.username}** caught you and you were fined **${currency}${paid.toLocaleString()}**, which went straight to them.`)
+                        .addFields(
+                            { name: 'Fine Paid',    value: `${currency}${paid.toLocaleString()}`,        inline: true },
+                            { name: 'Your Balance', value: `${currency}${robber.balance.toLocaleString()}`, inline: true }
+                        )
+                        .setTimestamp();
+                }
             }
 
             await interaction.reply({ embeds: [embed] });

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -19,6 +19,7 @@ const userSchema = new Schema({
     lastFish: { type: Date, default: null },
     lastMine: { type: Date, default: null },
     lastCrime: { type: Date, default: null },
+    wantedUntil: { type: Date, default: null },
     shiftsWorked: { type: Number, default: 0 },
 
     inventory: [{

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -696,8 +696,8 @@ function executeHunt(user, zoneId) {
 
         if (weapon.currentDurability <= 0) result.weaponBroke = true;
 
-        // ── Death event (dangerous zones, 8% of failures) ───────────────
-        if (DANGEROUS_ZONE_IDS.has(zone.id) && Math.random() < HUNT_DEATH_RATE) {
+        // ── Death event (dangerous zones, 8% of failures, weapon still intact) ──
+        if (DANGEROUS_ZONE_IDS.has(zone.id) && !result.weaponBroke && Math.random() < HUNT_DEATH_RATE) {
             if (hasEffect(user, 'lifesaver')) {
                 consumeEffect(user, 'lifesaver');
                 result.deathEvent = { saved: true, weaponName: weapon.name };

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -12,6 +12,11 @@ const {
     PRESTIGE_BONUSES,
     HUNT_QUEST_TEMPLATES
 } = require('../data/huntData');
+const { hasEffect, consumeEffect } = require('./effectsService');
+
+// Zones where a critical failure can destroy your weapon (death event)
+const DANGEROUS_ZONE_IDS = new Set(['desert_wastes', 'arctic_tundra', 'murky_swamp', 'legendary_peaks']);
+const HUNT_DEATH_RATE = 0.08;
 
 const DAILY_QUEST_COUNT = 3;
 
@@ -690,6 +695,19 @@ function executeHunt(user, zoneId) {
         result.failure    = { severity, message: severity.msg };
 
         if (weapon.currentDurability <= 0) result.weaponBroke = true;
+
+        // ── Death event (dangerous zones, 8% of failures) ───────────────
+        if (DANGEROUS_ZONE_IDS.has(zone.id) && Math.random() < HUNT_DEATH_RATE) {
+            if (hasEffect(user, 'lifesaver')) {
+                consumeEffect(user, 'lifesaver');
+                result.deathEvent = { saved: true, weaponName: weapon.name };
+            } else {
+                weapon.currentDurability = 0;
+                weapon.status = 'broken';
+                result.weaponBroke = true;
+                result.deathEvent = { saved: false, weaponName: weapon.name };
+            }
+        }
     }
 
     // ── Common post-hunt updates ────────────────────────────────────────


### PR DESCRIPTION
- /crime: 8% of failures trigger a critical "death" event — police seize
  15–30% of the user's wallet and impose a 1-hour wanted cooldown (stored
  as wantedUntil on the User model) during which further crimes are blocked
- /crime: Lifesaver now absorbs both normal fines and critical death losses
- /rob: Lifesaver now protects the robber from the 20% failure fine
- Hunt (dangerous zones): 8% of failures in desert_wastes, arctic_tundra,
  murky_swamp, and legendary_peaks trigger a severe-injury death event that
  instantly destroys the equipped weapon; Lifesaver absorbs this too
- Added wantedUntil (Date) to User schema

https://claude.ai/code/session_011nwgnYozXzjgGv16vyZysE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "wanted" system: crime attempts are blocked while wanted, with duration shown to players
  * Critical failure outcomes in crime command can now result in wallet loss (15-30%) and wanted status
  * Death and severe injury events introduced in dangerous hunting zones
  * Enhanced lifesaver effect to protect against multiple failure types across crime, robbery, and hunting commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->