### PR TITLE
Add season pass, pet system, server wars, and showcase features

### DIFF
--- a/src/commands/economy/pet.js
+++ b/src/commands/economy/pet.js
@@ -62,6 +62,7 @@ async function syncHungerAndRunaway(user, interaction) {
     for (let i = 0; i < keepPets.length; i++) {
         const d = keepPets[i];
         user.pets[i].hunger = d.hunger;
+        user.pets[i].lastFed = d.lastFed;   // persist advanced decay cursor
         user.pets[i].starving = d.starving;
         if (d.starvingStartAt) user.pets[i].starvingStartAt = d.starvingStartAt;
     }
@@ -145,9 +146,9 @@ async function executeAdopt(interaction) {
 }
 
 async function executeStatus(interaction) {
-    const user = await resolveUser(interaction);
-
     await interaction.deferReply();
+
+    const user = await resolveUser(interaction);
     await syncHungerAndRunaway(user, interaction);
 
     if (!user.pets || user.pets.length === 0) {
@@ -192,9 +193,9 @@ async function executeFeed(interaction) {
     const materialId = interaction.options.getString('material');
     const petIndex = interaction.options.getInteger('slot') ?? 0;
 
-    const user = await resolveUser(interaction);
-
     await interaction.deferReply();
+
+    const user = await resolveUser(interaction);
     await syncHungerAndRunaway(user, interaction);
 
     if (!user.pets || user.pets.length === 0) {
@@ -322,6 +323,7 @@ module.exports = {
     data: new SlashCommandBuilder()
         .setName('pet')
         .setDescription('Manage your pets.')
+        .setDMPermission(false)
         .addSubcommand(sub =>
             sub.setName('adopt')
                 .setDescription('Adopt a pet from the shop.')

--- a/src/commands/economy/pet.js
+++ b/src/commands/economy/pet.js
@@ -1,0 +1,411 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const User = require('../../models/User');
+const Guild = require('../../models/Guild');
+const {
+    PET_DEFINITIONS,
+    STARVING_THRESHOLD,
+    RUNAWAY_DAYS,
+    applyHungerDecay,
+    checkRunaway,
+    feedPet
+} = require('../../services/petService');
+
+const HUNGER_BAR_LENGTH = 10;
+
+function hungerBar(hunger) {
+    const filled = Math.round((hunger / 100) * HUNGER_BAR_LENGTH);
+    const color = hunger >= STARVING_THRESHOLD ? '🟩' : '🟥';
+    return color.repeat(filled) + '⬛'.repeat(HUNGER_BAR_LENGTH - filled) + ` ${hunger}%`;
+}
+
+function getMaterialSource(user, materialId) {
+    const huntMat  = user.hunt?.materials?.[materialId] ?? 0;
+    const fishMat  = user.fishing?.materials?.[materialId] ?? 0;
+    const mineMat  = user.mining?.materials?.[materialId] ?? 0;
+    return { huntMat, fishMat, mineMat, total: huntMat + fishMat + mineMat };
+}
+
+function decrementMaterial(user, materialId) {
+    if ((user.hunt?.materials?.[materialId] ?? 0) > 0) {
+        user.hunt.materials[materialId]--;
+        user.markModified('hunt.materials');
+        return true;
+    }
+    if ((user.fishing?.materials?.[materialId] ?? 0) > 0) {
+        user.fishing.materials[materialId]--;
+        user.markModified('fishing.materials');
+        return true;
+    }
+    if ((user.mining?.materials?.[materialId] ?? 0) > 0) {
+        user.mining.materials[materialId]--;
+        user.markModified('mining.materials');
+        return true;
+    }
+    return false;
+}
+
+async function resolveUser(interaction) {
+    return User.findOneAndUpdate(
+        { userId: interaction.user.id, guildId: interaction.guild.id },
+        { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
+        { upsert: true, new: true }
+    );
+}
+
+async function syncHungerAndRunaway(user, interaction) {
+    if (!user.pets || user.pets.length === 0) return;
+
+    const decayed = applyHungerDecay(user.pets);
+    const { keepPets, ranAwayPets } = checkRunaway(decayed);
+
+    user.pets = keepPets;
+    for (let i = 0; i < keepPets.length; i++) {
+        const d = keepPets[i];
+        user.pets[i].hunger = d.hunger;
+        user.pets[i].starving = d.starving;
+        if (d.starvingStartAt) user.pets[i].starvingStartAt = d.starvingStartAt;
+    }
+    user.markModified('pets');
+
+    if (ranAwayPets.length > 0) {
+        const names = ranAwayPets.map(p => {
+            const def = PET_DEFINITIONS[p.petId];
+            const displayName = p.name || def?.name || p.petId;
+            return `${def?.emoji ?? '🐾'} **${displayName}**`;
+        });
+        await interaction.followUp({
+            content: `💔 Your pet${ranAwayPets.length > 1 ? 's' : ''} ran away from starvation: ${names.join(', ')}`,
+            ephemeral: true
+        }).catch(() => {});
+    }
+}
+
+// ── Subcommand handlers ───────────────────────────────────────────────────────
+
+async function executeAdopt(interaction) {
+    const petId = interaction.options.getString('type');
+    const def = PET_DEFINITIONS[petId];
+
+    if (!def) {
+        return interaction.reply({ content: 'Unknown pet type.', ephemeral: true });
+    }
+    if (!def.purchasable) {
+        return interaction.reply({
+            content: `${def.emoji} **${def.name}** can only be obtained as a legendary drop — it's not sold in any shop!`,
+            ephemeral: true
+        });
+    }
+
+    const [user, guildSettings] = await Promise.all([
+        resolveUser(interaction),
+        Guild.findOne({ guildId: interaction.guild.id })
+    ]);
+
+    if (guildSettings?.economy?.enabled === false) {
+        return interaction.reply({ content: 'The economy is disabled in this server.', ephemeral: true });
+    }
+
+    if ((user.pets ?? []).some(p => p.petId === petId)) {
+        return interaction.reply({ content: `You already own a ${def.emoji} **${def.name}**!`, ephemeral: true });
+    }
+
+    if (user.balance < def.cost) {
+        const currency = guildSettings?.economy?.currency ?? '💰';
+        return interaction.reply({
+            content: `You need **${def.cost.toLocaleString()}** ${currency} to adopt this pet but only have **${user.balance.toLocaleString()}**.`,
+            ephemeral: true
+        });
+    }
+
+    user.balance -= def.cost;
+    user.pets.push({ petId, hunger: 100, lastFed: new Date(), adoptedAt: new Date() });
+    user.markModified('pets');
+
+    try {
+        await user.save();
+    } catch (err) {
+        if (err.name === 'VersionError') return interaction.reply({ content: 'Edit conflict — please try again.', ephemeral: true });
+        throw err;
+    }
+
+    const currency = guildSettings?.economy?.currency ?? '💰';
+    const embed = new EmbedBuilder()
+        .setColor('#4caf50')
+        .setTitle(`${def.emoji} New Pet Adopted!`)
+        .setDescription(`Welcome your new **${def.name}**! Take good care of it.`)
+        .addFields(
+            { name: 'Passive Bonus', value: `+${def.bonusPct}% ${def.bonusType.replace(/_/g, ' ')} (active when hunger ≥ 30%)`, inline: true },
+            { name: 'Favorite Food', value: `\`${def.favoriteMaterial}\` (restores 25 hunger)`, inline: true },
+            { name: 'Cost', value: `${def.cost.toLocaleString()} ${currency}`, inline: true }
+        )
+        .setFooter({ text: 'Use /pet feed to keep it happy!' })
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+async function executeStatus(interaction) {
+    const user = await resolveUser(interaction);
+
+    await interaction.deferReply();
+    await syncHungerAndRunaway(user, interaction);
+
+    if (!user.pets || user.pets.length === 0) {
+        return interaction.editReply('You have no pets. Use `/pet adopt` to get one!');
+    }
+
+    const fields = user.pets.map(pet => {
+        const def = PET_DEFINITIONS[pet.petId];
+        const displayName = pet.name || def?.name || pet.petId;
+        const bonusActive = pet.hunger >= STARVING_THRESHOLD;
+        const daysOwned = Math.floor((Date.now() - new Date(pet.adoptedAt).getTime()) / 86400000);
+        const starvingDays = (pet.hunger === 0 && pet.starvingStartAt)
+            ? Math.floor((Date.now() - new Date(pet.starvingStartAt).getTime()) / 86400000)
+            : 0;
+        const runawayWarning = starvingDays > 0
+            ? `\n⚠️ Starving for ${starvingDays}/${RUNAWAY_DAYS} days — feed it!`
+            : '';
+
+        return {
+            name: `${def?.emoji ?? '🐾'} ${displayName}`,
+            value: [
+                `Hunger: ${hungerBar(pet.hunger)}`,
+                `Bonus: +${def?.bonusPct ?? 0}% ${(def?.bonusType ?? '').replace(/_/g, ' ')} — ${bonusActive ? '✅ Active' : '❌ Inactive (feed me!)'}`,
+                `Days owned: ${daysOwned}${runawayWarning}`
+            ].join('\n'),
+            inline: false
+        };
+    });
+
+    const embed = new EmbedBuilder()
+        .setColor('#ff9800')
+        .setTitle('🐾 Your Pets')
+        .addFields(fields)
+        .setFooter({ text: 'Feed pets with /pet feed to keep bonuses active' })
+        .setTimestamp();
+
+    await user.save().catch(() => {});
+    return interaction.editReply({ embeds: [embed] });
+}
+
+async function executeFeed(interaction) {
+    const materialId = interaction.options.getString('material');
+    const petIndex = interaction.options.getInteger('slot') ?? 0;
+
+    const user = await resolveUser(interaction);
+
+    await interaction.deferReply();
+    await syncHungerAndRunaway(user, interaction);
+
+    if (!user.pets || user.pets.length === 0) {
+        return interaction.editReply('You have no pets to feed!');
+    }
+
+    if (petIndex < 0 || petIndex >= user.pets.length) {
+        return interaction.editReply(`Invalid pet slot. You have ${user.pets.length} pet(s) (slots 0–${user.pets.length - 1}).`);
+    }
+
+    const { total } = getMaterialSource(user, materialId);
+    if (total < 1) {
+        return interaction.editReply(`You don't have any \`${materialId}\` to feed your pet with.`);
+    }
+
+    const pet = user.pets[petIndex];
+    const def = PET_DEFINITIONS[pet.petId];
+    const result = feedPet(pet, materialId);
+
+    if (!result) return interaction.editReply('Could not feed that pet.');
+
+    decrementMaterial(user, materialId);
+    user.pets[petIndex].hunger = result.hunger;
+    user.pets[petIndex].lastFed = new Date();
+    user.pets[petIndex].starving = result.hunger < STARVING_THRESHOLD;
+    if (result.hunger >= STARVING_THRESHOLD) user.pets[petIndex].starvingStartAt = null;
+    user.markModified('pets');
+
+    try {
+        await user.save();
+    } catch (err) {
+        if (err.name === 'VersionError') return interaction.editReply('Edit conflict — please try again.');
+        throw err;
+    }
+
+    const displayName = pet.name || def?.name || pet.petId;
+    const favoriteNote = result.isFavorite ? ' *(favorite food — +25 hunger!)*' : ' *(not favorite — +10 hunger)*';
+
+    const embed = new EmbedBuilder()
+        .setColor(result.hunger >= STARVING_THRESHOLD ? '#4caf50' : '#ff5722')
+        .setTitle(`${def?.emoji ?? '🐾'} ${displayName} fed!`)
+        .addFields(
+            { name: 'Food', value: `\`${materialId}\`${favoriteNote}`, inline: true },
+            { name: 'Hunger', value: hungerBar(result.hunger), inline: false },
+            { name: 'Bonus', value: result.hunger >= STARVING_THRESHOLD ? '✅ Active' : '❌ Still inactive (need ≥ 30%)', inline: true }
+        )
+        .setTimestamp();
+
+    return interaction.editReply({ embeds: [embed] });
+}
+
+async function executeRelease(interaction) {
+    const petIndex = interaction.options.getInteger('slot');
+    const user = await resolveUser(interaction);
+
+    if (!user.pets || petIndex < 0 || petIndex >= user.pets.length) {
+        return interaction.reply({ content: 'Invalid pet slot.', ephemeral: true });
+    }
+
+    const pet = user.pets[petIndex];
+    const def = PET_DEFINITIONS[pet.petId];
+    const displayName = pet.name || def?.name || pet.petId;
+
+    user.pets.splice(petIndex, 1);
+    user.markModified('pets');
+
+    try {
+        await user.save();
+    } catch (err) {
+        if (err.name === 'VersionError') return interaction.reply({ content: 'Edit conflict — try again.', ephemeral: true });
+        throw err;
+    }
+
+    return interaction.reply({
+        content: `${def?.emoji ?? '🐾'} **${displayName}** has been released. Goodbye, friend!`,
+        ephemeral: true
+    });
+}
+
+async function executeRename(interaction) {
+    const petIndex = interaction.options.getInteger('slot');
+    const newName = interaction.options.getString('name').trim().slice(0, 32);
+    const user = await resolveUser(interaction);
+
+    if (!user.pets || petIndex < 0 || petIndex >= user.pets.length) {
+        return interaction.reply({ content: 'Invalid pet slot.', ephemeral: true });
+    }
+
+    user.pets[petIndex].name = newName;
+    user.markModified('pets');
+
+    try {
+        await user.save();
+    } catch (err) {
+        if (err.name === 'VersionError') return interaction.reply({ content: 'Edit conflict — try again.', ephemeral: true });
+        throw err;
+    }
+
+    const def = PET_DEFINITIONS[user.pets[petIndex].petId];
+    return interaction.reply({
+        content: `${def?.emoji ?? '🐾'} Pet renamed to **${newName}**!`,
+        ephemeral: true
+    });
+}
+
+async function executeList(interaction) {
+    const lines = Object.values(PET_DEFINITIONS)
+        .filter(d => d.purchasable)
+        .map(d => `${d.emoji} **${d.name}** — ${d.cost.toLocaleString()} coins\nBonus: +${d.bonusPct}% ${d.bonusType.replace(/_/g, ' ')}  |  Fave food: \`${d.favoriteMaterial}\``);
+
+    const embed = new EmbedBuilder()
+        .setColor('#ff9800')
+        .setTitle('🐾 Pet Shop')
+        .setDescription(lines.join('\n\n'))
+        .setFooter({ text: 'Rare pets (Eagle, Shark, Crystal Fox) drop from legendary hunt/fish/mine' })
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+// ── Module export ─────────────────────────────────────────────────────────────
+
+module.exports = {
+    cooldown: 5,
+    data: new SlashCommandBuilder()
+        .setName('pet')
+        .setDescription('Manage your pets.')
+        .addSubcommand(sub =>
+            sub.setName('adopt')
+                .setDescription('Adopt a pet from the shop.')
+                .addStringOption(opt =>
+                    opt.setName('type')
+                        .setDescription('Pet type to adopt')
+                        .setRequired(true)
+                        .addChoices(
+                            { name: '🐶 Dog (2,000)', value: 'dog' },
+                            { name: '🐱 Cat (2,000)', value: 'cat' },
+                            { name: '🐦 Bird (3,000)', value: 'bird' },
+                            { name: '🐠 Fish (3,000)', value: 'fish' },
+                            { name: '🦊 Fox (5,000)', value: 'fox' },
+                            { name: '🐺 Wolf (8,000)', value: 'wolf' }
+                        )
+                )
+        )
+        .addSubcommand(sub =>
+            sub.setName('status')
+                .setDescription('View your pets and their hunger levels.')
+        )
+        .addSubcommand(sub =>
+            sub.setName('feed')
+                .setDescription('Feed a pet using a hunt/fish/mine material.')
+                .addStringOption(opt =>
+                    opt.setName('material')
+                        .setDescription('Material to feed (e.g. rabbits_foot, fish_scale)')
+                        .setRequired(true)
+                )
+                .addIntegerOption(opt =>
+                    opt.setName('slot')
+                        .setDescription('Pet slot number (0 = first pet, default 0)')
+                        .setRequired(false)
+                        .setMinValue(0)
+                        .setMaxValue(9)
+                )
+        )
+        .addSubcommand(sub =>
+            sub.setName('release')
+                .setDescription('Release a pet permanently.')
+                .addIntegerOption(opt =>
+                    opt.setName('slot')
+                        .setDescription('Pet slot number (0 = first pet)')
+                        .setRequired(true)
+                        .setMinValue(0)
+                        .setMaxValue(9)
+                )
+        )
+        .addSubcommand(sub =>
+            sub.setName('rename')
+                .setDescription('Give your pet a custom name.')
+                .addIntegerOption(opt =>
+                    opt.setName('slot')
+                        .setDescription('Pet slot number (0 = first pet)')
+                        .setRequired(true)
+                        .setMinValue(0)
+                        .setMaxValue(9)
+                )
+                .addStringOption(opt =>
+                    opt.setName('name')
+                        .setDescription('New name (max 32 chars)')
+                        .setRequired(true)
+                        .setMaxLength(32)
+                )
+        )
+        .addSubcommand(sub =>
+            sub.setName('list')
+                .setDescription('View all available pets in the shop.')
+        ),
+
+    async execute(interaction) {
+        const sub = interaction.options.getSubcommand();
+        try {
+            if (sub === 'adopt')   return await executeAdopt(interaction);
+            if (sub === 'status')  return await executeStatus(interaction);
+            if (sub === 'feed')    return await executeFeed(interaction);
+            if (sub === 'release') return await executeRelease(interaction);
+            if (sub === 'rename')  return await executeRename(interaction);
+            if (sub === 'list')    return await executeList(interaction);
+        } catch (err) {
+            console.error('[pet] error:', err);
+            const msg = { content: 'Something went wrong with the pet command.', ephemeral: true };
+            if (interaction.replied || interaction.deferred) return interaction.followUp(msg);
+            return interaction.reply(msg);
+        }
+    }
+};

--- a/src/commands/economy/season.js
+++ b/src/commands/economy/season.js
@@ -1,0 +1,539 @@
+const { SlashCommandBuilder, EmbedBuilder, PermissionFlagsBits } = require('discord.js');
+const User = require('../../models/User');
+const Guild = require('../../models/Guild');
+const SeasonRecord = require('../../models/SeasonRecord');
+const { generateDailyMissions } = require('../../data/seasonMissions');
+
+// ── Battle pass tier reward definitions ──────────────────────────────────────
+// 20 tiers; alternating between coin bonuses, cosmetic badges, material bundles, rare items
+const TIER_REWARDS = [
+    { tier: 1,  coins: 500,   label: '💰 500 coins' },
+    { tier: 2,  coins: 0,     label: '🎖️ Apprentice Badge' },
+    { tier: 3,  coins: 1000,  label: '💰 1,000 coins' },
+    { tier: 4,  coins: 0,     label: '🗡️ Hunter\'s Crest Badge' },
+    { tier: 5,  coins: 2000,  label: '💰 2,000 coins' },
+    { tier: 6,  coins: 0,     label: '⚗️ Material Bundle (×5 random)' },
+    { tier: 7,  coins: 3000,  label: '💰 3,000 coins' },
+    { tier: 8,  coins: 0,     label: '🎭 Prestige Frame Badge' },
+    { tier: 9,  coins: 4000,  label: '💰 4,000 coins' },
+    { tier: 10, coins: 0,     label: '🛡️ Lifesaver (rare item)' },
+    { tier: 11, coins: 5000,  label: '💰 5,000 coins' },
+    { tier: 12, coins: 0,     label: '🌟 Elite Badge' },
+    { tier: 13, coins: 6000,  label: '💰 6,000 coins' },
+    { tier: 14, coins: 0,     label: '⚗️ Premium Material Bundle (×10)' },
+    { tier: 15, coins: 8000,  label: '💰 8,000 coins' },
+    { tier: 16, coins: 0,     label: '💫 Radiant Badge' },
+    { tier: 17, coins: 10000, label: '💰 10,000 coins' },
+    { tier: 18, coins: 0,     label: '🔥 Legend Badge' },
+    { tier: 19, coins: 15000, label: '💰 15,000 coins' },
+    { tier: 20, coins: 0,     label: '❄️ Streak Shield (rare item)' }
+];
+
+const XP_PER_TIER = 100;
+const MAX_TIERS = 20;
+
+function getTierFromXp(xp) {
+    return Math.min(MAX_TIERS, Math.floor(xp / XP_PER_TIER));
+}
+
+function xpProgressBar(xp) {
+    const currentTier = getTierFromXp(xp);
+    if (currentTier >= MAX_TIERS) return 'MAX TIER ✅';
+    const xpInTier = xp % XP_PER_TIER;
+    const pct = xpInTier / XP_PER_TIER;
+    const filled = Math.round(pct * 10);
+    return `${'█'.repeat(filled)}${'░'.repeat(10 - filled)} ${xpInTier}/${XP_PER_TIER} XP (Tier ${currentTier} → ${currentTier + 1})`;
+}
+
+async function ensureMissions(user) {
+    const now = new Date();
+    const todayUtc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+
+    if (!user.seasonMissionsDate || new Date(user.seasonMissionsDate).getTime() < todayUtc.getTime()) {
+        user.seasonMissions = generateDailyMissions();
+        user.seasonMissionsDate = todayUtc;
+        user.markModified('seasonMissions');
+        user.markModified('seasonMissionsDate');
+    }
+}
+
+// ── Subcommand handlers ───────────────────────────────────────────────────────
+
+async function executeView(interaction) {
+    const [user, guildSettings] = await Promise.all([
+        User.findOneAndUpdate(
+            { userId: interaction.user.id, guildId: interaction.guild.id },
+            { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
+            { upsert: true, new: true }
+        ),
+        Guild.findOne({ guildId: interaction.guild.id })
+    ]);
+
+    const season = guildSettings?.season;
+    if (!season?.enabled || !season?.seasonId) {
+        return interaction.reply({ content: 'No active season pass is running on this server right now.', ephemeral: true });
+    }
+
+    await ensureMissions(user);
+
+    const userXp = user.season?.xp ?? 0;
+    const currentTier = getTierFromXp(userXp);
+    const claimedTiers = new Set(user.season?.claimedTiers ?? []);
+    const currency = guildSettings?.economy?.currency ?? '💰';
+
+    const nextRewards = TIER_REWARDS
+        .filter(r => r.tier > currentTier)
+        .slice(0, 5)
+        .map(r => `Tier ${r.tier}: ${r.label}`)
+        .join('\n') || 'All tiers unlocked! 🎉';
+
+    const endsIn = season.endDate
+        ? `<t:${Math.floor(new Date(season.endDate).getTime() / 1000)}:R>`
+        : '*No end date set*';
+
+    const embed = new EmbedBuilder()
+        .setColor('#5865f2')
+        .setTitle(`🎫 ${season.name ?? 'Season Pass'}`)
+        .addFields(
+            { name: '📊 Your Progress', value: xpProgressBar(userXp) },
+            { name: '🏆 Current Tier', value: `**Tier ${currentTier} / ${MAX_TIERS}**`, inline: true },
+            { name: '⏰ Season Ends', value: endsIn, inline: true },
+            { name: '🎁 Upcoming Rewards', value: nextRewards },
+            {
+                name: '📋 Today\'s Missions',
+                value: (user.seasonMissions ?? []).map(m =>
+                    `${m.completed ? '✅' : '🔲'} ${m.description} (${m.progress}/${m.target}) → +${m.seasonXp} XP, ${m.coinReward} ${currency}`
+                ).join('\n') || '*No missions generated*'
+            }
+        )
+        .setFooter({ text: `Season XP: ${userXp} total | Use /season claim to collect tier rewards` })
+        .setTimestamp();
+
+    await user.save().catch(() => {});
+    return interaction.reply({ embeds: [embed] });
+}
+
+async function executeClaim(interaction) {
+    const tier = interaction.options.getInteger('tier');
+    const [user, guildSettings] = await Promise.all([
+        User.findOneAndUpdate(
+            { userId: interaction.user.id, guildId: interaction.guild.id },
+            { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
+            { upsert: true, new: true }
+        ),
+        Guild.findOne({ guildId: interaction.guild.id })
+    ]);
+
+    const season = guildSettings?.season;
+    if (!season?.enabled || !season?.seasonId) {
+        return interaction.reply({ content: 'No active season pass is running.', ephemeral: true });
+    }
+
+    const currency = guildSettings?.economy?.currency ?? '💰';
+    const userXp = user.season?.xp ?? 0;
+    const unlockedTier = getTierFromXp(userXp);
+    const claimedTiers = new Set(user.season?.claimedTiers ?? []);
+
+    if (tier > MAX_TIERS || tier < 1) {
+        return interaction.reply({ content: `Tier must be between 1 and ${MAX_TIERS}.`, ephemeral: true });
+    }
+    if (tier > unlockedTier) {
+        return interaction.reply({
+            content: `You haven't unlocked Tier ${tier} yet! You're at Tier ${unlockedTier}.`,
+            ephemeral: true
+        });
+    }
+    if (claimedTiers.has(tier)) {
+        return interaction.reply({ content: `You've already claimed Tier ${tier}'s reward!`, ephemeral: true });
+    }
+
+    const reward = TIER_REWARDS.find(r => r.tier === tier);
+    if (!reward) return interaction.reply({ content: 'Invalid tier.', ephemeral: true });
+
+    user.season.claimedTiers.push(tier);
+    if (reward.coins > 0) user.balance += reward.coins;
+    user.markModified('season');
+
+    try {
+        await user.save();
+    } catch (err) {
+        if (err.name === 'VersionError') return interaction.reply({ content: 'Edit conflict — try again.', ephemeral: true });
+        throw err;
+    }
+
+    const embed = new EmbedBuilder()
+        .setColor('#ffd700')
+        .setTitle(`🎁 Tier ${tier} Reward Claimed!`)
+        .setDescription(`You received: **${reward.label}**${reward.coins > 0 ? `\n+${reward.coins.toLocaleString()} ${currency} added to your wallet` : ''}`)
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+async function executeMissions(interaction) {
+    const [user, guildSettings] = await Promise.all([
+        User.findOneAndUpdate(
+            { userId: interaction.user.id, guildId: interaction.guild.id },
+            { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
+            { upsert: true, new: true }
+        ),
+        Guild.findOne({ guildId: interaction.guild.id })
+    ]);
+
+    const season = guildSettings?.season;
+    if (!season?.enabled) {
+        return interaction.reply({ content: 'No active season on this server.', ephemeral: true });
+    }
+
+    await ensureMissions(user);
+    const currency = guildSettings?.economy?.currency ?? '💰';
+
+    const missionLines = (user.seasonMissions ?? []).map((m, i) => {
+        const status = m.claimed ? '✅ Claimed' : m.completed ? '🎯 Complete — use /season claim-mission' : `🔲 ${m.progress}/${m.target}`;
+        return `**Mission ${i + 1}:** ${m.description}\n${status} → +${m.seasonXp} Season XP, ${m.coinReward.toLocaleString()} ${currency}`;
+    });
+
+    const resetAt = new Date();
+    resetAt.setUTCHours(24, 0, 0, 0);
+
+    const embed = new EmbedBuilder()
+        .setColor('#5865f2')
+        .setTitle('📋 Daily Missions')
+        .setDescription(missionLines.join('\n\n') || '*No missions generated*')
+        .setFooter({ text: `Resets at midnight UTC` })
+        .addFields({ name: '⏰ Next Reset', value: `<t:${Math.floor(resetAt.getTime() / 1000)}:R>`, inline: true })
+        .setTimestamp();
+
+    await user.save().catch(() => {});
+    return interaction.reply({ embeds: [embed] });
+}
+
+async function executeClaimMission(interaction) {
+    const missionIndex = interaction.options.getInteger('mission') - 1;
+    const [user, guildSettings] = await Promise.all([
+        User.findOneAndUpdate(
+            { userId: interaction.user.id, guildId: interaction.guild.id },
+            { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
+            { upsert: true, new: true }
+        ),
+        Guild.findOne({ guildId: interaction.guild.id })
+    ]);
+
+    const season = guildSettings?.season;
+    if (!season?.enabled) return interaction.reply({ content: 'No active season.', ephemeral: true });
+
+    await ensureMissions(user);
+    const currency = guildSettings?.economy?.currency ?? '💰';
+    const mission = user.seasonMissions?.[missionIndex];
+
+    if (!mission) return interaction.reply({ content: 'Invalid mission number.', ephemeral: true });
+    if (!mission.completed) return interaction.reply({ content: 'Mission not completed yet.', ephemeral: true });
+    if (mission.claimed) return interaction.reply({ content: 'Already claimed!', ephemeral: true });
+
+    user.seasonMissions[missionIndex].claimed = true;
+    if (!user.season) user.season = {};
+    user.season.xp = (user.season.xp ?? 0) + mission.seasonXp;
+    user.season.tier = getTierFromXp(user.season.xp);
+    user.balance += mission.coinReward;
+    user.markModified('seasonMissions');
+    user.markModified('season');
+
+    try {
+        await user.save();
+    } catch (err) {
+        if (err.name === 'VersionError') return interaction.reply({ content: 'Edit conflict — try again.', ephemeral: true });
+        throw err;
+    }
+
+    return interaction.reply({
+        content: `✅ Mission claimed! +**${mission.seasonXp} Season XP** and +**${mission.coinReward.toLocaleString()} ${currency}**`,
+        ephemeral: true
+    });
+}
+
+// ── Economy season (issue #238) subcommands ───────────────────────────────────
+
+async function executeLeaderboard(interaction) {
+    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const currentSeason = guildSettings?.currentSeason;
+
+    if (!currentSeason?.id) {
+        return interaction.reply({ content: 'No active economy season on this server.', ephemeral: true });
+    }
+
+    const topUsers = await User.find({ guildId: interaction.guild.id })
+        .sort({ seasonCoins: -1 })
+        .limit(10)
+        .select('userId seasonCoins');
+
+    if (topUsers.length === 0) {
+        return interaction.reply({ content: 'No season data yet.', ephemeral: true });
+    }
+
+    const currency = guildSettings?.economy?.currency ?? '💰';
+    const medals = ['🥇', '🥈', '🥉'];
+    const lines = topUsers.map((u, i) =>
+        `${medals[i] ?? `${i + 1}.`} <@${u.userId}> — **${(u.seasonCoins ?? 0).toLocaleString()}** ${currency}`
+    );
+
+    const endsAt = currentSeason.endsAt
+        ? `<t:${Math.floor(new Date(currentSeason.endsAt).getTime() / 1000)}:R>`
+        : '*No end date*';
+
+    const embed = new EmbedBuilder()
+        .setColor('#ffd700')
+        .setTitle(`📊 Season Leaderboard — ${currentSeason.name ?? currentSeason.id}`)
+        .setDescription(lines.join('\n'))
+        .addFields({ name: '⏰ Season Ends', value: endsAt, inline: true })
+        .setFooter({ text: 'Only season coins earned this season count — wallet is never reset!' })
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+async function executeSeasonMe(interaction) {
+    const [user, guildSettings] = await Promise.all([
+        User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }),
+        Guild.findOne({ guildId: interaction.guild.id })
+    ]);
+
+    const currentSeason = guildSettings?.currentSeason;
+    if (!currentSeason?.id) {
+        return interaction.reply({ content: 'No active economy season on this server.', ephemeral: true });
+    }
+
+    if (!user) {
+        return interaction.reply({ content: 'No profile found. Use an economy command first.', ephemeral: true });
+    }
+
+    const currency = guildSettings?.economy?.currency ?? '💰';
+    const rank = await User.countDocuments({
+        guildId: interaction.guild.id,
+        seasonCoins: { $gt: user.seasonCoins ?? 0 }
+    }) + 1;
+
+    const embed = new EmbedBuilder()
+        .setColor('#5865f2')
+        .setTitle(`📊 Your Season Stats — ${currentSeason.name ?? currentSeason.id}`)
+        .addFields(
+            { name: 'Season Rank', value: `#${rank}`, inline: true },
+            { name: 'Season Coins', value: `${(user.seasonCoins ?? 0).toLocaleString()} ${currency}`, inline: true }
+        )
+        .setFooter({ text: 'Season coins track earnings only — your wallet balance is unaffected' })
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+async function executeHistory(interaction) {
+    const records = await SeasonRecord.find({ guildId: interaction.guild.id })
+        .sort({ endedAt: -1 })
+        .limit(5);
+
+    if (records.length === 0) {
+        return interaction.reply({ content: 'No past seasons recorded for this server.', ephemeral: true });
+    }
+
+    const fields = records.map(r => ({
+        name: `${r.seasonName ?? r.seasonId} (ended <t:${Math.floor(new Date(r.endedAt).getTime() / 1000)}:D>)`,
+        value: r.top10.slice(0, 3).map((u, i) => {
+            const medals = ['🥇', '🥈', '🥉'];
+            return `${medals[i]} <@${u.userId}> — ${u.coins.toLocaleString()} coins`;
+        }).join('\n') || 'No data',
+        inline: false
+    }));
+
+    const embed = new EmbedBuilder()
+        .setColor('#9e9e9e')
+        .setTitle('📜 Season History')
+        .addFields(fields)
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+// Admin: start economy season
+async function executeAdminStart(interaction) {
+    if (!interaction.member.permissions.has(PermissionFlagsBits.Administrator)) {
+        return interaction.reply({ content: 'Administrator only.', ephemeral: true });
+    }
+
+    const name = interaction.options.getString('name') ?? `Season ${Date.now()}`;
+    const durationDays = interaction.options.getInteger('duration') ?? 90;
+    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+
+    if (guildSettings?.currentSeason?.id) {
+        return interaction.reply({ content: 'A season is already active. End it first with `/season end`.', ephemeral: true });
+    }
+
+    const seasonId = `season_${Date.now()}`;
+    const now = new Date();
+    const endsAt = new Date(now.getTime() + durationDays * 86400000);
+
+    await Guild.findOneAndUpdate(
+        { guildId: interaction.guild.id },
+        { $set: { currentSeason: { id: seasonId, name, startedAt: now, endsAt } } }
+    );
+
+    return interaction.reply({
+        content: `✅ Economy season **${name}** started! Ends <t:${Math.floor(endsAt.getTime() / 1000)}:R>.`,
+        ephemeral: false
+    });
+}
+
+// Admin: end economy season
+async function executeAdminEnd(interaction) {
+    if (!interaction.member.permissions.has(PermissionFlagsBits.Administrator)) {
+        return interaction.reply({ content: 'Administrator only.', ephemeral: true });
+    }
+
+    await interaction.deferReply();
+
+    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const currentSeason = guildSettings?.currentSeason;
+
+    if (!currentSeason?.id) {
+        return interaction.editReply('No active economy season to end.');
+    }
+
+    const topUsers = await User.find({ guildId: interaction.guild.id })
+        .sort({ seasonCoins: -1 })
+        .limit(10)
+        .select('userId seasonCoins');
+
+    let resolvedNames = {};
+    try {
+        for (const u of topUsers.slice(0, 3)) {
+            const member = await interaction.guild.members.fetch(u.userId).catch(() => null);
+            resolvedNames[u.userId] = member?.user?.username ?? 'Unknown';
+        }
+    } catch {}
+
+    await SeasonRecord.create({
+        guildId: interaction.guild.id,
+        seasonId: currentSeason.id,
+        seasonName: currentSeason.name,
+        startedAt: currentSeason.startedAt,
+        endedAt: new Date(),
+        top10: topUsers.map(u => ({
+            userId: u.userId,
+            username: resolvedNames[u.userId] ?? 'Unknown',
+            coins: u.seasonCoins ?? 0
+        }))
+    });
+
+    // Reset all seasonCoins for this guild
+    await User.updateMany({ guildId: interaction.guild.id }, { $set: { seasonCoins: 0 } });
+
+    // Clear currentSeason from guild
+    await Guild.findOneAndUpdate(
+        { guildId: interaction.guild.id },
+        { $set: { currentSeason: { id: null, name: null, startedAt: null, endsAt: null } } }
+    );
+
+    const medals = ['🥇', '🥈', '🥉'];
+    const winners = topUsers.slice(0, 3);
+    const winnerLines = winners.map((u, i) =>
+        `${medals[i]} <@${u.userId}> — ${(u.seasonCoins ?? 0).toLocaleString()} coins`
+    ).join('\n') || '*No participants*';
+
+    const embed = new EmbedBuilder()
+        .setColor('#ffd700')
+        .setTitle(`🏁 Season Ended: ${currentSeason.name ?? currentSeason.id}`)
+        .setDescription('The season leaderboard has been frozen and season coins have been reset.')
+        .addFields({ name: '🏆 Final Top 3', value: winnerLines })
+        .setTimestamp();
+
+    return interaction.editReply({ embeds: [embed] });
+}
+
+// ── Module export ─────────────────────────────────────────────────────────────
+
+module.exports = {
+    cooldown: 5,
+    data: new SlashCommandBuilder()
+        .setName('season')
+        .setDescription('Season pass and economy season commands.')
+        .addSubcommand(sub =>
+            sub.setName('view')
+                .setDescription('View your season pass progress and tier rewards.')
+        )
+        .addSubcommand(sub =>
+            sub.setName('claim')
+                .setDescription('Claim a tier reward from the season pass.')
+                .addIntegerOption(opt =>
+                    opt.setName('tier')
+                        .setDescription('Tier number to claim (1–20)')
+                        .setRequired(true)
+                        .setMinValue(1)
+                        .setMaxValue(20)
+                )
+        )
+        .addSubcommand(sub =>
+            sub.setName('missions')
+                .setDescription("View today's daily missions.")
+        )
+        .addSubcommand(sub =>
+            sub.setName('claim-mission')
+                .setDescription('Claim a completed daily mission reward.')
+                .addIntegerOption(opt =>
+                    opt.setName('mission')
+                        .setDescription('Mission number (1, 2, or 3)')
+                        .setRequired(true)
+                        .setMinValue(1)
+                        .setMaxValue(3)
+                )
+        )
+        .addSubcommand(sub =>
+            sub.setName('leaderboard')
+                .setDescription('View the current economy season leaderboard (top 10).')
+        )
+        .addSubcommand(sub =>
+            sub.setName('me')
+                .setDescription('View your economy season rank and coins earned.')
+        )
+        .addSubcommand(sub =>
+            sub.setName('history')
+                .setDescription('View past economy season winners.')
+        )
+        .addSubcommand(sub =>
+            sub.setName('start')
+                .setDescription('[Admin] Start a new 90-day economy season.')
+                .addStringOption(opt =>
+                    opt.setName('name')
+                        .setDescription('Season name (e.g. "Season 1")')
+                        .setRequired(false)
+                )
+                .addIntegerOption(opt =>
+                    opt.setName('duration')
+                        .setDescription('Duration in days (default 90)')
+                        .setRequired(false)
+                        .setMinValue(7)
+                        .setMaxValue(365)
+                )
+        )
+        .addSubcommand(sub =>
+            sub.setName('end')
+                .setDescription('[Admin] End the current economy season and freeze the leaderboard.')
+        ),
+
+    async execute(interaction) {
+        const sub = interaction.options.getSubcommand();
+        try {
+            if (sub === 'view')          return await executeView(interaction);
+            if (sub === 'claim')         return await executeClaim(interaction);
+            if (sub === 'missions')      return await executeMissions(interaction);
+            if (sub === 'claim-mission') return await executeClaimMission(interaction);
+            if (sub === 'leaderboard')   return await executeLeaderboard(interaction);
+            if (sub === 'me')            return await executeSeasonMe(interaction);
+            if (sub === 'history')       return await executeHistory(interaction);
+            if (sub === 'start')         return await executeAdminStart(interaction);
+            if (sub === 'end')           return await executeAdminEnd(interaction);
+        } catch (err) {
+            console.error('[season] error:', err);
+            const msg = { content: 'Something went wrong with the season command.', ephemeral: true };
+            if (interaction.replied || interaction.deferred) return interaction.followUp(msg);
+            return interaction.reply(msg);
+        }
+    }
+};

--- a/src/commands/economy/season.js
+++ b/src/commands/economy/season.js
@@ -6,6 +6,7 @@ const { generateDailyMissions } = require('../../data/seasonMissions');
 
 // ── Battle pass tier reward definitions ──────────────────────────────────────
 // 20 tiers; alternating between coin bonuses, cosmetic badges, material bundles, rare items
+// itemId present → add 1× to user.inventory on claim; cosmetic badges have no itemId
 const TIER_REWARDS = [
     { tier: 1,  coins: 500,   label: '💰 500 coins' },
     { tier: 2,  coins: 0,     label: '🎖️ Apprentice Badge' },
@@ -16,7 +17,7 @@ const TIER_REWARDS = [
     { tier: 7,  coins: 3000,  label: '💰 3,000 coins' },
     { tier: 8,  coins: 0,     label: '🎭 Prestige Frame Badge' },
     { tier: 9,  coins: 4000,  label: '💰 4,000 coins' },
-    { tier: 10, coins: 0,     label: '🛡️ Lifesaver (rare item)' },
+    { tier: 10, coins: 0,     label: '🛡️ Lifesaver (rare item)',      itemId: 'lifesaver'     },
     { tier: 11, coins: 5000,  label: '💰 5,000 coins' },
     { tier: 12, coins: 0,     label: '🌟 Elite Badge' },
     { tier: 13, coins: 6000,  label: '💰 6,000 coins' },
@@ -26,7 +27,7 @@ const TIER_REWARDS = [
     { tier: 17, coins: 10000, label: '💰 10,000 coins' },
     { tier: 18, coins: 0,     label: '🔥 Legend Badge' },
     { tier: 19, coins: 15000, label: '💰 15,000 coins' },
-    { tier: 20, coins: 0,     label: '❄️ Streak Shield (rare item)' }
+    { tier: 20, coins: 0,     label: '❄️ Streak Shield (rare item)',   itemId: 'streak_shield' }
 ];
 
 const XP_PER_TIER = 100;
@@ -150,8 +151,15 @@ async function executeClaim(interaction) {
     const reward = TIER_REWARDS.find(r => r.tier === tier);
     if (!reward) return interaction.reply({ content: 'Invalid tier.', ephemeral: true });
 
-    user.season.claimedTiers.push(tier);
+    // Guard against missing sub-document array on old docs
+    if (!Array.isArray(user.season?.claimedTiers)) {
+        if (!user.season) user.season = {};
+        user.season.claimedTiers = [];
+    }
+
     if (reward.coins > 0) user.balance += reward.coins;
+    if (reward.itemId) user.inventory.push({ itemId: reward.itemId, quantity: 1 });
+    user.season.claimedTiers.push(tier);
     user.markModified('season');
 
     try {
@@ -227,7 +235,9 @@ async function executeClaimMission(interaction) {
     const mission = user.seasonMissions?.[missionIndex];
 
     if (!mission) return interaction.reply({ content: 'Invalid mission number.', ephemeral: true });
-    if (!mission.completed) return interaction.reply({ content: 'Mission not completed yet.', ephemeral: true });
+    // Derive completion from progress vs target (completed flag is set by action handlers)
+    const isDone = mission.completed || mission.progress >= mission.target;
+    if (!isDone) return interaction.reply({ content: 'Mission not completed yet.', ephemeral: true });
     if (mission.claimed) return interaction.reply({ content: 'Already claimed!', ephemeral: true });
 
     user.seasonMissions[missionIndex].claimed = true;

--- a/src/commands/economy/showcase.js
+++ b/src/commands/economy/showcase.js
@@ -1,0 +1,150 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const User = require('../../models/User');
+const Guild = require('../../models/Guild');
+const { MATERIAL_RARITY, TIER_LABELS, TIER_STARS } = require('../../data/materialRarity');
+
+const PRESTIGE_LABELS = { 0: null, 1: '🥉 Bronze', 2: '🥈 Silver', 3: '🥇 Gold', 4: '💎 Platinum', 5: '👑 Diamond' };
+
+// Collect all materials from all three tracks into a flat list with amounts
+function collectMaterials(user) {
+    const results = [];
+    const tracks = ['hunt', 'fishing', 'mining'];
+
+    for (const track of tracks) {
+        const mats = user[track]?.materials ?? {};
+        for (const [key, qty] of Object.entries(mats)) {
+            if (qty > 0 && MATERIAL_RARITY[key]) {
+                results.push({ key, qty, ...MATERIAL_RARITY[key] });
+            }
+        }
+    }
+
+    // Sort by tier desc, then qty desc
+    results.sort((a, b) => b.tier - a.tier || b.qty - a.qty);
+    return results;
+}
+
+function collectTrophies(user) {
+    const all = [
+        ...(user.hunt?.trophies ?? []).map(t => ({ name: t, source: 'hunt' })),
+        ...(user.fishing?.trophies ?? []).map(t => ({ name: t, source: 'fish' })),
+        ...(user.mining?.trophies ?? []).map(t => ({ name: t, source: 'mine' }))
+    ];
+    return all;
+}
+
+module.exports = {
+    cooldown: 5,
+    data: new SlashCommandBuilder()
+        .setName('showcase')
+        .setDescription("Display a player's trophy case, rare materials, and achievements.")
+        .addUserOption(opt =>
+            opt.setName('user')
+                .setDescription('The player to view (defaults to yourself)')
+                .setRequired(false)
+        ),
+
+    async execute(interaction) {
+        try {
+            const target = interaction.options.getUser('user') ?? interaction.user;
+            const isSelf = target.id === interaction.user.id;
+
+            const [profileUser, guildSettings] = await Promise.all([
+                User.findOne({ userId: target.id, guildId: interaction.guild.id }),
+                Guild.findOne({ guildId: interaction.guild.id })
+            ]);
+
+            if (!profileUser) {
+                return interaction.reply({
+                    content: isSelf
+                        ? "You don't have a profile yet. Use some economy commands to get started!"
+                        : `${target.username} doesn't have a profile in this server.`,
+                    ephemeral: true
+                });
+            }
+
+            const currency = guildSettings?.economy?.currency ?? '💰';
+            const allMaterials = collectMaterials(profileUser);
+            const top5Mats = allMaterials.slice(0, 5);
+            const trophies = collectTrophies(profileUser);
+
+            // ── Trophy Case ──────────────────────────────────────────────────────
+            let trophyText;
+            if (trophies.length === 0) {
+                trophyText = '*No trophies yet — go hunt some legendaries!*';
+            } else {
+                const shown = trophies.slice(0, 6);
+                trophyText = shown.map(t => `🏆 ${t.name}`).join('  ') +
+                    (trophies.length > 6 ? `\n*...and ${trophies.length - 6} more*` : '');
+            }
+
+            // ── Rarest Materials ─────────────────────────────────────────────────
+            let matsText;
+            if (top5Mats.length === 0) {
+                matsText = '*No materials collected yet*';
+            } else {
+                matsText = top5Mats.map(m =>
+                    `${m.emoji} **${m.label}** ×${m.qty} ${TIER_STARS[m.tier]}`
+                ).join('\n');
+            }
+
+            // ── Prestige Badges ──────────────────────────────────────────────────
+            const huntPrestige  = profileUser.hunt?.prestige ?? 0;
+            const fishPrestige  = profileUser.fishing?.prestige ?? 0;
+            const minePrestige  = profileUser.mining?.prestige ?? 0;
+            const prestigeLines = [];
+            if (PRESTIGE_LABELS[huntPrestige])  prestigeLines.push(`Hunt: ${PRESTIGE_LABELS[huntPrestige]}`);
+            if (PRESTIGE_LABELS[fishPrestige])  prestigeLines.push(`Fish: ${PRESTIGE_LABELS[fishPrestige]}`);
+            if (PRESTIGE_LABELS[minePrestige])  prestigeLines.push(`Mine: ${PRESTIGE_LABELS[minePrestige]}`);
+            const prestigeText = prestigeLines.length > 0 ? prestigeLines.join('\n') : '*No prestige yet*';
+
+            // ── Recent Achievements ──────────────────────────────────────────────
+            const recentAchs = (profileUser.achievements ?? [])
+                .slice()
+                .sort((a, b) => new Date(b.earnedAt) - new Date(a.earnedAt))
+                .slice(0, 3);
+            const achText = recentAchs.length > 0
+                ? recentAchs.map(a => `🏅 \`${a.id}\``).join('  ')
+                : '*No achievements yet*';
+
+            // ── Lifetime Stats ───────────────────────────────────────────────────
+            const totalHunts = profileUser.hunt?.totalHunts ?? 0;
+            const legendaryKills = profileUser.hunt?.legendaryKills ?? 0;
+            const questsDone = profileUser.questsCompleted ?? 0;
+            const duelWins = profileUser.duelWins ?? 0;
+            const statsText = [
+                `Total Hunts: **${totalHunts.toLocaleString()}**`,
+                `Legendary Kills: **${legendaryKills.toLocaleString()}**`,
+                `Quests Completed: **${questsDone.toLocaleString()}**`,
+                `Duel Wins: **${duelWins.toLocaleString()}**`
+            ].join('   ');
+
+            // ── Build Embed ──────────────────────────────────────────────────────
+            // Pick embed color by highest rarity material tier
+            const topTier = top5Mats[0]?.tier ?? 1;
+            const colors = { 1: '#9e9e9e', 2: '#4caf50', 3: '#2196f3', 4: '#9c27b0', 5: '#ff9800' };
+            const color = colors[topTier] ?? '#5865f2';
+
+            const embed = new EmbedBuilder()
+                .setColor(color)
+                .setTitle(`${target.username}'s Showcase`)
+                .setThumbnail(target.displayAvatarURL({ dynamic: true }))
+                .addFields(
+                    { name: '🏆 Trophy Case', value: trophyText },
+                    { name: '⛏️ Rarest Materials', value: matsText },
+                    { name: '🎖️ Prestige Badges', value: prestigeText, inline: true },
+                    { name: '🏅 Recent Achievements', value: achText, inline: true },
+                    { name: '📊 Lifetime Stats', value: statsText }
+                )
+                .setFooter({ text: `Achievements: ${profileUser.achievementsCount ?? 0} earned` })
+                .setTimestamp();
+
+            return interaction.reply({ embeds: [embed] });
+        } catch (err) {
+            console.error('[showcase] error:', err);
+            const msg = { content: 'Something went wrong displaying the showcase.', ephemeral: true };
+            if (interaction.replied || interaction.deferred) return interaction.followUp(msg);
+            return interaction.reply(msg);
+        }
+    }
+};

--- a/src/commands/economy/showcase.js
+++ b/src/commands/economy/showcase.js
@@ -38,6 +38,7 @@ module.exports = {
     data: new SlashCommandBuilder()
         .setName('showcase')
         .setDescription("Display a player's trophy case, rare materials, and achievements.")
+        .setDMPermission(false)
         .addUserOption(opt =>
             opt.setName('user')
                 .setDescription('The player to view (defaults to yourself)')
@@ -128,7 +129,7 @@ module.exports = {
             const embed = new EmbedBuilder()
                 .setColor(color)
                 .setTitle(`${target.username}'s Showcase`)
-                .setThumbnail(target.displayAvatarURL({ dynamic: true }))
+                .setThumbnail(target.displayAvatarURL())
                 .addFields(
                     { name: '🏆 Trophy Case', value: trophyText },
                     { name: '⛏️ Rarest Materials', value: matsText },

--- a/src/commands/economy/war.js
+++ b/src/commands/economy/war.js
@@ -1,0 +1,360 @@
+const { SlashCommandBuilder, EmbedBuilder, PermissionFlagsBits } = require('discord.js');
+const Guild = require('../../models/Guild');
+const User = require('../../models/User');
+
+const WAR_DURATION_DAYS = 7;
+const WAR_DURATION_MS = WAR_DURATION_DAYS * 86400000;
+
+// Points earned per action during a war
+const WAR_POINTS = {
+    daily:    1,
+    work:     2,
+    hunt:     2,
+    fish:     2,
+    mine:     2,
+    quiz:     3,
+    casino:   1,
+    duel_win: 10
+};
+
+function progressBar(score, opponentScore) {
+    const total = score + opponentScore;
+    if (total === 0) return '░'.repeat(20) + ' (no points yet)';
+    const myFill = Math.round((score / total) * 20);
+    return '█'.repeat(myFill) + '░'.repeat(20 - myFill);
+}
+
+// ── Subcommand handlers ───────────────────────────────────────────────────────
+
+async function executeChallenge(interaction) {
+    if (!interaction.member.permissions.has(PermissionFlagsBits.Administrator)) {
+        return interaction.reply({ content: 'Only administrators can initiate a server war.', ephemeral: true });
+    }
+
+    const inviteCode = interaction.options.getString('invite_code').trim();
+
+    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    if (guildSettings?.activeWar?.status === 'active' || guildSettings?.activeWar?.status === 'pending') {
+        return interaction.reply({ content: 'Your server already has an active or pending war.', ephemeral: true });
+    }
+
+    await Guild.findOneAndUpdate(
+        { guildId: interaction.guild.id },
+        {
+            $set: {
+                activeWar: {
+                    status: 'pending',
+                    initiatorGuildId: interaction.guild.id,
+                    opponentGuildId: null,
+                    opponentGuildName: null,
+                    myScore: 0,
+                    opponentScore: 0,
+                    inviteCode,
+                    announcementChannelId: interaction.channelId
+                }
+            }
+        },
+        { upsert: true }
+    );
+
+    const embed = new EmbedBuilder()
+        .setColor('#ff4444')
+        .setTitle('⚔️ War Challenge Sent!')
+        .setDescription(
+            `**${interaction.guild.name}** has challenged another server to a **${WAR_DURATION_DAYS}-day war!**\n\n` +
+            `The challenged server admin must run \`/war accept\` on their bot to start the war.\n\n` +
+            `Share your server invite code: \`${inviteCode}\``
+        )
+        .addFields({
+            name: 'Scoring',
+            value: Object.entries(WAR_POINTS)
+                .map(([k, v]) => `${k.replace('_', ' ')}: **${v} pt${v > 1 ? 's' : ''}**`)
+                .join(' | ')
+        })
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+async function executeAccept(interaction) {
+    if (!interaction.member.permissions.has(PermissionFlagsBits.Administrator)) {
+        return interaction.reply({ content: 'Only administrators can accept a war.', ephemeral: true });
+    }
+
+    const challengerInvite = interaction.options.getString('challenger_invite').trim();
+
+    const myGuild = await Guild.findOne({ guildId: interaction.guild.id });
+    if (myGuild?.activeWar?.status === 'active' || myGuild?.activeWar?.status === 'pending') {
+        return interaction.reply({ content: 'Your server already has an active or pending war.', ephemeral: true });
+    }
+
+    // Find the challenger guild by invite code
+    const challengerGuild = await Guild.findOne({
+        'activeWar.inviteCode': challengerInvite,
+        'activeWar.status': 'pending'
+    });
+
+    if (!challengerGuild) {
+        return interaction.reply({
+            content: 'No pending war challenge found for that invite code. Make sure the challenger ran `/war challenge` first.',
+            ephemeral: true
+        });
+    }
+
+    if (challengerGuild.guildId === interaction.guild.id) {
+        return interaction.reply({ content: 'You can\'t accept your own war challenge.', ephemeral: true });
+    }
+
+    const now = new Date();
+    const endsAt = new Date(now.getTime() + WAR_DURATION_MS);
+
+    // Update both guilds
+    await Promise.all([
+        Guild.findOneAndUpdate(
+            { guildId: challengerGuild.guildId },
+            {
+                $set: {
+                    'activeWar.status': 'active',
+                    'activeWar.opponentGuildId': interaction.guild.id,
+                    'activeWar.opponentGuildName': interaction.guild.name,
+                    'activeWar.myScore': 0,
+                    'activeWar.opponentScore': 0,
+                    'activeWar.startedAt': now,
+                    'activeWar.endsAt': endsAt
+                }
+            }
+        ),
+        Guild.findOneAndUpdate(
+            { guildId: interaction.guild.id },
+            {
+                $set: {
+                    activeWar: {
+                        status: 'active',
+                        initiatorGuildId: challengerGuild.guildId,
+                        opponentGuildId: challengerGuild.guildId,
+                        opponentGuildName: challengerGuild.name,
+                        myScore: 0,
+                        opponentScore: 0,
+                        startedAt: now,
+                        endsAt,
+                        announcementChannelId: interaction.channelId
+                    }
+                }
+            },
+            { upsert: true }
+        )
+    ]);
+
+    const embed = new EmbedBuilder()
+        .setColor('#ff4444')
+        .setTitle('⚔️ WAR DECLARED!')
+        .setDescription(
+            `**${interaction.guild.name}** vs **${challengerGuild.name}**\n\n` +
+            `The **${WAR_DURATION_DAYS}-day war** has begun! Earn points for your server through daily activities.\n\n` +
+            `Victory: All members of the winning server receive a **2x coin booster (24h)** + a **server badge** for 30 days!`
+        )
+        .addFields(
+            { name: '⏰ War Ends', value: `<t:${Math.floor(endsAt.getTime() / 1000)}:R>`, inline: true },
+            {
+                name: 'Scoring',
+                value: Object.entries(WAR_POINTS)
+                    .map(([k, v]) => `${k.replace(/_/g, ' ')}: **${v} pt${v > 1 ? 's' : ''}**`)
+                    .join(' | ')
+            }
+        )
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+async function executeStatus(interaction) {
+    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const war = guildSettings?.activeWar;
+
+    if (!war?.status || war.status === 'ended') {
+        return interaction.reply({ content: 'No active war for this server.', ephemeral: true });
+    }
+
+    if (war.status === 'pending') {
+        return interaction.reply({
+            content: `⏳ War challenge pending. Waiting for the opponent server to run \`/war accept\`.`,
+            ephemeral: true
+        });
+    }
+
+    const now = Date.now();
+    const endsAt = new Date(war.endsAt).getTime();
+    const totalMs = WAR_DURATION_MS;
+    const elapsed = now - new Date(war.startedAt).getTime();
+    const day = Math.min(WAR_DURATION_DAYS, Math.ceil(elapsed / 86400000));
+
+    const myScore = war.myScore ?? 0;
+    const oppScore = war.opponentScore ?? 0;
+    const myName = interaction.guild.name;
+    const oppName = war.opponentGuildName ?? 'Enemy Server';
+
+    const embed = new EmbedBuilder()
+        .setColor('#ff4444')
+        .setTitle(`⚔️ Server War — Day ${day}/${WAR_DURATION_DAYS}`)
+        .setDescription(
+            `${'━'.repeat(30)}\n` +
+            `🏠 **${myName}**\n` +
+            `${progressBar(myScore, oppScore)} **${myScore.toLocaleString()} pts**\n\n` +
+            `⚔️ **${oppName}**\n` +
+            `${progressBar(oppScore, myScore)} **${oppScore.toLocaleString()} pts**\n` +
+            `${'━'.repeat(30)}`
+        )
+        .addFields(
+            { name: '⏰ Ends', value: `<t:${Math.floor(endsAt / 1000)}:R>`, inline: true },
+            {
+                name: 'Scoring',
+                value: Object.entries(WAR_POINTS)
+                    .map(([k, v]) => `${k.replace(/_/g, ' ')}: **${v} pt${v !== 1 ? 's' : ''}**`)
+                    .join(' | ')
+            }
+        )
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+async function executeCancel(interaction) {
+    if (!interaction.member.permissions.has(PermissionFlagsBits.Administrator)) {
+        return interaction.reply({ content: 'Administrator only.', ephemeral: true });
+    }
+
+    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const war = guildSettings?.activeWar;
+
+    if (!war?.status || war.status === 'ended') {
+        return interaction.reply({ content: 'No active war to cancel.', ephemeral: true });
+    }
+
+    await Guild.findOneAndUpdate(
+        { guildId: interaction.guild.id },
+        { $set: { 'activeWar.status': 'ended' } }
+    );
+
+    // Also clear the opponent's war if they're in an active one vs us
+    if (war.opponentGuildId) {
+        await Guild.findOneAndUpdate(
+            { guildId: war.opponentGuildId, 'activeWar.opponentGuildId': interaction.guild.id },
+            { $set: { 'activeWar.status': 'ended' } }
+        );
+    }
+
+    return interaction.reply({ content: '⚔️ The war has been cancelled.', ephemeral: false });
+}
+
+// ── Point granting utility (exported for use in other commands) ───────────────
+
+/**
+ * Grant war points to the guild for a given action type.
+ * Call this from daily.js, work.js, hunt.js, etc. with appropriate action type.
+ */
+async function grantWarPoints(guildId, action) {
+    const pts = WAR_POINTS[action];
+    if (!pts) return;
+
+    const guildSettings = await Guild.findOne({ guildId });
+    const war = guildSettings?.activeWar;
+
+    if (!war || war.status !== 'active') return;
+
+    // Auto-resolve expired wars
+    if (war.endsAt && Date.now() > new Date(war.endsAt).getTime()) {
+        await resolveExpiredWar(guildId, guildSettings);
+        return;
+    }
+
+    await Guild.findOneAndUpdate(
+        { guildId, 'activeWar.status': 'active' },
+        { $inc: { 'activeWar.myScore': pts } }
+    );
+
+    // Mirror the points increment to the opponent's opponentScore
+    if (war.opponentGuildId) {
+        await Guild.findOneAndUpdate(
+            { guildId: war.opponentGuildId, 'activeWar.status': 'active' },
+            { $inc: { 'activeWar.opponentScore': pts } }
+        );
+    }
+}
+
+async function resolveExpiredWar(guildId, guildSettings) {
+    const war = guildSettings?.activeWar;
+    if (!war || war.status !== 'active') return;
+
+    const myScore = war.myScore ?? 0;
+    const oppScore = war.opponentScore ?? 0;
+    const iWon = myScore >= oppScore;
+
+    await Guild.findOneAndUpdate(
+        { guildId },
+        { $set: { 'activeWar.status': 'ended' } }
+    );
+    if (war.opponentGuildId) {
+        await Guild.findOneAndUpdate(
+            { guildId: war.opponentGuildId },
+            { $set: { 'activeWar.status': 'ended' } }
+        );
+    }
+
+    // Apply 2x coin booster to all winners
+    if (iWon) {
+        const expiresAt = new Date(Date.now() + 86400000);
+        await User.updateMany(
+            { guildId },
+            { $push: { activeEffects: { type: 'coin_boost_2x', expiresAt, charges: -1 } } }
+        );
+    }
+}
+
+module.exports = {
+    cooldown: 5,
+    grantWarPoints,
+    data: new SlashCommandBuilder()
+        .setName('war')
+        .setDescription('Server vs server war events.')
+        .addSubcommand(sub =>
+            sub.setName('challenge')
+                .setDescription('[Admin] Challenge another server to a 7-day war.')
+                .addStringOption(opt =>
+                    opt.setName('invite_code')
+                        .setDescription('Your server invite code to share with the opponent')
+                        .setRequired(true)
+                )
+        )
+        .addSubcommand(sub =>
+            sub.setName('accept')
+                .setDescription('[Admin] Accept a war challenge from another server.')
+                .addStringOption(opt =>
+                    opt.setName('challenger_invite')
+                        .setDescription('The invite code from the server that challenged you')
+                        .setRequired(true)
+                )
+        )
+        .addSubcommand(sub =>
+            sub.setName('status')
+                .setDescription('View the current war scoreboard.')
+        )
+        .addSubcommand(sub =>
+            sub.setName('cancel')
+                .setDescription('[Admin] Cancel the current war.')
+        ),
+
+    async execute(interaction) {
+        const sub = interaction.options.getSubcommand();
+        try {
+            if (sub === 'challenge') return await executeChallenge(interaction);
+            if (sub === 'accept')    return await executeAccept(interaction);
+            if (sub === 'status')    return await executeStatus(interaction);
+            if (sub === 'cancel')    return await executeCancel(interaction);
+        } catch (err) {
+            console.error('[war] error:', err);
+            const msg = { content: 'Something went wrong with the war command.', ephemeral: true };
+            if (interaction.replied || interaction.deferred) return interaction.followUp(msg);
+            return interaction.reply(msg);
+        }
+    }
+};

--- a/src/commands/economy/war.js
+++ b/src/commands/economy/war.js
@@ -52,7 +52,9 @@ async function executeChallenge(interaction) {
                     inviteCode,
                     announcementChannelId: interaction.channelId
                 }
-            }
+            },
+            // Ensure new docs have the required name field
+            $setOnInsert: { name: interaction.guild.name }
         },
         { upsert: true }
     );
@@ -305,7 +307,7 @@ async function resolveExpiredWar(guildId, guildSettings) {
         const expiresAt = new Date(Date.now() + 86400000);
         await User.updateMany(
             { guildId },
-            { $push: { activeEffects: { type: 'coin_boost_2x', expiresAt, charges: -1 } } }
+            { $push: { activeEffects: { type: 'coin_booster_2x', expiresAt, charges: -1 } } }
         );
     }
 }

--- a/src/data/materialRarity.js
+++ b/src/data/materialRarity.js
@@ -1,0 +1,74 @@
+// Rarity tier mapping for all hunt/fish/mine materials
+// Tiers: 1=common, 2=uncommon, 3=rare, 4=epic, 5=legendary
+
+const MATERIAL_RARITY = {
+    // Hunt materials
+    rabbits_foot:      { tier: 1, emoji: '🐾', label: 'Rabbit\'s Foot',     source: 'hunt' },
+    acorn_cache:       { tier: 1, emoji: '🌰', label: 'Acorn Cache',         source: 'hunt' },
+    feather:           { tier: 1, emoji: '🪶', label: 'Feather',             source: 'hunt' },
+    down_feather:      { tier: 1, emoji: '🪶', label: 'Down Feather',        source: 'hunt' },
+    antler_fragment:   { tier: 2, emoji: '🦌', label: 'Antler Fragment',     source: 'hunt' },
+    tusk_shard:        { tier: 2, emoji: '🐗', label: 'Tusk Shard',          source: 'hunt' },
+    badger_pelt:       { tier: 2, emoji: '🦡', label: 'Badger Pelt',         source: 'hunt' },
+    beaver_pelt:       { tier: 2, emoji: '🦫', label: 'Beaver Pelt',         source: 'hunt' },
+    coyote_fang:       { tier: 3, emoji: '🐺', label: 'Coyote Fang',         source: 'hunt' },
+    wolf_pelt:         { tier: 3, emoji: '🐺', label: 'Wolf Pelt',           source: 'hunt' },
+    elk_antler:        { tier: 3, emoji: '🦌', label: 'Elk Antler',          source: 'hunt' },
+    lynx_fang:         { tier: 3, emoji: '🐱', label: 'Lynx Fang',          source: 'hunt' },
+    eagle_talon:       { tier: 4, emoji: '🦅', label: 'Eagle Talon',         source: 'hunt' },
+    mountain_horn:     { tier: 4, emoji: '🏔️', label: 'Mountain Horn',       source: 'hunt' },
+    bear_claw:         { tier: 4, emoji: '🐻', label: 'Bear Claw',           source: 'hunt' },
+    moose_rack:        { tier: 4, emoji: '🫎', label: 'Moose Rack',          source: 'hunt' },
+    lion_tooth:        { tier: 5, emoji: '🦁', label: 'Lion\'s Tooth',       source: 'hunt' },
+    wolverine_fur:     { tier: 5, emoji: '🦡', label: 'Wolverine Fur',       source: 'hunt' },
+    spirit_pelt:       { tier: 5, emoji: '👻', label: 'Spirit Pelt',         source: 'hunt' },
+    megaloceros_crown: { tier: 5, emoji: '⚡', label: 'Megaloceros Crown',   source: 'hunt' },
+    golden_fur:        { tier: 5, emoji: '🌟', label: 'Golden Fur',          source: 'hunt' },
+    spirit_essence:    { tier: 5, emoji: '💎', label: 'Spirit Essence',      source: 'hunt' },
+    ancient_claw:      { tier: 5, emoji: '🔮', label: 'Ancient Claw',        source: 'hunt' },
+    thunderfeather:    { tier: 5, emoji: '⚡', label: 'Thunderfeather',      source: 'hunt' },
+    spectral_bone:     { tier: 5, emoji: '💀', label: 'Spectral Bone',       source: 'hunt' },
+    bandit_mask:       { tier: 5, emoji: '🎭', label: 'Bandit Mask',         source: 'hunt' },
+
+    // Fishing materials
+    fish_scale:        { tier: 1, emoji: '🐟', label: 'Fish Scale',          source: 'fish' },
+    seaweed_bundle:    { tier: 1, emoji: '🌿', label: 'Seaweed Bundle',      source: 'fish' },
+    driftwood:         { tier: 1, emoji: '🪵', label: 'Driftwood',           source: 'fish' },
+    rare_scale:        { tier: 2, emoji: '✨', label: 'Rare Scale',          source: 'fish' },
+    old_coin:          { tier: 2, emoji: '🪙', label: 'Old Coin',            source: 'fish' },
+    pearl:             { tier: 3, emoji: '🫧', label: 'Pearl',               source: 'fish' },
+    coral_fragment:    { tier: 3, emoji: '🪸', label: 'Coral Fragment',      source: 'fish' },
+    shark_tooth:       { tier: 4, emoji: '🦈', label: 'Shark Tooth',         source: 'fish' },
+    tentacle_ink:      { tier: 4, emoji: '🦑', label: 'Tentacle Ink',        source: 'fish' },
+    mythic_scale:      { tier: 5, emoji: '💠', label: 'Mythic Scale',        source: 'fish' },
+
+    // Mining materials
+    rock_fragment:     { tier: 1, emoji: '🪨', label: 'Rock Fragment',       source: 'mine' },
+    coal_dust:         { tier: 1, emoji: '🖤', label: 'Coal Dust',           source: 'mine' },
+    copper_flake:      { tier: 1, emoji: '🟤', label: 'Copper Flake',        source: 'mine' },
+    iron_filing:       { tier: 2, emoji: '⚙️', label: 'Iron Filing',         source: 'mine' },
+    silver_dust:       { tier: 2, emoji: '🔘', label: 'Silver Dust',         source: 'mine' },
+    lead_slug:         { tier: 2, emoji: '🔩', label: 'Lead Slug',           source: 'mine' },
+    quartz_shard:      { tier: 3, emoji: '🔷', label: 'Quartz Shard',        source: 'mine' },
+    gold_nugget:       { tier: 3, emoji: '🌕', label: 'Gold Nugget',         source: 'mine' },
+    raw_sapphire:      { tier: 3, emoji: '💙', label: 'Raw Sapphire',        source: 'mine' },
+    amethyst_chip:     { tier: 3, emoji: '💜', label: 'Amethyst Chip',       source: 'mine' },
+    topaz_shard:       { tier: 3, emoji: '🟡', label: 'Topaz Shard',         source: 'mine' },
+    raw_emerald:       { tier: 4, emoji: '💚', label: 'Raw Emerald',         source: 'mine' },
+    raw_ruby:          { tier: 4, emoji: '❤️', label: 'Raw Ruby',            source: 'mine' },
+    obsidian_chip:     { tier: 4, emoji: '🖤', label: 'Obsidian Chip',       source: 'mine' },
+    platinum_dust:     { tier: 4, emoji: '⬜', label: 'Platinum Dust',       source: 'mine' },
+    raw_diamond:       { tier: 4, emoji: '💎', label: 'Raw Diamond',         source: 'mine' },
+    crystal_sliver:    { tier: 5, emoji: '🔮', label: 'Crystal Sliver',      source: 'mine' },
+    mythril_dust:      { tier: 5, emoji: '🌀', label: 'Mythril Dust',        source: 'mine' },
+    zenith_essence:    { tier: 5, emoji: '⭐', label: 'Zenith Essence',      source: 'mine' },
+    primordial_ash:    { tier: 5, emoji: '🌋', label: 'Primordial Ash',      source: 'mine' },
+    stardust:          { tier: 5, emoji: '✨', label: 'Stardust',            source: 'mine' },
+    void_essence:      { tier: 5, emoji: '🌑', label: 'Void Essence',        source: 'mine' }
+};
+
+const TIER_LABELS = { 1: 'Common', 2: 'Uncommon', 3: 'Rare', 4: 'Epic', 5: 'Legendary' };
+const TIER_STARS  = { 1: '⭐', 2: '⭐⭐', 3: '⭐⭐⭐', 4: '⭐⭐⭐⭐', 5: '⭐⭐⭐⭐⭐' };
+const TIER_COLORS = { 1: '#9e9e9e', 2: '#4caf50', 3: '#2196f3', 4: '#9c27b0', 5: '#ff9800' };
+
+module.exports = { MATERIAL_RARITY, TIER_LABELS, TIER_STARS, TIER_COLORS };

--- a/src/data/seasonMissions.js
+++ b/src/data/seasonMissions.js
@@ -121,8 +121,12 @@ const MISSION_TEMPLATES = [
  * (not truly seeded here — just random selection at generation time).
  */
 function generateDailyMissions() {
-    const shuffled = [...MISSION_TEMPLATES].sort(() => Math.random() - 0.5);
-    return shuffled.slice(0, 3).map(t => ({
+    const pool = [...MISSION_TEMPLATES];
+    for (let i = pool.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [pool[i], pool[j]] = [pool[j], pool[i]];
+    }
+    return pool.slice(0, 3).map(t => ({
         id: t.id,
         description: t.description,
         target: t.target,

--- a/src/data/seasonMissions.js
+++ b/src/data/seasonMissions.js
@@ -1,0 +1,138 @@
+// Daily mission template pool for the season pass system
+
+const MISSION_TEMPLATES = [
+    {
+        id: 'daily_claim',
+        description: 'Claim your daily reward',
+        target: 1,
+        event: 'daily',
+        seasonXp: 25,
+        coinReward: 100
+    },
+    {
+        id: 'hunt_3',
+        description: 'Complete 3 hunts',
+        target: 3,
+        event: 'hunt',
+        seasonXp: 30,
+        coinReward: 200
+    },
+    {
+        id: 'hunt_5',
+        description: 'Complete 5 hunts',
+        target: 5,
+        event: 'hunt',
+        seasonXp: 45,
+        coinReward: 350
+    },
+    {
+        id: 'fish_3',
+        description: 'Go fishing 3 times',
+        target: 3,
+        event: 'fish',
+        seasonXp: 30,
+        coinReward: 200
+    },
+    {
+        id: 'fish_5',
+        description: 'Go fishing 5 times',
+        target: 5,
+        event: 'fish',
+        seasonXp: 45,
+        coinReward: 350
+    },
+    {
+        id: 'mine_3',
+        description: 'Mine 3 times',
+        target: 3,
+        event: 'mine',
+        seasonXp: 30,
+        coinReward: 200
+    },
+    {
+        id: 'mine_5',
+        description: 'Mine 5 times',
+        target: 5,
+        event: 'mine',
+        seasonXp: 45,
+        coinReward: 350
+    },
+    {
+        id: 'work_1',
+        description: 'Complete a work shift',
+        target: 1,
+        event: 'work',
+        seasonXp: 20,
+        coinReward: 150
+    },
+    {
+        id: 'work_3',
+        description: 'Complete 3 work shifts',
+        target: 3,
+        event: 'work',
+        seasonXp: 35,
+        coinReward: 300
+    },
+    {
+        id: 'duel_win_1',
+        description: 'Win a duel',
+        target: 1,
+        event: 'duel_win',
+        seasonXp: 50,
+        coinReward: 500
+    },
+    {
+        id: 'casino_5',
+        description: 'Play 5 casino games',
+        target: 5,
+        event: 'casino',
+        seasonXp: 30,
+        coinReward: 300
+    },
+    {
+        id: 'crime_1',
+        description: 'Attempt a crime',
+        target: 1,
+        event: 'crime',
+        seasonXp: 25,
+        coinReward: 150
+    },
+    {
+        id: 'quiz_1',
+        description: 'Answer a quiz question',
+        target: 1,
+        event: 'quiz',
+        seasonXp: 20,
+        coinReward: 100
+    },
+    {
+        id: 'quiz_3',
+        description: 'Answer 3 quiz questions',
+        target: 3,
+        event: 'quiz',
+        seasonXp: 35,
+        coinReward: 250
+    }
+];
+
+/**
+ * Pick 3 random distinct missions for a given date.
+ * Uses the date string as a seed basis to keep missions consistent per day per server
+ * (not truly seeded here — just random selection at generation time).
+ */
+function generateDailyMissions() {
+    const shuffled = [...MISSION_TEMPLATES].sort(() => Math.random() - 0.5);
+    return shuffled.slice(0, 3).map(t => ({
+        id: t.id,
+        description: t.description,
+        target: t.target,
+        event: t.event,
+        seasonXp: t.seasonXp,
+        coinReward: t.coinReward,
+        progress: 0,
+        completed: false,
+        claimed: false
+    }));
+}
+
+module.exports = { MISSION_TEMPLATES, generateDailyMissions };

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -548,6 +548,28 @@ const guildSchema = new Schema({
         }]
     },
 
+    // Server vs server war
+    activeWar: {
+        opponentGuildId:   { type: String, default: null },
+        opponentGuildName: { type: String, default: null },
+        initiatorGuildId:  { type: String, default: null },
+        status:            { type: String, enum: ['pending', 'active', 'ended', null], default: null },
+        myScore:           { type: Number, default: 0 },
+        opponentScore:     { type: Number, default: 0 },
+        startedAt:         { type: Date, default: null },
+        endsAt:            { type: Date, default: null },
+        announcementChannelId: { type: String, default: null },
+        inviteCode:        { type: String, default: null }
+    },
+
+    // 90-day economy season (separate from battle pass season)
+    currentSeason: {
+        id:        { type: String, default: null },
+        name:      { type: String, default: null },
+        startedAt: { type: Date, default: null },
+        endsAt:    { type: Date, default: null }
+    },
+
     createdAt: { type: Date, default: Date.now },
     updatedAt: { type: Date, default: Date.now }
 });

--- a/src/models/SeasonRecord.js
+++ b/src/models/SeasonRecord.js
@@ -1,0 +1,19 @@
+const { Schema, model } = require('mongoose');
+
+const seasonRecordSchema = new Schema({
+    guildId:    { type: String, required: true },
+    seasonId:   { type: String, required: true },
+    seasonName: { type: String, default: null },
+    startedAt:  { type: Date, required: true },
+    endedAt:    { type: Date, required: true },
+    top10: [{
+        userId:   { type: String, required: true },
+        username: { type: String, default: 'Unknown' },
+        coins:    { type: Number, default: 0 }
+    }],
+    createdAt:  { type: Date, default: Date.now }
+});
+
+seasonRecordSchema.index({ guildId: 1, endedAt: -1 });
+
+module.exports = model('SeasonRecord', seasonRecordSchema);

--- a/src/models/SeasonRecord.js
+++ b/src/models/SeasonRecord.js
@@ -15,5 +15,6 @@ const seasonRecordSchema = new Schema({
 });
 
 seasonRecordSchema.index({ guildId: 1, endedAt: -1 });
+seasonRecordSchema.index({ guildId: 1, seasonId: 1 }, { unique: true });
 
 module.exports = model('SeasonRecord', seasonRecordSchema);

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -490,6 +490,7 @@ userSchema.index({ guildId: 1, 'streak.current': -1 });
 userSchema.index({ guildId: 1, 'streak.longest': -1 });
 userSchema.index({ guildId: 1, duelWins: -1 });
 userSchema.index({ guildId: 1, achievementsCount: -1 });
+userSchema.index({ guildId: 1, seasonCoins: -1 }); // used by executeLeaderboard / executeSeasonMe
 
 userSchema.pre('save', function(next) {
     this.updatedAt = Date.now();

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -429,6 +429,34 @@ const userSchema = new Schema({
         lastClimbedNotification:   { type: Date, default: null }
     },
 
+    // Pet system
+    pets: [{
+        petId:     { type: String, required: true },
+        name:      { type: String, default: null },
+        hunger:    { type: Number, default: 100, min: 0, max: 100 },
+        lastFed:   { type: Date, default: Date.now },
+        adoptedAt: { type: Date, default: Date.now },
+        starving:  { type: Boolean, default: false },
+        starvingStartAt: { type: Date, default: null }
+    }],
+
+    // Season pass daily missions (reset at midnight UTC)
+    seasonMissions: [{
+        id:          { type: String, required: true },
+        description: { type: String },
+        target:      { type: Number },
+        event:       { type: String },
+        seasonXp:    { type: Number },
+        coinReward:  { type: Number },
+        progress:    { type: Number, default: 0 },
+        completed:   { type: Boolean, default: false },
+        claimed:     { type: Boolean, default: false }
+    }],
+    seasonMissionsDate: { type: Date, default: null },
+
+    // Season economy tracking (separate from balance; resets each economy season)
+    seasonCoins: { type: Number, default: 0 },
+
     // Achievement tracking
     achievements: [{
         id:       { type: String, required: true },

--- a/src/services/petService.js
+++ b/src/services/petService.js
@@ -16,27 +16,40 @@ const HUNGER_RESTORE_FAVORITE = 25;
 const HUNGER_RESTORE_OTHER = 10;
 const STARVING_THRESHOLD = 30;
 const RUNAWAY_DAYS = 3;
+const MS_PER_DAY = 86400000;
 
 /**
  * Apply daily hunger decay to all pets. Call from a scheduled job or lazily on pet commands.
  * Returns the updated pet array.
+ *
+ * Idempotent: advances lastFed by the processed days so repeated calls
+ * don't re-apply the same decay. starvingStartAt is only set when hunger
+ * reaches 0 (not merely below the STARVING_THRESHOLD) so checkRunaway
+ * counts time at zero hunger only.
  */
 function applyHungerDecay(pets) {
     const now = Date.now();
     return pets.map(pet => {
         const lastFed = pet.lastFed ? new Date(pet.lastFed).getTime() : now;
-        const daysPassed = Math.floor((now - lastFed) / 86400000);
+        const daysPassed = Math.floor((now - lastFed) / MS_PER_DAY);
         if (daysPassed <= 0) return pet;
 
         const decay = daysPassed * HUNGER_DECAY_PER_DAY;
         const newHunger = Math.max(0, pet.hunger - decay);
-        const nowStarving = newHunger < STARVING_THRESHOLD;
+        // Advance the decay cursor by the days processed so re-calls are no-ops
+        const newLastFed = new Date(lastFed + daysPassed * MS_PER_DAY);
+
+        // Only start the runaway clock when hunger hits 0
+        const wasAtZero = pet.hunger === 0;
+        const nowAtZero = newHunger === 0;
+        const newStarvingStartAt = (nowAtZero && !wasAtZero) ? new Date() : pet.starvingStartAt;
 
         return {
             ...pet.toObject ? pet.toObject() : pet,
             hunger: newHunger,
-            starving: nowStarving,
-            starvingStartAt: (nowStarving && !pet.starving) ? new Date() : pet.starvingStartAt
+            lastFed: newLastFed,
+            starving: newHunger < STARVING_THRESHOLD,
+            starvingStartAt: newStarvingStartAt
         };
     });
 }
@@ -103,6 +116,7 @@ function getTotalBonus(pets, bonusType) {
 module.exports = {
     PET_DEFINITIONS,
     HUNGER_DECAY_PER_DAY,
+    MS_PER_DAY,
     STARVING_THRESHOLD,
     RUNAWAY_DAYS,
     applyHungerDecay,

--- a/src/services/petService.js
+++ b/src/services/petService.js
@@ -1,0 +1,113 @@
+// Pet definitions: passive bonuses and feeding materials
+const PET_DEFINITIONS = {
+    dog:          { petId: 'dog',         emoji: '🐶', name: 'Dog',         cost: 2000,  purchasable: true,  bonusType: 'work_earnings',    bonusPct: 5,  favoriteMaterial: 'rabbits_foot',  materialSource: 'hunt' },
+    cat:          { petId: 'cat',         emoji: '🐱', name: 'Cat',         cost: 2000,  purchasable: true,  bonusType: 'crime_success',     bonusPct: 5,  favoriteMaterial: 'feather',        materialSource: 'hunt' },
+    bird:         { petId: 'bird',        emoji: '🐦', name: 'Bird',        cost: 3000,  purchasable: true,  bonusType: 'xp_gain',           bonusPct: 10, favoriteMaterial: 'acorn_cache',    materialSource: 'hunt' },
+    fish:         { petId: 'fish',        emoji: '🐠', name: 'Fish',        cost: 3000,  purchasable: true,  bonusType: 'fish_yield',        bonusPct: 5,  favoriteMaterial: 'fish_scale',     materialSource: 'fish' },
+    fox:          { petId: 'fox',         emoji: '🦊', name: 'Fox',         cost: 5000,  purchasable: true,  bonusType: 'rob_success',       bonusPct: 8,  favoriteMaterial: 'coyote_fang',    materialSource: 'hunt' },
+    wolf:         { petId: 'wolf',        emoji: '🐺', name: 'Wolf',        cost: 8000,  purchasable: true,  bonusType: 'hunt_yield',        bonusPct: 10, favoriteMaterial: 'wolf_pelt',      materialSource: 'hunt' },
+    eagle:        { petId: 'eagle',       emoji: '🦅', name: 'Eagle',       cost: null,  purchasable: false, bonusType: 'hunt_xp',           bonusPct: 15, favoriteMaterial: 'eagle_talon',    materialSource: 'hunt' },
+    shark:        { petId: 'shark',       emoji: '🦈', name: 'Shark',       cost: null,  purchasable: false, bonusType: 'fish_yield',        bonusPct: 15, favoriteMaterial: 'shark_tooth',    materialSource: 'fish' },
+    crystal_fox:  { petId: 'crystal_fox', emoji: '💎', name: 'Crystal Fox', cost: null,  purchasable: false, bonusType: 'mine_yield',        bonusPct: 15, favoriteMaterial: 'crystal_sliver', materialSource: 'mine' }
+};
+
+const HUNGER_DECAY_PER_DAY = 10;
+const HUNGER_RESTORE_FAVORITE = 25;
+const HUNGER_RESTORE_OTHER = 10;
+const STARVING_THRESHOLD = 30;
+const RUNAWAY_DAYS = 3;
+
+/**
+ * Apply daily hunger decay to all pets. Call from a scheduled job or lazily on pet commands.
+ * Returns the updated pet array.
+ */
+function applyHungerDecay(pets) {
+    const now = Date.now();
+    return pets.map(pet => {
+        const lastFed = pet.lastFed ? new Date(pet.lastFed).getTime() : now;
+        const daysPassed = Math.floor((now - lastFed) / 86400000);
+        if (daysPassed <= 0) return pet;
+
+        const decay = daysPassed * HUNGER_DECAY_PER_DAY;
+        const newHunger = Math.max(0, pet.hunger - decay);
+        const nowStarving = newHunger < STARVING_THRESHOLD;
+
+        return {
+            ...pet.toObject ? pet.toObject() : pet,
+            hunger: newHunger,
+            starving: nowStarving,
+            starvingStartAt: (nowStarving && !pet.starving) ? new Date() : pet.starvingStartAt
+        };
+    });
+}
+
+/**
+ * Check which pets have been at zero hunger for 3+ days (runaway).
+ * Returns { keepPets, ranAwayPets }.
+ */
+function checkRunaway(pets) {
+    const now = Date.now();
+    const keepPets = [];
+    const ranAwayPets = [];
+
+    for (const pet of pets) {
+        if (pet.hunger === 0 && pet.starvingStartAt) {
+            const daysSinceStarving = (now - new Date(pet.starvingStartAt).getTime()) / 86400000;
+            if (daysSinceStarving >= RUNAWAY_DAYS) {
+                ranAwayPets.push(pet);
+                continue;
+            }
+        }
+        keepPets.push(pet);
+    }
+
+    return { keepPets, ranAwayPets };
+}
+
+/**
+ * Feed a pet with a given material. Returns { hunger, restored }.
+ */
+function feedPet(pet, materialId) {
+    const def = PET_DEFINITIONS[pet.petId];
+    if (!def) return null;
+
+    const isFavorite = def.favoriteMaterial === materialId;
+    const restored = isFavorite ? HUNGER_RESTORE_FAVORITE : HUNGER_RESTORE_OTHER;
+    const newHunger = Math.min(100, pet.hunger + restored);
+
+    return { hunger: newHunger, restored, isFavorite };
+}
+
+/**
+ * Returns the active passive bonus for a pet (only if hunger >= STARVING_THRESHOLD).
+ */
+function getPetBonus(pet) {
+    if (!pet || pet.hunger < STARVING_THRESHOLD) return null;
+    return PET_DEFINITIONS[pet.petId] ?? null;
+}
+
+/**
+ * Get total bonus of a given type from all active pets.
+ */
+function getTotalBonus(pets, bonusType) {
+    let total = 0;
+    for (const pet of pets) {
+        const bonus = getPetBonus(pet);
+        if (bonus && bonus.bonusType === bonusType) {
+            total += bonus.bonusPct;
+        }
+    }
+    return total;
+}
+
+module.exports = {
+    PET_DEFINITIONS,
+    HUNGER_DECAY_PER_DAY,
+    STARVING_THRESHOLD,
+    RUNAWAY_DAYS,
+    applyHungerDecay,
+    checkRunaway,
+    feedPet,
+    getPetBonus,
+    getTotalBonus
+};


### PR DESCRIPTION
## Summary
This PR introduces four major economy subsystems to enhance long-term player engagement and server competition:

1. **Season Pass System** (`/season`) — Battle pass with 20 tiers, daily missions, and tiered rewards
2. **Pet System** (`/pet`) — Adoptable pets with passive bonuses and hunger mechanics
3. **Server Wars** (`/war`) — Guild-vs-guild competition with point scoring and rewards
4. **Showcase Command** (`/showcase`) — Display player achievements, trophies, and rare materials

## Key Changes

### New Commands
- **`/season view`** — Display current season progress, tier, and daily missions
- **`/season claim <tier>`** — Claim tier rewards (coins, badges, items)
- **`/season missions`** — View detailed daily mission status
- **`/season claim-mission <mission>`** — Complete and claim mission rewards
- **`/season leaderboard`** — View top 10 season coin earners
- **`/season me`** — Personal season stats and rank
- **`/season history`** — View past season records and winners

- **`/pet adopt <type>`** — Adopt a purchasable pet (dog, cat, bird, fish, fox, wolf)
- **`/pet status`** — View all owned pets, hunger levels, and bonuses
- **`/pet feed <material> [slot]`** — Feed a pet to restore hunger and maintain bonuses
- **`/pet release <slot>`** — Release a pet
- **`/pet rename <slot> <name>`** — Rename a pet

- **`/war challenge <invite_code>`** — Initiate a 7-day server war
- **`/war accept <challenger_invite>`** — Accept a war challenge
- **`/war status`** — View current war progress and scoring
- **`/war cancel`** — End an active war (admin only)

- **`/showcase [user]`** — Display trophy case, rare materials, and prestige badges

### Data Models
- **User schema** — Added `pets` array, `seasonMissions`, `seasonMissionsDate`, `season` (xp, tier, claimedTiers), `seasonCoins`
- **Guild schema** — Added `activeWar` (opponent, status, scores, dates), `season` (enabled, seasonId, name, endDate)
- **New `SeasonRecord` model** — Archive completed seasons with top 10 leaderboards

### Services & Data
- **`petService.js`** — Pet definitions, hunger decay logic, feeding mechanics, runaway system
- **`seasonMissions.js`** — Daily mission templates and generation (3 random missions per day)
- **`materialRarity.js`** — Rarity tier mapping for all hunt/fish/mine materials

### Implementation Details
- **Season XP System**: 100 XP per tier, max 20 tiers; alternating coin rewards and cosmetic badges
- **Pet Hunger**: Decays 10% per day; pets run away after 3 days of starvation; favorite materials restore 25 hunger vs 10 for others
- **War Scoring**: Points awarded per action (daily: 1pt, work/hunt/fish/mine: 2pts, quiz: 3pts, duel win: 10pts)
- **Daily Missions**: Reset at midnight UTC; 3 random missions per day with season XP and coin rewards
- **Prestige Badges**: Displayed in showcase with tier labels (Bronze/Silver/Gold/Platinum/Diamond)
- **Version Error Handling**: Optimistic concurrency control for race condition prevention

## Notes
- Season missions use random selection (not cryptographically seeded) for daily variety
- Pet bonuses only apply when hunger ≥ 30% (STARVING_THRESHOLD)
- War points are tracked separately from regular economy; season coins track only season earnings
- All timestamps use Discord's relative time formatting (`<t:timestamp:R>`)

https://claude.ai/code/session_01YEV5tLExR5ADzyYPoapPHH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pet adoption and management system with feeding, care, and lifecycle mechanics
  * Season pass progression with tiered rewards, daily missions, and XP tracking
  * User showcase command displaying economy profiles, achievements, and rare materials
  * Guild-vs-guild war system with scoring, leaderboards, and admin controls

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/clawdia/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->