### PR TITLE
Add image generation commands (wanted, wasted, caption, achievement, meme)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,4 +18,9 @@ OPENAI_API_KEY=sk-your_openai_key_here
 # Music (optional)
 YOUTUBE_COOKIE=your_youtube_cookie_if_needed
 
+# Meme generation (optional — required for /meme command)
+# Free account at https://imgflip.com/api
+IMGFLIP_USERNAME=your_imgflip_username
+IMGFLIP_PASSWORD=your_imgflip_password
+
 NODE_ENV=production

--- a/src/commands/fun/achievement.js
+++ b/src/commands/fun/achievement.js
@@ -1,0 +1,103 @@
+const { SlashCommandBuilder, AttachmentBuilder } = require('discord.js');
+const { createCanvas } = require('canvas');
+const { checkImageRateLimit } = require('../../utils/imageRateLimit');
+
+const W         = 420;
+const H         = 90;
+const ICON_SIZE = 58;
+const PAD       = 16;
+
+// Minimal diamond-sword-style icon drawn with canvas primitives
+function drawIcon(ctx, x, y, size) {
+    const s = size / 18;
+
+    // Blade — cyan/aqua pixels along the diagonal
+    ctx.fillStyle = '#5de0e6';
+    const blade = [
+        [9,1],[10,1],[8,2],[9,2],[7,3],[8,3],[6,4],[7,4],
+        [5,5],[6,5],[4,6],[5,6],[3,7],[4,7],[2,8],[3,8],
+    ];
+    for (const [bx, by] of blade) ctx.fillRect(x + bx * s, y + by * s, s, s);
+
+    // Guard — lighter blue horizontal bar
+    ctx.fillStyle = '#8aeef2';
+    [[1,8],[2,8],[3,8],[4,8],[5,8]].forEach(([gx, gy]) =>
+        ctx.fillRect(x + gx * s, y + gy * s, s, s));
+
+    // Handle — brown
+    ctx.fillStyle = '#8b5e3c';
+    const handle = [[2,9],[2,10],[2,11],[2,12],[1,10],[3,10]];
+    for (const [hx, hy] of handle) ctx.fillRect(x + hx * s, y + hy * s, s, s);
+}
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('achievement')
+        .setDescription('Display a Minecraft-style achievement popup with custom text')
+        .addStringOption(opt =>
+            opt.setName('text')
+                .setDescription('Achievement name (e.g. "First Blood")')
+                .setRequired(true)
+                .setMaxLength(50)),
+
+    async execute(interaction) {
+        const { limited, wait } = checkImageRateLimit(interaction.user.id);
+        if (limited) {
+            return interaction.reply({
+                content: `⏱️ You're using image commands too fast! Please wait **${wait}s** before trying again.`,
+                ephemeral: true,
+            });
+        }
+
+        const text = interaction.options.getString('text');
+        await interaction.deferReply();
+
+        try {
+            const canvas = createCanvas(W, H);
+            const ctx    = canvas.getContext('2d');
+
+            // Dark background
+            ctx.fillStyle = '#3c3c3c';
+            ctx.fillRect(0, 0, W, H);
+
+            // Minecraft-style bevel border
+            ctx.fillStyle = '#5a5a5a';
+            ctx.fillRect(0, 0, W, 3);       // top
+            ctx.fillRect(0, 0, 3, H);       // left
+            ctx.fillStyle = '#1a1a1a';
+            ctx.fillRect(0, H - 3, W, 3);   // bottom
+            ctx.fillRect(W - 3, 0, 3, H);   // right
+
+            // Icon background slot
+            const iconX = PAD;
+            const iconY = (H - ICON_SIZE) / 2;
+            ctx.fillStyle = '#2a2a2a';
+            ctx.fillRect(iconX, iconY, ICON_SIZE, ICON_SIZE);
+            ctx.strokeStyle = '#111111';
+            ctx.lineWidth   = 2;
+            ctx.strokeRect(iconX, iconY, ICON_SIZE, ICON_SIZE);
+            ctx.strokeStyle = '#555555';
+            ctx.lineWidth   = 1;
+            ctx.strokeRect(iconX + 2, iconY + 2, ICON_SIZE - 4, ICON_SIZE - 4);
+
+            drawIcon(ctx, iconX + 2, iconY + 2, ICON_SIZE - 4);
+
+            // Text
+            const textX = iconX + ICON_SIZE + 14;
+            ctx.textBaseline = 'top';
+
+            ctx.font      = 'bold 15px Arial, sans-serif';
+            ctx.fillStyle = '#ffdf00';
+            ctx.fillText('Achievement Unlocked!', textX, 20);
+
+            ctx.font      = 'bold 21px Arial, sans-serif';
+            ctx.fillStyle = '#ffffff';
+            ctx.fillText(text, textX, 46);
+
+            const attachment = new AttachmentBuilder(canvas.toBuffer('image/png'), { name: 'achievement.png' });
+            await interaction.editReply({ files: [attachment] });
+        } catch {
+            await interaction.editReply('❌ Could not generate the achievement. Please try again.');
+        }
+    },
+};

--- a/src/commands/fun/caption.js
+++ b/src/commands/fun/caption.js
@@ -1,0 +1,110 @@
+const { SlashCommandBuilder, AttachmentBuilder } = require('discord.js');
+const { createCanvas, loadImage } = require('canvas');
+const { checkImageRateLimit } = require('../../utils/imageRateLimit');
+
+const MAX_WIDTH     = 800;
+const CAPTION_H     = 70;
+const FONT_SIZE     = 28;
+const LINE_HEIGHT   = FONT_SIZE * 1.25;
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('caption')
+        .setDescription('Add a caption to any image URL')
+        .addStringOption(opt =>
+            opt.setName('image_url')
+                .setDescription('URL of the image to caption')
+                .setRequired(true))
+        .addStringOption(opt =>
+            opt.setName('text')
+                .setDescription('Caption text')
+                .setRequired(true)
+                .setMaxLength(200)),
+
+    async execute(interaction) {
+        const { limited, wait } = checkImageRateLimit(interaction.user.id);
+        if (limited) {
+            return interaction.reply({
+                content: `⏱️ You're using image commands too fast! Please wait **${wait}s** before trying again.`,
+                ephemeral: true,
+            });
+        }
+
+        const imageUrl = interaction.options.getString('image_url');
+        const text     = interaction.options.getString('text');
+
+        if (!isValidHttpUrl(imageUrl)) {
+            return interaction.reply({
+                content: '❌ Please provide a valid image URL (must start with http:// or https://).',
+                ephemeral: true,
+            });
+        }
+
+        await interaction.deferReply();
+
+        try {
+            const src   = await loadImage(imageUrl);
+            const scale = src.width > MAX_WIDTH ? MAX_WIDTH / src.width : 1;
+            const w     = Math.round(src.width  * scale);
+            const h     = Math.round(src.height * scale);
+
+            // Measure how many lines the caption needs and size canvas accordingly
+            const measCanvas = createCanvas(w, 1);
+            const measCtx    = measCanvas.getContext('2d');
+            measCtx.font     = `bold ${FONT_SIZE}px Arial`;
+            const lines      = wrapText(measCtx, text, w - 20);
+            const captionH   = Math.max(CAPTION_H, lines.length * LINE_HEIGHT + 20);
+
+            const canvas = createCanvas(w, h + captionH);
+            const ctx    = canvas.getContext('2d');
+
+            // White caption bar at top
+            ctx.fillStyle = '#ffffff';
+            ctx.fillRect(0, 0, w, captionH);
+
+            // Caption text
+            ctx.font         = `bold ${FONT_SIZE}px Arial`;
+            ctx.fillStyle    = '#000000';
+            ctx.textAlign    = 'center';
+            ctx.textBaseline = 'middle';
+            const startY     = (captionH - (lines.length - 1) * LINE_HEIGHT) / 2;
+            for (let i = 0; i < lines.length; i++) {
+                ctx.fillText(lines[i], w / 2, startY + i * LINE_HEIGHT);
+            }
+
+            // Image below caption
+            ctx.drawImage(src, 0, captionH, w, h);
+
+            const attachment = new AttachmentBuilder(canvas.toBuffer('image/png'), { name: 'caption.png' });
+            await interaction.editReply({ files: [attachment] });
+        } catch {
+            await interaction.editReply('❌ Could not load that image. Make sure the URL points to a valid image.');
+        }
+    },
+};
+
+function isValidHttpUrl(str) {
+    try {
+        const { protocol } = new URL(str);
+        return protocol === 'http:' || protocol === 'https:';
+    } catch {
+        return false;
+    }
+}
+
+function wrapText(ctx, text, maxWidth) {
+    const words = text.split(' ');
+    const lines = [];
+    let line    = '';
+    for (const word of words) {
+        const candidate = line ? `${line} ${word}` : word;
+        if (ctx.measureText(candidate).width > maxWidth && line) {
+            lines.push(line);
+            line = word;
+        } else {
+            line = candidate;
+        }
+    }
+    if (line) lines.push(line);
+    return lines;
+}

--- a/src/commands/fun/meme.js
+++ b/src/commands/fun/meme.js
@@ -1,0 +1,106 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const axios = require('axios');
+const { checkImageRateLimit } = require('../../utils/imageRateLimit');
+
+const TEMPLATES = [
+    { name: 'Drake',                  value: '181913649' },
+    { name: 'Distracted Boyfriend',   value: '112126428' },
+    { name: 'This Is Fine',           value: '55311130'  },
+    { name: 'Change My Mind',         value: '129242436' },
+    { name: 'Two Buttons',            value: '87743020'  },
+    { name: 'One Does Not Simply',    value: '61579'     },
+    { name: 'Surprised Pikachu',      value: '155067746' },
+    { name: 'Mocking SpongeBob',      value: '102156234' },
+    { name: 'Woman Yelling at Cat',   value: '188390779' },
+    { name: "Gru's Plan",             value: '131940431' },
+    { name: 'Expanding Brain',        value: '93895088'  },
+    { name: 'Always Has Been',        value: '252600902' },
+    { name: 'Bernie Sanders',         value: '222403160' },
+    { name: 'UNO Draw 25 Cards',      value: '217743513' },
+];
+
+// key -> { url, expires }
+const cache = new Map();
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('meme')
+        .setDescription('Generate a classic meme using a popular template')
+        .addStringOption(opt =>
+            opt.setName('template')
+                .setDescription('The meme template to use')
+                .setRequired(true)
+                .addChoices(...TEMPLATES))
+        .addStringOption(opt =>
+            opt.setName('top_text')
+                .setDescription('Top caption text')
+                .setRequired(true)
+                .setMaxLength(200))
+        .addStringOption(opt =>
+            opt.setName('bottom_text')
+                .setDescription('Bottom caption text')
+                .setRequired(false)
+                .setMaxLength(200)),
+
+    async execute(interaction) {
+        const { limited, wait } = checkImageRateLimit(interaction.user.id);
+        if (limited) {
+            return interaction.reply({
+                content: `⏱️ You're using image commands too fast! Please wait **${wait}s** before trying again.`,
+                ephemeral: true,
+            });
+        }
+
+        const templateId = interaction.options.getString('template');
+        const topText    = interaction.options.getString('top_text');
+        const bottomText = interaction.options.getString('bottom_text') || '';
+
+        const cacheKey = `${templateId}:${topText}:${bottomText}`;
+        const cached   = cache.get(cacheKey);
+        if (cached && cached.expires > Date.now()) {
+            return interaction.reply({ embeds: [buildEmbed(interaction, cached.url, templateId)] });
+        }
+
+        const username = process.env.IMGFLIP_USERNAME;
+        const password = process.env.IMGFLIP_PASSWORD;
+        if (!username || !password) {
+            return interaction.reply({
+                content: '❌ Meme generation is not configured. Ask an admin to set `IMGFLIP_USERNAME` and `IMGFLIP_PASSWORD`.',
+                ephemeral: true,
+            });
+        }
+
+        await interaction.deferReply();
+
+        try {
+            const params = new URLSearchParams({ template_id: templateId, username, password, text0: topText, text1: bottomText });
+            const { data } = await axios.post('https://api.imgflip.com/caption_image', params.toString(), {
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                timeout: 10_000,
+            });
+
+            if (!data.success) {
+                return interaction.editReply(`❌ Imgflip API error: ${data.error_message || 'Unknown error'}`);
+            }
+
+            const url = data.data.url;
+            cache.set(cacheKey, { url, expires: Date.now() + 5 * 60_000 });
+            await interaction.editReply({ embeds: [buildEmbed(interaction, url, templateId)] });
+        } catch {
+            await interaction.editReply('❌ Failed to generate meme. Please try again later.');
+        }
+    },
+};
+
+function buildEmbed(interaction, url, templateId) {
+    const name = TEMPLATES.find(t => t.value === templateId)?.name || 'Meme';
+    return new EmbedBuilder()
+        .setColor('#ff6b6b')
+        .setTitle(`🎭 ${name}`)
+        .setImage(url)
+        .setFooter({
+            text: `Requested by ${interaction.user.username} • Powered by Imgflip`,
+            iconURL: interaction.user.displayAvatarURL({ dynamic: true }),
+        })
+        .setTimestamp();
+}

--- a/src/commands/fun/wanted.js
+++ b/src/commands/fun/wanted.js
@@ -1,0 +1,116 @@
+const { SlashCommandBuilder, AttachmentBuilder } = require('discord.js');
+const { createCanvas, loadImage } = require('canvas');
+const { checkImageRateLimit } = require('../../utils/imageRateLimit');
+
+const W           = 400;
+const H           = 530;
+const AVATAR_SIZE = 200;
+const AVATAR_X    = (W - AVATAR_SIZE) / 2;
+const AVATAR_Y    = 135;
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('wanted')
+        .setDescription('Generate a Wild West "Wanted" poster with a user\'s avatar')
+        .addUserOption(opt =>
+            opt.setName('user')
+                .setDescription('The wanted criminal (defaults to you)')
+                .setRequired(false)),
+
+    async execute(interaction) {
+        const { limited, wait } = checkImageRateLimit(interaction.user.id);
+        if (limited) {
+            return interaction.reply({
+                content: `⏱️ You're using image commands too fast! Please wait **${wait}s** before trying again.`,
+                ephemeral: true,
+            });
+        }
+
+        const target = interaction.options.getUser('user') || interaction.user;
+        await interaction.deferReply();
+
+        try {
+            const avatar = await loadImage(target.displayAvatarURL({ extension: 'png', size: 256 }));
+
+            const canvas = createCanvas(W, H);
+            const ctx    = canvas.getContext('2d');
+
+            // Parchment background
+            ctx.fillStyle = '#c8a86b';
+            ctx.fillRect(0, 0, W, H);
+
+            // Edge darkening
+            const vignette = ctx.createRadialGradient(W / 2, H / 2, 0, W / 2, H / 2, W);
+            vignette.addColorStop(0, 'rgba(200,168,107,0)');
+            vignette.addColorStop(1, 'rgba(60,30,0,0.55)');
+            ctx.fillStyle = vignette;
+            ctx.fillRect(0, 0, W, H);
+
+            // Borders
+            ctx.strokeStyle = '#4a2c00';
+            ctx.lineWidth   = 8;
+            ctx.strokeRect(12, 12, W - 24, H - 24);
+            ctx.strokeStyle = '#7a5200';
+            ctx.lineWidth   = 3;
+            ctx.strokeRect(22, 22, W - 44, H - 44);
+
+            // WANTED header
+            ctx.textAlign    = 'center';
+            ctx.shadowColor  = 'rgba(0,0,0,0.4)';
+            ctx.shadowBlur   = 6;
+            ctx.font         = 'bold 74px Georgia, serif';
+            ctx.fillStyle    = '#2b1500';
+            ctx.fillText('WANTED', W / 2, 88);
+
+            // DEAD OR ALIVE
+            ctx.shadowBlur = 0;
+            ctx.font       = 'bold 22px Georgia, serif';
+            ctx.fillStyle  = '#3d1a00';
+            ctx.fillText('DEAD OR ALIVE', W / 2, 118);
+
+            // Avatar photo frame
+            ctx.fillStyle = '#3a2000';
+            ctx.fillRect(AVATAR_X - 6, AVATAR_Y - 6, AVATAR_SIZE + 12, AVATAR_SIZE + 12);
+            ctx.fillStyle = '#d4b07a';
+            ctx.fillRect(AVATAR_X - 3, AVATAR_Y - 3, AVATAR_SIZE + 6,  AVATAR_SIZE + 6);
+
+            ctx.drawImage(avatar, AVATAR_X, AVATAR_Y, AVATAR_SIZE, AVATAR_SIZE);
+
+            // Sepia tint on avatar
+            const imgData    = ctx.getImageData(AVATAR_X, AVATAR_Y, AVATAR_SIZE, AVATAR_SIZE);
+            const { data }   = imgData;
+            for (let i = 0; i < data.length; i += 4) {
+                const g      = data[i] * 0.299 + data[i + 1] * 0.587 + data[i + 2] * 0.114;
+                data[i]      = Math.min(255, g * 1.2 + 40);
+                data[i + 1]  = Math.min(255, g       + 20);
+                data[i + 2]  = Math.min(255, g * 0.8);
+            }
+            ctx.putImageData(imgData, AVATAR_X, AVATAR_Y);
+
+            // Username (truncate if needed)
+            const displayName = target.username.length > 18 ? target.username.slice(0, 17) + '…' : target.username;
+            ctx.font          = 'bold 26px Georgia, serif';
+            ctx.fillStyle     = '#1a0a00';
+            ctx.fillText(displayName, W / 2, AVATAR_Y + AVATAR_SIZE + 38);
+
+            // Reward — deterministic per user so it doesn't change on repeat calls
+            const seed    = parseInt(target.id.slice(-6), 16) % 9000 + 1000;
+            const reward  = '$' + seed.toLocaleString();
+            ctx.font      = 'bold 18px Georgia, serif';
+            ctx.fillStyle = '#2b1500';
+            ctx.fillText('REWARD', W / 2, AVATAR_Y + AVATAR_SIZE + 68);
+            ctx.font      = 'bold 34px Georgia, serif';
+            ctx.fillStyle = '#5a2d00';
+            ctx.fillText(reward, W / 2, AVATAR_Y + AVATAR_SIZE + 105);
+
+            ctx.font      = 'italic 14px Georgia, serif';
+            ctx.fillStyle = '#3a1a00';
+            ctx.fillText('Contact your local sheriff', W / 2, AVATAR_Y + AVATAR_SIZE + 130);
+
+            const attachment = new AttachmentBuilder(canvas.toBuffer('image/png'), { name: 'wanted.png' });
+            await interaction.editReply({ files: [attachment] });
+        } catch {
+            await interaction.editReply('❌ Could not generate the wanted poster. Please try again.');
+        }
+    },
+};

--- a/src/commands/fun/wasted.js
+++ b/src/commands/fun/wasted.js
@@ -1,0 +1,76 @@
+const { SlashCommandBuilder, AttachmentBuilder } = require('discord.js');
+const { createCanvas, loadImage } = require('canvas');
+const { checkImageRateLimit } = require('../../utils/imageRateLimit');
+
+const SIZE = 512;
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('wasted')
+        .setDescription('Overlay the GTA "Wasted" screen on a user\'s avatar')
+        .addUserOption(opt =>
+            opt.setName('user')
+                .setDescription('The user to waste (defaults to you)')
+                .setRequired(false)),
+
+    async execute(interaction) {
+        const { limited, wait } = checkImageRateLimit(interaction.user.id);
+        if (limited) {
+            return interaction.reply({
+                content: `⏱️ You're using image commands too fast! Please wait **${wait}s** before trying again.`,
+                ephemeral: true,
+            });
+        }
+
+        const target = interaction.options.getUser('user') || interaction.user;
+        await interaction.deferReply();
+
+        try {
+            const avatar = await loadImage(target.displayAvatarURL({ extension: 'png', size: SIZE }));
+
+            const canvas = createCanvas(SIZE, SIZE);
+            const ctx    = canvas.getContext('2d');
+
+            ctx.drawImage(avatar, 0, 0, SIZE, SIZE);
+
+            // Grayscale
+            const img    = ctx.getImageData(0, 0, SIZE, SIZE);
+            const { data } = img;
+            for (let i = 0; i < data.length; i += 4) {
+                const g  = data[i] * 0.299 + data[i + 1] * 0.587 + data[i + 2] * 0.114;
+                data[i]     = g;
+                data[i + 1] = g;
+                data[i + 2] = g;
+            }
+            ctx.putImageData(img, 0, 0);
+
+            // Dark red vignette
+            const vignette = ctx.createRadialGradient(SIZE / 2, SIZE / 2, SIZE * 0.25, SIZE / 2, SIZE / 2, SIZE * 0.75);
+            vignette.addColorStop(0, 'rgba(100, 0, 0, 0.1)');
+            vignette.addColorStop(1, 'rgba(80, 0, 0, 0.55)');
+            ctx.fillStyle = vignette;
+            ctx.fillRect(0, 0, SIZE, SIZE);
+
+            // WASTED text
+            ctx.font         = 'bold 84px Impact, Arial Black, sans-serif';
+            ctx.textAlign    = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.shadowColor  = '#000000';
+            ctx.shadowBlur   = 16;
+            ctx.fillStyle    = '#cc0000';
+            ctx.fillText('WASTED', SIZE / 2, SIZE / 2);
+            ctx.shadowBlur   = 0;
+            ctx.strokeStyle  = '#550000';
+            ctx.lineWidth    = 4;
+            ctx.strokeText('WASTED', SIZE / 2, SIZE / 2);
+
+            const attachment = new AttachmentBuilder(canvas.toBuffer('image/png'), { name: 'wasted.png' });
+            await interaction.editReply({
+                content: `💀 **${target.username}** has been wasted.`,
+                files: [attachment],
+            });
+        } catch {
+            await interaction.editReply('❌ Could not generate the wasted image. Please try again.');
+        }
+    },
+};

--- a/src/utils/imageRateLimit.js
+++ b/src/utils/imageRateLimit.js
@@ -1,0 +1,17 @@
+const cooldowns = new Map();
+const MAX_USES = 10;
+const WINDOW_MS = 60_000;
+
+function checkImageRateLimit(userId) {
+    const now = Date.now();
+    const stamps = (cooldowns.get(userId) || []).filter(t => now - t < WINDOW_MS);
+    if (stamps.length >= MAX_USES) {
+        const wait = Math.ceil((WINDOW_MS - (now - stamps[0])) / 1000);
+        return { limited: true, wait };
+    }
+    stamps.push(now);
+    cooldowns.set(userId, stamps);
+    return { limited: false };
+}
+
+module.exports = { checkImageRateLimit };


### PR DESCRIPTION
## Summary
This PR adds five new fun image generation commands to the bot, along with a rate limiting utility to prevent abuse of image-heavy operations.

## Key Changes

- **New Commands:**
  - `/wanted` — Generate a Wild West "Wanted" poster with a user's avatar, featuring parchment styling, sepia-toned photo, and a deterministic reward amount
  - `/wasted` — Overlay the GTA "Wasted" screen effect (grayscale + red vignette) on a user's avatar
  - `/caption` — Add a custom caption to any image URL with automatic text wrapping and dynamic sizing
  - `/achievement` — Display a Minecraft-style achievement popup with custom text and a pixel-art sword icon
  - `/meme` — Generate classic memes using Imgflip API with 14 popular templates (Drake, Distracted Boyfriend, etc.), including 5-minute caching to reduce API calls

- **Rate Limiting Utility:**
  - New `src/utils/imageRateLimit.js` module that enforces a 10-uses-per-60-seconds limit per user across all image commands
  - Returns remaining wait time in seconds when limit is exceeded

- **Configuration:**
  - Updated `.env.example` with optional Imgflip credentials (`IMGFLIP_USERNAME`, `IMGFLIP_PASSWORD`) for meme generation

## Implementation Details

- All commands use Discord.js `SlashCommandBuilder` and support optional user selection (defaulting to the command invoker)
- Canvas-based commands (`wanted`, `wasted`, `achievement`, `caption`) use the `canvas` library for image manipulation
- The `wanted` command uses deterministic reward generation based on user ID to ensure consistency across repeated calls
- The `caption` command includes URL validation and responsive image scaling (max 800px width)
- The `meme` command implements client-side caching with 5-minute TTL to optimize Imgflip API usage
- All commands defer replies and include comprehensive error handling with user-friendly messages

https://claude.ai/code/session_01SKnBCsCjBd9yY5XbJPjNhT