### PR TITLE
Fix event log deprecations, add permission checks, and validate settings

### DIFF
--- a/PRODUCTIONREADY.md
+++ b/PRODUCTIONREADY.md
@@ -318,4 +318,38 @@ This file tracks the production readiness status of each feature/function in Cla
 
 ---
 
+## Event Log Function
+
+**Status: PRODUCTION READY** ✓
+
+**Files reviewed/fixed:**
+- `src/events/messageDelete.js`
+- `src/events/messageUpdate.js`
+- `src/events/guildMemberUpdate.js`
+- `src/events/channelCreate.js`
+- `src/events/channelDelete.js`
+- `src/dashboard/routes/api.js`
+- `tests/eventLog.test.js` (added)
+
+---
+
+### Issues Found & Fixed
+
+#### Warnings (all resolved)
+
+| # | Issue | Fix | Files |
+|---|-------|-----|-------|
+| 1 | `user.tag` deprecated in new Discord username system — used in `messageDelete`, `messageUpdate`, and `guildMemberUpdate` event handlers | Replaced with `globalName ?? username` in all three handlers | `messageDelete.js`, `messageUpdate.js`, `guildMemberUpdate.js` |
+| 2 | `displayAvatarURL({ dynamic: true })` deprecated in discord.js v14 — used in `messageDelete`, `messageUpdate`, `guildMemberUpdate` | Removed the `{ dynamic: true }` option; the method returns animated URLs by default | `messageDelete.js`, `messageUpdate.js`, `guildMemberUpdate.js` |
+| 3 | No bot `SendMessages` permission check before sending to the log channel — failures were silent | Added `PermissionFlagsBits.SendMessages` guard via `logChannel.permissionsFor(guild.members.me)` in all five event handlers | `messageDelete.js`, `messageUpdate.js`, `guildMemberUpdate.js`, `channelCreate.js`, `channelDelete.js` |
+| 4 | No field-level validation for `eventLog.*` settings in the dashboard API — invalid `channelId` and non-boolean toggle values bypassed every guard and hit Mongoose directly | Added `validateEventLogUpdate()` covering type checks for all boolean toggles and snowflake format for `channelId`; wired it into the settings route alongside existing validators | `api.js` |
+
+#### Informational (all resolved)
+
+| # | Issue | Fix | Files |
+|---|-------|-----|-------|
+| 5 | No tests | Added Jest; 24 passing tests covering `messageDelete` (enabled, disabled, logMessageDelete=false, bot skip, permission guard, globalName fallback, content truncation), `messageUpdate` (content changed, unchanged, bot skip, permission guard), `guildMemberUpdate` (role add, role remove, no changes, permission guard), and `validateEventLogUpdate` (valid booleans, invalid enabled, valid/invalid/null channelId, unrelated keys) | `tests/eventLog.test.js` |
+
+---
+
 *Last reviewed: 2026-05-28*

--- a/src/dashboard/routes/api.js
+++ b/src/dashboard/routes/api.js
@@ -293,6 +293,26 @@ function validateBirthdaysUpdate(updates) {
     return null;
 }
 
+function validateEventLogUpdate(updates) {
+    const EVENT_LOG_BOOLEAN_FIELDS = new Set([
+        'enabled', 'logMessageEdit', 'logMessageDelete',
+        'logMemberJoin', 'logMemberLeave', 'logRoleChanges', 'logChannelChanges',
+    ]);
+    for (const [key, value] of Object.entries(updates)) {
+        if (!key.startsWith('eventLog.') && key !== 'eventLog') continue;
+        const field = key.split('.')[1];
+        if (EVENT_LOG_BOOLEAN_FIELDS.has(field)) {
+            if (typeof value !== 'boolean') return `eventLog.${field} must be a boolean`;
+        }
+        if (field === 'channelId' && value !== null && value !== '') {
+            if (typeof value !== 'string' || !/^\d{17,20}$/.test(value)) {
+                return 'eventLog.channelId must be a valid Discord snowflake or null';
+            }
+        }
+    }
+    return null;
+}
+
 const VALID_BIBLE_TRANSLATIONS = new Set(['kjv', 'niv', 'asv', 'web', 'ylt', 'darby', 'bbe', 'webbe']);
 
 function validateBibleVerseUpdate(updates) {
@@ -357,6 +377,9 @@ router.post('/guild/:guildId/settings', checkAuth, checkGuildAccess, checkWriteR
 
     const bibleVerseError = validateBibleVerseUpdate(updates);
     if (bibleVerseError) return res.status(400).json({ error: bibleVerseError });
+
+    const eventLogError = validateEventLogUpdate(updates);
+    if (eventLogError) return res.status(400).json({ error: eventLogError });
 
     try {
         const guildSettings = await Guild.findOne({ guildId });
@@ -1073,3 +1096,4 @@ router.post('/guild/:guildId/achievements/grant', checkAuth, checkGuildAccess, c
 
 module.exports = router;
 module.exports.computeRetention = computeRetention;
+module.exports.validateEventLogUpdate = validateEventLogUpdate;

--- a/src/events/channelCreate.js
+++ b/src/events/channelCreate.js
@@ -1,4 +1,4 @@
-const { EmbedBuilder, AuditLogEvent } = require('discord.js');
+const { EmbedBuilder, AuditLogEvent, PermissionFlagsBits } = require('discord.js');
 const Guild = require('../models/Guild');
 const { trackAction } = require('../services/antiNukeService');
 
@@ -14,6 +14,8 @@ module.exports = {
 
         const logChannel = channel.guild.channels.cache.get(guildSettings.eventLog.channelId);
         if (!logChannel || logChannel.id === channel.id) return;
+
+        if (!logChannel.permissionsFor(channel.guild.members.me)?.has(PermissionFlagsBits.SendMessages)) return;
 
         const embed = new EmbedBuilder()
             .setColor('#00ff00')

--- a/src/events/channelDelete.js
+++ b/src/events/channelDelete.js
@@ -1,4 +1,4 @@
-const { EmbedBuilder, AuditLogEvent } = require('discord.js');
+const { EmbedBuilder, AuditLogEvent, PermissionFlagsBits } = require('discord.js');
 const Guild = require('../models/Guild');
 const { trackAction } = require('../services/antiNukeService');
 
@@ -23,6 +23,8 @@ module.exports = {
 
         const logChannel = channel.guild.channels.cache.get(guildSettings.eventLog.channelId);
         if (!logChannel) return;
+
+        if (!logChannel.permissionsFor(channel.guild.members.me)?.has(PermissionFlagsBits.SendMessages)) return;
 
         const embed = new EmbedBuilder()
             .setColor('#ff0000')

--- a/src/events/guildMemberUpdate.js
+++ b/src/events/guildMemberUpdate.js
@@ -1,4 +1,4 @@
-const { EmbedBuilder, AuditLogEvent } = require('discord.js');
+const { EmbedBuilder, AuditLogEvent, PermissionFlagsBits } = require('discord.js');
 const Guild = require('../models/Guild');
 
 module.exports = {
@@ -9,6 +9,8 @@ module.exports = {
 
         const logChannel = newMember.guild.channels.cache.get(guildSettings.eventLog.channelId);
         if (!logChannel) return;
+
+        if (!logChannel.permissionsFor(newMember.guild.members.me)?.has(PermissionFlagsBits.SendMessages)) return;
 
         const oldRoles = oldMember.roles.cache;
         const newRoles = newMember.roles.cache;
@@ -21,7 +23,7 @@ module.exports = {
         const embed = new EmbedBuilder()
             .setColor('#5865F2')
             .setTitle('Member Roles Updated')
-            .setAuthor({ name: newMember.user.tag, iconURL: newMember.user.displayAvatarURL({ dynamic: true }) })
+            .setAuthor({ name: newMember.user.globalName ?? newMember.user.username, iconURL: newMember.user.displayAvatarURL() })
             .setTimestamp();
 
         if (added.size) embed.addFields({ name: 'Roles Added', value: added.map(r => r.toString()).join(', ') });

--- a/src/events/messageDelete.js
+++ b/src/events/messageDelete.js
@@ -1,4 +1,4 @@
-const { EmbedBuilder } = require('discord.js');
+const { EmbedBuilder, PermissionFlagsBits } = require('discord.js');
 const Guild = require('../models/Guild');
 
 module.exports = {
@@ -12,10 +12,12 @@ module.exports = {
         const logChannel = message.guild.channels.cache.get(guildSettings.eventLog.channelId);
         if (!logChannel) return;
 
+        if (!logChannel.permissionsFor(message.guild.members.me)?.has(PermissionFlagsBits.SendMessages)) return;
+
         const embed = new EmbedBuilder()
             .setColor('#ff0000')
             .setTitle('Message Deleted')
-            .setAuthor({ name: message.author?.tag ?? 'Unknown', iconURL: message.author?.displayAvatarURL({ dynamic: true }) })
+            .setAuthor({ name: message.author?.globalName ?? message.author?.username ?? 'Unknown', iconURL: message.author?.displayAvatarURL() })
             .addFields(
                 { name: 'Content', value: (message.content || '*no text content*').substring(0, 1024) },
                 { name: 'Channel', value: `<#${message.channel.id}>`, inline: true }

--- a/src/events/messageUpdate.js
+++ b/src/events/messageUpdate.js
@@ -1,4 +1,4 @@
-const { EmbedBuilder } = require('discord.js');
+const { EmbedBuilder, PermissionFlagsBits } = require('discord.js');
 const Guild = require('../models/Guild');
 
 module.exports = {
@@ -13,10 +13,12 @@ module.exports = {
         const logChannel = newMessage.guild.channels.cache.get(guildSettings.eventLog.channelId);
         if (!logChannel) return;
 
+        if (!logChannel.permissionsFor(newMessage.guild.members.me)?.has(PermissionFlagsBits.SendMessages)) return;
+
         const embed = new EmbedBuilder()
             .setColor('#FFA500')
             .setTitle('Message Edited')
-            .setAuthor({ name: newMessage.author.tag, iconURL: newMessage.author.displayAvatarURL({ dynamic: true }) })
+            .setAuthor({ name: newMessage.author.globalName ?? newMessage.author.username, iconURL: newMessage.author.displayAvatarURL() })
             .addFields(
                 { name: 'Before', value: (oldMessage.content || '*empty*').substring(0, 1024) },
                 { name: 'After', value: (newMessage.content || '*empty*').substring(0, 1024) },

--- a/tests/eventLog.test.js
+++ b/tests/eventLog.test.js
@@ -1,0 +1,332 @@
+'use strict';
+
+jest.mock('discord.js', () => {
+    const EmbedBuilder = jest.fn().mockImplementation(() => {
+        const self = {
+            data: {},
+            setColor: jest.fn().mockReturnThis(),
+            setTitle: jest.fn().mockReturnThis(),
+            setAuthor: jest.fn().mockImplementation(function (opts) { self.data.author = opts; return self; }),
+            addFields: jest.fn().mockReturnThis(),
+            setTimestamp: jest.fn().mockReturnThis(),
+        };
+        return self;
+    });
+    return {
+        EmbedBuilder,
+        AuditLogEvent: { ChannelCreate: 10, ChannelDelete: 12 },
+        PermissionFlagsBits: { SendMessages: 1n << 11n },
+    };
+});
+
+jest.mock('../src/models/Guild', () => ({ findOne: jest.fn() }));
+jest.mock('../src/services/antiNukeService', () => ({ trackAction: jest.fn().mockResolvedValue(undefined) }));
+
+const Guild = require('../src/models/Guild');
+const messageDeleteEvent = require('../src/events/messageDelete');
+const messageUpdateEvent = require('../src/events/messageUpdate');
+const guildMemberUpdateEvent = require('../src/events/guildMemberUpdate');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSendMock() {
+    return jest.fn().mockResolvedValue(undefined);
+}
+
+function makeLogChannel(canSend = true) {
+    const send = makeSendMock();
+    return {
+        id: 'logchannel123',
+        send,
+        permissionsFor: jest.fn().mockReturnValue({ has: jest.fn().mockReturnValue(canSend) }),
+    };
+}
+
+function makeGuildSettings(overrides = {}) {
+    return {
+        eventLog: {
+            enabled: true,
+            channelId: 'logchannel123',
+            logMessageDelete: true,
+            logMessageEdit: true,
+            logRoleChanges: true,
+            logChannelChanges: true,
+        },
+        ...overrides,
+    };
+}
+
+function makeGuild(logChannel) {
+    return {
+        id: 'guild123',
+        memberCount: 5,
+        members: { me: {} },
+        channels: { cache: { get: jest.fn().mockReturnValue(logChannel) } },
+    };
+}
+
+function makeAuthor(overrides = {}) {
+    return {
+        bot: false,
+        id: 'user123',
+        globalName: 'DisplayName',
+        username: 'cooluser',
+        tag: 'cooluser#0',
+        displayAvatarURL: jest.fn().mockReturnValue('https://cdn.test/avatar.png'),
+        ...overrides,
+    };
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+// ---------------------------------------------------------------------------
+// messageDelete
+// ---------------------------------------------------------------------------
+
+describe('messageDelete event', () => {
+    function makeMessage(overrides = {}) {
+        const logChannel = makeLogChannel();
+        const guild = makeGuild(logChannel);
+        return {
+            author: makeAuthor(),
+            guild,
+            channel: { id: 'chan123' },
+            content: 'hello world',
+            attachments: { size: 0 },
+            _logChannel: logChannel,
+            ...overrides,
+        };
+    }
+
+    test('logs deleted message when event log enabled', async () => {
+        const msg = makeMessage();
+        Guild.findOne.mockResolvedValue(makeGuildSettings());
+        await messageDeleteEvent.execute(msg);
+        expect(msg._logChannel.send).toHaveBeenCalledTimes(1);
+    });
+
+    test('skips when event log disabled', async () => {
+        const msg = makeMessage();
+        Guild.findOne.mockResolvedValue(makeGuildSettings({ eventLog: { enabled: false } }));
+        await messageDeleteEvent.execute(msg);
+        expect(msg._logChannel.send).not.toHaveBeenCalled();
+    });
+
+    test('skips when logMessageDelete is false', async () => {
+        const msg = makeMessage();
+        Guild.findOne.mockResolvedValue(makeGuildSettings({
+            eventLog: { enabled: true, channelId: 'logchannel123', logMessageDelete: false },
+        }));
+        await messageDeleteEvent.execute(msg);
+        expect(msg._logChannel.send).not.toHaveBeenCalled();
+    });
+
+    test('skips for bot messages', async () => {
+        const msg = makeMessage({ author: makeAuthor({ bot: true }) });
+        Guild.findOne.mockResolvedValue(makeGuildSettings());
+        await messageDeleteEvent.execute(msg);
+        expect(Guild.findOne).not.toHaveBeenCalled();
+    });
+
+    test('skips when bot lacks SendMessages permission', async () => {
+        const logChannel = makeLogChannel(false);
+        const guild = makeGuild(logChannel);
+        const msg = makeMessage({ guild, _logChannel: logChannel });
+        Guild.findOne.mockResolvedValue(makeGuildSettings());
+        await messageDeleteEvent.execute(msg);
+        expect(logChannel.send).not.toHaveBeenCalled();
+    });
+
+    test('uses globalName ?? username in author field (not deprecated .tag)', async () => {
+        const msg = makeMessage();
+        Guild.findOne.mockResolvedValue(makeGuildSettings());
+        await messageDeleteEvent.execute(msg);
+        const [{ embeds }] = msg._logChannel.send.mock.calls[0];
+        expect(embeds[0].data.author.name).toBe('DisplayName');
+    });
+
+    test('falls back to username when globalName is null', async () => {
+        const author = makeAuthor({ globalName: null });
+        const msg = makeMessage({ author });
+        Guild.findOne.mockResolvedValue(makeGuildSettings());
+        await messageDeleteEvent.execute(msg);
+        const [{ embeds }] = msg._logChannel.send.mock.calls[0];
+        expect(embeds[0].data.author.name).toBe('cooluser');
+    });
+
+    test('truncates long message content at 1024 chars', async () => {
+        const longContent = 'x'.repeat(2000);
+        const msg = makeMessage({ content: longContent });
+        Guild.findOne.mockResolvedValue(makeGuildSettings());
+        // Just verify no error is thrown — embed builder receives truncated string
+        await expect(messageDeleteEvent.execute(msg)).resolves.toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// messageUpdate
+// ---------------------------------------------------------------------------
+
+describe('messageUpdate event', () => {
+    function makeMessages(oldContent = 'before', newContent = 'after') {
+        const logChannel = makeLogChannel();
+        const guild = makeGuild(logChannel);
+        const author = makeAuthor();
+        const newMessage = {
+            author,
+            guild,
+            channel: { id: 'chan123' },
+            content: newContent,
+            url: 'https://discord.com/channels/1/2/3',
+            _logChannel: logChannel,
+        };
+        const oldMessage = { content: oldContent };
+        return { oldMessage, newMessage };
+    }
+
+    test('logs edited message when content changed', async () => {
+        const { oldMessage, newMessage } = makeMessages();
+        Guild.findOne.mockResolvedValue(makeGuildSettings());
+        await messageUpdateEvent.execute(oldMessage, newMessage);
+        expect(newMessage._logChannel.send).toHaveBeenCalledTimes(1);
+    });
+
+    test('skips when content is unchanged', async () => {
+        const { oldMessage, newMessage } = makeMessages('same', 'same');
+        Guild.findOne.mockResolvedValue(makeGuildSettings());
+        await messageUpdateEvent.execute(oldMessage, newMessage);
+        expect(newMessage._logChannel.send).not.toHaveBeenCalled();
+    });
+
+    test('skips for bot authors', async () => {
+        const { oldMessage, newMessage } = makeMessages();
+        newMessage.author = makeAuthor({ bot: true });
+        await messageUpdateEvent.execute(oldMessage, newMessage);
+        expect(Guild.findOne).not.toHaveBeenCalled();
+    });
+
+    test('skips when bot lacks SendMessages permission', async () => {
+        const logChannel = makeLogChannel(false);
+        const guild = makeGuild(logChannel);
+        const { oldMessage, newMessage } = makeMessages();
+        newMessage.guild = guild;
+        newMessage._logChannel = logChannel;
+        Guild.findOne.mockResolvedValue(makeGuildSettings());
+        await messageUpdateEvent.execute(oldMessage, newMessage);
+        expect(logChannel.send).not.toHaveBeenCalled();
+    });
+
+    test('uses globalName ?? username (not deprecated .tag)', async () => {
+        const { oldMessage, newMessage } = makeMessages();
+        Guild.findOne.mockResolvedValue(makeGuildSettings());
+        await messageUpdateEvent.execute(oldMessage, newMessage);
+        const [{ embeds }] = newMessage._logChannel.send.mock.calls[0];
+        expect(embeds[0].data.author.name).toBe('DisplayName');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// guildMemberUpdate
+// ---------------------------------------------------------------------------
+
+describe('guildMemberUpdate event', () => {
+    function makeRole(id, name) {
+        return { id, toString: () => `<@&${id}>`, name };
+    }
+
+    function makeMembers({ addedRoles = [], removedRoles = [] } = {}) {
+        const logChannel = makeLogChannel();
+        const guild = makeGuild(logChannel);
+        const baseRoles = [makeRole('role_base', 'Base')];
+        const oldRoles = new Map([...baseRoles, ...removedRoles].map(r => [r.id, r]));
+        const newRoles = new Map([...baseRoles, ...addedRoles].map(r => [r.id, r]));
+
+        const common = {
+            guild,
+            user: makeAuthor(),
+            _logChannel: logChannel,
+        };
+        return {
+            oldMember: { ...common, roles: { cache: { filter: fn => ({ size: [...oldRoles.values()].filter(fn).length, map: cb => [...oldRoles.values()].filter(fn).map(cb) }), has: id => oldRoles.has(id) } } },
+            newMember: { ...common, roles: { cache: { filter: fn => ({ size: [...newRoles.values()].filter(fn).length, map: cb => [...newRoles.values()].filter(fn).map(cb) }), has: id => newRoles.has(id) } } },
+            logChannel,
+        };
+    }
+
+    test('logs when roles are added', async () => {
+        const { oldMember, newMember, logChannel } = makeMembers({ addedRoles: [makeRole('new_role', 'NewRole')] });
+        Guild.findOne.mockResolvedValue(makeGuildSettings());
+        await guildMemberUpdateEvent.execute(oldMember, newMember);
+        expect(logChannel.send).toHaveBeenCalledTimes(1);
+    });
+
+    test('logs when roles are removed', async () => {
+        const { oldMember, newMember, logChannel } = makeMembers({ removedRoles: [makeRole('old_role', 'OldRole')] });
+        Guild.findOne.mockResolvedValue(makeGuildSettings());
+        await guildMemberUpdateEvent.execute(oldMember, newMember);
+        expect(logChannel.send).toHaveBeenCalledTimes(1);
+    });
+
+    test('skips when no role changes', async () => {
+        const { oldMember, newMember, logChannel } = makeMembers();
+        Guild.findOne.mockResolvedValue(makeGuildSettings());
+        await guildMemberUpdateEvent.execute(oldMember, newMember);
+        expect(logChannel.send).not.toHaveBeenCalled();
+    });
+
+    test('skips when bot lacks SendMessages permission', async () => {
+        const logChannel = makeLogChannel(false);
+        const guild = makeGuild(logChannel);
+        const { oldMember, newMember } = makeMembers({ addedRoles: [makeRole('x', 'X')] });
+        oldMember.guild = guild;
+        newMember.guild = guild;
+        newMember._logChannel = logChannel;
+        Guild.findOne.mockResolvedValue(makeGuildSettings());
+        await guildMemberUpdateEvent.execute(oldMember, newMember);
+        expect(logChannel.send).not.toHaveBeenCalled();
+    });
+
+    test('uses globalName ?? username (not deprecated .tag)', async () => {
+        const { oldMember, newMember, logChannel } = makeMembers({ addedRoles: [makeRole('r', 'R')] });
+        Guild.findOne.mockResolvedValue(makeGuildSettings());
+        await guildMemberUpdateEvent.execute(oldMember, newMember);
+        const [{ embeds }] = logChannel.send.mock.calls[0];
+        expect(embeds[0].data.author.name).toBe('DisplayName');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// validateEventLogUpdate (API)
+// ---------------------------------------------------------------------------
+
+describe('validateEventLogUpdate', () => {
+    const { validateEventLogUpdate } = require('../src/dashboard/routes/api.js');
+
+    test('returns null for valid boolean fields', () => {
+        expect(validateEventLogUpdate({ 'eventLog.enabled': true, 'eventLog.logMessageEdit': false })).toBeNull();
+    });
+
+    test('returns error when enabled is not a boolean', () => {
+        const result = validateEventLogUpdate({ 'eventLog.enabled': 'yes' });
+        expect(result).toMatch(/boolean/);
+    });
+
+    test('returns null for valid channelId snowflake', () => {
+        expect(validateEventLogUpdate({ 'eventLog.channelId': '123456789012345678' })).toBeNull();
+    });
+
+    test('returns error for invalid channelId', () => {
+        const result = validateEventLogUpdate({ 'eventLog.channelId': 'not-a-snowflake' });
+        expect(result).toMatch(/snowflake/);
+    });
+
+    test('returns null for null channelId', () => {
+        expect(validateEventLogUpdate({ 'eventLog.channelId': null })).toBeNull();
+    });
+
+    test('ignores unrelated keys', () => {
+        expect(validateEventLogUpdate({ 'welcome.enabled': true })).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
This PR addresses production readiness issues in the event log feature by fixing Discord.js v14 deprecations, adding missing permission guards, implementing input validation, and adding comprehensive test coverage.

## Key Changes

### Event Handler Fixes (messageDelete, messageUpdate, guildMemberUpdate, channelCreate, channelDelete)
- **Deprecated API fixes:**
  - Replaced `user.tag` with `globalName ?? username` to support Discord's new username system
  - Removed deprecated `{ dynamic: true }` option from `displayAvatarURL()` calls (discord.js v14 returns animated URLs by default)

- **Permission guards:**
  - Added `PermissionFlagsBits.SendMessages` checks before sending embeds to log channels in all five event handlers
  - Prevents silent failures when the bot lacks required permissions

### Dashboard API Validation
- Added `validateEventLogUpdate()` function to validate all `eventLog.*` settings:
  - Type checks for boolean toggles: `enabled`, `logMessageEdit`, `logMessageDelete`, `logMemberJoin`, `logMemberLeave`, `logRoleChanges`, `logChannelChanges`
  - Snowflake format validation for `channelId` (17-20 digit strings)
  - Allows `null` or empty string for `channelId` to disable logging
- Integrated validation into the settings route to prevent invalid data from reaching the database

### Test Coverage
- Added `tests/eventLog.test.js` with 24 passing tests covering:
  - **messageDelete:** enabled/disabled states, feature toggles, bot message filtering, permission guards, author name fallback, content truncation
  - **messageUpdate:** content change detection, bot filtering, permission guards, author name handling
  - **guildMemberUpdate:** role addition/removal detection, no-change scenarios, permission guards, author name handling
  - **validateEventLogUpdate:** boolean validation, snowflake validation, null handling, unrelated key filtering

## Implementation Details
- All changes maintain backward compatibility with existing guild settings
- Permission checks use optional chaining (`?.has()`) for safety
- Validation regex `/^\d{17,20}$/` matches Discord snowflake format (18-20 digits typical, 17-20 for edge cases)
- Test mocks comprehensively simulate Discord.js objects and Mongoose models

https://claude.ai/code/session_01BK2DRfPYd3pHCahW88jVbD