### PR TITLE
Add visual shop browse UI with paginated category banners

### DIFF
--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -10,6 +10,7 @@ const {
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { getItemImageAttachment } = require('../../utils/itemImageHelper');
+const { runShopBrowse }          = require('../../utils/shopBrowse');
 const {
     LOCATIONS, LOCATION_LIST, TIER_COLORS, LIMITS, ROD_BY_TIER,
     ROD_UPGRADES, MATERIAL_NAMES, BAIT_PACKS, CONSUMABLES,
@@ -1393,68 +1394,81 @@ async function handleShop(interaction, sub) {
 
 async function showShopList(interaction, user, currency) {
     const f = user.fishing;
-    const COLOR = '#f39c12';
-    const embeds = [];
-    const files  = [];
 
-    embeds.push(new EmbedBuilder()
-        .setColor(COLOR)
-        .setTitle('🏪 Fishing Shop — Rods')
-        .setDescription('Browse the available rods. Upgrades, bait, consumables and locations are listed below.')
-    );
-
-    for (const r of ROD_TIERS) {
-        const card = new EmbedBuilder()
-            .setColor(COLOR)
-            .setTitle(`${r.emoji} T${r.tier} ${r.name}`)
-            .setDescription(r.description)
-            .addFields(
-                { name: 'Cost', value: `${currency}${r.cost.toLocaleString()}`, inline: true },
-                { name: 'Buy',  value: `\`/fish shop rod type:${r.slug}\``,      inline: true }
-            );
-        const img = await getItemImageAttachment(`fish:${r.slug}`).catch(() => null);
-        if (img) {
-            card.setThumbnail(img.url);
-            files.push(img.attachment);
-        }
-        embeds.push(card);
-    }
-
-    const upgradeSection = Object.values(ROD_UPGRADES).map(u =>
-        `${u.emoji} **${u.name}** — ~${Math.round(u.costMultiplier * 100)}% of rod price\n   *${u.description}*`
+    const rodItems = ROD_TIERS.map(r => ({
+        imageId: `fish:${r.slug}`,
+        name:    r.name,
+        price:   r.cost,
+        emoji:   r.emoji,
+        badge:   `T${r.tier}`
+    }));
+    const rodList = ROD_TIERS.map(r =>
+        `${r.emoji} **T${r.tier} ${r.name}** — ${currency}${r.cost.toLocaleString()} · \`/fish shop rod type:${r.slug}\``
     ).join('\n');
 
-    const baitSection = BAIT_PACKS.map(p =>
-        `${p.emoji} **${p.name}** — ${currency}${p.cost} \`${p.id}\``
+    const upgradeItems = Object.values(ROD_UPGRADES).map(u => ({
+        imageId: `fish:${u.id}`,
+        name:    u.name,
+        emoji:   u.emoji,
+        subline: `~${Math.round(u.costMultiplier * 100)}% of rod`
+    }));
+    const upgradeList = Object.values(ROD_UPGRADES).map(u =>
+        `${u.emoji} **${u.name}** — *${u.description}* · \`/fish shop upgrade module:${u.id}\``
     ).join('\n');
 
-    const consumableSection = Object.values(CONSUMABLES).map(c =>
-        `${c.emoji} **${c.name}** — ${currency}${c.cost}\n   *${c.description}*`
+    const baitItems = BAIT_PACKS.map(p => ({
+        imageId: `fish:${p.id}`,
+        name:    p.name,
+        price:   p.cost,
+        emoji:   p.emoji
+    }));
+    const baitList = BAIT_PACKS.map(p =>
+        `${p.emoji} **${p.name}** — ${currency}${p.cost} · \`/fish shop buy item:${p.id}\``
     ).join('\n');
 
-    const locationSection = LOCATION_LIST.map(loc => {
+    const consumableItems = Object.values(CONSUMABLES).map(c => ({
+        imageId: `fish:${c.id}`,
+        name:    c.name,
+        price:   c.cost,
+        emoji:   c.emoji
+    }));
+    const consumableList = Object.values(CONSUMABLES).map(c =>
+        `${c.emoji} **${c.name}** — ${currency}${c.cost} · \`/fish shop buy item:${c.id}\``
+    ).join('\n');
+
+    const locationItems = LOCATION_LIST.map(loc => {
+        const unlocked = f.unlockedLocations.includes(loc.id);
+        const isActive = f.activeLocation === loc.id;
+        return {
+            imageId: `fish:${loc.id}`,
+            name:    loc.name,
+            emoji:   loc.emoji,
+            badge:   isActive ? 'ACTIVE' : (unlocked ? 'OWNED' : `Lv.${loc.unlockLevel}`),
+            subline: unlocked ? (isActive ? 'Currently fishing' : 'Unlocked') : (loc.unlockCost > 0 ? `${currency}${loc.unlockCost.toLocaleString()}` : 'Free')
+        };
+    });
+    const locationList = LOCATION_LIST.map(loc => {
         const unlocked = f.unlockedLocations.includes(loc.id);
         const isActive = f.activeLocation === loc.id;
         const status = unlocked
             ? (isActive ? '✅ **ACTIVE**' : '✅ Unlocked')
             : `🔒 Lv.${loc.unlockLevel}${loc.unlockCost > 0 ? ` / ${currency}${loc.unlockCost.toLocaleString()}` : ' (free)'}`;
-        return `${loc.emoji} **${loc.name}** — ${status}\n   *${loc.description}*`;
+        return `${loc.emoji} **${loc.name}** — ${status}`;
     }).join('\n');
 
-    embeds.push(new EmbedBuilder()
-        .setColor(COLOR)
-        .setTitle('🛠️ Shop Extras')
-        .addFields(
-            { name: '🔧 Rod Upgrades (1 per rod)', value: upgradeSection,    inline: false },
-            { name: '🪱 Bait Packs',               value: baitSection,       inline: false },
-            { name: '🧪 Consumables',              value: consumableSection, inline: false },
-            { name: '🗺️ Locations',                value: locationSection,   inline: false }
-        )
-        .setFooter({ text: '/fish shop rod • /fish shop upgrade • /fish shop buy • /fish shop use • /fish shop repair • /fish shop unlock' })
-        .setTimestamp()
-    );
-
-    return interaction.reply({ embeds, files });
+    return runShopBrowse(interaction, {
+        activity: 'fish',
+        title:    'Fishing Shop',
+        currency,
+        footer:   'rod • upgrade • buy • use • repair • unlock',
+        pages: [
+            { id: 'rods',        label: 'Rods',        emoji: '🎣',  subtitle: 'Better rods, better catches.',           items: rodItems,        listText: rodList        },
+            { id: 'upgrades',    label: 'Upgrades',    emoji: '🔧',  subtitle: 'One module per rod, permanent.',         items: upgradeItems,    listText: upgradeList    },
+            { id: 'bait',        label: 'Bait',        emoji: '🪱',  subtitle: 'The right bait pulls the right fish.',   items: baitItems,       listText: baitList       },
+            { id: 'consumables', label: 'Consumables', emoji: '🧪',  subtitle: 'Luck, XP and quick boosts.',             items: consumableItems, listText: consumableList },
+            { id: 'locations',   label: 'Locations',   emoji: '🗺️', subtitle: 'New waters, new species.',                items: locationItems,   listText: locationList   }
+        ]
+    });
 }
 
 async function handleBuyRod(interaction, user, currency) {

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -1393,10 +1393,32 @@ async function handleShop(interaction, sub) {
 
 async function showShopList(interaction, user, currency) {
     const f = user.fishing;
+    const COLOR = '#f39c12';
+    const embeds = [];
+    const files  = [];
 
-    const rodSection = ROD_TIERS.map(r =>
-        `${r.emoji} **T${r.tier} ${r.name}** — ${currency}${r.cost.toLocaleString()}\n   ${r.description}`
-    ).join('\n');
+    embeds.push(new EmbedBuilder()
+        .setColor(COLOR)
+        .setTitle('🏪 Fishing Shop — Rods')
+        .setDescription('Browse the available rods. Upgrades, bait, consumables and locations are listed below.')
+    );
+
+    for (const r of ROD_TIERS) {
+        const card = new EmbedBuilder()
+            .setColor(COLOR)
+            .setTitle(`${r.emoji} T${r.tier} ${r.name}`)
+            .setDescription(r.description)
+            .addFields(
+                { name: 'Cost', value: `${currency}${r.cost.toLocaleString()}`, inline: true },
+                { name: 'Buy',  value: `\`/fish shop rod type:${r.slug}\``,      inline: true }
+            );
+        const img = await getItemImageAttachment(`fish:${r.slug}`).catch(() => null);
+        if (img) {
+            card.setThumbnail(img.url);
+            files.push(img.attachment);
+        }
+        embeds.push(card);
+    }
 
     const upgradeSection = Object.values(ROD_UPGRADES).map(u =>
         `${u.emoji} **${u.name}** — ~${Math.round(u.costMultiplier * 100)}% of rod price\n   *${u.description}*`
@@ -1419,20 +1441,20 @@ async function showShopList(interaction, user, currency) {
         return `${loc.emoji} **${loc.name}** — ${status}\n   *${loc.description}*`;
     }).join('\n');
 
-    const embed = new EmbedBuilder()
-        .setColor('#f39c12')
-        .setTitle('🏪 Fishing Shop')
+    embeds.push(new EmbedBuilder()
+        .setColor(COLOR)
+        .setTitle('🛠️ Shop Extras')
         .addFields(
-            { name: '🎣 Rods',                     value: rodSection,        inline: false },
             { name: '🔧 Rod Upgrades (1 per rod)', value: upgradeSection,    inline: false },
             { name: '🪱 Bait Packs',               value: baitSection,       inline: false },
-            { name: '🧪 Consumables',              value: consumableSection,  inline: false },
+            { name: '🧪 Consumables',              value: consumableSection, inline: false },
             { name: '🗺️ Locations',                value: locationSection,   inline: false }
         )
         .setFooter({ text: '/fish shop rod • /fish shop upgrade • /fish shop buy • /fish shop use • /fish shop repair • /fish shop unlock' })
-        .setTimestamp();
+        .setTimestamp()
+    );
 
-    return interaction.reply({ embeds: [embed] });
+    return interaction.reply({ embeds, files });
 }
 
 async function handleBuyRod(interaction, user, currency) {

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -1340,11 +1340,39 @@ async function executeShop(interaction, sub) {
 
 async function showShopList(interaction, user, currency) {
     const h = user.hunt;
+    const COLOR = '#f39c12';
+    const embeds = [];
+    const files  = [];
 
-    const weaponSection = WEAPON_TIERS.map(w => {
-        const ammo = w.requiresAmmo ? `${w.ammoType.replace(/_/g, ' ')} (${currency}${w.ammoCost}/hunt)` : 'None';
-        return `**T${w.tier} ${w.emoji} ${w.name}** — ${currency}${w.cost.toLocaleString()}\n   Success: ${Math.round(w.successRate * 100)}% | Rarity: +${Math.round(w.rarityBoost * 100)}% | Ammo: ${ammo}`;
-    }).join('\n');
+    embeds.push(new EmbedBuilder()
+        .setColor(COLOR)
+        .setTitle('🏪 Hunt Shop — Weapons')
+        .setDescription('Browse the available weapons. Upgrades, ammo, consumables and zones are listed below.')
+    );
+
+    for (const w of WEAPON_TIERS) {
+        const ammoText = w.requiresAmmo
+            ? `${w.ammoType.replace(/_/g, ' ')} (${currency}${w.ammoCost}/hunt)`
+            : 'None required';
+        const card = new EmbedBuilder()
+            .setColor(COLOR)
+            .setTitle(`${w.emoji} T${w.tier} ${w.name}`)
+            .setDescription(w.description)
+            .addFields(
+                { name: 'Cost',         value: `${currency}${w.cost.toLocaleString()}`,                                inline: true },
+                { name: 'Durability',   value: `${w.baseDurability}`,                                                  inline: true },
+                { name: 'Success',      value: `${Math.round(w.successRate * 100)}%`,                                  inline: true },
+                { name: 'Rarity Boost', value: w.rarityBoost > 0 ? `+${Math.round(w.rarityBoost * 100)}%` : 'None',    inline: true },
+                { name: 'Ammo',         value: ammoText,                                                               inline: true },
+                { name: 'Buy',          value: `\`/hunt shop weapon type:${w.slug}\``,                                  inline: true }
+            );
+        const img = await getItemImageAttachment(`hunt:${w.slug}`).catch(() => null);
+        if (img) {
+            card.setThumbnail(img.url);
+            files.push(img.attachment);
+        }
+        embeds.push(card);
+    }
 
     const upgradeSection = Object.values(WEAPON_UPGRADES).map(u =>
         `${u.emoji} **${u.name}** — ~${Math.round(u.costMultiplier * 100)}% of weapon price\n   *${u.description}*`
@@ -1367,20 +1395,20 @@ async function showShopList(interaction, user, currency) {
         return `${zone.emoji} **${zone.name}** — ${status}\n   *${zone.description}*`;
     }).join('\n');
 
-    const embed = new EmbedBuilder()
-        .setColor('#f39c12')
-        .setTitle('🏪 Hunt Shop')
+    embeds.push(new EmbedBuilder()
+        .setColor(COLOR)
+        .setTitle('🛠️ Shop Extras')
         .addFields(
-            { name: '🔫 Weapons',                        value: weaponSection,     inline: false },
             { name: '🔧 Weapon Upgrades (1 per weapon)', value: upgradeSection,    inline: false },
             { name: '🔶 Ammunition',                     value: ammoSection,       inline: false },
             { name: '🧪 Consumables',                    value: consumableSection, inline: false },
             { name: '🗺️ Zones',                          value: zoneSection,       inline: false }
         )
         .setFooter({ text: '/hunt shop weapon • /hunt shop upgrade • /hunt shop buy • /hunt shop use • /hunt shop repair • /hunt shop unlock' })
-        .setTimestamp();
+        .setTimestamp()
+    );
 
-    return interaction.reply({ embeds: [embed] });
+    return interaction.reply({ embeds, files });
 }
 
 async function handleBuyWeapon(interaction, user, currency) {

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -10,6 +10,7 @@ const {
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { getItemImageAttachment } = require('../../utils/itemImageHelper');
+const { runShopBrowse }          = require('../../utils/shopBrowse');
 const {
     ZONES, ZONE_LIST, TIER_COLORS, LIMITS, WEAPON_BY_TIER,
     CONSUMABLES, AMMO_PACKS,
@@ -1340,75 +1341,82 @@ async function executeShop(interaction, sub) {
 
 async function showShopList(interaction, user, currency) {
     const h = user.hunt;
-    const COLOR = '#f39c12';
-    const embeds = [];
-    const files  = [];
 
-    embeds.push(new EmbedBuilder()
-        .setColor(COLOR)
-        .setTitle('🏪 Hunt Shop — Weapons')
-        .setDescription('Browse the available weapons. Upgrades, ammo, consumables and zones are listed below.')
-    );
-
-    for (const w of WEAPON_TIERS) {
-        const ammoText = w.requiresAmmo
-            ? `${w.ammoType.replace(/_/g, ' ')} (${currency}${w.ammoCost}/hunt)`
-            : 'None required';
-        const card = new EmbedBuilder()
-            .setColor(COLOR)
-            .setTitle(`${w.emoji} T${w.tier} ${w.name}`)
-            .setDescription(w.description)
-            .addFields(
-                { name: 'Cost',         value: `${currency}${w.cost.toLocaleString()}`,                                inline: true },
-                { name: 'Durability',   value: `${w.baseDurability}`,                                                  inline: true },
-                { name: 'Success',      value: `${Math.round(w.successRate * 100)}%`,                                  inline: true },
-                { name: 'Rarity Boost', value: w.rarityBoost > 0 ? `+${Math.round(w.rarityBoost * 100)}%` : 'None',    inline: true },
-                { name: 'Ammo',         value: ammoText,                                                               inline: true },
-                { name: 'Buy',          value: `\`/hunt shop weapon type:${w.slug}\``,                                  inline: true }
-            );
-        const img = await getItemImageAttachment(`hunt:${w.slug}`).catch(() => null);
-        if (img) {
-            card.setThumbnail(img.url);
-            files.push(img.attachment);
-        }
-        embeds.push(card);
-    }
-
-    const upgradeSection = Object.values(WEAPON_UPGRADES).map(u =>
-        `${u.emoji} **${u.name}** — ~${Math.round(u.costMultiplier * 100)}% of weapon price\n   *${u.description}*`
+    const weaponItems = WEAPON_TIERS.map(w => ({
+        imageId: `hunt:${w.slug}`,
+        name:    w.name,
+        price:   w.cost,
+        emoji:   w.emoji,
+        badge:   `T${w.tier}`,
+        subline: `${Math.round(w.successRate * 100)}% • +${Math.round(w.rarityBoost * 100)}% rare`
+    }));
+    const weaponList = WEAPON_TIERS.map(w =>
+        `${w.emoji} **${w.name}** — ${currency}${w.cost.toLocaleString()} · \`/hunt shop weapon type:${w.slug}\``
     ).join('\n');
 
-    const ammoSection = AMMO_PACKS.map(a =>
-        `${a.emoji} **${a.name}** — ${currency}${a.cost}\n   *${a.description}*`
+    const upgradeItems = Object.values(WEAPON_UPGRADES).map(u => ({
+        imageId: `hunt:${u.id}`,
+        name:    u.name,
+        emoji:   u.emoji,
+        subline: `~${Math.round(u.costMultiplier * 100)}% of weapon`
+    }));
+    const upgradeList = Object.values(WEAPON_UPGRADES).map(u =>
+        `${u.emoji} **${u.name}** — *${u.description}* · \`/hunt shop upgrade module:${u.id}\``
     ).join('\n');
 
-    const consumableSection = Object.values(CONSUMABLES).map(c =>
-        `${c.emoji} **${c.name}** — ${currency}${c.cost}\n   *${c.description}*`
+    const ammoItems = AMMO_PACKS.map(a => ({
+        imageId: `hunt:${a.id}`,
+        name:    a.name,
+        price:   a.cost,
+        emoji:   a.emoji
+    }));
+    const ammoList = AMMO_PACKS.map(a =>
+        `${a.emoji} **${a.name}** — ${currency}${a.cost} · \`/hunt shop buy item:${a.id}\``
     ).join('\n');
 
-    const zoneSection = ZONE_LIST.map(zone => {
-        const unlocked = h.unlockedZones.includes(zone.id);
-        const isActive = h.activeZone === zone.id;
+    const consumableItems = Object.values(CONSUMABLES).map(c => ({
+        imageId: `hunt:${c.id}`,
+        name:    c.name,
+        price:   c.cost,
+        emoji:   c.emoji
+    }));
+    const consumableList = Object.values(CONSUMABLES).map(c =>
+        `${c.emoji} **${c.name}** — ${currency}${c.cost} · \`/hunt shop buy item:${c.id}\``
+    ).join('\n');
+
+    const zoneItems = ZONE_LIST.map(z => {
+        const unlocked = h.unlockedZones.includes(z.id);
+        const isActive = h.activeZone === z.id;
+        return {
+            imageId: `hunt:${z.id}`,
+            name:    z.name,
+            emoji:   z.emoji,
+            badge:   isActive ? 'ACTIVE' : (unlocked ? 'OWNED' : `Lv.${z.unlockLevel}`),
+            subline: unlocked ? (isActive ? 'Currently hunting' : 'Unlocked') : (z.unlockCost > 0 ? `${currency}${z.unlockCost.toLocaleString()}` : 'Free')
+        };
+    });
+    const zoneList = ZONE_LIST.map(z => {
+        const unlocked = h.unlockedZones.includes(z.id);
+        const isActive = h.activeZone === z.id;
         const status = unlocked
             ? (isActive ? '✅ **ACTIVE**' : '✅ Unlocked')
-            : `🔒 Lv.${zone.unlockLevel}${zone.unlockCost > 0 ? ` / ${currency}${zone.unlockCost.toLocaleString()}` : ' (free)'}`;
-        return `${zone.emoji} **${zone.name}** — ${status}\n   *${zone.description}*`;
+            : `🔒 Lv.${z.unlockLevel}${z.unlockCost > 0 ? ` / ${currency}${z.unlockCost.toLocaleString()}` : ' (free)'}`;
+        return `${z.emoji} **${z.name}** — ${status}`;
     }).join('\n');
 
-    embeds.push(new EmbedBuilder()
-        .setColor(COLOR)
-        .setTitle('🛠️ Shop Extras')
-        .addFields(
-            { name: '🔧 Weapon Upgrades (1 per weapon)', value: upgradeSection,    inline: false },
-            { name: '🔶 Ammunition',                     value: ammoSection,       inline: false },
-            { name: '🧪 Consumables',                    value: consumableSection, inline: false },
-            { name: '🗺️ Zones',                          value: zoneSection,       inline: false }
-        )
-        .setFooter({ text: '/hunt shop weapon • /hunt shop upgrade • /hunt shop buy • /hunt shop use • /hunt shop repair • /hunt shop unlock' })
-        .setTimestamp()
-    );
-
-    return interaction.reply({ embeds, files });
+    return runShopBrowse(interaction, {
+        activity: 'hunt',
+        title:    'Hunt Shop',
+        currency,
+        footer:   'weapon • upgrade • buy • use • repair • unlock',
+        pages: [
+            { id: 'weapons',     label: 'Weapons',     emoji: '🔫',  subtitle: 'Pick your tier — better gear, better trophies.', items: weaponItems,     listText: weaponList     },
+            { id: 'upgrades',    label: 'Upgrades',    emoji: '🔧',  subtitle: 'One module per weapon, permanent.',                items: upgradeItems,    listText: upgradeList    },
+            { id: 'ammo',        label: 'Ammunition',  emoji: '🔶',  subtitle: 'Keep your rifle fed.',                              items: ammoItems,       listText: ammoList       },
+            { id: 'consumables', label: 'Consumables', emoji: '🧪',  subtitle: 'Bait, charms, repairs and more.',                   items: consumableItems, listText: consumableList },
+            { id: 'zones',       label: 'Zones',       emoji: '🗺️', subtitle: 'New regions, new prey.',                            items: zoneItems,       listText: zoneList       }
+        ]
+    });
 }
 
 async function handleBuyWeapon(interaction, user, currency) {

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -4,6 +4,7 @@ const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, Butt
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { getItemImageAttachment } = require('../../utils/itemImageHelper');
+const { runShopBrowse }          = require('../../utils/shopBrowse');
 const {
     DEPTHS, DEPTH_LIST, TIER_COLORS, LIMITS, PICKAXE_BY_TIER,
     MATERIAL_NAMES, CONSUMABLES, BLAST_PACKS,
@@ -804,74 +805,81 @@ async function handleShop(interaction, sub) {
     const m = user.mining;
 
     if (sub === 'list') {
-        const COLOR = '#b5651d';
-        const embeds = [];
-        const files  = [];
+        const pickaxeItems = PICKAXE_TIERS.map(p => ({
+            imageId: `mine:${p.slug}`,
+            name:    p.name,
+            price:   p.cost,
+            emoji:   p.emoji,
+            badge:   `T${p.tier}`,
+            subline: `${Math.round(p.successRate * 100)}% • +${Math.round(p.rarityBoost * 100)}% rare`
+        }));
+        const pickaxeList = PICKAXE_TIERS.map(p =>
+            `${p.emoji} **${p.name}** — ${currency}${p.cost.toLocaleString()} · \`/mine shop pickaxe type:${p.slug}\``
+        ).join('\n');
 
-        embeds.push(new EmbedBuilder()
-            .setColor(COLOR)
-            .setTitle('⛏️ Mining Shop — Pickaxes')
-            .setDescription('Browse the available pickaxes. Upgrades, blast charges, consumables and depths are listed below.')
-        );
+        const upgradeItems = Object.values(PICKAXE_UPGRADES).map(u => ({
+            imageId: `mine:${u.id}`,
+            name:    u.name,
+            emoji:   u.emoji,
+            subline: `${Math.round(u.costMultiplier * 100)}% of pickaxe`
+        }));
+        const upgradeList = Object.values(PICKAXE_UPGRADES).map(u =>
+            `${u.emoji} **${u.name}** — *${u.description}* · \`/mine shop upgrade module:${u.id}\``
+        ).join('\n');
 
-        for (const p of PICKAXE_TIERS) {
-            const card = new EmbedBuilder()
-                .setColor(COLOR)
-                .setTitle(`${p.emoji} T${p.tier} ${p.name}`)
-                .addFields(
-                    { name: 'Cost',         value: `${currency}${p.cost.toLocaleString()}`,                       inline: true },
-                    { name: 'Durability',   value: `${p.baseDurability}`,                                          inline: true },
-                    { name: 'Success',      value: `${Math.round(p.successRate * 100)}%`,                          inline: true },
-                    { name: 'Rarity Boost', value: `+${Math.round(p.rarityBoost * 100)}%`,                         inline: true },
-                    { name: 'Charge',       value: p.requiresCharge ? p.chargeType.replace(/_/g, ' ') : 'None',    inline: true },
-                    { name: 'Buy',          value: `\`/mine shop pickaxe type:${p.slug}\``,                         inline: true }
-                );
-            const img = await getItemImageAttachment(`mine:${p.slug}`).catch(() => null);
-            if (img) {
-                card.setThumbnail(img.url);
-                files.push(img.attachment);
-            }
-            embeds.push(card);
-        }
+        const blastItems = BLAST_PACKS.map(b => ({
+            imageId: `mine:${b.id}`,
+            name:    b.name,
+            price:   b.cost,
+            emoji:   b.emoji
+        }));
+        const blastList = BLAST_PACKS.map(b =>
+            `${b.emoji} **${b.name}** — ${currency}${b.cost} · \`/mine shop buy item:${b.id}\``
+        ).join('\n');
 
-        embeds.push(new EmbedBuilder()
-            .setColor(COLOR)
-            .setTitle('🛠️ Shop Extras')
-            .addFields(
-                {
-                    name: '🔩 Upgrades (one per pickaxe)',
-                    value: Object.values(PICKAXE_UPGRADES).map(u =>
-                        `${u.emoji} **${u.name}** — ${Math.round(u.costMultiplier * 100)}% of pickaxe cost\n> ${u.description}`
-                    ).join('\n'),
-                    inline: false
-                },
-                {
-                    name: '💥 Blast Charges',
-                    value: BLAST_PACKS.map(b =>
-                        `${b.emoji} **${b.name}** — ${currency}${b.cost}\n> ${b.description}`
-                    ).join('\n'),
-                    inline: false
-                },
-                {
-                    name: '🎒 Consumables',
-                    value: Object.values(CONSUMABLES).map(c =>
-                        `${c.emoji} **${c.name}** — ${currency}${c.cost}\n> ${c.description}`
-                    ).join('\n'),
-                    inline: false
-                },
-                {
-                    name: '🗺️ Depths to Unlock',
-                    value: DEPTH_LIST.filter(d => !d.defaultUnlocked).map(d =>
-                        `${d.emoji} **${d.name}** — ${currency}${d.unlockCost.toLocaleString()} • Requires Lv.${d.unlockLevel}\n> ${d.description}`
-                    ).join('\n'),
-                    inline: false
-                }
-            )
-            .setFooter({ text: 'Use /mine shop pickaxe|buy|upgrade|repair|unlock to purchase' })
-            .setTimestamp()
-        );
+        const consumableItems = Object.values(CONSUMABLES).map(c => ({
+            imageId: `mine:${c.id}`,
+            name:    c.name,
+            price:   c.cost,
+            emoji:   c.emoji
+        }));
+        const consumableList = Object.values(CONSUMABLES).map(c =>
+            `${c.emoji} **${c.name}** — ${currency}${c.cost} · \`/mine shop buy item:${c.id}\``
+        ).join('\n');
 
-        return interaction.reply({ embeds, files });
+        const depthItems = DEPTH_LIST.map(d => {
+            const unlocked = m.unlockedDepths?.includes(d.id) ?? d.defaultUnlocked;
+            const isActive = m.activeDepth === d.id;
+            return {
+                imageId: `mine:${d.id}`,
+                name:    d.name,
+                emoji:   d.emoji,
+                badge:   isActive ? 'ACTIVE' : (unlocked ? 'OWNED' : `Lv.${d.unlockLevel}`),
+                subline: unlocked ? (isActive ? 'Currently mining' : 'Unlocked') : `${currency}${d.unlockCost.toLocaleString()}`
+            };
+        });
+        const depthList = DEPTH_LIST.map(d => {
+            const unlocked = m.unlockedDepths?.includes(d.id) ?? d.defaultUnlocked;
+            const isActive = m.activeDepth === d.id;
+            const status = unlocked
+                ? (isActive ? '✅ **ACTIVE**' : '✅ Unlocked')
+                : `🔒 Lv.${d.unlockLevel} / ${currency}${d.unlockCost.toLocaleString()}`;
+            return `${d.emoji} **${d.name}** — ${status}`;
+        }).join('\n');
+
+        return runShopBrowse(interaction, {
+            activity: 'mine',
+            title:    'Mining Shop',
+            currency,
+            footer:   'pickaxe • upgrade • buy • use • repair • unlock',
+            pages: [
+                { id: 'pickaxes',    label: 'Pickaxes',    emoji: '🪓',  subtitle: 'Stronger picks bite deeper veins.',     items: pickaxeItems,    listText: pickaxeList    },
+                { id: 'upgrades',    label: 'Upgrades',    emoji: '🔩',  subtitle: 'One module per pickaxe, permanent.',     items: upgradeItems,    listText: upgradeList    },
+                { id: 'blasts',      label: 'Blast Charges', emoji: '💥', subtitle: 'Crack through stubborn rock.',          items: blastItems,      listText: blastList      },
+                { id: 'consumables', label: 'Consumables', emoji: '🎒',  subtitle: 'Repairs, charms and quick boosts.',      items: consumableItems, listText: consumableList },
+                { id: 'depths',      label: 'Depths',      emoji: '🗺️', subtitle: 'New depths, new ores.',                  items: depthItems,      listText: depthList      }
+            ]
+        });
     }
 
     if (sub === 'pickaxe') {

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -804,17 +804,40 @@ async function handleShop(interaction, sub) {
     const m = user.mining;
 
     if (sub === 'list') {
-        const embed = new EmbedBuilder()
-            .setColor('#b5651d')
-            .setTitle('⛏️ Mining Shop')
+        const COLOR = '#b5651d';
+        const embeds = [];
+        const files  = [];
+
+        embeds.push(new EmbedBuilder()
+            .setColor(COLOR)
+            .setTitle('⛏️ Mining Shop — Pickaxes')
+            .setDescription('Browse the available pickaxes. Upgrades, blast charges, consumables and depths are listed below.')
+        );
+
+        for (const p of PICKAXE_TIERS) {
+            const card = new EmbedBuilder()
+                .setColor(COLOR)
+                .setTitle(`${p.emoji} T${p.tier} ${p.name}`)
+                .addFields(
+                    { name: 'Cost',         value: `${currency}${p.cost.toLocaleString()}`,                       inline: true },
+                    { name: 'Durability',   value: `${p.baseDurability}`,                                          inline: true },
+                    { name: 'Success',      value: `${Math.round(p.successRate * 100)}%`,                          inline: true },
+                    { name: 'Rarity Boost', value: `+${Math.round(p.rarityBoost * 100)}%`,                         inline: true },
+                    { name: 'Charge',       value: p.requiresCharge ? p.chargeType.replace(/_/g, ' ') : 'None',    inline: true },
+                    { name: 'Buy',          value: `\`/mine shop pickaxe type:${p.slug}\``,                         inline: true }
+                );
+            const img = await getItemImageAttachment(`mine:${p.slug}`).catch(() => null);
+            if (img) {
+                card.setThumbnail(img.url);
+                files.push(img.attachment);
+            }
+            embeds.push(card);
+        }
+
+        embeds.push(new EmbedBuilder()
+            .setColor(COLOR)
+            .setTitle('🛠️ Shop Extras')
             .addFields(
-                {
-                    name: '🪓 Pickaxes',
-                    value: PICKAXE_TIERS.map(p =>
-                        `${p.emoji} **${p.name}** — ${currency}${p.cost.toLocaleString()}\n> Success: ${Math.round(p.successRate * 100)}% • Rarity: +${Math.round(p.rarityBoost * 100)}% • Durability: ${p.baseDurability}${p.requiresCharge ? ` • Requires: ${p.chargeType.replace(/_/g, ' ')}` : ''}`
-                    ).join('\n'),
-                    inline: false
-                },
                 {
                     name: '🔩 Upgrades (one per pickaxe)',
                     value: Object.values(PICKAXE_UPGRADES).map(u =>
@@ -845,8 +868,10 @@ async function handleShop(interaction, sub) {
                 }
             )
             .setFooter({ text: 'Use /mine shop pickaxe|buy|upgrade|repair|unlock to purchase' })
-            .setTimestamp();
-        return interaction.reply({ embeds: [embed] });
+            .setTimestamp()
+        );
+
+        return interaction.reply({ embeds, files });
     }
 
     if (sub === 'pickaxe') {

--- a/src/utils/shopBanner.js
+++ b/src/utils/shopBanner.js
@@ -1,0 +1,161 @@
+'use strict';
+
+const { createCanvas, loadImage, registerFont } = require('canvas');
+
+try { registerFont('/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',      { family: 'DejaVu Sans' }); } catch {}
+try { registerFont('/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf', { family: 'DejaVu Sans', weight: 'bold' }); } catch {}
+
+const TILE_W   = 220;
+const TILE_H   = 260;
+const TILE_PAD = 18;
+const COLS     = 4;
+const HEADER_H = 80;
+
+const THEMES = {
+    hunt: { bgTop: '#1a3318', bgBottom: '#0a160a', accent: '#27ae60', tile: '#27512f', tileInner: '#16331c', name: '#ffffff', price: '#f1c40f', muted: '#9bc8a3' },
+    fish: { bgTop: '#0d2538', bgBottom: '#07182a', accent: '#2980b9', tile: '#1f4566', tileInner: '#12283d', name: '#ffffff', price: '#f1c40f', muted: '#9bc1dc' },
+    mine: { bgTop: '#2e1c10', bgBottom: '#170c05', accent: '#b5651d', tile: '#4d3119', tileInner: '#2b1a0c', name: '#ffffff', price: '#f1c40f', muted: '#d1a988' }
+};
+
+function getTheme(activity) {
+    return THEMES[activity] || THEMES.hunt;
+}
+
+async function renderCategoryBanner({ activity, title, subtitle, items, currency }) {
+    const theme = getTheme(activity);
+    const safeItems = items.slice(0, 16);
+    const count = Math.max(1, safeItems.length);
+    const cols  = Math.min(COLS, count);
+    const rows  = Math.ceil(count / COLS);
+
+    const width  = cols * TILE_W + (cols + 1) * TILE_PAD;
+    const height = HEADER_H + rows * TILE_H + (rows + 1) * TILE_PAD;
+
+    const canvas = createCanvas(width, height);
+    const ctx    = canvas.getContext('2d');
+
+    const bg = ctx.createLinearGradient(0, 0, 0, height);
+    bg.addColorStop(0, theme.bgTop);
+    bg.addColorStop(1, theme.bgBottom);
+    ctx.fillStyle = bg;
+    ctx.fillRect(0, 0, width, height);
+
+    ctx.fillStyle = theme.accent;
+    ctx.fillRect(0, 0, width, HEADER_H);
+    ctx.fillStyle = 'rgba(0,0,0,0.18)';
+    ctx.fillRect(0, HEADER_H - 4, width, 4);
+
+    ctx.fillStyle    = '#ffffff';
+    ctx.font         = 'bold 30px "DejaVu Sans"';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(title, 24, HEADER_H / 2 - (subtitle ? 10 : 0));
+    if (subtitle) {
+        ctx.fillStyle = 'rgba(255,255,255,0.85)';
+        ctx.font      = '16px "DejaVu Sans"';
+        ctx.fillText(subtitle, 24, HEADER_H / 2 + 16);
+    }
+
+    for (let i = 0; i < safeItems.length; i++) {
+        const col = i % COLS;
+        const row = Math.floor(i / COLS);
+        const x   = TILE_PAD + col * (TILE_W + TILE_PAD);
+        const y   = HEADER_H + TILE_PAD + row * (TILE_H + TILE_PAD);
+        await renderTile(ctx, safeItems[i], x, y, theme, currency);
+    }
+
+    return canvas.toBuffer('image/png');
+}
+
+async function renderTile(ctx, item, x, y, theme, currency) {
+    roundRect(ctx, x, y, TILE_W, TILE_H, 14);
+    ctx.fillStyle = theme.tile;
+    ctx.fill();
+
+    const imgX = x + 12;
+    const imgY = y + 12;
+    const imgW = TILE_W - 24;
+    const imgH = 170;
+    roundRect(ctx, imgX, imgY, imgW, imgH, 10);
+    ctx.fillStyle = theme.tileInner;
+    ctx.fill();
+
+    let drewImage = false;
+    if (item.imageBuffer) {
+        try {
+            const img = await loadImage(item.imageBuffer);
+            const fit = fitContain(img.width, img.height, imgW - 16, imgH - 16);
+            const dx  = imgX + (imgW - fit.w) / 2;
+            const dy  = imgY + (imgH - fit.h) / 2;
+            ctx.save();
+            roundRect(ctx, imgX, imgY, imgW, imgH, 10);
+            ctx.clip();
+            ctx.drawImage(img, dx, dy, fit.w, fit.h);
+            ctx.restore();
+            drewImage = true;
+        } catch { /* fall through to glyph */ }
+    }
+    if (!drewImage) {
+        ctx.fillStyle    = '#ffffff';
+        ctx.font         = 'bold 72px "DejaVu Sans"';
+        ctx.textAlign    = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(item.emoji || '?', imgX + imgW / 2, imgY + imgH / 2);
+        ctx.textAlign    = 'start';
+    }
+
+    if (item.badge) {
+        ctx.fillStyle = 'rgba(0,0,0,0.55)';
+        roundRect(ctx, imgX + 8, imgY + 8, 44, 22, 6);
+        ctx.fill();
+        ctx.fillStyle    = '#ffffff';
+        ctx.font         = 'bold 13px "DejaVu Sans"';
+        ctx.textBaseline = 'middle';
+        ctx.textAlign    = 'center';
+        ctx.fillText(item.badge, imgX + 8 + 22, imgY + 8 + 11);
+        ctx.textAlign    = 'start';
+    }
+
+    ctx.fillStyle    = theme.name;
+    ctx.font         = 'bold 17px "DejaVu Sans"';
+    ctx.textBaseline = 'top';
+    ctx.fillText(truncate(ctx, item.name, TILE_W - 24), x + 12, imgY + imgH + 10);
+
+    if (item.price != null) {
+        ctx.fillStyle = theme.price;
+        ctx.font      = 'bold 15px "DejaVu Sans"';
+        ctx.fillText(`${currency}${item.price.toLocaleString()}`, x + 12, imgY + imgH + 34);
+    } else if (item.subline) {
+        ctx.fillStyle = theme.muted;
+        ctx.font      = '14px "DejaVu Sans"';
+        ctx.fillText(truncate(ctx, item.subline, TILE_W - 24), x + 12, imgY + imgH + 34);
+    }
+
+    if (item.subline && item.price != null) {
+        ctx.fillStyle = theme.muted;
+        ctx.font      = '13px "DejaVu Sans"';
+        ctx.fillText(truncate(ctx, item.subline, TILE_W - 24), x + 12, imgY + imgH + 54);
+    }
+}
+
+function fitContain(w, h, maxW, maxH) {
+    const r = Math.min(maxW / w, maxH / h);
+    return { w: w * r, h: h * r };
+}
+
+function roundRect(ctx, x, y, w, h, r) {
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.arcTo(x + w, y,     x + w, y + h, r);
+    ctx.arcTo(x + w, y + h, x,     y + h, r);
+    ctx.arcTo(x,     y + h, x,     y,     r);
+    ctx.arcTo(x,     y,     x + w, y,     r);
+    ctx.closePath();
+}
+
+function truncate(ctx, text, maxW) {
+    if (ctx.measureText(text).width <= maxW) return text;
+    while (text.length && ctx.measureText(text + '…').width > maxW) text = text.slice(0, -1);
+    return text + '…';
+}
+
+module.exports = { renderCategoryBanner, getTheme };

--- a/src/utils/shopBrowse.js
+++ b/src/utils/shopBrowse.js
@@ -1,0 +1,160 @@
+'use strict';
+
+const {
+    EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle,
+    StringSelectMenuBuilder, AttachmentBuilder
+} = require('discord.js');
+
+const ItemImage = require('../models/ItemImage');
+const { renderCategoryBanner, getTheme } = require('./shopBanner');
+
+const COLOR_HEX = {
+    hunt: '#27ae60',
+    fish: '#2980b9',
+    mine: '#b5651d'
+};
+
+async function loadImagesByItemIds(itemIds) {
+    const out = {};
+    const ids = [...new Set(itemIds.filter(Boolean))];
+    if (!ids.length) return out;
+    const docs = await ItemImage.find({ itemId: { $in: ids } }).lean();
+    for (const d of docs) {
+        if (d.imageData?.length) out[d.itemId] = d.imageData;
+    }
+    return out;
+}
+
+/**
+ * Render a paginated shop browse UI.
+ *
+ * @param {import('discord.js').ChatInputCommandInteraction} interaction
+ * @param {object}   config
+ * @param {string}   config.activity   'hunt' | 'fish' | 'mine'
+ * @param {string}   config.title      e.g. 'Hunt Shop'
+ * @param {string}   config.currency   currency symbol/emoji
+ * @param {string}   [config.footer]   footer help text
+ * @param {Array}    config.pages      ordered page descriptors
+ *
+ * Each page:
+ * {
+ *   id:       string,
+ *   label:    string,            // category label
+ *   emoji:    string,            // for select menu
+ *   subtitle: string,            // shown on banner under title
+ *   items:    [{ id?: string, imageId?: string, name, price?, emoji, subline?, badge? }],
+ *   listText: string             // text block shown below banner (buy commands etc.)
+ * }
+ */
+async function runShopBrowse(interaction, config) {
+    const { activity, title, currency, pages, footer } = config;
+    const colorHex = COLOR_HEX[activity] || '#f39c12';
+
+    const imageCache = new Map();
+    async function hydrate(page) {
+        const wanted = page.items.map(it => it.imageId).filter(Boolean);
+        const missing = wanted.filter(id => !imageCache.has(id));
+        if (missing.length) {
+            const fetched = await loadImagesByItemIds(missing);
+            for (const id of missing) imageCache.set(id, fetched[id] || null);
+        }
+        return page.items.map(it => ({
+            ...it,
+            imageBuffer: it.imageId ? imageCache.get(it.imageId) : null
+        }));
+    }
+
+    let pageIdx = 0;
+
+    async function buildMessage(idx) {
+        const page  = pages[idx];
+        const items = await hydrate(page);
+
+        const buffer = await renderCategoryBanner({
+            activity,
+            title:    `${title} — ${page.label}`,
+            subtitle: page.subtitle,
+            items,
+            currency
+        });
+        const filename   = `${activity}-shop-${page.id}.png`;
+        const attachment = new AttachmentBuilder(buffer, { name: filename });
+
+        const embed = new EmbedBuilder()
+            .setColor(colorHex)
+            .setImage(`attachment://${filename}`);
+
+        if (page.listText) {
+            embed.setDescription(page.listText.slice(0, 4000));
+        }
+
+        embed.setFooter({
+            text: `Page ${idx + 1}/${pages.length} • ${footer || 'Use the menu to switch categories'}`
+        });
+
+        const prev = new ButtonBuilder()
+            .setCustomId('shop_prev')
+            .setEmoji('◀️')
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(idx === 0);
+        const next = new ButtonBuilder()
+            .setCustomId('shop_next')
+            .setEmoji('▶️')
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(idx === pages.length - 1);
+        const close = new ButtonBuilder()
+            .setCustomId('shop_close')
+            .setLabel('Close')
+            .setStyle(ButtonStyle.Danger);
+
+        const select = new StringSelectMenuBuilder()
+            .setCustomId('shop_cat')
+            .setPlaceholder('Jump to category…')
+            .addOptions(pages.map((p, i) => ({
+                label:   p.label.slice(0, 100),
+                value:   String(i),
+                emoji:   p.emoji,
+                default: i === idx
+            })));
+
+        return {
+            embeds:     [embed],
+            files:      [attachment],
+            components: [
+                new ActionRowBuilder().addComponents(prev, next, close),
+                new ActionRowBuilder().addComponents(select)
+            ]
+        };
+    }
+
+    const initial = await buildMessage(pageIdx);
+    const reply   = await interaction.reply({ ...initial, fetchReply: true });
+
+    const collector = reply.createMessageComponentCollector({ time: 5 * 60_000 });
+
+    collector.on('collect', async btn => {
+        if (btn.user.id !== interaction.user.id) {
+            return btn.reply({ content: 'These controls aren\'t for you — run the command yourself.', ephemeral: true });
+        }
+        if (btn.customId === 'shop_close') {
+            collector.stop('closed');
+            return btn.update({ components: [] }).catch(() => {});
+        }
+        if (btn.customId === 'shop_prev') pageIdx = Math.max(0, pageIdx - 1);
+        else if (btn.customId === 'shop_next') pageIdx = Math.min(pages.length - 1, pageIdx + 1);
+        else if (btn.customId === 'shop_cat')  pageIdx = Number(btn.values?.[0] ?? pageIdx);
+        try {
+            await btn.deferUpdate();
+            const updated = await buildMessage(pageIdx);
+            await interaction.editReply(updated);
+        } catch (err) {
+            console.error('[shopBrowse] update error:', err);
+        }
+    });
+
+    collector.on('end', () => {
+        interaction.editReply({ components: [] }).catch(() => {});
+    });
+}
+
+module.exports = { runShopBrowse, getTheme };


### PR DESCRIPTION
## Summary
Introduces a new visual shop browsing system for economy commands (hunt, fish, mine) that replaces text-based embed listings with paginated, image-based category banners. Players can now browse shop items with visual thumbnails, prices, and badges in an organized grid layout.

## Key Changes

- **New `shopBanner.js` utility**: Generates PNG banners using canvas with:
  - Configurable themes for each activity (hunt/fish/mine) with distinct color schemes
  - Grid layout rendering of shop items (up to 4 columns, 16 items per page)
  - Support for item images, emojis, prices, badges, and sublines
  - Rounded corners, gradient backgrounds, and responsive text truncation

- **New `shopBrowse.js` utility**: Implements paginated shop UI with:
  - Multi-page navigation using previous/next buttons and category select menu
  - Dynamic image loading and caching from ItemImage database
  - 5-minute interaction timeout with automatic cleanup
  - User permission checks to prevent unauthorized control

- **Updated economy commands** (hunt.js, fish.js, mine.js):
  - Replaced static embed-based shop listings with `runShopBrowse()` calls
  - Organized shop items into 5 category pages (weapons/rods/pickaxes, upgrades, consumables, ammo/bait/charges, zones/locations/depths)
  - Converted item descriptions to compact sublines and command hints in list text
  - Added visual badges (tier, status, level requirements) to items

## Implementation Details

- Canvas rendering uses DejaVu Sans font with fallback error handling for missing system fonts
- Item images are loaded from database and cached in-memory during session to minimize queries
- Banner dimensions scale based on item count (1-4 columns, variable rows)
- Each activity has distinct color theme (hunt: green, fish: blue, mine: brown)
- Graceful fallback to emoji display if item image fails to load

https://claude.ai/code/session_019zHcMHJHQje6Ak4d43Kek2