### PR TITLE
fix(deploy): fail loudly when slash command deploy errors

### DIFF
--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -2,11 +2,16 @@ require('dotenv').config();
 const { deployCommands } = require('./utils/commandDeployer');
 
 (async () => {
+    if (!process.env.CLIENT_ID || !process.env.DISCORD_TOKEN) {
+        console.error('Missing CLIENT_ID or DISCORD_TOKEN environment variable.');
+        process.exit(1);
+    }
     try {
         console.log('Started refreshing application (/) commands.');
         const count = await deployCommands(process.env.CLIENT_ID, process.env.DISCORD_TOKEN);
         console.log(`Successfully reloaded ${count} application (/) commands.`);
     } catch (error) {
-        console.error(error);
+        console.error('Failed to deploy commands:', error);
+        process.exit(1);
     }
 })();

--- a/src/index.js
+++ b/src/index.js
@@ -120,11 +120,6 @@ async function startBot() {
     await startDashboard();
 
     client.once('ready', () => {
-        const { deployCommands } = require('./utils/commandDeployer');
-        deployCommands(process.env.CLIENT_ID, process.env.DISCORD_TOKEN)
-            .then(count => console.log(`[COMMANDS] Deployed ${count} slash commands`))
-            .catch(err => console.error('[COMMANDS] Failed to deploy slash commands:', err));
-
         const { startSummaryService } = require('./services/summaryService');
         startSummaryService(client);
 

--- a/src/utils/commandDeployer.js
+++ b/src/utils/commandDeployer.js
@@ -4,6 +4,7 @@ const path = require('path');
 
 async function deployCommands(clientId, token) {
     const commands = [];
+    const failures = [];
     const foldersPath = path.join(__dirname, '../commands');
 
     for (const entry of fs.readdirSync(foldersPath, { withFileTypes: true })) {
@@ -11,19 +12,35 @@ async function deployCommands(clientId, token) {
         const commandsPath = path.join(foldersPath, entry.name);
 
         for (const file of fs.readdirSync(commandsPath).filter(f => f.endsWith('.js'))) {
+            const rel = `${entry.name}/${file}`;
             try {
                 const command = require(path.join(commandsPath, file));
                 if ('data' in command && 'execute' in command && typeof command.data?.toJSON === 'function') {
                     commands.push(command.data.toJSON());
+                } else {
+                    failures.push(`${rel} (missing data/execute or data.toJSON)`);
                 }
             } catch (error) {
-                console.error(`[DEPLOY] Failed to load command ${file}:`, error);
+                failures.push(`${rel} (${error.message})`);
             }
         }
     }
 
+    if (failures.length) {
+        console.error(`[DEPLOY] ${failures.length} command file(s) failed to load:`);
+        for (const f of failures) console.error(`  - ${f}`);
+        throw new Error(`${failures.length} command file(s) failed to load; aborting so the registered set is not silently truncated.`);
+    }
+
     const rest = new REST().setToken(token);
-    await rest.put(Routes.applicationCommands(clientId), { body: commands });
+    try {
+        await rest.put(Routes.applicationCommands(clientId), { body: commands });
+    } catch (error) {
+        if (error.rawError) {
+            console.error('[DEPLOY] Discord rejected the command payload:', JSON.stringify(error.rawError, null, 2));
+        }
+        throw error;
+    }
     return commands.length;
 }
 


### PR DESCRIPTION
The deploy-commands script and bot startup hook both registered slash
commands but swallowed every failure: per-command load errors were
logged-and-skipped, and the script always exited 0 even when Discord
rejected the bulk overwrite. That made workflow runs report "successful"
while silently truncating or not updating the registered command set.

- src/deploy-commands.js: validate CLIENT_ID/DISCORD_TOKEN and exit 1
  on any failure, so a green CI run actually means commands were
  registered.
- src/utils/commandDeployer.js: collect per-file load failures, log
  them, and throw before calling rest.put so a broken command file
  cannot silently shrink the registered set; surface Discord rawError
  details on bulk-overwrite rejection.
- src/index.js: drop the duplicate deployCommands call from the inline
  ready handler; events/ready.js already deploys on ready (with
  client.user.id, which is more reliable than the env CLIENT_ID).

https://claude.ai/code/session_01Ac46Qwqdim4d9j9reScwdT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and validation during command deployment to prevent silent failures and partial command registration.
  * Improved error reporting with explicit validation messages when command deployment encounters issues or missing configurations.
  * Commands now fail explicitly with clear error details instead of continuing with incomplete deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/clawdia/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->