### PR TITLE
fix(bible): add BBE and WEBBE translations to command and dashboard

### DIFF
--- a/src/commands/utility/bible.js
+++ b/src/commands/utility/bible.js
@@ -22,7 +22,9 @@ module.exports = {
                             { name: 'American Standard Version (ASV)', value: 'asv' },
                             { name: 'World English Bible (WEB)', value: 'web' },
                             { name: "Young's Literal Translation (YLT)", value: 'ylt' },
-                            { name: 'Darby', value: 'darby' }
+                            { name: 'Darby', value: 'darby' },
+                            { name: 'Bible in Basic English (BBE)', value: 'bbe' },
+                            { name: 'World English Bible British Edition (WEBBE)', value: 'webbe' }
                         )
                 )
         )

--- a/src/commands/utility/bible.js
+++ b/src/commands/utility/bible.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const { lookupVerse, getDailyVerse, createVerseEmbed } = require('../../services/bibleService');
+const Guild = require('../../models/Guild');
 
 module.exports = {
     cooldown: 5,
@@ -66,7 +67,16 @@ module.exports = {
                 });
             }
 
-            const embed = createVerseEmbed(verseData, '📖 Daily Bible Verse');
+            const guildSettings = await Guild.findOne({ guildId: interaction.guildId });
+            const translation = guildSettings?.bibleVerse?.translation || 'kjv';
+
+            let displayVerse = verseData;
+            if (translation !== 'kjv' && translation !== 'niv' && verseData.reference) {
+                const translated = await lookupVerse(verseData.reference, translation);
+                if (translated?.text) displayVerse = translated;
+            }
+
+            const embed = createVerseEmbed(displayVerse, '📖 Daily Bible Verse');
             await interaction.editReply({ embeds: [embed] });
         }
     }

--- a/src/commands/utility/bible.js
+++ b/src/commands/utility/bible.js
@@ -19,6 +19,7 @@ module.exports = {
                         .setDescription('Bible translation (default: KJV)')
                         .addChoices(
                             { name: 'King James Version (KJV)', value: 'kjv' },
+                            { name: 'New International Version (NIV)', value: 'niv' },
                             { name: 'American Standard Version (ASV)', value: 'asv' },
                             { name: 'World English Bible (WEB)', value: 'web' },
                             { name: "Young's Literal Translation (YLT)", value: 'ylt' },
@@ -40,6 +41,12 @@ module.exports = {
         if (sub === 'verse') {
             const reference = interaction.options.getString('reference');
             const translation = interaction.options.getString('translation') || 'kjv';
+
+            if (translation === 'niv') {
+                return interaction.editReply({
+                    content: `NIV is not available for on-demand verse lookup (it's a copyrighted translation). Use \`/bible daily\` to see today's verse in NIV, or choose a free translation like KJV, ASV, or WEB.`
+                });
+            }
 
             const verseData = await lookupVerse(reference, translation);
             if (!verseData?.text) {

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -1587,6 +1587,8 @@
                             <option value="web" <%= (settings.bibleVerse && settings.bibleVerse.translation === 'web') ? 'selected' : '' %>>World English Bible (WEB)</option>
                             <option value="ylt" <%= (settings.bibleVerse && settings.bibleVerse.translation === 'ylt') ? 'selected' : '' %>>Young's Literal Translation (YLT)</option>
                             <option value="darby" <%= (settings.bibleVerse && settings.bibleVerse.translation === 'darby') ? 'selected' : '' %>>Darby</option>
+                            <option value="bbe" <%= (settings.bibleVerse && settings.bibleVerse.translation === 'bbe') ? 'selected' : '' %>>Bible in Basic English (BBE)</option>
+                            <option value="webbe" <%= (settings.bibleVerse && settings.bibleVerse.translation === 'webbe') ? 'selected' : '' %>>World English Bible British Edition (WEBBE)</option>
                         </select>
                         <small>Used for both the daily verse and auto-responses. No API key required.</small>
                     </div>

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -1591,7 +1591,7 @@
                             <option value="bbe" <%= (settings.bibleVerse && settings.bibleVerse.translation === 'bbe') ? 'selected' : '' %>>Bible in Basic English (BBE)</option>
                             <option value="webbe" <%= (settings.bibleVerse && settings.bibleVerse.translation === 'webbe') ? 'selected' : '' %>>World English Bible British Edition (WEBBE)</option>
                         </select>
-                        <small>Used for both the daily verse and auto-responses. No API key required.</small>
+                        <small>Used for scheduled daily verses and the <code>/bible daily</code> command. Auto-response lookups also use this translation, except NIV — NIV auto-responses fall back to KJV.</small>
                     </div>
 
                     <div class="actions-row">

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -1583,6 +1583,7 @@
                         <label class="field-label" for="bv-translation">Default translation</label>
                         <select id="bv-translation">
                             <option value="kjv" <%= (!settings.bibleVerse || settings.bibleVerse.translation === 'kjv') ? 'selected' : '' %>>King James Version (KJV)</option>
+                            <option value="niv" <%= (settings.bibleVerse && settings.bibleVerse.translation === 'niv') ? 'selected' : '' %>>New International Version (NIV)</option>
                             <option value="asv" <%= (settings.bibleVerse && settings.bibleVerse.translation === 'asv') ? 'selected' : '' %>>American Standard Version (ASV)</option>
                             <option value="web" <%= (settings.bibleVerse && settings.bibleVerse.translation === 'web') ? 'selected' : '' %>>World English Bible (WEB)</option>
                             <option value="ylt" <%= (settings.bibleVerse && settings.bibleVerse.translation === 'ylt') ? 'selected' : '' %>>Young's Literal Translation (YLT)</option>

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -522,7 +522,9 @@ async function handleBibleVerseDetection(message, guildSettings) {
     if (!refs.length) return;
 
     const translation = guildSettings.bibleVerse?.translation || 'kjv';
-    const verseData = await lookupVerse(refs[0], translation);
+    // NIV is not available for on-demand lookup; fall back to KJV so auto-respond still works
+    const effectiveTranslation = translation === 'niv' ? 'kjv' : translation;
+    const verseData = await lookupVerse(refs[0], effectiveTranslation);
     if (!verseData?.text) return;
 
     await message.reply({ embeds: [createVerseEmbed(verseData)] }).catch(() => {});

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -486,8 +486,8 @@ const guildSchema = new Schema({
             type: String,
             default: 'kjv',
             enum: {
-                values: ['kjv', 'asv', 'web', 'ylt', 'darby', 'bbe', 'webbe'],
-                message: 'bibleVerse.translation must be one of: kjv, asv, web, ylt, darby, bbe, webbe'
+                values: ['kjv', 'niv', 'asv', 'web', 'ylt', 'darby', 'bbe', 'webbe'],
+                message: 'bibleVerse.translation must be one of: kjv, niv, asv, web, ylt, darby, bbe, webbe'
             }
         },
         autoRespond: { type: Boolean, default: true }

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -486,8 +486,8 @@ const guildSchema = new Schema({
             type: String,
             default: 'kjv',
             enum: {
-                values: ['kjv', 'asv', 'web', 'ylt', 'darby'],
-                message: 'bibleVerse.translation must be one of: kjv, asv, web, ylt, darby'
+                values: ['kjv', 'asv', 'web', 'ylt', 'darby', 'bbe', 'webbe'],
+                message: 'bibleVerse.translation must be one of: kjv, asv, web, ylt, darby, bbe, webbe'
             }
         },
         autoRespond: { type: Boolean, default: true }

--- a/src/services/bibleService.js
+++ b/src/services/bibleService.js
@@ -68,9 +68,12 @@ async function getDailyVerse() {
 }
 
 function createVerseEmbed(verseData, title = '📖 Bible Verse') {
-    const text = (verseData.text || '').trim().replace(/\s+/g, ' ');
+    let text = (verseData.text || '').trim().replace(/\s+/g, ' ');
     const reference = verseData.reference || '';
     const translation = verseData.translation_name || verseData.translation_id?.toUpperCase() || 'KJV';
+
+    // Discord embed description limit is 4096 chars; *"…"* wrapping adds 4
+    if (text.length > 4090) text = text.slice(0, 4087) + '…';
 
     return new EmbedBuilder()
         .setColor(0xF5C518)

--- a/src/services/dailyBibleService.js
+++ b/src/services/dailyBibleService.js
@@ -33,9 +33,10 @@ async function postDailyVerse(client, guildId, channelId, translation) {
         const verseData = await getDailyVerse();
         if (!verseData) return;
 
-        // Re-fetch in the guild's configured translation when it isn't the default KJV
+        // Re-fetch in the guild's configured translation when it isn't KJV or NIV.
+        // NIV is skipped because ourmanna.com already returns NIV text.
         let displayVerse = verseData;
-        if (translation && translation !== 'kjv' && verseData.reference) {
+        if (translation && translation !== 'kjv' && translation !== 'niv' && verseData.reference) {
             const translated = await lookupVerse(verseData.reference, translation);
             if (translated?.text) displayVerse = translated;
         }


### PR DESCRIPTION
Adds Bible in Basic English (BBE) and World English Bible British
Edition (WEBBE) — both supported by bible-api.com — to the /bible verse
command choices, the dashboard translation dropdown, and the Guild model
enum so all three sources stay in sync.

https://claude.ai/code/session_019E2xje7C1WhxCPk6FdaVhU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for additional Bible translations (BBE, WEBBE, NIV options)
  * Guilds can now set per-guild default Bible translation preferences for daily verses

* **Bug Fixes**
  * On-demand verse lookups no longer support NIV translation; users directed to daily verse feature instead
  * Long verse text now properly truncates to fit Discord message limits

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/Ultrabot/pull/159)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->