### PR TITLE
Add XP info command and XP exclusion hints to rank command

### DIFF
--- a/src/commands/leveling/rank.js
+++ b/src/commands/leveling/rank.js
@@ -43,6 +43,12 @@ module.exports = {
             const sb = guildSettings?.serverBoost;
             const hasServerBoost = (serverCoinMult > 1.0 || serverXpMult > 1.0) && sb?.expiresAt;
 
+            const hasExclusions = (guildSettings?.leveling?.noXpChannelIds?.length > 0) ||
+                                  (guildSettings?.leveling?.noXpRoleIds?.length > 0);
+            const xpHint = hasExclusions
+                ? '💡 Some channels or roles may not earn XP. Use /xpinfo to see details.'
+                : null;
+
             if (activeBoosters.length || hasServerBoost) {
                 const lines = [];
                 if (hasServerBoost) {
@@ -57,7 +63,13 @@ module.exports = {
                 const boosterEmbed = new EmbedBuilder()
                     .setColor('#f39c12')
                     .addFields({ name: '🚀 Active Boosters', value: lines.join('\n'), inline: false });
+                if (xpHint) boosterEmbed.setFooter({ text: xpHint });
                 await interaction.reply({ files: [attachment], embeds: [boosterEmbed] });
+            } else if (xpHint) {
+                const hintEmbed = new EmbedBuilder()
+                    .setColor('#95a5a6')
+                    .setFooter({ text: xpHint });
+                await interaction.reply({ files: [attachment], embeds: [hintEmbed] });
             } else {
                 await interaction.reply({ files: [attachment] });
             }

--- a/src/commands/leveling/xpinfo.js
+++ b/src/commands/leveling/xpinfo.js
@@ -31,6 +31,7 @@ module.exports = {
         .setDMPermission(false),
     async execute(interaction) {
         if (!interaction.inGuild()) return;
+        await interaction.deferReply({ ephemeral: true });
         try {
             const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
             const leveling = guildSettings?.leveling ?? {};
@@ -62,10 +63,10 @@ module.exports = {
                 )
                 .setFooter({ text: statusLine });
 
-            await interaction.reply({ embeds: [embed], ephemeral: true });
+            await interaction.editReply({ embeds: [embed] });
         } catch (error) {
             console.error('XP info error:', error);
-            await interaction.reply({ content: 'Failed to fetch XP settings.', ephemeral: true });
+            await interaction.editReply({ content: 'Failed to fetch XP settings.' });
         }
     }
 };

--- a/src/commands/leveling/xpinfo.js
+++ b/src/commands/leveling/xpinfo.js
@@ -2,13 +2,35 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const Guild = require('../../models/Guild');
 
 const XP_COOLDOWN_SECONDS = 60;
+const FIELD_LIMIT = 1024;
+
+function truncateMentionList(ids, format) {
+    const items = [];
+    let length = 0;
+    for (let i = 0; i < ids.length; i++) {
+        const mention = format(ids[i]);
+        const separator = items.length > 0 ? ', ' : '';
+        const added = separator.length + mention.length;
+        const remaining = ids.length - i;
+        const suffix = `, … and ${remaining} more`;
+        if (length + added + (remaining > 1 ? suffix.length : 0) > FIELD_LIMIT) {
+            items.push(`… and ${remaining} more`);
+            break;
+        }
+        items.push(mention);
+        length += added;
+    }
+    return items.length > 0 ? items.join(', ') : 'None';
+}
 
 module.exports = {
     cooldown: 5,
     data: new SlashCommandBuilder()
         .setName('xpinfo')
-        .setDescription('See which channels and roles are excluded from XP gain in this server.'),
+        .setDescription('See which channels and roles are excluded from XP gain in this server.')
+        .setDMPermission(false),
     async execute(interaction) {
+        if (!interaction.inGuild()) return;
         try {
             const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
             const leveling = guildSettings?.leveling ?? {};
@@ -18,13 +40,8 @@ module.exports = {
             const excludedChannelIds = leveling.noXpChannelIds ?? [];
             const excludedRoleIds = leveling.noXpRoleIds ?? [];
 
-            const channelMentions = excludedChannelIds
-                .map(id => `<#${id}>`)
-                .join(', ') || 'None';
-
-            const roleMentions = excludedRoleIds
-                .map(id => `<@&${id}>`)
-                .join(', ') || 'None';
+            const channelMentions = truncateMentionList(excludedChannelIds, id => `<#${id}>`);
+            const roleMentions = truncateMentionList(excludedRoleIds, id => `<@&${id}>`);
 
             const xpRateLabel = xpRate === 1.0 ? `${xpRate}x (default)` : `${xpRate}x`;
 

--- a/src/commands/leveling/xpinfo.js
+++ b/src/commands/leveling/xpinfo.js
@@ -1,0 +1,54 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const Guild = require('../../models/Guild');
+
+const XP_COOLDOWN_SECONDS = 60;
+
+module.exports = {
+    cooldown: 5,
+    data: new SlashCommandBuilder()
+        .setName('xpinfo')
+        .setDescription('See which channels and roles are excluded from XP gain in this server.'),
+    async execute(interaction) {
+        try {
+            const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+            const leveling = guildSettings?.leveling ?? {};
+
+            const xpRate = leveling.xpRate ?? 1.0;
+            const voiceEnabled = leveling.voiceXpEnabled ?? false;
+            const excludedChannelIds = leveling.noXpChannelIds ?? [];
+            const excludedRoleIds = leveling.noXpRoleIds ?? [];
+
+            const channelMentions = excludedChannelIds
+                .map(id => `<#${id}>`)
+                .join(', ') || 'None';
+
+            const roleMentions = excludedRoleIds
+                .map(id => `<@&${id}>`)
+                .join(', ') || 'None';
+
+            const xpRateLabel = xpRate === 1.0 ? `${xpRate}x (default)` : `${xpRate}x`;
+
+            const hasExclusions = excludedChannelIds.length > 0 || excludedRoleIds.length > 0;
+            const statusLine = hasExclusions
+                ? 'Some channels or roles may limit your XP gain — see above.'
+                : 'You are currently earning XP normally.';
+
+            const embed = new EmbedBuilder()
+                .setColor('#3498db')
+                .setTitle(`📊 XP Settings for ${interaction.guild.name}`)
+                .addFields(
+                    { name: 'XP Rate', value: xpRateLabel, inline: true },
+                    { name: 'Cooldown', value: `${XP_COOLDOWN_SECONDS} seconds`, inline: true },
+                    { name: 'Voice XP', value: voiceEnabled ? 'Enabled' : 'Disabled', inline: true },
+                    { name: '🚫 XP-Excluded Channels', value: channelMentions, inline: false },
+                    { name: '🚫 XP-Excluded Roles', value: roleMentions, inline: false }
+                )
+                .setFooter({ text: statusLine });
+
+            await interaction.reply({ embeds: [embed], ephemeral: true });
+        } catch (error) {
+            console.error('XP info error:', error);
+            await interaction.reply({ content: 'Failed to fetch XP settings.', ephemeral: true });
+        }
+    }
+};


### PR DESCRIPTION
## Summary
This PR adds a new `/xpinfo` command to display XP settings and exclusions for a server, and enhances the `/rank` command to notify users when XP-excluded channels or roles are configured.

## Key Changes
- **New `/xpinfo` command**: Displays server XP configuration including:
  - XP rate multiplier
  - XP cooldown duration
  - Voice XP status
  - List of XP-excluded channels and roles
  - Status indicator showing whether exclusions are active

- **Enhanced `/rank` command**: 
  - Detects when XP-excluded channels or roles are configured
  - Shows a hint footer directing users to `/xpinfo` for details
  - Displays hint even when no active boosters are present
  - Maintains existing booster display functionality

## Implementation Details
- The `/xpinfo` command retrieves guild leveling settings from the database and formats them in an embedded message
- XP exclusion detection checks both `noXpChannelIds` and `noXpRoleIds` arrays
- The hint is conditionally displayed in the `/rank` command's booster embed or as a standalone embed footer
- Both commands use ephemeral replies where appropriate for cleaner user experience
- Error handling included for database fetch failures

https://claude.ai/code/session_015R471HJqrobFYjNW2CgooU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New /xpinfo slash command: shows current leveling settings and lists channels/roles excluded from XP (ephemeral reply).
  * /rank now adds an XP-exclusion hint when exclusions exist—displayed alongside booster or as a dedicated hint—making excluded channels/roles clearer in rank responses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/Ultrabot/pull/167)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->