### PR TITLE
feat: tie streak to coin/XP earn multiplier (issue #126)

### DIFF
--- a/src/commands/community/streak.js
+++ b/src/commands/community/streak.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const User = require('../../models/User');
+const { getStreakMultiplier, getNextMultiplierTier, getNextMilestone } = require('../../utils/streakMultiplier');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -29,6 +30,19 @@ module.exports = {
         const flameEmoji = current >= 30 ? '🔥🔥🔥' : current >= 14 ? '🔥🔥' : current >= 7 ? '🔥' : '❄️';
         const status = isActive ? '✅ Active' : '⚠️ At risk — send a message to keep it!';
 
+        const multiplier = getStreakMultiplier(current);
+        const nextTier = getNextMultiplierTier(current);
+        const nextMilestone = getNextMilestone(current);
+        const multiplierText = multiplier > 1.0
+            ? `🔥 **${multiplier}x** coins and XP`
+            : '1.0x (reach 7 days for a bonus!)';
+        const nextTierText = nextTier
+            ? `Keep going! **${nextTier.days - current}** more day${nextTier.days - current !== 1 ? 's' : ''} for **${nextTier.multiplier}x**`
+            : '🏆 Maximum multiplier reached!';
+        const nextMilestoneText = nextMilestone
+            ? `**${nextMilestone.days}** days — ${nextMilestone.coins.toLocaleString()} coins + **${nextMilestone.badge}** badge`
+            : '✅ All milestones claimed!';
+
         const embed = new EmbedBuilder()
             .setColor(current >= 7 ? '#ff6600' : '#5865F2')
             .setTitle(`${flameEmoji} ${target.displayName}'s Streak`)
@@ -36,7 +50,10 @@ module.exports = {
             .addFields(
                 { name: 'Current Streak', value: `**${current}** day${current !== 1 ? 's' : ''}`, inline: true },
                 { name: 'Longest Streak', value: `**${longest}** day${longest !== 1 ? 's' : ''}`, inline: true },
-                { name: 'Status', value: status, inline: true }
+                { name: 'Status', value: status, inline: true },
+                { name: '⚡ Multiplier', value: multiplierText, inline: true },
+                { name: '📈 Next Multiplier', value: nextTierText, inline: false },
+                { name: '🎁 Next Reward Milestone', value: nextMilestoneText, inline: false }
             )
             .setFooter({ text: 'Send at least one message per day to keep your streak' })
             .setTimestamp();

--- a/src/commands/economy/balance.js
+++ b/src/commands/economy/balance.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const User = require('../../models/User');
 const { pruneEffects, EFFECT_CONFIGS, timeRemaining } = require('../../services/effectsService');
+const { getStreakMultiplier } = require('../../utils/streakMultiplier');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -23,6 +24,12 @@ module.exports = {
             // Prune expired effects before displaying
             pruneEffects(user);
 
+            const streakMult = getStreakMultiplier(user.streak?.current ?? 0);
+            const streakDays = user.streak?.current ?? 0;
+            const streakInfo = streakMult > 1.0
+                ? `🔥 ${streakDays}-day streak · **${streakMult}x** coins & XP`
+                : `❄️ ${streakDays}-day streak · 1.0x (7 days for bonus)`;
+
             const embed = new EmbedBuilder()
                 .setColor('#00ff00')
                 .setTitle(`${targetUser.username}'s Balance`)
@@ -30,7 +37,8 @@ module.exports = {
                 .addFields(
                     { name: '💰 Wallet', value: `${user.balance.toLocaleString()} coins`, inline: true },
                     { name: '🏦 Bank',   value: `${user.bank.toLocaleString()} coins`,    inline: true },
-                    { name: '💎 Total',  value: `${(user.balance + user.bank).toLocaleString()} coins`, inline: true }
+                    { name: '💎 Total',  value: `${(user.balance + user.bank).toLocaleString()} coins`, inline: true },
+                    { name: '⚡ Streak Bonus', value: streakInfo, inline: false }
                 )
                 .setTimestamp();
 

--- a/src/commands/economy/crime.js
+++ b/src/commands/economy/crime.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { hasEffect, consumeEffect } = require('../../services/effectsService');
+const { getStreakMultiplier } = require('../../utils/streakMultiplier');
 
 const COOLDOWN_MS      = 4 * 3_600_000; // 4 hours
 const WANTED_MS        = 1 * 3_600_000; // 1 hour wanted cooldown after death
@@ -68,17 +69,20 @@ module.exports = {
         const success = Math.random() < successChance;
         user.lastCrime = new Date();
 
+        const streakMult = getStreakMultiplier(user.streak?.current ?? 0);
         try {
             let embed;
             if (success) {
-                const earned = Math.floor(crime.minPayout + Math.random() * (crime.maxPayout - crime.minPayout));
+                const baseEarned = Math.floor(crime.minPayout + Math.random() * (crime.maxPayout - crime.minPayout));
+                const earned = Math.round(baseEarned * streakMult);
                 user.balance += earned;
                 await user.save();
 
+                const streakLine = streakMult > 1.0 ? `\n> 🔥 *${streakMult}x streak bonus applied!*` : '';
                 embed = new EmbedBuilder()
                     .setColor('#f39c12')
                     .setTitle(`${crime.emoji} Crime Pays — This Time`)
-                    .setDescription(`Your attempt at **${crime.name}** was a success! You pocketed **${currency}${earned.toLocaleString()}**.${luckyActive ? '\n> 🍀 *Lucky Charm boosted your success chance!*' : ''}`)
+                    .setDescription(`Your attempt at **${crime.name}** was a success! You pocketed **${currency}${earned.toLocaleString()}**.${luckyActive ? '\n> 🍀 *Lucky Charm boosted your success chance!*' : ''}${streakLine}`)
                     .addFields({ name: 'Balance', value: `${currency}${user.balance.toLocaleString()}`, inline: true })
                     .setFooter({ text: 'Crimes can be committed every 4 hours' })
                     .setTimestamp();

--- a/src/commands/economy/daily.js
+++ b/src/commands/economy/daily.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const User = require('../../models/User');
 const Guild = require('../../models/Guild');
+const { getStreakMultiplier } = require('../../utils/streakMultiplier');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -34,14 +35,20 @@ module.exports = {
             }
 
             const dailyAmount = guildSettings?.economy.dailyAmount || 100;
-            user.balance += dailyAmount;
+            const streakMult = getStreakMultiplier(user.streak?.current ?? 0);
+            const actualAmount = Math.round(dailyAmount * streakMult);
+            user.balance += actualAmount;
             user.lastDaily = new Date();
             await user.save();
+
+            const streakLine = streakMult > 1.0
+                ? `\n🔥 **${streakMult}x streak bonus** applied!`
+                : '';
 
             const embed = new EmbedBuilder()
                 .setColor('#00ff00')
                 .setTitle('Daily Reward Claimed!')
-                .setDescription(`You received **${dailyAmount}** coins!`)
+                .setDescription(`You received **${actualAmount.toLocaleString()}** coins!${streakLine}`)
                 .addFields(
                     { name: 'New Balance', value: `${user.balance.toLocaleString()} coins` }
                 )

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
+const { getStreakMultiplier } = require('../../utils/streakMultiplier');
 
 const COOLDOWN_MS = 2 * 3_600_000; // 2 hours
 
@@ -61,19 +62,22 @@ module.exports = {
         try {
             const ore = roll();
             const qty = quantity();
-            const earned = ore.payout * qty;
+            const baseEarned = ore.payout * qty;
+            const streakMult = getStreakMultiplier(user.streak?.current ?? 0);
+            const earned = Math.round(baseEarned * streakMult);
 
             user.balance += earned;
             user.lastMine = new Date();
             await user.save();
 
+            const streakLabel = streakMult > 1.0 ? ` *(🔥 ${streakMult}x)*` : '';
             const embed = new EmbedBuilder()
                 .setColor(ore.payout >= 600 ? '#f39c12' : ore.payout >= 200 ? '#2ecc71' : '#7f8c8d')
                 .setTitle(`${ore.emoji} Mining Results`)
                 .setDescription(
                     qty > 1
-                        ? `You struck **${qty}x ${ore.name}** and earned **${currency}${earned.toLocaleString()}**!`
-                        : `You found **${ore.name}** and earned **${currency}${earned.toLocaleString()}**!`
+                        ? `You struck **${qty}x ${ore.name}** and earned **${currency}${earned.toLocaleString()}**!${streakLabel}`
+                        : `You found **${ore.name}** and earned **${currency}${earned.toLocaleString()}**!${streakLabel}`
                 )
                 .addFields(
                     { name: 'Ore', value: `${ore.emoji} ${ore.name} ×${qty}`, inline: true },

--- a/src/commands/economy/work.js
+++ b/src/commands/economy/work.js
@@ -3,6 +3,7 @@ const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const DEFAULT_JOBS = require('../../data/defaultJobs');
 const DEFAULT_TIERS = require('../../data/defaultTiers');
+const { getStreakMultiplier } = require('../../utils/streakMultiplier');
 
 function resolveTiers(guildSettings) {
     const saved = guildSettings?.jobTiers;
@@ -77,7 +78,9 @@ module.exports = {
             const basePay = Math.floor(Math.random() * (maxPay - minPay + 1)) + minPay;
 
             const performance = rollPerformance();
-            const earned = Math.max(1, Math.floor(basePay * performance.multiplier));
+            const basedEarned = Math.max(1, Math.floor(basePay * performance.multiplier));
+            const streakMult = getStreakMultiplier(user.streak?.current ?? 0);
+            const earned = Math.round(basedEarned * streakMult);
 
             const jobLabel = job.emoji ? `${job.emoji} ${job.name}` : job.name;
             const scenario = WORK_SCENARIOS[Math.floor(Math.random() * WORK_SCENARIOS.length)]
@@ -91,12 +94,13 @@ module.exports = {
             const promotedTo = tierInfo.find(t => t.minShifts === user.shiftsWorked);
             const currency = guildSettings?.economy?.currency || '💰';
 
+            const streakLabel = streakMult > 1.0 ? ` *(🔥 ${streakMult}x streak)*` : '';
             const embed = new EmbedBuilder()
                 .setColor(performance.color)
                 .setTitle(`${performance.label} — Work Complete!`)
                 .setDescription(scenario)
                 .addFields(
-                    { name: 'Earned',       value: `${currency} **${earned.toLocaleString()}** coins`, inline: true },
+                    { name: 'Earned',       value: `${currency} **${earned.toLocaleString()}** coins${streakLabel}`, inline: true },
                     { name: 'Performance',  value: performance.label, inline: true },
                     { name: 'Career Tier',  value: `${userTier.name} · ${user.shiftsWorked.toLocaleString()} shifts`, inline: false },
                     {

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -4,6 +4,8 @@ const Case = require('../models/Case');
 const { handleAIChat } = require('../services/aiService');
 const { logModeration } = require('../utils/logger');
 const { ensureQuests, onMessage, notifyQuestComplete } = require('../services/questService');
+const { getStreakMultiplier, checkNewMilestones } = require('../utils/streakMultiplier');
+const { hasEffect, consumeEffect } = require('../services/effectsService');
 
 const BASE_BAD_WORDS = [
     'nigger', 'nigga', 'faggot', 'fag', 'retard', 'chink', 'spic', 'kike',
@@ -119,12 +121,17 @@ async function handleStreakAndQuests(message, guildSettings) {
 
         // Streak logic
         const lastActive = user.streak?.lastActive;
+        let shieldActivated = false;
         if (lastActive) {
             const lastDay = lastActive.toISOString().slice(0, 10);
             if (lastDay !== todayUTC) {
                 const msAgo = now - lastActive;
                 if (msAgo < 172800000) { // within 48h = streak continues
                     user.streak.current = (user.streak.current || 0) + 1;
+                } else if (hasEffect(user, 'streak_shield')) {
+                    consumeEffect(user, 'streak_shield');
+                    user.streak.current = (user.streak.current || 0) + 1;
+                    shieldActivated = true;
                 } else {
                     user.streak.current = 1; // broken
                 }
@@ -132,7 +139,15 @@ async function handleStreakAndQuests(message, guildSettings) {
                 user.streak.lastActive = now;
             }
         } else {
-            user.streak = { current: 1, longest: 1, lastActive: now };
+            user.streak = { current: 1, longest: 1, lastActive: now, claimedMilestones: [] };
+        }
+
+        // Milestone rewards
+        const newMilestones = checkNewMilestones(user);
+        for (const milestone of newMilestones) {
+            user.balance += milestone.coins;
+            if (!user.streak.claimedMilestones) user.streak.claimedMilestones = [];
+            user.streak.claimedMilestones.push(milestone.days);
         }
 
         // Daily message counter for raider track
@@ -151,6 +166,21 @@ async function handleStreakAndQuests(message, guildSettings) {
         await user.save();
 
         await notifyQuestComplete(guildSettings, message.member, completedQuests, message.channel);
+
+        if (shieldActivated) {
+            await message.channel.send(
+                `🔥🛡️ <@${message.author.id}> Your **Streak Shield** protected your streak! (consumed)`
+            ).catch(() => {});
+        }
+
+        for (const milestone of newMilestones) {
+            const multiplier = getStreakMultiplier(user.streak.current);
+            await message.channel.send(
+                `🔥 <@${message.author.id}> **${milestone.days}-day streak milestone!** ` +
+                `You earned **${milestone.coins.toLocaleString()} coins** and the **${milestone.badge}** badge! ` +
+                `You're now earning **${multiplier}x** coins and XP.`
+            ).catch(() => {});
+        }
     } catch (err) {
         console.error('Streak/quest error:', err);
     }
@@ -185,6 +215,9 @@ async function handleLeveling(message, guildSettings) {
             }
         }
     }
+
+    // Streak multiplier
+    if (user) xpGain *= getStreakMultiplier(user.streak?.current ?? 0);
     xpGain = Math.floor(xpGain);
 
     if (user) {

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -128,7 +128,7 @@ async function handleStreakAndQuests(message, guildSettings) {
                 const msAgo = now - lastActive;
                 if (msAgo < 172800000) { // within 48h = streak continues
                     user.streak.current = (user.streak.current || 0) + 1;
-                } else if (hasEffect(user, 'streak_shield')) {
+                } else if (msAgo <= 259200000 && hasEffect(user, 'streak_shield')) { // 48–72h: one missed day, shield applies
                     consumeEffect(user, 'streak_shield');
                     user.streak.current = (user.streak.current || 0) + 1;
                     shieldActivated = true;
@@ -216,8 +216,18 @@ async function handleLeveling(message, guildSettings) {
         }
     }
 
-    // Streak multiplier
-    if (user) xpGain *= getStreakMultiplier(user.streak?.current ?? 0);
+    // Streak multiplier — anticipate today's streak increment so the multiplier
+    // reflects the updated streak even though handleStreakAndQuests runs after this.
+    if (user) {
+        const lastActive = user.streak?.lastActive;
+        const todayUTC = new Date().toISOString().slice(0, 10);
+        let effectiveStreak = user.streak?.current ?? 0;
+        if (lastActive && lastActive.toISOString().slice(0, 10) !== todayUTC) {
+            const msAgo = Date.now() - lastActive.getTime();
+            effectiveStreak = msAgo < 172800000 ? effectiveStreak + 1 : 1;
+        }
+        xpGain *= getStreakMultiplier(effectiveStreak);
+    }
     xpGain = Math.floor(xpGain);
 
     if (user) {

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -40,7 +40,8 @@ const userSchema = new Schema({
     streak: {
         current: { type: Number, default: 0 },
         longest: { type: Number, default: 0 },
-        lastActive: { type: Date, default: null }
+        lastActive: { type: Date, default: null },
+        claimedMilestones: [{ type: Number }]
     },
 
     // Quest progress: each entry tracks one quest instance

--- a/src/services/effectsService.js
+++ b/src/services/effectsService.js
@@ -8,6 +8,7 @@ const EFFECT_CONFIGS = {
     knife:              { label: 'Knife',              emoji: '🔪',  durationMs: null,            charges: -1 },
     robbery_bag:        { label: 'Robbery Bag',        emoji: '💼',  durationMs: null,            charges: -1 },
     finders_fee:        { label: "Finder's Fee",       emoji: '💸',  durationMs: null,            charges: -1 },
+    streak_shield:      { label: 'Streak Shield',      emoji: '🔥🛡️', durationMs: null,           charges: 1  },
 };
 
 // Maps item names (as stored in inventory) to effect type keys
@@ -21,6 +22,7 @@ const ITEM_TO_EFFECT = {
     'robbery bag':        'robbery_bag',
     "finder's fee":       'finders_fee',
     'finders fee':        'finders_fee',
+    'streak shield':      'streak_shield',
 };
 
 function resolveEffectType(itemName) {

--- a/src/services/fishService.js
+++ b/src/services/fishService.js
@@ -15,6 +15,7 @@ const {
     FAILURE_SEVERITIES,
     FISH_QUEST_TEMPLATES
 } = require('../data/fishData');
+const { getStreakMultiplier } = require('../utils/streakMultiplier');
 
 const DAILY_QUEST_COUNT = 3;
 
@@ -495,9 +496,10 @@ function executeCast(user, locationId) {
         const catchType = rollCatchType(location);
         result.catchType = catchType;
 
+        const streakMult = getStreakMultiplier(user.streak?.current ?? 0);
         if (catchType === 'junk') {
             const junk         = weightedRoll(JUNK_ITEMS);
-            const payout       = randInt(junk.payoutMin, junk.payoutMax);
+            const payout       = Math.round(randInt(junk.payoutMin, junk.payoutMax) * streakMult);
             const { adjustedPayout, cappedByHard } = applyPayoutModifiers(user, payout, location);
 
             applyDurabilityLoss(rod, 1);
@@ -509,6 +511,7 @@ function executeCast(user, locationId) {
 
             let xpGain = 2;
             if (f.activeXpScroll) xpGain = Math.round(xpGain * 1.5);
+            xpGain = Math.round(xpGain * streakMult);
             const lvResult = applyXp(user, xpGain);
 
             Object.assign(result, {
@@ -520,7 +523,7 @@ function executeCast(user, locationId) {
 
         } else if (catchType === 'treasure') {
             const treasure     = weightedRoll(TREASURE_ITEMS);
-            const payout       = randInt(treasure.payoutMin, treasure.payoutMax);
+            const payout       = Math.round(randInt(treasure.payoutMin, treasure.payoutMax) * streakMult);
             const { adjustedPayout, cappedByHard } = applyPayoutModifiers(user, payout, location);
 
             applyDurabilityLoss(rod, 1);
@@ -533,6 +536,7 @@ function executeCast(user, locationId) {
 
             let xpGain = 15;
             if (f.activeXpScroll) xpGain = Math.round(xpGain * 1.5);
+            xpGain = Math.round(xpGain * streakMult);
             const lvResult = applyXp(user, xpGain);
 
             Object.assign(result, {
@@ -575,7 +579,7 @@ function executeCast(user, locationId) {
             const critChance     = calculateCritChance(user);
             const isCrit         = Math.random() < critChance;
             const critMultiplier = isCrit ? (1.5 + Math.random() * 1.0) : 1.0;
-            const preModPayout   = Math.round(sizedPayout * critMultiplier);
+            const preModPayout   = Math.round(sizedPayout * critMultiplier * streakMult);
 
             const { adjustedPayout, cappedByHard } = applyPayoutModifiers(user, preModPayout, location);
 
@@ -592,6 +596,7 @@ function executeCast(user, locationId) {
             let xpGain = fish.xp;
             if (isCrit) xpGain = Math.round(xpGain * 1.5);
             if (f.activeXpScroll) xpGain = Math.round(xpGain * 1.5);
+            xpGain = Math.round(xpGain * streakMult);
 
             applyDurabilityLoss(rod, 1);
             result.durabilityLost = 1;

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -13,6 +13,7 @@ const {
     HUNT_QUEST_TEMPLATES
 } = require('../data/huntData');
 const { hasEffect, consumeEffect } = require('./effectsService');
+const { getStreakMultiplier } = require('../utils/streakMultiplier');
 
 // Zones where a critical failure can destroy your weapon (death event)
 const DANGEROUS_ZONE_IDS = new Set(['desert_wastes', 'arctic_tundra', 'murky_swamp', 'legendary_peaks']);
@@ -628,7 +629,8 @@ function executeHunt(user, zoneId) {
         const isCrit         = Math.random() < critChance;
         const critMultiplier = isCrit ? (1.5 + Math.random() * 1.0) : 1.0;
 
-        const payoutBeforeMods = Math.round(rawPayout * critMultiplier);
+        const streakMult = getStreakMultiplier(user.streak?.current ?? 0);
+        const payoutBeforeMods = Math.round(rawPayout * critMultiplier * streakMult);
         const { adjustedPayout, cappedByHard } = applyPayoutModifiers(user, payoutBeforeMods, zone);
 
         // Special drop
@@ -645,6 +647,7 @@ function executeHunt(user, zoneId) {
         let xpGain = animal.xp;
         if (isCrit) xpGain = Math.round(xpGain * 1.5);
         if (h.activeXpScroll) xpGain = Math.round(xpGain * 1.5);
+        xpGain = Math.round(xpGain * streakMult);
 
         // Durability (-1 on success)
         applyDurabilityLoss(weapon, 1);

--- a/src/services/questService.js
+++ b/src/services/questService.js
@@ -1,5 +1,6 @@
 const User = require('../models/User');
 const Guild = require('../models/Guild');
+const { getStreakMultiplier } = require('../utils/streakMultiplier');
 
 // difficulty → reward multiplier
 const DIFFICULTY_MULTIPLIERS = { easy: 1, medium: 1.75, hard: 3 };
@@ -149,12 +150,13 @@ async function incrementQuest(user, questId, amount = 1) {
 async function awardQuest(user, questDef, guildSettings) {
     const isDaily = DAILY_QUEST_POOL.some(d => d.questId === questDef.questId);
     const mult = DIFFICULTY_MULTIPLIERS[questDef.difficulty] ?? 1;
+    const streakMult = getStreakMultiplier(user.streak?.current ?? 0);
 
     const baseXp    = isDaily ? (guildSettings?.quests?.dailyXpReward    ?? 50)  : (guildSettings?.quests?.weeklyXpReward    ?? 300);
     const baseCoins = isDaily ? (guildSettings?.quests?.dailyCoinReward   ?? 25)  : (guildSettings?.quests?.weeklyCoinReward  ?? 150);
 
-    const xp    = Math.round(baseXp    * mult);
-    const coins = Math.round(baseCoins * mult);
+    const xp    = Math.round(baseXp    * mult * streakMult);
+    const coins = Math.round(baseCoins * mult * streakMult);
 
     user.xp      += xp;
     user.balance += coins;

--- a/src/utils/streakMultiplier.js
+++ b/src/utils/streakMultiplier.js
@@ -1,0 +1,39 @@
+const MULTIPLIER_LADDER = [
+    { days: 100, multiplier: 2.0  },
+    { days:  60, multiplier: 1.75 },
+    { days:  30, multiplier: 1.5  },
+    { days:  14, multiplier: 1.2  },
+    { days:   7, multiplier: 1.1  },
+];
+
+const MILESTONES = [
+    { days:   7, coins:    500, badge: 'Week Warrior'   },
+    { days:  30, coins:  2_000, badge: 'Monthly Master' },
+    { days: 100, coins: 10_000, badge: 'Centurion'      },
+];
+
+function getStreakMultiplier(streakDays) {
+    for (const entry of MULTIPLIER_LADDER) {
+        if (streakDays >= entry.days) return entry.multiplier;
+    }
+    return 1.0;
+}
+
+// Next multiplier tier from the ladder (for display in /streak)
+function getNextMultiplierTier(streakDays) {
+    return [...MULTIPLIER_LADDER].reverse().find(e => e.days > streakDays) ?? null;
+}
+
+// Next coin+badge milestone
+function getNextMilestone(streakDays) {
+    return MILESTONES.find(m => m.days > streakDays) ?? null;
+}
+
+// Returns milestones the user just became eligible for and hasn't claimed yet
+function checkNewMilestones(user) {
+    const streak  = user.streak?.current ?? 0;
+    const claimed = new Set(user.streak?.claimedMilestones ?? []);
+    return MILESTONES.filter(m => streak >= m.days && !claimed.has(m.days));
+}
+
+module.exports = { getStreakMultiplier, getNextMultiplierTier, getNextMilestone, checkNewMilestones, MILESTONES };


### PR DESCRIPTION
- Add streakMultiplier utility with ladder (1.1x at 7d, 1.2x at 14d,
  1.5x at 30d, 1.75x at 60d, 2.0x cap at 100d)
- Apply multiplier across all coin/XP earning paths: daily, work, mine,
  crime, hunt, fish, quests, and message XP
- Award one-time milestone coins (500/2k/10k) with badge at 7/30/100 days;
  track claimed milestones in User.streak.claimedMilestones
- Add Streak Shield item (single-use, protects streak for 1 missed day)
  to effectsService; consume on streak break in messageCreate handler
- Update /streak to display current multiplier, next tier, and next
  coin-reward milestone
- Update /balance to show streak day count and active multiplier

https://claude.ai/code/session_01HL6QiSvTra68UXUJTEnRbm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced streak multiplier system increasing earnings across economy activities (daily, work, crime, mining)
  * Added streak shield effect to protect active streaks from inactivity resets
  * Implemented milestone tracking and rewards for streak progression
  * Streak multiplier now applies to XP gains from leveling, quests, fishing, and hunting
  * Enhanced commands to display current multiplier, next tier, and upcoming milestone information

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/Ultrabot/pull/148)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->