### PR TITLE
Upgrade jackpot announcement to broadcast embed with @here support

### DIFF
--- a/src/games/casino/slots.js
+++ b/src/games/casino/slots.js
@@ -323,7 +323,7 @@ async function playSlots(interaction, bet) {
             await targetChannel?.send({
                 content: pingHere ? '@here' : undefined,
                 embeds: [jackpotBroadcastEmbed(interaction, jackpotPool, JACKPOT_SEED)],
-            }).catch(() => null);
+            }).catch(err => console.error(`[Slots] jackpot broadcast failed — channel:${targetChannel?.id} interaction:${interaction.id}`, err));
         }
 
         const replayId   = `slots_replay_${interaction.id}_${Date.now()}`;

--- a/src/games/casino/slots.js
+++ b/src/games/casino/slots.js
@@ -141,6 +141,25 @@ function resultEmbed(reels, result, bet, balance, interaction, jackpotPool) {
         .setTimestamp();
 }
 
+function jackpotBroadcastEmbed(interaction, wonAmount, newPool) {
+    return new EmbedBuilder()
+        .setColor('#FF00FF')
+        .setThumbnail(interaction.user.displayAvatarURL({ dynamic: true }))
+        .setDescription(
+            `🎰 ━━━━━━━━━━━━━━━━━━━━━━━ 🎰\n` +
+            `　　　**J A C K P O T**\n` +
+            `🎰 ━━━━━━━━━━━━━━━━━━━━━━━ 🎰\n\n` +
+            `${interaction.user} just hit **TRIPLE WILD** 🃏🃏🃏\n` +
+            `and walked away with the entire pool.\n\n` +
+            `━━━━━━━━━━━━━━━━━━━━━━━━━━\n` +
+            `  💰 Won: **${wonAmount.toLocaleString()}** coins\n` +
+            `  🔄 New pool: **${newPool.toLocaleString()}** coins\n` +
+            `━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n` +
+            `> Think you can be next?`
+        )
+        .setTimestamp();
+}
+
 function paytableEmbed() {
     return new EmbedBuilder()
         .setColor('#FFD700')
@@ -294,15 +313,16 @@ async function playSlots(interaction, bet) {
         await interaction.editReply({ embeds: [spinEmbed(reelDisplay(reels, 2), bet, 2, interaction, jackpotPool)] });
         await delay(800);
 
-        // If jackpot won, post a public announcement first
-        if (jackpotWon) {
-            const displayName = interaction.member?.displayName || interaction.user.username;
-            interaction.channel?.send({
-                content: [
-                    '🎰✨ **JACKPOT WON!** ✨🎰',
-                    `${interaction.user} hit **TRIPLE WILD** and won the **${jackpotPool.toLocaleString()} coin** jackpot!`,
-                    `The jackpot resets to **${JACKPOT_SEED.toLocaleString()}** coins. Good luck next time!`,
-                ].join('\n'),
+        // If jackpot won, post the broadcast embed before the winner sees their result
+        if (jackpotWon && (guildSettings?.slots?.announceJackpot ?? true)) {
+            const pingHere       = guildSettings?.slots?.jackpotPingHere ?? false;
+            const jackpotChanId  = guildSettings?.slots?.jackpotChannelId ?? null;
+            const targetChannel  = jackpotChanId
+                ? (interaction.guild?.channels?.cache?.get(jackpotChanId) ?? interaction.channel)
+                : interaction.channel;
+            await targetChannel?.send({
+                content: pingHere ? '@here' : undefined,
+                embeds: [jackpotBroadcastEmbed(interaction, jackpotPool, JACKPOT_SEED)],
             }).catch(() => null);
         }
 

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -171,10 +171,13 @@ const guildSchema = new Schema({
     },
 
     slots: {
-        jackpotPool:       { type: Number, default: 5000 },
-        lastJackpotWinner: { type: String, default: null },
-        lastJackpotAmount: { type: Number, default: null },
-        lastJackpotAt:     { type: Date,   default: null }
+        jackpotPool:       { type: Number,  default: 5000 },
+        lastJackpotWinner: { type: String,  default: null },
+        lastJackpotAmount: { type: Number,  default: null },
+        lastJackpotAt:     { type: Date,    default: null },
+        announceJackpot:   { type: Boolean, default: true },
+        jackpotPingHere:   { type: Boolean, default: false },
+        jackpotChannelId:  { type: String,  default: null },
     },
 
     rssFeeds: [{


### PR DESCRIPTION
Replaces the plain-text jackpot channel.send with a rich embed:
- Color #FF00FF (magenta), winner avatar as thumbnail
- Decorative J A C K P O T title block with separator lines
- Shows amount won and new pool amount
- Awaited before the result embed so the channel sees it first

Adds three configurable guild fields under slots:
  announceJackpot (default true), jackpotPingHere (default false),
  jackpotChannelId (default null — falls back to spin channel)

https://claude.ai/code/session_01UJjR6xx9DCmzaQhohLce3N

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customizable jackpot win announcements: Enable/disable announcement broadcasts, toggle `@here` pings, and specify a dedicated announcement channel for jackpot win events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/clawdia/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->