### PR TITLE
Fix farewell feature: permissions, deprecations, validation & tests

### DIFF
--- a/PRODUCTIONREADY.md
+++ b/PRODUCTIONREADY.md
@@ -49,4 +49,42 @@ This file tracks the production readiness status of each feature/function in Cla
 
 ---
 
+## Farewell Function
+
+**Status: PRODUCTION READY** ✓
+
+**Files reviewed/fixed:**
+- `src/events/guildMemberRemove.js`
+- `src/models/Guild.js`
+- `src/dashboard/routes/api.js`
+- `tests/farewell.test.js` (added)
+
+---
+
+### Issues Found & Fixed
+
+#### Critical (all resolved)
+
+| # | Issue | Fix | Files |
+|---|-------|-----|-------|
+| 1 | Non-atomic analytics upsert (spurious `$push` with `$each: []` in increment path) | Removed no-op `$push` from the `$inc` path; only inserts a new entry when no match exists | `guildMemberRemove.js` |
+| 2 | No `maxlength` on `farewell.message` (Discord 4096 char limit) | Added `maxlength: 4000` to `farewell.message` in schema | `Guild.js` |
+
+#### Warnings (all resolved)
+
+| # | Issue | Fix | Files |
+|---|-------|-----|-------|
+| 3 | Deprecated `{ dynamic: true }` avatar option in farewell embed and log embed | Removed the deprecated option from both `setThumbnail` and `setAuthor` calls | `guildMemberRemove.js` |
+| 4 | `user.tag` deprecated in new Discord username system | Replaced `{user}` and `{username}` with `member.user.globalName ?? member.user.username`; `{tag}` with `member.user.username`; log embed author with `member.user.username` | `guildMemberRemove.js` |
+| 5 | No bot permission check before sending to farewell channel | Added `PermissionFlagsBits.SendMessages` check before attempting to send | `guildMemberRemove.js` |
+| 6 | No field-level validation for farewell settings in API | Added `validateFarewellUpdate()` that validates types, lengths, and snowflake format before hitting Mongoose | `api.js` |
+
+#### Informational (all resolved)
+
+| # | Issue | Fix | Files |
+|---|-------|-----|-------|
+| 7 | No tests | Added 7 passing Jest tests covering `applyVariables`, permission guard, disabled-state, and null-settings safety | `tests/farewell.test.js` |
+
+---
+
 *Last reviewed: 2026-05-28*

--- a/src/dashboard/routes/api.js
+++ b/src/dashboard/routes/api.js
@@ -227,6 +227,26 @@ function validateWelcomeUpdate(updates) {
     return null;
 }
 
+function validateFarewellUpdate(updates) {
+    for (const [key, value] of Object.entries(updates)) {
+        if (!key.startsWith('farewell.') && key !== 'farewell') continue;
+        const field = key.split('.')[1];
+        if (field === 'message') {
+            if (typeof value !== 'string') return 'farewell.message must be a string';
+            if (value.length > 4000) return 'farewell.message exceeds 4000 characters';
+        }
+        if (field === 'enabled') {
+            if (typeof value !== 'boolean') return 'farewell.enabled must be a boolean';
+        }
+        if (field === 'channelId' && value !== null && value !== '') {
+            if (typeof value !== 'string' || !/^\d{17,20}$/.test(value)) {
+                return 'farewell.channelId must be a valid Discord snowflake or null';
+            }
+        }
+    }
+    return null;
+}
+
 router.post('/guild/:guildId/settings', checkAuth, checkGuildAccess, checkWriteRateLimit, async (req, res) => {
     const { guildId } = req.params;
     const updates = req.body;
@@ -242,6 +262,9 @@ router.post('/guild/:guildId/settings', checkAuth, checkGuildAccess, checkWriteR
 
     const welcomeError = validateWelcomeUpdate(updates);
     if (welcomeError) return res.status(400).json({ error: welcomeError });
+
+    const farewellError = validateFarewellUpdate(updates);
+    if (farewellError) return res.status(400).json({ error: farewellError });
 
     try {
         const guildSettings = await Guild.findOne({ guildId });

--- a/src/events/guildMemberRemove.js
+++ b/src/events/guildMemberRemove.js
@@ -1,13 +1,10 @@
 const Guild = require('../models/Guild');
-const { EmbedBuilder, AuditLogEvent } = require('discord.js');
+const { EmbedBuilder, AuditLogEvent, PermissionFlagsBits } = require('discord.js');
 const { trackAction } = require('../services/antiNukeService');
 async function trackMemberEvent(guildSettings, dateKey, field) {
     const result = await guildSettings.constructor.updateOne(
         { guildId: guildSettings.guildId, 'analytics.memberEvents.date': dateKey },
-        {
-            $inc: { [`analytics.memberEvents.$.${field}`]: 1 },
-            $push: { 'analytics.memberEvents': { $each: [], $slice: -120 } }
-        }
+        { $inc: { [`analytics.memberEvents.$.${field}`]: 1 } }
     );
     if (!result.matchedCount) {
         await guildSettings.constructor.updateOne(
@@ -26,9 +23,9 @@ async function trackMemberEvent(guildSettings, dateKey, field) {
 
 function applyVariables(template, member) {
     return template
-        .replace(/{user}/g, member.user.tag)
-        .replace(/{username}/g, member.user.displayName ?? member.user.username)
-        .replace(/{tag}/g, member.user.tag)
+        .replace(/{user}/g, member.user.globalName ?? member.user.username)
+        .replace(/{username}/g, member.user.globalName ?? member.user.username)
+        .replace(/{tag}/g, member.user.username)
         .replace(/{server}/g, member.guild.name)
         .replace(/{memberCount}/g, member.guild.memberCount);
 }
@@ -55,13 +52,19 @@ module.exports = {
             const channel = member.guild.channels.cache.get(guildSettings.farewell.channelId);
             if (!channel) return;
 
+            const perms = channel.permissionsFor(member.guild.members.me);
+            if (!perms?.has(PermissionFlagsBits.SendMessages)) {
+                console.error(`Missing SendMessages permission for farewell channel ${channel.id} in guild ${member.guild.id}`);
+                return;
+            }
+
             const message = applyVariables(guildSettings.farewell.message, member);
 
             const embed = new EmbedBuilder()
                 .setColor('#ED4245')
                 .setTitle('Goodbye!')
                 .setDescription(message)
-                .setThumbnail(member.user.displayAvatarURL({ dynamic: true }))
+                .setThumbnail(member.user.displayAvatarURL())
                 .setTimestamp();
 
             await channel.send({ embeds: [embed] });
@@ -72,7 +75,7 @@ module.exports = {
                     const logEmbed = new EmbedBuilder()
                         .setColor('#ED4245')
                         .setTitle('Member Left')
-                        .setAuthor({ name: member.user.tag, iconURL: member.user.displayAvatarURL({ dynamic: true }) })
+                        .setAuthor({ name: member.user.username, iconURL: member.user.displayAvatarURL() })
                         .addFields(
                             { name: 'Joined', value: member.joinedAt ? `<t:${Math.floor(member.joinedTimestamp / 1000)}:R>` : 'Unknown', inline: true },
                             { name: 'Member Count', value: member.guild.memberCount.toString(), inline: true }

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -57,7 +57,7 @@ const guildSchema = new Schema({
     farewell: {
         enabled: { type: Boolean, default: false },
         channelId: { type: String, default: null },
-        message: { type: String, default: 'Goodbye {user}!' }
+        message: { type: String, default: 'Goodbye {user}!', maxlength: 4000 }
     },
 
     birthdays: {

--- a/tests/farewell.test.js
+++ b/tests/farewell.test.js
@@ -1,0 +1,134 @@
+'use strict';
+
+jest.mock('discord.js', () => {
+    const EmbedBuilder = jest.fn().mockImplementation(() => {
+        const self = {
+            data: {},
+            setColor: jest.fn().mockReturnThis(),
+            setTitle: jest.fn().mockReturnThis(),
+            setDescription: jest.fn().mockImplementation(function (desc) { self.data.description = desc; return self; }),
+            setThumbnail: jest.fn().mockReturnThis(),
+            setAuthor: jest.fn().mockReturnThis(),
+            addFields: jest.fn().mockReturnThis(),
+            setTimestamp: jest.fn().mockReturnThis(),
+        };
+        return self;
+    });
+    return {
+        EmbedBuilder,
+        AuditLogEvent: { MemberKick: 20 },
+        PermissionFlagsBits: { SendMessages: 1n << 11n },
+    };
+});
+
+jest.mock('../src/models/Guild', () => ({ findOne: jest.fn() }));
+jest.mock('../src/services/antiNukeService', () => ({ trackAction: jest.fn().mockResolvedValue(undefined) }));
+
+const farewellEvent = require('../src/events/guildMemberRemove');
+
+// ---------------------------------------------------------------------------
+// Shared mock helpers
+// ---------------------------------------------------------------------------
+
+function makeMember(overrides = {}) {
+    return {
+        id: '111222333444555666',
+        user: {
+            globalName: 'DisplayName',
+            username: 'cooluser',
+            tag: 'cooluser#0',
+            displayAvatarURL: jest.fn().mockReturnValue('https://cdn.discordapp.com/avatars/test.png'),
+        },
+        guild: {
+            id: '999888777666555444',
+            name: 'Cool Server',
+            memberCount: 10,
+            members: { me: {} },
+            channels: { cache: { get: jest.fn() } },
+        },
+        joinedAt: new Date('2024-01-01'),
+        joinedTimestamp: new Date('2024-01-01').getTime(),
+        ...overrides,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// applyVariables (tested via execute with farewell enabled)
+// We extract the module-internal logic by exercising channel.send captures.
+// ---------------------------------------------------------------------------
+
+describe('farewell applyVariables', () => {
+    let sendSpy;
+    let member;
+
+    beforeEach(() => {
+        sendSpy = jest.fn().mockResolvedValue(undefined);
+
+        const perms = { has: jest.fn().mockReturnValue(true) };
+        const channel = { send: sendSpy, permissionsFor: jest.fn().mockReturnValue(perms) };
+
+        member = makeMember();
+        member.guild.channels.cache.get = jest.fn().mockReturnValue(channel);
+
+        const Guild = require('../src/models/Guild');
+        Guild.findOne.mockResolvedValue({
+            guildId: member.guild.id,
+            farewell: { enabled: true, channelId: 'ch1', message: 'Bye {user}! You were in {server}.' },
+            eventLog: { enabled: false },
+            constructor: { updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }) },
+        });
+    });
+
+    afterEach(() => jest.clearAllMocks());
+
+    test('{user} resolves to globalName', async () => {
+        await farewellEvent.execute(member, {});
+        const embed = sendSpy.mock.calls[0][0].embeds[0];
+        expect(embed.data.description).toContain('DisplayName');
+    });
+
+    test('{user} falls back to username when globalName is null', async () => {
+        member.user.globalName = null;
+        await farewellEvent.execute(member, {});
+        const embed = sendSpy.mock.calls[0][0].embeds[0];
+        expect(embed.data.description).toContain('cooluser');
+    });
+
+    test('{server} resolves to guild name', async () => {
+        await farewellEvent.execute(member, {});
+        const embed = sendSpy.mock.calls[0][0].embeds[0];
+        expect(embed.data.description).toContain('Cool Server');
+    });
+
+    test('does not call channel.send when farewell is disabled', async () => {
+        const Guild = require('../src/models/Guild');
+        Guild.findOne.mockResolvedValue({
+            guildId: member.guild.id,
+            farewell: { enabled: false, channelId: 'ch1', message: 'Bye {user}!' },
+            eventLog: { enabled: false },
+            constructor: { updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }) },
+        });
+        await farewellEvent.execute(member, {});
+        expect(sendSpy).not.toHaveBeenCalled();
+    });
+
+    test('does not call channel.send when channel is not found', async () => {
+        member.guild.channels.cache.get = jest.fn().mockReturnValue(undefined);
+        await farewellEvent.execute(member, {});
+        expect(sendSpy).not.toHaveBeenCalled();
+    });
+
+    test('does not call channel.send when bot lacks SendMessages permission', async () => {
+        const perms = { has: jest.fn().mockReturnValue(false) };
+        const channel = { send: sendSpy, permissionsFor: jest.fn().mockReturnValue(perms) };
+        member.guild.channels.cache.get = jest.fn().mockReturnValue(channel);
+        await farewellEvent.execute(member, {});
+        expect(sendSpy).not.toHaveBeenCalled();
+    });
+
+    test('does not throw when guildSettings is null', async () => {
+        const Guild = require('../src/models/Guild');
+        Guild.findOne.mockResolvedValue(null);
+        await expect(farewellEvent.execute(member, {})).resolves.toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary
This PR brings the farewell feature to production readiness by fixing critical issues with analytics atomicity, removing deprecated Discord.js options, replacing deprecated user properties, adding permission checks, implementing field-level validation, and adding comprehensive test coverage.

## Key Changes

**src/events/guildMemberRemove.js**
- Fixed non-atomic analytics upsert by removing spurious `$push` with empty `$each` from increment operation
- Replaced deprecated `{ dynamic: true }` avatar option with standard `displayAvatarURL()` calls
- Updated user property references to use `globalName ?? username` instead of deprecated `tag` and `displayName`
- Added `PermissionFlagsBits.SendMessages` check before sending farewell message to prevent silent failures
- Updated event log embed author to use `username` instead of deprecated `tag`

**src/models/Guild.js**
- Added `maxlength: 4000` constraint to `farewell.message` field to enforce Discord's embed description limit

**src/dashboard/routes/api.js**
- Implemented `validateFarewellUpdate()` function with field-level validation:
  - `farewell.message`: type check (string) and length validation (≤4000 chars)
  - `farewell.enabled`: type check (boolean)
  - `farewell.channelId`: snowflake format validation (17-20 digits) or null/empty string
- Integrated validation into settings POST endpoint to catch invalid updates before database operations

**tests/farewell.test.js** (new)
- Added 7 comprehensive Jest tests covering:
  - Variable substitution (`{user}`, `{server}`)
  - Fallback behavior when `globalName` is null
  - Disabled state handling
  - Missing channel safety
  - Permission guard enforcement
  - Null settings safety

## Notable Implementation Details
- Analytics fix ensures only one document update per event (no spurious array operations)
- Permission check logs errors for debugging while gracefully skipping message send
- Validation occurs at API layer before Mongoose, providing immediate feedback to dashboard
- Tests use mocked Discord.js and database models to isolate farewell logic

https://claude.ai/code/session_01UkDQX8C7Npepz1jFZpygHf