### PR TITLE
feat(economy): add bonus mini-challenges to /daily and /work

### DIFF
--- a/src/commands/economy/daily.js
+++ b/src/commands/economy/daily.js
@@ -143,13 +143,18 @@ module.exports = {
                     );
                     await response.update({ embeds: [embed], components: [] });
                 }
-            } catch {
+            } catch (err) {
                 if (activateTimer) clearTimeout(activateTimer);
-                embed.spliceFields(0, embed.data.fields.length,
-                    { name: 'New Balance', value: `${updated.balance.toLocaleString()} coins` },
-                    { name: '🎯 Bonus Challenge', value: '⏱️ Time\'s up! No bonus this time — your daily reward is still yours.' },
-                );
-                await interaction.editReply({ embeds: [embed], components: [] }).catch(() => {});
+                if (err.name === 'InteractionCollectorError') {
+                    embed.spliceFields(0, embed.data.fields.length,
+                        { name: 'New Balance', value: `${updated.balance.toLocaleString()} coins` },
+                        { name: '🎯 Bonus Challenge', value: '⏱️ Time\'s up! No bonus this time — your daily reward is still yours.' },
+                    );
+                    await interaction.editReply({ embeds: [embed], components: [] }).catch(() => {});
+                } else {
+                    console.error('Daily challenge error:', err);
+                    await interaction.editReply({ components: [] }).catch(() => {});
+                }
             }
         } catch (error) {
             console.error('Daily error:', error);

--- a/src/commands/economy/daily.js
+++ b/src/commands/economy/daily.js
@@ -5,6 +5,7 @@ const { getStreakMultiplier } = require('../../utils/streakMultiplier');
 const { getCoinMultiplier, getServerCoinMultiplier } = require('../../services/effectsService');
 const { logTransaction } = require('../../utils/logTransaction');
 const { MAX_COMBINED_MULTIPLIER, clampMultiplier } = require('../../config/economy');
+const { generateDailyChallenge } = require('../../utils/dailyChallenge');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -95,7 +96,61 @@ module.exports = {
                 .setFooter({ text: 'Cooldown: 24h' })
                 .setTimestamp();
 
-            await interaction.reply({ embeds: [embed] });
+            const challenge = generateDailyChallenge();
+            embed.addFields({ name: '🎯 Bonus Challenge', value: `${challenge.description}\n*Answer correctly for a **+50% bonus** on your daily reward!*` });
+
+            const reply = await interaction.reply({ embeds: [embed], components: [challenge.row], fetchReply: true });
+
+            let activateTimer = null;
+            if (challenge.type === 'react_fast' && challenge.activeRow) {
+                activateTimer = setTimeout(() => {
+                    interaction.editReply({ components: [challenge.activeRow] }).catch(() => {});
+                }, challenge.activateDelay);
+            }
+
+            try {
+                const response = await reply.awaitMessageComponent({
+                    time: challenge.timeLimit,
+                    filter: i => i.user.id === interaction.user.id,
+                });
+                if (activateTimer) clearTimeout(activateTimer);
+
+                if (response.customId === challenge.correctId) {
+                    const bonusAmount = Math.round(actualAmount * 0.5);
+                    const bonusUpdated = await User.findOneAndUpdate(
+                        { userId: interaction.user.id, guildId: interaction.guild.id },
+                        { $inc: { balance: bonusAmount } },
+                        { new: true }
+                    );
+                    logTransaction({
+                        userId: interaction.user.id,
+                        guildId: interaction.guild.id,
+                        type: 'daily_challenge_bonus',
+                        amount: bonusAmount,
+                        balance: bonusUpdated?.balance ?? updated.balance + bonusAmount,
+                        note: `daily challenge bonus (${challenge.type})`,
+                    });
+                    embed.setColor('#ffd700');
+                    embed.spliceFields(0, embed.data.fields.length,
+                        { name: 'New Balance', value: `${(bonusUpdated?.balance ?? updated.balance + bonusAmount).toLocaleString()} coins` },
+                        { name: '🎯 Bonus Challenge', value: `✅ Correct! You earned an extra **+${bonusAmount.toLocaleString()}** coins!` },
+                    );
+                    await response.update({ embeds: [embed], components: [] });
+                } else {
+                    embed.spliceFields(0, embed.data.fields.length,
+                        { name: 'New Balance', value: `${updated.balance.toLocaleString()} coins` },
+                        { name: '🎯 Bonus Challenge', value: '❌ Wrong answer! No bonus this time — your daily reward is still yours.' },
+                    );
+                    await response.update({ embeds: [embed], components: [] });
+                }
+            } catch {
+                if (activateTimer) clearTimeout(activateTimer);
+                embed.spliceFields(0, embed.data.fields.length,
+                    { name: 'New Balance', value: `${updated.balance.toLocaleString()} coins` },
+                    { name: '🎯 Bonus Challenge', value: '⏱️ Time\'s up! No bonus this time — your daily reward is still yours.' },
+                );
+                await interaction.editReply({ embeds: [embed], components: [] }).catch(() => {});
+            }
         } catch (error) {
             console.error('Daily error:', error);
             await interaction.reply({ content: 'Failed to claim daily reward.', ephemeral: true });

--- a/src/commands/economy/work.js
+++ b/src/commands/economy/work.js
@@ -234,6 +234,7 @@ module.exports = {
                         filter: i => i.user.id === interaction.user.id,
                     });
                     responseRef = response;
+                    await responseRef.deferUpdate();
 
                     if (response.customId === challenge.correctId) {
                         bonusEarned = Math.round(earned * 0.4);
@@ -288,7 +289,7 @@ module.exports = {
                 }
 
                 if (responseRef) {
-                    await responseRef.update({ embeds: [workEmbed], components: [] }).catch(() => {});
+                    await responseRef.message.edit({ embeds: [workEmbed], components: [] }).catch(() => {});
                 } else {
                     await interaction.editReply({ embeds: [workEmbed], components: [] }).catch(() => {});
                 }

--- a/src/commands/economy/work.js
+++ b/src/commands/economy/work.js
@@ -7,6 +7,7 @@ const { getStreakMultiplier } = require('../../utils/streakMultiplier');
 const { getCoinMultiplier, getSalaryMultiplier, getServerCoinMultiplier } = require('../../services/effectsService');
 const { logTransaction } = require('../../utils/logTransaction');
 const { MAX_COMBINED_MULTIPLIER, clampMultiplier } = require('../../config/economy');
+const { generateWorkChallenge } = require('../../utils/workChallenge');
 
 function resolveTiers(guildSettings) {
     const saved = guildSettings?.jobTiers;
@@ -150,6 +151,9 @@ module.exports = {
                 finalEarned = Math.max(0, earned + specialEvent.coinDelta);
             }
 
+            // Challenge fires only when no special event is active (avoids embed conflicts)
+            const challengeFires = !specialEvent && Math.random() < 0.15;
+
             // Atomic update — cooldown condition in query prevents double-credit on concurrent requests
             const updated = await User.findOneAndUpdate(
                 {
@@ -194,7 +198,7 @@ module.exports = {
                 type: 'work',
                 amount: finalEarned,
                 balance: updated.balance,
-                note: `${job.name} (${performance.label})${capActive ? ', mult capped' : ''}`
+                note: `${job.name} (${performance.label})${capActive ? ', mult capped' : ''}${challengeFires ? ', challenge' : ''}`
             });
 
             const nextTier = tierInfo.find(t => t.minShifts > updated.shiftsWorked);
@@ -209,6 +213,89 @@ module.exports = {
             if (capActive)         bonusLabels.push(`⚠️ capped at ${MAX_COMBINED_MULTIPLIER}x`);
             const bonusStr = bonusLabels.length ? ` *(${bonusLabels.join(', ')})*` : '';
 
+            if (challengeFires) {
+                const challenge = generateWorkChallenge(job.name);
+                const challengeEmbed = new EmbedBuilder()
+                    .setColor(performance.color)
+                    .setTitle(challenge.title)
+                    .setDescription(`*${scenario}*\n\n${challenge.description}`)
+                    .addFields({ name: '💡 Bonus', value: 'Answer correctly for a **+40% bonus** on this shift!' })
+                    .setFooter({ text: 'You have 20 seconds to answer' })
+                    .setTimestamp();
+
+                const reply = await interaction.reply({ embeds: [challengeEmbed], components: [challenge.row], fetchReply: true });
+
+                let bonusEarned = 0;
+                let responseRef = null;
+
+                try {
+                    const response = await reply.awaitMessageComponent({
+                        time: challenge.timeLimit,
+                        filter: i => i.user.id === interaction.user.id,
+                    });
+                    responseRef = response;
+
+                    if (response.customId === challenge.correctId) {
+                        bonusEarned = Math.round(earned * 0.4);
+                        await User.findOneAndUpdate(
+                            { userId: interaction.user.id, guildId: interaction.guild.id },
+                            { $inc: { balance: bonusEarned } }
+                        );
+                        logTransaction({
+                            userId: interaction.user.id,
+                            guildId: interaction.guild.id,
+                            type: 'work_challenge_bonus',
+                            amount: bonusEarned,
+                            balance: updated.balance + bonusEarned,
+                            note: `work challenge bonus (${challenge.type}) for ${job.name}`,
+                        });
+                    }
+                } catch {
+                    // timed out — base payout already secured
+                }
+
+                const displayEarned  = finalEarned + bonusEarned;
+                const displayBalance = updated.balance + bonusEarned;
+
+                const workEmbed = new EmbedBuilder()
+                    .setColor(performance.color)
+                    .setTitle(`${performance.label} — Work Complete!`)
+                    .setDescription(scenario)
+                    .addFields(
+                        { name: 'Earned',      value: `${currency} **${displayEarned.toLocaleString()}** coins${bonusStr}`, inline: true },
+                        { name: 'Performance', value: performance.label, inline: true },
+                        { name: 'Career Tier', value: `${userTier.name} · ${updated.shiftsWorked.toLocaleString()} shifts`, inline: false },
+                        {
+                            name: 'Next Promotion',
+                            value: nextTier
+                                ? `${nextTier.name} in **${(nextTier.minShifts - updated.shiftsWorked).toLocaleString()}** shifts`
+                                : '✅ Max tier reached!',
+                            inline: false
+                        },
+                        { name: 'Balance', value: `${currency} ${displayBalance.toLocaleString()}`, inline: false }
+                    )
+                    .setFooter({ text: 'Cooldown: 1h' })
+                    .setTimestamp();
+
+                if (bonusEarned > 0) {
+                    workEmbed.addFields({ name: '🎯 Challenge Bonus!', value: `✅ Correct! You earned an extra **+${bonusEarned.toLocaleString()}** coins!` });
+                } else {
+                    workEmbed.addFields({ name: '🎯 Challenge Result', value: responseRef ? '❌ Wrong answer — no bonus this time.' : '⏱️ Time\'s up — no bonus this time.' });
+                }
+
+                if (promotedTo && promotedTo.minShifts > 0) {
+                    workEmbed.addFields({ name: '🎉 Promotion!', value: `You've been promoted to **${promotedTo.name}** — new jobs and higher pay are now available!` });
+                }
+
+                if (responseRef) {
+                    await responseRef.update({ embeds: [workEmbed], components: [] }).catch(() => {});
+                } else {
+                    await interaction.editReply({ embeds: [workEmbed], components: [] }).catch(() => {});
+                }
+                return;
+            }
+
+            // Normal (no challenge) path
             const embed = new EmbedBuilder()
                 .setColor(performance.color)
                 .setTitle(`${performance.label} — Work Complete!`)

--- a/src/utils/dailyChallenge.js
+++ b/src/utils/dailyChallenge.js
@@ -1,0 +1,106 @@
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+
+const MATH_PROBLEMS = [
+    { question: '6 × 7', answer: 42 },
+    { question: '8 × 9', answer: 72 },
+    { question: '7 × 8', answer: 56 },
+    { question: '4 × 9', answer: 36 },
+    { question: '6 × 8', answer: 48 },
+    { question: '5 × 7', answer: 35 },
+    { question: '9 × 9', answer: 81 },
+    { question: '3 × 8', answer: 24 },
+    { question: '11 × 7', answer: 77 },
+    { question: '11 × 6', answer: 66 },
+];
+
+const DECOY_EMOJIS = ['🌸', '🎲', '🌟', '🎯', '🌈', '🎪', '🎭', '🌺'];
+
+function shuffle(arr) {
+    const a = [...arr];
+    for (let i = a.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [a[i], a[j]] = [a[j], a[i]];
+    }
+    return a;
+}
+
+function generateWrongAnswers(correct, count) {
+    const offsets = [-15, -10, -8, -6, -5, 5, 6, 8, 10, 15, -3, 3, -12, 12];
+    const wrong = new Set();
+    for (const offset of shuffle(offsets)) {
+        if (wrong.size >= count) break;
+        const candidate = correct + offset;
+        if (candidate !== correct && candidate > 0 && candidate < 150) wrong.add(candidate);
+    }
+    while (wrong.size < count) {
+        const candidate = correct + Math.floor(Math.random() * 20) - 10;
+        if (candidate !== correct && candidate > 0) wrong.add(candidate);
+    }
+    return [...wrong].slice(0, count);
+}
+
+/**
+ * Returns a challenge descriptor for the /daily bonus mini-game.
+ * Types: 'emoji_pick', 'quick_math', 'react_fast'
+ *
+ * Returned object shape:
+ *   type, description, row (ActionRowBuilder), correctId, timeLimit (ms)
+ *   react_fast only: activeRow (enabled row), activateDelay (ms)
+ */
+function generateDailyChallenge() {
+    const types = ['emoji_pick', 'quick_math', 'react_fast'];
+    const type = types[Math.floor(Math.random() * types.length)];
+
+    if (type === 'emoji_pick') {
+        const decoys = shuffle(DECOY_EMOJIS).slice(0, 2);
+        const buttons = shuffle([
+            new ButtonBuilder().setCustomId('daily_challenge_correct').setLabel('🍀').setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('daily_challenge_wrong1').setLabel(decoys[0]).setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('daily_challenge_wrong2').setLabel(decoys[1]).setStyle(ButtonStyle.Secondary),
+        ]);
+        return {
+            type,
+            description: 'Click the **🍀** to earn a bonus!',
+            row: new ActionRowBuilder().addComponents(...buttons),
+            correctId: 'daily_challenge_correct',
+            timeLimit: 15_000,
+        };
+    }
+
+    if (type === 'quick_math') {
+        const problem = MATH_PROBLEMS[Math.floor(Math.random() * MATH_PROBLEMS.length)];
+        const wrong = generateWrongAnswers(problem.answer, 2);
+        const buttons = shuffle([
+            new ButtonBuilder().setCustomId('daily_challenge_correct').setLabel(String(problem.answer)).setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('daily_challenge_wrong1').setLabel(String(wrong[0])).setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('daily_challenge_wrong2').setLabel(String(wrong[1])).setStyle(ButtonStyle.Secondary),
+        ]);
+        return {
+            type,
+            description: `What is **${problem.question}**?`,
+            row: new ActionRowBuilder().addComponents(...buttons),
+            correctId: 'daily_challenge_correct',
+            timeLimit: 15_000,
+        };
+    }
+
+    // react_fast — button is disabled until activateDelay has elapsed
+    const activateDelay = 2000 + Math.floor(Math.random() * 1000);
+    const disabledRow = new ActionRowBuilder().addComponents(
+        new ButtonBuilder().setCustomId('daily_challenge_correct').setLabel('⚡ CLAIM').setStyle(ButtonStyle.Success).setDisabled(true),
+    );
+    const activeRow = new ActionRowBuilder().addComponents(
+        new ButtonBuilder().setCustomId('daily_challenge_correct').setLabel('⚡ CLAIM').setStyle(ButtonStyle.Success),
+    );
+    return {
+        type,
+        description: 'Click **⚡ CLAIM** when the button activates!',
+        row: disabledRow,
+        activeRow,
+        activateDelay,
+        correctId: 'daily_challenge_correct',
+        timeLimit: 15_000,
+    };
+}
+
+module.exports = { generateDailyChallenge };

--- a/src/utils/workChallenge.js
+++ b/src/utils/workChallenge.js
@@ -1,0 +1,145 @@
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+
+const SCRAMBLE_POOL = [
+    { word: 'BUDGET',  display: 'Budget',  wrong: ['Gadget',  'Basket']  },
+    { word: 'PROFIT',  display: 'Profit',  wrong: ['Forfeit', 'Import']  },
+    { word: 'CAREER',  display: 'Career',  wrong: ['Create',  'Radar']   },
+    { word: 'REPORT',  display: 'Report',  wrong: ['Resort',  'Deport']  },
+    { word: 'INVOICE', display: 'Invoice', wrong: ['Involve', 'Finance'] },
+    { word: 'MEETING', display: 'Meeting', wrong: ['Mailing', 'Beating'] },
+    { word: 'SALARY',  display: 'Salary',  wrong: ['Galaxy',  'Safety']  },
+    { word: 'PROJECT', display: 'Project', wrong: ['Subject', 'Protect'] },
+];
+
+const CRISIS_POOL = [
+    {
+        question: 'A client complaint just came in. How do you handle it?',
+        correct: 'Apologize and offer a fix',
+        wrong: ['Blame a coworker', 'Ignore the email'],
+    },
+    {
+        question: 'You spot a critical error in your work. What do you do?',
+        correct: 'Fix it and notify your manager',
+        wrong: ['Hope nobody notices', 'Delete the evidence'],
+    },
+    {
+        question: 'Your coworker is struggling to meet a deadline. You:',
+        correct: 'Offer to help them',
+        wrong: ['Report them to the boss', 'Do nothing'],
+    },
+    {
+        question: 'Two urgent tasks are due at the same time. You:',
+        correct: 'Prioritize the most impactful one',
+        wrong: ['Flip a coin', 'Take a coffee break'],
+    },
+    {
+        question: 'The system crashes right before a presentation. You:',
+        correct: 'Stay calm and troubleshoot quickly',
+        wrong: ['Blame IT and leave', 'Panic and go home'],
+    },
+];
+
+const COUNT_PAIRS = [
+    { target: '🍎', decoy: '🍊' },
+    { target: '⭐', decoy: '🌙' },
+    { target: '💎', decoy: '🔮' },
+    { target: '🔥', decoy: '💧' },
+    { target: '🐱', decoy: '🐶' },
+];
+
+function shuffle(arr) {
+    const a = [...arr];
+    for (let i = a.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [a[i], a[j]] = [a[j], a[i]];
+    }
+    return a;
+}
+
+function scrambleWord(word) {
+    let result;
+    let attempts = 0;
+    do {
+        result = word.split('').sort(() => Math.random() - 0.5).join('');
+        attempts++;
+    } while (result === word && attempts < 20);
+    return result;
+}
+
+/**
+ * Returns a challenge descriptor for the /work bonus mini-game.
+ * Types: 'word_scramble', 'crisis_decision', 'quick_count'
+ *
+ * Returned object shape:
+ *   type, title, description (string), row (ActionRowBuilder), correctId, timeLimit (ms)
+ */
+function generateWorkChallenge(jobName = 'your job') {
+    const types = ['word_scramble', 'crisis_decision', 'quick_count'];
+    const type = types[Math.floor(Math.random() * types.length)];
+
+    if (type === 'word_scramble') {
+        const entry = SCRAMBLE_POOL[Math.floor(Math.random() * SCRAMBLE_POOL.length)];
+        const scrambled = scrambleWord(entry.word);
+        const buttons = shuffle([
+            new ButtonBuilder().setCustomId('work_challenge_correct').setLabel(entry.display).setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('work_challenge_wrong1').setLabel(entry.wrong[0]).setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('work_challenge_wrong2').setLabel(entry.wrong[1]).setStyle(ButtonStyle.Secondary),
+        ]);
+        return {
+            type,
+            title: `🔡 Work Crisis — Word Scramble!`,
+            description: `Unscramble this word from your ${jobName} shift:\n\`\`\`${scrambled}\`\`\``,
+            row: new ActionRowBuilder().addComponents(...buttons),
+            correctId: 'work_challenge_correct',
+            timeLimit: 20_000,
+        };
+    }
+
+    if (type === 'crisis_decision') {
+        const entry = CRISIS_POOL[Math.floor(Math.random() * CRISIS_POOL.length)];
+        const buttons = shuffle([
+            new ButtonBuilder().setCustomId('work_challenge_correct').setLabel(entry.correct).setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('work_challenge_wrong1').setLabel(entry.wrong[0]).setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('work_challenge_wrong2').setLabel(entry.wrong[1]).setStyle(ButtonStyle.Secondary),
+        ]);
+        return {
+            type,
+            title: `⚠️ Work Crisis — Situation!`,
+            description: entry.question,
+            row: new ActionRowBuilder().addComponents(...buttons),
+            correctId: 'work_challenge_correct',
+            timeLimit: 20_000,
+        };
+    }
+
+    // quick_count
+    const pair = COUNT_PAIRS[Math.floor(Math.random() * COUNT_PAIRS.length)];
+    const targetCount = 2 + Math.floor(Math.random() * 4); // 2-5 targets
+    const decoyCount  = 2 + Math.floor(Math.random() * 4); // 2-5 decoys
+    const emojiStr = shuffle([
+        ...Array(targetCount).fill(pair.target),
+        ...Array(decoyCount).fill(pair.decoy),
+    ]).join('');
+
+    const wrong = new Set();
+    while (wrong.size < 2) {
+        const candidate = targetCount + Math.floor(Math.random() * 5) - 2;
+        if (candidate !== targetCount && candidate >= 0) wrong.add(candidate);
+    }
+    const wrongArr = [...wrong];
+    const buttons = shuffle([
+        new ButtonBuilder().setCustomId('work_challenge_correct').setLabel(String(targetCount)).setStyle(ButtonStyle.Secondary),
+        new ButtonBuilder().setCustomId('work_challenge_wrong1').setLabel(String(wrongArr[0])).setStyle(ButtonStyle.Secondary),
+        new ButtonBuilder().setCustomId('work_challenge_wrong2').setLabel(String(wrongArr[1])).setStyle(ButtonStyle.Secondary),
+    ]);
+    return {
+        type,
+        title: `🔢 Work Crisis — Quick Count!`,
+        description: `How many **${pair.target}** do you see?\n${emojiStr}`,
+        row: new ActionRowBuilder().addComponents(...buttons),
+        correctId: 'work_challenge_correct',
+        timeLimit: 20_000,
+    };
+}
+
+module.exports = { generateWorkChallenge };


### PR DESCRIPTION
- /daily now shows a 15-second bonus challenge after the base reward is
  granted; correct answer awards a +50% coin bonus (issues #219)
- /work has a 15% chance per shift of triggering a 20-second Work Crisis
  challenge; correct answer grants +40% on the earned amount (issue #220)
- Challenge never fires during special-event paths to avoid embed conflicts
- Base rewards are always secured before the challenge is presented;
  wrong answers and timeouts leave the base payout untouched
- New utils: src/utils/dailyChallenge.js (emoji_pick, quick_math,
  react_fast) and src/utils/workChallenge.js (word_scramble,
  crisis_decision, quick_count)

https://claude.ai/code/session_018YtryeTTFVgcgUvAC7HQLC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive Bonus Challenges to the daily rewards command, offering 50% additional bonuses for correct answers
  * Added occasional interactive challenges to the work command, granting 40% bonus rewards

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/clawdia/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->