### PR TITLE
Add warning auto-escalation system with configurable ladder

### DIFF
--- a/src/commands/admin/escalation.js
+++ b/src/commands/admin/escalation.js
@@ -1,0 +1,183 @@
+const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
+const Guild = require('../../models/Guild');
+const { simulate } = require('../../services/escalationService');
+
+const ACTION_CHOICES = [
+    { name: 'Mute (timeout)', value: 'mute' },
+    { name: 'Kick',           value: 'kick' },
+    { name: 'Ban (permanent)', value: 'ban' },
+    { name: 'Tempban',        value: 'tempban' }
+];
+
+function describeStep(step) {
+    let parts = [`**${step.threshold} warns →** ${step.action.toUpperCase()}`];
+    if (step.durationMinutes) parts.push(`${step.durationMinutes}m`);
+    parts.push(step.dmUser ? 'DM ✓' : 'DM ✗');
+    return parts.join(' · ');
+}
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('escalation')
+        .setDescription('Configure the warning auto-escalation ladder')
+        .addSubcommand(sub =>
+            sub.setName('list')
+                .setDescription('Show the current escalation ladder'))
+        .addSubcommand(sub =>
+            sub.setName('add')
+                .setDescription('Add or replace a step in the escalation ladder')
+                .addIntegerOption(o => o.setName('threshold').setDescription('Warning count that triggers this step').setMinValue(1).setRequired(true))
+                .addStringOption(o => o.setName('action').setDescription('Action to apply').setRequired(true).addChoices(...ACTION_CHOICES))
+                .addIntegerOption(o => o.setName('duration_minutes').setDescription('Duration in minutes (mute/tempban only)').setMinValue(1).setRequired(false))
+                .addBooleanOption(o => o.setName('dm_user').setDescription('DM the user when this fires (default: true)').setRequired(false))
+                .addStringOption(o => o.setName('reason').setDescription('Custom reason template (supports {count})').setRequired(false)))
+        .addSubcommand(sub =>
+            sub.setName('remove')
+                .setDescription('Remove a step from the ladder')
+                .addIntegerOption(o => o.setName('threshold').setDescription('Warning count of the step to remove').setMinValue(1).setRequired(true)))
+        .addSubcommand(sub =>
+            sub.setName('clear')
+                .setDescription('Remove every step from the ladder'))
+        .addSubcommand(sub =>
+            sub.setName('reset')
+                .setDescription('Reset the ladder to the default (3→mute10m, 5→mute1h, 7→kick, 10→ban)'))
+        .addSubcommand(sub =>
+            sub.setName('toggle')
+                .setDescription('Enable or disable auto-escalation')
+                .addBooleanOption(o => o.setName('enabled').setDescription('Enable auto-escalation').setRequired(true)))
+        .addSubcommand(sub =>
+            sub.setName('simulate')
+                .setDescription('Preview what would happen at a given warning count')
+                .addIntegerOption(o => o.setName('count').setDescription('Number of warnings to simulate').setMinValue(1).setRequired(true)))
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild),
+
+    async execute(interaction) {
+        const sub = interaction.options.getSubcommand();
+        const guildId = interaction.guild.id;
+
+        const guildSettings = await Guild.findOneAndUpdate(
+            { guildId },
+            { $setOnInsert: { guildId, name: interaction.guild.name } },
+            { upsert: true, new: true }
+        );
+        const escalation = guildSettings.moderation.escalation;
+
+        if (sub === 'list') {
+            const ladder = (escalation?.ladder || []).slice().sort((a, b) => a.threshold - b.threshold);
+            const embed = new EmbedBuilder()
+                .setColor('#5865F2')
+                .setTitle('Escalation Ladder')
+                .setDescription(ladder.length ? ladder.map(describeStep).join('\n') : '_No steps configured._')
+                .addFields({ name: 'Status', value: escalation?.enabled ? '✅ Enabled' : '❌ Disabled', inline: true })
+                .setTimestamp();
+            return interaction.reply({ embeds: [embed] });
+        }
+
+        if (sub === 'add') {
+            const threshold       = interaction.options.getInteger('threshold');
+            const action          = interaction.options.getString('action');
+            const durationMinutes = interaction.options.getInteger('duration_minutes');
+            const dmUserOpt       = interaction.options.getBoolean('dm_user');
+            const reasonOpt       = interaction.options.getString('reason');
+
+            if ((action === 'mute' || action === 'tempban') && !durationMinutes) {
+                return interaction.reply({
+                    content: `Action **${action}** requires \`duration_minutes\`.`,
+                    ephemeral: true
+                });
+            }
+            if (action === 'mute' && durationMinutes > 40320) {
+                return interaction.reply({ content: 'Mute duration cannot exceed 40320 minutes (28 days).', ephemeral: true });
+            }
+
+            const ladder = (escalation?.ladder || []).filter(s => s.threshold !== threshold);
+            ladder.push({
+                threshold,
+                action,
+                durationMinutes: (action === 'mute' || action === 'tempban') ? durationMinutes : null,
+                dmUser: dmUserOpt == null ? true : dmUserOpt,
+                reason: reasonOpt || 'Automatic escalation: {count} warnings reached'
+            });
+            ladder.sort((a, b) => a.threshold - b.threshold);
+
+            await Guild.updateOne({ guildId }, { $set: { 'moderation.escalation.ladder': ladder } });
+
+            return interaction.reply({
+                embeds: [new EmbedBuilder()
+                    .setColor('#00ff00')
+                    .setTitle('Escalation Step Saved')
+                    .setDescription(describeStep(ladder.find(s => s.threshold === threshold)))
+                    .setTimestamp()]
+            });
+        }
+
+        if (sub === 'remove') {
+            const threshold = interaction.options.getInteger('threshold');
+            const ladder = (escalation?.ladder || []).filter(s => s.threshold !== threshold);
+            if (ladder.length === (escalation?.ladder || []).length) {
+                return interaction.reply({ content: `No step found at threshold **${threshold}**.`, ephemeral: true });
+            }
+            await Guild.updateOne({ guildId }, { $set: { 'moderation.escalation.ladder': ladder } });
+            return interaction.reply({
+                embeds: [new EmbedBuilder()
+                    .setColor('#ff9900')
+                    .setTitle('Escalation Step Removed')
+                    .setDescription(`Removed step at threshold **${threshold}**.`)
+                    .setTimestamp()]
+            });
+        }
+
+        if (sub === 'clear') {
+            await Guild.updateOne({ guildId }, { $set: { 'moderation.escalation.ladder': [] } });
+            return interaction.reply({
+                embeds: [new EmbedBuilder()
+                    .setColor('#ff9900')
+                    .setTitle('Escalation Ladder Cleared')
+                    .setDescription('All steps have been removed.')
+                    .setTimestamp()]
+            });
+        }
+
+        if (sub === 'reset') {
+            const defaults = [
+                { threshold: 3,  action: 'mute', durationMinutes: 10,   dmUser: true, reason: 'Automatic escalation: {count} warnings reached' },
+                { threshold: 5,  action: 'mute', durationMinutes: 60,   dmUser: true, reason: 'Automatic escalation: {count} warnings reached' },
+                { threshold: 7,  action: 'kick', durationMinutes: null, dmUser: true, reason: 'Automatic escalation: {count} warnings reached' },
+                { threshold: 10, action: 'ban',  durationMinutes: null, dmUser: true, reason: 'Automatic escalation: {count} warnings reached' }
+            ];
+            await Guild.updateOne({ guildId }, { $set: { 'moderation.escalation.ladder': defaults } });
+            return interaction.reply({
+                embeds: [new EmbedBuilder()
+                    .setColor('#00ff00')
+                    .setTitle('Escalation Ladder Reset')
+                    .setDescription(defaults.map(describeStep).join('\n'))
+                    .setTimestamp()]
+            });
+        }
+
+        if (sub === 'toggle') {
+            const enabled = interaction.options.getBoolean('enabled');
+            await Guild.updateOne({ guildId }, { $set: { 'moderation.escalation.enabled': enabled } });
+            return interaction.reply({
+                embeds: [new EmbedBuilder()
+                    .setColor(enabled ? '#00ff00' : '#ff0000')
+                    .setTitle(`Auto-Escalation ${enabled ? 'Enabled' : 'Disabled'}`)
+                    .setTimestamp()]
+            });
+        }
+
+        if (sub === 'simulate') {
+            const count = interaction.options.getInteger('count');
+            const step = simulate(escalation?.ladder || [], count);
+            const embed = new EmbedBuilder()
+                .setColor(step ? '#cc3300' : '#888888')
+                .setTitle(`Simulation: ${count} warning(s)`)
+                .setDescription(step
+                    ? `Would trigger **${step.action.toUpperCase()}**${step.durationMinutes ? ` for ${step.durationMinutes} minute(s)` : ''}.\nReason: ${step.reason.replace(/\{count\}/g, count)}`
+                    : `No ladder step matches **${count}**. No auto-action would fire.`)
+                .setFooter({ text: escalation?.enabled ? 'Escalation is enabled.' : 'Escalation is currently disabled — nothing would actually fire.' })
+                .setTimestamp();
+            return interaction.reply({ embeds: [embed], ephemeral: true });
+        }
+    }
+};

--- a/src/commands/moderation/warn.js
+++ b/src/commands/moderation/warn.js
@@ -1,6 +1,8 @@
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
 const Case = require('../../models/Case');
 const { logModeration } = require('../../utils/logger');
+const { applyEscalation, findStepForCount } = require('../../services/escalationService');
+const Guild = require('../../models/Guild');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -10,7 +12,8 @@ module.exports = {
             sub.setName('add')
                 .setDescription('Issue a warning to a member')
                 .addUserOption(o => o.setName('user').setDescription('The user to warn').setRequired(true))
-                .addStringOption(o => o.setName('reason').setDescription('Reason for the warning').setRequired(true)))
+                .addStringOption(o => o.setName('reason').setDescription('Reason for the warning').setRequired(true))
+                .addBooleanOption(o => o.setName('bypass_escalation').setDescription('Suppress auto-escalation for this warning (requires Manage Messages)').setRequired(false)))
         .addSubcommand(sub =>
             sub.setName('list')
                 .setDescription('List all warnings for a member')
@@ -27,17 +30,26 @@ module.exports = {
         if (sub === 'add') {
             const user   = interaction.options.getUser('user');
             const reason = interaction.options.getString('reason');
+            const bypassRequested = interaction.options.getBoolean('bypass_escalation') === true;
 
             if (user.bot) return interaction.reply({ content: 'You cannot warn bots.', ephemeral: true });
 
             try {
-                await logModeration(interaction.guild.id, 'warn', user, interaction.user, reason);
+                const triggeringCase = await logModeration(interaction.guild.id, 'warn', user, interaction.user, reason);
 
                 const warningCount = await Case.countDocuments({
                     guildId: interaction.guild.id,
                     targetUserId: user.id,
                     type: 'warn'
                 });
+
+                const canBypass = interaction.memberPermissions?.has(PermissionFlagsBits.ManageMessages);
+                const bypassEscalation = bypassRequested && canBypass;
+
+                const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+                const matchedStep = !bypassEscalation
+                    ? findStepForCount(guildSettings?.moderation?.escalation?.ladder, warningCount)
+                    : null;
 
                 const embed = new EmbedBuilder()
                     .setColor('#ffff00')
@@ -50,8 +62,46 @@ module.exports = {
                     )
                     .setTimestamp();
 
+                if (bypassRequested && !canBypass) {
+                    embed.addFields({ name: 'Escalation Bypass', value: 'Requested but ignored — requires Manage Messages.' });
+                } else if (bypassEscalation && matchedStep === null) {
+                    embed.addFields({ name: 'Escalation', value: 'Bypassed (no matching step at this count anyway).' });
+                } else if (bypassEscalation) {
+                    embed.addFields({ name: 'Escalation', value: `Bypassed — would have triggered ${matchedStep?.action?.toUpperCase()} at ${warningCount} warnings.` });
+                }
+
                 await interaction.reply({ embeds: [embed] });
                 await user.send(`You have been warned in **${interaction.guild.name}** for: ${reason}`).catch(() => {});
+
+                if (!bypassEscalation && guildSettings?.moderation?.escalation?.enabled) {
+                    const result = await applyEscalation({
+                        guild: interaction.guild,
+                        targetUser: user,
+                        warningCount,
+                        triggeringCase,
+                        client: interaction.client
+                    });
+                    if (result?.applied) {
+                        await interaction.followUp({
+                            embeds: [new EmbedBuilder()
+                                .setColor('#cc3300')
+                                .setTitle('Auto-Escalation Triggered')
+                                .setDescription(`Threshold **${result.step.threshold}** reached — applied **${result.step.action.toUpperCase()}**${result.step.durationMinutes ? ` for ${result.step.durationMinutes} minute(s)` : ''}.`)
+                                .addFields({ name: 'Target', value: `${user.tag}`, inline: true })
+                                .setTimestamp()]
+                        }).catch(() => {});
+                    } else if (result?.skipped) {
+                        await interaction.followUp({
+                            content: `Auto-escalation step **${result.step.threshold} → ${result.step.action.toUpperCase()}** skipped: ${result.reason}`,
+                            ephemeral: true
+                        }).catch(() => {});
+                    } else if (result?.error) {
+                        await interaction.followUp({
+                            content: `Auto-escalation step **${result.step.threshold} → ${result.step.action.toUpperCase()}** failed — see logs.`,
+                            ephemeral: true
+                        }).catch(() => {});
+                    }
+                }
             } catch (error) {
                 console.error('Warn error:', error);
                 if (!interaction.replied) {

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -84,7 +84,25 @@ const guildSchema = new Schema({
         behaviorScoreBanAt: { type: Number, default: 30, min: 0 },
         behaviorScoreDecayDays: { type: Number, default: 7, min: 1 },
         appealsEnabled: { type: Boolean, default: false },
-        appealChannelId: { type: String, default: null }
+        appealChannelId: { type: String, default: null },
+        escalation: {
+            enabled: { type: Boolean, default: true },
+            ladder: {
+                type: [{
+                    threshold:       { type: Number, required: true, min: 1 },
+                    action:          { type: String, enum: ['mute', 'kick', 'ban', 'tempban'], required: true },
+                    durationMinutes: { type: Number, default: null, min: 1 },
+                    dmUser:          { type: Boolean, default: true },
+                    reason:          { type: String, default: 'Automatic escalation: {count} warnings reached' }
+                }],
+                default: () => [
+                    { threshold: 3,  action: 'mute',    durationMinutes: 10,   dmUser: true, reason: 'Automatic escalation: {count} warnings reached' },
+                    { threshold: 5,  action: 'mute',    durationMinutes: 60,   dmUser: true, reason: 'Automatic escalation: {count} warnings reached' },
+                    { threshold: 7,  action: 'kick',    durationMinutes: null, dmUser: true, reason: 'Automatic escalation: {count} warnings reached' },
+                    { threshold: 10, action: 'ban',     durationMinutes: null, dmUser: true, reason: 'Automatic escalation: {count} warnings reached' }
+                ]
+            }
+        }
     },
     
     leveling: {

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -26,6 +26,19 @@ function distinctChannelPersonaIds(personas) {
     return true;
 }
 
+function distinctLadderThresholds(ladder) {
+    if (!Array.isArray(ladder)) return true;
+
+    const seen = new Set();
+    for (const step of ladder) {
+        if (!step || step.threshold == null) continue;
+        if (seen.has(step.threshold)) return false;
+        seen.add(step.threshold);
+    }
+
+    return true;
+}
+
 const guildSchema = new Schema({
     guildId: { type: String, required: true, unique: true },
     name: { type: String, required: true },
@@ -91,7 +104,7 @@ const guildSchema = new Schema({
                 type: [{
                     threshold:       { type: Number, required: true, min: 1 },
                     action:          { type: String, enum: ['mute', 'kick', 'ban', 'tempban'], required: true },
-                    durationMinutes: { type: Number, default: null, min: 1 },
+                    durationMinutes: { type: Number, default: null, min: 1, max: 40320 },
                     dmUser:          { type: Boolean, default: true },
                     reason:          { type: String, default: 'Automatic escalation: {count} warnings reached' }
                 }],
@@ -100,7 +113,11 @@ const guildSchema = new Schema({
                     { threshold: 5,  action: 'mute',    durationMinutes: 60,   dmUser: true, reason: 'Automatic escalation: {count} warnings reached' },
                     { threshold: 7,  action: 'kick',    durationMinutes: null, dmUser: true, reason: 'Automatic escalation: {count} warnings reached' },
                     { threshold: 10, action: 'ban',     durationMinutes: null, dmUser: true, reason: 'Automatic escalation: {count} warnings reached' }
-                ]
+                ],
+                validate: {
+                    validator: distinctLadderThresholds,
+                    message: 'escalation.ladder contains duplicate threshold values.'
+                }
             }
         }
     },

--- a/src/services/escalationService.js
+++ b/src/services/escalationService.js
@@ -1,0 +1,134 @@
+const { EmbedBuilder } = require('discord.js');
+const Guild = require('../models/Guild');
+const Case = require('../models/Case');
+const TempBan = require('../models/TempBan');
+const { createCase } = require('./caseService');
+
+const MAX_TIMEOUT_MS = 28 * 24 * 60 * 60 * 1000;
+
+function findStepForCount(ladder, count) {
+    if (!Array.isArray(ladder) || ladder.length === 0) return null;
+    return ladder.find(step => step.threshold === count) || null;
+}
+
+function formatReason(template, count) {
+    if (!template) return `Automatic escalation: ${count} warnings reached`;
+    return template.replace(/\{count\}/g, String(count));
+}
+
+function simulate(ladder, count) {
+    return findStepForCount(ladder, count);
+}
+
+async function postAutoCaseLog(guild, guildSettings, embed) {
+    const channelId = guildSettings?.moderation?.logChannelId;
+    if (!channelId) return;
+    const channel = guild.channels.cache.get(channelId);
+    if (!channel) return;
+    await channel.send({ embeds: [embed] }).catch(() => {});
+}
+
+async function applyEscalation({ guild, targetUser, warningCount, triggeringCase, client }) {
+    const guildSettings = await Guild.findOne({ guildId: guild.id });
+    const escalation = guildSettings?.moderation?.escalation;
+    if (!escalation?.enabled) return null;
+
+    const step = findStepForCount(escalation.ladder, warningCount);
+    if (!step) return null;
+
+    const reason = formatReason(step.reason, warningCount);
+    const botUser = client.user;
+    const member = await guild.members.fetch(targetUser.id).catch(() => null);
+    let actionTaken = step.action;
+    let durationMs = step.durationMinutes ? step.durationMinutes * 60 * 1000 : null;
+
+    if (step.dmUser) {
+        await targetUser.send(
+            `You have been auto-${step.action}${durationMs ? `ed for ${step.durationMinutes} minute(s)` : (step.action.endsWith('e') ? 'd' : 'ed')} in **${guild.name}**: ${reason}`
+        ).catch(() => {});
+    }
+
+    try {
+        if (step.action === 'mute') {
+            if (!member || !member.moderatable) {
+                return { skipped: true, reason: 'Member not present or not moderatable.', step };
+            }
+            const timeoutMs = Math.min(durationMs ?? MAX_TIMEOUT_MS, MAX_TIMEOUT_MS);
+            await member.timeout(timeoutMs, reason);
+        } else if (step.action === 'kick') {
+            if (!member || !member.kickable) {
+                return { skipped: true, reason: 'Member not present or not kickable.', step };
+            }
+            await member.kick(reason);
+        } else if (step.action === 'ban') {
+            if (member && !member.bannable) {
+                return { skipped: true, reason: 'Member not bannable.', step };
+            }
+            await guild.members.ban(targetUser.id, { reason });
+        } else if (step.action === 'tempban') {
+            if (member && !member.bannable) {
+                return { skipped: true, reason: 'Member not bannable.', step };
+            }
+            if (!durationMs) {
+                return { skipped: true, reason: 'tempban step missing duration.', step };
+            }
+            await TempBan.findOneAndUpdate(
+                { guildId: guild.id, userId: targetUser.id },
+                { moderatorId: botUser.id, reason, expiresAt: new Date(Date.now() + durationMs) },
+                { upsert: true }
+            );
+            await guild.members.ban(targetUser.id, { reason });
+        }
+    } catch (err) {
+        console.error(`[ESCALATION] Failed to apply ${step.action} for ${targetUser.id} in ${guild.id}:`, err);
+        return { error: true, step };
+    }
+
+    const caseType = step.action === 'tempban' ? 'ban' : step.action;
+    const newCase = await createCase({
+        guildId: guild.id,
+        type: caseType,
+        targetUserId: targetUser.id,
+        moderatorId: botUser.id,
+        reason,
+        duration: durationMs ? Math.round(durationMs / 60000) : null
+    });
+
+    const embed = new EmbedBuilder()
+        .setColor('#cc3300')
+        .setTitle(`AutoMod | ${step.action.toUpperCase()} | ${targetUser.tag}`)
+        .setDescription(`Triggered by warning threshold **${step.threshold}** (user reached **${warningCount}** active warnings).`)
+        .addFields(
+            { name: 'User', value: `${targetUser.tag} (${targetUser.id})`, inline: true },
+            { name: 'Moderator', value: `${botUser.tag} (AutoMod)`, inline: true },
+            { name: 'Action', value: step.action.toUpperCase(), inline: true },
+            { name: 'Reason', value: reason }
+        )
+        .setTimestamp();
+
+    if (durationMs) {
+        embed.addFields({ name: 'Duration', value: `${step.durationMinutes} minute(s)`, inline: true });
+    }
+    if (triggeringCase?.caseId && triggeringCase.guildId) {
+        embed.addFields({ name: 'Triggering Warning', value: `Case #${triggeringCase.caseId}`, inline: true });
+    }
+    if (newCase?.caseId) {
+        embed.addFields({ name: 'Auto Case', value: `Case #${newCase.caseId}`, inline: true });
+    }
+
+    await postAutoCaseLog(guild, guildSettings, embed);
+
+    return { applied: true, step, actionTaken, autoCase: newCase };
+}
+
+async function countActiveWarnings(guildId, userId) {
+    return Case.countDocuments({ guildId, targetUserId: userId, type: 'warn' });
+}
+
+module.exports = {
+    applyEscalation,
+    simulate,
+    findStepForCount,
+    countActiveWarnings,
+    formatReason
+};

--- a/src/services/escalationService.js
+++ b/src/services/escalationService.js
@@ -6,6 +6,13 @@ const { createCase } = require('./caseService');
 
 const MAX_TIMEOUT_MS = 28 * 24 * 60 * 60 * 1000;
 
+const ACTION_PAST_TENSE = {
+    mute:    'muted',
+    kick:    'kicked',
+    ban:     'banned',
+    tempban: 'temporarily banned'
+};
+
 function findStepForCount(ladder, count) {
     if (!Array.isArray(ladder) || ladder.length === 0) return null;
     return ladder.find(step => step.threshold === count) || null;
@@ -43,8 +50,10 @@ async function applyEscalation({ guild, targetUser, warningCount, triggeringCase
     let durationMs = step.durationMinutes ? step.durationMinutes * 60 * 1000 : null;
 
     if (step.dmUser) {
+        const actionPast = ACTION_PAST_TENSE[step.action] || step.action;
+        const durationSuffix = durationMs ? ` for ${step.durationMinutes} minute(s)` : '';
         await targetUser.send(
-            `You have been auto-${step.action}${durationMs ? `ed for ${step.durationMinutes} minute(s)` : (step.action.endsWith('e') ? 'd' : 'ed')} in **${guild.name}**: ${reason}`
+            `You have been auto-${actionPast}${durationSuffix} in **${guild.name}**: ${reason}`
         ).catch(() => {});
     }
 
@@ -61,6 +70,7 @@ async function applyEscalation({ guild, targetUser, warningCount, triggeringCase
             }
             await member.kick(reason);
         } else if (step.action === 'ban') {
+            // member may be null if the user already left — Discord allows ban-by-ID.
             if (member && !member.bannable) {
                 return { skipped: true, reason: 'Member not bannable.', step };
             }
@@ -121,7 +131,7 @@ async function applyEscalation({ guild, targetUser, warningCount, triggeringCase
     return { applied: true, step, actionTaken, autoCase: newCase };
 }
 
-async function countActiveWarnings(guildId, userId) {
+async function countWarnings(guildId, userId) {
     return Case.countDocuments({ guildId, targetUserId: userId, type: 'warn' });
 }
 
@@ -129,6 +139,6 @@ module.exports = {
     applyEscalation,
     simulate,
     findStepForCount,
-    countActiveWarnings,
+    countWarnings,
     formatReason
 };

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -38,7 +38,7 @@ async function logModeration(guildId, action, target, moderator, reason, options
         }
 
         // Persist as a Case record
-        await createCase({
+        const newCase = await createCase({
             guildId,
             type: action,
             targetUserId: target.id,
@@ -47,8 +47,10 @@ async function logModeration(guildId, action, target, moderator, reason, options
             evidence: options.evidence || null,
             duration: options.duration || null
         });
+        return newCase;
     } catch (error) {
         console.error('Logger error:', error);
+        return null;
     }
 }
 


### PR DESCRIPTION
## Summary
Implements a comprehensive warning auto-escalation system that automatically applies moderation actions (mute, kick, ban, tempban) when users reach configured warning thresholds. Includes admin commands to manage the escalation ladder and a bypass mechanism for moderators.

## Key Changes

- **New Escalation Service** (`src/services/escalationService.js`)
  - `applyEscalation()`: Executes configured actions when warning thresholds are reached
  - `simulate()`: Previews what action would trigger at a given warning count
  - `countActiveWarnings()`: Counts active warnings for a user
  - Handles DM notifications, case logging, and temp ban scheduling
  - Gracefully handles permission/member availability issues

- **New Admin Command** (`src/commands/admin/escalation.js`)
  - `list`: Display current escalation ladder and status
  - `add`: Create/modify escalation steps with custom actions, durations, and reasons
  - `remove`: Delete specific steps from the ladder
  - `clear`: Remove all steps
  - `reset`: Restore default ladder (3→mute10m, 5→mute1h, 7→kick, 10→ban)
  - `toggle`: Enable/disable auto-escalation globally
  - `simulate`: Preview actions for a given warning count
  - Validates duration constraints (mute max 28 days, required for mute/tempban)

- **Enhanced Warning Command** (`src/commands/moderation/warn.js`)
  - Added `bypass_escalation` option (requires Manage Messages permission)
  - Triggers escalation automatically after warning is logged
  - Displays escalation status in response (applied, bypassed, or skipped)
  - Sends follow-up notifications for escalation results

- **Database Schema Updates** (`src/models/Guild.js`)
  - Added `moderation.escalation` object with:
    - `enabled`: Boolean flag for the system
    - `ladder`: Array of escalation steps with threshold, action, duration, DM flag, and custom reason template
    - Default ladder pre-configured with sensible values

- **Logger Enhancement** (`src/utils/logger.js`)
  - `logModeration()` now returns the created Case object for escalation triggering

## Notable Implementation Details

- Escalation steps match on exact warning count (e.g., step at threshold 5 fires when user reaches exactly 5 warnings)
- Reason templates support `{count}` placeholder for dynamic warning count insertion
- Auto-escalation creates audit cases linked to the triggering warning
- Comprehensive error handling with skip/error reporting when actions fail
- Respects Discord's 28-day timeout limit for mute actions
- Temp bans are scheduled via TempBan model for later processing
- All escalation actions are logged to the moderation log channel with detailed embeds

https://claude.ai/code/session_01MyhuCZftZpNzzemyCPrJHv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added `/escalation` admin command to manage warning auto-escalation ladder with subcommands to list, add, remove, clear, reset steps, toggle status, and simulate outcomes.
- `/warn add` command now includes optional `bypass_escalation` option to suppress auto-escalation for individual warnings.
- Auto-escalation system now applies moderation actions based on configurable warning thresholds.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/Ultrabot/pull/147)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->