### PR TITLE
Remove no news found message from daily RSS digest

### DIFF
--- a/src/services/rssService.js
+++ b/src/services/rssService.js
@@ -169,10 +169,7 @@ async function sendDailyNewsForProfile(client, guild, profile) {
         uniqueItems.push(item);
     }
 
-    if (uniqueItems.length === 0) {
-        await channel.send(`No news articles found in the last 24 hours for **${profile.title}**.`);
-        return;
-    }
+    if (uniqueItems.length === 0) return;
 
     uniqueItems.sort((a, b) => b.date - a.date);
 


### PR DESCRIPTION
## Summary
Removed the user-facing message that was sent when no news articles were found in the last 24 hours for an RSS profile.

## Changes
- Simplified the early return condition in `sendDailyNewsForProfile()` to exit silently when no unique items are found, rather than sending a notification message to the channel

## Details
Previously, when no news articles were found for a profile within the 24-hour window, the bot would send an explicit message to the channel notifying users of this. This change removes that notification, allowing the function to return early without any output. This reduces noise in channels when feeds have no new content.

https://claude.ai/code/session_014Q751dcwjE1CNuVE6QrLGh