### PR TITLE
Add OAuth integration success feedback and callback route

### DIFF
--- a/src/dashboard/routes/dashboard.js
+++ b/src/dashboard/routes/dashboard.js
@@ -58,7 +58,7 @@ router.get('/', checkAuth, (req, res) => {
     res.render('dashboard', { user: req.user, guilds });
 });
 
-router.get('/guild/:guildId', checkAuth, async (req, res) => {
+async function renderGuildSettings(req, res) {
     const { guildId } = req.params;
     const userGuilds = getManageableGuilds(req);
 
@@ -125,12 +125,19 @@ router.get('/guild/:guildId', checkAuth, async (req, res) => {
             roles: roles,
             defaultJobs: DEFAULT_JOBS,
             defaultTiers: DEFAULT_TIERS,
-            builtinAchievements
+            builtinAchievements,
+            oauthStatus: req.query.status || null,
+            oauthApp: req.query.connected_account_id ? 'integration' : null
         });
     } catch (error) {
         console.error('Dashboard error:', error);
         res.status(500).send('Internal server error');
     }
-});
+}
+
+router.get('/guild/:guildId', checkAuth, renderGuildSettings);
+
+// OAuth callback from Composio lands on this URL after an integration is connected
+router.get('/guild/:guildId/settings', checkAuth, renderGuildSettings);
 
 module.exports = router;

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -3742,6 +3742,20 @@
         document.querySelectorAll('.nav-item[data-tab="automations"]').forEach(btn => {
             btn.addEventListener('click', loadAutomations);
         });
+
+        // Show a toast when returning from an OAuth integration flow
+        (function () {
+            const params = new URLSearchParams(window.location.search);
+            if (params.get('status') === 'success') {
+                toast('Integration connected successfully!', 'success');
+                // Scroll to the integrations tab and activate it
+                const intTab = document.querySelector('.nav-item[data-tab="integrations"]');
+                if (intTab) intTab.click();
+                // Clean up the URL without triggering a reload
+                const clean = window.location.pathname;
+                history.replaceState(null, '', clean);
+            }
+        })();
     </script>
 </body>
 </html>

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -3749,7 +3749,7 @@
             if (params.get('status') === 'success') {
                 toast('Integration connected successfully!', 'success');
                 // Scroll to the integrations tab and activate it
-                const intTab = document.querySelector('.nav-item[data-tab="integrations"]');
+                const intTab = document.querySelector('.nav-item[data-tab="agentchannels"]');
                 if (intTab) intTab.click();
                 // Clean up the URL without triggering a reload
                 const clean = window.location.pathname;


### PR DESCRIPTION
## Summary
This PR enhances the OAuth integration flow by adding user feedback when an integration is successfully connected and supporting the OAuth callback redirect pattern used by third-party services like Composio.

## Key Changes
- **Frontend feedback**: Added a toast notification that displays "Integration connected successfully!" when returning from an OAuth flow with a `status=success` query parameter
- **Auto-navigation**: Automatically scrolls to and activates the integrations tab after a successful OAuth connection
- **URL cleanup**: Removes query parameters from the URL after displaying the toast using `history.replaceState()` to maintain a clean browser history
- **Callback route support**: Added a new `/guild/:guildId/settings` route that mirrors the existing `/guild/:guildId` route to handle OAuth callbacks from external services
- **Query parameter passing**: Modified the guild settings renderer to pass OAuth status and app information to the template via `oauthStatus` and `oauthApp` variables
- **Code refactoring**: Extracted the guild settings rendering logic into a reusable `renderGuildSettings()` function to avoid duplication between the two routes

## Implementation Details
- The OAuth detection uses `URLSearchParams` to check for the `status` query parameter
- The integrations tab is located and clicked programmatically to provide seamless navigation
- The `history.replaceState()` call ensures the success message displays before the URL is cleaned up
- Both `/guild/:guildId` and `/guild/:guildId/settings` routes now use the same rendering logic, allowing flexibility in how OAuth providers redirect back to the application

https://claude.ai/code/session_01HR2QpyAKmgsYaNcsemvBoB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration connection experience with success confirmation notification that displays after connecting an account
  * The integrations tab now automatically activates following a successful connection
  * URL is cleaned up after connection to provide a cleaner browsing state

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/Ultrabot/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->