### PR TITLE
feat(ux): add reusable button paginator and migrate /shop view

### DIFF
--- a/src/commands/economy/shop.js
+++ b/src/commands/economy/shop.js
@@ -9,13 +9,13 @@ const {
 } = require('discord.js');
 const Guild = require('../../models/Guild');
 const User = require('../../models/User');
+const { chunkArray, paginate } = require('../../utils/paginator');
 
 const PAGE_SIZE = 5;
 const CONFIRM_THRESHOLD = 500;
 
-function buildViewEmbed(items, page, totalPages, guildName, currency, userBalance) {
-    const start = page * PAGE_SIZE;
-    const slice = items.slice(start, start + PAGE_SIZE);
+function buildViewEmbed(slice, page, totalPages, guildName, currency, userBalance, absoluteStart) {
+    const start = absoluteStart;
 
     const lines = slice.map((item, i) => {
         const stock = item.stock === -1 ? '∞' : item.stock;
@@ -34,21 +34,6 @@ function buildViewEmbed(items, page, totalPages, guildName, currency, userBalanc
     embed.setFooter({ text: footerParts.join(' · ') });
 
     return embed;
-}
-
-function buildPageRow(page, totalPages) {
-    return new ActionRowBuilder().addComponents(
-        new ButtonBuilder()
-            .setCustomId('shop_prev')
-            .setLabel('◀ Previous')
-            .setStyle(ButtonStyle.Secondary)
-            .setDisabled(page === 0),
-        new ButtonBuilder()
-            .setCustomId('shop_next')
-            .setLabel('Next ▶')
-            .setStyle(ButtonStyle.Secondary)
-            .setDisabled(page >= totalPages - 1)
-    );
 }
 
 module.exports = {
@@ -107,40 +92,10 @@ module.exports = {
 
             const userData = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
             const userBalance = userData?.balance ?? 0;
-            const items = guildSettings.shop;
-            const totalPages = Math.ceil(items.length / PAGE_SIZE);
-
-            let page = 0;
-            const embed = buildViewEmbed(items, page, totalPages, interaction.guild.name, currency, userBalance);
-
-            if (totalPages <= 1) {
-                return interaction.reply({ embeds: [embed] });
-            }
-
-            const row = buildPageRow(page, totalPages);
-            const msg = await interaction.reply({ embeds: [embed], components: [row], fetchReply: true });
-
-            const collector = msg.createMessageComponentCollector({
-                componentType: ComponentType.Button,
-                filter: i => i.user.id === interaction.user.id,
-                time: 120_000
-            });
-
-            collector.on('collect', async btn => {
-                if (btn.customId === 'shop_prev') page = Math.max(0, page - 1);
-                else page = Math.min(totalPages - 1, page + 1);
-
-                await btn.update({
-                    embeds: [buildViewEmbed(items, page, totalPages, interaction.guild.name, currency, userBalance)],
-                    components: [buildPageRow(page, totalPages)]
-                });
-            });
-
-            collector.on('end', () => {
-                interaction.editReply({ components: [] }).catch(() => {});
-            });
-
-            return;
+            const pages = chunkArray(guildSettings.shop, PAGE_SIZE).map((slice, page) =>
+                buildViewEmbed(slice, page, Math.ceil(guildSettings.shop.length / PAGE_SIZE), interaction.guild.name, currency, userBalance, page * PAGE_SIZE)
+            );
+            return paginate(interaction, pages);
         }
 
         // ── BUY ───────────────────────────────────────────────────────────────

--- a/src/commands/economy/shop.js
+++ b/src/commands/economy/shop.js
@@ -14,13 +14,11 @@ const { chunkArray, paginate } = require('../../utils/paginator');
 const PAGE_SIZE = 5;
 const CONFIRM_THRESHOLD = 500;
 
-function buildViewEmbed(slice, page, totalPages, guildName, currency, userBalance, absoluteStart) {
-    const start = absoluteStart;
-
+function buildViewEmbed(slice, guildName, currency, userBalance, absoluteStart) {
     const lines = slice.map((item, i) => {
         const stock = item.stock === -1 ? '∞' : item.stock;
         const roleTag = item.roleId ? ` → <@&${item.roleId}>` : '';
-        return `**${start + i + 1}. ${item.name}** — ${currency}${item.price.toLocaleString()} (Stock: ${stock})${roleTag}\n${item.description || '*No description*'}`;
+        return `**${absoluteStart + i + 1}. ${item.name}** — ${currency}${item.price.toLocaleString()} (Stock: ${stock})${roleTag}\n${item.description || '*No description*'}`;
     });
 
     const embed = new EmbedBuilder()
@@ -30,7 +28,6 @@ function buildViewEmbed(slice, page, totalPages, guildName, currency, userBalanc
 
     const footerParts = [`Use /shop buy <item name> to purchase`];
     if (userBalance !== null) footerParts.push(`Your balance: ${currency}${userBalance.toLocaleString()}`);
-    if (totalPages > 1) footerParts.push(`Page ${page + 1}/${totalPages}`);
     embed.setFooter({ text: footerParts.join(' · ') });
 
     return embed;
@@ -93,7 +90,7 @@ module.exports = {
             const userData = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
             const userBalance = userData?.balance ?? 0;
             const pages = chunkArray(guildSettings.shop, PAGE_SIZE).map((slice, page) =>
-                buildViewEmbed(slice, page, Math.ceil(guildSettings.shop.length / PAGE_SIZE), interaction.guild.name, currency, userBalance, page * PAGE_SIZE)
+                buildViewEmbed(slice, interaction.guild.name, currency, userBalance, page * PAGE_SIZE)
             );
             return paginate(interaction, pages);
         }

--- a/src/utils/paginator.js
+++ b/src/utils/paginator.js
@@ -1,0 +1,82 @@
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, ComponentType } = require('discord.js');
+
+function chunkArray(items, chunkSize) {
+    if (!Array.isArray(items) || chunkSize <= 0) return [];
+    const chunks = [];
+    for (let i = 0; i < items.length; i += chunkSize) {
+        chunks.push(items.slice(i, i + chunkSize));
+    }
+    return chunks;
+}
+
+function buildControls(page, totalPages, interactionId) {
+    return new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+            .setCustomId(`paginate_prev_${interactionId}`)
+            .setLabel('◀ Previous')
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(page === 0),
+        new ButtonBuilder()
+            .setCustomId(`paginate_next_${interactionId}`)
+            .setLabel('Next ▶')
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(page >= totalPages - 1)
+    );
+}
+
+function buildDisabledControls(page, totalPages, interactionId) {
+    const row = buildControls(page, totalPages, interactionId);
+    row.components.forEach(component => component.setDisabled(true));
+    return row;
+}
+
+async function paginate(interaction, pages) {
+    if (!pages?.length) {
+        return interaction.reply({ content: 'Nothing to display.', ephemeral: true });
+    }
+
+    const normalizedPages = pages.map((embed, index) => {
+        const clone = embed.data ? embed.constructor.from(embed) : embed;
+        return clone.setFooter({ text: `Page ${index + 1} / ${pages.length}` });
+    });
+
+    if (normalizedPages.length === 1) {
+        return interaction.reply({ embeds: [normalizedPages[0]] });
+    }
+
+    const prevId = `paginate_prev_${interaction.id}`;
+    const nextId = `paginate_next_${interaction.id}`;
+    let page = 0;
+    const message = await interaction.reply({
+        embeds: [normalizedPages[page]],
+        components: [buildControls(page, normalizedPages.length, interaction.id)],
+        fetchReply: true
+    });
+
+    const collector = message.createMessageComponentCollector({
+        componentType: ComponentType.Button,
+        filter: btn => btn.user.id === interaction.user.id && (btn.customId === prevId || btn.customId === nextId),
+        time: 120_000
+    });
+
+    collector.on('collect', async btn => {
+        if (btn.customId === prevId) page = Math.max(0, page - 1);
+        if (btn.customId === nextId) page = Math.min(normalizedPages.length - 1, page + 1);
+
+        await btn.update({
+            embeds: [normalizedPages[page]],
+            components: [buildControls(page, normalizedPages.length, interaction.id)]
+        });
+    });
+
+    collector.on('end', async () => {
+        await interaction.editReply({
+            components: [buildDisabledControls(page, normalizedPages.length, interaction.id)]
+        }).catch(() => {});
+    });
+}
+
+module.exports = {
+    chunkArray,
+    paginate
+};

--- a/src/utils/paginator.js
+++ b/src/utils/paginator.js
@@ -1,4 +1,4 @@
-const { ActionRowBuilder, ButtonBuilder, ButtonStyle, ComponentType } = require('discord.js');
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, ComponentType, EmbedBuilder } = require('discord.js');
 
 function chunkArray(items, chunkSize) {
     if (!Array.isArray(items) || chunkSize <= 0) return [];
@@ -36,8 +36,11 @@ async function paginate(interaction, pages) {
     }
 
     const normalizedPages = pages.map((embed, index) => {
-        const clone = embed.data ? embed.constructor.from(embed) : embed;
-        return clone.setFooter({ text: `Page ${index + 1} / ${pages.length}` });
+        const clone = EmbedBuilder.from(embed);
+        const originalFooterText = clone.data?.footer?.text;
+        const pageText = `Page ${index + 1} / ${pages.length}`;
+        const footerText = originalFooterText ? `${originalFooterText} • ${pageText}` : pageText;
+        return clone.setFooter({ text: footerText });
     });
 
     if (normalizedPages.length === 1) {


### PR DESCRIPTION
### Motivation
- Provide a reusable button-based pagination component for long command outputs as requested in Issue #120. 
- Replace ad-hoc per-command pagination logic with a shared utility to reduce duplication and improve consistency.

### Description
- Add `src/utils/paginator.js` exporting `chunkArray(items, chunkSize)` and `paginate(interaction, pages)` which create Previous/Next buttons, scope interactions to the invoking user, auto-inject `Page X / Y` footers, and disable buttons after a 2-minute timeout. 
- Refactor `/shop view` in `src/commands/economy/shop.js` to build pages with `chunkArray(...)` and call `paginate(...)` instead of the command-local collector and button handlers. 
- Update `buildViewEmbed` signature to accept a page slice and absolute start index so numbering and footer text remain correct when paginating.

### Testing
- Ran `node --check src/utils/paginator.js` which completed without syntax errors. 
- Ran `node --check src/commands/economy/shop.js` which completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe23b208d48325a8d84bd68f7155f4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal pagination infrastructure for better code maintainability and consistency across features. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->