### PR TITLE
Redesign dashboard server picker to match home page cream/ink system

### DIFF
--- a/src/dashboard/public/styles.css
+++ b/src/dashboard/public/styles.css
@@ -1075,8 +1075,8 @@ textarea { resize: vertical; min-height: 80px; }
 .cw-dash-lp-status.active { color: var(--good); }
 .cw-dash-lp-status.inactive { color: var(--ink-400); }
 
-.cw-dash-lp-action { flex-shrink: 0; padding: 9px 16px !important; font-size: 13px !important; border-radius: 999px !important; }
-.cw-dash-lp-action:focus-visible { outline: 2px solid var(--ink-950); outline-offset: 3px; }
+.cw-btn.cw-dash-lp-action { flex-shrink: 0; padding: 9px 16px; font-size: 13px; border-radius: 999px; }
+.cw-btn.cw-dash-lp-action:focus-visible { outline: 2px solid var(--ink-950); outline-offset: 3px; }
 
 /* Empty state */
 .cw-dash-lp-empty {

--- a/src/dashboard/public/styles.css
+++ b/src/dashboard/public/styles.css
@@ -1028,96 +1028,72 @@ textarea { resize: vertical; min-height: 80px; }
 }
 
 /* ================================================================
-   NEW DASHBOARD — dark ink palette (server selector)
+   DASHBOARD — cream/light palette (server selector)
+   Matches the home page visual system.
    ================================================================ */
-.cw-dash-page {
-    background: var(--ink-950);
-    color: var(--cream-100);
-    font-family: 'Inter Tight', system-ui, sans-serif;
-    min-height: 100vh;
-    position: relative;
-    z-index: 0;
-}
 
-/* Dashboard nav */
-.cw-dash-nav {
-    background: var(--ink-900);
-    border-bottom: 1px solid var(--ink-800);
-    padding: 16px 36px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    position: sticky;
-    top: 0;
-    z-index: 50;
-}
-.cw-dash-brand { display: flex; align-items: center; gap: 10px; }
-.cw-dash-wordmark { font-family: 'Instrument Serif', serif; font-size: 24px; color: var(--cream-100); letter-spacing: -0.01em; }
-
-.cw-dash-user { display: flex; align-items: center; gap: 12px; }
+/* Shared avatar elements (also used in nav) */
 .cw-dash-avatar { width: 34px; height: 34px; border-radius: 10px; object-fit: cover; }
-.cw-dash-avatar-fallback { width: 34px; height: 34px; border-radius: 10px; background: var(--moss-500); display: flex; align-items: center; justify-content: center; color: #fff; font-weight: 600; font-size: 13px; }
-.cw-dash-username { font-size: 14px; color: var(--cream-50); font-weight: 500; }
-.cw-dash-nav-btn { display: inline-flex; align-items: center; gap: 6px; padding: 8px 14px; border-radius: 10px; font-size: 13.5px; font-weight: 500; border: 1px solid var(--ink-700); background: var(--ink-850); color: var(--ink-200); cursor: pointer; text-decoration: none; font-family: inherit; transition: border-color .15s, background .15s; }
-.cw-dash-nav-btn:hover { border-color: var(--ink-500); background: var(--ink-800); color: var(--cream-50); }
-.cw-dash-nav-btn:focus-visible { outline: 2px solid var(--claw-400); outline-offset: 3px; }
+.cw-dash-avatar-fallback { width: 34px; height: 34px; border-radius: 10px; display: flex; align-items: center; justify-content: center; font-weight: 600; font-size: 13px; }
 
-/* Dashboard main content */
-.cw-dash-main { max-width: 1200px; margin: 0 auto; padding: 52px 36px 80px; }
+/* Header */
+.cw-dash-lp-header { max-width: 1320px; margin: 0 auto; padding: 72px 48px 40px; }
+.cw-dash-lp-title { font-size: clamp(44px, 6vw, 72px); line-height: 1.02; margin: 12px 0 16px; color: var(--ink-950); }
+.cw-dash-lp-title em { font-style: italic; color: var(--claw-500); }
+.cw-dash-lp-sub { font-size: 17px; color: var(--ink-600); max-width: 520px; margin: 0; line-height: 1.55; }
 
-.cw-dash-header { margin-bottom: 48px; }
-.cw-dash-greeting { font-family: 'Instrument Serif', serif; font-size: 52px; margin: 0 0 10px; line-height: 1.05; color: var(--cream-50); }
-.cw-dash-greeting em { font-style: italic; color: var(--claw-400); }
-.cw-dash-subhead { color: var(--ink-300); font-size: 16px; }
-
-.cw-dash-section-label { font-family: 'JetBrains Mono', monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--ink-500); margin-bottom: 18px; }
+/* Server list section */
+.cw-dash-lp-section { max-width: 1320px; margin: 0 auto; padding: 0 48px 80px; }
+.cw-dash-lp-count { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: var(--ink-400); text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 20px; }
 
 /* Server grid */
-.cw-server-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px; }
-.cw-server-card {
-    background: var(--ink-900);
-    border: 1px solid var(--ink-800);
+.cw-dash-lp-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 16px; }
+
+.cw-dash-lp-card {
+    background: #fff;
+    border: 1px solid rgba(20,17,13,.08);
     border-radius: 20px;
-    padding: 24px;
+    padding: 20px 22px;
     display: flex;
     align-items: center;
     gap: 16px;
-    transition: border-color .2s, transform .2s, box-shadow .2s;
-    cursor: pointer;
-    text-decoration: none;
-    color: inherit;
+    transition: transform .2s, box-shadow .2s, border-color .2s;
 }
-.cw-server-card:hover { border-color: var(--ink-600); transform: translateY(-2px); box-shadow: 0 16px 40px -20px rgba(20,17,13,.6); }
-.cw-server-card:focus-visible { outline: 2px solid var(--claw-400); outline-offset: 3px; border-color: var(--ink-600); }
-.cw-server-card.invite { border-style: dashed; border-color: var(--ink-700); background: transparent; }
-.cw-server-card.invite:hover { border-color: var(--claw-500); background: rgba(217,119,66,.04); }
-.cw-server-icon { width: 56px; height: 56px; border-radius: 16px; object-fit: cover; flex-shrink: 0; }
-.cw-server-icon-fallback {
-    width: 56px; height: 56px; border-radius: 16px; flex-shrink: 0;
+.cw-dash-lp-card:hover { transform: translateY(-3px); box-shadow: 0 16px 40px -20px rgba(20,17,13,.14); border-color: rgba(20,17,13,.14); }
+
+.cw-dash-lp-icon { width: 52px; height: 52px; border-radius: 14px; object-fit: cover; flex-shrink: 0; border: 1px solid rgba(20,17,13,.06); }
+.cw-dash-lp-icon-fallback {
+    width: 52px; height: 52px; border-radius: 14px; flex-shrink: 0;
     display: flex; align-items: center; justify-content: center;
-    font-family: 'Instrument Serif', serif; font-size: 24px; color: #fff;
+    font-family: 'Instrument Serif', serif; font-size: 22px; color: #fff;
+    background: linear-gradient(135deg, var(--claw-500), var(--plum-500));
 }
-.cw-server-info { flex: 1; min-width: 0; }
-.cw-server-name { font-size: 15.5px; font-weight: 600; color: var(--cream-50); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.cw-server-meta { font-size: 12.5px; color: var(--ink-400); margin-top: 3px; font-family: 'JetBrains Mono', monospace; }
-.cw-server-action { flex-shrink: 0; display: inline-flex; align-items: center; gap: 6px; padding: 8px 14px; border-radius: 10px; font-size: 13px; font-weight: 500; border: none; cursor: pointer; font-family: inherit; text-decoration: none; transition: background .15s, transform .15s; }
-.cw-server-action:hover { transform: translateY(-1px); }
-.cw-server-action:focus-visible { outline: 2px solid var(--cream-50); outline-offset: 2px; }
-.cw-server-action.manage { background: var(--claw-500); color: #fff; }
-.cw-server-action.manage:hover { background: var(--claw-400); }
-.cw-server-action.invite-btn { background: var(--ink-800); color: var(--ink-200); border: 1px solid var(--ink-700); }
-.cw-server-action.invite-btn:hover { background: var(--ink-700); color: var(--cream-50); }
 
-/* Empty state (dashboard) */
-.cw-dash-empty {
-    padding: 60px 40px;
+.cw-dash-lp-info { flex: 1; min-width: 0; }
+.cw-dash-lp-name { font-size: 15px; font-weight: 600; color: var(--ink-950); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cw-dash-lp-meta { font-size: 12px; margin-top: 3px; }
+.cw-dash-lp-status.active { color: var(--good); }
+.cw-dash-lp-status.inactive { color: var(--ink-400); }
+
+.cw-dash-lp-action { flex-shrink: 0; padding: 9px 16px !important; font-size: 13px !important; border-radius: 999px !important; }
+.cw-dash-lp-action:focus-visible { outline: 2px solid var(--ink-950); outline-offset: 3px; }
+
+/* Empty state */
+.cw-dash-lp-empty {
+    background: #fff;
+    border: 1.5px dashed rgba(20,17,13,.14);
+    border-radius: 24px;
+    padding: 72px 40px;
     text-align: center;
-    border-radius: 20px;
-    border: 1px dashed var(--ink-700);
-    background: rgba(255,255,255,.01);
+    max-width: 540px;
 }
-.cw-dash-empty h3 { font-family: 'Instrument Serif', serif; font-size: 28px; color: var(--cream-50); margin: 0 0 10px; }
-.cw-dash-empty p { color: var(--ink-400); font-size: 15px; max-width: 420px; margin: 0 auto 24px; line-height: 1.6; }
+.cw-dash-lp-empty-icon { width: 52px; height: 52px; border-radius: 16px; background: var(--cream-100); display: flex; align-items: center; justify-content: center; color: var(--ink-400); margin: 0 auto 20px; }
+.cw-dash-lp-empty h3 { font-family: 'Instrument Serif', serif; font-size: 30px; color: var(--ink-950); margin: 0 0 10px; }
+.cw-dash-lp-empty p { font-size: 15px; color: var(--ink-600); max-width: 380px; margin: 0 auto 28px; line-height: 1.6; }
 
-/* Dashboard footer */
-.cw-dash-footer { border-top: 1px solid var(--ink-800); padding: 24px 36px; display: flex; justify-content: space-between; align-items: center; font-size: 12px; color: var(--ink-500); font-family: 'JetBrains Mono', monospace; max-width: 1200px; margin: 0 auto; }
+/* Responsive */
+@media (max-width: 768px) {
+    .cw-dash-lp-header { padding: 48px 24px 32px; }
+    .cw-dash-lp-section { padding: 0 24px 60px; }
+    .cw-dash-lp-grid { grid-template-columns: 1fr; }
+}

--- a/src/dashboard/public/styles.css
+++ b/src/dashboard/public/styles.css
@@ -1091,11 +1091,15 @@ textarea { resize: vertical; min-height: 80px; }
 .cw-dash-lp-empty h3 { font-family: 'Instrument Serif', serif; font-size: 30px; color: var(--ink-950); margin: 0 0 10px; }
 .cw-dash-lp-empty p { font-size: 15px; color: var(--ink-600); max-width: 380px; margin: 0 auto 28px; line-height: 1.6; }
 
+/* Dashboard server-picker footer */
+.cw-dash-lp-footer { border-top: 1px solid rgba(20,17,13,.08); padding: 28px 48px; max-width: 1320px; margin: 60px auto 0; display: flex; justify-content: space-between; align-items: center; font-size: 12px; color: var(--ink-400); font-family: 'JetBrains Mono', monospace; }
+
 /* Responsive */
 @media (max-width: 768px) {
     .cw-dash-lp-header { padding: 48px 24px 32px; }
     .cw-dash-lp-section { padding: 0 24px 60px; }
     .cw-dash-lp-grid { grid-template-columns: 1fr; }
+    .cw-dash-lp-footer { padding: 24px; flex-direction: column; gap: 8px; text-align: center; }
 }
 
 /* ================================================================
@@ -1157,7 +1161,7 @@ textarea { resize: vertical; min-height: 80px; }
 
 /* Modules grid */
 .dash-module-list { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-.dash-module { background: var(--ink-850); border: 1px solid var(--ink-800); border-radius: 14px; padding: 16px; display: flex; gap: 12px; align-items: flex-start; cursor: pointer; transition: border-color .15s, background .15s; text-decoration: none; color: inherit; }
+.dash-module { background: var(--ink-850); border: 1px solid var(--ink-800); border-radius: 14px; padding: 16px; display: flex; gap: 12px; align-items: flex-start; cursor: pointer; transition: border-color .15s, background .15s; text-decoration: none; color: inherit; font: inherit; -webkit-appearance: none; appearance: none; width: 100%; text-align: left; }
 .dash-module:hover { border-color: var(--ink-600); background: var(--ink-800); }
 .dash-module-icon { width: 36px; height: 36px; border-radius: 10px; background: var(--ink-800); color: var(--cream-100); display: flex; align-items: center; justify-content: center; flex-shrink: 0; font-size: 18px; }
 .dash-module-body { flex: 1; min-width: 0; }
@@ -1202,6 +1206,9 @@ textarea { resize: vertical; min-height: 80px; }
 .dash-bot-text { flex: 1; font-size: 14px; line-height: 1.55; color: rgba(255,255,255,.92); }
 .dash-bot-btn { background: rgba(0,0,0,.25); color: #fff; border: 1px solid rgba(255,255,255,.2); padding: 8px 14px; border-radius: 10px; font-size: 13px; font-family: inherit; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; margin-top: 4px; transition: background .15s; }
 .dash-bot-btn:hover { background: rgba(0,0,0,.4); }
+
+/* Nav item keyboard focus */
+.dash-nav li:focus-visible { outline: 2px solid var(--claw-500); outline-offset: 2px; border-radius: 10px; }
 
 /* Quick-action bar at top of settings panels */
 .dash-panel-bar { display: flex; align-items: center; gap: 12px; margin-bottom: 24px; padding-bottom: 20px; border-bottom: 1px solid var(--ink-800); }

--- a/src/dashboard/public/styles.css
+++ b/src/dashboard/public/styles.css
@@ -1097,3 +1097,126 @@ textarea { resize: vertical; min-height: 80px; }
     .cw-dash-lp-section { padding: 0 24px 60px; }
     .cw-dash-lp-grid { grid-template-columns: 1fr; }
 }
+
+/* ================================================================
+   GUILD DASHBOARD — dark ink palette (per-server management)
+   Design: Clawdia Redesign.html (claude.ai/design handoff)
+   ================================================================ */
+.dash { background: var(--ink-950); color: var(--cream-100); font-family: 'Inter Tight', system-ui, sans-serif; min-height: 100vh; display: grid; grid-template-columns: 260px 1fr; }
+
+/* Sidebar */
+.dash-side { background: var(--ink-900); border-right: 1px solid var(--ink-800); padding: 22px 18px; display: flex; flex-direction: column; min-height: 100vh; position: sticky; top: 0; max-height: 100vh; overflow-y: auto; }
+.dash-server-switch { background: var(--ink-850); border: 1px solid var(--ink-800); border-radius: 14px; padding: 10px 12px; display: flex; align-items: center; gap: 10px; cursor: pointer; margin-bottom: 22px; transition: border-color .15s; }
+.dash-server-switch:hover { border-color: var(--ink-600); }
+.dash-server-avatar { width: 36px; height: 36px; border-radius: 10px; background: linear-gradient(135deg, var(--claw-500), var(--plum-500)); display: flex; align-items: center; justify-content: center; font-family: 'Instrument Serif', serif; color: #fff; font-size: 18px; flex-shrink: 0; }
+.dash-server-name { flex: 1; min-width: 0; }
+.dash-server-name b { font-size: 14px; display: block; color: var(--cream-50); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dash-server-name span { font-size: 11.5px; color: var(--ink-400); }
+.dash-nav-label { font-family: 'JetBrains Mono', monospace; font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--ink-500); margin: 18px 8px 8px; }
+.dash-nav { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 1px; }
+.dash-nav li { display: flex; align-items: center; gap: 10px; padding: 9px 12px; border-radius: 10px; font-size: 14px; color: var(--ink-200); cursor: pointer; border: none; background: transparent; width: 100%; text-align: left; font-family: inherit; transition: background .12s, color .12s; }
+.dash-nav li:hover { background: var(--ink-850); color: var(--cream-50); }
+.dash-nav li.active { background: var(--claw-500); color: #fff; }
+.dash-nav li.active .badge { background: rgba(255,255,255,.2); color: #fff; }
+.dash-nav li svg { flex-shrink: 0; color: inherit; }
+.dash-nav .nav-emoji { font-size: 15px; width: 17px; display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0; }
+.dash-nav .badge { margin-left: auto; background: var(--ink-800); color: var(--ink-300); font-size: 10.5px; padding: 2px 7px; border-radius: 999px; font-family: 'JetBrains Mono', monospace; }
+.dash-side-footer { margin-top: auto; padding-top: 18px; border-top: 1px solid var(--ink-800); }
+.dash-user { display: flex; align-items: center; gap: 10px; padding: 4px; }
+.dash-user-avatar { width: 34px; height: 34px; border-radius: 10px; background: var(--moss-500); display: flex; align-items: center; justify-content: center; color: #fff; font-weight: 600; font-size: 13px; flex-shrink: 0; }
+.dash-user b { font-size: 13.5px; color: var(--cream-50); display: block; }
+.dash-user span { font-size: 11.5px; color: var(--ink-400); }
+
+/* Main content */
+.dash-main { min-width: 0; padding: 28px 36px 60px; overflow-y: auto; }
+.dash-topbar { display: flex; align-items: center; gap: 12px; margin-bottom: 28px; padding-bottom: 20px; border-bottom: 1px solid var(--ink-800); }
+.dash-header { display: flex; justify-content: space-between; align-items: flex-end; margin-bottom: 28px; gap: 16px; flex-wrap: wrap; }
+.dash-greeting { font-family: 'Instrument Serif', serif; font-size: 44px; margin: 0; line-height: 1.05; color: var(--cream-50); }
+.dash-greeting em { font-style: italic; color: var(--claw-400); }
+.dash-subgreeting { color: var(--ink-300); margin-top: 8px; font-size: 15px; }
+
+/* KPI cards */
+.dash-kpis { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 20px; }
+.dash-kpi { background: var(--ink-900); border: 1px solid var(--ink-800); border-radius: 18px; padding: 22px; position: relative; overflow: hidden; }
+.dash-kpi-label { font-size: 12.5px; color: var(--ink-400); letter-spacing: 0.04em; text-transform: uppercase; font-family: 'JetBrains Mono', monospace; margin-bottom: 14px; display: flex; align-items: center; gap: 8px; }
+.dash-kpi-value { font-family: 'Instrument Serif', serif; font-size: 44px; line-height: 1; color: var(--cream-50); }
+.dash-kpi-meta { display: flex; align-items: center; gap: 8px; margin-top: 10px; font-size: 12.5px; }
+.dash-kpi-delta { display: inline-flex; align-items: center; gap: 4px; padding: 3px 8px; border-radius: 999px; font-family: 'JetBrains Mono', monospace; font-size: 11.5px; font-weight: 500; }
+.dash-kpi-delta.up { background: rgba(93,138,90,.18); color: #92c490; }
+.dash-kpi-delta.down { background: rgba(185,76,60,.18); color: #d68a7e; }
+.dash-kpi-foot { color: var(--ink-400); font-size: 12.5px; }
+.dash-kpi.feature { background: linear-gradient(135deg, #2b1d14, #1c1814); border-color: var(--ink-700); }
+.dash-kpi.feature .dash-kpi-value { color: var(--claw-300); }
+
+/* Dashboard cards */
+.dash-card { background: var(--ink-900); border: 1px solid var(--ink-800); border-radius: 18px; padding: 22px; }
+.dash-card-header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 18px; gap: 16px; }
+.dash-card-title { font-family: 'Instrument Serif', serif; font-size: 22px; margin: 0; line-height: 1.1; color: var(--cream-50); }
+.dash-card-sub { font-size: 13px; color: var(--ink-400); margin-top: 4px; }
+.dash-pill { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: 999px; background: var(--ink-850); font-size: 12px; color: var(--ink-200); border: 1px solid var(--ink-800); font-family: 'JetBrains Mono', monospace; }
+
+/* Modules grid */
+.dash-module-list { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.dash-module { background: var(--ink-850); border: 1px solid var(--ink-800); border-radius: 14px; padding: 16px; display: flex; gap: 12px; align-items: flex-start; cursor: pointer; transition: border-color .15s, background .15s; text-decoration: none; color: inherit; }
+.dash-module:hover { border-color: var(--ink-600); background: var(--ink-800); }
+.dash-module-icon { width: 36px; height: 36px; border-radius: 10px; background: var(--ink-800); color: var(--cream-100); display: flex; align-items: center; justify-content: center; flex-shrink: 0; font-size: 18px; }
+.dash-module-body { flex: 1; min-width: 0; }
+.dash-module-body h4 { margin: 0 0 2px; font-size: 14px; color: var(--cream-50); font-weight: 600; }
+.dash-module-body p { margin: 0; font-size: 12px; color: var(--ink-400); line-height: 1.4; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dash-module-toggle { position: relative; width: 32px; height: 18px; border-radius: 999px; background: var(--ink-700); flex-shrink: 0; margin-top: 4px; transition: background .2s; pointer-events: none; }
+.dash-module-toggle::after { content: ""; position: absolute; top: 2px; left: 2px; width: 14px; height: 14px; border-radius: 50%; background: var(--ink-300); transition: transform .2s; }
+.dash-module.on .dash-module-toggle { background: var(--claw-500); }
+.dash-module.on .dash-module-toggle::after { transform: translateX(14px); background: #fff; }
+.dash-module.on .dash-module-icon { background: rgba(217,119,66,.18); color: var(--claw-300); }
+
+/* Row layouts */
+.dash-two-col { display: grid; grid-template-columns: 1.6fr 1fr; gap: 16px; margin-top: 20px; }
+.dash-three-col { display: grid; grid-template-columns: 1.4fr 1fr 1fr; gap: 16px; margin-top: 20px; }
+
+/* Status row */
+.dash-status { display: flex; gap: 16px; padding: 14px 18px; background: var(--ink-900); border: 1px solid var(--ink-800); border-radius: 12px; align-items: center; margin-top: 18px; flex-wrap: wrap; }
+.dash-status > div { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--ink-300); }
+.dash-status .v { color: var(--cream-50); font-family: 'JetBrains Mono', monospace; }
+.dash-status i.sep { width: 1px; height: 16px; background: var(--ink-800); }
+
+/* Activity feed */
+.dash-feed { display: flex; flex-direction: column; gap: 12px; }
+.dash-feed-item { display: flex; gap: 12px; padding: 10px 0; border-bottom: 1px dashed var(--ink-800); }
+.dash-feed-item:last-child { border-bottom: none; }
+.dash-feed-icon { width: 32px; height: 32px; border-radius: 9px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; font-size: 14px; }
+.dash-feed-icon.warn { background: rgba(200,152,52,.18); color: #e0b85a; }
+.dash-feed-icon.bad { background: rgba(185,76,60,.18); color: #db8478; }
+.dash-feed-icon.good { background: rgba(93,138,90,.18); color: #91c08e; }
+.dash-feed-icon.info { background: rgba(217,119,66,.18); color: var(--claw-300); }
+.dash-feed-body { font-size: 13.5px; color: var(--cream-100); flex: 1; line-height: 1.4; }
+.dash-feed-body b { color: var(--cream-50); font-weight: 600; }
+.dash-feed-body .who { color: var(--claw-300); }
+.dash-feed-time { font-size: 11.5px; color: var(--ink-500); font-family: 'JetBrains Mono', monospace; margin-top: 4px; }
+
+/* Bot card */
+.dash-bot-card { background: linear-gradient(135deg, var(--claw-500) 0%, var(--claw-600) 100%); border: none; color: #fff; }
+.dash-bot-card .dash-card-title { color: #fff; }
+.dash-bot-card .dash-card-sub { color: rgba(255,255,255,.8); }
+.dash-bot-content { display: flex; align-items: flex-start; gap: 16px; padding: 8px 0 12px; }
+.dash-bot-avatar { width: 52px; height: 52px; border-radius: 16px; background: rgba(0,0,0,.25); display: flex; align-items: center; justify-content: center; flex-shrink: 0; font-size: 24px; }
+.dash-bot-text { flex: 1; font-size: 14px; line-height: 1.55; color: rgba(255,255,255,.92); }
+.dash-bot-btn { background: rgba(0,0,0,.25); color: #fff; border: 1px solid rgba(255,255,255,.2); padding: 8px 14px; border-radius: 10px; font-size: 13px; font-family: inherit; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; margin-top: 4px; transition: background .15s; }
+.dash-bot-btn:hover { background: rgba(0,0,0,.4); }
+
+/* Quick-action bar at top of settings panels */
+.dash-panel-bar { display: flex; align-items: center; gap: 12px; margin-bottom: 24px; padding-bottom: 20px; border-bottom: 1px solid var(--ink-800); }
+.dash-panel-bar h1 { font-family: 'Instrument Serif', serif; font-size: 32px; margin: 0; color: var(--cream-50); }
+
+/* Responsive */
+@media (max-width: 1024px) {
+    .dash-kpis { grid-template-columns: repeat(2, 1fr); }
+    .dash-two-col { grid-template-columns: 1fr; }
+    .dash-three-col { grid-template-columns: 1fr; }
+}
+@media (max-width: 768px) {
+    .dash { grid-template-columns: 1fr; }
+    .dash-side { min-height: auto; max-height: none; position: static; }
+    .dash-main { padding: 20px 20px 40px; }
+    .dash-kpis { grid-template-columns: 1fr 1fr; }
+    .dash-module-list { grid-template-columns: 1fr; }
+}

--- a/src/dashboard/views/dashboard.ejs
+++ b/src/dashboard/views/dashboard.ejs
@@ -2,90 +2,100 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Dashboard — Clawdia</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="/styles.css">
 </head>
-<body style="background:var(--ink-950);">
+<body style="background:var(--cream-50);">
 
-<div class="cw-dash-page">
+<div class="cw-home">
 
-    <!-- NAV -->
-    <nav class="cw-dash-nav">
-        <div class="cw-dash-brand">
-            <a href="/" style="display:flex;align-items:center;gap:10px;text-decoration:none;">
-                <svg width="24" height="24" viewBox="0 0 32 32" fill="none">
-                    <ellipse cx="16" cy="22" rx="8.5" ry="6" fill="#ece4d2"/>
-                    <ellipse cx="7" cy="12.5" rx="2.6" ry="3.8" fill="#ece4d2" transform="rotate(-18 7 12.5)"/>
-                    <ellipse cx="12.5" cy="9" rx="2.6" ry="4" fill="#ece4d2" transform="rotate(-6 12.5 9)"/>
-                    <ellipse cx="19.5" cy="9" rx="2.6" ry="4" fill="#ece4d2" transform="rotate(6 19.5 9)"/>
-                    <ellipse cx="25" cy="12.5" rx="2.6" ry="3.8" fill="#ece4d2" transform="rotate(18 25 12.5)"/>
-                    <path d="M14 20.5c0.6-1.6 3.4-1.6 4 0" stroke="#e89163" stroke-width="1.2" stroke-linecap="round" fill="none"/>
-                </svg>
-                <span class="cw-dash-wordmark">Clawdia</span>
-            </a>
-        </div>
-        <div class="cw-dash-user">
-            <% if (user.avatar) { %>
-                <img src="https://cdn.discordapp.com/avatars/<%= user.id %>/<%= user.avatar %>.png" alt="" class="cw-dash-avatar">
-            <% } else { %>
-                <div class="cw-dash-avatar-fallback"><%= user.username.charAt(0).toUpperCase() %></div>
-            <% } %>
-            <span class="cw-dash-username"><%= user.username %></span>
-            <a href="/auth/logout" class="cw-dash-nav-btn">Logout</a>
+    <!-- NAV (same cream nav as home page) -->
+    <nav class="cw-nav">
+        <div class="cw-nav-inner">
+            <div class="cw-brand">
+                <a href="/" style="display:flex;align-items:center;gap:10px;text-decoration:none;">
+                    <svg width="28" height="28" viewBox="0 0 32 32" fill="none">
+                        <ellipse cx="16" cy="22" rx="8.5" ry="6" fill="#14110d"/>
+                        <ellipse cx="7" cy="12.5" rx="2.6" ry="3.8" fill="#14110d" transform="rotate(-18 7 12.5)"/>
+                        <ellipse cx="12.5" cy="9" rx="2.6" ry="4" fill="#14110d" transform="rotate(-6 12.5 9)"/>
+                        <ellipse cx="19.5" cy="9" rx="2.6" ry="4" fill="#14110d" transform="rotate(6 19.5 9)"/>
+                        <ellipse cx="25" cy="12.5" rx="2.6" ry="3.8" fill="#14110d" transform="rotate(18 25 12.5)"/>
+                        <path d="M14 20.5c0.6-1.6 3.4-1.6 4 0" stroke="#d97742" stroke-width="1.2" stroke-linecap="round" fill="none"/>
+                    </svg>
+                    <span class="cw-wordmark">Clawdia</span>
+                </a>
+            </div>
+            <div class="cw-nav-cta">
+                <% if (user.avatar) { %>
+                    <img src="https://cdn.discordapp.com/avatars/<%= user.id %>/<%= user.avatar %>.png" alt="" class="cw-dash-avatar" style="border-radius:10px;">
+                <% } else { %>
+                    <div class="cw-dash-avatar-fallback" style="background:var(--ink-700);color:var(--cream-100);"><%= user.username.charAt(0).toUpperCase() %></div>
+                <% } %>
+                <span style="font-size:14px;color:var(--ink-700);font-weight:500;"><%= user.username %></span>
+                <a href="/auth/logout" class="cw-btn cw-btn-dark" style="padding:9px 16px;font-size:13.5px;">Logout</a>
+            </div>
         </div>
     </nav>
 
-    <!-- MAIN -->
-    <main class="cw-dash-main">
+    <!-- HEADER -->
+    <header class="cw-dash-lp-header">
+        <div class="cw-eyebrow">Your Dashboard</div>
+        <h1 class="font-display cw-dash-lp-title">Good to see you, <em><%= user.username %>.</em></h1>
+        <p class="cw-dash-lp-sub">Pick a server to configure Clawdia. You'll see every server where you have <strong style="color:var(--ink-950);">Manage Server</strong> permission.</p>
+    </header>
 
-        <div class="cw-dash-header">
-            <h1 class="cw-dash-greeting">Good to see you, <em><%= user.username %>.</em></h1>
-            <p class="cw-dash-subhead">Pick a server to configure Clawdia. You'll see every server where you have <strong style="color:var(--cream-50)">Manage Server</strong> permission.</p>
-        </div>
+    <!-- SERVER LIST -->
+    <section class="cw-dash-lp-section">
 
         <% if (guilds.length === 0) { %>
 
-            <div class="cw-dash-empty">
+            <div class="cw-dash-lp-empty">
+                <div class="cw-dash-lp-empty-icon">
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 15s1.5-2 4-2 4 2 4 2"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></svg>
+                </div>
                 <h3>No manageable servers found</h3>
-                <p>You need <strong>Manage Server</strong> permission (or to be the owner) on at least one server. If you just got the role, log out and back in to refresh your Discord session.</p>
-                <div style="display:flex;gap:12px;justify-content:center;margin-top:24px;">
-                    <a href="/auth/logout" class="cw-btn cw-btn-dark" style="padding:10px 18px;font-size:14px;">Refresh login</a>
-                    <a href="/" class="cw-dash-nav-btn">← Back home</a>
+                <p>You need <strong>Manage Server</strong> permission (or be the owner) on at least one server. If you just got the role, log out and back in to refresh your Discord session.</p>
+                <div style="display:flex;gap:12px;justify-content:center;flex-wrap:wrap;">
+                    <a href="/auth/logout" class="cw-btn cw-btn-dark">Refresh login</a>
+                    <a href="/" class="cw-btn cw-btn-ghost">← Back home</a>
                 </div>
             </div>
 
         <% } else { %>
 
-            <div class="cw-dash-section-label">// Your servers — <%= guilds.length %> found</div>
-            <div class="cw-server-grid">
+            <div class="cw-dash-lp-count">
+                <span class="font-mono">// <%= guilds.length %> server<%= guilds.length === 1 ? '' : 's' %> found</span>
+            </div>
+
+            <div class="cw-dash-lp-grid">
                 <% guilds.forEach(function(guild) { %>
-                    <div class="cw-server-card">
+                    <div class="cw-dash-lp-card">
                         <% if (guild.icon) { %>
-                            <img src="https://cdn.discordapp.com/icons/<%= guild.id %>/<%= guild.icon %>.png" alt="<%= guild.name %>" class="cw-server-icon">
+                            <img src="https://cdn.discordapp.com/icons/<%= guild.id %>/<%= guild.icon %>.png" alt="<%= guild.name %>" class="cw-dash-lp-icon">
                         <% } else { %>
-                            <div class="cw-server-icon-fallback" style="background:linear-gradient(135deg, #d97742, #7e5570);">
+                            <div class="cw-dash-lp-icon-fallback">
                                 <%= guild.name.charAt(0).toUpperCase() %>
                             </div>
                         <% } %>
-                        <div class="cw-server-info">
-                            <div class="cw-server-name"><%= guild.name %></div>
-                            <div class="cw-server-meta">
+                        <div class="cw-dash-lp-info">
+                            <div class="cw-dash-lp-name"><%= guild.name %></div>
+                            <div class="cw-dash-lp-meta font-mono">
                                 <% if (guild.botPresent) { %>
-                                    <span style="color:var(--good);">● bot active</span>
+                                    <span class="cw-dash-lp-status active">● bot active</span>
                                 <% } else { %>
-                                    <span style="color:var(--ink-500);">○ bot not added</span>
+                                    <span class="cw-dash-lp-status inactive">○ not added</span>
                                 <% } %>
                             </div>
                         </div>
                         <% if (guild.botPresent) { %>
-                            <a href="/dashboard/guild/<%= guild.id %>" class="cw-server-action manage">Manage</a>
+                            <a href="/dashboard/guild/<%= guild.id %>" class="cw-btn cw-btn-dark cw-dash-lp-action">Manage <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
                         <% } else if (guild.inviteUrl) { %>
-                            <a href="<%= guild.inviteUrl %>" target="_blank" rel="noopener" class="cw-server-action invite-btn">Invite bot</a>
+                            <a href="<%= guild.inviteUrl %>" target="_blank" rel="noopener" class="cw-btn cw-btn-ghost cw-dash-lp-action">Invite bot</a>
                         <% } else { %>
-                            <span class="cw-server-action invite-btn" style="opacity:.5;cursor:not-allowed;">Not configured</span>
+                            <span class="cw-btn cw-btn-ghost cw-dash-lp-action" style="opacity:.45;cursor:not-allowed;">Not configured</span>
                         <% } %>
                     </div>
                 <% }); %>
@@ -93,14 +103,15 @@
 
         <% } %>
 
-    </main>
+    </section>
 
-    <footer class="cw-dash-footer">
+    <!-- FOOTER -->
+    <footer style="border-top:1px solid rgba(20,17,13,.08);padding:28px 48px;max-width:1320px;margin:60px auto 0;display:flex;justify-content:space-between;align-items:center;font-size:12px;color:var(--ink-400);font-family:'JetBrains Mono',monospace;">
         <span>© <%= new Date().getFullYear() %> Clawdia · MIT licensed</span>
         <span>v4.2.0</span>
     </footer>
 
-</div><!-- .cw-dash-page -->
+</div><!-- .cw-home -->
 
 </body>
 </html>

--- a/src/dashboard/views/dashboard.ejs
+++ b/src/dashboard/views/dashboard.ejs
@@ -17,7 +17,7 @@
         <div class="cw-nav-inner">
             <div class="cw-brand">
                 <a href="/" style="display:flex;align-items:center;gap:10px;text-decoration:none;">
-                    <svg width="28" height="28" viewBox="0 0 32 32" fill="none">
+                    <svg width="28" height="28" viewBox="0 0 32 32" fill="none" aria-hidden="true">
                         <ellipse cx="16" cy="22" rx="8.5" ry="6" fill="#14110d"/>
                         <ellipse cx="7" cy="12.5" rx="2.6" ry="3.8" fill="#14110d" transform="rotate(-18 7 12.5)"/>
                         <ellipse cx="12.5" cy="9" rx="2.6" ry="4" fill="#14110d" transform="rotate(-6 12.5 9)"/>
@@ -30,7 +30,7 @@
             </div>
             <div class="cw-nav-cta">
                 <% if (user.avatar) { %>
-                    <img src="https://cdn.discordapp.com/avatars/<%= user.id %>/<%= user.avatar %>.png" alt="" class="cw-dash-avatar" style="border-radius:10px;">
+                    <img src="https://cdn.discordapp.com/avatars/<%= user.id %>/<%= user.avatar %>.png" alt="<%= user.username %>'s avatar" class="cw-dash-avatar" style="border-radius:10px;">
                 <% } else { %>
                     <div class="cw-dash-avatar-fallback" style="background:var(--ink-700);color:var(--cream-100);"><%= user.username.charAt(0).toUpperCase() %></div>
                 <% } %>
@@ -54,7 +54,7 @@
 
             <div class="cw-dash-lp-empty">
                 <div class="cw-dash-lp-empty-icon">
-                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 15s1.5-2 4-2 4 2 4 2"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></svg>
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M8 15s1.5-2 4-2 4 2 4 2"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></svg>
                 </div>
                 <h3>No manageable servers found</h3>
                 <p>You need <strong>Manage Server</strong> permission (or be the owner) on at least one server. If you just got the role, log out and back in to refresh your Discord session.</p>
@@ -74,7 +74,7 @@
                 <% guilds.forEach(function(guild) { %>
                     <div class="cw-dash-lp-card">
                         <% if (guild.icon) { %>
-                            <img src="https://cdn.discordapp.com/icons/<%= guild.id %>/<%= guild.icon %>.png" alt="<%= guild.name %>" class="cw-dash-lp-icon">
+                            <img src="https://cdn.discordapp.com/icons/<%= guild.id %>/<%= guild.icon %>.png" alt="Icon for <%= guild.name %> server" class="cw-dash-lp-icon">
                         <% } else { %>
                             <div class="cw-dash-lp-icon-fallback">
                                 <%= guild.name.charAt(0).toUpperCase() %>
@@ -91,7 +91,7 @@
                             </div>
                         </div>
                         <% if (guild.botPresent) { %>
-                            <a href="/dashboard/guild/<%= guild.id %>" class="cw-btn cw-btn-dark cw-dash-lp-action">Manage <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+                            <a href="/dashboard/guild/<%= guild.id %>" class="cw-btn cw-btn-dark cw-dash-lp-action">Manage <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
                         <% } else if (guild.inviteUrl) { %>
                             <a href="<%= guild.inviteUrl %>" target="_blank" rel="noopener" class="cw-btn cw-btn-ghost cw-dash-lp-action">Invite bot</a>
                         <% } else { %>
@@ -106,7 +106,7 @@
     </section>
 
     <!-- FOOTER -->
-    <footer style="border-top:1px solid rgba(20,17,13,.08);padding:28px 48px;max-width:1320px;margin:60px auto 0;display:flex;justify-content:space-between;align-items:center;font-size:12px;color:var(--ink-400);font-family:'JetBrains Mono',monospace;">
+    <footer class="cw-dash-lp-footer">
         <span>© <%= new Date().getFullYear() %> Clawdia · MIT licensed</span>
         <span>v4.2.0</span>
     </footer>

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -47,23 +47,23 @@
         <div class="dash-nav-label">// Configure</div>
         <ul class="dash-nav">
             <li class="nav-item active" data-tab="overview">
-                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M7 14l4-4 3 3 5-6"/></svg>
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M3 3v18h18"/><path d="M7 14l4-4 3 3 5-6"/></svg>
                 <span>Overview</span>
             </li>
             <li class="nav-item" data-tab="welcome">
-                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 16c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3"/><path d="M3 11c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3"/></svg>
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M3 16c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3"/><path d="M3 11c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3"/></svg>
                 <span>Welcome</span>
             </li>
             <li class="nav-item" data-tab="farewell">
-                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 16c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3"/><path d="M3 11c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3"/></svg>
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M3 16c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3"/><path d="M3 11c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3"/></svg>
                 <span>Farewell</span>
             </li>
             <li class="nav-item" data-tab="leveling">
-                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M8 4h8v4a4 4 0 0 1-8 0V4z"/><path d="M5 6H3v2a3 3 0 0 0 3 3M19 6h2v2a3 3 0 0 1-3 3"/><path d="M9 14h6l1 6H8z"/></svg>
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M8 4h8v4a4 4 0 0 1-8 0V4z"/><path d="M5 6H3v2a3 3 0 0 0 3 3M19 6h2v2a3 3 0 0 1-3 3"/><path d="M9 14h6l1 6H8z"/></svg>
                 <span>Leveling</span>
             </li>
             <li class="nav-item" data-tab="economy">
-                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8"/><path d="M10 9h3a2 2 0 0 1 0 4h-3v-4zM10 13v3"/></svg>
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><circle cx="12" cy="12" r="8"/><path d="M10 9h3a2 2 0 0 1 0 4h-3v-4zM10 13v3"/></svg>
                 <span>Economy</span>
             </li>
             <li class="nav-item" data-tab="birthdays"><span class="nav-emoji">🎂</span><span>Birthdays</span></li>
@@ -73,12 +73,12 @@
         <div class="dash-nav-label">// Moderation</div>
         <ul class="dash-nav">
             <li class="nav-item" data-tab="moderation">
-                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8.5-8 9-4.5-.5-8-4-8-9V6l8-3z"/></svg>
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M12 3l8 3v6c0 5-3.5 8.5-8 9-4.5-.5-8-4-8-9V6l8-3z"/></svg>
                 <span>Moderation</span>
             </li>
             <li class="nav-item" data-tab="raiddetection"><span class="nav-emoji">🚨</span><span>Raid Detection</span></li>
             <li class="nav-item" data-tab="antinuke">
-                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg>
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg>
                 <span>Anti-Nuke</span>
             </li>
             <li class="nav-item" data-tab="casesettings"><span class="nav-emoji">📁</span><span>Case Settings</span></li>
@@ -88,7 +88,7 @@
         <div class="dash-nav-label">// Engagement</div>
         <ul class="dash-nav">
             <li class="nav-item" data-tab="music">
-                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l11-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="17" cy="16" r="3"/></svg>
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M9 18V5l11-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="17" cy="16" r="3"/></svg>
                 <span>Music</span>
             </li>
             <li class="nav-item" data-tab="achievements"><span class="nav-emoji">🏅</span><span>Achievements</span></li>
@@ -104,11 +104,11 @@
         <div class="dash-nav-label">// Tools</div>
         <ul class="dash-nav">
             <li class="nav-item" data-tab="commandpolicies">
-                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1.1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1.1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8V9a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z"/></svg>
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1.1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1.1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8V9a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z"/></svg>
                 <span>Command Policies</span>
             </li>
             <li class="nav-item" data-tab="ai">
-                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l1.6 4.6L18 9l-4.4 1.4L12 15l-1.6-4.6L6 9l4.4-1.4z"/><path d="M19 14l.8 2.2L22 17l-2.2.8L19 20l-.8-2.2L16 17l2.2-.8z"/></svg>
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M12 3l1.6 4.6L18 9l-4.4 1.4L12 15l-1.6-4.6L6 9l4.4-1.4z"/><path d="M19 14l.8 2.2L22 17l-2.2.8L19 20l-.8-2.2L16 17l2.2-.8z"/></svg>
                 <span>AI Chat</span>
             </li>
             <li class="nav-item" data-tab="tempvoice"><span class="nav-emoji">🔊</span><span>Temp Voice</span></li>
@@ -120,13 +120,13 @@
         <ul class="dash-nav">
             <li class="nav-item" data-tab="bibleverses"><span class="nav-emoji">📖</span><span>Bible Verses</span></li>
             <li class="nav-item" data-tab="rss">
-                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4a16 16 0 0 1 16 16"/><path d="M4 11a9 9 0 0 1 9 9"/><circle cx="5" cy="19" r="1.4" fill="currentColor"/></svg>
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M4 4a16 16 0 0 1 16 16"/><path d="M4 11a9 9 0 0 1 9 9"/><circle cx="5" cy="19" r="1.4" fill="currentColor"/></svg>
                 <span>RSS Feeds</span>
             </li>
             <% if (guild.owner) { %>
             <li class="nav-item" data-tab="agentchannels"><span class="nav-emoji">🤖</span><span>Agent Channels</span></li>
             <li class="nav-item" data-tab="automations">
-                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2L4 14h6l-1 8 9-12h-6l1-8z"/></svg>
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M13 2L4 14h6l-1 8 9-12h-6l1-8z"/></svg>
                 <span>Automations</span>
             </li>
             <% } %>
@@ -136,7 +136,7 @@
         <div class="dash-nav-label">// Insights</div>
         <ul class="dash-nav">
             <li class="nav-item" data-tab="analytics">
-                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M7 14l4-4 3 3 5-6"/></svg>
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M3 3v18h18"/><path d="M7 14l4-4 3 3 5-6"/></svg>
                 <span>Analytics</span>
             </li>
             <li class="nav-item" data-tab="eventlog"><span class="nav-emoji">📋</span><span>Event Log</span></li>
@@ -213,8 +213,7 @@
                     if (settings.moderation && settings.moderation.enabled) moduleCount++;
                     if (settings.music && settings.music.enabled) moduleCount++;
                     if (settings.ai && settings.ai.enabled) moduleCount++;
-                    if (settings.dailyNewsProfiles && settings.dailyNewsProfiles.length > 0) moduleCount++;
-                    if (settings.rss && settings.rss.enabled) moduleCount++;
+                    if (settings.rss?.enabled || settings.rssFeeds?.length > 0 || settings.dailyNews?.enabled || settings.dailyNewsProfiles?.length > 0) moduleCount++;
                     %>
                     <div class="dash-kpi-value"><%= moduleCount %></div>
                     <div class="dash-kpi-meta"><span class="dash-kpi-foot">of 8 modules</span></div>
@@ -282,7 +281,7 @@
                             <div class="dash-module-body"><h4>AI Chat</h4><p>Conversational AI</p></div>
                             <div class="dash-module-toggle"></div>
                         </button>
-                        <button type="button" class="dash-module <%= (settings.dailyNewsProfiles && settings.dailyNewsProfiles.length > 0) ? 'on' : '' %>" data-tab-link="rss">
+                        <button type="button" class="dash-module <%= (settings.rss?.enabled || settings.rssFeeds?.length > 0 || settings.dailyNews?.enabled || settings.dailyNewsProfiles?.length > 0) ? 'on' : '' %>" data-tab-link="rss">
                             <div class="dash-module-icon">
                                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4a16 16 0 0 1 16 16"/><path d="M4 11a9 9 0 0 1 9 9"/><circle cx="5" cy="19" r="1.4" fill="currentColor"/></svg>
                             </div>
@@ -2101,7 +2100,12 @@
                 if (panel) { panel.classList.add('active'); panel.style.display = 'block'; }
                 if (topbarSection) topbarSection.textContent = item.querySelector('span:last-child')?.textContent || tab;
                 if (tab === 'analytics') loadAnalytics();
-                if (history.replaceState) history.replaceState(null, '', '#' + tab);
+                if (history.replaceState) {
+                    const innerToParent = { knowledgebase: 'ai', aisummaries: 'ai', aipersonas: 'ai', dailynews: 'rss' };
+                    const curInner = location.hash.slice(1);
+                    const newHash = (innerToParent[curInner] === tab) ? location.hash : '#' + tab;
+                    history.replaceState(null, '', newHash);
+                }
             });
         });
 
@@ -3672,6 +3676,12 @@
             if (!list) return;
             try {
                 const res = await fetch(`/api/automations/${GUILD_ID}`);
+                if (!res.ok) {
+                    const errText = await res.text();
+                    list.innerHTML = '<p style="font-size:.85rem;color:var(--muted)">Could not load automations.</p>';
+                    console.error('Automations fetch failed:', res.status, errText);
+                    return;
+                }
                 const automations = await res.json();
                 if (!automations.length) {
                     list.innerHTML = '<p style="font-size:.85rem;color:var(--muted)">No automations yet. Create one below.</p>';

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -240,62 +240,62 @@
                         <span class="dash-pill"><span style="width:6px;height:6px;border-radius:50%;background:var(--good);display:inline-block;"></span> live</span>
                     </div>
                     <div class="dash-module-list">
-                        <a class="dash-module <%= (settings.welcome && settings.welcome.enabled) ? 'on' : '' %>" data-tab-link="welcome">
+                        <button type="button" class="dash-module <%= (settings.welcome && settings.welcome.enabled) ? 'on' : '' %>" data-tab-link="welcome">
                             <div class="dash-module-icon">
-                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 16c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3"/><path d="M3 11c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3"/></svg>
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 16c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3"/><path d="M3 11c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3"/></svg>
                             </div>
                             <div class="dash-module-body"><h4>Welcome</h4><p>Cards &amp; farewell</p></div>
                             <div class="dash-module-toggle"></div>
-                        </a>
-                        <a class="dash-module <%= (settings.moderation && settings.moderation.enabled) ? 'on' : '' %>" data-tab-link="moderation">
+                        </button>
+                        <button type="button" class="dash-module <%= (settings.moderation && settings.moderation.enabled) ? 'on' : '' %>" data-tab-link="moderation">
                             <div class="dash-module-icon">
-                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8.5-8 9-4.5-.5-8-4-8-9V6l8-3z"/></svg>
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3l8 3v6c0 5-3.5 8.5-8 9-4.5-.5-8-4-8-9V6l8-3z"/></svg>
                             </div>
                             <div class="dash-module-body"><h4>Moderation</h4><p>Auto-mod, mute, logging</p></div>
                             <div class="dash-module-toggle"></div>
-                        </a>
-                        <a class="dash-module <%= (settings.leveling && settings.leveling.enabled) ? 'on' : '' %>" data-tab-link="leveling">
+                        </button>
+                        <button type="button" class="dash-module <%= (settings.leveling && settings.leveling.enabled) ? 'on' : '' %>" data-tab-link="leveling">
                             <div class="dash-module-icon">
-                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M8 4h8v4a4 4 0 0 1-8 0V4z"/><path d="M5 6H3v2a3 3 0 0 0 3 3M19 6h2v2a3 3 0 0 1-3 3"/><path d="M9 14h6l1 6H8z"/></svg>
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8 4h8v4a4 4 0 0 1-8 0V4z"/><path d="M5 6H3v2a3 3 0 0 0 3 3M19 6h2v2a3 3 0 0 1-3 3"/><path d="M9 14h6l1 6H8z"/></svg>
                             </div>
                             <div class="dash-module-body"><h4>Leveling</h4><p>XP &amp; rank cards</p></div>
                             <div class="dash-module-toggle"></div>
-                        </a>
-                        <a class="dash-module <%= (settings.economy && settings.economy.enabled) ? 'on' : '' %>" data-tab-link="economy">
+                        </button>
+                        <button type="button" class="dash-module <%= (settings.economy && settings.economy.enabled) ? 'on' : '' %>" data-tab-link="economy">
                             <div class="dash-module-icon">
-                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8"/><path d="M10 9h3a2 2 0 0 1 0 4h-3v-4zM10 13v3"/></svg>
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="8"/><path d="M10 9h3a2 2 0 0 1 0 4h-3v-4zM10 13v3"/></svg>
                             </div>
                             <div class="dash-module-body"><h4>Economy</h4><p>Currency · 🪙 Crowns</p></div>
                             <div class="dash-module-toggle"></div>
-                        </a>
-                        <a class="dash-module <%= (settings.music && settings.music.enabled) ? 'on' : '' %>" data-tab-link="music">
+                        </button>
+                        <button type="button" class="dash-module <%= (settings.music && settings.music.enabled) ? 'on' : '' %>" data-tab-link="music">
                             <div class="dash-module-icon">
-                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l11-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="17" cy="16" r="3"/></svg>
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 18V5l11-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="17" cy="16" r="3"/></svg>
                             </div>
                             <div class="dash-module-body"><h4>Music</h4><p>24/7 playback</p></div>
                             <div class="dash-module-toggle"></div>
-                        </a>
-                        <a class="dash-module <%= (settings.ai && settings.ai.enabled) ? 'on' : '' %>" data-tab-link="ai">
+                        </button>
+                        <button type="button" class="dash-module <%= (settings.ai && settings.ai.enabled) ? 'on' : '' %>" data-tab-link="ai">
                             <div class="dash-module-icon">
-                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l1.6 4.6L18 9l-4.4 1.4L12 15l-1.6-4.6L6 9l4.4-1.4z"/></svg>
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3l1.6 4.6L18 9l-4.4 1.4L12 15l-1.6-4.6L6 9l4.4-1.4z"/></svg>
                             </div>
                             <div class="dash-module-body"><h4>AI Chat</h4><p>Conversational AI</p></div>
                             <div class="dash-module-toggle"></div>
-                        </a>
-                        <a class="dash-module <%= (settings.dailyNewsProfiles && settings.dailyNewsProfiles.length > 0) ? 'on' : '' %>" data-tab-link="rss">
+                        </button>
+                        <button type="button" class="dash-module <%= (settings.dailyNewsProfiles && settings.dailyNewsProfiles.length > 0) ? 'on' : '' %>" data-tab-link="rss">
                             <div class="dash-module-icon">
-                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4a16 16 0 0 1 16 16"/><path d="M4 11a9 9 0 0 1 9 9"/><circle cx="5" cy="19" r="1.4" fill="currentColor"/></svg>
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 4a16 16 0 0 1 16 16"/><path d="M4 11a9 9 0 0 1 9 9"/><circle cx="5" cy="19" r="1.4" fill="currentColor"/></svg>
                             </div>
                             <div class="dash-module-body"><h4>Daily Digest</h4><p>RSS &amp; news feeds</p></div>
                             <div class="dash-module-toggle"></div>
-                        </a>
-                        <a class="dash-module" data-tab-link="analytics">
+                        </button>
+                        <button type="button" class="dash-module" data-tab-link="analytics">
                             <div class="dash-module-icon">
-                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M7 14l4-4 3 3 5-6"/></svg>
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 3v18h18"/><path d="M7 14l4-4 3 3 5-6"/></svg>
                             </div>
                             <div class="dash-module-body"><h4>Analytics</h4><p>Insights &amp; event log</p></div>
                             <div class="dash-module-toggle"></div>
-                        </a>
+                        </button>
                     </div>
                 </div>
 
@@ -1687,23 +1687,23 @@
                         </div>
                         <div class="field ai-key-field" data-provider="openai">
                             <label class="field-label" for="ai-openai-key">OpenAI API key</label>
-                            <input type="password" id="ai-openai-key" value="<%= settings.ai.openaiKey || '' %>" placeholder="sk-…">
-                            <small>Leave empty to use the bot's default key</small>
+                            <input type="password" id="ai-openai-key" value="" placeholder="<%= settings.ai.openaiKey ? '••••••••••••' : 'sk-…' %>">
+                            <small><% if (settings.ai.openaiKey) { %>Key configured — enter a new value to replace it<% } else { %>Leave empty to use the bot's default key<% } %></small>
                         </div>
                         <div class="field ai-key-field" data-provider="anthropic">
                             <label class="field-label" for="ai-anthropic-key">Anthropic API key</label>
-                            <input type="password" id="ai-anthropic-key" value="<%= settings.ai.anthropicKey || '' %>" placeholder="sk-ant-…">
-                            <small>Leave empty to use the bot's default key</small>
+                            <input type="password" id="ai-anthropic-key" value="" placeholder="<%= settings.ai.anthropicKey ? '••••••••••••' : 'sk-ant-…' %>">
+                            <small><% if (settings.ai.anthropicKey) { %>Key configured — enter a new value to replace it<% } else { %>Leave empty to use the bot's default key<% } %></small>
                         </div>
                         <div class="field ai-key-field" data-provider="gemini">
                             <label class="field-label" for="ai-gemini-key">Gemini API key</label>
-                            <input type="password" id="ai-gemini-key" value="<%= settings.ai.geminiKey || '' %>" placeholder="AIza…">
-                            <small>Leave empty to use the bot's default key</small>
+                            <input type="password" id="ai-gemini-key" value="" placeholder="<%= settings.ai.geminiKey ? '••••••••••••' : 'AIza…' %>">
+                            <small><% if (settings.ai.geminiKey) { %>Key configured — enter a new value to replace it<% } else { %>Leave empty to use the bot's default key<% } %></small>
                         </div>
                         <div class="field ai-key-field" data-provider="openrouter">
                             <label class="field-label" for="ai-openrouter-key">OpenRouter API key</label>
-                            <input type="password" id="ai-openrouter-key" value="<%= settings.ai.openrouterKey || '' %>" placeholder="sk-or-…">
-                            <small>Get a key at openrouter.ai. Use any model OpenRouter supports (e.g. <code>anthropic/claude-3.5-sonnet</code>).</small>
+                            <input type="password" id="ai-openrouter-key" value="" placeholder="<%= settings.ai.openrouterKey ? '••••••••••••' : 'sk-or-…' %>">
+                            <small><% if (settings.ai.openrouterKey) { %>Key configured — enter a new value to replace it<% } else { %>Get a key at openrouter.ai. Use any model OpenRouter supports (e.g. <code>anthropic/claude-3.5-sonnet</code>).<% } %></small>
                         </div>
                         <div class="field ai-key-field" data-provider="ollama">
                             <label class="field-label" for="ai-ollama-url">Ollama base URL</label>
@@ -2078,13 +2078,25 @@
         const navItems = document.querySelectorAll('.nav-item');
         const panels = document.querySelectorAll('.panel');
         const topbarSection = document.getElementById('topbar-section');
+
+        // Keyboard + ARIA accessibility for nav items
+        navItems.forEach(item => {
+            item.setAttribute('role', 'button');
+            item.setAttribute('tabindex', '0');
+            item.setAttribute('aria-pressed', item.classList.contains('active') ? 'true' : 'false');
+            item.addEventListener('keydown', e => {
+                if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); item.click(); }
+            });
+        });
+
         navItems.forEach(item => {
             item.addEventListener('click', () => {
                 const tab = item.dataset.tab;
                 if (!tab) return;
-                navItems.forEach(n => n.classList.remove('active'));
+                navItems.forEach(n => { n.classList.remove('active'); n.setAttribute('aria-pressed', 'false'); });
                 panels.forEach(p => { p.classList.remove('active'); p.style.display = 'none'; });
                 item.classList.add('active');
+                item.setAttribute('aria-pressed', 'true');
                 const panel = document.getElementById(tab);
                 if (panel) { panel.classList.add('active'); panel.style.display = 'block'; }
                 if (topbarSection) topbarSection.textContent = item.querySelector('span:last-child')?.textContent || tab;
@@ -2569,10 +2581,10 @@
                     'ai.enabled': document.getElementById('ai-enabled').checked,
                     'ai.provider': document.getElementById('ai-provider').value,
                     'ai.model': document.getElementById('ai-model').value.trim(),
-                    'ai.openaiKey': document.getElementById('ai-openai-key').value,
-                    'ai.anthropicKey': document.getElementById('ai-anthropic-key').value,
-                    'ai.geminiKey': document.getElementById('ai-gemini-key').value,
-                    'ai.openrouterKey': document.getElementById('ai-openrouter-key').value,
+                    ...(document.getElementById('ai-openai-key').value ? {'ai.openaiKey': document.getElementById('ai-openai-key').value} : {}),
+                    ...(document.getElementById('ai-anthropic-key').value ? {'ai.anthropicKey': document.getElementById('ai-anthropic-key').value} : {}),
+                    ...(document.getElementById('ai-gemini-key').value ? {'ai.geminiKey': document.getElementById('ai-gemini-key').value} : {}),
+                    ...(document.getElementById('ai-openrouter-key').value ? {'ai.openrouterKey': document.getElementById('ai-openrouter-key').value} : {}),
                     'ai.ollamaBaseUrl': document.getElementById('ai-ollama-url').value.trim(),
                     'ai.channelId': document.getElementById('ai-channel').value,
                     'ai.systemPrompt': document.getElementById('ai-prompt').value,
@@ -3658,10 +3670,6 @@
         async function loadAutomations() {
             const list = document.getElementById('automationsList');
             if (!list) return;
-            try {
-                const res = await fetch(`/api/automations/${GUILD_ID}/logs`);
-                // logs endpoint — actually load automations first
-            } catch {}
             try {
                 const res = await fetch(`/api/automations/${GUILD_ID}`);
                 const automations = await res.json();

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -2,86 +2,351 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><%= guild.name %> · Settings — Clawdia</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><%= guild.name %> · Dashboard — Clawdia</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/styles.css">
 </head>
-<body>
-    <div class="mesh-bg"><div class="grid"></div><div class="blob-3"></div></div>
+<body style="background:var(--ink-950);margin:0;">
+<div class="dash">
 
-    <header class="topbar">
-        <a href="/dashboard" class="brand" style="text-decoration:none;color:inherit;">
-            <span class="brand-mark"></span>
-            <span>Clawdia</span>
-        </a>
-        <div class="topbar-right">
-            <div class="user-chip">
-                <span style="padding:0 .35rem;">⚙️ <strong style="color:var(--text);"><%= guild.name %></strong></span>
-            </div>
-            <a href="/dashboard" class="btn btn-sm">← Back</a>
+    <!-- ── SIDEBAR ───────────────────────────────────────────── -->
+    <aside class="dash-side">
+
+        <!-- Brand -->
+        <div style="padding:4px 8px 22px;">
+            <a href="/" style="display:flex;align-items:center;gap:10px;text-decoration:none;">
+                <svg width="24" height="24" viewBox="0 0 32 32" fill="none">
+                    <ellipse cx="16" cy="22" rx="8.5" ry="6" fill="#ece4d2"/>
+                    <ellipse cx="7" cy="12.5" rx="2.6" ry="3.8" fill="#ece4d2" transform="rotate(-18 7 12.5)"/>
+                    <ellipse cx="12.5" cy="9" rx="2.6" ry="4" fill="#ece4d2" transform="rotate(-6 12.5 9)"/>
+                    <ellipse cx="19.5" cy="9" rx="2.6" ry="4" fill="#ece4d2" transform="rotate(6 19.5 9)"/>
+                    <ellipse cx="25" cy="12.5" rx="2.6" ry="3.8" fill="#ece4d2" transform="rotate(18 25 12.5)"/>
+                    <path d="M14 20.5c0.6-1.6 3.4-1.6 4 0" stroke="#e89163" stroke-width="1.2" stroke-linecap="round" fill="none"/>
+                </svg>
+                <span class="cw-wordmark" style="color:var(--cream-100);font-size:24px;">Clawdia</span>
+            </a>
         </div>
-    </header>
 
-    <main class="container">
-        <div class="settings-layout">
-            <aside class="sidebar" role="tablist">
-                <!-- Members -->
-                <div class="nav-section-header">Members</div>
-                <button class="nav-item" data-tab="economy"><span class="nav-emoji">💎</span> Economy</button>
-                <button class="nav-item" data-tab="farewell"><span class="nav-emoji">👋</span> Farewell</button>
-                <button class="nav-item" data-tab="leveling"><span class="nav-emoji">📈</span> Leveling</button>
-                <button class="nav-item active" data-tab="welcome"><span class="nav-emoji">👋</span> Welcome</button>
+        <!-- Server switcher -->
+        <a href="/dashboard" class="dash-server-switch" style="text-decoration:none;">
+            <% if (guild.icon) { %>
+                <img src="https://cdn.discordapp.com/icons/<%= guild.id %>/<%= guild.icon %>.png" alt="" style="width:36px;height:36px;border-radius:10px;object-fit:cover;flex-shrink:0;">
+            <% } else { %>
+                <div class="dash-server-avatar"><%= guild.name.charAt(0).toUpperCase() %></div>
+            <% } %>
+            <div class="dash-server-name">
+                <b><%= guild.name %></b>
+                <span>Switch server</span>
+            </div>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M8 9l4-4 4 4M8 15l4 4 4-4"/></svg>
+        </a>
 
-                
+        <!-- Configure -->
+        <div class="dash-nav-label">// Configure</div>
+        <ul class="dash-nav">
+            <li class="nav-item active" data-tab="overview">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M7 14l4-4 3 3 5-6"/></svg>
+                <span>Overview</span>
+            </li>
+            <li class="nav-item" data-tab="welcome">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 16c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3"/><path d="M3 11c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3"/></svg>
+                <span>Welcome</span>
+            </li>
+            <li class="nav-item" data-tab="farewell">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 16c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3"/><path d="M3 11c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3"/></svg>
+                <span>Farewell</span>
+            </li>
+            <li class="nav-item" data-tab="leveling">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M8 4h8v4a4 4 0 0 1-8 0V4z"/><path d="M5 6H3v2a3 3 0 0 0 3 3M19 6h2v2a3 3 0 0 1-3 3"/><path d="M9 14h6l1 6H8z"/></svg>
+                <span>Leveling</span>
+            </li>
+            <li class="nav-item" data-tab="economy">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8"/><path d="M10 9h3a2 2 0 0 1 0 4h-3v-4zM10 13v3"/></svg>
+                <span>Economy</span>
+            </li>
+            <li class="nav-item" data-tab="birthdays"><span class="nav-emoji">🎂</span><span>Birthdays</span></li>
+        </ul>
 
-                <button class="nav-item" data-tab="birthdays"><span class="nav-emoji">🎂</span> Birthdays</button>
+        <!-- Moderation -->
+        <div class="dash-nav-label">// Moderation</div>
+        <ul class="dash-nav">
+            <li class="nav-item" data-tab="moderation">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8.5-8 9-4.5-.5-8-4-8-9V6l8-3z"/></svg>
+                <span>Moderation</span>
+            </li>
+            <li class="nav-item" data-tab="raiddetection"><span class="nav-emoji">🚨</span><span>Raid Detection</span></li>
+            <li class="nav-item" data-tab="antinuke">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg>
+                <span>Anti-Nuke</span>
+            </li>
+            <li class="nav-item" data-tab="casesettings"><span class="nav-emoji">📁</span><span>Case Settings</span></li>
+        </ul>
 
-                <!-- Moderation -->
-                <div class="nav-section-header">Moderation</div>
-                <button class="nav-item" data-tab="moderation"><span class="nav-emoji">🛡️</span> Moderation</button>
-                <button class="nav-item" data-tab="raiddetection"><span class="nav-emoji">🚨</span> Raid Detection</button>
-                <button class="nav-item" data-tab="antinuke"><span class="nav-emoji">🔒</span> Anti-Nuke</button>
-                <button class="nav-item" data-tab="casesettings"><span class="nav-emoji">📁</span> Case Settings</button>
+        <!-- Engagement -->
+        <div class="dash-nav-label">// Engagement</div>
+        <ul class="dash-nav">
+            <li class="nav-item" data-tab="music">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l11-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="17" cy="16" r="3"/></svg>
+                <span>Music</span>
+            </li>
+            <li class="nav-item" data-tab="achievements"><span class="nav-emoji">🏅</span><span>Achievements</span></li>
+            <li class="nav-item" data-tab="quests"><span class="nav-emoji">🗺️</span><span>Quests</span></li>
+            <li class="nav-item" data-tab="season"><span class="nav-emoji">🏆</span><span>Season Pass</span></li>
+            <li class="nav-item" data-tab="progressiontracks"><span class="nav-emoji">🧭</span><span>Progression Tracks</span></li>
+            <li class="nav-item" data-tab="starboard"><span class="nav-emoji">⭐</span><span>Starboard</span></li>
+            <li class="nav-item" data-tab="suggestions"><span class="nav-emoji">💡</span><span>Suggestions</span></li>
+            <li class="nav-item" data-tab="reactionroles"><span class="nav-emoji">🎭</span><span>Reaction Roles</span></li>
+        </ul>
 
-                <!-- Engagement -->
-                <div class="nav-section-header">Engagement</div>
-                <button class="nav-item" data-tab="music"><span class="nav-emoji">🎵</span> Music</button>
-                <button class="nav-item" data-tab="achievements"><span class="nav-emoji">🏅</span> Achievements</button>
-                <button class="nav-item" data-tab="quests"><span class="nav-emoji">🗺️</span> Quests</button>
-                <button class="nav-item" data-tab="season"><span class="nav-emoji">🏆</span> Season Pass</button>
-                <button class="nav-item" data-tab="progressiontracks"><span class="nav-emoji">🧭</span> Progression Tracks</button>
-                <button class="nav-item" data-tab="starboard"><span class="nav-emoji">⭐</span> Starboard</button>
-                <button class="nav-item" data-tab="suggestions"><span class="nav-emoji">💡</span> Suggestions</button>
-                <button class="nav-item" data-tab="reactionroles"><span class="nav-emoji">🎭</span> Reaction Roles</button>
+        <!-- Tools -->
+        <div class="dash-nav-label">// Tools</div>
+        <ul class="dash-nav">
+            <li class="nav-item" data-tab="commandpolicies">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1.1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1.1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8V9a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z"/></svg>
+                <span>Command Policies</span>
+            </li>
+            <li class="nav-item" data-tab="ai">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l1.6 4.6L18 9l-4.4 1.4L12 15l-1.6-4.6L6 9l4.4-1.4z"/><path d="M19 14l.8 2.2L22 17l-2.2.8L19 20l-.8-2.2L16 17l2.2-.8z"/></svg>
+                <span>AI Chat</span>
+            </li>
+            <li class="nav-item" data-tab="tempvoice"><span class="nav-emoji">🔊</span><span>Temp Voice</span></li>
+            <li class="nav-item" data-tab="tickets"><span class="nav-emoji">🎫</span><span>Tickets</span></li>
+        </ul>
 
-                <!-- Tools & Support -->
-                <div class="nav-section-header">Tools &amp; Support</div>
-                <button class="nav-item" data-tab="commandpolicies"><span class="nav-emoji">⚙️</span> Command Policies</button>
-                <button class="nav-item" data-tab="ai"><span class="nav-emoji">🧠</span> AI</button>
-                <button class="nav-item" data-tab="tempvoice"><span class="nav-emoji">🔊</span> Temp Voice</button>
-                <button class="nav-item" data-tab="tickets"><span class="nav-emoji">🎫</span> Tickets</button>
+        <!-- Feeds & Automation -->
+        <div class="dash-nav-label">// Feeds &amp; Automation</div>
+        <ul class="dash-nav">
+            <li class="nav-item" data-tab="bibleverses"><span class="nav-emoji">📖</span><span>Bible Verses</span></li>
+            <li class="nav-item" data-tab="rss">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4a16 16 0 0 1 16 16"/><path d="M4 11a9 9 0 0 1 9 9"/><circle cx="5" cy="19" r="1.4" fill="currentColor"/></svg>
+                <span>RSS Feeds</span>
+            </li>
+            <% if (guild.owner) { %>
+            <li class="nav-item" data-tab="agentchannels"><span class="nav-emoji">🤖</span><span>Agent Channels</span></li>
+            <li class="nav-item" data-tab="automations">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2L4 14h6l-1 8 9-12h-6l1-8z"/></svg>
+                <span>Automations</span>
+            </li>
+            <% } %>
+        </ul>
 
-                <!-- Feeds & Automation -->
-                <div class="nav-section-header">Feeds &amp; Automation</div>
-                <button class="nav-item" data-tab="bibleverses"><span class="nav-emoji">📖</span> Bible Verses</button>
-                <button class="nav-item" data-tab="rss"><span class="nav-emoji">📰</span> RSS Feeds</button>
-                <% if (guild.owner) { %>
-                <button class="nav-item" data-tab="agentchannels"><span class="nav-emoji">🤖</span> Agent Channels</button>
-                <button class="nav-item" data-tab="automations"><span class="nav-emoji">⚡</span> Automations</button>
+        <!-- Insights -->
+        <div class="dash-nav-label">// Insights</div>
+        <ul class="dash-nav">
+            <li class="nav-item" data-tab="analytics">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M7 14l4-4 3 3 5-6"/></svg>
+                <span>Analytics</span>
+            </li>
+            <li class="nav-item" data-tab="eventlog"><span class="nav-emoji">📋</span><span>Event Log</span></li>
+        </ul>
+
+        <!-- User footer -->
+        <div class="dash-side-footer">
+            <div class="dash-user">
+                <% if (user.avatar) { %>
+                    <img src="https://cdn.discordapp.com/avatars/<%= user.id %>/<%= user.avatar %>.png" alt="" style="width:34px;height:34px;border-radius:10px;object-fit:cover;flex-shrink:0;">
+                <% } else { %>
+                    <div class="dash-user-avatar"><%= user.username.charAt(0).toUpperCase() %></div>
                 <% } %>
+                <div>
+                    <b><%= user.username %></b>
+                    <span><%= guild.owner ? 'Owner' : 'Admin' %> · <%= guild.name %></span>
+                </div>
+            </div>
+        </div>
 
-                <!-- Insights -->
-                <div class="nav-section-header">Insights</div>
-                <button class="nav-item" data-tab="analytics"><span class="nav-emoji">📊</span> Analytics</button>
-                <button class="nav-item" data-tab="eventlog"><span class="nav-emoji">📋</span> Event Log</button>
-            </aside>
+    </aside><!-- /.dash-side -->
 
-            <div class="settings-content">
+    <!-- ── MAIN ──────────────────────────────────────────────── -->
+    <main class="dash-main">
+
+        <!-- Top bar -->
+        <div class="dash-topbar">
+            <div style="flex:1;font-family:'JetBrains Mono',monospace;font-size:12px;color:var(--ink-500);">
+                <%= guild.name %> / <span style="color:var(--cream-100);" id="topbar-section">Overview</span>
+            </div>
+            <a href="/dashboard" style="display:inline-flex;align-items:center;gap:6px;padding:8px 14px;border-radius:10px;background:var(--ink-850);border:1px solid var(--ink-800);color:var(--ink-200);font-size:13px;font-family:inherit;text-decoration:none;transition:border-color .15s,color .15s;" onmouseover="this.style.color='var(--cream-50)'" onmouseout="this.style.color='var(--ink-200)'">← All servers</a>
+        </div>
+
+        <!-- ═══════════════════════════════════
+             OVERVIEW PANEL
+             ═══════════════════════════════════ -->
+        <section id="overview" class="panel active" style="display:block;">
+
+            <div class="dash-header">
+                <div>
+                    <h1 class="dash-greeting">Good to see you, <em><%= user.username %>.</em></h1>
+                    <div class="dash-subgreeting">Clawdia is running — managing <b style="color:var(--cream-50);"><%= guild.name %></b>.</div>
+                </div>
+            </div>
+
+            <!-- KPIs -->
+            <div class="dash-kpis">
+                <div class="dash-kpi">
+                    <div class="dash-kpi-label">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l11-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="17" cy="16" r="3"/></svg>
+                        Channels
+                    </div>
+                    <div class="dash-kpi-value"><%= channels.length + voiceChannels.length %></div>
+                    <div class="dash-kpi-meta"><span class="dash-kpi-foot">text + voice</span></div>
+                </div>
+                <div class="dash-kpi">
+                    <div class="dash-kpi-label">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="8" r="3.5"/><path d="M2 20c0-3.5 3-6 7-6s7 2.5 7 6"/><circle cx="17" cy="9" r="2.5"/><path d="M22 19c0-2.5-2-4.5-5-4.5"/></svg>
+                        Roles
+                    </div>
+                    <div class="dash-kpi-value"><%= roles.length %></div>
+                    <div class="dash-kpi-meta"><span class="dash-kpi-foot">configured</span></div>
+                </div>
+                <div class="dash-kpi">
+                    <div class="dash-kpi-label">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8.5-8 9-4.5-.5-8-4-8-9V6l8-3z"/></svg>
+                        Modules on
+                    </div>
+                    <%
+                    var moduleCount = 0;
+                    if (settings.welcome && settings.welcome.enabled) moduleCount++;
+                    if (settings.leveling && settings.leveling.enabled) moduleCount++;
+                    if (settings.economy && settings.economy.enabled) moduleCount++;
+                    if (settings.moderation && settings.moderation.enabled) moduleCount++;
+                    if (settings.music && settings.music.enabled) moduleCount++;
+                    if (settings.ai && settings.ai.enabled) moduleCount++;
+                    if (settings.dailyNewsProfiles && settings.dailyNewsProfiles.length > 0) moduleCount++;
+                    if (settings.rss && settings.rss.enabled) moduleCount++;
+                    %>
+                    <div class="dash-kpi-value"><%= moduleCount %></div>
+                    <div class="dash-kpi-meta"><span class="dash-kpi-foot">of 8 modules</span></div>
+                </div>
+                <div class="dash-kpi feature">
+                    <div class="dash-kpi-label">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2L4 14h6l-1 8 9-12h-6l1-8z"/></svg>
+                        Bot Status
+                    </div>
+                    <div class="dash-kpi-value" style="font-size:34px;">Online</div>
+                    <div class="dash-kpi-meta"><span style="color:var(--good);font-size:12px;font-family:'JetBrains Mono',monospace;">● Active</span></div>
+                </div>
+            </div>
+
+            <!-- Modules grid + bot card -->
+            <div class="dash-two-col">
+                <div class="dash-card">
+                    <div class="dash-card-header">
+                        <div>
+                            <h2 class="dash-card-title">Modules</h2>
+                            <div class="dash-card-sub">Click to configure · toggle reflects saved state</div>
+                        </div>
+                        <span class="dash-pill"><span style="width:6px;height:6px;border-radius:50%;background:var(--good);display:inline-block;"></span> live</span>
+                    </div>
+                    <div class="dash-module-list">
+                        <a class="dash-module <%= (settings.welcome && settings.welcome.enabled) ? 'on' : '' %>" data-tab-link="welcome">
+                            <div class="dash-module-icon">
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 16c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3"/><path d="M3 11c2 0 2-3 4-3s2 3 4 3 2-3 4-3 2 3 4 3"/></svg>
+                            </div>
+                            <div class="dash-module-body"><h4>Welcome</h4><p>Cards &amp; farewell</p></div>
+                            <div class="dash-module-toggle"></div>
+                        </a>
+                        <a class="dash-module <%= (settings.moderation && settings.moderation.enabled) ? 'on' : '' %>" data-tab-link="moderation">
+                            <div class="dash-module-icon">
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8.5-8 9-4.5-.5-8-4-8-9V6l8-3z"/></svg>
+                            </div>
+                            <div class="dash-module-body"><h4>Moderation</h4><p>Auto-mod, mute, logging</p></div>
+                            <div class="dash-module-toggle"></div>
+                        </a>
+                        <a class="dash-module <%= (settings.leveling && settings.leveling.enabled) ? 'on' : '' %>" data-tab-link="leveling">
+                            <div class="dash-module-icon">
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M8 4h8v4a4 4 0 0 1-8 0V4z"/><path d="M5 6H3v2a3 3 0 0 0 3 3M19 6h2v2a3 3 0 0 1-3 3"/><path d="M9 14h6l1 6H8z"/></svg>
+                            </div>
+                            <div class="dash-module-body"><h4>Leveling</h4><p>XP &amp; rank cards</p></div>
+                            <div class="dash-module-toggle"></div>
+                        </a>
+                        <a class="dash-module <%= (settings.economy && settings.economy.enabled) ? 'on' : '' %>" data-tab-link="economy">
+                            <div class="dash-module-icon">
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8"/><path d="M10 9h3a2 2 0 0 1 0 4h-3v-4zM10 13v3"/></svg>
+                            </div>
+                            <div class="dash-module-body"><h4>Economy</h4><p>Currency · 🪙 Crowns</p></div>
+                            <div class="dash-module-toggle"></div>
+                        </a>
+                        <a class="dash-module <%= (settings.music && settings.music.enabled) ? 'on' : '' %>" data-tab-link="music">
+                            <div class="dash-module-icon">
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l11-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="17" cy="16" r="3"/></svg>
+                            </div>
+                            <div class="dash-module-body"><h4>Music</h4><p>24/7 playback</p></div>
+                            <div class="dash-module-toggle"></div>
+                        </a>
+                        <a class="dash-module <%= (settings.ai && settings.ai.enabled) ? 'on' : '' %>" data-tab-link="ai">
+                            <div class="dash-module-icon">
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l1.6 4.6L18 9l-4.4 1.4L12 15l-1.6-4.6L6 9l4.4-1.4z"/></svg>
+                            </div>
+                            <div class="dash-module-body"><h4>AI Chat</h4><p>Conversational AI</p></div>
+                            <div class="dash-module-toggle"></div>
+                        </a>
+                        <a class="dash-module <%= (settings.dailyNewsProfiles && settings.dailyNewsProfiles.length > 0) ? 'on' : '' %>" data-tab-link="rss">
+                            <div class="dash-module-icon">
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4a16 16 0 0 1 16 16"/><path d="M4 11a9 9 0 0 1 9 9"/><circle cx="5" cy="19" r="1.4" fill="currentColor"/></svg>
+                            </div>
+                            <div class="dash-module-body"><h4>Daily Digest</h4><p>RSS &amp; news feeds</p></div>
+                            <div class="dash-module-toggle"></div>
+                        </a>
+                        <a class="dash-module" data-tab-link="analytics">
+                            <div class="dash-module-icon">
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M7 14l4-4 3 3 5-6"/></svg>
+                            </div>
+                            <div class="dash-module-body"><h4>Analytics</h4><p>Insights &amp; event log</p></div>
+                            <div class="dash-module-toggle"></div>
+                        </a>
+                    </div>
+                </div>
+
+                <!-- Ask Clawdia card -->
+                <div class="dash-card dash-bot-card">
+                    <div class="dash-card-header">
+                        <div>
+                            <h2 class="dash-card-title">Ask Clawdia</h2>
+                            <div class="dash-card-sub">AI mod assistant</div>
+                        </div>
+                        <svg width="28" height="28" viewBox="0 0 32 32" fill="none">
+                            <ellipse cx="16" cy="22" rx="8.5" ry="6" fill="#fff"/>
+                            <ellipse cx="7" cy="12.5" rx="2.6" ry="3.8" fill="#fff" transform="rotate(-18 7 12.5)"/>
+                            <ellipse cx="12.5" cy="9" rx="2.6" ry="4" fill="#fff" transform="rotate(-6 12.5 9)"/>
+                            <ellipse cx="19.5" cy="9" rx="2.6" ry="4" fill="#fff" transform="rotate(6 19.5 9)"/>
+                            <ellipse cx="25" cy="12.5" rx="2.6" ry="3.8" fill="#fff" transform="rotate(18 25 12.5)"/>
+                            <path d="M14 20.5c0.6-1.6 3.4-1.6 4 0" stroke="#14110d" stroke-width="1.2" stroke-linecap="round" fill="none"/>
+                        </svg>
+                    </div>
+                    <div class="dash-bot-content">
+                        <div class="dash-bot-avatar">🐱</div>
+                        <div class="dash-bot-text">
+                            <b>Everything looks good on <%= guild.name %>.</b><br>
+                            Open a module to configure it, or head to Analytics to see server activity trends.
+                        </div>
+                    </div>
+                    <button class="dash-bot-btn" onclick="document.querySelector('.nav-item[data-tab=analytics]').click()">Open Analytics →</button>
+                    <button class="dash-bot-btn" onclick="document.querySelector('.nav-item[data-tab=moderation]').click()" style="margin-left:8px;background:transparent;">Configure Moderation</button>
+                </div>
+            </div>
+
+            <!-- Bot status bar -->
+            <div class="dash-status">
+                <div><span style="width:7px;height:7px;border-radius:50%;background:var(--good);display:inline-block;"></span> Bot online</div>
+                <i class="sep"></i>
+                <div>Server · <span class="v"><%= guild.name %></span></div>
+                <i class="sep"></i>
+                <div>Channels · <span class="v"><%= channels.length %> text, <%= voiceChannels.length %> voice</span></div>
+                <i class="sep"></i>
+                <div>Roles · <span class="v"><%= roles.length %></span></div>
+                <i class="sep"></i>
+                <div>Modules · <span class="v"><%= moduleCount %> active</span></div>
+            </div>
+
+        </section><!-- /#overview -->
+
+        <!-- ═══════════════════════════════════
+             SETTINGS PANELS (existing)
+             ═══════════════════════════════════ -->
                 <!-- Welcome -->
-                <section id="welcome" class="panel active">
+                <section id="welcome" class="panel">
                     <div class="panel-head">
                         <h2>Welcome Settings</h2>
                         <p>Greet new members with a custom message and optional welcome card.</p>
@@ -1799,9 +2064,9 @@
                 </section>
                 <% } %>
 
-            </div>
-        </div>
-    </main>
+        </main><!-- /.dash-main -->
+
+</div><!-- /.dash -->
 
     <div class="toast" id="toast"></div>
 
@@ -1812,16 +2077,34 @@
         // Sidebar tab navigation
         const navItems = document.querySelectorAll('.nav-item');
         const panels = document.querySelectorAll('.panel');
+        const topbarSection = document.getElementById('topbar-section');
         navItems.forEach(item => {
             item.addEventListener('click', () => {
                 const tab = item.dataset.tab;
+                if (!tab) return;
                 navItems.forEach(n => n.classList.remove('active'));
-                panels.forEach(p => p.classList.remove('active'));
+                panels.forEach(p => { p.classList.remove('active'); p.style.display = 'none'; });
                 item.classList.add('active');
-                document.getElementById(tab).classList.add('active');
+                const panel = document.getElementById(tab);
+                if (panel) { panel.classList.add('active'); panel.style.display = 'block'; }
+                if (topbarSection) topbarSection.textContent = item.querySelector('span:last-child')?.textContent || tab;
                 if (tab === 'analytics') loadAnalytics();
                 if (history.replaceState) history.replaceState(null, '', '#' + tab);
             });
+        });
+
+        // Module card click-to-navigate
+        document.querySelectorAll('.dash-module[data-tab-link]').forEach(card => {
+            card.addEventListener('click', () => {
+                const target = card.dataset.tabLink;
+                const navBtn = document.querySelector(`.nav-item[data-tab="${target}"]`);
+                if (navBtn) navBtn.click();
+            });
+        });
+
+        // Hide all panels except the active one on load
+        panels.forEach(p => {
+            if (!p.classList.contains('active')) p.style.display = 'none';
         });
 
         // AI inner tab navigation


### PR DESCRIPTION
The previous PR redesigned the home page with the cream/ink visual system
but left the server picker dashboard on a dark ink theme — visually
inconsistent. This aligns the dashboard to the same design language:

- Swap dark ink background for cream-50 (matches home page body)
- Reuse the home page .cw-nav for the sticky nav (cream, backdrop blur)
  with user avatar and logout in the right slot instead of nav links
- Replace dark server cards with white cards and subtle ink border,
  matching the editorial card aesthetic of the home page feature grid
- Instrument Serif greeting title with italic claw-amber username
- JetBrains Mono eyebrow and server-count metadata label
- Responsive: single-column at ≤768px, padding collapses to 24px
- Remove now-unused dark cw-dash-* / cw-server-* CSS classes

https://claude.ai/code/session_01EKrcfdYDXrRauzCtNb253r

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned dashboard with a light-themed server picker and dark-themed management layout, refreshed cards, headers, and empty states.
  * Reworked sidebar/navigation visuals and improved responsive behavior for small viewports.

* **New Features**
  * Keyboard/ARIA-friendly tab navigation and tighter focus styling for sidebar items.
  * Enhanced avatar/fallback handling and clearer empty-state messaging.

* **Bug Fixes**
  * Avoids an extra automations network call; AI provider keys only submitted when newly entered.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/Ultrabot/pull/183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->