### PR TITLE
Implement streak leaderboard, legendary drop announcements, and milestone celebrations (#260, #261, #262)

### DIFF
--- a/src/commands/community/streak.js
+++ b/src/commands/community/streak.js
@@ -5,63 +5,132 @@ const { getStreakMultiplier, getNextMultiplierTier, getNextMilestone } = require
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('streak')
-        .setDescription('View your activity streak')
+        .setDescription('View the server streak leaderboard or a user\'s streak')
         .addUserOption(o =>
-            o.setName('user').setDescription('User to check (default: yourself)').setRequired(false)),
+            o.setName('user').setDescription('User to check (default: leaderboard view)').setRequired(false)),
 
     async execute(interaction) {
-        const target = interaction.options.getUser('user') ?? interaction.user;
-        const user = await User.findOne({ userId: target.id, guildId: interaction.guild.id });
+        const target = interaction.options.getUser('user');
 
-        if (!user) {
-            return interaction.reply({
-                content: `${target.id === interaction.user.id ? 'You have' : `${target.tag} has`} no activity recorded yet.`,
-                ephemeral: true
-            });
+        // ── Personal streak view ──────────────────────────────────────────────
+        if (target) {
+            const user = await User.findOne({ userId: target.id, guildId: interaction.guild.id });
+
+            if (!user) {
+                return interaction.reply({
+                    content: `${target.id === interaction.user.id ? 'You have' : `${target.tag} has`} no activity recorded yet.`,
+                    ephemeral: true
+                });
+            }
+
+            const current = user.streak?.current ?? 0;
+            const longest = user.streak?.longest ?? 0;
+            const lastActive = user.streak?.lastActive;
+
+            const now = new Date();
+            const isActive = lastActive && (now - lastActive) < 172800000;
+
+            const flameEmoji = current >= 30 ? '🔥🔥🔥' : current >= 14 ? '🔥🔥' : current >= 7 ? '🔥' : '❄️';
+            const status = isActive ? '✅ Active' : '⚠️ At risk — send a message to keep it!';
+
+            const multiplier = getStreakMultiplier(current);
+            const nextTier = getNextMultiplierTier(current);
+            const nextMilestone = getNextMilestone(current);
+            const multiplierText = multiplier > 1.0
+                ? `🔥 **${multiplier}x** coins and XP`
+                : '1.0x (reach 7 days for a bonus!)';
+            const nextTierText = nextTier
+                ? `Keep going! **${nextTier.days - current}** more day${nextTier.days - current !== 1 ? 's' : ''} for **${nextTier.multiplier}x**`
+                : '🏆 Maximum multiplier reached!';
+            const nextMilestoneText = nextMilestone
+                ? `**${nextMilestone.days}** days — ${nextMilestone.coins.toLocaleString()} coins + **${nextMilestone.badge}** badge`
+                : '✅ All milestones claimed!';
+
+            const embed = new EmbedBuilder()
+                .setColor(current >= 7 ? '#ff6600' : '#5865F2')
+                .setTitle(`${flameEmoji} ${target.displayName}'s Streak`)
+                .setThumbnail(target.displayAvatarURL({ dynamic: true }))
+                .addFields(
+                    { name: 'Current Streak', value: `**${current}** day${current !== 1 ? 's' : ''}`, inline: true },
+                    { name: 'Longest Streak', value: `**${longest}** day${longest !== 1 ? 's' : ''}`, inline: true },
+                    { name: 'Status', value: status, inline: true },
+                    { name: '⚡ Multiplier', value: multiplierText, inline: true },
+                    { name: '📈 Next Multiplier', value: nextTierText, inline: false },
+                    { name: '🎁 Next Reward Milestone', value: nextMilestoneText, inline: false }
+                )
+                .setFooter({ text: 'Send at least one message per day to keep your streak' })
+                .setTimestamp();
+
+            if (lastActive) {
+                embed.addFields({ name: 'Last Active', value: `<t:${Math.floor(lastActive / 1000)}:R>`, inline: true });
+            }
+
+            return interaction.reply({ embeds: [embed], ephemeral: target.id !== interaction.user.id });
         }
 
-        const current = user.streak?.current ?? 0;
-        const longest = user.streak?.longest ?? 0;
-        const lastActive = user.streak?.lastActive;
+        // ── Server leaderboard view ───────────────────────────────────────────
+        const [topUsers, selfUser] = await Promise.all([
+            User.find(
+                { guildId: interaction.guild.id, 'streak.current': { $gt: 0 } },
+                { userId: 1, 'streak.current': 1 }
+            ).sort({ 'streak.current': -1 }).limit(5).lean(),
+            User.findOne(
+                { userId: interaction.user.id, guildId: interaction.guild.id },
+                { userId: 1, 'streak.current': 1 }
+            ).lean()
+        ]);
 
-        const now = new Date();
-        const isActive = lastActive && (now - lastActive) < 172800000; // within 48h
+        const medals = ['🥇', '🥈', '🥉'];
+        const div = '━━━━━━━━━━━━━━━━━━━━━━━━━━';
 
-        const flameEmoji = current >= 30 ? '🔥🔥🔥' : current >= 14 ? '🔥🔥' : current >= 7 ? '🔥' : '❄️';
-        const status = isActive ? '✅ Active' : '⚠️ At risk — send a message to keep it!';
+        // Resolve display names for top 5
+        const nameCache = new Map();
+        await Promise.allSettled(
+            topUsers.map(async u => {
+                try {
+                    const member = await interaction.guild.members.fetch(u.userId);
+                    nameCache.set(u.userId, member.displayName);
+                } catch {
+                    nameCache.set(u.userId, `<@${u.userId}>`);
+                }
+            })
+        );
 
-        const multiplier = getStreakMultiplier(current);
-        const nextTier = getNextMultiplierTier(current);
-        const nextMilestone = getNextMilestone(current);
-        const multiplierText = multiplier > 1.0
-            ? `🔥 **${multiplier}x** coins and XP`
-            : '1.0x (reach 7 days for a bonus!)';
-        const nextTierText = nextTier
-            ? `Keep going! **${nextTier.days - current}** more day${nextTier.days - current !== 1 ? 's' : ''} for **${nextTier.multiplier}x**`
-            : '🏆 Maximum multiplier reached!';
-        const nextMilestoneText = nextMilestone
-            ? `**${nextMilestone.days}** days — ${nextMilestone.coins.toLocaleString()} coins + **${nextMilestone.badge}** badge`
-            : '✅ All milestones claimed!';
+        const leaderboardLines = topUsers.map((u, i) => {
+            const prefix = medals[i] ?? `${i + 1}.`;
+            const name = nameCache.get(u.userId) ?? `<@${u.userId}>`;
+            const days = u.streak.current;
+            return `${prefix}  ${name}  ━━  **${days}** day${days !== 1 ? 's' : ''}`;
+        });
+
+        if (leaderboardLines.length === 0) {
+            leaderboardLines.push('No active streaks on this server yet.');
+        }
+
+        // Self rank
+        const selfCurrent = selfUser?.streak?.current ?? 0;
+        let selfRankText = 'You have no active streak.';
+        if (selfCurrent > 0) {
+            const aheadCount = await User.countDocuments({
+                guildId: interaction.guild.id,
+                'streak.current': { $gt: selfCurrent }
+            });
+            const selfRank = aheadCount + 1;
+            const rankMedals = { 1: '🥇', 2: '🥈', 3: '🥉' };
+            const rankBadge = rankMedals[selfRank] ? `${rankMedals[selfRank]} ` : '';
+            selfRankText = `Your streak: 🔥 **${selfCurrent}** day${selfCurrent !== 1 ? 's' : ''}  ·  ${rankBadge}Rank #${selfRank}`;
+        }
+
+        const description = leaderboardLines.join('\n') +
+            `\n\n${div}\n  ${selfRankText}\n${div}`;
 
         const embed = new EmbedBuilder()
-            .setColor(current >= 7 ? '#ff6600' : '#5865F2')
-            .setTitle(`${flameEmoji} ${target.displayName}'s Streak`)
-            .setThumbnail(target.displayAvatarURL({ dynamic: true }))
-            .addFields(
-                { name: 'Current Streak', value: `**${current}** day${current !== 1 ? 's' : ''}`, inline: true },
-                { name: 'Longest Streak', value: `**${longest}** day${longest !== 1 ? 's' : ''}`, inline: true },
-                { name: 'Status', value: status, inline: true },
-                { name: '⚡ Multiplier', value: multiplierText, inline: true },
-                { name: '📈 Next Multiplier', value: nextTierText, inline: false },
-                { name: '🎁 Next Reward Milestone', value: nextMilestoneText, inline: false }
-            )
-            .setFooter({ text: 'Send at least one message per day to keep your streak' })
+            .setColor('#ff6b00')
+            .setTitle(`🔥 Streak Leaderboard — ${interaction.guild.name}`)
+            .setDescription(description)
+            .setFooter({ text: 'Claim /daily every day to build your streak' })
             .setTimestamp();
 
-        if (lastActive) {
-            embed.addFields({ name: 'Last Active', value: `<t:${Math.floor(lastActive / 1000)}:R>`, inline: true });
-        }
-
-        await interaction.reply({ embeds: [embed], ephemeral: target.id !== interaction.user.id });
+        await interaction.reply({ embeds: [embed] });
     }
 };

--- a/src/commands/community/streak.js
+++ b/src/commands/community/streak.js
@@ -18,7 +18,7 @@ module.exports = {
 
             if (!user) {
                 return interaction.reply({
-                    content: `${target.id === interaction.user.id ? 'You have' : `${target.tag} has`} no activity recorded yet.`,
+                    content: `${target.id === interaction.user.id ? 'You have' : `${target.username} has`} no activity recorded yet.`,
                     ephemeral: true
                 });
             }

--- a/src/commands/economy/daily.js
+++ b/src/commands/economy/daily.js
@@ -263,6 +263,23 @@ module.exports = {
             if (capActive)        bonusLines.push(`⚠️ Combined multiplier capped at **${MAX_COMBINED_MULTIPLIER}x**.`);
 
             const streakColor = getStreakColor(streakCurrent);
+            // ── Streak rank lookup ────────────────────────────────────────────────
+            let streakRank = null;
+            if (streakCurrent > 0) {
+                const aheadCount = await User.countDocuments({
+                    guildId: interaction.guild.id,
+                    'streak.current': { $gt: streakCurrent }
+                });
+                streakRank = aheadCount + 1;
+            }
+            // ─────────────────────────────────────────────────────────────────────
+
+            const rankMedals = { 1: '🥇', 2: '🥈', 3: '🥉' };
+            const rankMedal = streakRank && rankMedals[streakRank] ? `${rankMedals[streakRank]} ` : '';
+            const rankText = streakRank
+                ? `🔥 Your ${streakCurrent}-day streak · ${rankMedal}Ranked #${streakRank} on this server  •  Cooldown: 24h`
+                : 'Cooldown: 24h';
+
             const rewardEmbed = new EmbedBuilder()
                 .setColor(streakColor)
                 .setTitle(getStreakTitle(streakCurrent, isMilestone))
@@ -270,7 +287,7 @@ module.exports = {
                     getStreakDescription(streakCurrent, isMilestone) + '\n\n' +
                     buildRewardBlock(actualAmount, streakCurrent, streakMult, updated.balance, bonusLines, droppedItem, isMilestone, streakCurrent)
                 )
-                .setFooter({ text: 'Cooldown: 24h' })
+                .setFooter({ text: rankText })
                 .setTimestamp();
 
             const freezeCount = user.streak?.freezes ?? 0;
@@ -290,20 +307,41 @@ module.exports = {
                 : await interaction.reply(sendOpts);
 
             // ── Milestone public announcement ─────────────────────────────────────
-            if (isMilestone) {
+            if (isMilestone && guildSettings?.economy?.announceStreakMilestones !== false) {
                 const announcementChannelId = guildSettings?.economy?.announcementChannelId;
                 const channel = announcementChannelId
                     ? interaction.guild.channels.cache.get(announcementChannelId)
                     : null;
 
                 if (channel?.isTextBased()) {
+                    const milestoneConfigs = {
+                        7: {
+                            title: '🔥 One Week Strong',
+                            description: `${interaction.user} has claimed their daily reward 7 days in a row.\nThat streak is just getting started.`,
+                            color: '#f39c12'
+                        },
+                        30: {
+                            title: '🔥 30-Day Streak Milestone',
+                            description: `${interaction.user} has kept their streak alive for a full month.\nConsistent. Relentless.` +
+                                (droppedItem ? `\n\nThey received a ${droppedItem.emoji} **${droppedItem.name}** for the dedication.` : ''),
+                            color: '#FFD700'
+                        },
+                        100: {
+                            title: '🏆 100-Day Streak — Legendary Dedication',
+                            description: `${interaction.user} has claimed their daily reward every single day\nfor 100 days straight.\n\nThis server has witnessed something rare.`,
+                            color: '#9b59b6'
+                        }
+                    };
+                    const cfg = milestoneConfigs[streakCurrent] ?? {
+                        title: `🔥 ${streakCurrent}-Day Streak Milestone!`,
+                        description: `${interaction.user} just hit a **${streakCurrent}-day streak**!` +
+                            (droppedItem ? `\nThey found a ${droppedItem.emoji} **${droppedItem.name}** from their milestone drop!` : ''),
+                        color: streakColor
+                    };
                     const milestoneAnnounce = new EmbedBuilder()
-                        .setColor(streakColor)
-                        .setTitle(`🔥 ${streakCurrent}-Day Streak Milestone!`)
-                        .setDescription(
-                            `${interaction.user} just hit a **${streakCurrent}-day streak**!\n` +
-                            (droppedItem ? `They found a ${droppedItem.emoji} **${droppedItem.name}** from their milestone drop!` : '')
-                        )
+                        .setColor(cfg.color)
+                        .setTitle(cfg.title)
+                        .setDescription(cfg.description)
                         .setTimestamp();
                     channel.send({ embeds: [milestoneAnnounce] }).catch(() => {});
                 }

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -558,10 +558,8 @@ async function handleCast(interaction) {
 
     if (result.success && result.tier === 'legendary' && guildSettings?.economy?.announceRareDrops !== false) {
         const announceChannelId = guildSettings?.economy?.announcementChannelId;
-        const announceChannel = announceChannelId
-            ? interaction.guild.channels.cache.get(announceChannelId) ?? interaction.channel
-            : interaction.channel;
-        const displayName = interaction.member?.displayName || interaction.user.username;
+        const resolved = announceChannelId ? interaction.guild.channels.cache.get(announceChannelId) : null;
+        const announceChannel = resolved?.isTextBased() ? resolved : interaction.channel;
         const announcementEmbed = new EmbedBuilder()
             .setColor('#ff9800')
             .setTitle('✨ Legendary Catch! ✨')

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -556,18 +556,18 @@ async function handleCast(interaction) {
 
     await interaction.editReply({ embeds: [embed] });
 
-    if (result.success && result.tier === 'legendary') {
-        const announceChannelId = guildSettings?.leveling?.announceChannel;
+    if (result.success && result.tier === 'legendary' && guildSettings?.economy?.announceRareDrops !== false) {
+        const announceChannelId = guildSettings?.economy?.announcementChannelId;
         const announceChannel = announceChannelId
             ? interaction.guild.channels.cache.get(announceChannelId) ?? interaction.channel
             : interaction.channel;
         const displayName = interaction.member?.displayName || interaction.user.username;
         const announcementEmbed = new EmbedBuilder()
-            .setColor(TIER_COLORS.legendary)
+            .setColor('#ff9800')
             .setTitle('✨ Legendary Catch! ✨')
             .setDescription(
-                `**${displayName}** just pulled a ${result.fish.emoji} **${result.fish.name}** [⭐⭐⭐⭐⭐]\n` +
-                `while fishing in **${location.emoji} ${location.name}**.\n\n` +
+                `<@${interaction.user.id}> just pulled a ${result.fish.emoji} **${result.fish.name}** [⭐⭐⭐⭐⭐]\n` +
+                `while fishing in the **${location.name}**.\n\n` +
                 `That's incredibly rare.`
             )
             .setTimestamp();

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -487,19 +487,18 @@ async function executeStart(interaction) {
     }
     await interaction.editReply({ embeds: [embed] });
 
-    if (result.success && result.tier === 'legendary') {
-        const announceChannelId = guildSettings?.leveling?.announceChannel;
+    if (result.success && result.tier === 'legendary' && guildSettings?.economy?.announceRareDrops !== false) {
+        const announceChannelId = guildSettings?.economy?.announcementChannelId;
         const announceChannel = announceChannelId
             ? interaction.guild.channels.cache.get(announceChannelId) ?? interaction.channel
             : interaction.channel;
-        const displayName = interaction.member?.displayName || interaction.user.username;
         const announcementEmbed = new EmbedBuilder()
-            .setColor(TIER_COLORS.legendary)
-            .setTitle('✨ Legendary Find! ✨')
+            .setColor('#ff9800')
+            .setTitle('✨ Legendary Trophy! ✨')
             .setDescription(
-                `**${displayName}** just found a ${result.animal.emoji} **${result.animal.name}** [⭐⭐⭐⭐⭐]\n` +
-                `while hunting in **${zone.emoji} ${zone.name}**.\n\n` +
-                `That's incredibly rare.`
+                `<@${interaction.user.id}> just brought down a ${result.animal.emoji} **${result.animal.name}** [⭐⭐⭐⭐⭐]\n` +
+                `deep in the **${zone.name}**.\n\n` +
+                `Only a handful of hunters have ever managed that.`
             )
             .setTimestamp();
         announceChannel.send({ embeds: [announcementEmbed] }).catch(() => null);

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -489,9 +489,8 @@ async function executeStart(interaction) {
 
     if (result.success && result.tier === 'legendary' && guildSettings?.economy?.announceRareDrops !== false) {
         const announceChannelId = guildSettings?.economy?.announcementChannelId;
-        const announceChannel = announceChannelId
-            ? interaction.guild.channels.cache.get(announceChannelId) ?? interaction.channel
-            : interaction.channel;
+        const resolved = announceChannelId ? interaction.guild.channels.cache.get(announceChannelId) : null;
+        const announceChannel = resolved?.isTextBased() ? resolved : interaction.channel;
         const announcementEmbed = new EmbedBuilder()
             .setColor('#ff9800')
             .setTitle('✨ Legendary Trophy! ✨')

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -373,19 +373,18 @@ async function handleDig(interaction) {
     }
     await interaction.editReply({ embeds: [embed] });
 
-    if (result.success && result.tier === 'legendary') {
-        const announceChannelId = guildSettings?.leveling?.announceChannel;
+    if (result.success && result.tier === 'legendary' && guildSettings?.economy?.announceRareDrops !== false) {
+        const announceChannelId = guildSettings?.economy?.announcementChannelId;
         const announceChannel = announceChannelId
             ? interaction.guild.channels.cache.get(announceChannelId) ?? interaction.channel
             : interaction.channel;
-        const displayName = interaction.member?.displayName || interaction.user.username;
         const announcementEmbed = new EmbedBuilder()
-            .setColor(TIER_COLORS.legendary)
+            .setColor('#ff9800')
             .setTitle('✨ Legendary Strike! ✨')
             .setDescription(
-                `**${displayName}** just struck a ${result.ore.emoji} **${result.ore.name}** [⭐⭐⭐⭐⭐]\n` +
-                `while mining in **${depth.emoji} ${depth.name}**.\n\n` +
-                `That's incredibly rare.`
+                `<@${interaction.user.id}> just unearthed ${result.ore.emoji} **${result.ore.name}** [⭐⭐⭐⭐⭐]\n` +
+                `at the **${depth.name}** depth.\n\n` +
+                `That vein runs deep — and dangerous.`
             )
             .setTimestamp();
         announceChannel.send({ embeds: [announcementEmbed] }).catch(() => null);

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -375,9 +375,8 @@ async function handleDig(interaction) {
 
     if (result.success && result.tier === 'legendary' && guildSettings?.economy?.announceRareDrops !== false) {
         const announceChannelId = guildSettings?.economy?.announcementChannelId;
-        const announceChannel = announceChannelId
-            ? interaction.guild.channels.cache.get(announceChannelId) ?? interaction.channel
-            : interaction.channel;
+        const resolved = announceChannelId ? interaction.guild.channels.cache.get(announceChannelId) : null;
+        const announceChannel = resolved?.isTextBased() ? resolved : interaction.channel;
         const announcementEmbed = new EmbedBuilder()
             .setColor('#ff9800')
             .setTitle('✨ Legendary Strike! ✨')

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -167,7 +167,9 @@ const guildSchema = new Schema({
         // max: 0.5 ensures winnerPayout >= amount so netGain is never negative
         duelHouseCut: { type: Number, default: 0.05, min: 0, max: 0.5 },
         betConfirmThreshold: { type: Number, default: 10000, min: 0 },
-        announcementChannelId: { type: String, default: null }
+        announcementChannelId: { type: String, default: null },
+        announceRareDrops: { type: Boolean, default: true },
+        announceStreakMilestones: { type: Boolean, default: true }
     },
 
     slots: {


### PR DESCRIPTION
Issue #260 — Streak leaderboard:
- /streak now shows a server leaderboard (top 5) with medals for top 3
- User's own rank and streak are shown at the bottom of the leaderboard embed
- /streak <user> still shows that user's personal streak details
- /daily footer now shows the user's streak rank on the server after claiming

Issue #261 — Legendary drop announcements:
- Added economy.announceRareDrops guild setting (default: true)
- Legendary tier drops from /fish, /hunt, /mine send a public embed announcement
- Announcements now use economy.announcementChannelId (was incorrectly using leveling.announceChannel)
- Embed color updated to #ff9800 per spec; uses @mention instead of display name
- Distinct titles/copy per activity (Catch / Trophy / Strike)

Issue #262 — Streak milestone celebrations:
- Added economy.announceStreakMilestones guild setting (default: true)
- Day 7 announcement uses gold/orange with short motivational copy
- Day 30 announcement is gold, includes milestone drop item if one was awarded
- Day 100 announcement uses purple (#9b59b6) with ceremonial copy
- Announcements are still deduplicated via claimedDropMilestones (existing behavior)

https://claude.ai/code/session_01Uo7mfVjrR31mrHsFbK4k2w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streak command now displays a server leaderboard of top 5 active streaks when no user is specified; personal view available when a user is provided
  * Daily rewards now show ranked medals based on your server streak position
  * Legendary catch announcements and streak milestone announcements are now configurable per server

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/clawdia/pull/283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->