### PR TITLE
fix(shop): coerce mongo Binary to Buffer + render safeguards

### DIFF
--- a/src/utils/shopBanner.js
+++ b/src/utils/shopBanner.js
@@ -82,7 +82,10 @@ async function renderTile(ctx, item, x, y, theme, currency) {
     let drewImage = false;
     if (item.imageBuffer) {
         try {
-            const img = await loadImage(item.imageBuffer);
+            const img = await Promise.race([
+                loadImage(item.imageBuffer),
+                new Promise((_, reject) => setTimeout(() => reject(new Error('loadImage timeout')), 2000))
+            ]);
             const fit = fitContain(img.width, img.height, imgW - 16, imgH - 16);
             const dx  = imgX + (imgW - fit.w) / 2;
             const dy  = imgY + (imgH - fit.h) / 2;

--- a/src/utils/shopBrowse.js
+++ b/src/utils/shopBrowse.js
@@ -18,9 +18,12 @@ async function loadImagesByItemIds(itemIds) {
     const out = {};
     const ids = [...new Set(itemIds.filter(Boolean))];
     if (!ids.length) return out;
-    const docs = await ItemImage.find({ itemId: { $in: ids } }).lean();
+    const docs = await ItemImage.find({ itemId: { $in: ids } });
     for (const d of docs) {
-        if (d.imageData?.length) out[d.itemId] = d.imageData;
+        const raw = d.imageData;
+        if (!raw) continue;
+        const buf = Buffer.isBuffer(raw) ? raw : Buffer.from(raw.buffer || raw);
+        if (buf.length) out[d.itemId] = buf;
     }
     return out;
 }
@@ -130,8 +133,15 @@ async function runShopBrowse(interaction, config) {
     if (!interaction.deferred && !interaction.replied) {
         await interaction.deferReply();
     }
-    const initial = await buildMessage(pageIdx);
-    const reply   = await interaction.editReply(initial);
+    let reply;
+    try {
+        const initial = await buildMessage(pageIdx);
+        reply = await interaction.editReply(initial);
+    } catch (err) {
+        console.error('[shopBrowse] initial render error:', err);
+        await interaction.editReply({ content: 'Failed to render the shop. Please try again.', embeds: [], components: [], files: [] }).catch(() => {});
+        return;
+    }
 
     const collector = reply.createMessageComponentCollector({ time: 5 * 60_000 });
 


### PR DESCRIPTION
The lean ItemImage query returns a mongodb.Binary for Buffer fields in Mongoose 8. Binary.length is a method (truthy), so the check passed and the Binary was handed to canvas.loadImage, which doesn't accept that shape and could hang on certain builds — leaving /hunt shop list spinning forever after the defer.

- Drop .lean() and explicitly coerce to a Node Buffer.
- Race loadImage against a 2s timeout so one bad icon can't stall the whole banner.
- Wrap the initial render so any unexpected failure surfaces an error message instead of an indefinite 'thinking…' state.