### PR TITLE
fix(tempVoice): resolve all production-readiness issues

### DIFF
--- a/PRODUCTIONREADY.md
+++ b/PRODUCTIONREADY.md
@@ -173,4 +173,42 @@ This file tracks the production readiness status of each feature/function in Cla
 
 ---
 
+## Temp Voice Function
+
+**Status: PRODUCTION READY** ✓
+
+**Files reviewed/fixed:**
+- `src/services/tempVoiceService.js`
+- `src/events/channelDelete.js`
+- `src/index.js`
+- `src/commands/utility/vc.js`
+- `tests/tempVoice.test.js` (added)
+
+---
+
+### Issues Found & Fixed
+
+#### Critical (all resolved)
+
+| # | Issue | Fix | Files |
+|---|-------|-----|-------|
+| 1 | `checkTempVoice` exported but never scheduled — stale channels from restarts accumulated forever | Added `checkTempVoice(client)` call + 5-minute `setInterval` inside the `ready` event | `index.js` |
+| 2 | `channelDelete` event had no temp voice cleanup — manually deleted temp channels left ghost IDs in `activeChannels` forever | Added `$pull` update in `channelDelete` handler when deleted channel is in `activeChannels` | `channelDelete.js` |
+| 3 | Non-atomic push/save pattern for `activeChannels` — concurrent lobby joins could lose each other's update | Replaced `push` + `save` with `$addToSet` and `filter` + `save` with `$pull`/`$set` atomic MongoDB operations | `tempVoiceService.js` |
+
+#### Warnings (all resolved)
+
+| # | Issue | Fix | Files |
+|---|-------|-----|-------|
+| 4 | `{tag}` template variable used deprecated `member.user.tag` | Replaced with `member.user.globalName ?? member.user.username` | `tempVoiceService.js` |
+| 5 | No bot `ManageChannels` permission check before channel creation — failures were silent | Added `botMember.permissionsIn(...).has(ManageChannels)` guard with a logged warning | `tempVoiceService.js` |
+
+#### Informational (all resolved)
+
+| # | Issue | Fix | Files |
+|---|-------|-----|-------|
+| 6 | No tests | Added Jest; 11 passing tests covering lobby join, channel naming templates, permission guard, leave cleanup, and periodic `checkTempVoice` sweep | `tests/tempVoice.test.js` |
+
+---
+
 *Last reviewed: 2026-05-28*

--- a/src/events/channelDelete.js
+++ b/src/events/channelDelete.js
@@ -10,6 +10,15 @@ module.exports = {
         await trackAction(channel.guild, 'channelDelete', AuditLogEvent.ChannelDelete, channel.id).catch(console.error);
 
         const guildSettings = await Guild.findOne({ guildId: channel.guild.id });
+
+        // If a temp voice channel was manually deleted, remove it from the active list
+        if (guildSettings?.tempVoice?.enabled && guildSettings.tempVoice.activeChannels.includes(channel.id)) {
+            await Guild.updateOne(
+                { guildId: channel.guild.id },
+                { $pull: { 'tempVoice.activeChannels': channel.id } }
+            ).catch(console.error);
+        }
+
         if (!guildSettings?.eventLog?.enabled || !guildSettings.eventLog.logChannelChanges) return;
 
         const logChannel = channel.guild.channels.cache.get(guildSettings.eventLog.channelId);

--- a/src/index.js
+++ b/src/index.js
@@ -138,6 +138,10 @@ async function startBot() {
         const { startTempBanService } = require('./services/tempBanService');
         startTempBanService(client);
 
+        const { checkTempVoice } = require('./services/tempVoiceService');
+        checkTempVoice(client);
+        setInterval(() => checkTempVoice(client), 5 * 60_000);
+
         const { startRaidMonitor } = require('./services/raidService');
         startRaidMonitor(client);
     });

--- a/src/services/tempVoiceService.js
+++ b/src/services/tempVoiceService.js
@@ -13,11 +13,20 @@ async function handleVoiceStateUpdate(oldState, newState, client) {
     // Member joined the lobby → create their channel
     if (newState.channelId === lobbyChannelId && newState.member) {
         const member = newState.member;
+
+        const botMember = guild.members.me;
+        if (!botMember) return;
+        const targetParent = categoryId ? guild.channels.cache.get(categoryId) : null;
+        if (!botMember.permissionsIn(targetParent ?? guild).has(PermissionFlagsBits.ManageChannels)) {
+            console.warn(`[TEMPVOICE] Bot lacks ManageChannels in guild ${guild.id}`);
+            return;
+        }
+
         const nameTemplate = channelName || "{username}'s VC";
         const resolvedName = nameTemplate
             .replace(/{username}/gi, member.user.username)
             .replace(/{displayname}/gi, member.displayName)
-            .replace(/{tag}/gi, member.user.tag ?? member.user.username);
+            .replace(/{tag}/gi, member.user.globalName ?? member.user.username);
 
         const channel = await guild.channels.create({
             name: resolvedName,
@@ -34,8 +43,10 @@ async function handleVoiceStateUpdate(oldState, newState, client) {
 
         await member.voice.setChannel(channel).catch(console.error);
 
-        guildSettings.tempVoice.activeChannels.push(channel.id);
-        await guildSettings.save();
+        await Guild.updateOne(
+            { guildId: guild.id },
+            { $addToSet: { 'tempVoice.activeChannels': channel.id } }
+        );
     }
 
     // Member left a temp channel → delete if empty
@@ -45,10 +56,10 @@ async function handleVoiceStateUpdate(oldState, newState, client) {
         const leftChannel = guild.channels.cache.get(oldState.channelId);
         if (leftChannel && leftChannel.members.size === 0) {
             await leftChannel.delete().catch(console.error);
-            guildSettings.tempVoice.activeChannels = guildSettings.tempVoice.activeChannels.filter(
-                id => id !== oldState.channelId
+            await Guild.updateOne(
+                { guildId: guild.id },
+                { $pull: { 'tempVoice.activeChannels': oldState.channelId } }
             );
-            await guildSettings.save();
         }
     }
 }
@@ -62,22 +73,22 @@ async function checkTempVoice(client) {
             const guild = client.guilds.cache.get(guildSettings.guildId);
             if (!guild) continue;
 
-            let dirty = false;
             const toKeep = [];
 
             for (const channelId of guildSettings.tempVoice.activeChannels) {
                 const channel = guild.channels.cache.get(channelId);
                 if (!channel || channel.members.size === 0) {
                     if (channel) await channel.delete().catch(() => {});
-                    dirty = true;
                 } else {
                     toKeep.push(channelId);
                 }
             }
 
-            if (dirty) {
-                guildSettings.tempVoice.activeChannels = toKeep;
-                await guildSettings.save();
+            if (toKeep.length !== guildSettings.tempVoice.activeChannels.length) {
+                await Guild.updateOne(
+                    { guildId: guildSettings.guildId },
+                    { $set: { 'tempVoice.activeChannels': toKeep } }
+                );
             }
         }
     } catch (err) {

--- a/tests/tempVoice.test.js
+++ b/tests/tempVoice.test.js
@@ -1,0 +1,264 @@
+'use strict';
+
+jest.mock('discord.js', () => ({
+    ChannelType: { GuildVoice: 2 },
+    PermissionFlagsBits: { ManageChannels: 1n << 4n, MuteMembers: 1n << 22n, DeafenMembers: 1n << 23n },
+}));
+
+jest.mock('../src/models/Guild', () => ({
+    findOne: jest.fn(),
+    find: jest.fn(),
+    updateOne: jest.fn().mockResolvedValue({}),
+}));
+
+const { handleVoiceStateUpdate, checkTempVoice } = require('../src/services/tempVoiceService');
+const Guild = require('../src/models/Guild');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeGuildSettings(overrides = {}) {
+    return {
+        guildId: 'guild1',
+        tempVoice: {
+            enabled: true,
+            lobbyChannelId: 'lobby1',
+            categoryId: null,
+            activeChannels: [],
+            channelName: "{username}'s VC",
+            userLimit: 0,
+            bitrate: 64,
+            ...overrides,
+        },
+    };
+}
+
+function makeGuild({ createChannel = null, canManage = true } = {}) {
+    const createdChannel = { id: 'newchan1', members: { size: 0 }, delete: jest.fn().mockResolvedValue() };
+    const botMember = {
+        permissionsIn: jest.fn().mockReturnValue({ has: jest.fn().mockReturnValue(canManage) }),
+    };
+    const guild = {
+        id: 'guild1',
+        members: {
+            me: botMember,
+            cache: { get: jest.fn() },
+        },
+        channels: {
+            cache: { get: jest.fn() },
+            create: createChannel ?? jest.fn().mockResolvedValue(createdChannel),
+        },
+    };
+    guild._createdChannel = createdChannel;
+    return guild;
+}
+
+function makeMember(username = 'testuser', displayName = 'TestUser', globalName = 'TestGlobal') {
+    return {
+        id: 'user1',
+        user: { username, globalName, tag: 'DEPRECATED#0001' },
+        displayName,
+        voice: { setChannel: jest.fn().mockResolvedValue() },
+    };
+}
+
+function makeNewState(guild, member, channelId) {
+    return { guild, member, channelId };
+}
+
+function makeOldState(guild, channelId) {
+    return { guild, channelId };
+}
+
+// ---------------------------------------------------------------------------
+// Channel creation on lobby join
+// ---------------------------------------------------------------------------
+
+describe('handleVoiceStateUpdate — lobby join', () => {
+    afterEach(() => jest.clearAllMocks());
+
+    test('creates a temp channel when member joins lobby', async () => {
+        const guild = makeGuild();
+        const member = makeMember();
+        const guildSettings = makeGuildSettings();
+        Guild.findOne.mockResolvedValue(guildSettings);
+
+        const newState = makeNewState(guild, member, 'lobby1');
+        const oldState = makeOldState(guild, null);
+
+        await handleVoiceStateUpdate(oldState, newState, {});
+
+        expect(guild.channels.create).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 2 })
+        );
+        expect(member.voice.setChannel).toHaveBeenCalledWith(guild._createdChannel);
+        expect(Guild.updateOne).toHaveBeenCalledWith(
+            { guildId: 'guild1' },
+            { $addToSet: { 'tempVoice.activeChannels': 'newchan1' } }
+        );
+    });
+
+    test('resolves {tag} using globalName, not deprecated user.tag', async () => {
+        const guild = makeGuild();
+        const member = makeMember('alice', 'Alice', 'AliceGlobal');
+        const guildSettings = makeGuildSettings({ channelName: '{tag} channel' });
+        Guild.findOne.mockResolvedValue(guildSettings);
+
+        const newState = makeNewState(guild, member, 'lobby1');
+        const oldState = makeOldState(guild, null);
+
+        await handleVoiceStateUpdate(oldState, newState, {});
+
+        expect(guild.channels.create).toHaveBeenCalledWith(
+            expect.objectContaining({ name: 'AliceGlobal channel' })
+        );
+    });
+
+    test('resolves {username} in channel name', async () => {
+        const guild = makeGuild();
+        const member = makeMember('bob', 'Bob');
+        const guildSettings = makeGuildSettings({ channelName: "{username}'s room" });
+        Guild.findOne.mockResolvedValue(guildSettings);
+
+        await handleVoiceStateUpdate(makeOldState(guild, null), makeNewState(guild, member, 'lobby1'), {});
+
+        expect(guild.channels.create).toHaveBeenCalledWith(
+            expect.objectContaining({ name: "bob's room" })
+        );
+    });
+
+    test('does nothing when bot lacks ManageChannels', async () => {
+        const guild = makeGuild({ canManage: false });
+        const member = makeMember();
+        Guild.findOne.mockResolvedValue(makeGuildSettings());
+
+        await handleVoiceStateUpdate(makeOldState(guild, null), makeNewState(guild, member, 'lobby1'), {});
+
+        expect(guild.channels.create).not.toHaveBeenCalled();
+        expect(Guild.updateOne).not.toHaveBeenCalled();
+    });
+
+    test('does nothing when tempVoice is disabled', async () => {
+        const guild = makeGuild();
+        const member = makeMember();
+        Guild.findOne.mockResolvedValue(makeGuildSettings({ enabled: false }));
+
+        await handleVoiceStateUpdate(makeOldState(guild, null), makeNewState(guild, member, 'lobby1'), {});
+
+        expect(guild.channels.create).not.toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Channel deletion on leave
+// ---------------------------------------------------------------------------
+
+describe('handleVoiceStateUpdate — channel leave', () => {
+    afterEach(() => jest.clearAllMocks());
+
+    test('deletes empty temp channel when last member leaves', async () => {
+        const tempChannel = { id: 'temp1', members: { size: 0 }, delete: jest.fn().mockResolvedValue() };
+        const guild = makeGuild();
+        guild.channels.cache.get.mockReturnValue(tempChannel);
+
+        const guildSettings = makeGuildSettings({ activeChannels: ['temp1'] });
+        Guild.findOne.mockResolvedValue(guildSettings);
+
+        const oldState = makeOldState(guild, 'temp1');
+        const newState = { guild, member: null, channelId: null };
+
+        await handleVoiceStateUpdate(oldState, newState, {});
+
+        expect(tempChannel.delete).toHaveBeenCalled();
+        expect(Guild.updateOne).toHaveBeenCalledWith(
+            { guildId: 'guild1' },
+            { $pull: { 'tempVoice.activeChannels': 'temp1' } }
+        );
+    });
+
+    test('does not delete temp channel when members remain', async () => {
+        const tempChannel = { id: 'temp1', members: { size: 2 }, delete: jest.fn() };
+        const guild = makeGuild();
+        guild.channels.cache.get.mockReturnValue(tempChannel);
+
+        Guild.findOne.mockResolvedValue(makeGuildSettings({ activeChannels: ['temp1'] }));
+
+        const oldState = makeOldState(guild, 'temp1');
+        const newState = { guild, member: null, channelId: null };
+
+        await handleVoiceStateUpdate(oldState, newState, {});
+
+        expect(tempChannel.delete).not.toHaveBeenCalled();
+        expect(Guild.updateOne).not.toHaveBeenCalled();
+    });
+
+    test('ignores leave from the lobby channel itself', async () => {
+        const guild = makeGuild();
+        Guild.findOne.mockResolvedValue(makeGuildSettings({ activeChannels: ['lobby1'] }));
+
+        const oldState = makeOldState(guild, 'lobby1');
+        const newState = { guild, member: null, channelId: null };
+
+        await handleVoiceStateUpdate(oldState, newState, {});
+
+        expect(Guild.updateOne).not.toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// checkTempVoice periodic cleanup
+// ---------------------------------------------------------------------------
+
+describe('checkTempVoice', () => {
+    afterEach(() => jest.clearAllMocks());
+
+    test('deletes and removes stale channels with no members', async () => {
+        const staleChannel = { id: 'stale1', members: { size: 0 }, delete: jest.fn().mockResolvedValue() };
+        const guild = { channels: { cache: { get: jest.fn().mockReturnValue(staleChannel) } } };
+        const client = { guilds: { cache: { get: jest.fn().mockReturnValue(guild) } } };
+
+        Guild.find.mockResolvedValue([
+            makeGuildSettings({ activeChannels: ['stale1'] }),
+        ]);
+
+        await checkTempVoice(client);
+
+        expect(staleChannel.delete).toHaveBeenCalled();
+        expect(Guild.updateOne).toHaveBeenCalledWith(
+            { guildId: 'guild1' },
+            { $set: { 'tempVoice.activeChannels': [] } }
+        );
+    });
+
+    test('keeps active channels with members', async () => {
+        const activeChannel = { id: 'active1', members: { size: 3 }, delete: jest.fn() };
+        const guild = { channels: { cache: { get: jest.fn().mockReturnValue(activeChannel) } } };
+        const client = { guilds: { cache: { get: jest.fn().mockReturnValue(guild) } } };
+
+        Guild.find.mockResolvedValue([
+            makeGuildSettings({ activeChannels: ['active1'] }),
+        ]);
+
+        await checkTempVoice(client);
+
+        expect(activeChannel.delete).not.toHaveBeenCalled();
+        expect(Guild.updateOne).not.toHaveBeenCalled();
+    });
+
+    test('removes ghost channel IDs not in guild cache', async () => {
+        const guild = { channels: { cache: { get: jest.fn().mockReturnValue(undefined) } } };
+        const client = { guilds: { cache: { get: jest.fn().mockReturnValue(guild) } } };
+
+        Guild.find.mockResolvedValue([
+            makeGuildSettings({ activeChannels: ['ghost1'] }),
+        ]);
+
+        await checkTempVoice(client);
+
+        expect(Guild.updateOne).toHaveBeenCalledWith(
+            { guildId: 'guild1' },
+            { $set: { 'tempVoice.activeChannels': [] } }
+        );
+    });
+});


### PR DESCRIPTION
- Schedule checkTempVoice on bot ready (5-min interval) so stale channels from restarts are cleaned up automatically
- Clean up activeChannels in channelDelete event when a temp channel is manually deleted by an admin
- Replace non-atomic push/save pattern with $addToSet / $pull / $set MongoDB operations to prevent race conditions on concurrent joins
- Replace deprecated user.tag with user.globalName ?? user.username in the {tag} channel name template
- Add ManageChannels permission guard before channel creation with a logged warning on failure
- Add 11 Jest tests covering all happy paths and edge cases

https://claude.ai/code/session_01Kq9wtvaUhxG7h2RHCUuRHY