### PR TITLE
Add leaderboard rivalry notifications system

### DIFF
--- a/src/commands/community/notifications.js
+++ b/src/commands/community/notifications.js
@@ -1,0 +1,67 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const User = require('../../models/User');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('notifications')
+        .setDescription('Manage your personal notification preferences.')
+        .addSubcommand(sub => sub
+            .setName('leaderboard')
+            .setDescription('Toggle leaderboard rivalry DM notifications.')
+            .addStringOption(opt => opt
+                .setName('type')
+                .setDescription('Which notification to toggle')
+                .setRequired(true)
+                .addChoices(
+                    { name: 'Overtaken — when someone passes your rank (default: on)', value: 'overtaken' },
+                    { name: 'Climbed — when you hit a major rank milestone (default: off)', value: 'climbed' }
+                ))
+            .addStringOption(opt => opt
+                .setName('value')
+                .setDescription('Turn the notification on or off')
+                .setRequired(true)
+                .addChoices(
+                    { name: 'On', value: 'on' },
+                    { name: 'Off', value: 'off' }
+                ))
+        ),
+    async execute(interaction) {
+        const sub = interaction.options.getSubcommand();
+
+        if (sub === 'leaderboard') {
+            const type = interaction.options.getString('type');
+            const value = interaction.options.getString('value') === 'on';
+            const field = `notifications.leaderboard.${type}`;
+
+            await User.updateOne(
+                { userId: interaction.user.id, guildId: interaction.guild.id },
+                { $set: { [field]: value } },
+                { upsert: true }
+            );
+
+            const label = type === 'overtaken'
+                ? 'Overtaken notifications'
+                : 'Climbed notifications';
+            const status = value ? 'enabled' : 'disabled';
+            const icon = value ? '✅' : '🔕';
+
+            const embed = new EmbedBuilder()
+                .setColor(value ? '#57f287' : '#ed4245')
+                .setTitle(`${icon} Leaderboard Notifications Updated`)
+                .setDescription(`**${label}** have been **${status}** for this server.`)
+                .addFields({
+                    name: 'What this means',
+                    value: type === 'overtaken'
+                        ? value
+                            ? 'You will receive a DM when someone passes your rank on the leaderboard.'
+                            : 'You will no longer be notified when someone passes your rank.'
+                        : value
+                            ? 'You will receive a DM when you reach a major rank milestone (top 100, 50, or 10).'
+                            : 'You will no longer be notified when you reach a major rank milestone.'
+                })
+                .setFooter({ text: 'Use /notifications leaderboard to change this at any time.' });
+
+            await interaction.reply({ embeds: [embed], ephemeral: true });
+        }
+    }
+};

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -6,6 +6,7 @@ const { logModeration } = require('../utils/logger');
 const { ensureQuests, onMessage, notifyQuestComplete } = require('../services/questService');
 const { getStreakMultiplier, checkNewMilestones } = require('../utils/streakMultiplier');
 const { hasEffect, consumeEffect } = require('../services/effectsService');
+const { checkRivalry } = require('../services/rivalryService');
 
 const BASE_BAD_WORDS = [
     'nigger', 'nigga', 'faggot', 'fag', 'retard', 'chink', 'spic', 'kike',
@@ -262,6 +263,7 @@ async function handleLeveling(message, guildSettings) {
         }
 
         await user.save();
+        checkRivalry(message.client, message.guild, user).catch(() => {});
     } else {
         await User.create({
             userId: message.author.id,

--- a/src/events/voiceStateUpdate.js
+++ b/src/events/voiceStateUpdate.js
@@ -1,6 +1,7 @@
 const { handleVoiceStateUpdate } = require('../services/tempVoiceService');
 const Guild = require('../models/Guild');
 const User = require('../models/User');
+const { checkRivalry } = require('../services/rivalryService');
 
 // userId -> joinTimestamp (ms)
 const voiceJoinTimes = new Map();
@@ -9,11 +10,11 @@ module.exports = {
     name: 'voiceStateUpdate',
     async execute(oldState, newState, client) {
         await handleVoiceStateUpdate(oldState, newState, client);
-        await handleVoiceXp(oldState, newState);
+        await handleVoiceXp(oldState, newState, client);
     }
 };
 
-async function handleVoiceXp(oldState, newState) {
+async function handleVoiceXp(oldState, newState, client) {
     const member = newState.member || oldState.member;
     if (!member || member.user.bot) return;
 
@@ -77,6 +78,7 @@ async function handleVoiceXp(oldState, newState) {
         }
 
         await user.save();
+        if (guild) checkRivalry(client, guild, user).catch(() => {});
     } catch (err) {
         console.error('Voice XP error:', err);
     }

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -288,6 +288,20 @@ const userSchema = new Schema({
         charges:   { type: Number, default: -1 }
     }],
 
+    // Per-user notification preferences
+    notifications: {
+        leaderboard: {
+            overtaken: { type: Boolean, default: true },  // DM when someone passes you
+            climbed:   { type: Boolean, default: false }  // DM when you hit a major rank threshold
+        }
+    },
+
+    // Leaderboard rivalry anti-spam timestamps
+    leaderboard: {
+        lastOvertakenNotification: { type: Date, default: null },
+        lastClimbedNotification:   { type: Date, default: null }
+    },
+
     createdAt: { type: Date, default: Date.now },
     updatedAt: { type: Date, default: Date.now }
 });

--- a/src/services/rivalryService.js
+++ b/src/services/rivalryService.js
@@ -33,50 +33,55 @@ async function getLeaderboard(guildId) {
  */
 async function checkRivalry(client, guild, savedUser) {
     try {
-        const entries = await getLeaderboard(guild.id);
+        const cached = await getLeaderboard(guild.id);
 
-        // Find old rank in the cached list
-        const oldIdx = entries.findIndex(e => e.userId === savedUser.userId);
+        // Capture old rank from the unmodified snapshot
+        const oldIdx = cached.findIndex(e => e.userId === savedUser.userId);
         const oldRank = oldIdx === -1 ? null : oldIdx + 1;
 
-        // Update (or insert) this user's entry in the cache and re-sort
-        if (oldIdx !== -1) {
-            entries[oldIdx] = { userId: savedUser.userId, level: savedUser.level, xp: savedUser.xp };
-        } else {
-            entries.push({ userId: savedUser.userId, level: savedUser.level, xp: savedUser.xp });
+        // Build a new sorted array — never mutate the cached reference so
+        // concurrent calls always see a consistent snapshot
+        const updated = cached.map(e =>
+            e.userId === savedUser.userId
+                ? { userId: savedUser.userId, level: savedUser.level, xp: savedUser.xp }
+                : e
+        );
+        if (oldIdx === -1) {
+            updated.push({ userId: savedUser.userId, level: savedUser.level, xp: savedUser.xp });
         }
-        entries.sort((a, b) => b.level - a.level || b.xp - a.xp);
+        updated.sort((a, b) => b.level - a.level || b.xp - a.xp);
 
-        const newIdx = entries.findIndex(e => e.userId === savedUser.userId);
+        // Replace the cache entry atomically with the fully-built array
+        rankCache.set(guild.id, { entries: updated, updatedAt: Date.now() });
+
+        const newIdx = updated.findIndex(e => e.userId === savedUser.userId);
         const newRank = newIdx + 1;
 
-        // Only care about top 100
         if (newRank > MAX_RANK) return;
-
-        // User must have actually climbed
         if (!oldRank || newRank >= oldRank) return;
 
+        // Number of positions gained — used to derive the overtaken slice
+        const climbCount = oldRank - newRank;
         const now = Date.now();
 
-        // Fetch the climber's Discord user once for DM content
         const climberDiscord = await client.users.fetch(savedUser.userId).catch(() => null);
         const climberTag = climberDiscord?.tag || 'Someone';
 
-        // Notify each overtaken user (slice between newIdx+1 and oldIdx, exclusive)
-        const overtakenSlice = entries.slice(newIdx + 1, oldIdx);
+        // After sorting, overtaken users occupy the climbCount slots directly
+        // below the climber's new position
+        const overtakenSlice = updated.slice(newIdx + 1, newIdx + 1 + climbCount);
         for (const entry of overtakenSlice) {
-            const overtakenIdx = entries.findIndex(e => e.userId === entry.userId);
-            const overtakenRank = overtakenIdx + 1;
-
+            const overtakenRank = updated.findIndex(e => e.userId === entry.userId) + 1;
             if (overtakenRank - newRank > MAX_RANK_DIFF) continue;
 
-            // Fetch preferences + anti-spam timestamp with a targeted projection
             const overtakenDoc = await User.findOne(
                 { userId: entry.userId, guildId: guild.id },
                 { 'notifications.leaderboard.overtaken': 1, 'leaderboard.lastOvertakenNotification': 1 }
             ).lean();
             if (!overtakenDoc) continue;
-            if (overtakenDoc.notifications?.leaderboard?.overtaken === false) continue;
+
+            const overtakenAllowed = overtakenDoc.notifications?.leaderboard?.overtaken ?? true;
+            if (!overtakenAllowed) continue;
 
             const lastNotif = overtakenDoc.leaderboard?.lastOvertakenNotification;
             if (lastNotif && now - new Date(lastNotif).getTime() < NOTIFY_COOLDOWN) continue;
@@ -103,7 +108,9 @@ async function checkRivalry(client, guild, savedUser) {
             { userId: savedUser.userId, guildId: guild.id },
             { 'notifications.leaderboard.climbed': 1, 'leaderboard.lastClimbedNotification': 1 }
         ).lean();
-        if (!selfDoc?.notifications?.leaderboard?.climbed) return;
+
+        const climbedEnabled = selfDoc?.notifications?.leaderboard?.climbed ?? false;
+        if (!climbedEnabled) return;
 
         const lastClimb = selfDoc.leaderboard?.lastClimbedNotification;
         if (lastClimb && now - new Date(lastClimb).getTime() < NOTIFY_COOLDOWN) return;

--- a/src/services/rivalryService.js
+++ b/src/services/rivalryService.js
@@ -1,0 +1,125 @@
+const User = require('../models/User');
+
+// guildId -> { entries: [{userId, level, xp}], updatedAt }
+const rankCache = new Map();
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+const MAX_RANK = 100;             // only notify users within top 100
+const MAX_RANK_DIFF = 10;         // only notify when rival is within 10 ranks
+const NOTIFY_COOLDOWN = 60 * 60 * 1000; // 1 notification per user per hour
+
+// Significant rank thresholds that trigger the optional "climbed" DM
+const CLIMB_THRESHOLDS = [10, 50, 100];
+
+async function getLeaderboard(guildId) {
+    const cached = rankCache.get(guildId);
+    if (cached && Date.now() - cached.updatedAt < CACHE_TTL) {
+        return cached.entries;
+    }
+    const users = await User.find({ guildId })
+        .sort({ level: -1, xp: -1 })
+        .select('userId level xp')
+        .lean();
+    rankCache.set(guildId, { entries: users, updatedAt: Date.now() });
+    return users;
+}
+
+/**
+ * Called after a user's XP/level is saved. Checks whether they overtook any
+ * rivals and sends rivalry DMs as appropriate, then updates the rank cache.
+ *
+ * @param {import('discord.js').Client} client
+ * @param {import('discord.js').Guild}  guild
+ * @param {{ userId: string, level: number, xp: number }} savedUser
+ */
+async function checkRivalry(client, guild, savedUser) {
+    try {
+        const entries = await getLeaderboard(guild.id);
+
+        // Find old rank in the cached list
+        const oldIdx = entries.findIndex(e => e.userId === savedUser.userId);
+        const oldRank = oldIdx === -1 ? null : oldIdx + 1;
+
+        // Update (or insert) this user's entry in the cache and re-sort
+        if (oldIdx !== -1) {
+            entries[oldIdx] = { userId: savedUser.userId, level: savedUser.level, xp: savedUser.xp };
+        } else {
+            entries.push({ userId: savedUser.userId, level: savedUser.level, xp: savedUser.xp });
+        }
+        entries.sort((a, b) => b.level - a.level || b.xp - a.xp);
+
+        const newIdx = entries.findIndex(e => e.userId === savedUser.userId);
+        const newRank = newIdx + 1;
+
+        // Only care about top 100
+        if (newRank > MAX_RANK) return;
+
+        // User must have actually climbed
+        if (!oldRank || newRank >= oldRank) return;
+
+        const now = Date.now();
+
+        // Fetch the climber's Discord user once for DM content
+        const climberDiscord = await client.users.fetch(savedUser.userId).catch(() => null);
+        const climberTag = climberDiscord?.tag || 'Someone';
+
+        // Notify each overtaken user (slice between newIdx+1 and oldIdx, exclusive)
+        const overtakenSlice = entries.slice(newIdx + 1, oldIdx);
+        for (const entry of overtakenSlice) {
+            const overtakenIdx = entries.findIndex(e => e.userId === entry.userId);
+            const overtakenRank = overtakenIdx + 1;
+
+            if (overtakenRank - newRank > MAX_RANK_DIFF) continue;
+
+            // Fetch preferences + anti-spam timestamp with a targeted projection
+            const overtakenDoc = await User.findOne(
+                { userId: entry.userId, guildId: guild.id },
+                { 'notifications.leaderboard.overtaken': 1, 'leaderboard.lastOvertakenNotification': 1 }
+            ).lean();
+            if (!overtakenDoc) continue;
+            if (overtakenDoc.notifications?.leaderboard?.overtaken === false) continue;
+
+            const lastNotif = overtakenDoc.leaderboard?.lastOvertakenNotification;
+            if (lastNotif && now - new Date(lastNotif).getTime() < NOTIFY_COOLDOWN) continue;
+
+            const target = await client.users.fetch(entry.userId).catch(() => null);
+            if (!target) continue;
+
+            await target.send(
+                `📉 **${climberTag}** just passed you on the **${guild.name}** leaderboard! ` +
+                `They're now rank **#${newRank}** and you're **#${overtakenRank}**. Time to catch up!`
+            ).catch(() => {});
+
+            await User.updateOne(
+                { userId: entry.userId, guildId: guild.id },
+                { $set: { 'leaderboard.lastOvertakenNotification': new Date() } }
+            ).catch(() => {});
+        }
+
+        // Optional "climbed" DM — only on significant threshold crossings
+        const crossedThreshold = CLIMB_THRESHOLDS.find(t => newRank <= t && (!oldRank || oldRank > t));
+        if (!crossedThreshold) return;
+
+        const selfDoc = await User.findOne(
+            { userId: savedUser.userId, guildId: guild.id },
+            { 'notifications.leaderboard.climbed': 1, 'leaderboard.lastClimbedNotification': 1 }
+        ).lean();
+        if (!selfDoc?.notifications?.leaderboard?.climbed) return;
+
+        const lastClimb = selfDoc.leaderboard?.lastClimbedNotification;
+        if (lastClimb && now - new Date(lastClimb).getTime() < NOTIFY_COOLDOWN) return;
+
+        if (climberDiscord) {
+            await climberDiscord.send(
+                `📈 You've moved up to rank **#${newRank}** on the **${guild.name}** leaderboard!`
+            ).catch(() => {});
+            await User.updateOne(
+                { userId: savedUser.userId, guildId: guild.id },
+                { $set: { 'leaderboard.lastClimbedNotification': new Date() } }
+            ).catch(() => {});
+        }
+    } catch (err) {
+        console.error('Rivalry check error:', err);
+    }
+}
+
+module.exports = { checkRivalry };


### PR DESCRIPTION
## Summary
Implements a competitive leaderboard rivalry system that notifies users when they're overtaken on the rank ladder or when they reach major rank milestones. Includes user preference controls and anti-spam cooldowns.

## Key Changes
- **New `rivalryService.js`**: Core service that detects rank changes and sends rivalry DMs
  - Tracks leaderboard position changes with 5-minute caching
  - Notifies users when overtaken (within top 100 ranks, max 10-rank difference)
  - Sends optional "climbed" notifications for threshold crossings (top 100, 50, 10)
  - Implements 1-hour per-user cooldown to prevent notification spam
  
- **New `/notifications` command**: Allows users to toggle leaderboard notifications
  - `overtaken`: DM when someone passes your rank (default: enabled)
  - `climbed`: DM when you hit a major rank milestone (default: disabled)
  - Per-guild, per-user preference storage

- **Updated `User` model**: Added schema fields for notification preferences and anti-spam tracking
  - `notifications.leaderboard.{overtaken, climbed}` boolean flags
  - `leaderboard.{lastOvertakenNotification, lastClimbedNotification}` timestamps

- **Integrated into XP events**: 
  - `voiceStateUpdate.js`: Calls `checkRivalry()` after voice XP is awarded
  - `messageCreate.js`: Calls `checkRivalry()` after message XP is awarded

## Implementation Details
- Leaderboard cache is guild-specific and automatically invalidates after 5 minutes
- Rank calculations are done in-memory on cached data for performance
- Only notifies users in top 100 to reduce spam and focus on competitive players
- Gracefully handles missing Discord users or DM failures
- All database operations use targeted projections to minimize query overhead

https://claude.ai/code/session_015PrHSMwbNCib8cJwy2aZau

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New slash command to manage leaderboard notification preferences—receive DMs when rivals are overtaken or when you climb major ranks
  * Rivalry notifications now integrated into chat and voice activity tracking with cooldown-based spam prevention

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/Ultrabot/pull/155)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->