### PR TITLE
Sync Composio connections and remove admin protection from rob command

### DIFF
--- a/src/commands/economy/rob.js
+++ b/src/commands/economy/rob.js
@@ -51,10 +51,6 @@ module.exports = {
         if (target.bot) {
             return interaction.reply({ content: "You can't rob a bot.", ephemeral: true });
         }
-        const targetMember = await interaction.guild.members.fetch(target.id).catch(() => null);
-        if (targetMember?.permissions.has('Administrator')) {
-            return interaction.reply({ content: "You can't rob server admins.", ephemeral: true });
-        }
 
         const [robber, victim] = await Promise.all([
             User.findOneAndUpdate({ userId: interaction.user.id, guildId: interaction.guild.id }, {}, { upsert: true, new: true }),

--- a/src/dashboard/routes/dashboard.js
+++ b/src/dashboard/routes/dashboard.js
@@ -4,6 +4,7 @@ const Guild = require('../../models/Guild');
 const DEFAULT_JOBS = require('../../data/defaultJobs');
 const DEFAULT_TIERS = require('../../data/defaultTiers');
 const { ACHIEVEMENTS } = require('../../data/achievements');
+const composioService = require('../../services/composioService');
 
 function checkAuth(req, res, next) {
     if (req.isAuthenticated()) return next();
@@ -106,6 +107,31 @@ async function renderGuildSettings(req, res) {
             emoji: a.emoji, category: a.category,
             xpReward: a.xpReward, coinReward: a.coinReward
         }));
+
+        // Reconcile the local connectedApps cache against Composio's live state so the
+        // dashboard reflects what's actually connected without the client needing to
+        // POST after the OAuth flow completes.
+        const apiKey = guildSettings.integrations?.composioApiKey;
+        if (apiKey) {
+            try {
+                const connections = await composioService.getConnections(guildId, apiKey);
+                const liveApps = [...new Set(connections
+                    .filter(c => !c.status || String(c.status).toUpperCase() === 'ACTIVE')
+                    .map(c => c.appName)
+                    .filter(Boolean)
+                    .map(s => String(s).toLowerCase()))];
+
+                const cached = (guildSettings.integrations.connectedApps || []).map(s => String(s).toLowerCase());
+                const sameSet = liveApps.length === cached.length && liveApps.every(a => cached.includes(a));
+                if (!sameSet) {
+                    guildSettings.integrations.connectedApps = liveApps;
+                    guildSettings.markModified('integrations');
+                    await guildSettings.save();
+                }
+            } catch (err) {
+                console.error('[Dashboard] Composio connection sync failed:', err.message);
+            }
+        }
 
         // Redact the composioApiKey before sending to the template — the template only
         // needs to know whether a key is configured (truthy), not the key itself.


### PR DESCRIPTION
## Summary
This PR makes two changes: (1) adds automatic synchronization of connected apps between the local cache and Composio's live state when rendering guild settings, and (2) removes the admin protection check from the rob command.

## Key Changes

- **Dashboard Composio sync**: Added logic to `renderGuildSettings()` that reconciles the locally cached `connectedApps` list against Composio's actual live connections. This ensures the dashboard always reflects the current state without requiring a manual POST after OAuth flows complete.
  - Fetches active connections from Composio using the guild's API key
  - Compares normalized app names between live state and cache
  - Updates and persists the cache if differences are detected
  - Includes error handling to prevent dashboard rendering failures

- **Rob command**: Removed the check that prevented robbing server administrators, simplifying the command logic.

## Implementation Details

The Composio sync:
- Only runs if a Composio API key is configured for the guild
- Filters connections to only active ones (status is null or 'ACTIVE')
- Normalizes app names to lowercase for consistent comparison
- Uses `markModified()` to ensure Mongoose detects the nested object change before saving
- Logs errors without interrupting the dashboard render flow

https://claude.ai/code/session_01JhUF4YrhEoftGBcxVz12AP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an incorrect restriction that prevented users from robbing guild members with administrator permissions.

* **New Features**
  * Added automatic synchronization between guild integration settings and connected third-party services. Dashboard information now reflects live connection statuses, eliminating manual updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/clawdia/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->