### PR TITLE
Fix Quest settings save returning 400 Bad Request

### DIFF
--- a/src/dashboard/routes/api.js
+++ b/src/dashboard/routes/api.js
@@ -194,7 +194,7 @@ const ALLOWED_SETTING_PARENTS = new Set([
     'dailyNews', 'dailyNewsProfiles', 'bibleVerse', 'suggestions', 'starboard',
     'tempVoice', 'autoRoles', 'reactionRoles', 'levelRoles', 'progressionTracks',
     'analytics', 'logging', 'tickets', 'giveaways', 'antiNuke', 'raids',
-    'escalation', 'notifications', 'music'
+    'escalation', 'notifications', 'music', 'quests'
 ]);
 
 function isAllowedSettingKey(key) {


### PR DESCRIPTION
The dashboard settings POST handler whitelisted setting key prefixes via ALLOWED_SETTING_PARENTS, but `quests` was missing. Saving the Quests panel sent keys like `quests.enabled`, which were rejected with "Disallowed setting key(s)" before reaching the Guild model. Adding `quests` to the allowlist lets these saves through.