### PR TITLE
UX: improve command cooldown replies with dynamic Discord timestamps

### DIFF
--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -155,8 +155,11 @@ module.exports = {
 
             if (now < expirationTime) {
                 const expiredTimestamp = Math.round(expirationTime / 1000);
+                const longCooldown = (expirationTime - now) > 12 * 60 * 60 * 1000;
+                const exactTime = longCooldown ? ` (<t:${expiredTimestamp}:F>)` : '';
+
                 return interaction.reply({
-                    content: `Please wait, you are on cooldown. You can use \`/${command.data.name}\` again <t:${expiredTimestamp}:R>.`,
+                    content: `Please wait, you are on cooldown. You can use \`/${command.data.name}\` again <t:${expiredTimestamp}:R>${exactTime}.`,
                     ephemeral: true
                 });
             }


### PR DESCRIPTION
### Motivation
- Improve UX for command cooldown messages by using Discord relative timestamps for live countdowns and including an exact full timestamp when the remaining wait is long (>12 hours).

### Description
- Updated `src/events/interactionCreate.js` to reply with `<t:...:R>` for cooldowns and append ` (<t:...:F>)` when `(expirationTime - now) > 12 * 60 * 60 * 1000`, adding `longCooldown` and `exactTime` variables and updating the reply content accordingly.

### Testing
- Ran the automated patch and verification steps which all succeeded: the in-place patch script applied, `git diff -- src/events/interactionCreate.js` showed the change, `nl -ba src/events/interactionCreate.js | sed -n '150,175p'` confirmed the new logic, and `git commit -m "Improve cooldown replies with Discord timestamps"` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf90ea9fc83258bd0b30ab7c2ba51)