### PR TITLE
feat(ux): reward reveal suspense, rarity ribbons, multiplier stack-bars

### DIFF
--- a/src/commands/economy/crime.js
+++ b/src/commands/economy/crime.js
@@ -7,6 +7,7 @@ const { clampMultiplier } = require('../../config/economy');
 const { logTransaction } = require('../../utils/logTransaction');
 const { getTotalBonus } = require('../../services/petService');
 const { randomFrom, CRIME_WIN_LINES, CRIME_BUST_LINES } = require('../../utils/copyLines');
+const { delay } = require('../../utils/delay');
 
 const COOLDOWN_MS    = 1.5 * 3_600_000; // 1.5 hours
 const DEATH_RATE     = 0.08;            // 8% of failures trigger critical death
@@ -98,6 +99,8 @@ module.exports = {
                 time: 15_000,
             });
             crime = CRIMES.find(c => c.name === buttonInteraction.customId);
+            // Acknowledge the button immediately so Discord doesn't time it out
+            await buttonInteraction.deferUpdate();
         } catch {
             // Timeout — auto-select from the presented choices
             crime = choices[Math.floor(Math.random() * choices.length)];
@@ -222,11 +225,14 @@ module.exports = {
                 }
             }
 
-            if (buttonInteraction) {
-                await buttonInteraction.update({ embeds: [embed], components: [] });
-            } else {
-                await interaction.editReply({ embeds: [embed], components: [] });
-            }
+            // Suspense delay between selection and result reveal
+            const suspenseEmbed = new EmbedBuilder()
+                .setColor('#f39c12')
+                .setTitle(`${crime.emoji} Running the Job…`)
+                .setDescription(`*${crime.displayName} in progress…*`);
+            await interaction.editReply({ embeds: [suspenseEmbed], components: [] });
+            await delay(900);
+            await interaction.editReply({ embeds: [embed], components: [] });
         } catch (error) {
             console.error('Crime command error:', error);
             if (!interaction.replied && !interaction.deferred) {

--- a/src/commands/economy/daily.js
+++ b/src/commands/economy/daily.js
@@ -7,6 +7,7 @@ const { logTransaction } = require('../../utils/logTransaction');
 const { MAX_COMBINED_MULTIPLIER, clampMultiplier } = require('../../config/economy');
 const { generateDailyChallenge } = require('../../utils/dailyChallenge');
 const { DROP_TABLE, RARE_DROP_TABLE, DROP_MILESTONES, DROP_BASE_CHANCE, weightedRandom } = require('../../data/dailyDropTable');
+const { stackBar } = require('../../utils/rewardReveal');
 
 function getStreakColor(streak) {
     if (streak >= 100) return '#9b59b6';
@@ -33,12 +34,20 @@ function getStreakDescription(streak, isMilestone) {
     return "Good to see you today.";
 }
 
-function buildRewardBlock(amount, streak, streakMult, balance, bonusLines, droppedItem, isMilestone, streakCurrent) {
+function buildRewardBlock(amount, streak, streakMult, coinMult, serverMult, combined, balance, capActive, droppedItem, isMilestone, streakCurrent, currency) {
     const div = '━━━━━━━━━━━━━━━━━━━━━━━━━━';
     const lines = [div];
     lines.push(`💰 Today's Reward: **${amount.toLocaleString()} coins**`);
-    if (streak >= 7 && streakMult > 1.0) lines.push(`🔥 Streak Bonus: **${streakMult}x**  (day ${streak})`);
-    if (bonusLines.length) lines.push(...bonusLines);
+
+    // Canonical stack-bar line when any multiplier is active
+    const mults = [];
+    if (streakMult > 1.0) mults.push({ emoji: '🔥', label: `${streak}d` });
+    if (coinMult > 1.0)   mults.push({ emoji: '💰🚀', label: `${coinMult}x` });
+    if (serverMult > 1.0) mults.push({ emoji: '🌐', label: `${serverMult}x` });
+    const bar = stackBar(mults, combined, amount, currency);
+    if (bar) lines.push(bar);
+    if (capActive) lines.push(`⚠️ Combined multiplier capped at **${MAX_COMBINED_MULTIPLIER}x**.`);
+
     lines.push(div);
     lines.push(`Balance: **${balance.toLocaleString()} coins**`);
     if (droppedItem) {
@@ -257,11 +266,7 @@ module.exports = {
             }
             // ─────────────────────────────────────────────────────────────────────
 
-            const bonusLines = [];
-            if (coinMult > 1.0)   bonusLines.push(`💰🚀 **${coinMult}x Coin Booster** active!`);
-            if (serverMult > 1.0) bonusLines.push(`🌐 **${serverMult}x Server Boost** active!`);
-            if (capActive)        bonusLines.push(`⚠️ Combined multiplier capped at **${MAX_COMBINED_MULTIPLIER}x**.`);
-
+            const currency = guildSettings?.economy?.currency || '💰';
             const streakColor = getStreakColor(streakCurrent);
             // ── Streak rank lookup ────────────────────────────────────────────────
             let streakRank = null;
@@ -285,7 +290,7 @@ module.exports = {
                 .setTitle(getStreakTitle(streakCurrent, isMilestone))
                 .setDescription(
                     getStreakDescription(streakCurrent, isMilestone) + '\n\n' +
-                    buildRewardBlock(actualAmount, streakCurrent, streakMult, updated.balance, bonusLines, droppedItem, isMilestone, streakCurrent)
+                    buildRewardBlock(actualAmount, streakCurrent, streakMult, coinMult, serverMult, combined, updated.balance, capActive, droppedItem, isMilestone, streakCurrent, currency)
                 )
                 .setFooter({ text: rankText })
                 .setTimestamp();
@@ -381,7 +386,7 @@ module.exports = {
                     const finalBalance = bonusUpdated?.balance ?? updated.balance + bonusAmount;
                     rewardEmbed.setDescription(
                         getStreakDescription(streakCurrent, isMilestone) + '\n\n' +
-                        buildRewardBlock(actualAmount, streakCurrent, streakMult, finalBalance, bonusLines, droppedItem, isMilestone, streakCurrent)
+                        buildRewardBlock(actualAmount, streakCurrent, streakMult, coinMult, serverMult, combined, finalBalance, capActive, droppedItem, isMilestone, streakCurrent, currency)
                     );
                     const winChallengeEmbed = new EmbedBuilder()
                         .setColor('#ffd700')

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -44,6 +44,8 @@ const {
 const { getCurrentWeather } = require('../../services/weatherService');
 const { FISH_TRAITS, TIME_OF_DAY_BONUSES, getTimeOfDay } = require('../../data/fishData');
 const { ensureHuntData } = require('../../services/huntService');
+const { TIER_NUM, TIER_RIBBON } = require('../../data/materialRarity');
+const { randomFrom, FISH_MISS_POOL } = require('../../utils/copyLines');
 
 const LOCATION_CHOICES = LOCATION_LIST.map(l => ({ name: l.name, value: l.id }));
 
@@ -424,7 +426,7 @@ async function handleCast(interaction) {
             embeds: [new EmbedBuilder()
                 .setColor('#888888')
                 .setTitle('🐟 The Fish Got Away!')
-                .setDescription('*You were too slow — the fish slipped free.*\n\nStamina spent, no reward.')
+                .setDescription(`*${randomFrom(FISH_MISS_POOL)}*\n\nStamina spent, no reward.`)
                 .setAuthor({ name: interaction.member?.displayName || interaction.user.username, iconURL: interaction.user.displayAvatarURL({ dynamic: true }) })],
             components: [],
         });
@@ -636,12 +638,13 @@ function buildCastEmbed(result, user, location, rod, currency, discordUser) {
             : `**${currency}${finalPayout.toLocaleString()}**`;
 
         const isLegendary = tier === 'legendary';
+        const ribbon = TIER_RIBBON(TIER_NUM[tier] ?? 1);
         const embedTitle = isLegendary
             ? `🌊✨ LEGENDARY CATCH ✨🌊`
             : `${fish.emoji} ${isCrit ? '✨ CRITICAL! ' : ''}${fish.name}${sizeStr}${isCrit ? ' ✨' : ''}`;
         const embedDesc = isLegendary
-            ? `You pulled something impossible from the deep.\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  ${fish.emoji}  **${fish.name}**${sizeStr}  [⭐⭐⭐⭐⭐]\n  *${fish.flavor}*\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n\nAdded to your inventory.`
-            : `*${fish.flavor}*`;
+            ? `${ribbon}\n\nYou pulled something impossible from the deep.\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  ${fish.emoji}  **${fish.name}**${sizeStr}  [⭐⭐⭐⭐⭐]\n  *${fish.flavor}*\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n\nAdded to your inventory.`
+            : `${ribbon}\n\n*${fish.flavor}*`;
 
         const embed = new EmbedBuilder()
             .setColor(color)

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -19,6 +19,8 @@ const {
     ANIMAL_TRAITS
 } = require('../../data/huntData');
 const { checkAndAward, announceAchievements } = require('../../services/achievementService');
+const { TIER_NUM, TIER_RIBBON } = require('../../data/materialRarity');
+const { randomFrom, HUNT_EMPTY_LINES } = require('../../utils/copyLines');
 const {
     ensureHuntData,
     applyStaminaRegen,
@@ -520,12 +522,13 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
             : '—';
 
         const isLegendary = tier === 'legendary';
+        const ribbon = TIER_RIBBON(TIER_NUM[tier] ?? 1);
         const embedTitle = isLegendary
             ? `🌟✨ LEGENDARY FIND ✨🌟`
             : `${animal.emoji} ${isCrit ? '✨ CRITICAL! ' : ''}${trophyQuality ? trophyQuality.label + ' ' : ''}${animal.name}${isCrit ? ' ✨' : ''}`;
         const embedDesc = isLegendary
-            ? `You found something impossible in the wild.\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  ${animal.emoji}  **${animal.name}**  [⭐⭐⭐⭐⭐]\n  *${animal.flavor}*\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n\nAdded to your inventory.`
-            : `*${animal.flavor}*`;
+            ? `${ribbon}\n\nYou found something impossible in the wild.\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  ${animal.emoji}  **${animal.name}**  [⭐⭐⭐⭐⭐]\n  *${animal.flavor}*\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n\nAdded to your inventory.`
+            : `${ribbon}\n\n*${animal.flavor}*`;
 
         const embed = new EmbedBuilder()
             .setColor(color)
@@ -588,7 +591,7 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
     const embed = new EmbedBuilder()
         .setColor('#e74c3c')
         .setTitle(buildFailureTitle(failure.severity.id))
-        .setDescription(failAnimal ? `*Encountered: ${failAnimal.emoji} **${failAnimal.name}***\n${failure.message}` : `*${failure.message}*`)
+        .setDescription(failAnimal ? `*Encountered: ${failAnimal.emoji} **${failAnimal.name}***\n${failure.message}` : `*${failure.severity.id === 'clean_miss' ? randomFrom(HUNT_EMPTY_LINES) : failure.message}*`)
         .addFields(
             { name: 'Zone',    value: `${zone.emoji} ${zone.name}`,  inline: true },
             { name: 'Reward',  value: 'Nothing',                      inline: true },

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -12,6 +12,8 @@ const {
     MINER_LEVELS, PRESTIGE_BONUSES, MINE_QUEST_TEMPLATES
 } = require('../../data/mineData');
 const { checkAndAward, announceAchievements } = require('../../services/achievementService');
+const { TIER_NUM, TIER_RIBBON } = require('../../data/materialRarity');
+const { randomFrom, MINE_CAVE_LINES } = require('../../utils/copyLines');
 const {
     ensureMineData,
     applyStaminaRegen,
@@ -364,7 +366,7 @@ async function handleDig(interaction) {
     const embed = buildMineEmbed(result, user, depth, pickaxe, currency, interaction.user);
     if (result.caveIn) {
         const desc = embed.data.description ?? '';
-        embed.setDescription(desc + '\n> 💥 *Cave-in! No payout — watch your durability.*');
+        embed.setDescription(desc + `\n> 💥 *${randomFrom(MINE_CAVE_LINES)}*`);
     } else if (result.intensityLevel && result.intensityLevel.multiplier !== 1.0) {
         const desc = embed.data.description ?? '';
         embed.setDescription(desc + `\n> ${result.intensityLevel.emoji} *${result.intensityLevel.name} depth: ${result.intensityLevel.multiplier}× payout applied*`);
@@ -1161,12 +1163,13 @@ function buildMineEmbed(result, user, depth, pickaxe, currency, discordUser) {
         const payoutDisplay = cappedByHard ? `~~${currency}${finalPayout}~~ (daily cap reached)` : `**${currency}${finalPayout.toLocaleString()}**`;
 
         const isLegendary = tier === 'legendary';
+        const ribbon = TIER_RIBBON(TIER_NUM[tier] ?? 1);
         const embedTitle = isLegendary
             ? `⛏️✨ LEGENDARY STRIKE ✨⛏️`
             : `${ore.emoji} ${isCrit ? '✨ CRITICAL! ' : ''}${ore.name} ${isCrit ? '✨' : ''}`;
         const embedDesc = isLegendary
-            ? `You struck something impossible in the deep.\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  ${ore.emoji}  **${ore.name}**  [⭐⭐⭐⭐⭐]\n  *${ore.flavor}*\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n\nAdded to your inventory.`
-            : `*${ore.flavor}*`;
+            ? `${ribbon}\n\nYou struck something impossible in the deep.\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  ${ore.emoji}  **${ore.name}**  [⭐⭐⭐⭐⭐]\n  *${ore.flavor}*\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n\nAdded to your inventory.`
+            : `${ribbon}\n\n*${ore.flavor}*`;
 
         const embed = new EmbedBuilder()
             .setColor(color)

--- a/src/commands/economy/rob.js
+++ b/src/commands/economy/rob.js
@@ -5,6 +5,7 @@ const { hasEffect, consumeEffect, timeRemaining } = require('../../services/effe
 const { checkAndAward, announceAchievements } = require('../../services/achievementService');
 const { getTotalBonus } = require('../../services/petService');
 const { randomFrom, ROB_WIN_LINES, ROB_FAIL_LINES } = require('../../utils/copyLines');
+const { delay } = require('../../utils/delay');
 
 const ROBBER_COOLDOWN_MS = 1 * 3_600_000; // 1 hour
 const VICTIM_IMMUNITY_MS = 30 * 60_000;   // 30 minutes
@@ -134,6 +135,22 @@ module.exports = {
             successChance += getTotalBonus(robber.pets || [], 'rob_success') / 100; // Fox pet: +8%
             successChance = Math.max(0, Math.min(0.95, successChance));
 
+            // ── Suspense reveal ───────────────────────────────────────────────
+            await interaction.reply({
+                embeds: [new EmbedBuilder()
+                    .setColor('#8B4513')
+                    .setTitle('🔎 Casing the House…')
+                    .setDescription(`*Scoping out ${target.username}'s place...*`)]
+            });
+            await delay(800);
+            await interaction.editReply({
+                embeds: [new EmbedBuilder()
+                    .setColor('#8B4513')
+                    .setTitle('🔓 Picking the Lock…')
+                    .setDescription('*Almost in...*')]
+            });
+            await delay(800);
+
             const success = Math.random() < successChance;
 
             let embed;
@@ -218,11 +235,13 @@ module.exports = {
                 }
             }
 
-            await interaction.reply({ embeds: [embed] });
+            await interaction.editReply({ embeds: [embed] });
         } catch (error) {
             console.error('Rob command error:', error);
-            if (!interaction.replied) {
+            if (!interaction.replied && !interaction.deferred) {
                 await interaction.reply({ content: 'Something went wrong.', ephemeral: true });
+            } else {
+                await interaction.editReply({ content: 'Something went wrong.' }).catch(() => {});
             }
         }
     }

--- a/src/commands/economy/season.js
+++ b/src/commands/economy/season.js
@@ -6,6 +6,7 @@ const { generateDailyMissions } = require('../../data/seasonMissions');
 const { SEASONAL_EVENTS } = require('../../data/seasonalEvents');
 const { getEventCurrencyBalance } = require('../../services/seasonalEventService');
 const { progressBar } = require('../../utils/progressBar');
+const { rewardReveal } = require('../../utils/rewardReveal');
 
 // ── Battle pass tier reward definitions ──────────────────────────────────────
 // 20 tiers; alternating between coin bonuses, cosmetic badges, material bundles, rare items
@@ -178,7 +179,14 @@ async function executeClaim(interaction) {
         .setDescription(`You received: **${reward.label}**${reward.coins > 0 ? `\n+${reward.coins.toLocaleString()} ${currency} added to your wallet` : ''}`)
         .setTimestamp();
 
-    return interaction.reply({ embeds: [embed] });
+    return rewardReveal({
+        interaction,
+        suspenseTitle: `🎫 Opening Tier ${tier} Reward…`,
+        suspenseText: '*Unlocking your season pass reward…*',
+        suspenseColor: '#5865f2',
+        resultEmbed: embed,
+        delayMs: 900,
+    });
 }
 
 async function executeMissions(interaction) {

--- a/src/commands/economy/work.js
+++ b/src/commands/economy/work.js
@@ -10,6 +10,8 @@ const { MAX_COMBINED_MULTIPLIER, clampMultiplier } = require('../../config/econo
 const { generateWorkChallenge } = require('../../utils/workChallenge');
 const { getTotalBonus } = require('../../services/petService');
 const { randomFrom, WORK_ROUGH_LINES, WORK_EXCEPTIONAL_LINES } = require('../../utils/copyLines');
+const { stackBar } = require('../../utils/rewardReveal');
+const { delay } = require('../../utils/delay');
 
 function resolveTiers(guildSettings) {
     const saved = guildSettings?.jobTiers;
@@ -219,14 +221,16 @@ module.exports = {
             const promotedTo = tierInfo.find(t => t.minShifts === updated.shiftsWorked);
             const currency = guildSettings?.economy?.currency || '💰';
 
-            const bonusLabels = [];
-            if (streakMult > 1.0)   bonusLabels.push(`🔥 ${streakMult}x streak`);
-            if (salaryMult > 1.0)   bonusLabels.push(`📈 ${salaryMult}x salary raise`);
-            if (coinMult > 1.0)     bonusLabels.push(`💰🚀 ${coinMult}x coin booster`);
-            if (serverMult > 1.0)   bonusLabels.push(`🌐 ${serverMult}x server boost`);
-            if (petWorkBonus > 1.0) bonusLabels.push(`🐶 ${petWorkBonus.toFixed(2)}x pet bonus`);
-            if (capActive)          bonusLabels.push(`⚠️ capped at ${MAX_COMBINED_MULTIPLIER}x`);
-            const bonusStr = bonusLabels.length ? ` *(${bonusLabels.join(', ')})*` : '';
+            // Canonical stack-bar for multiplier display
+            const multEntries = [];
+            if (streakMult > 1.0)   multEntries.push({ emoji: '🔥', label: `${streakMult}x` });
+            if (salaryMult > 1.0)   multEntries.push({ emoji: '📈', label: `${salaryMult}x` });
+            if (coinMult > 1.0)     multEntries.push({ emoji: '💰🚀', label: `${coinMult}x` });
+            if (serverMult > 1.0)   multEntries.push({ emoji: '🌐', label: `${serverMult}x` });
+            if (petWorkBonus > 1.0) multEntries.push({ emoji: '🐶', label: `${petWorkBonus.toFixed(2)}x` });
+            const bar = stackBar(multEntries, combined, finalEarned, currency);
+            const capNote = capActive ? `\n  ⚠️ capped at ${MAX_COMBINED_MULTIPLIER}x` : '';
+            const bonusStr = bar ? `\n  ${bar}${capNote}` : '';
 
             const careerValue = nextTier
                 ? `${userTier.name} · ${updated.shiftsWorked.toLocaleString()} shifts\nNext up: ${nextTier.name} in **${(nextTier.minShifts - updated.shiftsWorked).toLocaleString()}** more shifts`
@@ -344,7 +348,18 @@ module.exports = {
                 });
             }
 
-            await interaction.reply({ embeds: [embed] });
+            if (specialEvent) {
+                // Suspense reveal for special work events
+                const suspenseEmbed = new EmbedBuilder()
+                    .setColor(performance.color)
+                    .setTitle('💼 Shift Update…')
+                    .setDescription(`*${scenario}*`);
+                await interaction.reply({ embeds: [suspenseEmbed] });
+                await delay(900);
+                await interaction.editReply({ embeds: [embed] });
+            } else {
+                await interaction.reply({ embeds: [embed] });
+            }
         } catch (error) {
             console.error('Work error:', error);
             await interaction.reply({ content: 'Failed to work.', ephemeral: true });

--- a/src/data/materialRarity.js
+++ b/src/data/materialRarity.js
@@ -71,4 +71,18 @@ const TIER_LABELS = { 1: 'Common', 2: 'Uncommon', 3: 'Rare', 4: 'Epic', 5: 'Lege
 const TIER_STARS  = { 1: '⭐', 2: '⭐⭐', 3: '⭐⭐⭐', 4: '⭐⭐⭐⭐', 5: '⭐⭐⭐⭐⭐' };
 const TIER_COLORS = { 1: '#9e9e9e', 2: '#4caf50', 3: '#2196f3', 4: '#9c27b0', 5: '#ff9800' };
 
-module.exports = { MATERIAL_RARITY, TIER_LABELS, TIER_STARS, TIER_COLORS };
+// Maps tier name strings (used in hunt/fish/mine results) to numeric tier levels.
+const TIER_NUM = { common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5 };
+
+const RIBBON_DOTS = ['🟢', '🔵', '🟣', '🟡', '🌌'];
+
+// Returns the formatted rarity ribbon for a tier number (1–5).
+// e.g. TIER_RIBBON(3) → "🟢 ─ 🔵 ─ [🟣] ─ 🟡 ─ 🌌"
+function TIER_RIBBON(tier) {
+    return RIBBON_DOTS.map((dot, i) => {
+        const t = i + 1;
+        return t === tier ? `[${dot}]` : dot;
+    }).join(' ─ ');
+}
+
+module.exports = { MATERIAL_RARITY, TIER_LABELS, TIER_STARS, TIER_COLORS, TIER_NUM, TIER_RIBBON };

--- a/src/utils/copyLines.js
+++ b/src/utils/copyLines.js
@@ -54,6 +54,13 @@ const ROB_FAIL_LINES = [
     'They were ready for you.',
     'The target had backup. You didn\'t.',
     'Next time, scout the target first.',
+    'The dog gave you up — barked the whole block awake.',
+    'Floodlights. Sirens. And you standing there.',
+    'Security footage doesn\'t lie. Neither does your mugshot.',
+    'You got three steps in before the alarm tripped.',
+    'They must have known you were coming.',
+    'You froze. That was your one window.',
+    'Neighborhood watch, meet neighborhood criminal.',
 ];
 
 const BJ_WIN_LINES = [
@@ -83,6 +90,30 @@ const BJ_PUSH_LINES = [
     'Tied up. The table shrugs.',
 ];
 
+const HUNT_EMPTY_LINES = [
+    'The trail went cold.',
+    'A branch snapped — and it was gone.',
+    'You found tracks. The animal found an exit.',
+    'The forest was quiet. Too quiet.',
+    'You waited. Nothing moved.',
+];
+
+const FISH_MISS_POOL = [
+    'The line went slack. Whatever it was, it\'s gone.',
+    'Something was there. Now it\'s not.',
+    'You reeled in nothing but patience.',
+    'The water gives back nothing today.',
+    'Just weed and silence.',
+];
+
+const MINE_CAVE_LINES = [
+    'The ceiling groaned. Then it gave.',
+    'Too deep, too fast — the shaft collapsed.',
+    'Rock and dust. Nothing to show for it.',
+    'The walls weren\'t bluffing.',
+    'You made it out. Your dignity didn\'t.',
+];
+
 module.exports = {
     randomFrom,
     CRIME_WIN_LINES,
@@ -97,4 +128,7 @@ module.exports = {
     BJ_LOSE_LINES,
     BJ_BUST_LINES,
     BJ_PUSH_LINES,
+    HUNT_EMPTY_LINES,
+    FISH_MISS_POOL,
+    MINE_CAVE_LINES,
 };

--- a/src/utils/rewardReveal.js
+++ b/src/utils/rewardReveal.js
@@ -2,18 +2,7 @@
 
 const { EmbedBuilder } = require('discord.js');
 const { delay } = require('./delay');
-
-// Rarity ribbon: tier 1=Common(🟢), 2=Uncommon(🔵), 3=Rare(🟣), 4=Epic(🟡), 5=Legendary(🌌)
-const RIBBON_DOTS = ['🟢', '🔵', '🟣', '🟡', '🌌'];
-
-// Returns the formatted rarity ribbon string for a given tier (1–5).
-// e.g. rarityRibbon(4) → "🟢 ─ 🔵 ─ 🟣 ─ [🟡] ─ 🌌"
-function rarityRibbon(tier) {
-    return RIBBON_DOTS.map((dot, i) => {
-        const t = i + 1;
-        return t === tier ? `[${dot}]` : dot;
-    }).join(' ─ ');
-}
+const { TIER_RIBBON: rarityRibbon } = require('../data/materialRarity');
 
 // Formats a canonical multiplier stack-bar line.
 // multipliers: Array of { emoji, label } where label is the pre-formatted string

--- a/src/utils/rewardReveal.js
+++ b/src/utils/rewardReveal.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const { EmbedBuilder } = require('discord.js');
+const { delay } = require('./delay');
+
+// Rarity ribbon: tier 1=Common(🟢), 2=Uncommon(🔵), 3=Rare(🟣), 4=Epic(🟡), 5=Legendary(🌌)
+const RIBBON_DOTS = ['🟢', '🔵', '🟣', '🟡', '🌌'];
+
+// Returns the formatted rarity ribbon string for a given tier (1–5).
+// e.g. rarityRibbon(4) → "🟢 ─ 🔵 ─ 🟣 ─ [🟡] ─ 🌌"
+function rarityRibbon(tier) {
+    return RIBBON_DOTS.map((dot, i) => {
+        const t = i + 1;
+        return t === tier ? `[${dot}]` : dot;
+    }).join(' ─ ');
+}
+
+// Formats a canonical multiplier stack-bar line.
+// multipliers: Array of { emoji, label } where label is the pre-formatted string
+//   e.g. { emoji: '🔥', label: '1.5x' }  or  { emoji: '🐺', label: '+12%' }
+//   Pass label: null or omit to show only the emoji (binary presence indicator).
+// finalMult: combined multiplier after clamping
+// finalAmount: final coin payout
+// currency: currency emoji/symbol
+// Returns empty string if multipliers is empty.
+function stackBar(multipliers, finalMult, finalAmount, currency) {
+    if (!multipliers || multipliers.length === 0) return '';
+    const parts = multipliers.map(m => m.label ? `${m.emoji} ${m.label}` : m.emoji);
+    return `${parts.join(' × ')} = **${finalMult.toFixed(2)}x** → **+${finalAmount.toLocaleString()} ${currency}**`;
+}
+
+// 2-stage reward reveal: suspense embed → delay → result embed.
+// Handles both fresh replies and deferred/already-replied interactions.
+//
+// Options:
+//   interaction     – Discord interaction object
+//   suspenseTitle   – Title for the suspense embed  (default: '⏳ Rolling…')
+//   suspenseText    – Description text              (default: '*Hold on…*')
+//   suspenseColor   – Embed color for suspense      (default: '#888888')
+//   resultEmbed     – Final EmbedBuilder to display
+//   delayMs         – Delay between suspense and result (default: 700–1200 random)
+//   broadcast       – Optional async () => void called after reveal (fire-and-forget)
+async function rewardReveal({ interaction, suspenseTitle, suspenseText, suspenseColor, resultEmbed, delayMs, broadcast }) {
+    const ms = delayMs ?? (700 + Math.floor(Math.random() * 500));
+
+    const suspense = new EmbedBuilder()
+        .setColor(suspenseColor ?? '#888888')
+        .setTitle(suspenseTitle ?? '⏳ Rolling…')
+        .setDescription(suspenseText ?? '*Hold on…*');
+
+    if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({ embeds: [suspense] });
+    } else {
+        await interaction.editReply({ embeds: [suspense], components: [] });
+    }
+
+    await delay(ms);
+    await interaction.editReply({ embeds: [resultEmbed], components: [] });
+
+    if (broadcast) broadcast().catch(() => {});
+}
+
+module.exports = { rarityRibbon, stackBar, rewardReveal };

--- a/tests/rewardReveal.test.js
+++ b/tests/rewardReveal.test.js
@@ -1,0 +1,136 @@
+'use strict';
+
+// The rewardReveal helpers are pure formatting functions — no Discord.js or DB needed.
+// We mock discord.js only for the rewardReveal() async flow test.
+
+jest.mock('discord.js', () => {
+    const EmbedBuilder = jest.fn().mockImplementation(() => {
+        const self = {
+            setColor: jest.fn().mockReturnThis(),
+            setTitle: jest.fn().mockReturnThis(),
+            setDescription: jest.fn().mockReturnThis(),
+            setTimestamp: jest.fn().mockReturnThis(),
+            addFields: jest.fn().mockReturnThis(),
+            setFooter: jest.fn().mockReturnThis(),
+            data: {},
+        };
+        return self;
+    });
+    return { EmbedBuilder };
+});
+
+// Stub delay so tests don't actually wait
+jest.mock('../src/utils/delay', () => ({ delay: jest.fn().mockResolvedValue(undefined) }));
+
+const { rarityRibbon, stackBar, rewardReveal } = require('../src/utils/rewardReveal');
+
+// ─── rarityRibbon ─────────────────────────────────────────────────────────────
+
+describe('rarityRibbon', () => {
+    test('highlights the correct tier and leaves others plain', () => {
+        expect(rarityRibbon(1)).toBe('[🟢] ─ 🔵 ─ 🟣 ─ 🟡 ─ 🌌');
+        expect(rarityRibbon(3)).toBe('🟢 ─ 🔵 ─ [🟣] ─ 🟡 ─ 🌌');
+        expect(rarityRibbon(5)).toBe('🟢 ─ 🔵 ─ 🟣 ─ 🟡 ─ [🌌]');
+    });
+
+    test('contains exactly 5 segments separated by " ─ "', () => {
+        for (let tier = 1; tier <= 5; tier++) {
+            const segments = rarityRibbon(tier).split(' ─ ');
+            expect(segments).toHaveLength(5);
+        }
+    });
+
+    test('exactly one segment is wrapped in brackets per tier', () => {
+        for (let tier = 1; tier <= 5; tier++) {
+            const bracketed = rarityRibbon(tier).match(/\[.*?\]/g);
+            expect(bracketed).toHaveLength(1);
+        }
+    });
+});
+
+// ─── stackBar ────────────────────────────────────────────────────────────────
+
+describe('stackBar', () => {
+    test('returns empty string for empty multipliers', () => {
+        expect(stackBar([], 1.0, 500, '💰')).toBe('');
+        expect(stackBar(null, 1.0, 500, '💰')).toBe('');
+    });
+
+    test('formats single multiplier correctly', () => {
+        const result = stackBar([{ emoji: '🔥', label: '1.5x' }], 1.5, 150, '💰');
+        expect(result).toBe('🔥 1.5x = **1.50x** → **+150 💰**');
+    });
+
+    test('joins multiple multipliers with ×', () => {
+        const mults = [
+            { emoji: '🔥', label: '7d' },
+            { emoji: '🌐', label: '2x' },
+            { emoji: '🐺', label: '+12%' },
+        ];
+        const result = stackBar(mults, 4.31, 12540, '💰');
+        expect(result).toContain('🔥 7d × 🌐 2x × 🐺 +12%');
+        expect(result).toContain('**4.31x**');
+        expect(result).toContain('**+12,540 💰**');
+    });
+
+    test('renders emoji-only entry when label is omitted', () => {
+        const mults = [{ emoji: '🍀' }, { emoji: '🌐', label: '2x' }];
+        const result = stackBar(mults, 2.0, 200, '💰');
+        expect(result).toContain('🍀 × 🌐 2x');
+    });
+
+    test('uses toLocaleString for large amounts', () => {
+        const result = stackBar([{ emoji: '🔥', label: '3x' }], 3.0, 1000000, '💰');
+        expect(result).toContain('1,000,000');
+    });
+
+    test('formats finalMult to 2 decimal places', () => {
+        const result = stackBar([{ emoji: '🔥', label: '1.5x' }], 1.5, 100, '💰');
+        expect(result).toContain('**1.50x**');
+    });
+});
+
+// ─── rewardReveal (async flow) ────────────────────────────────────────────────
+
+describe('rewardReveal', () => {
+    let interaction;
+    let resultEmbed;
+
+    beforeEach(() => {
+        interaction = {
+            replied: false,
+            deferred: false,
+            reply: jest.fn().mockResolvedValue(undefined),
+            editReply: jest.fn().mockResolvedValue(undefined),
+        };
+        resultEmbed = { data: { title: 'Result' } };
+    });
+
+    test('replies with suspense then edits with result', async () => {
+        await rewardReveal({ interaction, resultEmbed, delayMs: 0 });
+
+        expect(interaction.reply).toHaveBeenCalledTimes(1);
+        expect(interaction.editReply).toHaveBeenCalledTimes(1);
+        const editCall = interaction.editReply.mock.calls[0][0];
+        expect(editCall.embeds[0]).toBe(resultEmbed);
+    });
+
+    test('uses editReply for suspense when already replied', async () => {
+        interaction.replied = true;
+
+        await rewardReveal({ interaction, resultEmbed, delayMs: 0 });
+
+        expect(interaction.reply).not.toHaveBeenCalled();
+        expect(interaction.editReply).toHaveBeenCalledTimes(2);
+        const finalCall = interaction.editReply.mock.calls[1][0];
+        expect(finalCall.embeds[0]).toBe(resultEmbed);
+    });
+
+    test('calls broadcast fire-and-forget after reveal', async () => {
+        const broadcast = jest.fn().mockResolvedValue(undefined);
+
+        await rewardReveal({ interaction, resultEmbed, delayMs: 0, broadcast });
+
+        expect(broadcast).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
- Add src/utils/rewardReveal.js: rarityRibbon(), stackBar(), rewardReveal()
  2-stage embed pattern (suspense → result) with configurable delay
- Add TIER_NUM + TIER_RIBBON() to materialRarity.js for ribbon rendering
- Expand copyLines.js with HUNT_EMPTY_LINES, FISH_MISS_POOL, MINE_CAVE_LINES
  and extend ROB_FAIL_LINES to 10 varied flavor lines
- Wire rewardReveal() into season.js claim ceremony
- Add 3-stage heist suspense to rob.js (casing → picking lock → result)
- Add deferUpdate + suspense delay to crime.js button flow
- Use stackBar() in daily.js buildRewardBlock() and work.js payout embeds
- Add special-event suspense step in work.js non-challenge path
- Surface rarity ribbon in hunt/fish/mine success embeds
- Replace static failure text with randomized flavor lines in hunt/fish/mine
- Add 12 unit tests for rewardReveal helpers (all passing)

https://claude.ai/code/session_013mdgMG2xJthYjy89fUoc7F

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Economy commands now feature animated reward reveal sequences with suspenseful delays.
- Failure and empty-state messages are randomized for greater variety.
- Reward displays include visual multiplier stack bars for clearer bonus information.
- Rarity tiers are now displayed with enhanced visual ribbon indicators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/clawdia/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->