### PR TITLE
feat(moderation): raid mode auto-trigger and auto-disable (#114)

### DIFF
--- a/src/commands/admin/raidmode.js
+++ b/src/commands/admin/raidmode.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
 const Guild = require('../../models/Guild');
+const { setRaidMode, raidModeActive, raidModeActivatedBy } = require('../../services/raidService');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -20,7 +21,22 @@ module.exports = {
                             { name: 'Kick new accounts', value: 'kick' }
                         ))
                 .addChannelOption(o => o.setName('alert_channel').setDescription('Channel for raid alerts (default: mod log)').setRequired(false))
-                .addRoleOption(o => o.setName('quarantine_role').setDescription('Role applied when action is quarantine').setRequired(false)))
+                .addRoleOption(o => o.setName('quarantine_role').setDescription('Role applied when action is quarantine').setRequired(false))
+                .addBooleanOption(o => o.setName('auto_disable').setDescription('Automatically disable raid mode when server calms down (default: true)').setRequired(false))
+                .addIntegerOption(o => o.setName('calm_window').setDescription('Seconds of low join activity before auto-disable (default 300)').setMinValue(30).setRequired(false))
+                .addBooleanOption(o => o.setName('require_manual_disable').setDescription('Require a moderator to manually turn raid mode off (default: false)').setRequired(false)))
+        .addSubcommand(sub =>
+            sub.setName('toggle')
+                .setDescription('Manually enable or disable raid mode — always overrides auto detection')
+                .addStringOption(o =>
+                    o.setName('status').setDescription('Turn raid mode on or off').setRequired(true)
+                        .addChoices(
+                            { name: 'On', value: 'on' },
+                            { name: 'Off', value: 'off' }
+                        )))
+        .addSubcommand(sub =>
+            sub.setName('status')
+                .setDescription('Show current raid mode state and detection settings'))
         .addSubcommand(sub =>
             sub.setName('cases')
                 .setDescription('Configure case SLA and appeals')
@@ -57,6 +73,9 @@ module.exports = {
             const action = interaction.options.getString('action');
             const alertChannel = interaction.options.getChannel('alert_channel');
             const quarantineRole = interaction.options.getRole('quarantine_role');
+            const autoDisable = interaction.options.getBoolean('auto_disable');
+            const calmWindow = interaction.options.getInteger('calm_window');
+            const requireManualDisable = interaction.options.getBoolean('require_manual_disable');
 
             const update = { 'raidDetection.enabled': enabled };
             if (threshold != null) update['raidDetection.threshold'] = threshold;
@@ -65,6 +84,9 @@ module.exports = {
             if (action) update['raidDetection.action'] = action;
             if (alertChannel) update['raidDetection.alertChannelId'] = alertChannel.id;
             if (quarantineRole) update['raidDetection.quarantineRoleId'] = quarantineRole.id;
+            if (autoDisable != null) update['raidDetection.autoDisable'] = autoDisable;
+            if (calmWindow != null) update['raidDetection.calmWindowSeconds'] = calmWindow;
+            if (requireManualDisable != null) update['raidDetection.requireManualDisable'] = requireManualDisable;
 
             await Guild.updateOne({ guildId: interaction.guild.id }, { $set: update });
 
@@ -74,10 +96,82 @@ module.exports = {
                 .addFields(
                     { name: 'Threshold', value: (threshold ?? 10).toString(), inline: true },
                     { name: 'Window', value: `${window ?? 60}s`, inline: true },
-                    { name: 'Action', value: action ?? 'alert', inline: true }
+                    { name: 'Action', value: action ?? 'alert', inline: true },
+                    { name: 'Auto-Disable', value: autoDisable != null ? (autoDisable ? 'Yes' : 'No') : 'Yes (default)', inline: true },
+                    { name: 'Calm Window', value: `${calmWindow ?? 300}s`, inline: true },
+                    { name: 'Require Manual Disable', value: requireManualDisable != null ? (requireManualDisable ? 'Yes' : 'No') : 'No (default)', inline: true }
                 )
                 .setTimestamp();
 
+            return interaction.reply({ embeds: [embed] });
+        }
+
+        if (sub === 'toggle') {
+            const status = interaction.options.getString('status');
+            const active = status === 'on';
+
+            const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+            if (!guildSettings?.raidDetection?.enabled) {
+                return interaction.reply({
+                    content: 'Raid detection is not enabled. Use `/raidmode raid enabled:true` first.',
+                    ephemeral: true
+                });
+            }
+
+            await setRaidMode(interaction.guild.id, interaction.guild, active, guildSettings);
+
+            const embed = new EmbedBuilder()
+                .setColor(active ? '#ff0000' : '#00ff00')
+                .setTitle(active ? '🔒 Raid Mode Enabled' : '🔓 Raid Mode Disabled')
+                .setDescription(
+                    active
+                        ? 'Raid mode manually enabled. All new joins will have the configured action applied.'
+                        : 'Raid mode manually disabled. Auto-detection resumes normally.'
+                )
+                .addFields({ name: 'Triggered By', value: 'Manual (moderator override)', inline: true })
+                .setTimestamp();
+
+            return interaction.reply({ embeds: [embed] });
+        }
+
+        if (sub === 'status') {
+            const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+            const rd = guildSettings?.raidDetection;
+
+            if (!rd?.enabled) {
+                return interaction.reply({
+                    embeds: [new EmbedBuilder()
+                        .setColor('#888888')
+                        .setTitle('Raid Detection: Disabled')
+                        .setDescription('Raid detection is not configured. Use `/raidmode raid enabled:true` to set it up.')
+                        .setTimestamp()]
+                });
+            }
+
+            const isActive = raidModeActive.has(interaction.guild.id) || rd.raidModeActive;
+            const activatedBy = raidModeActivatedBy.get(interaction.guild.id) || rd.raidModeActivatedBy;
+            const activatedAt = rd.raidModeActivatedAt;
+
+            const embed = new EmbedBuilder()
+                .setColor(isActive ? '#ff0000' : '#00ff00')
+                .setTitle(`Raid Detection Status`)
+                .addFields(
+                    { name: 'Detection Enabled', value: 'Yes', inline: true },
+                    { name: 'Raid Mode Active', value: isActive ? '🔴 YES' : '🟢 No', inline: true },
+                    { name: 'Triggered By', value: isActive ? (activatedBy === 'manual' ? 'Manual' : 'Automatic') : 'N/A', inline: true },
+                    { name: 'Threshold', value: `${rd.threshold} joins / ${rd.windowSeconds}s`, inline: true },
+                    { name: 'Action', value: rd.action.toUpperCase(), inline: true },
+                    { name: 'Min Account Age', value: `${rd.minAccountAgeDays} days`, inline: true },
+                    { name: 'Auto-Disable', value: rd.autoDisable ? 'Yes' : 'No', inline: true },
+                    { name: 'Calm Window', value: `${rd.calmWindowSeconds}s`, inline: true },
+                    { name: 'Require Manual Disable', value: rd.requireManualDisable ? 'Yes' : 'No', inline: true }
+                );
+
+            if (isActive && activatedAt) {
+                embed.addFields({ name: 'Active Since', value: `<t:${Math.floor(new Date(activatedAt).getTime() / 1000)}:R>`, inline: true });
+            }
+
+            embed.setTimestamp();
             return interaction.reply({ embeds: [embed] });
         }
 

--- a/src/commands/utility/serverinfo.js
+++ b/src/commands/utility/serverinfo.js
@@ -1,4 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const Guild = require('../../models/Guild');
+const { raidModeActive, raidModeActivatedBy } = require('../../services/raidService');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -6,6 +8,20 @@ module.exports = {
         .setDescription('Display server stats: member count, channels, roles, boost level, and creation date.'),
     async execute(interaction) {
         const { guild } = interaction;
+
+        const guildSettings = await Guild.findOne({ guildId: guild.id }).catch(() => null);
+        const rd = guildSettings?.raidDetection;
+
+        let raidStatus = 'Detection disabled';
+        if (rd?.enabled) {
+            const isActive = raidModeActive.has(guild.id) || rd.raidModeActive;
+            if (isActive) {
+                const by = raidModeActivatedBy.get(guild.id) || rd.raidModeActivatedBy;
+                raidStatus = `🔴 ACTIVE (${by === 'manual' ? 'manual' : 'auto'})`;
+            } else {
+                raidStatus = `🟢 Monitoring (${rd.threshold} joins/${rd.windowSeconds}s)`;
+            }
+        }
 
         const embed = new EmbedBuilder()
             .setColor('#00ff00')
@@ -20,7 +36,8 @@ module.exports = {
                 { name: 'Roles', value: guild.roles.cache.size.toString(), inline: true },
                 { name: 'Created', value: `<t:${Math.floor(guild.createdTimestamp / 1000)}:R>`, inline: true },
                 { name: 'Boost Tier', value: `Tier ${guild.premiumTier}`, inline: true },
-                { name: 'Boosts', value: guild.premiumSubscriptionCount.toString(), inline: true }
+                { name: 'Boosts', value: guild.premiumSubscriptionCount.toString(), inline: true },
+                { name: 'Raid Mode', value: raidStatus, inline: true }
             )
             .setTimestamp();
 

--- a/src/index.js
+++ b/src/index.js
@@ -133,6 +133,9 @@ async function startBot() {
 
         const { startTempBanService } = require('./services/tempBanService');
         startTempBanService(client);
+
+        const { startRaidMonitor } = require('./services/raidService');
+        startRaidMonitor(client);
     });
 
     client.login(process.env.DISCORD_TOKEN);

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -269,7 +269,13 @@ const guildSchema = new Schema({
         },
         quarantineRoleId: { type: String, default: null },
         alertChannelId: { type: String, default: null },
-        caseIdCounter: { type: Number, default: 0, min: 0 }
+        caseIdCounter: { type: Number, default: 0, min: 0 },
+        autoDisable: { type: Boolean, default: true },
+        calmWindowSeconds: { type: Number, default: 300, min: 30 },
+        requireManualDisable: { type: Boolean, default: false },
+        raidModeActive: { type: Boolean, default: false },
+        raidModeActivatedBy: { type: String, enum: ['auto', 'manual', null], default: null },
+        raidModeActivatedAt: { type: Date, default: null }
     },
 
     antiNuke: {

--- a/src/services/raidService.js
+++ b/src/services/raidService.js
@@ -7,11 +7,30 @@ const Guild = require('../models/Guild');
 // store using sorted sets (ZADD/ZRANGEBYSCORE with TTL) for atomic, shared state.
 const joinLog = new Map();
 
+// Tracks which guilds are currently in active raid mode (in-memory mirror of DB field).
+const raidModeActive = new Set();
+// 'auto' | 'manual' per guild
+const raidModeActivatedBy = new Map();
+// Last join timestamp per guild (used for calm-window detection)
+const lastJoinTime = new Map();
+
 function pruneLog(guildId, windowMs) {
     const now = Date.now();
     const entries = (joinLog.get(guildId) || []).filter(e => now - e.timestamp < windowMs);
     joinLog.set(guildId, entries);
     return entries;
+}
+
+async function applyRaidAction(member, rd, minAccountAgeDays) {
+    const accountAgeDays = (Date.now() - member.user.createdTimestamp) / 86400000;
+    if (accountAgeDays >= minAccountAgeDays) return;
+
+    if (rd.action === 'kick' && member.kickable) {
+        await member.kick('[AutoMod] Raid mode active — new account').catch(console.error);
+    } else if (rd.action === 'quarantine' && rd.quarantineRoleId) {
+        const role = member.guild.roles.cache.get(rd.quarantineRoleId);
+        if (role) await member.roles.add(role).catch(console.error);
+    }
 }
 
 async function handleMemberJoin(member, client) {
@@ -37,12 +56,24 @@ async function handleMemberJoin(member, client) {
     const entries = pruneLog(guildId, windowMs);
     entries.push({ timestamp: Date.now(), userId: member.id, accountAgeDays });
     joinLog.set(guildId, entries);
+    lastJoinTime.set(guildId, Date.now());
 
+    // Sync in-memory state from DB on the first join we see for this guild after a restart
+    if (!raidModeActive.has(guildId) && rd.raidModeActive) {
+        raidModeActive.add(guildId);
+        raidModeActivatedBy.set(guildId, rd.raidModeActivatedBy || 'manual');
+    }
+
+    // If raid mode is already active, apply the configured action to every new join
+    if (raidModeActive.has(guildId)) {
+        await applyRaidAction(member, rd, minAccountAgeDays);
+        return;
+    }
+
+    // Not yet in raid mode — check whether the threshold has been exceeded
     if (entries.length < threshold) return;
 
-    // Raid triggered — clear log to avoid repeated triggers within same window
-    joinLog.set(guildId, []);
-
+    // Threshold crossed: auto-enable raid mode
     const alertChannelId = rd.alertChannelId || guildSettings.moderation?.logChannelId;
     const alertChannel = alertChannelId ? member.guild.channels.cache.get(alertChannelId) : null;
 
@@ -50,11 +81,14 @@ async function handleMemberJoin(member, client) {
 
     const embed = new EmbedBuilder()
         .setColor('#ff0000')
-        .setTitle('RAID DETECTED')
-        .setDescription(`**${entries.length}** members joined within **${rd.windowSeconds}s** (threshold: ${threshold})`)
+        .setTitle('⚠️ Raid Detected! Raid Mode Auto-Enabled')
+        .setDescription(
+            `**${entries.length}** members joined within **${rd.windowSeconds}s** (threshold: ${threshold})`
+        )
         .addFields(
             { name: 'New Accounts', value: `${newAccounts} joined with accounts < ${minAccountAgeDays} days old`, inline: true },
-            { name: 'Action', value: rd.action.toUpperCase(), inline: true }
+            { name: 'Action', value: rd.action.toUpperCase(), inline: true },
+            { name: 'Triggered By', value: 'Automatic', inline: true }
         )
         .setTimestamp();
 
@@ -62,6 +96,18 @@ async function handleMemberJoin(member, client) {
         await alertChannel.send({ embeds: [embed] }).catch(console.error);
     }
 
+    raidModeActive.add(guildId);
+    raidModeActivatedBy.set(guildId, 'auto');
+
+    await Guild.updateOne({ guildId }, {
+        $set: {
+            'raidDetection.raidModeActive': true,
+            'raidDetection.raidModeActivatedBy': 'auto',
+            'raidDetection.raidModeActivatedAt': new Date()
+        }
+    }).catch(console.error);
+
+    // Apply action to all members in the current window
     if (rd.action === 'kick' || rd.action === 'quarantine') {
         for (const entry of entries) {
             if (entry.accountAgeDays >= minAccountAgeDays) continue;
@@ -78,4 +124,119 @@ async function handleMemberJoin(member, client) {
     }
 }
 
-module.exports = { handleMemberJoin };
+// Called by /raidmode toggle to manually enable or disable raid mode.
+async function setRaidMode(guildId, guild, active, guildSettings) {
+    const rd = guildSettings.raidDetection;
+    const alertChannelId = rd.alertChannelId || guildSettings.moderation?.logChannelId;
+    const alertChannel = alertChannelId ? guild.channels.cache.get(alertChannelId) : null;
+
+    if (active) {
+        raidModeActive.add(guildId);
+        raidModeActivatedBy.set(guildId, 'manual');
+
+        await Guild.updateOne({ guildId }, {
+            $set: {
+                'raidDetection.raidModeActive': true,
+                'raidDetection.raidModeActivatedBy': 'manual',
+                'raidDetection.raidModeActivatedAt': new Date()
+            }
+        });
+
+        if (alertChannel) {
+            const embed = new EmbedBuilder()
+                .setColor('#ff9900')
+                .setTitle('🔒 Raid Mode Manually Enabled')
+                .setDescription('Raid mode has been manually enabled by a moderator.')
+                .setTimestamp();
+            await alertChannel.send({ embeds: [embed] }).catch(console.error);
+        }
+    } else {
+        raidModeActive.delete(guildId);
+        raidModeActivatedBy.delete(guildId);
+
+        await Guild.updateOne({ guildId }, {
+            $set: {
+                'raidDetection.raidModeActive': false,
+                'raidDetection.raidModeActivatedBy': null,
+                'raidDetection.raidModeActivatedAt': null
+            }
+        });
+
+        if (alertChannel) {
+            const embed = new EmbedBuilder()
+                .setColor('#00ff00')
+                .setTitle('🔓 Raid Mode Manually Disabled')
+                .setDescription('Raid mode has been manually disabled by a moderator.')
+                .setTimestamp();
+            await alertChannel.send({ embeds: [embed] }).catch(console.error);
+        }
+    }
+}
+
+// Periodic tick: auto-disable raid mode once the server calms down.
+function startRaidMonitor(client) {
+    setInterval(async () => {
+        if (raidModeActive.size === 0) return;
+
+        for (const guildId of [...raidModeActive]) {
+            // Never auto-disable a manually activated raid mode
+            if (raidModeActivatedBy.get(guildId) === 'manual') continue;
+
+            let guildSettings;
+            try {
+                guildSettings = await Guild.findOne({ guildId });
+            } catch (err) {
+                console.error(`[RaidService] DB error fetching guild ${guildId}:`, err);
+                continue;
+            }
+
+            if (!guildSettings?.raidDetection?.enabled) {
+                raidModeActive.delete(guildId);
+                raidModeActivatedBy.delete(guildId);
+                continue;
+            }
+
+            const rd = guildSettings.raidDetection;
+
+            if (!rd.autoDisable || rd.requireManualDisable) continue;
+
+            const calmWindowMs = (rd.calmWindowSeconds || 300) * 1000;
+            const last = lastJoinTime.get(guildId) || 0;
+
+            // Require silence for the full calm window before auto-disabling
+            if (Date.now() - last < calmWindowMs) continue;
+
+            // Also verify the window itself has fewer than 2 joins
+            const entries = pruneLog(guildId, calmWindowMs);
+            if (entries.length >= 2) continue;
+
+            raidModeActive.delete(guildId);
+            raidModeActivatedBy.delete(guildId);
+
+            await Guild.updateOne({ guildId }, {
+                $set: {
+                    'raidDetection.raidModeActive': false,
+                    'raidDetection.raidModeActivatedBy': null,
+                    'raidDetection.raidModeActivatedAt': null
+                }
+            }).catch(console.error);
+
+            const guild = client.guilds.cache.get(guildId);
+            if (!guild) continue;
+
+            const alertChannelId = rd.alertChannelId || guildSettings.moderation?.logChannelId;
+            const alertChannel = alertChannelId ? guild.channels.cache.get(alertChannelId) : null;
+
+            if (alertChannel) {
+                const embed = new EmbedBuilder()
+                    .setColor('#00ff00')
+                    .setTitle('✅ Raid Stopped — Raid Mode Auto-Disabled')
+                    .setDescription('Raid appears to have stopped. Raid mode auto-disabled.')
+                    .setTimestamp();
+                await alertChannel.send({ embeds: [embed] }).catch(console.error);
+            }
+        }
+    }, 60_000);
+}
+
+module.exports = { handleMemberJoin, startRaidMonitor, setRaidMode, raidModeActive, raidModeActivatedBy };


### PR DESCRIPTION
- raidService: track active raid state in-memory (synced to DB); on threshold breach auto-enable raid mode, alert the mod-log channel, and apply the configured action (alert/kick/quarantine) to all members in the current window and every subsequent join while active
- raidService: add startRaidMonitor() — 60-second tick that auto-disables raid mode once join rate drops below the calm-window threshold (configurable, defaults to < 2 joins in 300 s)
- raidService: add setRaidMode() helper for manual moderator override; manual activations are never auto-disabled
- Guild schema: extend raidDetection with autoDisable, calmWindowSeconds, requireManualDisable, raidModeActive, raidModeActivatedBy, raidModeActivatedAt
- raidmode command: new auto_disable / calm_window / require_manual_disable options on the 'raid' subcommand; new 'toggle' subcommand for manual on/off override; new 'status' subcommand showing current state
- serverinfo command: include live raid mode status (monitoring vs active, trigger source) in the server info embed
- index.js: start startRaidMonitor(client) on bot ready

https://claude.ai/code/session_01BZ3TGCEFw4ZQjo7gf2zU9C