### PR TITLE
feat: add ceremonies and social moments for all major milestones (#299)

### DIFF
--- a/src/commands/economy/season.js
+++ b/src/commands/economy/season.js
@@ -37,6 +37,30 @@ const TIER_REWARDS = [
 const XP_PER_TIER = 100;
 const MAX_TIERS = 20;
 
+// Flavor lore shown on claim embeds
+const TIER_LORE = [
+    'Every journey starts with a single step.',
+    'The spark of ambition ignites here.',
+    'Diligence rewarded — this is just the beginning.',
+    'Forged in discipline, tempered by purpose.',
+    'Halfway to legendary. The path sharpens.',
+    'Matter responds to mastery.',
+    'A warrior refined — not born.',
+    'Prestige is earned, never given.',
+    'Nine tiers climbed. Eleven more await.',
+    'The rarest items demand the rarest resolve.',
+    'Champions do not rest at the summit.',
+    'A radiant mark for those who endure.',
+    'Six thousand reasons to keep going.',
+    'Only the tireless reach this depth.',
+    'Wealth and will in equal measure.',
+    'Radiance touches those who refuse to quit.',
+    'Ten thousand coins — a testament to grind.',
+    'Legends write their names in fire.',
+    'Fifteen thousand. The last stretch burns bright.',
+    'You have reached the pinnacle. The season bows to you.',
+];
+
 function getTierFromXp(xp) {
     return Math.min(MAX_TIERS, Math.floor(xp / XP_PER_TIER));
 }
@@ -173,11 +197,58 @@ async function executeClaim(interaction) {
         throw err;
     }
 
+    // Social proof: how many users in this guild have claimed this tier
+    const claimedCount = await User.countDocuments({
+        guildId: interaction.guild.id,
+        'season.claimedTiers': tier
+    }).catch(() => null);
+
+    // Next tier teaser
+    const nextTier = TIER_REWARDS.find(r => r.tier === tier + 1);
+    const xpToNext = nextTier ? Math.max(0, (tier) * XP_PER_TIER - (user.season?.xp ?? 0)) : 0;
+
+    const lore = TIER_LORE[tier - 1] ?? 'Your dedication speaks louder than words.';
+
     const embed = new EmbedBuilder()
         .setColor('#ffd700')
-        .setTitle(`🎁 Tier ${tier} Reward Claimed!`)
-        .setDescription(`You received: **${reward.label}**${reward.coins > 0 ? `\n+${reward.coins.toLocaleString()} ${currency} added to your wallet` : ''}`)
-        .setTimestamp();
+        .setTitle(`# ${reward.label}`)
+        .setDescription(
+            `> *${lore}*\n\n` +
+            `You received: **${reward.label}**` +
+            (reward.coins > 0 ? `\n+**${reward.coins.toLocaleString()} ${currency}** added to your wallet` : '')
+        );
+
+    if (nextTier) {
+        embed.addFields({
+            name: `⏭️ Next: Tier ${nextTier.tier}`,
+            value: `${nextTier.label}${xpToNext > 0 ? ` — ${xpToNext} XP away` : ' — **Ready to claim!**'}`
+        });
+    }
+
+    if (claimedCount !== null) {
+        embed.setFooter({ text: `${claimedCount.toLocaleString()} player${claimedCount === 1 ? '' : 's'} have unlocked Tier ${tier}` });
+    }
+
+    embed.setTimestamp();
+
+    // Broadcast to announcement channel for mythic-tier (≥ 10) rewards
+    if (tier >= 10) {
+        const announceChannelId = guildSettings?.economy?.announcementChannelId;
+        if (announceChannelId) {
+            const announceChannel = interaction.guild.channels.cache.get(announceChannelId);
+            if (announceChannel?.isTextBased?.()) {
+                const broadcastEmbed = new EmbedBuilder()
+                    .setColor('#ff6200')
+                    .setTitle('🌟 Mythic Tier Unlocked!')
+                    .setDescription(
+                        `<@${interaction.user.id}> just claimed **Tier ${tier}** of the Season Pass!\n` +
+                        `Reward: **${reward.label}**`
+                    )
+                    .setTimestamp();
+                announceChannel.send({ embeds: [broadcastEmbed] }).catch(() => {});
+            }
+        }
+    }
 
     return rewardReveal({
         interaction,

--- a/src/commands/economy/season.js
+++ b/src/commands/economy/season.js
@@ -205,13 +205,13 @@ async function executeClaim(interaction) {
 
     // Next tier teaser
     const nextTier = TIER_REWARDS.find(r => r.tier === tier + 1);
-    const xpToNext = nextTier ? Math.max(0, (tier) * XP_PER_TIER - (user.season?.xp ?? 0)) : 0;
+    const xpToNext = nextTier ? Math.max(0, (tier + 1) * XP_PER_TIER - (user.season?.xp ?? 0)) : 0;
 
     const lore = TIER_LORE[tier - 1] ?? 'Your dedication speaks louder than words.';
 
     const embed = new EmbedBuilder()
         .setColor('#ffd700')
-        .setTitle(`# ${reward.label}`)
+        .setTitle(reward.label)
         .setDescription(
             `> *${lore}*\n\n` +
             `You received: **${reward.label}**` +

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -9,6 +9,7 @@ const { getStreakMultiplier, checkNewMilestones } = require('../utils/streakMult
 const { hasEffect, consumeEffect, getXpMultiplier, getServerXpMultiplier } = require('../services/effectsService');
 const { checkRivalry } = require('../services/rivalryService');
 const { checkAndAward, announceAchievements } = require('../services/achievementService');
+const { checkAndBroadcastWealthMilestone } = require('../utils/wealthMilestone');
 const BASE_BAD_WORDS = require('../data/profanityList');
 
 // Pre-compile base word regexes once at module load — avoids per-message regex construction
@@ -186,6 +187,9 @@ async function handleStreakAndQuests(message, guildSettings, existingUser = null
 
         await user.save();
 
+        // Check wealth milestones after any coins may have been awarded (streak rewards, etc.)
+        checkAndBroadcastWealthMilestone(message.client, guildSettings, user, message.channel).catch(() => {});
+
         if (newlyEarned.length) {
             announceAchievements(message.client, guildSettings, user, message.member, newlyEarned).catch(() => null);
         }
@@ -273,16 +277,36 @@ async function handleLeveling(message, guildSettings) {
             user.level += 1;
             user.xp = 0;
 
-            const levelUpMsg = guildSettings.leveling.levelUpMessage
-                .replace(/{user}/g, `<@${message.author.id}>`)
-                .replace(/{level}/g, user.level);
+            const userOptOut   = user.disableLevelUpAnnounce === true;
+            const guildOptOut  = guildSettings.leveling?.disableLevelUpAnnounce === true;
+            if (!userOptOut && !guildOptOut) {
+                const { EmbedBuilder } = require('discord.js');
+                const TIER_STYLES = [
+                    { min: 0,   color: '#cd7f32', label: 'Bronze',  glyph: '⬡' },
+                    { min: 10,  color: '#c0c0c0', label: 'Silver',  glyph: '◈' },
+                    { min: 25,  color: '#ffd700', label: 'Gold',    glyph: '◆' },
+                    { min: 50,  color: '#b9f2ff', label: 'Diamond', glyph: '◇' },
+                    { min: 100, color: '#ff6200', label: 'Mythic',  glyph: '✦' },
+                ];
+                const tierStyle = [...TIER_STYLES].reverse().find(t => user.level >= t.min) ?? TIER_STYLES[0];
 
-            const rewardChannelId = guildSettings.leveling.rewardChannelId || guildSettings.leveling.announceChannel;
-            if (guildSettings.leveling.announceInChannel && !rewardChannelId) {
-                await message.reply(levelUpMsg).catch(console.error);
-            } else if (rewardChannelId) {
-                const ch = message.guild.channels.cache.get(rewardChannelId);
-                if (ch) await ch.send(levelUpMsg).catch(console.error);
+                const lvlEmbed = new EmbedBuilder()
+                    .setColor(tierStyle.color)
+                    .setTitle(`${tierStyle.glyph} TIER ${tierStyle.label.toUpperCase()} PROMOTION`)
+                    .setDescription(
+                        `<@${message.author.id}> has advanced to **Level ${user.level}**!\n\n` +
+                        `*${tierStyle.label} tier — keep climbing!*`
+                    )
+                    .setThumbnail(message.author.displayAvatarURL({ extension: 'png', size: 128 }))
+                    .setTimestamp();
+
+                const rewardChannelId = guildSettings.leveling.rewardChannelId || guildSettings.leveling.announceChannel;
+                if (guildSettings.leveling.announceInChannel && !rewardChannelId) {
+                    await message.channel.send({ embeds: [lvlEmbed] }).catch(console.error);
+                } else if (rewardChannelId) {
+                    const ch = message.guild.channels.cache.get(rewardChannelId);
+                    if (ch) await ch.send({ embeds: [lvlEmbed] }).catch(console.error);
+                }
             }
 
             if (guildSettings.levelRoles?.length) {

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -6,7 +6,7 @@ const { checkGiveaways } = require('../services/giveawayService');
 const { checkTempVoice } = require('../services/tempVoiceService');
 const { checkBirthdays } = require('../services/birthdayService');
 const { checkSeasonalEvents } = require('../services/seasonalEventService');
-const { resolveExpiredWars, resolveExpiredSeasons } = require('../services/schedulerService');
+const { resolveExpiredWars, resolveExpiredSeasons, awardWeeklyLeaderboardBadges } = require('../services/schedulerService');
 const { runJob } = require('../utils/jobRunner');
 const User = require('../models/User');
 const { logTransaction } = require('../utils/logTransaction');
@@ -63,6 +63,11 @@ module.exports = {
         );
         cron.schedule('*/5 * * * *', () =>
             runJob('schedulerService', 'resolveExpiredSeasons', () => resolveExpiredSeasons(client))
+        );
+
+        // Award weekly leaderboard badges every Sunday at 23:59 UTC
+        cron.schedule('59 23 * * 0', () =>
+            runJob('schedulerService', 'awardWeeklyLeaderboardBadges', () => awardWeeklyLeaderboardBadges(client))
         );
 
         // Refund any bets that were deducted during a crash game that was interrupted by a restart

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -67,7 +67,8 @@ module.exports = {
 
         // Award weekly leaderboard badges every Sunday at 23:59 UTC
         cron.schedule('59 23 * * 0', () =>
-            runJob('schedulerService', 'awardWeeklyLeaderboardBadges', () => awardWeeklyLeaderboardBadges(client))
+            runJob('schedulerService', 'awardWeeklyLeaderboardBadges', () => awardWeeklyLeaderboardBadges(client)),
+            { timezone: 'Etc/UTC' }
         );
 
         // Refund any bets that were deducted during a crash game that was interrupted by a restart

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -133,7 +133,8 @@ const guildSchema = new Schema({
         noXpChannelIds: [{ type: String }],
         rewardChannelId: { type: String, default: null },
         voiceXpEnabled: { type: Boolean, default: false },
-        voiceXpRate: { type: Number, default: 1.0 }
+        voiceXpRate: { type: Number, default: 1.0 },
+        disableLevelUpAnnounce: { type: Boolean, default: false }
     },
     
     serverBoost: {

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -472,6 +472,19 @@ const userSchema = new Schema({
     duelWins:   { type: Number, default: 0 },
     duelLosses: { type: Number, default: 0 },
 
+    // Transient social badges (war victor, leaderboard #1, etc.) with optional expiry
+    badges: [{
+        id:        { type: String, required: true },
+        label:     { type: String, required: true },
+        expiresAt: { type: Date, default: null }
+    }],
+
+    // Highest wealth milestone tier ever broadcast (0=none,1=1M,2=10M,3=100M,4=1B)
+    wealthTier: { type: Number, default: 0 },
+
+    // Opt-out of level-up announce embeds in chat
+    disableLevelUpAnnounce: { type: Boolean, default: false },
+
     // Gift cap tracking (daily outgoing coin gifts)
     dailyGiftSent:  { type: Number, default: 0 },
     dailyGiftReset: { type: Date,   default: null },

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -1,17 +1,20 @@
 const Guild = require('../models/Guild');
 const User = require('../models/User');
 const SeasonRecord = require('../models/SeasonRecord');
+const { createWarVictoryBanner } = require('../utils/cardGenerator');
 
 const WAR_BOOSTER_DURATION_MS = 24 * 60 * 60 * 1000;
+const WAR_BADGE_DURATION_MS   = 30 * 24 * 60 * 60 * 1000;
+const LEADERBOARD_BADGE_DURATION_MS = 7 * 24 * 60 * 60 * 1000;
 
-async function postAnnouncement(client, guildId, channelId, embed) {
+async function postAnnouncement(client, guildId, channelId, payload) {
     if (!channelId) return;
     try {
         const guild = await client.guilds.fetch(guildId).catch(() => null);
         if (!guild) return;
         const channel = await guild.channels.fetch(channelId).catch(() => null);
         if (!channel?.isTextBased?.()) return;
-        await channel.send({ embeds: [embed] }).catch(() => {});
+        await channel.send(typeof payload === 'object' && !payload.embeds ? { embeds: [payload] } : payload).catch(() => {});
     } catch (err) {
         console.error(`[scheduler] announcement post failed for guild ${guildId}:`, err.message);
     }
@@ -36,41 +39,147 @@ async function resolveOneWar(client, guildDoc) {
     const tied = myScore === oppScore;
     const iWon = myScore > oppScore;
 
+    // Opponent guild id and doc
+    const opponentGuildId = war.opponentGuildId;
+    const oppName = war.opponentGuildName ?? 'Enemy Server';
+
     // End the opponent's mirrored war record too
-    if (war.opponentGuildId) {
+    if (opponentGuildId) {
         await Guild.findOneAndUpdate(
-            { guildId: war.opponentGuildId, 'activeWar.opponentGuildId': guildId, 'activeWar.status': 'active' },
+            { guildId: opponentGuildId, 'activeWar.opponentGuildId': guildId, 'activeWar.status': 'active' },
             { $set: { 'activeWar.status': 'ended' } }
         ).catch(err => console.error(`[scheduler] opponent war end failed:`, err.message));
     }
 
-    // Reward winners with a 24h 2x coin booster
-    if (iWon) {
-        const expiresAt = new Date(Date.now() + WAR_BOOSTER_DURATION_MS);
-        await User.updateMany(
-            { guildId },
-            { $push: { activeEffects: { type: 'coin_booster_2x', expiresAt, charges: -1 } } }
-        ).catch(err => console.error(`[scheduler] war booster grant failed:`, err.message));
+    // Determine winning/losing guild ids for badge and booster grants
+    const winnerGuildId = iWon ? guildId : (tied ? null : opponentGuildId);
+    const winnerName    = iWon ? guildDoc.name : (tied ? null : oppName);
+    const winnerScore   = iWon ? myScore : oppScore;
+    const loserScore    = iWon ? oppScore : myScore;
+
+    // Find MVP (highest duel wins in winning guild) and most-clutch (highest streak)
+    let mvpUserId = null, mvpName = null, clutchUserId = null, clutchName = null;
+    if (winnerGuildId && !tied) {
+        try {
+            const discordGuild = await client.guilds.fetch(winnerGuildId).catch(() => null);
+            const [mvpUser, clutchUser] = await Promise.all([
+                User.findOne({ guildId: winnerGuildId }).sort({ duelWins: -1 }).select('userId duelWins').lean(),
+                User.findOne({ guildId: winnerGuildId }).sort({ 'streak.current': -1 }).select('userId streak').lean(),
+            ]);
+            if (mvpUser && discordGuild) {
+                const m = await discordGuild.members.fetch(mvpUser.userId).catch(() => null);
+                mvpUserId = mvpUser.userId;
+                mvpName = m?.user?.username ?? null;
+            }
+            if (clutchUser && discordGuild && clutchUser.userId !== mvpUserId) {
+                const c = await discordGuild.members.fetch(clutchUser.userId).catch(() => null);
+                clutchUserId = clutchUser.userId;
+                clutchName = c?.user?.username ?? null;
+            }
+        } catch {}
     }
 
-    const { EmbedBuilder } = require('discord.js');
-    const oppName = war.opponentGuildName ?? 'Enemy Server';
-    const title = tied ? '⚔️ War Ended — Tie!' : iWon ? '🏆 War Victory!' : '⚔️ War Lost';
-    const desc = tied
-        ? `The war against **${oppName}** ended in a tie at **${myScore.toLocaleString()}** points each.`
-        : iWon
-            ? `**${guildDoc.name}** has defeated **${oppName}**!\n\n` +
-              `Final score: **${myScore.toLocaleString()}** vs **${oppScore.toLocaleString()}**\n\n` +
-              `All members receive a **2x coin booster** for the next 24 hours!`
-            : `**${oppName}** has defeated us.\n\nFinal score: **${myScore.toLocaleString()}** vs **${oppScore.toLocaleString()}**`;
+    // Reward winners with a 24h 2x coin booster + 30d War Victor badge
+    if (!tied && winnerGuildId) {
+        const boosterExpiry = new Date(Date.now() + WAR_BOOSTER_DURATION_MS);
+        const badgeExpiry   = new Date(Date.now() + WAR_BADGE_DURATION_MS);
+        await User.updateMany(
+            { guildId: winnerGuildId },
+            {
+                $push: {
+                    activeEffects: { type: 'coin_booster_2x', expiresAt: boosterExpiry, charges: -1 },
+                    badges:        { id: 'war_victor', label: '🎖️ War Victor', expiresAt: badgeExpiry }
+                }
+            }
+        ).catch(err => console.error(`[scheduler] war rewards grant failed:`, err.message));
+    }
 
-    const embed = new EmbedBuilder()
-        .setColor(tied ? '#95a5a6' : iWon ? '#FFD700' : '#e74c3c')
-        .setTitle(title)
-        .setDescription(desc)
-        .setTimestamp();
+    const { EmbedBuilder, AttachmentBuilder } = require('discord.js');
 
-    await postAnnouncement(client, guildId, war.announcementChannelId, embed);
+    // Build the victory banner image for the winning guild announcement
+    let bannerAttachment = null;
+    if (!tied && winnerName) {
+        try {
+            const buf = await createWarVictoryBanner(winnerName, winnerScore, oppName, loserScore, mvpName);
+            bannerAttachment = new AttachmentBuilder(buf, { name: 'war_victory.png' });
+        } catch (err) {
+            console.error('[scheduler] war banner generation failed:', err.message);
+        }
+    }
+
+    // Helper to build guild-specific embed
+    function buildWarEmbed(perspective) {
+        // perspective: 'winner' | 'loser' | 'tie'
+        if (perspective === 'tie') {
+            return new EmbedBuilder()
+                .setColor('#95a5a6')
+                .setTitle('⚔️ War Ended — Tie!')
+                .setDescription(
+                    `The war between **${guildDoc.name}** and **${oppName}** ended in a tie!\n\n` +
+                    `**${myScore.toLocaleString()}** pts — **${oppScore.toLocaleString()}** pts`
+                )
+                .setTimestamp();
+        }
+        if (perspective === 'winner') {
+            const embed = new EmbedBuilder()
+                .setColor('#FFD700')
+                .setTitle(`🏆 ${winnerName} WINS THE WAR`)
+                .setDescription(
+                    `**${winnerName}** has crushed **${oppName}**!\n\n` +
+                    `**Score:** ${winnerScore.toLocaleString()} — ${loserScore.toLocaleString()}\n\n` +
+                    `All members receive a **2× coin booster** for 24 hours and a **🎖️ War Victor** badge for 30 days!`
+                )
+                .setImage('attachment://war_victory.png');
+            if (mvpUserId) embed.addFields({ name: '🏅 MVP', value: `<@${mvpUserId}> • ${mvpName ?? ''}`, inline: true });
+            if (clutchUserId) embed.addFields({ name: '💪 Most Clutch', value: `<@${clutchUserId}> • ${clutchName ?? ''}`, inline: true });
+            embed.setTimestamp();
+            return embed;
+        }
+        // loser perspective
+        return new EmbedBuilder()
+            .setColor('#e74c3c')
+            .setTitle('⚔️ War Lost')
+            .setDescription(
+                `**${oppName}** has defeated **${guildDoc.name}**.\n\n` +
+                `**Score:** ${myScore.toLocaleString()} — ${oppScore.toLocaleString()}\n\n` +
+                `Train harder and challenge them again!`
+            )
+            .setTimestamp();
+    }
+
+    if (tied) {
+        const embed = buildWarEmbed('tie');
+        await postAnnouncement(client, guildId, war.announcementChannelId, embed);
+        if (opponentGuildId) {
+            const oppDoc = await Guild.findOne({ guildId: opponentGuildId }).lean();
+            await postAnnouncement(client, opponentGuildId, oppDoc?.activeWar?.announcementChannelId ?? null, embed);
+        }
+    } else if (iWon) {
+        // Winner = this guild, loser = opponent
+        const winEmbed = buildWarEmbed('winner');
+        const loseEmbed = buildWarEmbed('loser');
+        const winPayload = bannerAttachment
+            ? { embeds: [winEmbed], files: [bannerAttachment] }
+            : { embeds: [winEmbed] };
+        await postAnnouncement(client, guildId, war.announcementChannelId, winPayload);
+        if (opponentGuildId) {
+            const oppDoc = await Guild.findOne({ guildId: opponentGuildId }).lean();
+            await postAnnouncement(client, opponentGuildId, oppDoc?.activeWar?.announcementChannelId ?? null, loseEmbed);
+        }
+    } else {
+        // Loser = this guild, winner = opponent
+        const loseEmbed = buildWarEmbed('loser');
+        await postAnnouncement(client, guildId, war.announcementChannelId, loseEmbed);
+        if (opponentGuildId) {
+            const oppDoc = await Guild.findOne({ guildId: opponentGuildId }).lean();
+            const winEmbed = buildWarEmbed('winner');
+            const winPayload = bannerAttachment
+                ? { embeds: [winEmbed], files: [bannerAttachment] }
+                : { embeds: [winEmbed] };
+            await postAnnouncement(client, opponentGuildId, oppDoc?.activeWar?.announcementChannelId ?? null, winPayload);
+        }
+    }
+
     return true;
 }
 
@@ -183,4 +292,78 @@ async function resolveExpiredSeasons(client) {
     }
 }
 
-module.exports = { resolveExpiredWars, resolveExpiredSeasons };
+// Awards 7-day 👑 #1 badges to the top user in each leaderboard category across all guilds.
+// Run once per week (Sunday 23:59 UTC recommended).
+async function awardWeeklyLeaderboardBadges(client) {
+    const { EmbedBuilder } = require('discord.js');
+
+    const guilds = await Guild.find({}, 'guildId name economy').lean();
+
+    for (const guildDoc of guilds) {
+        const guildId = guildDoc.guildId;
+        try {
+            const categories = [
+                { key: 'levels',       sort: { level: -1, xp: -1 },            label: '📈 Top Level' },
+                { key: 'economy',      sort: { balance: -1 },                   label: '💰 Wealthiest' },
+                { key: 'streaks',      sort: { 'streak.current': -1 },          label: '🔥 Longest Streak' },
+                { key: 'duels',        sort: { duelWins: -1 },                  label: '⚔️ Duel Champion' },
+                { key: 'achievements', sort: { achievementsCount: -1 },         label: '🏅 Achievement Hunter' },
+            ];
+
+            const badgeExpiry = new Date(Date.now() + LEADERBOARD_BADGE_DURATION_MS);
+            const champLines = [];
+            const discordGuild = await client.guilds.fetch(guildId).catch(() => null);
+
+            for (const cat of categories) {
+                const top = await User.findOne({ guildId }).sort(cat.sort).select('userId').lean();
+                if (!top) continue;
+
+                // Award badge (deduplicate: remove existing #1 badge for this category first)
+                await User.updateOne(
+                    { userId: top.userId, guildId },
+                    {
+                        $pull:  { badges: { id: `leaderboard_1_${cat.key}` } },
+                    }
+                ).catch(() => {});
+                await User.updateOne(
+                    { userId: top.userId, guildId },
+                    {
+                        $push: { badges: { id: `leaderboard_1_${cat.key}`, label: '👑 #1', expiresAt: badgeExpiry } }
+                    }
+                ).catch(() => {});
+
+                let username = `<@${top.userId}>`;
+                if (discordGuild) {
+                    const member = await discordGuild.members.fetch(top.userId).catch(() => null);
+                    if (member) username = `<@${top.userId}> (${member.user.username})`;
+                }
+                champLines.push(`${cat.label}: ${username}`);
+            }
+
+            if (!champLines.length) continue;
+
+            // Find announcement channel: economy.announcementChannelId or systemChannel
+            let announceChannelId = guildDoc.economy?.announcementChannelId ?? null;
+            if (!announceChannelId && discordGuild) {
+                announceChannelId = discordGuild.systemChannelId ?? null;
+            }
+            if (!announceChannelId) continue;
+
+            const embed = new EmbedBuilder()
+                .setColor('#ffd700')
+                .setTitle('👑 Last Week\'s Champions')
+                .setDescription(
+                    'These legends dominated the leaderboards this week.\n' +
+                    'Each earns a **👑 #1** badge for 7 days, visible on `/rank` and `/leaderboard`.'
+                )
+                .addFields({ name: '🏆 Winners', value: champLines.join('\n') })
+                .setTimestamp();
+
+            await postAnnouncement(client, guildId, announceChannelId, embed);
+        } catch (err) {
+            console.error(`[scheduler] weeklyLeaderboardBadges failed for guild ${guildId}:`, err.message);
+        }
+    }
+}
+
+module.exports = { resolveExpiredWars, resolveExpiredSeasons, awardWeeklyLeaderboardBadges };

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -54,6 +54,7 @@ async function resolveOneWar(client, guildDoc) {
     // Determine winning/losing guild ids for badge and booster grants
     const winnerGuildId = iWon ? guildId : (tied ? null : opponentGuildId);
     const winnerName    = iWon ? guildDoc.name : (tied ? null : oppName);
+    const loserName     = iWon ? oppName        : (tied ? null : guildDoc.name);
     const winnerScore   = iWon ? myScore : oppScore;
     const loserScore    = iWon ? oppScore : myScore;
 
@@ -100,7 +101,7 @@ async function resolveOneWar(client, guildDoc) {
     let bannerAttachment = null;
     if (!tied && winnerName) {
         try {
-            const buf = await createWarVictoryBanner(winnerName, winnerScore, oppName, loserScore, mvpName);
+            const buf = await createWarVictoryBanner(winnerName, winnerScore, loserName, loserScore, mvpName);
             bannerAttachment = new AttachmentBuilder(buf, { name: 'war_victory.png' });
         } catch (err) {
             console.error('[scheduler] war banner generation failed:', err.message);
@@ -125,7 +126,7 @@ async function resolveOneWar(client, guildDoc) {
                 .setColor('#FFD700')
                 .setTitle(`🏆 ${winnerName} WINS THE WAR`)
                 .setDescription(
-                    `**${winnerName}** has crushed **${oppName}**!\n\n` +
+                    `**${winnerName}** has crushed **${loserName}**!\n\n` +
                     `**Score:** ${winnerScore.toLocaleString()} — ${loserScore.toLocaleString()}\n\n` +
                     `All members receive a **2× coin booster** for 24 hours and a **🎖️ War Victor** badge for 30 days!`
                 )

--- a/src/utils/cardGenerator.js
+++ b/src/utils/cardGenerator.js
@@ -210,4 +210,112 @@ async function createRankCard(user, userData, rank, requiredXp, opts = {}) {
     return canvas.toBuffer();
 }
 
-module.exports = { createWelcomeCard, createRankCard };
+const WAR_VICTORY_LINES = [
+    'Victory belongs to the bold!',
+    'The battlefield remembers the brave.',
+    'Strength, unity, conquest.',
+    'They fought — and they prevailed.',
+    'No mercy. No retreat. All glory.',
+];
+
+async function createWarVictoryBanner(winnerName, winnerScore, loserName, loserScore, mvpName) {
+    const canvas = createCanvas(900, 260);
+    const ctx = canvas.getContext('2d');
+    const gold = '#FFD700';
+
+    ctx.fillStyle = '#1a1a2e';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    // Gold accent bar
+    ctx.fillStyle = gold;
+    ctx.fillRect(0, 0, canvas.width, 8);
+    ctx.fillRect(0, canvas.height - 8, canvas.width, 8);
+
+    // Trophy icon area
+    ctx.font = `bold 64px ${EMOJI_FONT}`;
+    ctx.textBaseline = 'middle';
+    ctx.textAlign = 'center';
+    ctx.fillText('🏆', 80, 90);
+    ctx.textBaseline = 'alphabetic';
+    ctx.textAlign = 'left';
+
+    // Winner title
+    ctx.font = 'bold 36px "DejaVu Sans"';
+    ctx.fillStyle = gold;
+    const titleText = truncateText(ctx, `${winnerName} WINS THE WAR`, canvas.width - 160 - 20);
+    ctx.fillText(titleText, 150, 70);
+
+    // Score bar
+    const total = (winnerScore + loserScore) || 1;
+    const barX = 150, barY = 85, barW = 680, barH = 22;
+    const winFrac = Math.min(winnerScore / total, 1);
+    ctx.fillStyle = '#2e2e4a';
+    ctx.fillRect(barX, barY, barW, barH);
+    ctx.fillStyle = gold;
+    ctx.fillRect(barX, barY, Math.floor(winFrac * barW), barH);
+    ctx.fillStyle = '#e74c3c';
+    ctx.fillRect(barX + Math.floor(winFrac * barW), barY, barW - Math.floor(winFrac * barW), barH);
+
+    ctx.font = '16px "DejaVu Sans"';
+    ctx.fillStyle = '#ffffff';
+    ctx.fillText(`${winnerScore.toLocaleString()} pts`, barX, barY + barH + 20);
+    ctx.textAlign = 'right';
+    ctx.fillText(`${loserScore.toLocaleString()} pts`, barX + barW, barY + barH + 20);
+    ctx.textAlign = 'left';
+
+    // Flavor line
+    const flavor = WAR_VICTORY_LINES[Math.floor(Math.random() * WAR_VICTORY_LINES.length)];
+    ctx.font = 'italic 17px "DejaVu Sans"';
+    ctx.fillStyle = '#aaaaaa';
+    ctx.fillText(`"${flavor}"`, 150, 150);
+
+    // MVP line
+    if (mvpName) {
+        ctx.font = 'bold 20px "DejaVu Sans"';
+        ctx.fillStyle = '#ffd700';
+        ctx.fillText(`🏅 MVP: ${truncateText(ctx, mvpName, 400)}`, 150, 185);
+    }
+
+    // Spoils
+    ctx.font = '16px "DejaVu Sans"';
+    ctx.fillStyle = '#98FB98';
+    ctx.fillText('Spoils: 2× coin booster (24h) + 🎖️ War Victor badge (30d)', 150, 215);
+
+    return canvas.toBuffer();
+}
+
+async function createWealthTierBanner(username, tierLabel, tierColor) {
+    const canvas = createCanvas(900, 200);
+    const ctx = canvas.getContext('2d');
+
+    ctx.fillStyle = '#111122';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.fillStyle = tierColor;
+    ctx.fillRect(0, 0, canvas.width, 8);
+    ctx.fillRect(0, canvas.height - 8, canvas.width, 8);
+
+    ctx.font = `bold 64px ${EMOJI_FONT}`;
+    ctx.textBaseline = 'middle';
+    ctx.textAlign = 'center';
+    ctx.fillText('💰', 80, 100);
+
+    ctx.font = 'bold 42px "DejaVu Sans"';
+    ctx.fillStyle = tierColor;
+    ctx.textAlign = 'left';
+    ctx.fillText(tierLabel, 140, 80);
+
+    ctx.font = '22px "DejaVu Sans"';
+    ctx.fillStyle = '#dddddd';
+    ctx.fillText(truncateText(ctx, username, 700), 140, 120);
+
+    ctx.font = 'italic 16px "DejaVu Sans"';
+    ctx.fillStyle = '#888888';
+    ctx.fillText('has reached a legendary wealth milestone!', 140, 155);
+
+    ctx.textBaseline = 'alphabetic';
+    ctx.textAlign = 'left';
+    return canvas.toBuffer();
+}
+
+module.exports = { createWelcomeCard, createRankCard, createWarVictoryBanner, createWealthTierBanner };

--- a/src/utils/cardGenerator.js
+++ b/src/utils/cardGenerator.js
@@ -299,10 +299,11 @@ async function createWealthTierBanner(username, tierLabel, tierColor) {
     ctx.textBaseline = 'middle';
     ctx.textAlign = 'center';
     ctx.fillText('💰', 80, 100);
+    ctx.textBaseline = 'alphabetic';
+    ctx.textAlign = 'left';
 
     ctx.font = 'bold 42px "DejaVu Sans"';
     ctx.fillStyle = tierColor;
-    ctx.textAlign = 'left';
     ctx.fillText(tierLabel, 140, 80);
 
     ctx.font = '22px "DejaVu Sans"';
@@ -313,8 +314,6 @@ async function createWealthTierBanner(username, tierLabel, tierColor) {
     ctx.fillStyle = '#888888';
     ctx.fillText('has reached a legendary wealth milestone!', 140, 155);
 
-    ctx.textBaseline = 'alphabetic';
-    ctx.textAlign = 'left';
     return canvas.toBuffer();
 }
 

--- a/src/utils/wealthMilestone.js
+++ b/src/utils/wealthMilestone.js
@@ -53,8 +53,9 @@ async function checkAndBroadcastWealthMilestone(client, guildSettings, user, cha
             .setColor(milestone.color)
             .setTitle(`${milestone.label}`)
             .setDescription(`<@${user.userId}> has crossed a legendary wealth milestone!`)
-            .setImage('attachment://wealth_banner.png')
             .setTimestamp();
+
+        if (attachment) embed.setImage('attachment://wealth_banner.png');
 
         await channel.send({
             embeds: [embed],

--- a/src/utils/wealthMilestone.js
+++ b/src/utils/wealthMilestone.js
@@ -1,0 +1,68 @@
+const { EmbedBuilder, AttachmentBuilder } = require('discord.js');
+const { createWealthTierBanner } = require('./cardGenerator');
+
+const WEALTH_MILESTONES = [
+    { tier: 1, threshold: 1_000_000,     label: '💎 MILLIONAIRE',       color: '#5865f2' },
+    { tier: 2, threshold: 10_000_000,    label: '💫 DECAMILLIONAIRE',   color: '#ffd700' },
+    { tier: 3, threshold: 100_000_000,   label: '🌟 CENTIMILLIONAIRE',  color: '#ff6200' },
+    { tier: 4, threshold: 1_000_000_000, label: '👑 BILLIONAIRE',       color: '#b9f2ff' },
+];
+
+// Returns the milestone tier number for the given total, or 0 if none.
+function computeWealthTierNumber(total) {
+    let tier = 0;
+    for (const m of WEALTH_MILESTONES) {
+        if (total >= m.threshold) tier = m.tier;
+    }
+    return tier;
+}
+
+/**
+ * Check whether the user has crossed a new wealth milestone and broadcast if so.
+ * Mutates user.wealthTier and calls user.save() when a new milestone is reached.
+ * Never throws — a failure must never break the caller.
+ *
+ * @param {import('discord.js').Client} client
+ * @param {object} guildSettings  - Mongoose Guild document
+ * @param {object} user           - Mongoose User document (balance + bank must be current)
+ * @param {import('discord.js').TextChannel|null} channel - channel to post in
+ */
+async function checkAndBroadcastWealthMilestone(client, guildSettings, user, channel) {
+    try {
+        const total = (user.balance ?? 0) + (user.bank ?? 0);
+        const newTier = computeWealthTierNumber(total);
+        if (newTier <= (user.wealthTier ?? 0)) return;
+
+        const milestone = WEALTH_MILESTONES.find(m => m.tier === newTier);
+        if (!milestone) return;
+
+        user.wealthTier = newTier;
+        await user.save().catch(() => {});
+
+        if (!channel) return;
+
+        let attachment = null;
+        try {
+            const memberName = (await channel.guild.members.fetch(user.userId).catch(() => null))
+                ?.user?.username ?? 'Someone';
+            const bannerBuf = await createWealthTierBanner(memberName, milestone.label, milestone.color);
+            attachment = new AttachmentBuilder(bannerBuf, { name: 'wealth_banner.png' });
+        } catch {}
+
+        const embed = new EmbedBuilder()
+            .setColor(milestone.color)
+            .setTitle(`${milestone.label}`)
+            .setDescription(`<@${user.userId}> has crossed a legendary wealth milestone!`)
+            .setImage('attachment://wealth_banner.png')
+            .setTimestamp();
+
+        await channel.send({
+            embeds: [embed],
+            ...(attachment ? { files: [attachment] } : {})
+        }).catch(() => {});
+    } catch (err) {
+        console.error('[wealthMilestone] check failed:', err.message);
+    }
+}
+
+module.exports = { checkAndBroadcastWealthMilestone, WEALTH_MILESTONES };


### PR DESCRIPTION
Implements UX Phase 4 — every milestone now triggers a visible celebration:

War end ceremony
- Resolves war to both guilds (winner AND loser announcements)
- Canvas victory banner with score bar, flavor quote, MVP and Most Clutch callouts
- Awards 🎖️ War Victor badge (30 days) + 2× coin booster to winning guild members
- MVP derived from highest duel wins; Most Clutch from highest active streak

Season tier claim ceremony
- Rich hero embed with tier-specific lore quote
- Next-tier teaser with XP delta
- Social-proof footer: "N players have unlocked Tier X"
- Mythic-tier (≥ 10) broadcast to the economy announcement channel

Level-up auto-announce
- Replaces plain text with a rarity-ribbon "TIER X PROMOTION" embed
- Color and glyph scale with level band (Bronze/Silver/Gold/Diamond/Mythic)
- Respects per-user (User.disableLevelUpAnnounce) and server-level (Guild.leveling.disableLevelUpAnnounce) opt-outs

Wealth milestone broadcasts
- New wealthMilestone.js utility with 4 tiers: MILLIONAIRE / DECAMILLIONAIRE / CENTIMILLIONAIRE / BILLIONAIRE
- Canvas wealth tier banner sent on first crossing of each threshold
- User.wealthTier persisted so each tier broadcasts only once
- Checked after streak milestone coin awards in handleStreakAndQuests

Weekly leaderboard badges
- awardWeeklyLeaderboardBadges() scheduled Sunday 23:59 UTC via cron
- Snapshots top-1 of levels, economy, streaks, duels, achievements per guild
- Awards 7-day 👑 #1 badge stored in User.badges[]
- Sends "Last Week's Champions" recap embed to announcement channel

Model additions: User.badges[], User.wealthTier, User.disableLevelUpAnnounce,
Guild.leveling.disableLevelUpAnnounce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tier-specific lore text displayed when claiming seasonal rewards
  * Weekly leaderboard champion badges automatically awarded
  * Wealth milestone tracking with announcement banners
  * War victory broadcasts featuring MVP recognition and spoils awards

* **Enhancements**
  * Season reward embeds now include tier progression teasers and claim counts
  * Mythic tier claims announced server-wide
  * Level-up announcements redesigned with tier-based embed styling
  * War resolutions include victory banners and achievement badges

* **Settings**
  * Added opt-out flags for level-up announcements (user and guild-level)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/clawdia/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->