### PR TITLE
Add legendary drop fanfare and public announcements for tier-5 items

### DIFF
--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -555,6 +555,24 @@ async function handleCast(interaction) {
     }
 
     await interaction.editReply({ embeds: [embed] });
+
+    if (result.success && result.tier === 'legendary') {
+        const announceChannelId = guildSettings?.leveling?.announceChannel;
+        const announceChannel = announceChannelId
+            ? interaction.guild.channels.cache.get(announceChannelId) ?? interaction.channel
+            : interaction.channel;
+        const displayName = interaction.member?.displayName || interaction.user.username;
+        const announcementEmbed = new EmbedBuilder()
+            .setColor(TIER_COLORS.legendary)
+            .setTitle('✨ Legendary Catch! ✨')
+            .setDescription(
+                `**${displayName}** just pulled a ${result.fish.emoji} **${result.fish.name}** [⭐⭐⭐⭐⭐]\n` +
+                `while fishing in **${location.emoji} ${location.name}**.\n\n` +
+                `That's incredibly rare.`
+            )
+            .setTimestamp();
+        announceChannel.send({ embeds: [announcementEmbed] }).catch(() => null);
+    }
 }
 
 // ─── EMBED BUILDER ────────────────────────────────────────────────────────────
@@ -618,10 +636,18 @@ function buildCastEmbed(result, user, location, rod, currency, discordUser) {
             ? `~~${currency}${finalPayout}~~ (daily cap)`
             : `**${currency}${finalPayout.toLocaleString()}**`;
 
+        const isLegendary = tier === 'legendary';
+        const embedTitle = isLegendary
+            ? `🌊✨ LEGENDARY CATCH ✨🌊`
+            : `${fish.emoji} ${isCrit ? '✨ CRITICAL! ' : ''}${fish.name}${sizeStr}${isCrit ? ' ✨' : ''}`;
+        const embedDesc = isLegendary
+            ? `You pulled something impossible from the deep.\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  ${fish.emoji}  **${fish.name}**${sizeStr}  [⭐⭐⭐⭐⭐]\n  *${fish.flavor}*\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n\nAdded to your inventory.`
+            : `*${fish.flavor}*`;
+
         const embed = new EmbedBuilder()
             .setColor(color)
-            .setTitle(`${fish.emoji} ${isCrit ? '✨ CRITICAL! ' : ''}${fish.name}${sizeStr}${isCrit ? ' ✨' : ''}`)
-            .setDescription(`*${fish.flavor}*`)
+            .setTitle(embedTitle)
+            .setDescription(embedDesc)
             .addFields(
                 { name: 'Location', value: `${location.emoji} ${location.name}`,    inline: true },
                 { name: 'Tier',     value: tierLabel,                                inline: true },

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -486,6 +486,24 @@ async function executeStart(interaction) {
         embed.addFields({ name: '🦅 Pet XP Bonus', value: `+${result.petXpBonus} XP (${petXpPct}%)`, inline: true });
     }
     await interaction.editReply({ embeds: [embed] });
+
+    if (result.success && result.tier === 'legendary') {
+        const announceChannelId = guildSettings?.leveling?.announceChannel;
+        const announceChannel = announceChannelId
+            ? interaction.guild.channels.cache.get(announceChannelId) ?? interaction.channel
+            : interaction.channel;
+        const displayName = interaction.member?.displayName || interaction.user.username;
+        const announcementEmbed = new EmbedBuilder()
+            .setColor(TIER_COLORS.legendary)
+            .setTitle('✨ Legendary Find! ✨')
+            .setDescription(
+                `**${displayName}** just found a ${result.animal.emoji} **${result.animal.name}** [⭐⭐⭐⭐⭐]\n` +
+                `while hunting in **${zone.emoji} ${zone.name}**.\n\n` +
+                `That's incredibly rare.`
+            )
+            .setTimestamp();
+        announceChannel.send({ embeds: [announcementEmbed] }).catch(() => null);
+    }
 }
 
 function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
@@ -502,10 +520,18 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
             ? `${trophyQuality.emoji} **${trophyQuality.label}** (×${trophyQuality.multiplier.toFixed(2)})`
             : '—';
 
+        const isLegendary = tier === 'legendary';
+        const embedTitle = isLegendary
+            ? `🌟✨ LEGENDARY FIND ✨🌟`
+            : `${animal.emoji} ${isCrit ? '✨ CRITICAL! ' : ''}${trophyQuality ? trophyQuality.label + ' ' : ''}${animal.name}${isCrit ? ' ✨' : ''}`;
+        const embedDesc = isLegendary
+            ? `You found something impossible in the wild.\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  ${animal.emoji}  **${animal.name}**  [⭐⭐⭐⭐⭐]\n  *${animal.flavor}*\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n\nAdded to your inventory.`
+            : `*${animal.flavor}*`;
+
         const embed = new EmbedBuilder()
             .setColor(color)
-            .setTitle(`${animal.emoji} ${isCrit ? '✨ CRITICAL! ' : ''}${trophyQuality ? trophyQuality.label + ' ' : ''}${animal.name}${isCrit ? ' ✨' : ''}`)
-            .setDescription(`*${animal.flavor}*`)
+            .setTitle(embedTitle)
+            .setDescription(embedDesc)
             .addFields(
                 { name: 'Zone',     value: `${zone.emoji} ${zone.name}`,         inline: true },
                 { name: 'Tier',     value: `${tierLabel}`,                        inline: true },

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -372,6 +372,24 @@ async function handleDig(interaction) {
         embed.addFields({ name: '💎 Pet Bonus', value: `+${result.petYieldBonus.toLocaleString()} coins (${petMineYieldPct}% yield)`, inline: true });
     }
     await interaction.editReply({ embeds: [embed] });
+
+    if (result.success && result.tier === 'legendary') {
+        const announceChannelId = guildSettings?.leveling?.announceChannel;
+        const announceChannel = announceChannelId
+            ? interaction.guild.channels.cache.get(announceChannelId) ?? interaction.channel
+            : interaction.channel;
+        const displayName = interaction.member?.displayName || interaction.user.username;
+        const announcementEmbed = new EmbedBuilder()
+            .setColor(TIER_COLORS.legendary)
+            .setTitle('✨ Legendary Strike! ✨')
+            .setDescription(
+                `**${displayName}** just struck a ${result.ore.emoji} **${result.ore.name}** [⭐⭐⭐⭐⭐]\n` +
+                `while mining in **${depth.emoji} ${depth.name}**.\n\n` +
+                `That's incredibly rare.`
+            )
+            .setTimestamp();
+        announceChannel.send({ embeds: [announcementEmbed] }).catch(() => null);
+    }
 }
 
 // ─── PROFILE ──────────────────────────────────────────────────────────────────
@@ -1111,10 +1129,18 @@ function buildMineEmbed(result, user, depth, pickaxe, currency, discordUser) {
         const tierLabel = tier.charAt(0).toUpperCase() + tier.slice(1);
         const payoutDisplay = cappedByHard ? `~~${currency}${finalPayout}~~ (daily cap reached)` : `**${currency}${finalPayout.toLocaleString()}**`;
 
+        const isLegendary = tier === 'legendary';
+        const embedTitle = isLegendary
+            ? `⛏️✨ LEGENDARY STRIKE ✨⛏️`
+            : `${ore.emoji} ${isCrit ? '✨ CRITICAL! ' : ''}${ore.name} ${isCrit ? '✨' : ''}`;
+        const embedDesc = isLegendary
+            ? `You struck something impossible in the deep.\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  ${ore.emoji}  **${ore.name}**  [⭐⭐⭐⭐⭐]\n  *${ore.flavor}*\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n\nAdded to your inventory.`
+            : `*${ore.flavor}*`;
+
         const embed = new EmbedBuilder()
             .setColor(color)
-            .setTitle(`${ore.emoji} ${isCrit ? '✨ CRITICAL! ' : ''}${ore.name} ${isCrit ? '✨' : ''}`)
-            .setDescription(`*${ore.flavor}*`)
+            .setTitle(embedTitle)
+            .setDescription(embedDesc)
             .addFields(
                 { name: 'Depth',    value: `${depth.emoji} ${depth.name}`,         inline: true },
                 { name: 'Tier',     value: tierLabel,                               inline: true },


### PR DESCRIPTION
- Legendary (tier='legendary') fish/animal/ore catches now use a distinct embed:
  unique title (LEGENDARY CATCH / FIND / STRIKE), bordered item display with
  5-star rating, and special flavor description
- After each legendary drop, sends a public embed to the server's configured
  announcement channel (leveling.announceChannel), falling back to the command
  channel if none is set
- Embed color for legendary catches uses the existing TIER_COLORS.legendary
  (#f39c12) already defined in each data file
- Non-legendary and crit drops are unaffected

Closes #253

https://claude.ai/code/session_01TvxwKXeQNAs1Q8ZAWLnXMS