### PR TITLE
feat(economy): implement coin & XP multiplier booster system (issue #109)

### DIFF
--- a/src/commands/economy/balance.js
+++ b/src/commands/economy/balance.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const User = require('../../models/User');
-const { pruneEffects, EFFECT_CONFIGS, timeRemaining } = require('../../services/effectsService');
+const Guild = require('../../models/Guild');
+const { pruneEffects, EFFECT_CONFIGS, timeRemaining, getServerCoinMultiplier, getServerXpMultiplier } = require('../../services/effectsService');
 const { getStreakMultiplier } = require('../../utils/streakMultiplier');
 
 module.exports = {
@@ -15,8 +16,12 @@ module.exports = {
         const targetUser = interaction.options.getUser('user') || interaction.user;
 
         try {
-            let user = await User.findOne({ userId: targetUser.id, guildId: interaction.guild.id });
+            const [user_raw, guildSettings] = await Promise.all([
+                User.findOne({ userId: targetUser.id, guildId: interaction.guild.id }),
+                Guild.findOne({ guildId: interaction.guild.id })
+            ]);
 
+            let user = user_raw;
             if (!user) {
                 user = await User.create({ userId: targetUser.id, guildId: interaction.guild.id });
             }
@@ -42,17 +47,40 @@ module.exports = {
                 )
                 .setTimestamp();
 
-            // Show active protective effects as indicators
-            if (user.activeEffects?.length) {
-                const indicators = user.activeEffects.map(e => {
-                    const cfg = EFFECT_CONFIGS[e.type];
-                    if (!cfg) return null;
-                    const duration = e.expiresAt ? timeRemaining(e.expiresAt) : (e.charges === 1 ? '1 use left' : 'permanent');
-                    return `${cfg.emoji} **${cfg.label}** — ${duration}`;
-                }).filter(Boolean);
+            // Show server boost banner if active
+            const serverCoinMult = getServerCoinMultiplier(guildSettings);
+            const serverXpMult   = getServerXpMultiplier(guildSettings);
+            const sb = guildSettings?.serverBoost;
+            if ((serverCoinMult > 1.0 || serverXpMult > 1.0) && sb?.expiresAt) {
+                const boostType  = sb.type === 'coin' ? `💰 ${serverCoinMult}x Coins` : `⭐ ${serverXpMult}x XP`;
+                const remaining  = timeRemaining(sb.expiresAt);
+                embed.addFields({
+                    name:   '🌐 Server Boost Active!',
+                    value:  `${boostType} — **${remaining}** remaining`,
+                    inline: false
+                });
+            }
 
-                if (indicators.length) {
-                    embed.addFields({ name: '🔮 Active Effects', value: indicators.join('\n'), inline: false });
+            // Show active effects as indicators
+            if (user.activeEffects?.length) {
+                const BOOSTER_TYPES = new Set(['coin_booster_2x', 'xp_booster_2x', 'lucky_streak', 'salary_raise']);
+                const boosters   = [];
+                const protectors = [];
+
+                for (const e of user.activeEffects) {
+                    const cfg = EFFECT_CONFIGS[e.type];
+                    if (!cfg) continue;
+                    const duration = e.expiresAt ? timeRemaining(e.expiresAt) : (e.charges === 1 ? '1 use left' : 'permanent');
+                    const line = `${cfg.emoji} **${cfg.label}** — ${duration}`;
+                    if (BOOSTER_TYPES.has(e.type)) boosters.push(line);
+                    else protectors.push(line);
+                }
+
+                if (boosters.length) {
+                    embed.addFields({ name: '🚀 Active Boosters', value: boosters.join('\n'), inline: false });
+                }
+                if (protectors.length) {
+                    embed.addFields({ name: '🔮 Active Effects', value: protectors.join('\n'), inline: false });
                 }
             }
 

--- a/src/commands/economy/blackjack.js
+++ b/src/commands/economy/blackjack.js
@@ -8,7 +8,7 @@ const {
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
-const { hasEffect } = require('../../services/effectsService');
+const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier } = require('../../services/effectsService');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f0cf.png';
 const MIN_BET = 10;
@@ -135,10 +135,13 @@ module.exports = {
                 const embed = buildEmbed(interaction, playerHand, dealerHand, bet, currency, '🤝 Push — both got blackjack', '#f39c12', false);
                 return interaction.reply({ embeds: [embed], components: [buildButtons(gameId, true)] });
             }
-            const payout = Math.floor(bet * 1.5);
+            const bjCoinMult   = getCoinMultiplier(user);
+            const bjServerMult = getServerCoinMultiplier(guildSettings);
+            const payout = Math.round(Math.floor(bet * 1.5) * bjCoinMult * bjServerMult);
             user.balance += bet + payout;
             await user.save();
-            const embed = buildEmbed(interaction, playerHand, dealerHand, bet, currency, `🎉 Blackjack! +${currency}${payout.toLocaleString()}`, '#2ecc71', false);
+            const boostNote = (bjCoinMult * bjServerMult) > 1.0 ? ` *(🚀 ${(bjCoinMult * bjServerMult).toFixed(1)}x)*` : '';
+            const embed = buildEmbed(interaction, playerHand, dealerHand, bet, currency, `🎉 Blackjack! +${currency}${payout.toLocaleString()}${boostNote}`, '#2ecc71', false);
             return interaction.reply({ embeds: [embed], components: [buildButtons(gameId, true)] });
         }
 
@@ -192,20 +195,32 @@ module.exports = {
             let freshUser = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
             if (!freshUser) freshUser = user;
 
-            const luckyActive = hasEffect(freshUser, 'lucky_charm');
+            const luckyActive      = hasEffect(freshUser, 'lucky_charm');
+            const luckyStreakBonus = getLuckyStreakBonus(freshUser);
+            const coinMult         = getCoinMultiplier(freshUser);
+            const serverMult       = getServerCoinMultiplier(guildSettings);
+            const totalCoinMult    = coinMult * serverMult;
 
             if (dealerTotal > 21 || playerTotal > dealerTotal) {
-                freshUser.balance += bet * 2;
-                status = `✅ You win! +${currency}${bet.toLocaleString()}`;
+                // Win: return original bet + net profit scaled by booster
+                const netProfit = Math.round(bet * totalCoinMult);
+                freshUser.balance += bet + netProfit;
+                const boostNote = totalCoinMult > 1.0 ? ` *(🚀 ${totalCoinMult.toFixed(1)}x)*` : '';
+                status = `✅ You win! +${currency}${netProfit.toLocaleString()}${boostNote}`;
                 color  = '#2ecc71';
             } else if (playerTotal === dealerTotal) {
                 freshUser.balance += bet;
                 status = `🤝 Push — bet returned`;
                 color  = '#f39c12';
             } else if (luckyActive && Math.random() < 0.20) {
-                // Lucky Charm: convert loss to push
+                // Lucky Charm: convert 20% of losses to push
                 freshUser.balance += bet;
                 status = `🍀 Lucky Charm! Push — bet returned (${currency}${bet.toLocaleString()})`;
+                color  = '#f39c12';
+            } else if (luckyStreakBonus > 0 && Math.random() < luckyStreakBonus) {
+                // Lucky Streak: convert 25% of remaining losses to push
+                freshUser.balance += bet;
+                status = `🎯 Lucky Streak! Push — bet returned (${currency}${bet.toLocaleString()})`;
                 color  = '#f39c12';
             } else {
                 status = `❌ Dealer wins. -${currency}${bet.toLocaleString()}`;

--- a/src/commands/economy/blackjack.js
+++ b/src/commands/economy/blackjack.js
@@ -192,13 +192,16 @@ module.exports = {
             const dealerTotal = handTotal(dealerHand);
 
             let color, status;
-            let freshUser = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
-            if (!freshUser) freshUser = user;
+            const [freshUser_raw, freshGuild] = await Promise.all([
+                User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }),
+                Guild.findOne({ guildId: interaction.guild.id }),
+            ]);
+            const freshUser = freshUser_raw ?? user;
 
             const luckyActive      = hasEffect(freshUser, 'lucky_charm');
             const luckyStreakBonus = getLuckyStreakBonus(freshUser);
             const coinMult         = getCoinMultiplier(freshUser);
-            const serverMult       = getServerCoinMultiplier(guildSettings);
+            const serverMult       = getServerCoinMultiplier(freshGuild);
             const totalCoinMult    = coinMult * serverMult;
 
             if (dealerTotal > 21 || playerTotal > dealerTotal) {

--- a/src/commands/economy/boost.js
+++ b/src/commands/economy/boost.js
@@ -1,0 +1,144 @@
+const { SlashCommandBuilder, EmbedBuilder, PermissionFlagsBits } = require('discord.js');
+const Guild = require('../../models/Guild');
+const { timeRemaining, getServerCoinMultiplier, getServerXpMultiplier } = require('../../services/effectsService');
+
+const BOOST_LABELS = {
+    coin: { emoji: '💰', label: 'Coin Boost', description: 'Increases coin earnings from work, daily, and games' },
+    xp:   { emoji: '⭐', label: 'XP Boost',   description: 'Increases XP gained from messages'                 },
+};
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('boost')
+        .setDescription('Manage server-wide economy boosts (Admin only)')
+        .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+        .addSubcommand(sub =>
+            sub.setName('server')
+                .setDescription('Activate a server-wide boost')
+                .addStringOption(o =>
+                    o.setName('type')
+                        .setDescription('Type of boost to activate')
+                        .setRequired(true)
+                        .addChoices(
+                            { name: '💰 Coin Boost — multiplies all coin earnings', value: 'coin' },
+                            { name: '⭐ XP Boost — multiplies XP from messages',    value: 'xp'   }
+                        ))
+                .addIntegerOption(o =>
+                    o.setName('duration')
+                        .setDescription('Duration in minutes (1–1440, i.e. up to 24 hours)')
+                        .setRequired(true)
+                        .setMinValue(1)
+                        .setMaxValue(1440))
+                .addNumberOption(o =>
+                    o.setName('multiplier')
+                        .setDescription('Boost strength (e.g. 1.5 for 1.5x, 2 for 2x). Default: 1.5')
+                        .setRequired(false)
+                        .setMinValue(1.1)
+                        .setMaxValue(10.0)))
+        .addSubcommand(sub =>
+            sub.setName('end')
+                .setDescription('End the currently active server boost'))
+        .addSubcommand(sub =>
+            sub.setName('status')
+                .setDescription('Check the current server boost status')),
+
+    async execute(interaction) {
+        const sub = interaction.options.getSubcommand();
+
+        try {
+            let guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+            if (!guildSettings) {
+                return interaction.reply({ content: 'Guild settings not found.', ephemeral: true });
+            }
+
+            if (sub === 'server') {
+                const type       = interaction.options.getString('type');
+                const duration   = interaction.options.getInteger('duration');
+                const multiplier = interaction.options.getNumber('multiplier') ?? 1.5;
+                const expiresAt  = new Date(Date.now() + duration * 60_000);
+                const info       = BOOST_LABELS[type];
+
+                guildSettings.serverBoost = {
+                    type,
+                    multiplier,
+                    expiresAt,
+                    activatedBy: interaction.user.id,
+                };
+                await guildSettings.save();
+
+                const announcementChannelId = guildSettings.economy?.announcementChannelId;
+                const embed = new EmbedBuilder()
+                    .setColor('#f39c12')
+                    .setTitle(`🚀 Server Boost Activated!`)
+                    .setDescription(`${info.emoji} **${multiplier}x ${info.label}** is now active!\n${info.description}.`)
+                    .addFields(
+                        { name: 'Multiplier', value: `**${multiplier}x**`,             inline: true },
+                        { name: 'Duration',   value: `**${duration} minutes**`,         inline: true },
+                        { name: 'Expires',    value: `<t:${Math.floor(expiresAt.getTime() / 1000)}:R>`, inline: true },
+                        { name: 'Activated by', value: `<@${interaction.user.id}>`,    inline: false }
+                    )
+                    .setTimestamp();
+
+                await interaction.reply({ embeds: [embed] });
+
+                // Announce in configured channel if different from this channel
+                if (announcementChannelId && announcementChannelId !== interaction.channel.id) {
+                    const announceChannel = interaction.guild.channels.cache.get(announcementChannelId);
+                    if (announceChannel) {
+                        await announceChannel.send({ embeds: [embed] }).catch(() => {});
+                    }
+                }
+                return;
+            }
+
+            if (sub === 'end') {
+                const sb = guildSettings.serverBoost;
+                if (!sb?.type || !sb.expiresAt || new Date(sb.expiresAt).getTime() <= Date.now()) {
+                    return interaction.reply({ content: 'There is no active server boost to end.', ephemeral: true });
+                }
+
+                const endedType = sb.type;
+                guildSettings.serverBoost = { type: null, multiplier: 1.5, expiresAt: null, activatedBy: null };
+                await guildSettings.save();
+
+                const info = BOOST_LABELS[endedType];
+                const embed = new EmbedBuilder()
+                    .setColor('#e74c3c')
+                    .setTitle('Server Boost Ended')
+                    .setDescription(`${info.emoji} The **${info.label}** has been manually ended.`)
+                    .setTimestamp();
+
+                return interaction.reply({ embeds: [embed] });
+            }
+
+            if (sub === 'status') {
+                const coinMult = getServerCoinMultiplier(guildSettings);
+                const xpMult   = getServerXpMultiplier(guildSettings);
+                const sb       = guildSettings.serverBoost;
+                const isActive = (coinMult > 1.0 || xpMult > 1.0) && sb?.expiresAt;
+
+                if (!isActive) {
+                    return interaction.reply({ content: '❌ No server boost is currently active.', ephemeral: true });
+                }
+
+                const info = BOOST_LABELS[sb.type];
+                const embed = new EmbedBuilder()
+                    .setColor('#2ecc71')
+                    .setTitle('🚀 Server Boost Status')
+                    .addFields(
+                        { name: 'Type',       value: `${info.emoji} ${info.label}`,                inline: true },
+                        { name: 'Multiplier', value: `**${sb.multiplier}x**`,                      inline: true },
+                        { name: 'Remaining',  value: `**${timeRemaining(sb.expiresAt)}**`,          inline: true },
+                        { name: 'Expires',    value: `<t:${Math.floor(new Date(sb.expiresAt).getTime() / 1000)}:F>`, inline: false }
+                    )
+                    .setTimestamp();
+
+                return interaction.reply({ embeds: [embed] });
+            }
+
+        } catch (error) {
+            console.error('Boost error:', error);
+            await interaction.reply({ content: 'Failed to manage server boost.', ephemeral: true });
+        }
+    }
+};

--- a/src/commands/economy/boost.js
+++ b/src/commands/economy/boost.js
@@ -84,8 +84,8 @@ module.exports = {
                 // Announce in configured channel if different from this channel
                 if (announcementChannelId && announcementChannelId !== interaction.channel.id) {
                     const announceChannel = interaction.guild.channels.cache.get(announcementChannelId);
-                    if (announceChannel) {
-                        await announceChannel.send({ embeds: [embed] }).catch(() => {});
+                    if (announceChannel?.isTextBased()) {
+                        await announceChannel.send({ embeds: [embed] }).catch(console.error);
                     }
                 }
                 return;
@@ -138,7 +138,12 @@ module.exports = {
 
         } catch (error) {
             console.error('Boost error:', error);
-            await interaction.reply({ content: 'Failed to manage server boost.', ephemeral: true });
+            const errMsg = { content: 'Failed to manage server boost.', ephemeral: true };
+            if (interaction.replied || interaction.deferred) {
+                await interaction.followUp(errMsg);
+            } else {
+                await interaction.reply(errMsg);
+            }
         }
     }
 };

--- a/src/commands/economy/daily.js
+++ b/src/commands/economy/daily.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { getStreakMultiplier } = require('../../utils/streakMultiplier');
+const { getCoinMultiplier, getServerCoinMultiplier } = require('../../services/effectsService');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -34,21 +35,25 @@ module.exports = {
                 });
             }
 
-            const dailyAmount = guildSettings?.economy.dailyAmount || 100;
-            const streakMult = getStreakMultiplier(user.streak?.current ?? 0);
-            const actualAmount = Math.round(dailyAmount * streakMult);
+            const dailyAmount  = guildSettings?.economy.dailyAmount || 100;
+            const streakMult   = getStreakMultiplier(user.streak?.current ?? 0);
+            const coinMult     = getCoinMultiplier(user);
+            const serverMult   = getServerCoinMultiplier(guildSettings);
+            const actualAmount = Math.round(dailyAmount * streakMult * coinMult * serverMult);
             user.balance += actualAmount;
             user.lastDaily = new Date();
             await user.save();
 
-            const streakLine = streakMult > 1.0
-                ? `\n🔥 **${streakMult}x streak bonus** applied!`
-                : '';
+            const bonusLines = [];
+            if (streakMult > 1.0) bonusLines.push(`🔥 **${streakMult}x streak bonus** applied!`);
+            if (coinMult > 1.0)   bonusLines.push(`💰🚀 **${coinMult}x Coin Booster** active!`);
+            if (serverMult > 1.0) bonusLines.push(`🌐 **${serverMult}x Server Boost** active!`);
+            const bonusLine = bonusLines.length ? `\n${bonusLines.join('\n')}` : '';
 
             const embed = new EmbedBuilder()
                 .setColor('#00ff00')
                 .setTitle('Daily Reward Claimed!')
-                .setDescription(`You received **${actualAmount.toLocaleString()}** coins!${streakLine}`)
+                .setDescription(`You received **${actualAmount.toLocaleString()}** coins!${bonusLine}`)
                 .addFields(
                     { name: 'New Balance', value: `${user.balance.toLocaleString()} coins` }
                 )

--- a/src/commands/economy/daily.js
+++ b/src/commands/economy/daily.js
@@ -35,7 +35,7 @@ module.exports = {
                 });
             }
 
-            const dailyAmount  = guildSettings?.economy.dailyAmount || 100;
+            const dailyAmount  = guildSettings?.economy?.dailyAmount ?? 100;
             const streakMult   = getStreakMultiplier(user.streak?.current ?? 0);
             const coinMult     = getCoinMultiplier(user);
             const serverMult   = getServerCoinMultiplier(guildSettings);

--- a/src/commands/economy/slots.js
+++ b/src/commands/economy/slots.js
@@ -108,6 +108,7 @@ function resultEmbed(reels, result, bet, balance, interaction) {
         mult3:   { color: '#00FFFF', title: '🎰 ⚡ Triple Boost! ⚡',     line: '⚡⚡⚡ **TRIPLE MULTIPLIER BONUS!**\n*Electrifying win!*' },
         three:   { color: '#00FF00', title: `🎰 🏆 Three ${symbol?.name ?? ''}s!`, line: `${symbol?.emoji.repeat(3)} **THREE OF A KIND!**\n*${symbol?.name} power!*` },
         two:     { color: '#FFAA00', title: '🎰 Two of a Kind',           line: `${symbol?.emoji.repeat(2)} **Two ${symbol?.name ?? ''}s** — partial win!` },
+        push:    { color: '#f39c12', title: '🎰 🎯 Lucky Push!',          line: '🎯 **Lucky Streak** saved you — bet returned!' },
         lose:    { color: '#FF4444', title: '🎰 No Match',                line: '💨 *No matching symbols — better luck next time!*' },
     };
     const { color, title, line } = cfg[outcome] ?? cfg.lose;
@@ -170,19 +171,21 @@ module.exports = {
         const wallet = user?.balance ?? 0;
         if (!await confirmBet(interaction, bet, wallet, 'Slots')) return;
         await interaction.deferReply();
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
-        await playSlots(interaction, bet, guildSettings);
+        await playSlots(interaction, bet);
     },
 };
 
-async function playSlots(interaction, bet, guildSettings) {
+async function playSlots(interaction, bet) {
     const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
     try {
-        const userDoc = await User.findOneAndUpdate(
-            userFilter,
-            { $setOnInsert: { ...userFilter, balance: 0 } },
-            { upsert: true, new: true, setDefaultsOnInsert: true }
-        );
+        const [userDoc, guildSettings] = await Promise.all([
+            User.findOneAndUpdate(
+                userFilter,
+                { $setOnInsert: { ...userFilter, balance: 0 } },
+                { upsert: true, new: true, setDefaultsOnInsert: true }
+            ),
+            Guild.findOne({ guildId: interaction.guild.id }),
+        ]);
         const luckyActive      = hasEffect(userDoc, 'lucky_charm');
         const luckyStreakBonus = getLuckyStreakBonus(userDoc);
         const coinMult         = getCoinMultiplier(userDoc);
@@ -200,10 +203,9 @@ async function playSlots(interaction, bet, guildSettings) {
             result = evaluate(reels, bet);
             charmTriggered = true;
         }
-        // Lucky Streak: on remaining loss, 25% chance to re-spin
+        // Lucky Streak: on remaining loss, 25% chance to convert to a push (bet returned)
         if (result.outcome === 'lose' && luckyStreakBonus > 0 && Math.random() < luckyStreakBonus) {
-            reels  = [spinReel(), spinReel(), spinReel()];
-            result = evaluate(reels, bet);
+            result = { ...result, outcome: 'push', payout: bet };
             luckyStreakTriggered = true;
         }
 
@@ -251,11 +253,8 @@ async function playSlots(interaction, bet, guildSettings) {
             const desc = finalEmbed.data.description ?? '';
             finalEmbed.setDescription(desc + '\n> 🍀 *Lucky Charm gave you a second chance!*');
         }
-        if (luckyStreakTriggered) {
-            const desc = finalEmbed.data.description ?? '';
-            finalEmbed.setDescription(desc + '\n> 🎯 *Lucky Streak gave you a second chance!*');
-        }
-        if (totalCoinMult > 1.0 && result.payout > 0) {
+        // luckyStreakTriggered outcome already communicates via the 'push' embed title/line
+        if (totalCoinMult > 1.0 && adjustedPayout > bet) {
             const desc = finalEmbed.data.description ?? '';
             finalEmbed.setDescription(desc + `\n> 🚀 *${totalCoinMult.toFixed(1)}x Coin Booster applied to winnings!*`);
         }
@@ -277,7 +276,7 @@ async function playSlots(interaction, bet, guildSettings) {
             }
             collector.stop('replay');
             await i.deferUpdate();
-            await playSlots(interaction, bet, guildSettings);
+            await playSlots(interaction, bet);
         });
 
         collector.on('end', (_, reason) => {

--- a/src/commands/economy/slots.js
+++ b/src/commands/economy/slots.js
@@ -7,7 +7,8 @@ const {
 } = require('discord.js');
 const User = require('../../models/User');
 const { confirmBet } = require('../../utils/confirmBet');
-const { hasEffect } = require('../../services/effectsService');
+const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier } = require('../../services/effectsService');
+const Guild = require('../../models/Guild');
 
 const THUMB = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3b0.png';
 
@@ -169,11 +170,12 @@ module.exports = {
         const wallet = user?.balance ?? 0;
         if (!await confirmBet(interaction, bet, wallet, 'Slots')) return;
         await interaction.deferReply();
-        await playSlots(interaction, bet);
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        await playSlots(interaction, bet, guildSettings);
     },
 };
 
-async function playSlots(interaction, bet) {
+async function playSlots(interaction, bet, guildSettings) {
     const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
     try {
         const userDoc = await User.findOneAndUpdate(
@@ -181,18 +183,37 @@ async function playSlots(interaction, bet) {
             { $setOnInsert: { ...userFilter, balance: 0 } },
             { upsert: true, new: true, setDefaultsOnInsert: true }
         );
-        const luckyActive = hasEffect(userDoc, 'lucky_charm');
+        const luckyActive      = hasEffect(userDoc, 'lucky_charm');
+        const luckyStreakBonus = getLuckyStreakBonus(userDoc);
+        const coinMult         = getCoinMultiplier(userDoc);
+        const serverMult       = getServerCoinMultiplier(guildSettings);
+        const totalCoinMult    = coinMult * serverMult;
 
         let reels  = [spinReel(), spinReel(), spinReel()];
         let result = evaluate(reels, bet);
+        let charmTriggered        = false;
+        let luckyStreakTriggered   = false;
+
         // Lucky Charm: on loss, 20% chance to re-spin
-        let charmTriggered = false;
         if (result.outcome === 'lose' && luckyActive && Math.random() < 0.20) {
             reels  = [spinReel(), spinReel(), spinReel()];
             result = evaluate(reels, bet);
             charmTriggered = true;
         }
-        const net    = result.payout - bet;
+        // Lucky Streak: on remaining loss, 25% chance to re-spin
+        if (result.outcome === 'lose' && luckyStreakBonus > 0 && Math.random() < luckyStreakBonus) {
+            reels  = [spinReel(), spinReel(), spinReel()];
+            result = evaluate(reels, bet);
+            luckyStreakTriggered = true;
+        }
+
+        // Apply coin booster to payout (net profit portion only)
+        let adjustedPayout = result.payout;
+        if (result.payout > 0 && totalCoinMult > 1.0) {
+            // Scale net profit by multiplier, keep original bet return whole
+            adjustedPayout = bet + Math.round((result.payout - bet) * totalCoinMult);
+        }
+        const net = adjustedPayout - bet;
 
         const user = await User.findOneAndUpdate(
             { ...userFilter, balance: { $gte: bet } },
@@ -225,10 +246,18 @@ async function playSlots(interaction, bet) {
             new ButtonBuilder().setCustomId(paytableId).setLabel('📊 Paytable').setStyle(ButtonStyle.Secondary),
         );
 
-        const finalEmbed = resultEmbed(reels, result, bet, user.balance, interaction);
+        const finalEmbed = resultEmbed(reels, { ...result, payout: adjustedPayout }, bet, user.balance, interaction);
         if (charmTriggered) {
             const desc = finalEmbed.data.description ?? '';
             finalEmbed.setDescription(desc + '\n> 🍀 *Lucky Charm gave you a second chance!*');
+        }
+        if (luckyStreakTriggered) {
+            const desc = finalEmbed.data.description ?? '';
+            finalEmbed.setDescription(desc + '\n> 🎯 *Lucky Streak gave you a second chance!*');
+        }
+        if (totalCoinMult > 1.0 && result.payout > 0) {
+            const desc = finalEmbed.data.description ?? '';
+            finalEmbed.setDescription(desc + `\n> 🚀 *${totalCoinMult.toFixed(1)}x Coin Booster applied to winnings!*`);
         }
         await interaction.editReply({
             embeds: [finalEmbed],
@@ -248,7 +277,7 @@ async function playSlots(interaction, bet) {
             }
             collector.stop('replay');
             await i.deferUpdate();
-            await playSlots(interaction, bet);
+            await playSlots(interaction, bet, guildSettings);
         });
 
         collector.on('end', (_, reason) => {

--- a/src/commands/economy/work.js
+++ b/src/commands/economy/work.js
@@ -4,6 +4,7 @@ const Guild = require('../../models/Guild');
 const DEFAULT_JOBS = require('../../data/defaultJobs');
 const DEFAULT_TIERS = require('../../data/defaultTiers');
 const { getStreakMultiplier } = require('../../utils/streakMultiplier');
+const { getCoinMultiplier, getSalaryMultiplier, getServerCoinMultiplier } = require('../../services/effectsService');
 
 function resolveTiers(guildSettings) {
     const saved = guildSettings?.jobTiers;
@@ -79,8 +80,11 @@ module.exports = {
 
             const performance = rollPerformance();
             const basedEarned = Math.max(1, Math.floor(basePay * performance.multiplier));
-            const streakMult = getStreakMultiplier(user.streak?.current ?? 0);
-            const earned = Math.round(basedEarned * streakMult);
+            const streakMult  = getStreakMultiplier(user.streak?.current ?? 0);
+            const salaryMult  = getSalaryMultiplier(user);
+            const coinMult    = getCoinMultiplier(user);
+            const serverMult  = getServerCoinMultiplier(guildSettings);
+            const earned = Math.round(basedEarned * streakMult * salaryMult * coinMult * serverMult);
 
             const jobLabel = job.emoji ? `${job.emoji} ${job.name}` : job.name;
             const scenario = WORK_SCENARIOS[Math.floor(Math.random() * WORK_SCENARIOS.length)]
@@ -94,13 +98,19 @@ module.exports = {
             const promotedTo = tierInfo.find(t => t.minShifts === user.shiftsWorked);
             const currency = guildSettings?.economy?.currency || '💰';
 
-            const streakLabel = streakMult > 1.0 ? ` *(🔥 ${streakMult}x streak)*` : '';
+            const bonusLabels = [];
+            if (streakMult > 1.0)  bonusLabels.push(`🔥 ${streakMult}x streak`);
+            if (salaryMult > 1.0)  bonusLabels.push(`📈 ${salaryMult}x salary raise`);
+            if (coinMult > 1.0)    bonusLabels.push(`💰🚀 ${coinMult}x coin booster`);
+            if (serverMult > 1.0)  bonusLabels.push(`🌐 ${serverMult}x server boost`);
+            const bonusStr = bonusLabels.length ? ` *(${bonusLabels.join(', ')})*` : '';
+
             const embed = new EmbedBuilder()
                 .setColor(performance.color)
                 .setTitle(`${performance.label} — Work Complete!`)
                 .setDescription(scenario)
                 .addFields(
-                    { name: 'Earned',       value: `${currency} **${earned.toLocaleString()}** coins${streakLabel}`, inline: true },
+                    { name: 'Earned',       value: `${currency} **${earned.toLocaleString()}** coins${bonusStr}`, inline: true },
                     { name: 'Performance',  value: performance.label, inline: true },
                     { name: 'Career Tier',  value: `${userTier.name} · ${user.shiftsWorked.toLocaleString()} shifts`, inline: false },
                     {

--- a/src/commands/leveling/rank.js
+++ b/src/commands/leveling/rank.js
@@ -1,6 +1,8 @@
 const { SlashCommandBuilder, EmbedBuilder, AttachmentBuilder } = require('discord.js');
 const User = require('../../models/User');
+const Guild = require('../../models/Guild');
 const { createRankCard } = require('../../utils/cardGenerator');
+const { pruneEffects, EFFECT_CONFIGS, timeRemaining, getServerCoinMultiplier, getServerXpMultiplier } = require('../../services/effectsService');
 
 module.exports = {
     cooldown: 5,
@@ -15,21 +17,50 @@ module.exports = {
         const targetUser = interaction.options.getUser('user') || interaction.user;
 
         try {
-            let user = await User.findOne({ userId: targetUser.id, guildId: interaction.guild.id });
+            const [user, guildSettings, allUsers] = await Promise.all([
+                User.findOne({ userId: targetUser.id, guildId: interaction.guild.id }),
+                Guild.findOne({ guildId: interaction.guild.id }),
+                User.find({ guildId: interaction.guild.id }).sort({ level: -1, xp: -1 })
+            ]);
 
             if (!user) {
                 return interaction.reply({ content: `${targetUser.username} hasn't earned any XP yet!`, ephemeral: true });
             }
 
-            const allUsers = await User.find({ guildId: interaction.guild.id }).sort({ level: -1, xp: -1 });
-            const rank = allUsers.findIndex(u => u.userId === targetUser.id) + 1;
+            pruneEffects(user);
 
+            const rank       = allUsers.findIndex(u => u.userId === targetUser.id) + 1;
             const requiredXp = user.level * 100 + 100;
-            
-            const card = await createRankCard(targetUser, user, rank, requiredXp);
+
+            const card       = await createRankCard(targetUser, user, rank, requiredXp);
             const attachment = new AttachmentBuilder(card, { name: 'rank.png' });
 
-            await interaction.reply({ files: [attachment] });
+            const BOOSTER_TYPES = new Set(['coin_booster_2x', 'xp_booster_2x', 'lucky_streak', 'salary_raise']);
+            const activeBoosters = (user.activeEffects || []).filter(e => BOOSTER_TYPES.has(e.type));
+
+            const serverCoinMult = getServerCoinMultiplier(guildSettings);
+            const serverXpMult   = getServerXpMultiplier(guildSettings);
+            const sb = guildSettings?.serverBoost;
+            const hasServerBoost = (serverCoinMult > 1.0 || serverXpMult > 1.0) && sb?.expiresAt;
+
+            if (activeBoosters.length || hasServerBoost) {
+                const lines = [];
+                if (hasServerBoost) {
+                    const boostType = sb.type === 'coin' ? `💰 ${serverCoinMult}x Coins` : `⭐ ${serverXpMult}x XP`;
+                    lines.push(`🌐 **Server Boost** — ${boostType} (${timeRemaining(sb.expiresAt)} remaining)`);
+                }
+                for (const e of activeBoosters) {
+                    const cfg = EFFECT_CONFIGS[e.type];
+                    if (!cfg) continue;
+                    lines.push(`${cfg.emoji} **${cfg.label}** — ${timeRemaining(e.expiresAt)}`);
+                }
+                const boosterEmbed = new EmbedBuilder()
+                    .setColor('#f39c12')
+                    .addFields({ name: '🚀 Active Boosters', value: lines.join('\n'), inline: false });
+                await interaction.reply({ files: [attachment], embeds: [boosterEmbed] });
+            } else {
+                await interaction.reply({ files: [attachment] });
+            }
         } catch (error) {
             console.error('Rank error:', error);
             await interaction.reply({ content: 'Failed to fetch rank.', ephemeral: true });

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -5,7 +5,7 @@ const { handleAIChat } = require('../services/aiService');
 const { logModeration } = require('../utils/logger');
 const { ensureQuests, onMessage, notifyQuestComplete } = require('../services/questService');
 const { getStreakMultiplier, checkNewMilestones } = require('../utils/streakMultiplier');
-const { hasEffect, consumeEffect } = require('../services/effectsService');
+const { hasEffect, consumeEffect, getXpMultiplier, getServerXpMultiplier } = require('../services/effectsService');
 const { checkRivalry } = require('../services/rivalryService');
 const { checkAndAward, announceAchievements } = require('../services/achievementService');
 
@@ -235,7 +235,9 @@ async function handleLeveling(message, guildSettings) {
             effectiveStreak = msAgo < 172800000 ? effectiveStreak + 1 : 1;
         }
         xpGain *= getStreakMultiplier(effectiveStreak);
+        xpGain *= getXpMultiplier(user);
     }
+    xpGain *= getServerXpMultiplier(guildSettings);
     xpGain = Math.floor(xpGain);
 
     if (user) {

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -136,6 +136,13 @@ const guildSchema = new Schema({
         voiceXpRate: { type: Number, default: 1.0 }
     },
     
+    serverBoost: {
+        type:        { type: String, enum: ['coin', 'xp', null], default: null },
+        multiplier:  { type: Number, default: 1.5, min: 1.0, max: 10.0 },
+        expiresAt:   { type: Date,   default: null },
+        activatedBy: { type: String, default: null }
+    },
+
     economy: {
         enabled: { type: Boolean, default: true },
         currency: { type: String, default: '💰' },

--- a/src/services/effectsService.js
+++ b/src/services/effectsService.js
@@ -1,14 +1,20 @@
 // Configuration for every usable item effect
 const EFFECT_CONFIGS = {
-    shield:             { label: 'Shield',            emoji: '🛡️',  durationMs: 12 * 3_600_000, charges: -1 },
-    padlock:            { label: 'Padlock',            emoji: '🔒',  durationMs: null,            charges: -1 },
-    lucky_charm:        { label: 'Lucky Charm',        emoji: '🍀',  durationMs: 2  * 3_600_000, charges: -1 },
-    lifesaver:          { label: 'Lifesaver',          emoji: '🛟',  durationMs: null,            charges: 1  },
-    invisibility_cloak: { label: 'Invisibility Cloak', emoji: '🧥',  durationMs: 6  * 3_600_000, charges: -1 },
-    knife:              { label: 'Knife',              emoji: '🔪',  durationMs: null,            charges: -1 },
-    robbery_bag:        { label: 'Robbery Bag',        emoji: '💼',  durationMs: null,            charges: -1 },
-    finders_fee:        { label: "Finder's Fee",       emoji: '💸',  durationMs: null,            charges: -1 },
-    streak_shield:      { label: 'Streak Shield',      emoji: '🔥🛡️', durationMs: null,           charges: 1  },
+    shield:             { label: 'Shield',            emoji: '🛡️',   durationMs: 12 * 3_600_000, charges: -1 },
+    padlock:            { label: 'Padlock',            emoji: '🔒',   durationMs: null,            charges: -1 },
+    lucky_charm:        { label: 'Lucky Charm',        emoji: '🍀',   durationMs: 2  * 3_600_000, charges: -1 },
+    lifesaver:          { label: 'Lifesaver',          emoji: '🛟',   durationMs: null,            charges: 1  },
+    invisibility_cloak: { label: 'Invisibility Cloak', emoji: '🧥',   durationMs: 6  * 3_600_000, charges: -1 },
+    knife:              { label: 'Knife',              emoji: '🔪',   durationMs: null,            charges: -1 },
+    robbery_bag:        { label: 'Robbery Bag',        emoji: '💼',   durationMs: null,            charges: -1 },
+    finders_fee:        { label: "Finder's Fee",       emoji: '💸',   durationMs: null,            charges: -1 },
+    streak_shield:      { label: 'Streak Shield',      emoji: '🔥🛡️', durationMs: null,            charges: 1  },
+
+    // ── Booster effects ───────────────────────────────────────────────────────
+    coin_booster_2x:    { label: '2x Coin Booster',   emoji: '💰🚀', durationMs: 1  * 3_600_000, charges: -1 },
+    xp_booster_2x:      { label: '2x XP Booster',     emoji: '⭐🚀', durationMs: 1  * 3_600_000, charges: -1 },
+    lucky_streak:       { label: 'Lucky Streak',       emoji: '🎯',   durationMs: 30 * 60_000,     charges: -1 },
+    salary_raise:       { label: 'Salary Raise',       emoji: '📈',   durationMs: 2  * 3_600_000, charges: -1 },
 };
 
 // Maps item names (as stored in inventory) to effect type keys
@@ -23,6 +29,12 @@ const ITEM_TO_EFFECT = {
     "finder's fee":       'finders_fee',
     'finders fee':        'finders_fee',
     'streak shield':      'streak_shield',
+    '2x coin booster':    'coin_booster_2x',
+    'coin booster':       'coin_booster_2x',
+    '2x xp booster':      'xp_booster_2x',
+    'xp booster':         'xp_booster_2x',
+    'lucky streak':       'lucky_streak',
+    'salary raise':       'salary_raise',
 };
 
 function resolveEffectType(itemName) {
@@ -89,6 +101,44 @@ function timeRemaining(expiresAt) {
     return `${m}m`;
 }
 
+// ── Booster multiplier helpers ────────────────────────────────────────────────
+
+// Returns coin multiplier from personal boosters (coin_booster_2x stacks with salary_raise for work)
+function getCoinMultiplier(user) {
+    return hasEffect(user, 'coin_booster_2x') ? 2.0 : 1.0;
+}
+
+// Returns the salary raise multiplier (applies only to /work earnings)
+function getSalaryMultiplier(user) {
+    return hasEffect(user, 'salary_raise') ? 1.5 : 1.0;
+}
+
+// Returns XP multiplier from personal booster
+function getXpMultiplier(user) {
+    return hasEffect(user, 'xp_booster_2x') ? 2.0 : 1.0;
+}
+
+// Returns the lucky_streak win-rate bonus (0.25 if active, else 0)
+function getLuckyStreakBonus(user) {
+    return hasEffect(user, 'lucky_streak') ? 0.25 : 0.0;
+}
+
+// Returns server-wide coin boost multiplier (1.0 if none active)
+function getServerCoinMultiplier(guildSettings) {
+    const sb = guildSettings?.serverBoost;
+    if (!sb || sb.type !== 'coin' || !sb.expiresAt) return 1.0;
+    if (new Date(sb.expiresAt).getTime() <= Date.now()) return 1.0;
+    return sb.multiplier ?? 1.5;
+}
+
+// Returns server-wide XP boost multiplier (1.0 if none active)
+function getServerXpMultiplier(guildSettings) {
+    const sb = guildSettings?.serverBoost;
+    if (!sb || sb.type !== 'xp' || !sb.expiresAt) return 1.0;
+    if (new Date(sb.expiresAt).getTime() <= Date.now()) return 1.0;
+    return sb.multiplier ?? 1.5;
+}
+
 module.exports = {
     EFFECT_CONFIGS,
     resolveEffectType,
@@ -98,4 +148,10 @@ module.exports = {
     addEffect,
     consumeEffect,
     timeRemaining,
+    getCoinMultiplier,
+    getSalaryMultiplier,
+    getXpMultiplier,
+    getLuckyStreakBonus,
+    getServerCoinMultiplier,
+    getServerXpMultiplier,
 };


### PR DESCRIPTION
Adds temporary booster effects that multiply coin/XP earnings for a set
duration, plus a server-wide boost that admins can activate globally.

Personal booster effects (usable via /use):
- 2x Coin Booster (1h): doubles net coin earnings from work, daily, and gambling wins
- 2x XP Booster (1h): doubles XP gained from messages
- Lucky Streak (30m): +25% chance to convert gambling losses to push in blackjack/slots
- Salary Raise (2h): +50% work earnings on top of other multipliers

Server boost (admin-only via /boost server):
- /boost server <coin|xp> <duration_mins> [multiplier] — activates a server-wide multiplier
- /boost end — manually ends an active server boost
- /boost status — shows current boost details
- Multiplier is configurable (default 1.5x); auto-announces to configured economy channel
- Stored in Guild.serverBoost with type, multiplier, expiresAt, activatedBy

Stacking rules:
- Personal boosters stack multiplicatively with server boosts
- Same-type personal boosters do NOT stack (refresh duration only, via existing addEffect)

Integration points updated:
- work.js: salary_raise × coin_booster_2x × server coin boost applied to earned coins
- daily.js: coin_booster_2x × server coin boost applied to daily reward
- blackjack.js: lucky_streak (25% loss→push) + coin booster scales net winnings
- slots.js: lucky_streak re-spin chance + coin booster scales winning payout
- messageCreate.js: xp_booster_2x × server XP boost applied to message XP gain
- balance.js: separate "🚀 Active Boosters" section + server boost banner
- rank.js: shows active boosters embed alongside rank card

https://claude.ai/code/session_018ywURjuwGVHEVyc29fAi2d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/boost` command (admin-only) to activate server-wide coin or XP multipliers with configurable duration
  * Economy commands now apply multipliers from personal effects and active server boosts to earnings

* **Improvements**
  * Balance, rank, and daily commands display active server boosts with remaining time
  * Blackjack, slots, and work payouts now reflect combined multiplier effects

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/Ultrabot/pull/162)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->