### PR TITLE
Fix raid detection race condition and Discord timeout issues

### DIFF
--- a/PRODUCTIONREADY.md
+++ b/PRODUCTIONREADY.md
@@ -211,4 +211,40 @@ This file tracks the production readiness status of each feature/function in Cla
 
 ---
 
+## Raid Detection Function
+
+**Status: PRODUCTION READY** ✓
+
+**Files reviewed/fixed:**
+- `src/services/raidService.js`
+- `src/commands/admin/raidmode.js`
+- `tests/raid.test.js` (added)
+
+---
+
+### Issues Found & Fixed
+
+#### Critical (all resolved)
+
+| # | Issue | Fix | Files |
+|---|-------|-----|-------|
+| 1 | Double-activation race condition: `raidModeActive.add(guildId)` was called *after* `await alertChannel.send()`, allowing two concurrent threshold-crossing joins to both pass the `raidModeActive.has()` guard simultaneously — sending two alerts and running the bulk-action loop twice | Moved `raidModeActive.add(guildId)` and `raidModeActivatedBy.set()` to before the first `await` in the activation block | `raidService.js` |
+| 2 | `raid` subcommand had a `Guild.updateOne` DB call before `interaction.reply` — at-risk of Discord's 3-second response timeout | Added `interaction.deferReply()` before DB call; changed `reply` to `editReply` | `raidmode.js` |
+| 3 | `toggle` subcommand had a `Guild.findOne` + `setRaidMode` (DB + Discord message) before `interaction.reply` — at-risk of 3-second timeout | Added `interaction.deferReply()` before DB call; changed `reply`/`ephemeral reply` to `editReply` | `raidmode.js` |
+| 4 | `status` subcommand had a `Guild.findOne` DB call before `interaction.reply` — at-risk of 3-second timeout | Added `interaction.deferReply()` before DB call; changed `reply` to `editReply` | `raidmode.js` |
+
+#### Warnings (all resolved)
+
+| # | Issue | Fix | Files |
+|---|-------|-----|-------|
+| 5 | `rd.action.toUpperCase()` in the status embed crashes if `action` is null (e.g. a guild document created before the schema default was added) | Changed to `(rd.action ?? 'alert').toUpperCase()` | `raidmode.js` |
+
+#### Informational (all resolved)
+
+| # | Issue | Fix | Files |
+|---|-------|-----|-------|
+| 6 | No tests | Added Jest; 15 passing tests covering threshold detection, auto-activation, double-activation guard, bulk kick/quarantine, active-mode joins, old-account exemption, DB error safety, DB→memory sync on restart, and manual enable/disable | `tests/raid.test.js` |
+
+---
+
 *Last reviewed: 2026-05-28*

--- a/src/commands/admin/raidmode.js
+++ b/src/commands/admin/raidmode.js
@@ -66,6 +66,8 @@ module.exports = {
         const sub = interaction.options.getSubcommand();
 
         if (sub === 'raid') {
+            await interaction.deferReply();
+
             const enabled = interaction.options.getBoolean('enabled');
             const threshold = interaction.options.getInteger('threshold');
             const window = interaction.options.getInteger('window');
@@ -103,18 +105,19 @@ module.exports = {
                 )
                 .setTimestamp();
 
-            return interaction.reply({ embeds: [embed] });
+            return interaction.editReply({ embeds: [embed] });
         }
 
         if (sub === 'toggle') {
+            await interaction.deferReply();
+
             const status = interaction.options.getString('status');
             const active = status === 'on';
 
             const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
             if (!guildSettings?.raidDetection?.enabled) {
-                return interaction.reply({
-                    content: 'Raid detection is not enabled. Use `/raidmode raid enabled:true` first.',
-                    ephemeral: true
+                return interaction.editReply({
+                    content: 'Raid detection is not enabled. Use `/raidmode raid enabled:true` first.'
                 });
             }
 
@@ -131,15 +134,17 @@ module.exports = {
                 .addFields({ name: 'Triggered By', value: 'Manual (moderator override)', inline: true })
                 .setTimestamp();
 
-            return interaction.reply({ embeds: [embed] });
+            return interaction.editReply({ embeds: [embed] });
         }
 
         if (sub === 'status') {
+            await interaction.deferReply();
+
             const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
             const rd = guildSettings?.raidDetection;
 
             if (!rd?.enabled) {
-                return interaction.reply({
+                return interaction.editReply({
                     embeds: [new EmbedBuilder()
                         .setColor('#888888')
                         .setTitle('Raid Detection: Disabled')
@@ -160,7 +165,7 @@ module.exports = {
                     { name: 'Raid Mode Active', value: isActive ? '🔴 YES' : '🟢 No', inline: true },
                     { name: 'Triggered By', value: isActive ? (activatedBy === 'manual' ? 'Manual' : 'Automatic') : 'N/A', inline: true },
                     { name: 'Threshold', value: `${rd.threshold} joins / ${rd.windowSeconds}s`, inline: true },
-                    { name: 'Action', value: rd.action.toUpperCase(), inline: true },
+                    { name: 'Action', value: (rd.action ?? 'alert').toUpperCase(), inline: true },
                     { name: 'Min Account Age', value: `${rd.minAccountAgeDays} days`, inline: true },
                     { name: 'Auto-Disable', value: rd.autoDisable ? 'Yes' : 'No', inline: true },
                     { name: 'Calm Window', value: `${rd.calmWindowSeconds}s`, inline: true },
@@ -172,7 +177,7 @@ module.exports = {
             }
 
             embed.setTimestamp();
-            return interaction.reply({ embeds: [embed] });
+            return interaction.editReply({ embeds: [embed] });
         }
 
         if (sub === 'cases') {

--- a/src/services/raidService.js
+++ b/src/services/raidService.js
@@ -92,12 +92,14 @@ async function handleMemberJoin(member, client) {
         )
         .setTimestamp();
 
+    // Set in-memory state before the first await so concurrent joins can't
+    // both pass the raidModeActive.has() guard and double-trigger the alert.
+    raidModeActive.add(guildId);
+    raidModeActivatedBy.set(guildId, 'auto');
+
     if (alertChannel) {
         await alertChannel.send({ embeds: [embed] }).catch(console.error);
     }
-
-    raidModeActive.add(guildId);
-    raidModeActivatedBy.set(guildId, 'auto');
 
     await Guild.updateOne({ guildId }, {
         $set: {

--- a/tests/raid.test.js
+++ b/tests/raid.test.js
@@ -1,0 +1,339 @@
+'use strict';
+
+jest.mock('discord.js', () => ({
+    EmbedBuilder: jest.fn().mockImplementation(() => ({
+        setColor: jest.fn().mockReturnThis(),
+        setTitle: jest.fn().mockReturnThis(),
+        setDescription: jest.fn().mockReturnThis(),
+        addFields: jest.fn().mockReturnThis(),
+        setTimestamp: jest.fn().mockReturnThis(),
+    })),
+}));
+
+jest.mock('../src/models/Guild', () => ({
+    findOne: jest.fn(),
+    updateOne: jest.fn().mockResolvedValue({}),
+}));
+
+const { handleMemberJoin, setRaidMode, raidModeActive, raidModeActivatedBy } = require('../src/services/raidService');
+const Guild = require('../src/models/Guild');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Use unique guild IDs per test to keep the in-memory joinLog clean between runs.
+let _guildSeq = 0;
+function freshGuildId() { return `guild_${++_guildSeq}`; }
+
+function makeGuildSettings(guildId, overrides = {}) {
+    return {
+        guildId,
+        raidDetection: {
+            enabled: true,
+            threshold: 3,
+            windowSeconds: 60,
+            minAccountAgeDays: 7,
+            action: 'alert',
+            alertChannelId: null,
+            quarantineRoleId: null,
+            autoDisable: true,
+            calmWindowSeconds: 300,
+            requireManualDisable: false,
+            raidModeActive: false,
+            raidModeActivatedBy: null,
+            raidModeActivatedAt: null,
+            ...(overrides.raidDetection || {}),
+        },
+        moderation: { logChannelId: 'log1' },
+    };
+}
+
+function makeSharedGuild(guildId) {
+    return {
+        id: guildId,
+        members: { cache: new Map() },
+        channels: { cache: new Map() },
+        roles: { cache: new Map() },
+    };
+}
+
+function makeMember(guild) {
+    const member = {
+        id: `user_${Math.random().toString(36).slice(2)}`,
+        guild,
+        user: {
+            // 1 day old — below the 7-day minAccountAgeDays threshold
+            createdTimestamp: Date.now() - 86_400_000,
+        },
+        kickable: true,
+        kick: jest.fn().mockResolvedValue(undefined),
+        roles: { add: jest.fn().mockResolvedValue(undefined) },
+    };
+    return member;
+}
+
+function makeOldMember(guild) {
+    const member = makeMember(guild);
+    // 30 days old — above threshold, should never be actioned
+    member.user.createdTimestamp = Date.now() - 30 * 86_400_000;
+    return member;
+}
+
+// ---------------------------------------------------------------------------
+// Reset shared in-memory state between tests.
+// joinLog is not exported; unique guild IDs prevent cross-test bleed.
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+    raidModeActive.clear();
+    raidModeActivatedBy.clear();
+    Guild.findOne.mockReset();
+    Guild.updateOne.mockResolvedValue({});
+});
+
+// ---------------------------------------------------------------------------
+// handleMemberJoin
+// ---------------------------------------------------------------------------
+
+describe('handleMemberJoin', () => {
+    test('returns early when guild has no settings', async () => {
+        Guild.findOne.mockResolvedValue(null);
+        const gid = freshGuildId();
+        const guild = makeSharedGuild(gid);
+        await handleMemberJoin(makeMember(guild), {});
+        expect(Guild.updateOne).not.toHaveBeenCalled();
+    });
+
+    test('returns early when raid detection is disabled', async () => {
+        const gid = freshGuildId();
+        Guild.findOne.mockResolvedValue(makeGuildSettings(gid, { raidDetection: { enabled: false } }));
+        await handleMemberJoin(makeMember(makeSharedGuild(gid)), {});
+        expect(Guild.updateOne).not.toHaveBeenCalled();
+    });
+
+    test('logs joins below threshold without activating raid mode', async () => {
+        const gid = freshGuildId();
+        const guild = makeSharedGuild(gid);
+        Guild.findOne.mockResolvedValue(makeGuildSettings(gid));
+
+        await handleMemberJoin(makeMember(guild), {});
+        await handleMemberJoin(makeMember(guild), {});
+
+        expect(raidModeActive.has(gid)).toBe(false);
+        expect(Guild.updateOne).not.toHaveBeenCalled();
+    });
+
+    test('activates raid mode and sends alert when threshold is reached', async () => {
+        const gid = freshGuildId();
+        const guild = makeSharedGuild(gid);
+        const alertChannel = { send: jest.fn().mockResolvedValue(undefined) };
+        guild.channels.cache.set('alert1', alertChannel);
+
+        Guild.findOne.mockResolvedValue(
+            makeGuildSettings(gid, { raidDetection: { alertChannelId: 'alert1' } })
+        );
+
+        for (let i = 0; i < 3; i++) {
+            await handleMemberJoin(makeMember(guild), {});
+        }
+
+        expect(raidModeActive.has(gid)).toBe(true);
+        expect(raidModeActivatedBy.get(gid)).toBe('auto');
+        expect(alertChannel.send).toHaveBeenCalledTimes(1);
+        expect(Guild.updateOne).toHaveBeenCalledWith(
+            { guildId: gid },
+            expect.objectContaining({
+                $set: expect.objectContaining({ 'raidDetection.raidModeActive': true }),
+            })
+        );
+    });
+
+    test('raidModeActive is set before alertChannel.send (double-activation guard)', async () => {
+        const gid = freshGuildId();
+        const guild = makeSharedGuild(gid);
+
+        let raidActiveAtSendTime = false;
+        guild.channels.cache.set('alert1', {
+            send: jest.fn().mockImplementation(() => {
+                raidActiveAtSendTime = raidModeActive.has(gid);
+                return Promise.resolve();
+            }),
+        });
+
+        Guild.findOne.mockResolvedValue(
+            makeGuildSettings(gid, { raidDetection: { alertChannelId: 'alert1' } })
+        );
+
+        for (let i = 0; i < 3; i++) {
+            await handleMemberJoin(makeMember(guild), {});
+        }
+
+        expect(raidActiveAtSendTime).toBe(true);
+    });
+
+    test('kicks new accounts in bulk when raid triggers with kick action', async () => {
+        const gid = freshGuildId();
+        const guild = makeSharedGuild(gid);
+        Guild.findOne.mockResolvedValue(makeGuildSettings(gid, { raidDetection: { action: 'kick' } }));
+
+        const members = [makeMember(guild), makeMember(guild), makeMember(guild)];
+        members.forEach(m => guild.members.cache.set(m.id, m));
+
+        for (const m of members) {
+            await handleMemberJoin(m, {});
+        }
+
+        const kicked = members.filter(m => m.kick.mock.calls.length > 0);
+        expect(kicked.length).toBeGreaterThan(0);
+    });
+
+    test('quarantines new accounts in bulk when raid triggers with quarantine action', async () => {
+        const gid = freshGuildId();
+        const guild = makeSharedGuild(gid);
+        const qRole = { id: 'qrole' };
+        guild.roles.cache.set('qrole', qRole);
+
+        Guild.findOne.mockResolvedValue(
+            makeGuildSettings(gid, {
+                raidDetection: { action: 'quarantine', quarantineRoleId: 'qrole' },
+            })
+        );
+
+        const members = [makeMember(guild), makeMember(guild), makeMember(guild)];
+        members.forEach(m => guild.members.cache.set(m.id, m));
+
+        for (const m of members) {
+            await handleMemberJoin(m, {});
+        }
+
+        const quarantined = members.filter(m => m.roles.add.mock.calls.length > 0);
+        expect(quarantined.length).toBeGreaterThan(0);
+    });
+
+    test('applies configured action to new joins when raid mode is already active', async () => {
+        const gid = freshGuildId();
+        const guild = makeSharedGuild(gid);
+        raidModeActive.add(gid);
+        raidModeActivatedBy.set(gid, 'manual');
+
+        Guild.findOne.mockResolvedValue(
+            makeGuildSettings(gid, {
+                raidDetection: {
+                    action: 'kick',
+                    raidModeActive: true,
+                    raidModeActivatedBy: 'manual',
+                },
+            })
+        );
+
+        const member = makeMember(guild);
+        await handleMemberJoin(member, {});
+
+        expect(member.kick).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not action accounts above minAccountAgeDays', async () => {
+        const gid = freshGuildId();
+        const guild = makeSharedGuild(gid);
+        Guild.findOne.mockResolvedValue(makeGuildSettings(gid, { raidDetection: { action: 'kick' } }));
+
+        const members = [makeOldMember(guild), makeOldMember(guild), makeOldMember(guild)];
+        members.forEach(m => guild.members.cache.set(m.id, m));
+
+        for (const m of members) {
+            await handleMemberJoin(m, {});
+        }
+
+        const kicked = members.filter(m => m.kick.mock.calls.length > 0);
+        expect(kicked.length).toBe(0);
+    });
+
+    test('handles DB error gracefully without throwing', async () => {
+        Guild.findOne.mockRejectedValue(new Error('DB down'));
+        const guild = makeSharedGuild(freshGuildId());
+        await expect(handleMemberJoin(makeMember(guild), {})).resolves.toBeUndefined();
+    });
+
+    test('syncs raidModeActive from DB field on first join after restart', async () => {
+        const gid = freshGuildId();
+        const guild = makeSharedGuild(gid);
+        Guild.findOne.mockResolvedValue(
+            makeGuildSettings(gid, {
+                raidDetection: { raidModeActive: true, raidModeActivatedBy: 'manual' },
+            })
+        );
+
+        await handleMemberJoin(makeMember(guild), {});
+
+        expect(raidModeActive.has(gid)).toBe(true);
+        expect(raidModeActivatedBy.get(gid)).toBe('manual');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// setRaidMode
+// ---------------------------------------------------------------------------
+
+describe('setRaidMode', () => {
+    test('enables raid mode and sends alert', async () => {
+        const gid = freshGuildId();
+        const alertChannel = { send: jest.fn().mockResolvedValue(undefined) };
+        const guild = { channels: { cache: new Map([['alert1', alertChannel]]) } };
+        const settings = makeGuildSettings(gid, { raidDetection: { alertChannelId: 'alert1' } });
+
+        await setRaidMode(gid, guild, true, settings);
+
+        expect(raidModeActive.has(gid)).toBe(true);
+        expect(raidModeActivatedBy.get(gid)).toBe('manual');
+        expect(Guild.updateOne).toHaveBeenCalledWith(
+            { guildId: gid },
+            expect.objectContaining({
+                $set: expect.objectContaining({ 'raidDetection.raidModeActive': true }),
+            })
+        );
+        expect(alertChannel.send).toHaveBeenCalledTimes(1);
+    });
+
+    test('disables raid mode and sends alert', async () => {
+        const gid = freshGuildId();
+        raidModeActive.add(gid);
+        raidModeActivatedBy.set(gid, 'auto');
+
+        const alertChannel = { send: jest.fn().mockResolvedValue(undefined) };
+        const guild = { channels: { cache: new Map([['alert1', alertChannel]]) } };
+        const settings = makeGuildSettings(gid, { raidDetection: { alertChannelId: 'alert1' } });
+
+        await setRaidMode(gid, guild, false, settings);
+
+        expect(raidModeActive.has(gid)).toBe(false);
+        expect(raidModeActivatedBy.has(gid)).toBe(false);
+        expect(Guild.updateOne).toHaveBeenCalledWith(
+            { guildId: gid },
+            expect.objectContaining({
+                $set: expect.objectContaining({ 'raidDetection.raidModeActive': false }),
+            })
+        );
+        expect(alertChannel.send).toHaveBeenCalledTimes(1);
+    });
+
+    test('falls back to moderation logChannelId when no alertChannelId is set', async () => {
+        const gid = freshGuildId();
+        const logChannel = { send: jest.fn().mockResolvedValue(undefined) };
+        const guild = { channels: { cache: new Map([['log1', logChannel]]) } };
+        const settings = makeGuildSettings(gid);
+
+        await setRaidMode(gid, guild, true, settings);
+
+        expect(logChannel.send).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not throw when alert channel is not in cache', async () => {
+        const gid = freshGuildId();
+        const guild = { channels: { cache: new Map() } };
+        const settings = makeGuildSettings(gid);
+
+        await expect(setRaidMode(gid, guild, true, settings)).resolves.toBeUndefined();
+        expect(raidModeActive.has(gid)).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

This PR resolves critical race condition and timeout vulnerabilities in the raid detection system that could cause double-activation alerts, missed Discord response deadlines, and potential crashes.

## Key Changes

### Race Condition Fix (raidService.js)
- **Moved in-memory state updates before async operations**: `raidModeActive.add()` and `raidModeActivatedBy.set()` are now called before `await alertChannel.send()`, preventing concurrent threshold-crossing joins from both passing the guard check and triggering duplicate alerts and bulk actions.

### Discord Timeout Fixes (raidmode.js)
- **`/raidmode raid` subcommand**: Added `interaction.deferReply()` before DB operations and changed `reply()` to `editReply()` to ensure response within Discord's 3-second deadline.
- **`/raidmode toggle` subcommand**: Added `interaction.deferReply()` before `Guild.findOne()` and `setRaidMode()` calls; changed `reply()` to `editReply()` and removed unnecessary `ephemeral` flag.
- **`/raidmode status` subcommand**: Added `interaction.deferReply()` before DB query and changed `reply()` to `editReply()`.

### Null Safety Fix (raidmode.js)
- **Status embed action display**: Changed `rd.action.toUpperCase()` to `(rd.action ?? 'alert').toUpperCase()` to prevent crashes when `action` field is null (e.g., legacy guild documents).

### Test Coverage (tests/raid.test.js)
- Added comprehensive Jest test suite with 15 passing tests covering:
  - Threshold detection and auto-activation
  - Double-activation guard verification
  - Bulk kick/quarantine actions
  - Active-mode join handling
  - Old-account exemption logic
  - Database error resilience
  - DB→memory state sync on restart
  - Manual enable/disable operations

## Notable Implementation Details

- The race condition fix ensures atomicity of the "raid mode activated" state check and set operation relative to the alert message send, preventing the window where two concurrent joins could both see `raidModeActive` as false.
- All Discord interaction response changes use `deferReply()` + `editReply()` pattern to safely handle long-running operations without timeout risk.
- Test suite uses unique guild IDs per test to isolate in-memory state and prevent cross-test contamination.

https://claude.ai/code/session_01RRuGCADeEgi6S5PnucK1Tm