### PR TITLE
fix(portainer): point stack at clawdia GHCR image, not stale ultrabot

### DIFF
--- a/portainer-stack.yml
+++ b/portainer-stack.yml
@@ -4,8 +4,8 @@ version: '3.8'
 #
 # BEFORE DEPLOYING:
 #   1. Build and push the image to GHCR:
-#        docker build -t ghcr.io/theshield2594/ultrabot:latest .
-#        docker push ghcr.io/theshield2594/ultrabot:latest
+#        docker build -t ghcr.io/theshield2594/clawdia:latest .
+#        docker push ghcr.io/theshield2594/clawdia:latest
 #
 #   2. If the GHCR package is private, add registry credentials in Portainer first:
 #        Portainer > Registries > Add registry > Custom registry
@@ -33,7 +33,7 @@ services:
       start_period: 30s
 
   bot:
-    image: ghcr.io/theshield2594/ultrabot:latest
+    image: ghcr.io/theshield2594/clawdia:latest
     container_name: ultrabot
     restart: unless-stopped
     environment:


### PR DESCRIPTION
The repo was renamed to clawdia, so docker-publish.yml now pushes ghcr.io/theshield2594/clawdia:latest. The Portainer stack still referenced ghcr.io/theshield2594/ultrabot:latest, so every "Update" in Portainer kept re-pulling a stale image that hadn't been built since the rename — none of the new slash commands ever shipped.

Container/volume/network names are intentionally left as ultrabot-* so existing Mongo data and the running stack aren't orphaned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container deployment configuration with the latest image reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/clawdia/pull/290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->