### PR TITLE
feat(fishing): implement /fishcraft command with cross-system crafting

### DIFF
--- a/src/commands/economy/fishcraft.js
+++ b/src/commands/economy/fishcraft.js
@@ -1,0 +1,189 @@
+'use strict';
+
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const User  = require('../../models/User');
+const Guild = require('../../models/Guild');
+const { FISH_CRAFT_RECIPES, CONSUMABLES, MATERIAL_NAMES } = require('../../data/fishData');
+const { MATERIAL_NAMES: HUNT_MATERIAL_NAMES }              = require('../../data/huntData');
+const { ensureFishingData } = require('../../services/fishService');
+const { ensureHuntData }    = require('../../services/huntService');
+
+const RECIPE_CHOICES = Object.values(FISH_CRAFT_RECIPES).map(r => ({ name: r.name, value: r.id }));
+
+function getMaterialName(materialId, source) {
+    if (source === 'hunt') return HUNT_MATERIAL_NAMES[materialId] ?? materialId;
+    return MATERIAL_NAMES[materialId] ?? materialId;
+}
+
+function getMaterialStock(materialId, source, h, f) {
+    if (source === 'hunt') return h.materials[materialId] ?? 0;
+    return f.materials[materialId] ?? 0;
+}
+
+module.exports = {
+    cooldown: 3,
+
+    data: new SlashCommandBuilder()
+        .setName('fishcraft')
+        .setDescription('Craft items from fishing (and hunting) materials')
+        .addSubcommand(sub =>
+            sub.setName('list')
+                .setDescription('Browse all available fishing crafting recipes'))
+        .addSubcommand(sub =>
+            sub.setName('make')
+                .setDescription('Craft an item from your materials')
+                .addStringOption(o =>
+                    o.setName('recipe')
+                        .setDescription('Recipe to craft')
+                        .setRequired(true)
+                        .addChoices(...RECIPE_CHOICES))),
+
+    async execute(interaction) {
+        const sub = interaction.options.getSubcommand();
+
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        if (guildSettings?.economy?.enabled === false) {
+            return interaction.reply({ content: 'The economy is disabled on this server.', ephemeral: true });
+        }
+
+        const user = await User.findOneAndUpdate(
+            { userId: interaction.user.id, guildId: interaction.guild.id },
+            { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
+            { upsert: true, new: true }
+        );
+        ensureFishingData(user);
+        ensureHuntData(user);
+        const f = user.fishing;
+        const h = user.hunt;
+
+        // ── LIST ───────────────────────────────────────────────────────────
+        if (sub === 'list') {
+            const lines = Object.values(FISH_CRAFT_RECIPES).map(r => {
+                const ingredientStr = r.ingredients
+                    .map(ing => {
+                        const name = getMaterialName(ing.material, ing.source);
+                        const tag  = ing.source === 'hunt' ? ' *(hunt)*' : '';
+                        return `${name}${tag} ×${ing.qty}`;
+                    })
+                    .join(', ');
+
+                const canCraft = r.ingredients.every(ing =>
+                    getMaterialStock(ing.material, ing.source, h, f) >= ing.qty
+                );
+                const uniqueDone = r.unique && r.output.id === 'luckyHook' && f.luckyHook;
+                const status = uniqueDone ? '✅ **[OWNED]**' : canCraft ? '✅' : '❌';
+
+                return `${status} **${r.emoji} ${r.name}**\n> ${r.description}\n> Requires: ${ingredientStr}`;
+            });
+
+            const embed = new EmbedBuilder()
+                .setColor('#3498db')
+                .setTitle('🎣 Fishing Crafting Recipes')
+                .setDescription(lines.join('\n\n'))
+                .setFooter({ text: '✅ = you can craft now  •  Use /fishcraft make <recipe> to craft  •  /fishinv materials to check stock' });
+
+            return interaction.reply({ embeds: [embed] });
+        }
+
+        // ── MAKE ───────────────────────────────────────────────────────────
+        if (sub === 'make') {
+            const recipeId = interaction.options.getString('recipe');
+            const recipe   = FISH_CRAFT_RECIPES[recipeId];
+
+            if (!recipe) {
+                return interaction.reply({
+                    content: 'Unknown recipe. Use `/fishcraft list` to see available recipes.',
+                    ephemeral: true
+                });
+            }
+
+            // Unique upgrade guard
+            if (recipe.unique && recipe.output.id === 'luckyHook' && f.luckyHook) {
+                return interaction.reply({
+                    content: 'You already have the **🎣 Lucky Hook** upgrade!',
+                    ephemeral: true
+                });
+            }
+
+            // Stack limit guard for consumables and dual_stamina
+            if (recipe.output.type === 'consumable' || recipe.output.type === 'dual_stamina') {
+                const def          = CONSUMABLES[recipe.output.id];
+                const currentStock = f.consumables[recipe.output.id] ?? 0;
+                const qty          = recipe.output.qty ?? 1;
+                if (def && currentStock + qty > def.maxStack) {
+                    return interaction.reply({
+                        content: `You can only hold **${def.maxStack}× ${def.name}** (you have ${currentStock}). ` +
+                                 `Free up space before crafting more.`,
+                        ephemeral: true
+                    });
+                }
+            }
+
+            // Check ingredients (cross-system aware)
+            const missing = recipe.ingredients
+                .filter(ing => getMaterialStock(ing.material, ing.source, h, f) < ing.qty)
+                .map(ing => {
+                    const have = getMaterialStock(ing.material, ing.source, h, f);
+                    const name = getMaterialName(ing.material, ing.source);
+                    const tag  = ing.source === 'hunt' ? ' (hunt material)' : '';
+                    return `**${name}${tag}** (need ${ing.qty}, have ${have})`;
+                });
+
+            if (missing.length) {
+                return interaction.reply({
+                    content: `You are missing the following materials:\n${missing.join('\n')}`,
+                    ephemeral: true
+                });
+            }
+
+            // Consume materials (cross-system aware)
+            for (const ing of recipe.ingredients) {
+                if (ing.source === 'hunt') {
+                    h.materials[ing.material] -= ing.qty;
+                } else {
+                    f.materials[ing.material] -= ing.qty;
+                }
+            }
+
+            // Apply output
+            let outputDesc = '';
+            if (recipe.output.type === 'consumable') {
+                const qty = recipe.output.qty ?? 1;
+                f.consumables[recipe.output.id] = (f.consumables[recipe.output.id] ?? 0) + qty;
+                const def = CONSUMABLES[recipe.output.id];
+                outputDesc = `${def?.emoji ?? '📦'} **${qty}× ${def?.name ?? recipe.output.id}**`;
+            } else if (recipe.output.type === 'dual_stamina') {
+                const qty = recipe.output.qty ?? 1;
+                f.consumables[recipe.output.id] = (f.consumables[recipe.output.id] ?? 0) + qty;
+                outputDesc = `⚗️ **${qty}× Hunter's Brew** — use with \`/fishuse\` to restore stamina in both systems`;
+            } else if (recipe.output.type === 'permanent') {
+                if (recipe.output.id === 'luckyHook') {
+                    f.luckyHook = true;
+                    outputDesc = '🎣 **Lucky Hook** — permanently +1% critical catch chance!';
+                }
+            }
+
+            const huntModified = recipe.ingredients.some(ing => ing.source === 'hunt');
+            if (huntModified) user.markModified('hunt');
+            user.markModified('fishing');
+            await user.save();
+
+            const usedLines = recipe.ingredients.map(ing => {
+                const remaining = getMaterialStock(ing.material, ing.source, h, f);
+                const name      = getMaterialName(ing.material, ing.source);
+                const tag       = ing.source === 'hunt' ? ' *(hunt)*' : '';
+                return `• ${name}${tag} ×${ing.qty}  (remaining: ${remaining})`;
+            }).join('\n');
+
+            const embed = new EmbedBuilder()
+                .setColor('#2ecc71')
+                .setTitle(`${recipe.emoji} Crafted: ${recipe.name}`)
+                .setDescription(`You crafted ${outputDesc}!`)
+                .addFields({ name: 'Materials Consumed', value: usedLines, inline: false })
+                .setFooter({ text: 'Use /fishinv materials to check your remaining stock' })
+                .setTimestamp();
+
+            return interaction.reply({ embeds: [embed] });
+        }
+    }
+};

--- a/src/commands/economy/fishcraft.js
+++ b/src/commands/economy/fishcraft.js
@@ -155,7 +155,8 @@ module.exports = {
             } else if (recipe.output.type === 'dual_stamina') {
                 const qty = recipe.output.qty ?? 1;
                 f.consumables[recipe.output.id] = (f.consumables[recipe.output.id] ?? 0) + qty;
-                outputDesc = `⚗️ **${qty}× Hunter's Brew** — use with \`/fishuse\` to restore stamina in both systems`;
+                const def = CONSUMABLES[recipe.output.id];
+                outputDesc = `${def?.emoji ?? '⚗️'} **${qty}× ${def?.name ?? recipe.output.id}** — use with \`/fishuse\` to restore stamina in both systems`;
             } else if (recipe.output.type === 'permanent') {
                 if (recipe.output.id === 'luckyHook') {
                     f.luckyHook = true;

--- a/src/commands/economy/fishinv.js
+++ b/src/commands/economy/fishinv.js
@@ -192,7 +192,7 @@ async function showMaterials(interaction, user) {
         embed.addFields({ name: 'Hunt Materials (cross-system)', value: huntMatLines.join('\n'), inline: false });
     }
 
-    embed.setFooter({ text: 'Materials are used in crafting recipes. /fishcraft (coming soon)' });
+    embed.setFooter({ text: 'Materials are used in crafting recipes. Use /fishcraft list to see what you can make.' });
     embed.setTimestamp();
 
     return interaction.reply({ embeds: [embed] });

--- a/src/data/fishData.js
+++ b/src/data/fishData.js
@@ -139,6 +139,12 @@ const CONSUMABLES = {
         cost: 185, type: 'stamina', staminaRestore: 3,
         description: 'Restores 3 stamina (max 2 uses per day)',
         maxStack: 5
+    },
+    hunters_brew: {
+        id: 'hunters_brew', name: "Hunter's Brew", emoji: '⚗️',
+        type: 'dual_stamina', staminaRestore: 2,
+        description: 'Restores 2 stamina in both fishing AND hunting',
+        maxStack: 5
     }
 };
 

--- a/src/data/fishData.js
+++ b/src/data/fishData.js
@@ -662,7 +662,7 @@ const FISH_CRAFT_RECIPES = {
             { material: 'feather',      qty: 2, source: 'hunt' },
             { material: 'rare_scale',   qty: 1 }
         ],
-        output: { type: 'dual_stamina', qty: 2 },
+        output: { type: 'dual_stamina', id: 'hunters_brew', qty: 2 },
         unique: false
     }
 };

--- a/src/services/fishService.js
+++ b/src/services/fishService.js
@@ -420,6 +420,28 @@ function activateConsumable(user, consumableId) {
         f.consumables[consumableId] -= 1;
         f.stamina = Math.min(max, f.stamina + def.staminaRestore);
         f.energyDrinksToday += 1;
+    } else if (def.type === 'dual_stamina') {
+        applyStaminaRegen(user);
+        const now = Date.now();
+        const drinkWindowOk = f.lastDrinkDayReset && (now - f.lastDrinkDayReset.getTime() < LIMITS.DAILY_WINDOW_MS);
+        if (!drinkWindowOk) {
+            f.energyDrinksToday = 0;
+            f.lastDrinkDayReset = new Date(now);
+        }
+        if (f.energyDrinksToday >= LIMITS.ENERGY_DRINKS_PER_DAY) {
+            return { success: false, error: `You've already used ${LIMITS.ENERGY_DRINKS_PER_DAY} stamina items today.` };
+        }
+        const max = getMaxStamina(user);
+        if (f.stamina >= max && (user.hunt?.stamina ?? 0) >= 10) {
+            return { success: false, error: `Both stamina bars are already full.` };
+        }
+        f.consumables[consumableId] -= 1;
+        f.stamina = Math.min(max, f.stamina + def.staminaRestore);
+        f.energyDrinksToday += 1;
+        // Also restore hunt stamina
+        if (!user.hunt) user.hunt = {};
+        user.hunt.stamina = Math.min(10, (user.hunt.stamina ?? 0) + def.staminaRestore);
+        user.markModified('hunt');
     } else if (def.type === 'repair') {
         return { success: false, error: `Use repair kits with \`/fishrepair\`.` };
     } else {

--- a/src/services/fishService.js
+++ b/src/services/fishService.js
@@ -16,6 +16,7 @@ const {
     FISH_QUEST_TEMPLATES
 } = require('../data/fishData');
 const { getStreakMultiplier } = require('../utils/streakMultiplier');
+const { ensureHuntData, getMaxStamina: getHuntMaxStamina } = require('./huntService');
 
 const DAILY_QUEST_COUNT = 3;
 
@@ -432,15 +433,15 @@ function activateConsumable(user, consumableId) {
             return { success: false, error: `You've already used ${LIMITS.ENERGY_DRINKS_PER_DAY} stamina items today.` };
         }
         const max = getMaxStamina(user);
-        if (f.stamina >= max && (user.hunt?.stamina ?? 0) >= 10) {
+        ensureHuntData(user);
+        const huntMax = getHuntMaxStamina(user);
+        if (f.stamina >= max && user.hunt.stamina >= huntMax) {
             return { success: false, error: `Both stamina bars are already full.` };
         }
         f.consumables[consumableId] -= 1;
         f.stamina = Math.min(max, f.stamina + def.staminaRestore);
         f.energyDrinksToday += 1;
-        // Also restore hunt stamina
-        if (!user.hunt) user.hunt = {};
-        user.hunt.stamina = Math.min(10, (user.hunt.stamina ?? 0) + def.staminaRestore);
+        user.hunt.stamina = Math.min(huntMax, user.hunt.stamina + def.staminaRestore);
         user.markModified('hunt');
     } else if (def.type === 'repair') {
         return { success: false, error: `Use repair kits with \`/fishrepair\`.` };


### PR DESCRIPTION
Fishing materials were collectable but had no crafting outlet. This
adds the complete /fishcraft command (list + make subcommands) wired
to the 7 pre-defined FISH_CRAFT_RECIPES, including cross-system recipes
that consume hunt materials (rabbit's foot, feather). Also adds the
Hunter's Brew dual-stamina consumable to fishData and its activation
handler in fishService so crafted brews restore stamina in both fishing
and hunting when used. Updates fishinv footer to point users to
/fishcraft list instead of the old "coming soon" placeholder.

https://claude.ai/code/session_01UxLDRkbHrrkLMUFqDhzxks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/fishcraft` slash command with recipe listing and crafting functionality to create items from your fishing and hunting materials
  * Introduced "hunters_brew" consumable item that restores stamina for both fishing and hunting activities

* **Updates**
  * Updated help documentation to reference the new `/fishcraft list` command

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/Ultrabot/pull/157)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->