### PR TITLE
feat(blackjack): add double down, split, and insurance

### DIFF
--- a/src/games/casino/blackjack.js
+++ b/src/games/casino/blackjack.js
@@ -174,6 +174,61 @@ module.exports = {
         const dealerShowsAce  = dealerHand[0].value === 'A';
         const insuranceCost   = Math.floor(bet / 2);
 
+        // Dealer peek: if dealer shows Ace and has natural blackjack, resolve before player acts
+        if (dealerShowsAce && handTotal(dealerHand) === 21) {
+            const peekRow = new ActionRowBuilder().addComponents(
+                new ButtonBuilder().setCustomId(`bj_hit_${gameId}`).setLabel('Hit').setStyle(ButtonStyle.Primary).setDisabled(true),
+                new ButtonBuilder().setCustomId(`bj_stand_${gameId}`).setLabel('Stand').setStyle(ButtonStyle.Secondary).setDisabled(true),
+                ...(insuranceCost > 0 ? [new ButtonBuilder()
+                    .setCustomId(`bj_insurance_${gameId}`)
+                    .setLabel(`Insurance (${insuranceCost.toLocaleString()})`)
+                    .setStyle(ButtonStyle.Danger)] : []),
+            );
+            await interaction.reply({
+                embeds: [buildEmbed(interaction, playerHand, dealerHand, bet, currency,
+                    insuranceCost > 0
+                        ? `🛡️ Insurance? (${currency}${insuranceCost.toLocaleString()}) — Dealer may have Blackjack`
+                        : `⏳ Dealer revealing...`,
+                    '#f39c12', true)],
+                components: [peekRow],
+            });
+
+            let peekInsuranceBet = 0;
+            if (insuranceCost > 0) {
+                const peekMsg = await interaction.fetchReply();
+                try {
+                    const insI = await peekMsg.awaitMessageComponent({
+                        filter: i2 => i2.user.id === interaction.user.id && i2.customId === `bj_insurance_${gameId}`,
+                        time: 15_000,
+                    });
+                    await insI.deferUpdate();
+                    const peekUpdated = await User.findOneAndUpdate(
+                        { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: insuranceCost } },
+                        { $inc: { balance: -insuranceCost, lifetimeGambled: insuranceCost } },
+                        { new: true },
+                    );
+                    if (peekUpdated) peekInsuranceBet = insuranceCost;
+                } catch {
+                    // No insurance taken within timeout
+                }
+            }
+
+            let peekStatus = `❌ Dealer Blackjack! -${currency}${bet.toLocaleString()}`;
+            let peekCredit = 0;
+            if (peekInsuranceBet > 0) {
+                peekCredit = peekInsuranceBet * 3;
+                peekStatus += `\n🛡️ Insurance paid! +${currency}${(peekInsuranceBet * 2).toLocaleString()}`;
+            }
+            if (peekCredit > 0) {
+                await User.updateOne(
+                    { userId: interaction.user.id, guildId: interaction.guild.id },
+                    { $inc: { balance: peekCredit } },
+                );
+            }
+            const peekEmbed = buildEmbed(interaction, playerHand, dealerHand, bet, currency, peekStatus, '#e74c3c', false);
+            return interaction.editReply({ embeds: [peekEmbed], components: [buildButtons(gameId, true)] });
+        }
+
         // Mutable game state
         let insuranceBet      = 0;
         let activeBet         = bet;
@@ -361,7 +416,18 @@ module.exports = {
         });
 
         collector.on('end', async (_, reason) => {
-            if (reason === 'bust') return;
+            if (reason === 'bust') {
+                if (insuranceBet > 0 && handTotal(dealerHand.slice(0, 2)) === 21) {
+                    await User.updateOne(
+                        { userId: interaction.user.id, guildId: interaction.guild.id },
+                        { $inc: { balance: insuranceBet * 3 } },
+                    );
+                    const bustStatus = `💥 Bust! -${currency}${activeBet.toLocaleString()}\n🛡️ Insurance paid! +${currency}${(insuranceBet * 2).toLocaleString()}`;
+                    const embed = buildEmbed(interaction, playerHand, dealerHand, activeBet, currency, bustStatus, '#e74c3c', false);
+                    await interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] }).catch(() => {});
+                }
+                return;
+            }
 
             while (handTotal(dealerHand) < 17) dealerHand.push(deck.pop());
             const dealerTotal = handTotal(dealerHand);
@@ -448,8 +514,10 @@ module.exports = {
                 }
             }
 
-            freshUser.balance += totalCredit;
-            await freshUser.save();
+            await User.updateOne(
+                { userId: interaction.user.id, guildId: interaction.guild.id },
+                { $inc: { balance: totalCredit } },
+            );
 
             if (splitActive) {
                 const splitState = { splitHands, splitBets, currentSplitHand: -1, splitHandDone: [true, true] };

--- a/src/games/casino/blackjack.js
+++ b/src/games/casino/blackjack.js
@@ -21,7 +21,6 @@ function buildDeck() {
     for (const suit of SUITS) {
         for (const value of VALUES) deck.push({ suit, value });
     }
-    // Fisher-Yates shuffle
     for (let i = deck.length - 1; i > 0; i--) {
         const j = Math.floor(Math.random() * (i + 1));
         [deck[i], deck[j]] = [deck[j], deck[i]];
@@ -46,45 +45,74 @@ function displayHand(hand, hideSecond = false) {
     return hand.map((c, i) => (hideSecond && i === 1) ? '🂠' : `${c.value}${c.suit}`).join('  ');
 }
 
-function embedAuthor(interaction) {
-    return {
-        name: interaction.member?.displayName || interaction.user.username,
-        iconURL: interaction.user.displayAvatarURL(),
-    };
+function canDoubleDown(hand) {
+    const total = handTotal(hand);
+    return hand.length === 2 && (total === 9 || total === 10 || total === 11);
 }
 
-function buildEmbed(interaction, playerHand, dealerHand, bet, currency, status, color, hideDealer) {
-    const playerTotal = handTotal(playerHand);
+function canSplitHand(hand) {
+    return hand.length === 2 && cardValue(hand[0]) === cardValue(hand[1]);
+}
+
+function buildEmbed(interaction, playerHand, dealerHand, bet, currency, status, color, hideDealer, splitState = null) {
     const dealerShown = hideDealer ? cardValue(dealerHand[0]) : handTotal(dealerHand);
 
-    return new EmbedBuilder()
-        .setAuthor(embedAuthor(interaction))
+    const embed = new EmbedBuilder()
+        .setAuthor({
+            name: interaction.member?.displayName || interaction.user.username,
+            iconURL: interaction.user.displayAvatarURL(),
+        })
         .setThumbnail(THUMB)
         .setColor(color)
         .setTitle('🃏 Blackjack')
-        .addFields(
-            { name: `Dealer's Hand (${hideDealer ? dealerShown : dealerShown})`, value: displayHand(dealerHand, hideDealer), inline: false },
-            { name: `Your Hand (${playerTotal})`, value: displayHand(playerHand), inline: false },
-            { name: 'Bet', value: `${currency}${bet.toLocaleString()}`, inline: true },
-            { name: 'Status', value: status, inline: true },
-        )
+        .addFields({ name: `Dealer's Hand (${dealerShown})`, value: displayHand(dealerHand, hideDealer), inline: false })
         .setFooter({ text: 'Blackjack pays 3:2 · Dealer stands on 17' })
         .setTimestamp();
+
+    if (splitState) {
+        const { splitHands, splitBets, currentSplitHand, splitHandDone } = splitState;
+        for (let h = 0; h < 2; h++) {
+            const total = handTotal(splitHands[h]);
+            let indicator;
+            if (splitHandDone[h])          indicator = '✓ ';
+            else if (h === currentSplitHand) indicator = '▶ ';
+            else                            indicator = '⏳ ';
+            embed.addFields({ name: `${indicator}Hand ${h + 1} (${total})`, value: displayHand(splitHands[h]), inline: true });
+        }
+        embed.addFields(
+            { name: 'Bet per Hand', value: `${currency}${splitBets[0].toLocaleString()}`, inline: true },
+            { name: 'Status', value: status, inline: false },
+        );
+    } else {
+        embed.addFields(
+            { name: `Your Hand (${handTotal(playerHand)})`, value: displayHand(playerHand), inline: false },
+            { name: 'Bet', value: `${currency}${bet.toLocaleString()}`, inline: true },
+            { name: 'Status', value: status, inline: true },
+        );
+    }
+
+    return embed;
 }
 
-function buildButtons(gameId, disabled = false) {
-    return new ActionRowBuilder().addComponents(
-        new ButtonBuilder()
-            .setCustomId(`bj_hit_${gameId}`)
-            .setLabel('Hit')
-            .setStyle(ButtonStyle.Primary)
-            .setDisabled(disabled),
-        new ButtonBuilder()
-            .setCustomId(`bj_stand_${gameId}`)
-            .setLabel('Stand')
-            .setStyle(ButtonStyle.Secondary)
-            .setDisabled(disabled),
-    );
+function buildButtons(gameId, disabled = false, opts = {}) {
+    const {
+        canDouble = false, doubleCost = 0,
+        canSplit = false,  splitCost  = 0,
+        canInsurance = false, insuranceCost = 0,
+    } = opts;
+
+    const buttons = [
+        new ButtonBuilder().setCustomId(`bj_hit_${gameId}`).setLabel('Hit').setStyle(ButtonStyle.Primary).setDisabled(disabled),
+        new ButtonBuilder().setCustomId(`bj_stand_${gameId}`).setLabel('Stand').setStyle(ButtonStyle.Secondary).setDisabled(disabled),
+    ];
+
+    if (!disabled) {
+        if (canDouble)    buttons.push(new ButtonBuilder().setCustomId(`bj_double_${gameId}`).setLabel(`Double Down (${doubleCost.toLocaleString()})`).setStyle(ButtonStyle.Success));
+        if (canSplit)     buttons.push(new ButtonBuilder().setCustomId(`bj_split_${gameId}`).setLabel(`Split (${splitCost.toLocaleString()})`).setStyle(ButtonStyle.Success));
+        if (canInsurance) buttons.push(new ButtonBuilder().setCustomId(`bj_insurance_${gameId}`).setLabel(`Insurance (${insuranceCost.toLocaleString()})`).setStyle(ButtonStyle.Danger));
+    }
+
+    return new ActionRowBuilder().addComponents(buttons);
 }
 
 module.exports = {
@@ -116,7 +144,6 @@ module.exports = {
 
         if (!await confirmBet(interaction, bet, user.balance, 'Blackjack', guildSettings)) return;
 
-        // Deduct bet upfront
         user.balance -= bet;
         user.lifetimeGambled = (user.lifetimeGambled || 0) + bet;
         await user.save();
@@ -126,7 +153,7 @@ module.exports = {
         const dealerHand = [deck.pop(), deck.pop()];
         const gameId     = `${interaction.user.id}_${Date.now()}`;
 
-        // Natural blackjack check — push if dealer also has 21
+        // Natural blackjack check
         if (handTotal(playerHand) === 21) {
             if (handTotal(dealerHand) === 21) {
                 user.balance += bet;
@@ -144,53 +171,201 @@ module.exports = {
             return interaction.reply({ embeds: [embed], components: [buildButtons(gameId, true)] });
         }
 
+        const dealerShowsAce  = dealerHand[0].value === 'A';
+        const insuranceCost   = Math.floor(bet / 2);
+
+        // Mutable game state
+        let insuranceBet      = 0;
+        let activeBet         = bet;
+        let doubleAvailable   = canDoubleDown(playerHand);
+        let splitAvailable    = canSplitHand(playerHand);
+        let insuranceAvailable = dealerShowsAce && insuranceCost > 0;
+        let splitActive       = false;
+        let splitHands        = null;
+        let splitBets         = null;
+        let currentSplitHand  = 0;
+        let splitHandDone     = [false, false];
+
+        function currentOpts() {
+            if (splitActive) return {};
+            return {
+                canDouble: doubleAvailable, doubleCost: bet,
+                canSplit: splitAvailable,   splitCost: bet,
+                canInsurance: insuranceAvailable, insuranceCost,
+            };
+        }
+
         await interaction.reply({
             embeds:     [buildEmbed(interaction, playerHand, dealerHand, bet, currency, '🎲 Your turn', '#5865F2', true)],
-            components: [buildButtons(gameId)],
+            components: [buildButtons(gameId, false, currentOpts())],
         });
 
         const msg       = await interaction.fetchReply();
         const collector = msg.createMessageComponentCollector({
-            filter: i => i.user.id === interaction.user.id && (i.customId === `bj_hit_${gameId}` || i.customId === `bj_stand_${gameId}`),
-            time:   60_000,
+            filter: i => i.user.id === interaction.user.id && [
+                `bj_hit_${gameId}`, `bj_stand_${gameId}`, `bj_double_${gameId}`,
+                `bj_split_${gameId}`, `bj_insurance_${gameId}`,
+            ].includes(i.customId),
+            time: 60_000,
         });
 
         collector.on('collect', async i => {
             await i.deferUpdate();
 
+            // ── Insurance ──────────────────────────────────────────────────────────
+            if (i.customId === `bj_insurance_${gameId}`) {
+                insuranceAvailable = false;
+                const updated = await User.findOneAndUpdate(
+                    { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: insuranceCost } },
+                    { $inc: { balance: -insuranceCost, lifetimeGambled: insuranceCost } },
+                    { new: true },
+                );
+                if (updated) insuranceBet = insuranceCost;
+                const statusMsg = updated
+                    ? `🛡️ Insurance taken (${currency}${insuranceCost.toLocaleString()}) · Your turn`
+                    : `⚠️ Not enough balance for insurance · Your turn`;
+                const embed = buildEmbed(interaction, playerHand, dealerHand, activeBet, currency, statusMsg, '#5865F2', true);
+                return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, false, currentOpts())] });
+            }
+
+            // ── Double Down ────────────────────────────────────────────────────────
+            if (i.customId === `bj_double_${gameId}`) {
+                doubleAvailable = false;
+                splitAvailable  = false;
+                const updated = await User.findOneAndUpdate(
+                    { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: bet } },
+                    { $inc: { balance: -bet, lifetimeGambled: bet } },
+                    { new: true },
+                );
+                if (!updated) {
+                    const embed = buildEmbed(interaction, playerHand, dealerHand, activeBet, currency, `⚠️ Not enough balance for double down · Your turn`, '#5865F2', true);
+                    return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, false, currentOpts())] });
+                }
+                activeBet = bet * 2;
+                playerHand.push(deck.pop());
+                const total = handTotal(playerHand);
+                if (total > 21) {
+                    collector.stop('bust');
+                    const embed = buildEmbed(interaction, playerHand, dealerHand, activeBet, currency, `💥 Bust! -${currency}${activeBet.toLocaleString()}`, '#e74c3c', false);
+                    return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] });
+                }
+                const embed = buildEmbed(interaction, playerHand, dealerHand, activeBet, currency, `📊 Doubled to ${currency}${activeBet.toLocaleString()} — dealer reveals...`, '#5865F2', true);
+                await interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] });
+                collector.stop('stand');
+                return;
+            }
+
+            // ── Split ──────────────────────────────────────────────────────────────
+            if (i.customId === `bj_split_${gameId}`) {
+                doubleAvailable = false;
+                splitAvailable  = false;
+                const updated = await User.findOneAndUpdate(
+                    { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: bet } },
+                    { $inc: { balance: -bet, lifetimeGambled: bet } },
+                    { new: true },
+                );
+                if (!updated) {
+                    const embed = buildEmbed(interaction, playerHand, dealerHand, activeBet, currency, `⚠️ Not enough balance for split · Your turn`, '#5865F2', true);
+                    return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, false, currentOpts())] });
+                }
+
+                const isAceSplit = playerHand[0].value === 'A';
+                splitHands       = [[playerHand[0], deck.pop()], [playerHand[1], deck.pop()]];
+                splitBets        = [bet, bet];
+                currentSplitHand = 0;
+                splitHandDone    = [false, false];
+                splitActive      = true;
+
+                if (isAceSplit) {
+                    splitHandDone = [true, true];
+                    const splitState = { splitHands, splitBets, currentSplitHand: -1, splitHandDone };
+                    const embed = buildEmbed(interaction, null, dealerHand, bet, currency, '🎲 Split aces — dealer reveals...', '#5865F2', true, splitState);
+                    await interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] });
+                    collector.stop('split_done');
+                    return;
+                }
+
+                const splitState = { splitHands, splitBets, currentSplitHand, splitHandDone };
+                const embed = buildEmbed(interaction, null, dealerHand, bet, currency, '▶ Playing Hand 1', '#5865F2', true, splitState);
+                return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, false)] });
+            }
+
+            // ── Hit ────────────────────────────────────────────────────────────────
             if (i.customId === `bj_hit_${gameId}`) {
+                if (splitActive) {
+                    splitHands[currentSplitHand].push(deck.pop());
+                    const total = handTotal(splitHands[currentSplitHand]);
+
+                    if (total > 21 || total === 21) {
+                        splitHandDone[currentSplitHand] = true;
+                        if (currentSplitHand === 0) {
+                            currentSplitHand = 1;
+                            const splitState = { splitHands, splitBets, currentSplitHand, splitHandDone };
+                            const label = total > 21 ? '💥 Hand 1 bust! ▶ Playing Hand 2' : '✓ Hand 1 at 21 · ▶ Playing Hand 2';
+                            const embed = buildEmbed(interaction, null, dealerHand, bet, currency, label, '#5865F2', true, splitState);
+                            return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, false)] });
+                        } else {
+                            const splitState = { splitHands, splitBets, currentSplitHand, splitHandDone };
+                            const embed = buildEmbed(interaction, null, dealerHand, bet, currency, '🎲 Both hands done — dealer reveals...', '#5865F2', true, splitState);
+                            await interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] });
+                            collector.stop('split_done');
+                            return;
+                        }
+                    }
+
+                    const splitState = { splitHands, splitBets, currentSplitHand, splitHandDone };
+                    const embed = buildEmbed(interaction, null, dealerHand, bet, currency, `▶ Playing Hand ${currentSplitHand + 1}`, '#5865F2', true, splitState);
+                    return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, false)] });
+                }
+
+                // Normal hit
                 playerHand.push(deck.pop());
                 const total = handTotal(playerHand);
 
                 if (total > 21) {
                     collector.stop('bust');
-                    const embed = buildEmbed(interaction, playerHand, dealerHand, bet, currency, `💥 Bust! -${currency}${bet.toLocaleString()}`, '#e74c3c', false);
+                    const embed = buildEmbed(interaction, playerHand, dealerHand, activeBet, currency, `💥 Bust! -${currency}${activeBet.toLocaleString()}`, '#e74c3c', false);
                     return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] });
                 }
+
+                doubleAvailable = false;
+                splitAvailable  = false;
 
                 if (total === 21) {
                     collector.stop('stand');
                 } else {
-                    const embed = buildEmbed(interaction, playerHand, dealerHand, bet, currency, '🎲 Your turn', '#5865F2', true);
-                    return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId)] });
+                    const embed = buildEmbed(interaction, playerHand, dealerHand, activeBet, currency, '🎲 Your turn', '#5865F2', true);
+                    return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, false, currentOpts())] });
                 }
             }
 
-            if (i.customId === `bj_stand_${gameId}` || handTotal(playerHand) === 21) {
+            // ── Stand ──────────────────────────────────────────────────────────────
+            if (i.customId === `bj_stand_${gameId}`) {
+                if (splitActive) {
+                    splitHandDone[currentSplitHand] = true;
+                    if (currentSplitHand === 0) {
+                        currentSplitHand = 1;
+                        const splitState = { splitHands, splitBets, currentSplitHand, splitHandDone };
+                        const embed = buildEmbed(interaction, null, dealerHand, bet, currency, '✓ Hand 1 done · ▶ Playing Hand 2', '#5865F2', true, splitState);
+                        return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, false)] });
+                    } else {
+                        const splitState = { splitHands, splitBets, currentSplitHand, splitHandDone };
+                        const embed = buildEmbed(interaction, null, dealerHand, bet, currency, '🎲 Both hands done — dealer reveals...', '#5865F2', true, splitState);
+                        await interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] });
+                        collector.stop('split_done');
+                        return;
+                    }
+                }
                 collector.stop('stand');
             }
         });
 
         collector.on('end', async (_, reason) => {
-            if (reason === 'bust') return; // already handled above
+            if (reason === 'bust') return;
 
-            // Dealer draws to 17+
             while (handTotal(dealerHand) < 17) dealerHand.push(deck.pop());
-
-            const playerTotal = handTotal(playerHand);
             const dealerTotal = handTotal(dealerHand);
 
-            let color, status;
             const [freshUser_raw, freshGuild] = await Promise.all([
                 User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }),
                 Guild.findOne({ guildId: interaction.guild.id }),
@@ -203,36 +378,87 @@ module.exports = {
             const serverMult       = getServerCoinMultiplier(freshGuild);
             const totalCoinMult    = coinMult * serverMult;
 
-            if (dealerTotal > 21 || playerTotal > dealerTotal) {
-                // Win: return original bet + net profit scaled by booster
-                const netProfit = Math.round(bet * totalCoinMult);
-                freshUser.balance += bet + netProfit;
-                const boostNote = totalCoinMult > 1.0 ? ` *(🚀 ${totalCoinMult.toFixed(1)}x)*` : '';
-                status = `✅ You win! +${currency}${netProfit.toLocaleString()}${boostNote}`;
-                color  = '#2ecc71';
-            } else if (playerTotal === dealerTotal) {
-                freshUser.balance += bet;
-                status = `🤝 Push — bet returned`;
-                color  = '#f39c12';
-            } else if (luckyActive && Math.random() < 0.20) {
-                // Lucky Charm: convert 20% of losses to push
-                freshUser.balance += bet;
-                status = `🍀 Lucky Charm! Push — bet returned (${currency}${bet.toLocaleString()})`;
-                color  = '#f39c12';
-            } else if (luckyStreakBonus > 0 && Math.random() < luckyStreakBonus) {
-                // Lucky Streak: convert 25% of remaining losses to push
-                freshUser.balance += bet;
-                status = `🎯 Lucky Streak! Push — bet returned (${currency}${bet.toLocaleString()})`;
-                color  = '#f39c12';
+            let totalCredit = 0;
+            let color, status;
+
+            if (splitActive) {
+                const handResults = [];
+                for (let h = 0; h < 2; h++) {
+                    const hTotal = handTotal(splitHands[h]);
+                    const hBet   = splitBets[h];
+
+                    if (hTotal > 21) {
+                        handResults.push(`Hand ${h + 1}: 💥 Bust (-${currency}${hBet.toLocaleString()})`);
+                    } else if (dealerTotal > 21 || hTotal > dealerTotal) {
+                        const netProfit = Math.round(hBet * totalCoinMult);
+                        totalCredit += hBet + netProfit;
+                        const boostNote = totalCoinMult > 1.0 ? ` *(🚀 ${totalCoinMult.toFixed(1)}x)*` : '';
+                        handResults.push(`Hand ${h + 1}: ✅ Win (+${currency}${netProfit.toLocaleString()}${boostNote})`);
+                    } else if (hTotal === dealerTotal) {
+                        totalCredit += hBet;
+                        handResults.push(`Hand ${h + 1}: 🤝 Push`);
+                    } else if (luckyActive && Math.random() < 0.20) {
+                        totalCredit += hBet;
+                        handResults.push(`Hand ${h + 1}: 🍀 Lucky Push`);
+                    } else if (luckyStreakBonus > 0 && Math.random() < luckyStreakBonus) {
+                        totalCredit += hBet;
+                        handResults.push(`Hand ${h + 1}: 🎯 Lucky Push`);
+                    } else {
+                        handResults.push(`Hand ${h + 1}: ❌ Loss (-${currency}${hBet.toLocaleString()})`);
+                    }
+                }
+                const net = totalCredit - (splitBets[0] + splitBets[1]);
+                color  = net > 0 ? '#2ecc71' : net === 0 ? '#f39c12' : '#e74c3c';
+                status = handResults.join('\n');
             } else {
-                status = `❌ Dealer wins. -${currency}${bet.toLocaleString()}`;
-                color  = '#e74c3c';
+                const playerTotal = handTotal(playerHand);
+
+                if (dealerTotal > 21 || playerTotal > dealerTotal) {
+                    const netProfit = Math.round(activeBet * totalCoinMult);
+                    totalCredit = activeBet + netProfit;
+                    const boostNote = totalCoinMult > 1.0 ? ` *(🚀 ${totalCoinMult.toFixed(1)}x)*` : '';
+                    status = `✅ You win! +${currency}${netProfit.toLocaleString()}${boostNote}`;
+                    color  = '#2ecc71';
+                } else if (playerTotal === dealerTotal) {
+                    totalCredit = activeBet;
+                    status = `🤝 Push — bet returned`;
+                    color  = '#f39c12';
+                } else if (luckyActive && Math.random() < 0.20) {
+                    totalCredit = activeBet;
+                    status = `🍀 Lucky Charm! Push — bet returned (${currency}${activeBet.toLocaleString()})`;
+                    color  = '#f39c12';
+                } else if (luckyStreakBonus > 0 && Math.random() < luckyStreakBonus) {
+                    totalCredit = activeBet;
+                    status = `🎯 Lucky Streak! Push — bet returned (${currency}${activeBet.toLocaleString()})`;
+                    color  = '#f39c12';
+                } else {
+                    status = `❌ Dealer wins. -${currency}${activeBet.toLocaleString()}`;
+                    color  = '#e74c3c';
+                }
             }
 
+            // Resolve insurance (only pays on dealer natural blackjack)
+            if (insuranceBet > 0) {
+                const dealerNaturalBJ = handTotal(dealerHand.slice(0, 2)) === 21;
+                if (dealerNaturalBJ) {
+                    totalCredit += insuranceBet * 3; // return bet + 2:1 payout
+                    status += `\n🛡️ Insurance paid! +${currency}${(insuranceBet * 2).toLocaleString()}`;
+                } else {
+                    status += `\n🛡️ Insurance lost (-${currency}${insuranceBet.toLocaleString()})`;
+                }
+            }
+
+            freshUser.balance += totalCredit;
             await freshUser.save();
 
-            const embed = buildEmbed(interaction, playerHand, dealerHand, bet, currency, status, color, false);
-            await interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] }).catch(() => {});
+            if (splitActive) {
+                const splitState = { splitHands, splitBets, currentSplitHand: -1, splitHandDone: [true, true] };
+                const embed = buildEmbed(interaction, null, dealerHand, bet, currency, status, color, false, splitState);
+                await interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] }).catch(() => {});
+            } else {
+                const embed = buildEmbed(interaction, playerHand, dealerHand, activeBet, currency, status, color, false);
+                await interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] }).catch(() => {});
+            }
         });
     },
 };


### PR DESCRIPTION
- Double down: available on 2-card 9/10/11 hands; doubles the bet atomically,
  deals one card, then auto-stands
- Split: available on pairs; splits into two hands played sequentially;
  split aces each receive one card with no further hits
- Insurance: available when dealer shows an Ace; costs half the original bet,
  pays 2:1 on dealer natural blackjack, resolved at end of round
- Action row dynamically shows/hides Double Down, Split, and Insurance
  based on hand state; all three use atomic $inc with balance check to
  prevent negative balances
- Split resolution evaluates both hands independently against dealer,
  applies coin/server multipliers and Lucky Charm per hand

Closes #235

https://claude.ai/code/session_015qNiN7DJpX3WxehoF4Mi67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added double down action in blackjack gameplay
* Added hand split functionality, including special handling for split aces
* Added insurance side-bets
* Enhanced UI to display multiple hands with individual action buttons
* Improved outcome resolution for multi-hand rounds

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/clawdia/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->