### PR TITLE
Refactor crash to multiplayer lobby system & add marketplace

### DIFF
--- a/src/commands/economy/duel.js
+++ b/src/commands/economy/duel.js
@@ -93,10 +93,9 @@ async function finalizeDuel({ interaction, targetUser, challengerId, opponentId,
         const winnerId   = challengerWins ? challengerId : opponentId;
         const loserId    = challengerWins ? opponentId   : challengerId;
         const winnerName = challengerWins ? interaction.user.username : targetUser.username;
-        // Winner receives the full pot minus house cut; loser's stake was already taken by escrow
         await Promise.all([
-            User.updateOne({ userId: winnerId, guildId }, { $inc: { balance: winnerPayout }, $set: { lastDuel: new Date() } }),
-            User.updateOne({ userId: loserId,  guildId }, { $set: { lastDuel: new Date() } }),
+            User.updateOne({ userId: winnerId, guildId }, { $inc: { balance: winnerPayout, duelWins: 1 }, $set: { lastDuel: new Date() } }),
+            User.updateOne({ userId: loserId,  guildId }, { $inc: { duelLosses: 1 }, $set: { lastDuel: new Date() } }),
         ]);
         description = `${gameResult}\n\n**${winnerName}** wins **${currency}${netGain.toLocaleString()}** net (after ${Math.round(houseCut * 100)}% house cut)!`;
     }
@@ -106,6 +105,11 @@ async function finalizeDuel({ interaction, targetUser, challengerId, opponentId,
         User.findOne({ userId: opponentId,   guildId }),
     ]);
 
+    const cWins   = challenger?.duelWins   ?? 0;
+    const cLosses = challenger?.duelLosses ?? 0;
+    const oWins   = opponent?.duelWins     ?? 0;
+    const oLosses = opponent?.duelLosses   ?? 0;
+
     const embed = new EmbedBuilder()
         .setColor(tie ? '#f39c12' : '#2ecc71')
         .setTitle(`⚔️ Duel Result — ${GAME_NAMES[game]}`)
@@ -113,6 +117,8 @@ async function finalizeDuel({ interaction, targetUser, challengerId, opponentId,
         .addFields(
             { name: `${interaction.user.username}'s Balance`, value: `${currency}${(challenger?.balance ?? 0).toLocaleString()}`, inline: true },
             { name: `${targetUser.username}'s Balance`,       value: `${currency}${(opponent?.balance  ?? 0).toLocaleString()}`, inline: true },
+            { name: `${interaction.user.username}'s Record`,  value: `${cWins}W / ${cLosses}L`, inline: true },
+            { name: `${targetUser.username}'s Record`,        value: `${oWins}W / ${oLosses}L`, inline: true },
         )
         .setTimestamp();
 
@@ -285,7 +291,18 @@ module.exports = {
             opt.setName('amount')
                 .setDescription('Amount to bet from your wallet')
                 .setRequired(true)
-                .setMinValue(1)),
+                .setMinValue(1))
+        .addStringOption(opt =>
+            opt.setName('game')
+                .setDescription('Minigame to play (default: random)')
+                .setRequired(false)
+                .addChoices(
+                    { name: '🪙 Coin Flip',           value: 'coinflip'   },
+                    { name: '🎲 Dice Roll',            value: 'dice'       },
+                    { name: '🃏 Higher Card',          value: 'highercard' },
+                    { name: '✊ Rock Paper Scissors',  value: 'rps'        },
+                    { name: '🎲 Random',               value: 'random'     }
+                )),
 
     async execute(interaction) {
         if (!interaction.guild) {
@@ -305,8 +322,9 @@ module.exports = {
         const maxBet   = guildSettings?.economy?.duelMaxBet  ?? 10000;
         const houseCut = guildSettings?.economy?.duelHouseCut ?? 0.05;
 
-        const target = interaction.options.getUser('user');
-        const amount = interaction.options.getInteger('amount');
+        const target    = interaction.options.getUser('user');
+        const amount    = interaction.options.getInteger('amount');
+        const gameChoice = interaction.options.getString('game') ?? 'random';
 
         if (target.id === interaction.user.id) {
             return interaction.reply({ content: "You can't duel yourself.", ephemeral: true });
@@ -344,7 +362,8 @@ module.exports = {
             .setDescription(
                 `**${interaction.user.username}** challenges <@${target.id}> to a duel!\n\n` +
                 `Bet: **${currency}${amount.toLocaleString()}** each\n` +
-                `House cut: **${Math.round(houseCut * 100)}%**\n\n` +
+                `House cut: **${Math.round(houseCut * 100)}%**\n` +
+                `Game: **${gameChoice === 'random' ? '🎲 Random' : GAME_NAMES[gameChoice]}**\n\n` +
                 `<@${target.id}>, do you accept?`
             )
             .setFooter({ text: 'Challenge expires in 60 seconds' })
@@ -387,7 +406,9 @@ module.exports = {
                 }
                 escrowTaken = true;
 
-                const game = MINI_GAMES[randomInt(MINI_GAMES.length)];
+                const game = (gameChoice === 'random')
+                    ? MINI_GAMES[randomInt(MINI_GAMES.length)]
+                    : gameChoice;
                 if (game === 'rps') {
                     await runRPS(interaction, msg, target, amount, currency, houseCut, duelId);
                 } else {

--- a/src/commands/economy/gift.js
+++ b/src/commands/economy/gift.js
@@ -4,13 +4,8 @@ const Guild = require('../../models/Guild');
 
 const DAILY_COIN_CAP = 10_000;
 
-function resetGiftCapIfNeeded(user) {
-    const now = Date.now();
-    if (!user.dailyGiftReset || now - new Date(user.dailyGiftReset).getTime() >= 86_400_000) {
-        user.dailyGiftSent  = 0;
-        user.dailyGiftReset = new Date();
-    }
-}
+// Items that cannot be gifted (soulbound — matches market.js)
+const SOULBOUND_ITEMS = new Set(['lifesaver', 'streak_shield']);
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -58,22 +53,29 @@ module.exports = {
             return interaction.reply({ content: "You can't gift a bot.", ephemeral: true });
         }
 
-        const [sender, recipient] = await Promise.all([
-            User.findOneAndUpdate({ userId: interaction.user.id, guildId: interaction.guild.id }, {}, { upsert: true, new: true }),
-            User.findOneAndUpdate({ userId: target.id,           guildId: interaction.guild.id }, {}, { upsert: true, new: true }),
-        ]);
-
         if (type === 'coins') {
-            const amount = interaction.options.getInteger('amount');
+            const amount  = interaction.options.getInteger('amount');
+            const guildId = interaction.guild.id;
+
             if (!amount) {
                 return interaction.reply({ content: 'Specify an `amount` when gifting coins.', ephemeral: true });
             }
-            if (sender.balance < amount) {
-                return interaction.reply({ content: `You only have **${currency}${sender.balance.toLocaleString()}** in your wallet.`, ephemeral: true });
+
+            // Read current state to provide user-facing balance/cap feedback before the atomic update
+            const senderNow = await User.findOne({ userId: interaction.user.id, guildId });
+            if (!senderNow || senderNow.balance < amount) {
+                return interaction.reply({
+                    content: `You only have **${currency}${(senderNow?.balance ?? 0).toLocaleString()}** in your wallet.`,
+                    ephemeral: true,
+                });
             }
 
-            resetGiftCapIfNeeded(sender);
-            const remaining = DAILY_COIN_CAP - (sender.dailyGiftSent || 0);
+            const capResetAge = senderNow.dailyGiftReset
+                ? Date.now() - new Date(senderNow.dailyGiftReset).getTime()
+                : Infinity;
+            const currentSent = capResetAge >= 86_400_000 ? 0 : (senderNow.dailyGiftSent ?? 0);
+            const remaining   = DAILY_COIN_CAP - currentSent;
+
             if (amount > remaining) {
                 return interaction.reply({
                     content: `Daily gift cap reached. You can still gift up to **${currency}${remaining.toLocaleString()}** today.`,
@@ -81,19 +83,43 @@ module.exports = {
                 });
             }
 
-            sender.balance          -= amount;
-            sender.dailyGiftSent    = (sender.dailyGiftSent || 0) + amount;
-            recipient.balance       += amount;
+            // Atomic deduction: filter enforces balance and daily cap atomically so concurrent
+            // gifts can't race past either check. Reset cap counter if the 24h window expired.
+            const capFilter = capResetAge >= 86_400_000
+                ? {}
+                : { $expr: { $lte: [{ $add: ['$dailyGiftSent', amount] }, DAILY_COIN_CAP] } };
 
-            await Promise.all([sender.save(), recipient.save()]);
+            const capUpdate = capResetAge >= 86_400_000
+                ? { $inc: { balance: -amount }, $set: { dailyGiftSent: amount, dailyGiftReset: new Date() } }
+                : { $inc: { balance: -amount, dailyGiftSent: amount } };
+
+            const deducted = await User.findOneAndUpdate(
+                { userId: interaction.user.id, guildId, balance: { $gte: amount }, ...capFilter },
+                capUpdate,
+                { new: true }
+            );
+            if (!deducted) {
+                return interaction.reply({
+                    content: 'Could not complete the transfer — your balance or daily gift cap may have changed.',
+                    ephemeral: true,
+                });
+            }
+
+            await User.findOneAndUpdate(
+                { userId: target.id, guildId },
+                { $inc: { balance: amount } },
+                { upsert: true }
+            );
+
+            const newRemaining = DAILY_COIN_CAP - (deducted.dailyGiftSent ?? 0);
 
             const embed = new EmbedBuilder()
                 .setColor('#f1c40f')
                 .setTitle('🎁 Gift Sent!')
                 .setDescription(`**${interaction.user.username}** gifted **${currency}${amount.toLocaleString()}** to <@${target.id}>!`)
                 .addFields(
-                    { name: 'Your Wallet',      value: `${currency}${sender.balance.toLocaleString()}`,    inline: true },
-                    { name: 'Daily Cap Remaining', value: `${currency}${(remaining - amount).toLocaleString()}`, inline: true },
+                    { name: 'Your Wallet',         value: `${currency}${deducted.balance.toLocaleString()}`, inline: true },
+                    { name: 'Daily Cap Remaining', value: `${currency}${Math.max(0, newRemaining).toLocaleString()}`, inline: true },
                 )
                 .setTimestamp();
 
@@ -108,12 +134,21 @@ module.exports = {
 
         } else {
             // Gift item
-            const itemId  = interaction.options.getString('item');
-            const qty     = interaction.options.getInteger('quantity') ?? 1;
+            const itemId = interaction.options.getString('item');
+            const qty    = interaction.options.getInteger('quantity') ?? 1;
 
             if (!itemId) {
                 return interaction.reply({ content: 'Specify an `item` ID when gifting an item.', ephemeral: true });
             }
+
+            if (SOULBOUND_ITEMS.has(itemId)) {
+                return interaction.reply({ content: `\`${itemId}\` is soulbound and cannot be gifted.`, ephemeral: true });
+            }
+
+            const [sender, recipient] = await Promise.all([
+                User.findOneAndUpdate({ userId: interaction.user.id, guildId: interaction.guild.id }, {}, { upsert: true, new: true }),
+                User.findOneAndUpdate({ userId: target.id,           guildId: interaction.guild.id }, {}, { upsert: true, new: true }),
+            ]);
 
             const slot = sender.inventory.find(i => i.itemId === itemId);
             if (!slot || slot.quantity < qty) {
@@ -124,24 +159,21 @@ module.exports = {
             }
 
             // Cannot gift actively equipped effects
-            const activeTypes = (sender.activeEffects || []).map(e => e.type);
             const { resolveEffectType } = require('../../services/effectsService');
             const effectType = resolveEffectType(itemId);
-            if (effectType && activeTypes.includes(effectType)) {
+            if (effectType && (sender.activeEffects || []).some(e => e.type === effectType)) {
                 return interaction.reply({
                     content: `You can't gift \`${itemId}\` while it's active as an effect. Deactivate it first.`,
                     ephemeral: true,
                 });
             }
 
-            // Deduct from sender
             slot.quantity -= qty;
             if (slot.quantity <= 0) {
                 sender.inventory = sender.inventory.filter(i => i.itemId !== itemId);
             }
             sender.markModified('inventory');
 
-            // Add to recipient
             const recipientSlot = recipient.inventory.find(i => i.itemId === itemId);
             if (recipientSlot) {
                 recipientSlot.quantity += qty;

--- a/src/commands/economy/gift.js
+++ b/src/commands/economy/gift.js
@@ -1,0 +1,171 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const User  = require('../../models/User');
+const Guild = require('../../models/Guild');
+
+const DAILY_COIN_CAP = 10_000;
+
+function resetGiftCapIfNeeded(user) {
+    const now = Date.now();
+    if (!user.dailyGiftReset || now - new Date(user.dailyGiftReset).getTime() >= 86_400_000) {
+        user.dailyGiftSent  = 0;
+        user.dailyGiftReset = new Date();
+    }
+}
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('gift')
+        .setDescription('Send coins or an item from your inventory to another user.')
+        .addUserOption(o =>
+            o.setName('user')
+                .setDescription('The recipient.')
+                .setRequired(true))
+        .addStringOption(o =>
+            o.setName('type')
+                .setDescription('What to gift: coins or an item.')
+                .setRequired(true)
+                .addChoices(
+                    { name: 'Coins', value: 'coins' },
+                    { name: 'Item',  value: 'item'  }
+                ))
+        .addIntegerOption(o =>
+            o.setName('amount')
+                .setDescription('Amount of coins (if gifting coins).')
+                .setMinValue(1))
+        .addStringOption(o =>
+            o.setName('item')
+                .setDescription('Item ID to gift (if gifting an item).')
+                .setAutocomplete(false))
+        .addIntegerOption(o =>
+            o.setName('quantity')
+                .setDescription('How many of the item to gift (default 1).')
+                .setMinValue(1)),
+
+    async execute(interaction) {
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        if (guildSettings?.economy?.enabled === false) {
+            return interaction.reply({ content: 'The economy is disabled on this server.', ephemeral: true });
+        }
+
+        const currency = guildSettings?.economy?.currency || '💰';
+        const target   = interaction.options.getUser('user');
+        const type     = interaction.options.getString('type');
+
+        if (target.id === interaction.user.id) {
+            return interaction.reply({ content: "You can't gift yourself.", ephemeral: true });
+        }
+        if (target.bot) {
+            return interaction.reply({ content: "You can't gift a bot.", ephemeral: true });
+        }
+
+        const [sender, recipient] = await Promise.all([
+            User.findOneAndUpdate({ userId: interaction.user.id, guildId: interaction.guild.id }, {}, { upsert: true, new: true }),
+            User.findOneAndUpdate({ userId: target.id,           guildId: interaction.guild.id }, {}, { upsert: true, new: true }),
+        ]);
+
+        if (type === 'coins') {
+            const amount = interaction.options.getInteger('amount');
+            if (!amount) {
+                return interaction.reply({ content: 'Specify an `amount` when gifting coins.', ephemeral: true });
+            }
+            if (sender.balance < amount) {
+                return interaction.reply({ content: `You only have **${currency}${sender.balance.toLocaleString()}** in your wallet.`, ephemeral: true });
+            }
+
+            resetGiftCapIfNeeded(sender);
+            const remaining = DAILY_COIN_CAP - (sender.dailyGiftSent || 0);
+            if (amount > remaining) {
+                return interaction.reply({
+                    content: `Daily gift cap reached. You can still gift up to **${currency}${remaining.toLocaleString()}** today.`,
+                    ephemeral: true,
+                });
+            }
+
+            sender.balance          -= amount;
+            sender.dailyGiftSent    = (sender.dailyGiftSent || 0) + amount;
+            recipient.balance       += amount;
+
+            await Promise.all([sender.save(), recipient.save()]);
+
+            const embed = new EmbedBuilder()
+                .setColor('#f1c40f')
+                .setTitle('🎁 Gift Sent!')
+                .setDescription(`**${interaction.user.username}** gifted **${currency}${amount.toLocaleString()}** to <@${target.id}>!`)
+                .addFields(
+                    { name: 'Your Wallet',      value: `${currency}${sender.balance.toLocaleString()}`,    inline: true },
+                    { name: 'Daily Cap Remaining', value: `${currency}${(remaining - amount).toLocaleString()}`, inline: true },
+                )
+                .setTimestamp();
+
+            const recipientEmbed = new EmbedBuilder()
+                .setColor('#2ecc71')
+                .setTitle('🎁 You Received a Gift!')
+                .setDescription(`**${interaction.user.username}** sent you **${currency}${amount.toLocaleString()}**!`)
+                .setTimestamp();
+
+            await interaction.reply({ embeds: [embed] });
+            await interaction.followUp({ embeds: [recipientEmbed], content: `<@${target.id}>` });
+
+        } else {
+            // Gift item
+            const itemId  = interaction.options.getString('item');
+            const qty     = interaction.options.getInteger('quantity') ?? 1;
+
+            if (!itemId) {
+                return interaction.reply({ content: 'Specify an `item` ID when gifting an item.', ephemeral: true });
+            }
+
+            const slot = sender.inventory.find(i => i.itemId === itemId);
+            if (!slot || slot.quantity < qty) {
+                return interaction.reply({
+                    content: `You don't have ${qty}x \`${itemId}\` in your inventory.`,
+                    ephemeral: true,
+                });
+            }
+
+            // Cannot gift actively equipped effects
+            const activeTypes = (sender.activeEffects || []).map(e => e.type);
+            const { resolveEffectType } = require('../../services/effectsService');
+            const effectType = resolveEffectType(itemId);
+            if (effectType && activeTypes.includes(effectType)) {
+                return interaction.reply({
+                    content: `You can't gift \`${itemId}\` while it's active as an effect. Deactivate it first.`,
+                    ephemeral: true,
+                });
+            }
+
+            // Deduct from sender
+            slot.quantity -= qty;
+            if (slot.quantity <= 0) {
+                sender.inventory = sender.inventory.filter(i => i.itemId !== itemId);
+            }
+            sender.markModified('inventory');
+
+            // Add to recipient
+            const recipientSlot = recipient.inventory.find(i => i.itemId === itemId);
+            if (recipientSlot) {
+                recipientSlot.quantity += qty;
+            } else {
+                recipient.inventory.push({ itemId, quantity: qty });
+            }
+            recipient.markModified('inventory');
+
+            await Promise.all([sender.save(), recipient.save()]);
+
+            const embed = new EmbedBuilder()
+                .setColor('#f1c40f')
+                .setTitle('🎁 Gift Sent!')
+                .setDescription(`**${interaction.user.username}** gifted **${qty}x \`${itemId}\`** to <@${target.id}>!`)
+                .setTimestamp();
+
+            const recipientEmbed = new EmbedBuilder()
+                .setColor('#2ecc71')
+                .setTitle('🎁 You Received a Gift!')
+                .setDescription(`**${interaction.user.username}** sent you **${qty}x \`${itemId}\`**!`)
+                .setTimestamp();
+
+            await interaction.reply({ embeds: [embed] });
+            await interaction.followUp({ embeds: [recipientEmbed], content: `<@${target.id}>` });
+        }
+    },
+};

--- a/src/commands/economy/market.js
+++ b/src/commands/economy/market.js
@@ -87,20 +87,35 @@ async function handleList(interaction, currency) {
         return interaction.reply({ content: `You can only have ${MAX_LISTINGS_PER_USER} active listings at a time.`, ephemeral: true });
     }
 
-    // Deduct item from inventory
+    // Deduct item from inventory before creating listing
     slot.quantity -= qty;
     if (slot.quantity <= 0) seller.inventory = seller.inventory.filter(i => i.itemId !== itemId);
     seller.markModified('inventory');
     await seller.save();
 
-    const listing = await MarketListing.create({
-        guildId:      interaction.guild.id,
-        sellerId:     interaction.user.id,
-        itemId,
-        quantity:     qty,
-        pricePerUnit: price,
-        expiresAt:    new Date(Date.now() + LISTING_TTL_MS),
-    });
+    let listing;
+    try {
+        listing = await MarketListing.create({
+            guildId:      interaction.guild.id,
+            sellerId:     interaction.user.id,
+            itemId,
+            quantity:     qty,
+            pricePerUnit: price,
+            expiresAt:    new Date(Date.now() + LISTING_TTL_MS),
+        });
+    } catch (err) {
+        // Restore inventory if listing creation fails
+        const restored = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+        if (restored) {
+            const s = restored.inventory.find(i => i.itemId === itemId);
+            if (s) { s.quantity += qty; }
+            else   { restored.inventory.push({ itemId, quantity: qty }); }
+            restored.markModified('inventory');
+            await restored.save().catch(console.error);
+        }
+        console.error('[market list] MarketListing.create failed:', err);
+        return interaction.reply({ content: 'Failed to create listing. Your item has been returned.', ephemeral: true });
+    }
 
     const embed = new EmbedBuilder()
         .setColor('#3498db')
@@ -118,15 +133,12 @@ async function handleList(interaction, currency) {
 
 async function handleBrowse(interaction, currency) {
     const filterItem = interaction.options.getString('item')?.toLowerCase() ?? null;
-    const page       = (interaction.options.getInteger('page') ?? 1) - 1;
+    const rawPage    = (interaction.options.getInteger('page') ?? 1) - 1;
 
     const query = { guildId: interaction.guild.id };
     if (filterItem) query.itemId = filterItem;
 
-    const [listings, total] = await Promise.all([
-        MarketListing.find(query).sort({ pricePerUnit: 1 }).skip(page * PAGE_SIZE).limit(PAGE_SIZE),
-        MarketListing.countDocuments(query),
-    ]);
+    const total = await MarketListing.countDocuments(query);
 
     if (total === 0) {
         return interaction.reply({
@@ -136,6 +148,18 @@ async function handleBrowse(interaction, currency) {
             ephemeral: true,
         });
     }
+
+    const totalPages = Math.ceil(total / PAGE_SIZE);
+    const page = Math.max(0, Math.min(rawPage, totalPages - 1));
+
+    if (rawPage >= totalPages) {
+        return interaction.reply({
+            content: `Page ${rawPage + 1} is out of range. There are only **${totalPages}** page(s).`,
+            ephemeral: true,
+        });
+    }
+
+    const listings = await MarketListing.find(query).sort({ pricePerUnit: 1 }).skip(page * PAGE_SIZE).limit(PAGE_SIZE);
 
     const title = filterItem
         ? `📦 Marketplace — ${filterItem}`
@@ -147,7 +171,6 @@ async function handleBrowse(interaction, currency) {
         return `\`${String(l._id).slice(-6)}\`  @${sellerTag}  **${l.quantity}x \`${l.itemId}\`**  ${currency}${l.pricePerUnit.toLocaleString()}/ea  *(${currency}${total_price.toLocaleString()} total)*`;
     }));
 
-    const totalPages = Math.ceil(total / PAGE_SIZE);
     const embed = new EmbedBuilder()
         .setColor('#3498db')
         .setTitle(title)

--- a/src/commands/economy/market.js
+++ b/src/commands/economy/market.js
@@ -1,0 +1,263 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const User           = require('../../models/User');
+const Guild          = require('../../models/Guild');
+const MarketListing  = require('../../models/MarketListing');
+
+const MAX_LISTINGS_PER_USER = 5;
+const LISTING_TTL_MS        = 48 * 3_600_000; // 48 hours
+const MARKET_FEE_RATE       = 0.05;           // 5%
+const MIN_PRICE_PER_ITEM    = 10;
+const PAGE_SIZE             = 10;
+
+// Items that cannot be listed (soulbound)
+const SOULBOUND_ITEMS = new Set(['lifesaver', 'streak_shield']);
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('market')
+        .setDescription('Server player-to-player item marketplace.')
+        .addSubcommand(sub =>
+            sub.setName('list')
+                .setDescription('List an item for sale.')
+                .addStringOption(o =>
+                    o.setName('item').setDescription('Item ID to sell.').setRequired(true))
+                .addIntegerOption(o =>
+                    o.setName('quantity').setDescription('How many to sell.').setRequired(true).setMinValue(1))
+                .addIntegerOption(o =>
+                    o.setName('price').setDescription('Price per unit (coins).').setRequired(true).setMinValue(MIN_PRICE_PER_ITEM)))
+        .addSubcommand(sub =>
+            sub.setName('browse')
+                .setDescription('Browse active listings.')
+                .addStringOption(o =>
+                    o.setName('item').setDescription('Filter by item ID (optional).').setRequired(false))
+                .addIntegerOption(o =>
+                    o.setName('page').setDescription('Page number.').setMinValue(1).setRequired(false)))
+        .addSubcommand(sub =>
+            sub.setName('buy')
+                .setDescription('Buy a listing by its ID.')
+                .addStringOption(o =>
+                    o.setName('listing_id').setDescription('Listing ID from /market browse.').setRequired(true)))
+        .addSubcommand(sub =>
+            sub.setName('cancel')
+                .setDescription('Cancel one of your active listings and get your item back.')
+                .addStringOption(o =>
+                    o.setName('listing_id').setDescription('Listing ID to cancel.').setRequired(true))),
+
+    async execute(interaction) {
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        if (guildSettings?.economy?.enabled === false) {
+            return interaction.reply({ content: 'The economy is disabled on this server.', ephemeral: true });
+        }
+
+        const currency = guildSettings?.economy?.currency || '💰';
+        const sub      = interaction.options.getSubcommand();
+
+        if (sub === 'list')   return handleList(interaction, currency);
+        if (sub === 'browse') return handleBrowse(interaction, currency);
+        if (sub === 'buy')    return handleBuy(interaction, currency);
+        if (sub === 'cancel') return handleCancel(interaction, currency);
+    },
+};
+
+async function handleList(interaction, currency) {
+    const itemId = interaction.options.getString('item').toLowerCase();
+    const qty    = interaction.options.getInteger('quantity');
+    const price  = interaction.options.getInteger('price');
+
+    if (SOULBOUND_ITEMS.has(itemId)) {
+        return interaction.reply({ content: `\`${itemId}\` is soulbound and cannot be listed.`, ephemeral: true });
+    }
+
+    const seller = await User.findOneAndUpdate(
+        { userId: interaction.user.id, guildId: interaction.guild.id },
+        {},
+        { upsert: true, new: true }
+    );
+
+    const slot = seller.inventory.find(i => i.itemId === itemId);
+    if (!slot || slot.quantity < qty) {
+        return interaction.reply({ content: `You don't have ${qty}x \`${itemId}\` in your inventory.`, ephemeral: true });
+    }
+
+    const activeListing = await MarketListing.countDocuments({
+        guildId:  interaction.guild.id,
+        sellerId: interaction.user.id,
+    });
+    if (activeListing >= MAX_LISTINGS_PER_USER) {
+        return interaction.reply({ content: `You can only have ${MAX_LISTINGS_PER_USER} active listings at a time.`, ephemeral: true });
+    }
+
+    // Deduct item from inventory
+    slot.quantity -= qty;
+    if (slot.quantity <= 0) seller.inventory = seller.inventory.filter(i => i.itemId !== itemId);
+    seller.markModified('inventory');
+    await seller.save();
+
+    const listing = await MarketListing.create({
+        guildId:      interaction.guild.id,
+        sellerId:     interaction.user.id,
+        itemId,
+        quantity:     qty,
+        pricePerUnit: price,
+        expiresAt:    new Date(Date.now() + LISTING_TTL_MS),
+    });
+
+    const embed = new EmbedBuilder()
+        .setColor('#3498db')
+        .setTitle('📦 Item Listed!')
+        .setDescription(`**${qty}x \`${itemId}\`** listed for **${currency}${price.toLocaleString()}** per unit.`)
+        .addFields(
+            { name: 'Listing ID', value: `\`${listing._id}\``, inline: false },
+            { name: 'Expires',    value: `<t:${Math.floor(listing.expiresAt.getTime() / 1000)}:R>`, inline: true },
+            { name: 'Fee Note',   value: `5% market fee deducted on sale`, inline: true },
+        )
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed], ephemeral: true });
+}
+
+async function handleBrowse(interaction, currency) {
+    const filterItem = interaction.options.getString('item')?.toLowerCase() ?? null;
+    const page       = (interaction.options.getInteger('page') ?? 1) - 1;
+
+    const query = { guildId: interaction.guild.id };
+    if (filterItem) query.itemId = filterItem;
+
+    const [listings, total] = await Promise.all([
+        MarketListing.find(query).sort({ pricePerUnit: 1 }).skip(page * PAGE_SIZE).limit(PAGE_SIZE),
+        MarketListing.countDocuments(query),
+    ]);
+
+    if (total === 0) {
+        return interaction.reply({
+            content: filterItem
+                ? `No listings found for \`${filterItem}\`.`
+                : 'The marketplace is empty.',
+            ephemeral: true,
+        });
+    }
+
+    const title = filterItem
+        ? `📦 Marketplace — ${filterItem}`
+        : `📦 Server Marketplace`;
+
+    const lines = await Promise.all(listings.map(async (l, idx) => {
+        const sellerTag = await interaction.client.users.fetch(l.sellerId).then(u => u.username).catch(() => 'Unknown');
+        const total_price = l.pricePerUnit * l.quantity;
+        return `\`${String(l._id).slice(-6)}\`  @${sellerTag}  **${l.quantity}x \`${l.itemId}\`**  ${currency}${l.pricePerUnit.toLocaleString()}/ea  *(${currency}${total_price.toLocaleString()} total)*`;
+    }));
+
+    const totalPages = Math.ceil(total / PAGE_SIZE);
+    const embed = new EmbedBuilder()
+        .setColor('#3498db')
+        .setTitle(title)
+        .setDescription(lines.join('\n'))
+        .setFooter({ text: `Page ${page + 1}/${totalPages} · ${total} listings · 5% market fee on purchase · Use /market buy <listing_id>` })
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+async function handleBuy(interaction, currency) {
+    const rawId = interaction.options.getString('listing_id');
+
+    let listing;
+    try {
+        listing = await MarketListing.findOne({ _id: rawId, guildId: interaction.guild.id });
+    } catch {
+        return interaction.reply({ content: 'Invalid listing ID.', ephemeral: true });
+    }
+
+    if (!listing) {
+        return interaction.reply({ content: 'Listing not found or already expired/sold.', ephemeral: true });
+    }
+    if (listing.sellerId === interaction.user.id) {
+        return interaction.reply({ content: "You can't buy your own listing.", ephemeral: true });
+    }
+
+    const totalCost = listing.pricePerUnit * listing.quantity;
+    const feeAmount = Math.floor(totalCost * MARKET_FEE_RATE);
+    const sellerReceives = totalCost - feeAmount;
+
+    // Atomically deduct from buyer
+    const buyer = await User.findOneAndUpdate(
+        { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: totalCost } },
+        { $inc: { balance: -totalCost } },
+        { new: true }
+    );
+    if (!buyer) {
+        const fresh = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+        return interaction.reply({
+            content: `You need **${currency}${totalCost.toLocaleString()}** but only have **${currency}${(fresh?.balance ?? 0).toLocaleString()}**.`,
+            ephemeral: true,
+        });
+    }
+
+    // Remove listing atomically — prevent double-buys
+    const removed = await MarketListing.findOneAndDelete({ _id: listing._id, guildId: interaction.guild.id });
+    if (!removed) {
+        // Someone else bought it first — refund buyer
+        await User.updateOne({ userId: interaction.user.id, guildId: interaction.guild.id }, { $inc: { balance: totalCost } });
+        return interaction.reply({ content: 'This listing was just sold. Your coins have been refunded.', ephemeral: true });
+    }
+
+    // Credit seller and give item to buyer
+    await Promise.all([
+        User.updateOne({ userId: listing.sellerId, guildId: interaction.guild.id }, { $inc: { balance: sellerReceives } }),
+        (async () => {
+            const buyerDoc = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+            const slot = buyerDoc.inventory.find(i => i.itemId === listing.itemId);
+            if (slot) { slot.quantity += listing.quantity; }
+            else       { buyerDoc.inventory.push({ itemId: listing.itemId, quantity: listing.quantity }); }
+            buyerDoc.markModified('inventory');
+            await buyerDoc.save();
+        })(),
+    ]);
+
+    const embed = new EmbedBuilder()
+        .setColor('#2ecc71')
+        .setTitle('✅ Purchase Complete!')
+        .setDescription(`You bought **${listing.quantity}x \`${listing.itemId}\`** for **${currency}${totalCost.toLocaleString()}**.`)
+        .addFields(
+            { name: 'Fee Burned',       value: `${currency}${feeAmount.toLocaleString()}`, inline: true },
+            { name: 'Seller Received',  value: `${currency}${sellerReceives.toLocaleString()}`, inline: true },
+        )
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+async function handleCancel(interaction, currency) {
+    const rawId = interaction.options.getString('listing_id');
+
+    let listing;
+    try {
+        listing = await MarketListing.findOneAndDelete({
+            _id:      rawId,
+            guildId:  interaction.guild.id,
+            sellerId: interaction.user.id,
+        });
+    } catch {
+        return interaction.reply({ content: 'Invalid listing ID.', ephemeral: true });
+    }
+
+    if (!listing) {
+        return interaction.reply({ content: 'Listing not found, already sold, or not yours.', ephemeral: true });
+    }
+
+    // Return item to seller
+    const seller = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+    const slot = seller.inventory.find(i => i.itemId === listing.itemId);
+    if (slot) { slot.quantity += listing.quantity; }
+    else       { seller.inventory.push({ itemId: listing.itemId, quantity: listing.quantity }); }
+    seller.markModified('inventory');
+    await seller.save();
+
+    const embed = new EmbedBuilder()
+        .setColor('#e67e22')
+        .setTitle('↩️ Listing Cancelled')
+        .setDescription(`Returned **${listing.quantity}x \`${listing.itemId}\`** to your inventory.`)
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed], ephemeral: true });
+}

--- a/src/commands/economy/robstatus.js
+++ b/src/commands/economy/robstatus.js
@@ -45,6 +45,7 @@ module.exports = {
             return interaction.reply({ content: `You're on cooldown. Try again in **${secs}s**.`, ephemeral: true });
         }
         statusCooldowns.set(cdKey, Date.now());
+        setTimeout(() => statusCooldowns.delete(cdKey), STATUS_COOLDOWN_MS);
 
         const victim = await User.findOne({ userId: target.id, guildId: interaction.guild.id });
 

--- a/src/commands/economy/robstatus.js
+++ b/src/commands/economy/robstatus.js
@@ -1,0 +1,87 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const User  = require('../../models/User');
+const Guild = require('../../models/Guild');
+const { getPublicProtectionStatus, timeRemaining } = require('../../services/effectsService');
+
+const STATUS_COOLDOWN_MS = 2 * 60_000; // 2 minutes
+const VICTIM_IMMUNITY_MS = 30 * 60_000;
+
+// Per-user cooldown map (in-memory; resets on restart)
+const statusCooldowns = new Map();
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('robstatus')
+        .setDescription("Spy on a target's active rob protections before committing to a heist.")
+        .addUserOption(o =>
+            o.setName('target')
+                .setDescription('The user to check.')
+                .setRequired(true)),
+
+    async execute(interaction) {
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        if (guildSettings?.economy?.enabled === false) {
+            return interaction.reply({ content: 'The economy is disabled on this server.', ephemeral: true });
+        }
+        if (guildSettings?.economy?.robEnabled === false) {
+            return interaction.reply({ content: 'Robbing is disabled on this server.', ephemeral: true });
+        }
+
+        const target = interaction.options.getUser('target');
+
+        if (target.id === interaction.user.id) {
+            return interaction.reply({ content: "Checking your own status is pointless.", ephemeral: true });
+        }
+        if (target.bot) {
+            return interaction.reply({ content: "Bots can't be robbed.", ephemeral: true });
+        }
+
+        // Per-user cooldown
+        const cdKey = `${interaction.user.id}_${interaction.guild.id}`;
+        const lastUsed = statusCooldowns.get(cdKey) || 0;
+        const elapsed  = Date.now() - lastUsed;
+        if (elapsed < STATUS_COOLDOWN_MS) {
+            const secs = Math.ceil((STATUS_COOLDOWN_MS - elapsed) / 1000);
+            return interaction.reply({ content: `You're on cooldown. Try again in **${secs}s**.`, ephemeral: true });
+        }
+        statusCooldowns.set(cdKey, Date.now());
+
+        const victim = await User.findOne({ userId: target.id, guildId: interaction.guild.id });
+
+        const lines = [];
+
+        if (!victim) {
+            lines.push('⬜ No data on this user — they may not have used the bot yet.');
+        } else {
+            const { shield, cloak } = getPublicProtectionStatus(victim);
+
+            if (shield) {
+                lines.push(`🛡️ **Protected** — this user has an active Shield (${timeRemaining(shield.expiresAt)} remaining)`);
+            }
+            if (cloak) {
+                lines.push(`🧥 **Invisible** — this user has an active Invisibility Cloak (${timeRemaining(cloak.expiresAt)} remaining)`);
+            }
+            if (!shield && !cloak) {
+                lines.push('✅ **No active blocking protection** detected.');
+            }
+
+            // Recent rob immunity
+            if (victim.lastRobbedAt) {
+                const immunityLeft = VICTIM_IMMUNITY_MS - (Date.now() - new Date(victim.lastRobbedAt).getTime());
+                if (immunityLeft > 0) {
+                    const mins = Math.ceil(immunityLeft / 60_000);
+                    lines.push(`⏰ **Recently robbed** — immune for **${mins}m** more`);
+                }
+            }
+        }
+
+        const embed = new EmbedBuilder()
+            .setColor('#9b59b6')
+            .setTitle(`🔍 Rob Status: ${target.username}`)
+            .setDescription(lines.join('\n'))
+            .setFooter({ text: 'Padlock status is not revealed. Cooldown: 2m' })
+            .setTimestamp();
+
+        return interaction.reply({ embeds: [embed], ephemeral: true });
+    },
+};

--- a/src/commands/leveling/leaderboard.js
+++ b/src/commands/leveling/leaderboard.js
@@ -37,7 +37,10 @@ module.exports = {
                     ? 'Top 10 by Current Active Streak'
                     : 'Top 10 by Longest Streak Ever';
             } else if (type === 'duels') {
-                users = await User.find({ guildId: interaction.guild.id }).sort({ duelWins: -1 }).limit(10);
+                users = await User.find({
+                    guildId: interaction.guild.id,
+                    $or: [{ duelWins: { $gt: 0 } }, { duelLosses: { $gt: 0 } }],
+                }).sort({ duelWins: -1 }).limit(10);
                 title = '⚔️ Duel Leaderboard';
                 descriptionHeader = 'Top 10 Duelists by Win Count';
             } else {

--- a/src/commands/leveling/leaderboard.js
+++ b/src/commands/leveling/leaderboard.js
@@ -14,7 +14,8 @@ module.exports = {
                     { name: 'Levels',          value: 'levels' },
                     { name: 'Economy',         value: 'economy' },
                     { name: 'Streaks',         value: 'streaks' },
-                    { name: 'Streaks (Longest All-Time)', value: 'streaks_longest' }
+                    { name: 'Streaks (Longest All-Time)', value: 'streaks_longest' },
+                    { name: 'Duels (Most Wins)',          value: 'duels'           }
                 )),
     async execute(interaction) {
         const type = interaction.options.getString('type') || 'levels';
@@ -35,6 +36,10 @@ module.exports = {
                 descriptionHeader = type === 'streaks'
                     ? 'Top 10 by Current Active Streak'
                     : 'Top 10 by Longest Streak Ever';
+            } else if (type === 'duels') {
+                users = await User.find({ guildId: interaction.guild.id }).sort({ duelWins: -1 }).limit(10);
+                title = '⚔️ Duel Leaderboard';
+                descriptionHeader = 'Top 10 Duelists by Win Count';
             } else {
                 const sortField = type === 'levels' ? { level: -1, xp: -1 } : { balance: -1, bank: -1 };
                 users = await User.find({ guildId: interaction.guild.id }).sort(sortField).limit(10);
@@ -91,9 +96,13 @@ module.exports = {
                 } else if (type === 'streaks') {
                     const days = user.streak?.current ?? 0;
                     description += `${medal} ${discordUser.tag} — 🔥 ${days} day${days !== 1 ? 's' : ''}\n`;
-                } else {
+                } else if (type === 'streaks_longest') {
                     const days = user.streak?.longest ?? 0;
                     description += `${medal} ${discordUser.tag} — 🔥 ${days} day${days !== 1 ? 's' : ''}\n`;
+                } else {
+                    const wins   = user.duelWins   ?? 0;
+                    const losses = user.duelLosses ?? 0;
+                    description += `${medal} ${discordUser.tag} — ⚔️ ${wins}W / ${losses}L\n`;
                 }
             }
 

--- a/src/games/casino/crash.js
+++ b/src/games/casino/crash.js
@@ -7,8 +7,15 @@ const {
 const User = require('../../models/User');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect } = require('../../services/effectsService');
+const {
+    LOBBY_JOIN_WINDOW_MS,
+    MAX_PLAYERS,
+    createLobby,
+    getLobby,
+    deleteLobby,
+    addPlayer,
+} = require('../../utils/crashLobby');
 
-const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f4a5.png';
 const GROWTH  = 1.12;
 const TICK_MS = 1200;
 const MIN_BET = 10;
@@ -32,9 +39,7 @@ function multLabel(m) {
     return m >= 10 ? m.toFixed(1) + 'x' : m.toFixed(2) + 'x';
 }
 
-// Color transitions from calm green → danger red as multiplier climbs
-function crashColor(m, cashedOut) {
-    if (cashedOut) return '#00cc66';
+function crashColor(m) {
     if (m < 1.5)  return '#00ff88';
     if (m < 2.0)  return '#44ff44';
     if (m < 3.0)  return '#aaee00';
@@ -44,7 +49,6 @@ function crashColor(m, cashedOut) {
     return '#ff2200';
 }
 
-// Risk label changes as multiplier rises
 function riskLabel(m) {
     if (m < 1.5)  return '🟢 Safe Zone';
     if (m < 2.0)  return '🟢 Low Risk';
@@ -55,109 +59,100 @@ function riskLabel(m) {
     return '🚨 EXTREME!';
 }
 
-// Log-scale bar that fills on a 1x–100x range, with zone color blocks
 function progressBar(m) {
     const total  = 20;
     const filled = Math.min(total, Math.round((Math.log(m) / Math.log(100)) * total));
     const empty  = total - filled;
     const glyph  = m < 5 ? '▰' : m < 15 ? '▮' : '█';
-    const bar    = glyph.repeat(filled) + '▱'.repeat(empty);
-    return `\`${bar}\``;
+    return `\`${glyph.repeat(filled)}${'▱'.repeat(empty)}\``;
 }
 
-function embedAuthor(interaction) {
-    return {
-        name: interaction.member?.displayName || interaction.user.username,
-        iconURL: interaction.user.displayAvatarURL({ dynamic: true }),
-    };
-}
-
-function liveEmbed(multiplier, bet, interaction, cashedOut, cashedOutAt) {
-    const label  = multLabel(multiplier);
-    const color  = crashColor(multiplier, cashedOut);
-    const risk   = riskLabel(multiplier);
-    const bar    = progressBar(multiplier);
-
-    let desc;
-    if (cashedOut) {
-        desc = `✅ **Cashed out at ${multLabel(cashedOutAt)}** — riding out the crash…\n\n${bar}  ${label}`;
-    } else {
-        desc = `🚀 **Multiplier rising** — hit Cash Out before it crashes!\n\n${bar}  **${label}**`;
-    }
-
+// ── Lobby embed (join window) ───────────────────────────────────────────────
+function lobbyEmbed(lobby, playerNames) {
+    const secsLeft = Math.max(0, Math.ceil((lobby.joinDeadline - Date.now()) / 1000));
+    const lines = playerNames.length
+        ? playerNames.map(n => `• ${n}`).join('\n')
+        : '*No players yet*';
     return new EmbedBuilder()
-        .setAuthor(embedAuthor(interaction))
-        .setThumbnail(THUMB)
-        .setColor(color)
-        .setTitle('💥 Crash')
-        .setDescription(desc)
-        .addFields(
-            { name: '📈 Multiplier', value: `**${label}**`,                       inline: true },
-            { name: '⚠️ Risk Level', value: risk,                                  inline: true },
-            { name: '💰 Bet',        value: `${bet.toLocaleString()} coins`,       inline: true },
+        .setColor('#5865F2')
+        .setTitle('💥 Crash — Lobby Open')
+        .setDescription(
+            `**Bet:** ${lobby.bet.toLocaleString()} coins each\n` +
+            `**Joining:** ${lobby.players.size}/${MAX_PLAYERS} players\n\n` +
+            `**Players:**\n${lines}\n\n` +
+            `Lobby closes in **${secsLeft}s** or when host starts.`
         )
-        .setFooter({ text: 'Cash out before it crashes to secure your winnings!' });
+        .setFooter({ text: 'Click Join to enter · Host can start early' })
+        .setTimestamp();
 }
 
-function crashedEmbed(crashPoint, bet, cashedOut, cashedOutAt, newBalance, interaction) {
-    const crashLabel = multLabel(crashPoint);
-    let color, headline, fields;
+function buildLobbyRow(lobbyId) {
+    return new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+            .setCustomId(`crash_join_${lobbyId}`)
+            .setLabel('Join Lobby')
+            .setStyle(ButtonStyle.Primary),
+        new ButtonBuilder()
+            .setCustomId(`crash_start_${lobbyId}`)
+            .setLabel('Start Now')
+            .setStyle(ButtonStyle.Success),
+    );
+}
 
-    if (cashedOut) {
-        const payout = Math.floor(bet * cashedOutAt);
-        const net    = payout - bet;
-        color    = '#00cc66';
-        headline = `✅ You cashed out at **${multLabel(cashedOutAt)}** before the crash!`;
-        fields   = [
-            { name: '💸 Bet',           value: `${bet.toLocaleString()} coins`,    inline: true },
-            { name: '🏆 Payout',        value: `${payout.toLocaleString()} coins`, inline: true },
-            { name: '📊 Net',           value: `**+${net.toLocaleString()}** coins`, inline: true },
-            { name: '💥 Crashed At',    value: `**${crashLabel}**`,                inline: true },
-            { name: '💰 New Balance',   value: `**${newBalance.toLocaleString()}** coins`, inline: true },
-        ];
-    } else {
-        color    = '#ff3333';
-        headline = `💀 You didn't cash out in time! Everything is gone.`;
-        fields   = [
-            { name: '💥 Crashed At',  value: `**${crashLabel}**`,                  inline: true },
-            { name: '💀 Lost',        value: `${bet.toLocaleString()} coins`,       inline: true },
-            { name: '💰 New Balance', value: `**${newBalance.toLocaleString()}** coins`, inline: true },
-        ];
-    }
-
+// ── Live game embed (multiplayer) ───────────────────────────────────────────
+function liveMultiEmbed(multiplier, bet, playerLines) {
+    const bar  = progressBar(multiplier);
+    const label = multLabel(multiplier);
     return new EmbedBuilder()
-        .setAuthor(embedAuthor(interaction))
-        .setThumbnail(THUMB)
-        .setColor(color)
+        .setColor(crashColor(multiplier))
+        .setTitle('💥 Crash — Live')
+        .setDescription(
+            `🚀 **Multiplier rising!**\n\n${bar}  **${label}**\n\n` +
+            `${riskLabel(multiplier)}\n\n` +
+            '**Players:**\n' + (playerLines.join('\n') || '*—*')
+        )
+        .addFields(
+            { name: '📈 Multiplier', value: `**${label}**`,                    inline: true },
+            { name: '💰 Bet',        value: `${bet.toLocaleString()} coins`,   inline: true },
+        )
+        .setFooter({ text: 'Hit Cash Out before it crashes!' });
+}
+
+function buildMultiCashOutRow(lobbyId, multiplier, userId, cashedOut) {
+    return new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+            .setCustomId(`crash_co_${lobbyId}_${userId}`)
+            .setLabel(cashedOut ? '✅ Cashed Out' : `💰 Cash Out  ${multLabel(multiplier)}`)
+            .setStyle(cashedOut ? ButtonStyle.Secondary : ButtonStyle.Success)
+            .setDisabled(cashedOut),
+    );
+}
+
+// ── Final result embed ───────────────────────────────────────────────────────
+async function buildFinalEmbed(crashPoint, bet, players, client, guildId) {
+    const crashLabel = multLabel(crashPoint);
+    const lines = [];
+    for (const [uid, state] of players.entries()) {
+        const user = await client.users.fetch(uid).catch(() => ({ username: uid }));
+        if (state.cashedOutAt) {
+            const payout = Math.floor(bet * state.cashedOutAt);
+            const net    = payout - bet;
+            lines.push(`✅ **${user.username}** cashed at **${multLabel(state.cashedOutAt)}** (+${net.toLocaleString()} coins)`);
+        } else {
+            lines.push(`💀 **${user.username}** didn't cash out (-${bet.toLocaleString()} coins)`);
+        }
+    }
+    return new EmbedBuilder()
+        .setColor('#ff3333')
         .setTitle(`💥 Crashed at ${crashLabel}!`)
-        .setDescription(headline)
-        .addFields(fields)
+        .setDescription(lines.join('\n') || '*No players*')
         .setFooter({ text: 'The house always has a 1% edge — play responsibly!' })
         .setTimestamp();
 }
 
-function buildCashOutRow(id, multiplier, disabled) {
-    return new ActionRowBuilder().addComponents(
-        new ButtonBuilder()
-            .setCustomId(id)
-            .setLabel(disabled ? '✅ Cashed Out' : `💰 Cash Out  ${multLabel(multiplier)}`)
-            .setStyle(disabled ? ButtonStyle.Secondary : ButtonStyle.Success)
-            .setDisabled(disabled),
-    );
-}
-
-function buildResultRow(replayId) {
-    return new ActionRowBuilder().addComponents(
-        new ButtonBuilder()
-            .setCustomId(replayId)
-            .setLabel('💥 Play Again')
-            .setStyle(ButtonStyle.Primary),
-    );
-}
-
 module.exports = {
     name: 'crash',
-    description: 'Bet on a rising multiplier — cash out before it crashes!',
+    description: 'Multiplayer crash — bet and cash out before the curve crashes!',
     cooldown: 10,
     configure: sub => sub
         .addIntegerOption(opt =>
@@ -168,153 +163,240 @@ module.exports = {
                 .setRequired(true)),
 
     async execute(interaction) {
-        const bet = interaction.options.getInteger('bet');
+        const bet  = interaction.options.getInteger('bet');
         const user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
-        const wallet = user?.balance ?? 0;
-        if (!await confirmBet(interaction, bet, wallet, 'Crash')) return;
+        if (!await confirmBet(interaction, bet, user?.balance ?? 0, 'Crash')) return;
         await interaction.deferReply();
-        await playCrash(interaction, bet);
+        await openLobby(interaction, bet);
     },
 };
 
-async function playCrash(interaction, bet) {
-    try {
-        const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
+async function openLobby(interaction, bet) {
+    const channelId = interaction.channel.id;
+    const lobbyId   = `${channelId}_${Date.now()}`;
 
-        await User.findOneAndUpdate(
-            userFilter,
-            { $setOnInsert: { ...userFilter, balance: 0 } },
-            { upsert: true, new: true, setDefaultsOnInsert: true }
-        );
+    // Prevent two lobbies in the same channel
+    if (getLobby(channelId)) {
+        return interaction.editReply({ content: 'A crash lobby is already open in this channel.', components: [] });
+    }
 
-        const debited = await User.findOneAndUpdate(
-            { ...userFilter, balance: { $gte: bet } },
-            { $inc: { balance: -bet } },
-            { new: true }
-        );
+    const lobby = createLobby(channelId, interaction.user.id, bet);
+    if (!lobby) {
+        return interaction.editReply({ content: 'A crash lobby is already open in this channel.', components: [] });
+    }
 
-        if (!debited) {
-            const fresh = await User.findOne(userFilter);
-            return interaction.editReply({
-                content: `❌ Not enough coins! Your balance: **${(fresh?.balance ?? 0).toLocaleString()}** coins.`,
-                components: [],
-            });
+    // Deduct host's bet immediately
+    const deducted = await User.findOneAndUpdate(
+        { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: bet } },
+        { $inc: { balance: -bet } },
+        { new: true }
+    );
+    if (!deducted) {
+        deleteLobby(channelId);
+        return interaction.editReply({ content: `❌ Not enough coins! You need **${bet.toLocaleString()}** coins.`, components: [] });
+    }
+
+    addPlayer(channelId, interaction.user.id);
+
+    const msg = await interaction.editReply({
+        embeds:     [lobbyEmbed(lobby, [interaction.user.username])],
+        components: [buildLobbyRow(lobbyId)],
+    });
+
+    // Lobby join collector
+    const joinCollector = msg.createMessageComponentCollector({
+        filter: i => i.customId === `crash_join_${lobbyId}` || i.customId === `crash_start_${lobbyId}`,
+        time:   LOBBY_JOIN_WINDOW_MS + 5_000,
+    });
+
+    async function updateLobbyEmbed() {
+        const names = [];
+        for (const uid of lobby.players.keys()) {
+            const u = await interaction.client.users.fetch(uid).catch(() => ({ username: uid }));
+            names.push(u.username);
         }
+        await interaction.editReply({
+            embeds:     [lobbyEmbed(lobby, names)],
+            components: [buildLobbyRow(lobbyId)],
+        }).catch(() => {});
+    }
 
-        // Lucky Charm: boost crash point by 20% (higher crash = more time to cash out)
-        const luckyActive = hasEffect(debited, 'lucky_charm');
-        const crash    = luckyActive
-            ? Math.min(100.00, parseFloat((generateCrashPoint() * 1.2).toFixed(2)))
-            : generateCrashPoint();
-        const cashOutId = `crash_co_${interaction.id}_${Date.now()}`;
+    joinCollector.on('collect', async i => {
+        if (lobby.locked) { await i.deferUpdate().catch(() => {}); return; }
 
-        // Instant crash — no time to react
-        if (crash <= 1.00) {
-            const replayId = `crash_replay_${interaction.id}_${Date.now()}`;
-            const fresh    = await User.findOne(userFilter);
-            await interaction.editReply({
-                embeds:     [crashedEmbed(1.00, bet, false, 0, fresh?.balance ?? debited.balance, interaction)],
-                components: [buildResultRow(replayId)],
-            });
-            setupReplay(interaction, replayId, bet);
+        if (i.customId === `crash_start_${lobbyId}`) {
+            if (i.user.id !== lobby.hostId) {
+                return i.reply({ content: 'Only the host can start early.', ephemeral: true });
+            }
+            await i.deferUpdate().catch(() => {});
+            joinCollector.stop('started');
             return;
         }
 
-        let tick        = 0;
-        let currentMult = multiplierAt(0);
-        let cashedOut   = false;
-        let cashedOutAt = 0;
-        let gameOver    = false;
-        const crashTick   = ticksUntilCrash(crash);
-        const collectorMs = (crashTick + 3) * TICK_MS + 8000;
+        // Join button
+        if (lobby.players.has(i.user.id)) {
+            return i.reply({ content: "You're already in this lobby.", ephemeral: true });
+        }
+        if (lobby.players.size >= MAX_PLAYERS) {
+            return i.reply({ content: 'Lobby is full.', ephemeral: true });
+        }
 
-        await interaction.editReply({
-            embeds:     [liveEmbed(currentMult, bet, interaction, false, 0)],
-            components: [buildCashOutRow(cashOutId, currentMult, false)],
-        });
+        // Deduct joining player's bet
+        const deducted = await User.findOneAndUpdate(
+            { userId: i.user.id, guildId: interaction.guild.id, balance: { $gte: bet } },
+            { $inc: { balance: -bet } },
+            { new: true }
+        );
+        if (!deducted) {
+            return i.reply({ content: `You need **${bet.toLocaleString()}** coins to join.`, ephemeral: true });
+        }
 
-        const message   = await interaction.fetchReply();
-        const collector = message.createMessageComponentCollector({
-            filter: i => i.user.id === interaction.user.id && i.customId === cashOutId,
-            max:    1,
-            time:   collectorMs,
-        });
+        addPlayer(channelId, i.user.id);
+        await i.deferUpdate().catch(() => {});
+        await updateLobbyEmbed();
+    });
 
-        collector.on('collect', async i => {
-            if (gameOver || cashedOut) { await i.deferUpdate().catch(() => {}); return; }
+    joinCollector.on('end', async (_, reason) => {
+        if (lobby.locked) return; // already started
+        lobby.locked = true;
 
-            cashedOut   = true;
-            cashedOutAt = currentMult;
-            const payout = Math.floor(bet * cashedOutAt);
+        if (lobby.players.size === 0) {
+            deleteLobby(channelId);
+            await interaction.editReply({ content: 'Nobody joined — lobby cancelled.', components: [] }).catch(() => {});
+            return;
+        }
 
-            await User.findOneAndUpdate(
-                { userId: interaction.user.id, guildId: interaction.guild.id },
-                { $inc: { balance: payout } },
-            );
+        await startCrashGame(interaction, lobby, lobbyId);
+    });
 
-            await i.update({
-                embeds:     [liveEmbed(currentMult, bet, interaction, true, cashedOutAt)],
-                components: [buildCashOutRow(cashOutId, currentMult, true)],
-            }).catch(() => {});
-        });
-
-        const interval = setInterval(async () => {
-            if (gameOver) return;
-
-            tick++;
-            currentMult = multiplierAt(tick);
-
-            if (currentMult >= crash) {
-                gameOver = true;
-                clearInterval(interval);
-                collector.stop('crashed');
-
-                const freshUser  = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
-                const replayId   = `crash_replay_${interaction.id}_${Date.now()}`;
-
-                await interaction.editReply({
-                    embeds:     [crashedEmbed(crash, bet, cashedOut, cashedOutAt, freshUser?.balance ?? debited.balance, interaction)],
-                    components: [buildResultRow(replayId)],
-                }).catch(() => {});
-
-                setupReplay(interaction, replayId, bet);
-                return;
-            }
-
-            if (!cashedOut) {
-                await interaction.editReply({
-                    embeds:     [liveEmbed(currentMult, bet, interaction, false, 0)],
-                    components: [buildCashOutRow(cashOutId, currentMult, false)],
-                }).catch(() => {});
-            }
-        }, TICK_MS);
-
-        collector.on('end', (_, reason) => {
-            if (reason !== 'crashed' && !gameOver) {
-                gameOver = true;
-                clearInterval(interval);
-            }
-        });
-
-    } catch (err) {
-        console.error('[Crash] error:', err);
-        await interaction.editReply({ content: 'Something went wrong. Please try again.', components: [] }).catch(() => {});
-    }
+    // Auto-start after join window
+    setTimeout(async () => {
+        if (!lobby.locked) {
+            lobby.locked = true;
+            joinCollector.stop('timeout');
+        }
+    }, LOBBY_JOIN_WINDOW_MS);
 }
 
-function setupReplay(interaction, replayId, bet) {
-    interaction.fetchReply().then(msg => {
-        const collector = msg.createMessageComponentCollector({
-            filter: i => i.user.id === interaction.user.id && i.customId === replayId,
-            max: 1,
-            time: 60_000,
-        });
-        collector.on('collect', async i => {
-            await i.deferUpdate();
-            await playCrash(interaction, bet);
-        });
-        collector.on('end', (_, reason) => {
-            if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
-        });
+async function startCrashGame(interaction, lobby, lobbyId) {
+    const channelId = lobby.channelId;
+    const bet       = lobby.bet;
+    const guildId   = interaction.guild.id;
+
+    // Determine crash point (use Lucky Charm of host if active)
+    const hostDoc     = await User.findOne({ userId: lobby.hostId, guildId });
+    const luckyActive = hostDoc ? hasEffect(hostDoc, 'lucky_charm') : false;
+    const crash       = luckyActive
+        ? Math.min(100.00, parseFloat((generateCrashPoint() * 1.2).toFixed(2)))
+        : generateCrashPoint();
+
+    // Instant crash — refund everyone and done
+    if (crash <= 1.00) {
+        const finalEmbed = await buildFinalEmbed(crash, bet, lobby.players, interaction.client, guildId);
+        deleteLobby(channelId);
+        return interaction.editReply({ embeds: [finalEmbed], components: [] }).catch(() => {});
+    }
+
+    let tick        = 0;
+    let currentMult = multiplierAt(0);
+    let gameOver    = false;
+    const crashTick   = ticksUntilCrash(crash);
+    const collectorMs = (crashTick + 3) * TICK_MS + 8000;
+
+    async function getPlayerLines() {
+        const lines = [];
+        for (const [uid, state] of lobby.players.entries()) {
+            const u = await interaction.client.users.fetch(uid).catch(() => ({ username: uid }));
+            if (state.cashedOutAt) {
+                lines.push(`✅ **${u.username}** cashed at **${multLabel(state.cashedOutAt)}**`);
+            } else {
+                lines.push(`🎮 **${u.username}** — still in`);
+            }
+        }
+        return lines;
+    }
+
+    // Build per-player cash out rows — show each player their own button via ephemeral
+    // Since Discord has one shared message, we show a single public embed and the
+    // cash out button is public. Each player can click it; we filter by userId.
+    await interaction.editReply({
+        embeds:     [liveMultiEmbed(currentMult, bet, await getPlayerLines())],
+        components: [new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId(`crash_co_${lobbyId}`)
+                .setLabel(`💰 Cash Out  ${multLabel(currentMult)}`)
+                .setStyle(ButtonStyle.Success),
+        )],
     }).catch(() => {});
+
+    const message   = await interaction.fetchReply().catch(() => null);
+    if (!message) { deleteLobby(channelId); return; }
+
+    const collector = message.createMessageComponentCollector({
+        filter: i => i.customId === `crash_co_${lobbyId}` && lobby.players.has(i.user.id),
+        time:   collectorMs,
+    });
+
+    collector.on('collect', async i => {
+        if (gameOver) { await i.deferUpdate().catch(() => {}); return; }
+        const state = lobby.players.get(i.user.id);
+        if (!state || state.cashedOutAt !== null) {
+            return i.reply({ content: "You've already cashed out.", ephemeral: true });
+        }
+
+        state.cashedOutAt = currentMult;
+        const payout = Math.floor(bet * currentMult);
+        await User.findOneAndUpdate(
+            { userId: i.user.id, guildId },
+            { $inc: { balance: payout } }
+        );
+
+        await i.reply({
+            content: `✅ Cashed out at **${multLabel(currentMult)}** — **+${(payout - bet).toLocaleString()} coins**!`,
+            ephemeral: true,
+        }).catch(() => {});
+
+        // Update shared embed with new player lines
+        const lines = await getPlayerLines();
+        await interaction.editReply({
+            embeds: [liveMultiEmbed(currentMult, bet, lines)],
+        }).catch(() => {});
+    });
+
+    lobby.interval = setInterval(async () => {
+        if (gameOver) return;
+
+        tick++;
+        currentMult = multiplierAt(tick);
+
+        if (currentMult >= crash) {
+            gameOver = true;
+            clearInterval(lobby.interval);
+            collector.stop('crashed');
+
+            const finalEmbed = await buildFinalEmbed(crash, bet, lobby.players, interaction.client, guildId);
+            deleteLobby(channelId);
+            await interaction.editReply({ embeds: [finalEmbed], components: [] }).catch(() => {});
+            return;
+        }
+
+        const lines = await getPlayerLines();
+        await interaction.editReply({
+            embeds:     [liveMultiEmbed(currentMult, bet, lines)],
+            components: [new ActionRowBuilder().addComponents(
+                new ButtonBuilder()
+                    .setCustomId(`crash_co_${lobbyId}`)
+                    .setLabel(`💰 Cash Out  ${multLabel(currentMult)}`)
+                    .setStyle(ButtonStyle.Success),
+            )],
+        }).catch(() => {});
+    }, TICK_MS);
+
+    collector.on('end', (_, reason) => {
+        if (reason !== 'crashed' && !gameOver) {
+            gameOver = true;
+            clearInterval(lobby.interval);
+            deleteLobby(channelId);
+        }
+    });
 }

--- a/src/games/casino/crash.js
+++ b/src/games/casino/crash.js
@@ -118,16 +118,6 @@ function liveMultiEmbed(multiplier, bet, playerLines) {
         .setFooter({ text: 'Hit Cash Out before it crashes!' });
 }
 
-function buildMultiCashOutRow(lobbyId, multiplier, userId, cashedOut) {
-    return new ActionRowBuilder().addComponents(
-        new ButtonBuilder()
-            .setCustomId(`crash_co_${lobbyId}_${userId}`)
-            .setLabel(cashedOut ? '✅ Cashed Out' : `💰 Cash Out  ${multLabel(multiplier)}`)
-            .setStyle(cashedOut ? ButtonStyle.Secondary : ButtonStyle.Success)
-            .setDisabled(cashedOut),
-    );
-}
-
 // ── Final result embed ───────────────────────────────────────────────────────
 async function buildFinalEmbed(crashPoint, bet, players, client, guildId) {
     const crashLabel = multLabel(crashPoint);
@@ -165,8 +155,9 @@ module.exports = {
     async execute(interaction) {
         const bet  = interaction.options.getInteger('bet');
         const user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
-        if (!await confirmBet(interaction, bet, user?.balance ?? 0, 'Crash')) return;
-        await interaction.deferReply();
+        const { shouldProceed, alreadyReplied } = await confirmBet(interaction, bet, user?.balance ?? 0, 'Crash');
+        if (!shouldProceed) return;
+        if (!alreadyReplied) await interaction.deferReply();
         await openLobby(interaction, bet);
     },
 };
@@ -251,7 +242,15 @@ async function openLobby(interaction, bet) {
             return i.reply({ content: `You need **${bet.toLocaleString()}** coins to join.`, ephemeral: true });
         }
 
-        addPlayer(channelId, i.user.id);
+        const joined = addPlayer(channelId, i.user.id);
+        if (!joined) {
+            // Lobby became full or player was added concurrently — refund the deducted bet
+            await User.findOneAndUpdate(
+                { userId: i.user.id, guildId: interaction.guild.id },
+                { $inc: { balance: bet } }
+            ).catch(err => console.error('[crash] join refund failed:', err));
+            return i.reply({ content: 'Could not join the lobby (it may have just filled up). Your coins have been refunded.', ephemeral: true });
+        }
         await i.deferUpdate().catch(() => {});
         await updateLobbyEmbed();
     });
@@ -269,12 +268,10 @@ async function openLobby(interaction, bet) {
         await startCrashGame(interaction, lobby, lobbyId);
     });
 
-    // Auto-start after join window
-    setTimeout(async () => {
-        if (!lobby.locked) {
-            lobby.locked = true;
-            joinCollector.stop('timeout');
-        }
+    // Auto-start after join window. Only stop the collector; the 'end' handler
+    // is responsible for setting lobby.locked and calling startCrashGame.
+    setTimeout(() => {
+        if (!lobby.locked) joinCollector.stop('timeout');
     }, LOBBY_JOIN_WINDOW_MS);
 }
 
@@ -290,7 +287,7 @@ async function startCrashGame(interaction, lobby, lobbyId) {
         ? Math.min(100.00, parseFloat((generateCrashPoint() * 1.2).toFixed(2)))
         : generateCrashPoint();
 
-    // Instant crash — refund everyone and done
+    // Instant crash (1% chance) — standard loss, no reaction time
     if (crash <= 1.00) {
         const finalEmbed = await buildFinalEmbed(crash, bet, lobby.players, interaction.client, guildId);
         deleteLobby(channelId);

--- a/src/games/casino/cupgame.js
+++ b/src/games/casino/cupgame.js
@@ -287,8 +287,9 @@ module.exports = {
             });
         }
 
-        if (!await confirmBet(interaction, bet, user.balance, 'Cup Game', guildSettings)) return;
-        await interaction.deferReply();
+        const { shouldProceed: cgProceed, alreadyReplied: cgReplied } = await confirmBet(interaction, bet, user.balance, 'Cup Game', guildSettings);
+        if (!cgProceed) return;
+        if (!cgReplied) await interaction.deferReply();
         await playCupGame(interaction, bet);
     },
 };

--- a/src/games/casino/higherlower.js
+++ b/src/games/casino/higherlower.js
@@ -157,10 +157,9 @@ module.exports = {
             Guild.findOne({ guildId: interaction.guild.id })
         ]);
         const wallet = user?.balance ?? 0;
-        if (!await confirmBet(interaction, bet, wallet, 'Higher or Lower', guildSettings)) return;
-        // Acknowledge immediately so Discord doesn't reject the interaction
-        // while User.findOneAndUpdate runs.
-        await interaction.deferReply();
+        const { shouldProceed: hlProceed, alreadyReplied: hlReplied } = await confirmBet(interaction, bet, wallet, 'Higher or Lower', guildSettings);
+        if (!hlProceed) return;
+        if (!hlReplied) await interaction.deferReply();
         try {
             if (guildSettings?.economy?.enabled === false || guildSettings?.economy?.gamesEnabled === false) {
                 return interaction.editReply({ content: 'Economy games are disabled in this server.' });

--- a/src/games/casino/keno.js
+++ b/src/games/casino/keno.js
@@ -257,8 +257,9 @@ module.exports = {
             });
         }
 
-        if (!await confirmBet(interaction, bet, user.balance, 'Keno', guildSettings)) return;
-        await interaction.deferReply();
+        const { shouldProceed: knProceed, alreadyReplied: knReplied } = await confirmBet(interaction, bet, user.balance, 'Keno', guildSettings);
+        if (!knProceed) return;
+        if (!knReplied) await interaction.deferReply();
         await playKeno(interaction, bet, uniquePicked.sort((a, b) => a - b));
     },
 };

--- a/src/games/casino/poker.js
+++ b/src/games/casino/poker.js
@@ -402,8 +402,9 @@ module.exports = {
             });
         }
 
-        if (!await confirmBet(interaction, bet, user.balance, 'Poker', guildSettings)) return;
-        await interaction.deferReply();
+        const { shouldProceed: pkProceed, alreadyReplied: pkReplied } = await confirmBet(interaction, bet, user.balance, 'Poker', guildSettings);
+        if (!pkProceed) return;
+        if (!pkReplied) await interaction.deferReply();
         await playPoker(interaction, bet);
     },
 };

--- a/src/games/casino/roulette.js
+++ b/src/games/casino/roulette.js
@@ -185,9 +185,9 @@ module.exports = {
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
         const user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
         const wallet = user?.balance ?? 0;
-        if (!await confirmBet(interaction, bet, wallet, 'Roulette', guildSettings)) return;
-
-        await interaction.deferReply();
+        const { shouldProceed: rProceed, alreadyReplied: rReplied } = await confirmBet(interaction, bet, wallet, 'Roulette', guildSettings);
+        if (!rProceed) return;
+        if (!rReplied) await interaction.deferReply();
         await playRoulette(interaction, betKey, bet, target);
     },
 };

--- a/src/games/casino/slots.js
+++ b/src/games/casino/slots.js
@@ -168,8 +168,9 @@ module.exports = {
         const bet = interaction.options.getInteger('bet');
         const user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
         const wallet = user?.balance ?? 0;
-        if (!await confirmBet(interaction, bet, wallet, 'Slots')) return;
-        await interaction.deferReply();
+        const { shouldProceed: slProceed, alreadyReplied: slReplied } = await confirmBet(interaction, bet, wallet, 'Slots');
+        if (!slProceed) return;
+        if (!slReplied) await interaction.deferReply();
         await playSlots(interaction, bet);
     },
 };

--- a/src/models/MarketListing.js
+++ b/src/models/MarketListing.js
@@ -1,0 +1,18 @@
+const { Schema, model } = require('mongoose');
+
+const marketListingSchema = new Schema({
+    guildId:      { type: String, required: true },
+    sellerId:     { type: String, required: true },
+    itemId:       { type: String, required: true },
+    quantity:     { type: Number, required: true, min: 1 },
+    pricePerUnit: { type: Number, required: true, min: 1 },
+    listedAt:     { type: Date, default: Date.now },
+    expiresAt:    { type: Date, required: true },
+});
+
+// TTL index for automatic expiry cleanup (MongoDB removes docs after expiresAt)
+marketListingSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+marketListingSchema.index({ guildId: 1, itemId: 1, pricePerUnit: 1 });
+marketListingSchema.index({ guildId: 1, sellerId: 1 });
+
+module.exports = model('MarketListing', marketListingSchema);

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -459,6 +459,7 @@ userSchema.set('optimisticConcurrency', true);
 userSchema.index({ userId: 1, guildId: 1 }, { unique: true });
 userSchema.index({ guildId: 1, 'streak.current': -1 });
 userSchema.index({ guildId: 1, 'streak.longest': -1 });
+userSchema.index({ guildId: 1, duelWins: -1 });
 
 userSchema.pre('save', function(next) {
     this.updatedAt = Date.now();

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -436,6 +436,14 @@ const userSchema = new Schema({
         claimed:  { type: Boolean, default: false }
     }],
 
+    // Duel win/loss tracking
+    duelWins:   { type: Number, default: 0 },
+    duelLosses: { type: Number, default: 0 },
+
+    // Gift cap tracking (daily outgoing coin gifts)
+    dailyGiftSent:  { type: Number, default: 0 },
+    dailyGiftReset: { type: Date,   default: null },
+
     // Lifetime stats used for achievement checks
     lifetimeGambled: { type: Number, default: 0 },
     successfulRobs:  { type: Number, default: 0 },

--- a/src/services/effectsService.js
+++ b/src/services/effectsService.js
@@ -149,6 +149,14 @@ function getServerXpMultiplier(guildSettings) {
     return sb.multiplier ?? 1.5;
 }
 
+// Returns public-safe protection status for a target user (omits padlock intentionally).
+function getPublicProtectionStatus(user) {
+    pruneEffects(user);
+    const shield = user.activeEffects.find(e => e.type === 'shield');
+    const cloak  = user.activeEffects.find(e => e.type === 'invisibility_cloak');
+    return { shield: shield ?? null, cloak: cloak ?? null };
+}
+
 module.exports = {
     EFFECT_CONFIGS,
     resolveEffectType,
@@ -164,4 +172,5 @@ module.exports = {
     getLuckyStreakBonus,
     getServerCoinMultiplier,
     getServerXpMultiplier,
+    getPublicProtectionStatus,
 };

--- a/src/utils/confirmBet.js
+++ b/src/utils/confirmBet.js
@@ -2,16 +2,22 @@ const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('
 
 const DEFAULT_THRESHOLD = 10_000;
 
+/**
+ * Returns { shouldProceed: boolean, alreadyReplied: boolean }.
+ * alreadyReplied is true when a confirmation prompt was sent (so callers must
+ * NOT call interaction.deferReply() afterwards — the interaction is already
+ * acknowledged by the ephemeral prompt).
+ */
 async function confirmBet(interaction, amount, walletBalance, gameName, guildSettings = null) {
     const economy = guildSettings?.economy || {};
     const configured = economy.betConfirmThreshold;
-    if (configured === 0) return true;
+    if (configured === 0) return { shouldProceed: true, alreadyReplied: false };
 
     const threshold = typeof configured === 'number' && configured > 0
         ? configured
         : Math.min(DEFAULT_THRESHOLD, Math.floor(walletBalance * 0.5));
 
-    if (amount <= threshold) return true;
+    if (amount <= threshold) return { shouldProceed: true, alreadyReplied: false };
 
     const currency = economy.currency || '💰';
     const pct = walletBalance > 0 ? Math.round((amount / walletBalance) * 100) : 100;
@@ -41,14 +47,14 @@ async function confirmBet(interaction, amount, walletBalance, gameName, guildSet
 
         if (response.customId === 'confirm_large_bet') {
             await response.update({ content: '✅ Bet confirmed.', embeds: [], components: [] });
-            return true;
+            return { shouldProceed: true, alreadyReplied: true };
         }
 
         await response.update({ content: '❌ Bet cancelled. Your coins are safe.', embeds: [], components: [] });
-        return false;
+        return { shouldProceed: false, alreadyReplied: true };
     } catch {
         await interaction.editReply({ content: '⏱️ Bet cancelled. Your coins are safe.', embeds: [], components: [] }).catch(() => {});
-        return false;
+        return { shouldProceed: false, alreadyReplied: true };
     }
 }
 

--- a/src/utils/crashLobby.js
+++ b/src/utils/crashLobby.js
@@ -1,0 +1,53 @@
+// In-memory lobby state for multiplayer crash. One active lobby per channel.
+// Keyed by channelId.
+
+const lobbies = new Map();
+
+const LOBBY_JOIN_WINDOW_MS = 30_000;
+const MAX_PLAYERS          = 10;
+
+/**
+ * Creates a new lobby. Returns the lobby object or null if one already exists.
+ */
+function createLobby(channelId, hostId, bet) {
+    if (lobbies.has(channelId)) return null;
+    const lobby = {
+        channelId,
+        hostId,
+        bet,
+        players: new Map(), // userId -> { cashedOutAt: number|null }
+        locked:  false,
+        started: false,
+        joinDeadline: Date.now() + LOBBY_JOIN_WINDOW_MS,
+        interval: null,
+    };
+    lobbies.set(channelId, lobby);
+    return lobby;
+}
+
+function getLobby(channelId) {
+    return lobbies.get(channelId) ?? null;
+}
+
+function deleteLobby(channelId) {
+    const lobby = lobbies.get(channelId);
+    if (lobby?.interval) clearInterval(lobby.interval);
+    lobbies.delete(channelId);
+}
+
+function addPlayer(channelId, userId) {
+    const lobby = lobbies.get(channelId);
+    if (!lobby || lobby.locked || lobby.players.size >= MAX_PLAYERS) return false;
+    if (lobby.players.has(userId)) return false;
+    lobby.players.set(userId, { cashedOutAt: null });
+    return true;
+}
+
+module.exports = {
+    LOBBY_JOIN_WINDOW_MS,
+    MAX_PLAYERS,
+    createLobby,
+    getLobby,
+    deleteLobby,
+    addPlayer,
+};


### PR DESCRIPTION
## Summary
This PR transforms the crash game from a single-player experience into a multiplayer lobby-based system, and introduces a new player-to-player marketplace for trading items. It also adds gift functionality and rob status checking.

## Key Changes

### Crash Game Refactor (Multiplayer)
- **Lobby System**: Replaced single-player crash with a pre-game lobby phase where players join within a 30-second window before the game starts
  - Host can start early; auto-starts after join window expires
  - Supports up to 10 players per lobby
  - One active lobby per channel to prevent conflicts
- **Game Flow**: 
  - `openLobby()` creates a lobby and collects join requests via buttons
  - `startCrashGame()` runs the multiplayer game with shared multiplier and per-player cash-out tracking
  - Final embed shows all players' outcomes (who cashed out, who lost)
- **Embed Updates**: Simplified embeds to remove single-player context; added `liveMultiEmbed()` and `buildFinalEmbed()` for multiplayer display
- **Utility Module**: Created `src/utils/crashLobby.js` for in-memory lobby state management (keyed by channel ID)

### New Marketplace Command (`/market`)
- **List Items**: Players can list items from inventory for sale with custom pricing (5% market fee on sale)
- **Browse Listings**: View active listings with pagination, optional item filtering, and seller info
- **Buy Listings**: Atomically purchase listings with race-condition protection (prevents double-buys)
- **Cancel Listings**: Sellers can cancel and reclaim items
- **Soulbound Items**: Certain items (lifesaver, streak_shield) cannot be listed
- **TTL**: Listings auto-expire after 48 hours via MongoDB TTL index
- **Model**: New `MarketListing` schema with guildId, sellerId, itemId, quantity, price, and expiry tracking

### New Gift Command (`/gift`)
- **Coin Gifting**: Send coins to other users with a daily cap (10,000 coins/day per sender)
- **Item Gifting**: Transfer inventory items to other users
- **Restrictions**: Cannot gift soulbound items or actively equipped effects; cannot gift to self or bots
- **Tracking**: Daily gift cap resets every 24 hours; stored in User model

### New Rob Status Command (`/robstatus`)
- **Spy Feature**: Check a target's active protections (Shield, Invisibility Cloak) before robbing
- **Immunity Display**: Shows remaining rob immunity if recently robbed
- **Cooldown**: 2-minute per-user cooldown to prevent spam
- **Omits Padlock**: Intentionally hides padlock status for strategic uncertainty

### Model Updates
- **User Schema**: Added `duelWins`, `duelLosses`, `dailyGiftSent`, `dailyGiftReset` fields
- **Duel Tracking**: Win/loss counts now incremented on duel completion (in `duel.js`)
- **Leaderboard**: Added 'duels' category to show most duel wins

### Code Quality
- Removed unused `THUMB` constant and `embedAuthor()` helper from crash.js
- Simplified `crashColor()` to remove unused `cashedOut` parameter
- Removed redundant comments; streamlined progress bar logic
- Atomic database operations to prevent race conditions in marketplace and duel settlement

## Notable Implementation Details
- **In-Memory Lobbies**: Crash lobbies stored in-memory per channel; cleared on game end or bot restart
- **Multiplayer State**: Each player in a lobby tracks their own `cashedOutAt` value independently
- **Market Fee Burn**: 5% of marketplace transactions are deducted and not credited to anyone (house cut)
- **Cooldown Maps**: Rob status and other cooldowns use in-memory Maps (reset on restart)
- **Atomic Transactions**: Marketplace buys use `findOneAndDelete()` to prevent double-purchases; User balance updates use `$gte` conditions

https://claude.ai/code/session_0143DevFkPfvuAMw9KWwF8zR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Duel records now track wins/losses with dedicated leaderboard
  * `/duel` command accepts optional game selection (coinflip/dice/highercard/rps/random)
  * New `/gift` command to trade coins or items with other players
  * New `/market` command for player marketplace (list, browse, buy, cancel listings)
  * New `/robstatus` command to check another player's protection status
  * Crash game now supports multiplayer lobbies
  * Leaderboard expanded to include streaks and duel rankings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/clawdia/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->