### PR TITLE
Fix mobile layout: max 3 inline fields, critical numbers in description

### DIFF
--- a/src/commands/economy/crime.js
+++ b/src/commands/economy/crime.js
@@ -80,7 +80,7 @@ module.exports = {
             .addFields(
                 choices.map(c => ({
                     name: `${c.emoji} ${c.displayName}`,
-                    value: `${c.riskLabel}\n[${c.riskTag}]`,
+                    value: `${c.riskLabel}\n🎯 ${Math.round(c.successRate * 100)}% success\n💵 ${c.minPayout}–${c.maxPayout}  ·  Fine: ${c.minFine}–${c.maxFine}`,
                     inline: true,
                 }))
             )

--- a/src/commands/economy/work.js
+++ b/src/commands/economy/work.js
@@ -272,7 +272,7 @@ module.exports = {
 
                 const challengeDescription = performance.exceptional
                     ? `${scenario}\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  ${currency} **${displayEarned.toLocaleString()} coins**  ·  🔥 ${performance.multiplier}x performance\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n${careerValueIndented}\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  Balance: ${currency} ${displayBalance.toLocaleString()} coins`
-                    : `${scenario}\n\n${currency} ${displayBalance.toLocaleString()} coins`;
+                    : `${scenario}\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  💰 **${displayEarned.toLocaleString()} coins**${bonusStr}\n  Balance: ${currency} ${displayBalance.toLocaleString()} coins\n━━━━━━━━━━━━━━━━━━━━━━━━━━`;
 
                 const workEmbed = new EmbedBuilder()
                     .setColor(performance.color)
@@ -283,7 +283,6 @@ module.exports = {
 
                 if (!performance.exceptional) {
                     workEmbed.addFields(
-                        { name: '💰 Earned',      value: `**${displayEarned.toLocaleString()}** coins${bonusStr}`, inline: true },
                         { name: '📊 Performance', value: performance.label, inline: true },
                         { name: '📈 Career',      value: careerValue, inline: false }
                     );
@@ -310,7 +309,7 @@ module.exports = {
             // Normal (no challenge) path
             const normalDescription = performance.exceptional
                 ? `${scenario}\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  ${currency} **${finalEarned.toLocaleString()} coins**  ·  🔥 ${performance.multiplier}x performance\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n${careerValueIndented}\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  Balance: ${currency} ${updated.balance.toLocaleString()} coins`
-                : `${scenario}\n\n${currency} ${updated.balance.toLocaleString()} coins`;
+                : `${scenario}\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  💰 **${finalEarned.toLocaleString()} coins**${bonusStr}\n  Balance: ${currency} ${updated.balance.toLocaleString()} coins\n━━━━━━━━━━━━━━━━━━━━━━━━━━`;
 
             const embed = new EmbedBuilder()
                 .setColor(performance.color)
@@ -321,7 +320,6 @@ module.exports = {
 
             if (!performance.exceptional) {
                 embed.addFields(
-                    { name: '💰 Earned',      value: `**${finalEarned.toLocaleString()}** coins${bonusStr}`, inline: true },
                     { name: '📊 Performance', value: performance.label, inline: true },
                     { name: '📈 Career',      value: careerValue, inline: false }
                 );

--- a/src/games/casino/blackjack.js
+++ b/src/games/casino/blackjack.js
@@ -103,18 +103,22 @@ function buildButtons(gameId, disabled = false, opts = {}) {
         canInsurance = false,
     } = opts;
 
-    const buttons = [
+    const row1 = new ActionRowBuilder().addComponents(
         new ButtonBuilder().setCustomId(`bj_hit_${gameId}`).setLabel('🎯 Hit').setStyle(ButtonStyle.Primary).setDisabled(disabled),
         new ButtonBuilder().setCustomId(`bj_stand_${gameId}`).setLabel('✋ Stand').setStyle(ButtonStyle.Secondary).setDisabled(disabled),
-    ];
+    );
 
+    const extraButtons = [];
     if (!disabled) {
-        if (canDouble)    buttons.push(new ButtonBuilder().setCustomId(`bj_double_${gameId}`).setLabel('⚡ Double Down').setStyle(ButtonStyle.Success));
-        if (canSplit)     buttons.push(new ButtonBuilder().setCustomId(`bj_split_${gameId}`).setLabel('🃏 Split').setStyle(ButtonStyle.Success));
-        if (canInsurance) buttons.push(new ButtonBuilder().setCustomId(`bj_insurance_${gameId}`).setLabel('🛡️ Insurance').setStyle(ButtonStyle.Danger));
+        if (canDouble)    extraButtons.push(new ButtonBuilder().setCustomId(`bj_double_${gameId}`).setLabel('⚡ Double Down').setStyle(ButtonStyle.Success));
+        if (canSplit)     extraButtons.push(new ButtonBuilder().setCustomId(`bj_split_${gameId}`).setLabel('🃏 Split').setStyle(ButtonStyle.Success));
+        if (canInsurance) extraButtons.push(new ButtonBuilder().setCustomId(`bj_insurance_${gameId}`).setLabel('🛡️ Insurance').setStyle(ButtonStyle.Danger));
     }
 
-    return new ActionRowBuilder().addComponents(buttons);
+    if (extraButtons.length > 0) {
+        return [row1, new ActionRowBuilder().addComponents(extraButtons)];
+    }
+    return [row1];
 }
 
 function buildDealerRevealEmbed(interaction, dealerHand, playerHand, splitHands, currency, bet) {
@@ -222,7 +226,7 @@ module.exports = {
                 await user.save();
                 const embed = buildFinalEmbed(interaction, dealerHand, playerHand, null, currency, bet,
                     '🃏 Blackjack — Push', 'Both got blackjack. Bet returned.', '#f39c12', user.balance);
-                return interaction.reply({ embeds: [embed], components: [buildButtons(gameId, true)] });
+                return interaction.reply({ embeds: [embed], components: buildButtons(gameId, true) });
             }
             const bjCoinMult   = getCoinMultiplier(user);
             const bjServerMult = getServerCoinMultiplier(guildSettings);
@@ -243,7 +247,7 @@ module.exports = {
                 )
                 .setFooter({ text: 'Blackjack pays 3:2 · Dealer stands on 17' })
                 .setTimestamp();
-            return interaction.reply({ embeds: [embed], components: [buildButtons(gameId, true)] });
+            return interaction.reply({ embeds: [embed], components: buildButtons(gameId, true) });
         }
 
         const dealerShowsAce  = dealerHand[0].value === 'A';
@@ -301,7 +305,7 @@ module.exports = {
                 );
             }
             const peekEmbed = buildEmbed(interaction, playerHand, dealerHand, bet, currency, peekStatus, '#e74c3c', false);
-            return interaction.editReply({ embeds: [peekEmbed], components: [buildButtons(gameId, true)] });
+            return interaction.editReply({ embeds: [peekEmbed], components: buildButtons(gameId, true) });
         }
 
         // Mutable game state
@@ -327,7 +331,7 @@ module.exports = {
 
         await interaction.reply({
             embeds:     [buildEmbed(interaction, playerHand, dealerHand, bet, currency, '🎲 Your turn', '#5865F2', true)],
-            components: [buildButtons(gameId, false, currentOpts())],
+            components: buildButtons(gameId, false, currentOpts()),
         });
 
         const msg       = await interaction.fetchReply();
@@ -355,7 +359,7 @@ module.exports = {
                     ? `🛡️ Insurance taken (${currency}${insuranceCost.toLocaleString()}) · Your turn`
                     : `⚠️ Not enough balance for insurance · Your turn`;
                 const embed = buildEmbed(interaction, playerHand, dealerHand, activeBet, currency, statusMsg, '#5865F2', true);
-                return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, false, currentOpts())] });
+                return interaction.editReply({ embeds: [embed], components: buildButtons(gameId, false, currentOpts()) });
             }
 
             // ── Double Down ────────────────────────────────────────────────────────
@@ -369,7 +373,7 @@ module.exports = {
                 );
                 if (!updated) {
                     const embed = buildEmbed(interaction, playerHand, dealerHand, activeBet, currency, `⚠️ Not enough balance for double down · Your turn`, '#5865F2', true);
-                    return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, false, currentOpts())] });
+                    return interaction.editReply({ embeds: [embed], components: buildButtons(gameId, false, currentOpts()) });
                 }
                 activeBet = bet * 2;
                 playerHand.push(deck.pop());
@@ -380,10 +384,10 @@ module.exports = {
                     const embed = buildFinalEmbed(interaction, dealerHand, playerHand, null, currency, activeBet,
                         '🃏 Blackjack — Bust', 'Went over. The house collects.',
                         '#e74c3c', bustUser?.balance ?? 0);
-                    return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] });
+                    return interaction.editReply({ embeds: [embed], components: buildButtons(gameId, true) });
                 }
                 const embed = buildEmbed(interaction, playerHand, dealerHand, activeBet, currency, `📊 Doubled to ${currency}${activeBet.toLocaleString()} — dealer reveals...`, '#5865F2', true);
-                await interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] });
+                await interaction.editReply({ embeds: [embed], components: buildButtons(gameId, true) });
                 collector.stop('stand');
                 return;
             }
@@ -399,7 +403,7 @@ module.exports = {
                 );
                 if (!updated) {
                     const embed = buildEmbed(interaction, playerHand, dealerHand, activeBet, currency, `⚠️ Not enough balance for split · Your turn`, '#5865F2', true);
-                    return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, false, currentOpts())] });
+                    return interaction.editReply({ embeds: [embed], components: buildButtons(gameId, false, currentOpts()) });
                 }
 
                 const isAceSplit = playerHand[0].value === 'A';
@@ -413,14 +417,14 @@ module.exports = {
                     splitHandDone = [true, true];
                     const splitState = { splitHands, splitBets, currentSplitHand: -1, splitHandDone };
                     const embed = buildEmbed(interaction, null, dealerHand, bet, currency, '🎲 Split aces — dealer reveals...', '#5865F2', true, splitState);
-                    await interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] });
+                    await interaction.editReply({ embeds: [embed], components: buildButtons(gameId, true) });
                     collector.stop('split_done');
                     return;
                 }
 
                 const splitState = { splitHands, splitBets, currentSplitHand, splitHandDone };
                 const embed = buildEmbed(interaction, null, dealerHand, bet, currency, '▶ Playing Hand 1', '#5865F2', true, splitState);
-                return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, false)] });
+                return interaction.editReply({ embeds: [embed], components: buildButtons(gameId, false) });
             }
 
             // ── Hit ────────────────────────────────────────────────────────────────
@@ -436,11 +440,11 @@ module.exports = {
                             const splitState = { splitHands, splitBets, currentSplitHand, splitHandDone };
                             const label = total > 21 ? '💥 Hand 1 bust! ▶ Playing Hand 2' : '✓ Hand 1 at 21 · ▶ Playing Hand 2';
                             const embed = buildEmbed(interaction, null, dealerHand, bet, currency, label, '#5865F2', true, splitState);
-                            return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, false)] });
+                            return interaction.editReply({ embeds: [embed], components: buildButtons(gameId, false) });
                         } else {
                             const splitState = { splitHands, splitBets, currentSplitHand, splitHandDone };
                             const embed = buildEmbed(interaction, null, dealerHand, bet, currency, '🎲 Both hands done — dealer reveals...', '#5865F2', true, splitState);
-                            await interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] });
+                            await interaction.editReply({ embeds: [embed], components: buildButtons(gameId, true) });
                             collector.stop('split_done');
                             return;
                         }
@@ -448,7 +452,7 @@ module.exports = {
 
                     const splitState = { splitHands, splitBets, currentSplitHand, splitHandDone };
                     const embed = buildEmbed(interaction, null, dealerHand, bet, currency, `▶ Playing Hand ${currentSplitHand + 1}`, '#5865F2', true, splitState);
-                    return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, false)] });
+                    return interaction.editReply({ embeds: [embed], components: buildButtons(gameId, false) });
                 }
 
                 // Normal hit
@@ -461,7 +465,7 @@ module.exports = {
                     const embed = buildFinalEmbed(interaction, dealerHand, playerHand, null, currency, activeBet,
                         '🃏 Blackjack — Bust', 'Went over. The house collects.',
                         '#e74c3c', bustUser2?.balance ?? 0);
-                    return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] });
+                    return interaction.editReply({ embeds: [embed], components: buildButtons(gameId, true) });
                 }
 
                 doubleAvailable = false;
@@ -471,7 +475,7 @@ module.exports = {
                     collector.stop('stand');
                 } else {
                     const embed = buildEmbed(interaction, playerHand, dealerHand, activeBet, currency, '🎲 Your turn', '#5865F2', true);
-                    return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, false, currentOpts())] });
+                    return interaction.editReply({ embeds: [embed], components: buildButtons(gameId, false, currentOpts()) });
                 }
             }
 
@@ -483,11 +487,11 @@ module.exports = {
                         currentSplitHand = 1;
                         const splitState = { splitHands, splitBets, currentSplitHand, splitHandDone };
                         const embed = buildEmbed(interaction, null, dealerHand, bet, currency, '✓ Hand 1 done · ▶ Playing Hand 2', '#5865F2', true, splitState);
-                        return interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, false)] });
+                        return interaction.editReply({ embeds: [embed], components: buildButtons(gameId, false) });
                     } else {
                         const splitState = { splitHands, splitBets, currentSplitHand, splitHandDone };
                         const embed = buildEmbed(interaction, null, dealerHand, bet, currency, '🎲 Both hands done — dealer reveals...', '#5865F2', true, splitState);
-                        await interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] });
+                        await interaction.editReply({ embeds: [embed], components: buildButtons(gameId, true) });
                         collector.stop('split_done');
                         return;
                     }
@@ -508,7 +512,7 @@ module.exports = {
                         '🃏 Blackjack — Bust',
                         `Went over. The house collects.\n🛡️ Insurance paid! +${currency}${(insuranceBet * 2).toLocaleString()}`,
                         '#e74c3c', insUser?.balance ?? 0);
-                    await interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] }).catch(() => {});
+                    await interaction.editReply({ embeds: [embed], components: buildButtons(gameId, true) }).catch(() => {});
                 }
                 return;
             }
@@ -631,11 +635,11 @@ module.exports = {
                 const splitState = { splitHands, splitBets, currentSplitHand: -1, splitHandDone: [true, true] };
                 const embed = buildEmbed(interaction, null, dealerHand, bet, currency, description, color, false, splitState);
                 embed.setTitle(title);
-                await interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] }).catch(() => {});
+                await interaction.editReply({ embeds: [embed], components: buildButtons(gameId, true) }).catch(() => {});
             } else {
                 const embed = buildFinalEmbed(interaction, dealerHand, playerHand, null, currency, activeBet,
                     title, description, color, finalUser?.balance ?? 0);
-                await interaction.editReply({ embeds: [embed], components: [buildButtons(gameId, true)] }).catch(() => {});
+                await interaction.editReply({ embeds: [embed], components: buildButtons(gameId, true) }).catch(() => {});
             }
         });
     },

--- a/src/games/casino/keno.js
+++ b/src/games/casino/keno.js
@@ -161,20 +161,24 @@ async function playKeno(interaction, bet, picked) {
         let boostNote = '';
         if (totalCoinMult > 1.0 && adjustedPayout > bet) boostNote = `\n> 🚀 *${totalCoinMult.toFixed(1)}x Coin Booster applied!*`;
 
+        const payoutLabel = credit > 0 ? '🏆 Payout' : '💀 Lost';
+        const payoutAmt   = credit > 0 ? adjustedPayout : bet;
         const resultEmbed = new EmbedBuilder()
             .setAuthor(embedAuthor(interaction))
             .setThumbnail(THUMB)
             .setColor(color)
             .setTitle(title)
-            .setDescription(`${desc}${boostNote}`)
+            .setDescription(
+                `${desc}${boostNote}\n\n` +
+                `━━━━━━━━━━━━━━━━━━━━━━━━━━\n` +
+                `  💸 Bet: ${bet.toLocaleString()}  ·  ${payoutLabel}: ${payoutAmt.toLocaleString()}  ·  📊 Net: **${netStr}**\n` +
+                `━━━━━━━━━━━━━━━━━━━━━━━━━━`
+            )
             .addFields(
-                { name: '🎯 Your Numbers', value: pickedStr, inline: false },
-                { name: `🔵 Drawn Numbers`, value: drawnStr, inline: false },
-                { name: '✅ Matches', value: `**${matches}** / ${PICK_COUNT}`, inline: true },
-                { name: '💰 Bet',     value: `**${bet.toLocaleString()}** coins`, inline: true },
-                { name: credit > 0 ? '🏆 Payout' : '💀 Lost', value: credit > 0 ? `${adjustedPayout.toLocaleString()} coins` : `${bet.toLocaleString()} coins`, inline: true },
-                { name: '📊 Net',     value: `**${netStr}** coins`, inline: true },
-                { name: '💰 Balance', value: `**${(updated?.balance ?? 0).toLocaleString()}** coins`, inline: true },
+                { name: '🎯 Your Numbers', value: pickedStr,                                                    inline: false },
+                { name: '🔵 Drawn Numbers', value: drawnStr,                                                    inline: false },
+                { name: '✅ Matches',       value: `**${matches}** / ${PICK_COUNT}`,                            inline: true  },
+                { name: '💰 Balance',       value: `**${(updated?.balance ?? 0).toLocaleString()}** coins`,     inline: true  },
             )
             .setFooter({ text: '3 matches = 3× · 4 matches = 10× · 5 matches = 50×' })
             .setTimestamp();

--- a/src/games/casino/roulette.js
+++ b/src/games/casino/roulette.js
@@ -117,13 +117,15 @@ function resultEmbed({ result, won, betKey, target, bet, profit, balance, intera
         .setThumbnail(THUMB)
         .setColor(color)
         .setTitle(`🎡 Roulette — ${won ? 'Winner!' : 'No Luck'}`)
-        .setDescription(`${pocketStrip(result)}\n\n${headline}\n*${colorDesc}*`)
+        .setDescription(
+            `${pocketStrip(result)}\n\n${headline}\n*${colorDesc}*\n\n` +
+            `━━━━━━━━━━━━━━━━━━━━━━━━━━\n` +
+            `  📊 Net: **${netStr}**  ·  💰 Balance: **${balance.toLocaleString()}** coins\n` +
+            `━━━━━━━━━━━━━━━━━━━━━━━━━━`
+        )
         .addFields(
-            { name: '🎯 Bet',      value: `${describeBet(betKey, target)} (${betOdds(betKey)})`, inline: true  },
-            { name: '💰 Wager',    value: `${bet.toLocaleString()} coins`,                        inline: true  },
-            { name: '​',           value: '​',                                                     inline: false },
-            { name: '📊 Net',      value: `**${netStr}** coins`,                                  inline: true  },
-            { name: '💰 Balance',  value: `**${balance.toLocaleString()}** coins`,                inline: true  },
+            { name: '🎯 Bet',   value: `${describeBet(betKey, target)} (${betOdds(betKey)})`, inline: true },
+            { name: '💰 Wager', value: `${bet.toLocaleString()} coins`,                        inline: true },
         )
         .setFooter({ text: 'European Roulette  •  Straight number pays 35:1' })
         .setTimestamp();

--- a/src/games/casino/slots.js
+++ b/src/games/casino/slots.js
@@ -119,19 +119,23 @@ function resultEmbed(reels, result, bet, balance, interaction, jackpotPool) {
     if (wildCount > 0 && outcome !== 'jackpot') extras += '\n> 🃏 *Wild card assisted!*';
     if (multFactor > 1 && outcome !== 'mult3')  extras += `\n> ⚡ *${multFactor}x Boost applied!*`;
 
+    const payoutVal = payout > 0 ? payout : bet;
+    const payoutLabel = payout > 0 ? '🏆 Payout' : '💀 Lost';
     return new EmbedBuilder()
         .setAuthor(embedAuthor(interaction))
         .setThumbnail(THUMB)
         .setColor(color)
         .setTitle(title)
-        .setDescription(`> **[ ${display} ]**\n\n${line}${extras}`)
-        .addFields(
-            { name: '💸 Bet',                                value: `${bet.toLocaleString()} coins`,    inline: true },
-            { name: payout > 0 ? '🏆 Payout' : '💀 Lost',   value: payout > 0 ? `${payout.toLocaleString()} coins` : `${bet.toLocaleString()} coins`, inline: true },
-            { name: '📊 Net',                                value: `**${netStr}** coins`,              inline: true },
-            { name: '💰 Balance',                            value: `**${balance.toLocaleString()}** coins` },
+        .setDescription(
+            `> **[ ${display} ]**\n\n${line}${extras}\n\n` +
+            `━━━━━━━━━━━━━━━━━━━━━━━━━━\n` +
+            `  💸 Bet: ${bet.toLocaleString()}  ·  ${payoutLabel}: ${payoutVal.toLocaleString()}  ·  📊 Net: **${netStr}**\n` +
+            `━━━━━━━━━━━━━━━━━━━━━━━━━━`
         )
-        .addFields({ name: '🏆 Jackpot Pool', value: `**${jackpotPool.toLocaleString()}** coins`, inline: true })
+        .addFields(
+            { name: '💰 Balance',      value: `**${balance.toLocaleString()}** coins`,      inline: true },
+            { name: '🏆 Jackpot Pool', value: `**${jackpotPool.toLocaleString()}** coins`, inline: true },
+        )
         .setFooter({ text: '🃏 Wild substitutes for any symbol  •  ⚡ Boost multiplies your win' })
         .setTimestamp();
 }


### PR DESCRIPTION
- slots: move Bet/Payout/Net into description block; keep Balance + Jackpot Pool as 2 inline fields
- blackjack: split buildButtons into two ActionRows when extra options (Double Down/Split/Insurance) are present, so no row ever exceeds 3 buttons
- work: move earned amount into description with separator lines; keep Performance and Career fields only
- crime: add success %, payout range, and fine range to each crime's selection field value
- keno: move Bet/Payout/Net into description block; keep Matches + Balance as 2 inline fields
- roulette: move Net and Balance into description block; keep Bet + Wager as 2 inline fields

Closes #255

https://claude.ai/code/session_01JuY3fFegXAby761vQ11P9p