### PR TITLE
ci: install canvas native deps before npm ci in deploy-commands workflow

### DIFF
--- a/.github/workflows/deploy-commands.yml
+++ b/.github/workflows/deploy-commands.yml
@@ -21,6 +21,9 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      - name: Install canvas system dependencies
+        run: sudo apt-get install -y libcairo2-dev libpixman-1-dev libpango1.0-dev libjpeg-dev libgif-dev
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
canvas@2.11.2 has no pre-built binary for Node 22 (ABI v127) and falls
back to source compilation, which requires pixman-1 and other system
libraries not present on the default ubuntu-latest runner.

https://claude.ai/code/session_01ToP4j4fDEWn3murfoNWLrQ