### PR TITLE
Fix shop browse interaction reply handling

### DIFF
--- a/src/utils/shopBrowse.js
+++ b/src/utils/shopBrowse.js
@@ -127,8 +127,11 @@ async function runShopBrowse(interaction, config) {
         };
     }
 
+    if (!interaction.deferred && !interaction.replied) {
+        await interaction.deferReply();
+    }
     const initial = await buildMessage(pageIdx);
-    const reply   = await interaction.reply({ ...initial, fetchReply: true });
+    const reply   = await interaction.editReply(initial);
 
     const collector = reply.createMessageComponentCollector({ time: 5 * 60_000 });
 


### PR DESCRIPTION
## Summary
Fixed interaction reply handling in the shop browse command to properly defer replies before editing them, preventing potential "interaction has already been replied to" errors.

## Key Changes
- Added a check to defer the interaction reply if it hasn't already been deferred or replied to
- Changed from using `interaction.reply()` with `fetchReply: true` to `interaction.editReply()` after deferring
- This ensures the interaction is always deferred before attempting to edit the reply

## Implementation Details
The change addresses a race condition where the interaction could be replied to before the deferred state was established. By explicitly deferring the interaction first (if not already deferred), we guarantee that subsequent `editReply()` calls will work correctly. This is a more robust pattern for handling Discord interactions that may be processed asynchronously.

https://claude.ai/code/session_01Y5NNQkXY8WHB6Zdk8FxXzN