### PR TITLE
feat(ux-phase5): emotional depth — pets, quests, recap, and achievements

### DIFF
--- a/src/commands/economy/pet.js
+++ b/src/commands/economy/pet.js
@@ -1,5 +1,10 @@
-const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
-const User = require('../../models/User');
+'use strict';
+
+const {
+    SlashCommandBuilder, EmbedBuilder,
+    ActionRowBuilder, ButtonBuilder, ButtonStyle, AttachmentBuilder
+} = require('discord.js');
+const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
 const {
     PET_DEFINITIONS,
@@ -7,40 +12,32 @@ const {
     RUNAWAY_DAYS,
     applyHungerDecay,
     checkRunaway,
-    feedPet
+    feedPet,
+    getMoodLine,
+    getMoodColor,
+    heartBar,
 } = require('../../services/petService');
+const { generatePetSprite } = require('../../utils/cardGenerator');
 
 const HUNGER_BAR_LENGTH = 10;
 
 function hungerBar(hunger) {
     const filled = Math.round((hunger / 100) * HUNGER_BAR_LENGTH);
-    const color = hunger >= STARVING_THRESHOLD ? '🟩' : '🟥';
+    const color  = hunger >= STARVING_THRESHOLD ? '🟩' : '🟥';
     return color.repeat(filled) + '⬛'.repeat(HUNGER_BAR_LENGTH - filled) + ` ${hunger}%`;
 }
 
 function getMaterialSource(user, materialId) {
-    const huntMat  = user.hunt?.materials?.[materialId] ?? 0;
-    const fishMat  = user.fishing?.materials?.[materialId] ?? 0;
-    const mineMat  = user.mining?.materials?.[materialId] ?? 0;
+    const huntMat = user.hunt?.materials?.[materialId]   ?? 0;
+    const fishMat = user.fishing?.materials?.[materialId] ?? 0;
+    const mineMat = user.mining?.materials?.[materialId]  ?? 0;
     return { huntMat, fishMat, mineMat, total: huntMat + fishMat + mineMat };
 }
 
 function decrementMaterial(user, materialId) {
-    if ((user.hunt?.materials?.[materialId] ?? 0) > 0) {
-        user.hunt.materials[materialId]--;
-        user.markModified('hunt.materials');
-        return true;
-    }
-    if ((user.fishing?.materials?.[materialId] ?? 0) > 0) {
-        user.fishing.materials[materialId]--;
-        user.markModified('fishing.materials');
-        return true;
-    }
-    if ((user.mining?.materials?.[materialId] ?? 0) > 0) {
-        user.mining.materials[materialId]--;
-        user.markModified('mining.materials');
-        return true;
-    }
+    if ((user.hunt?.materials?.[materialId]    ?? 0) > 0) { user.hunt.materials[materialId]--;    user.markModified('hunt.materials');    return true; }
+    if ((user.fishing?.materials?.[materialId] ?? 0) > 0) { user.fishing.materials[materialId]--; user.markModified('fishing.materials'); return true; }
+    if ((user.mining?.materials?.[materialId]  ?? 0) > 0) { user.mining.materials[materialId]--;  user.markModified('mining.materials');  return true; }
     return false;
 }
 
@@ -61,9 +58,9 @@ async function syncHungerAndRunaway(user, interaction) {
     user.pets = keepPets;
     for (let i = 0; i < keepPets.length; i++) {
         const d = keepPets[i];
-        user.pets[i].hunger = d.hunger;
-        user.pets[i].lastFed = d.lastFed;   // persist advanced decay cursor
-        user.pets[i].starving = d.starving;
+        user.pets[i].hunger         = d.hunger;
+        user.pets[i].lastFed        = d.lastFed;
+        user.pets[i].starving       = d.starving;
         if (d.starvingStartAt) user.pets[i].starvingStartAt = d.starvingStartAt;
     }
     user.markModified('pets');
@@ -71,8 +68,7 @@ async function syncHungerAndRunaway(user, interaction) {
     if (ranAwayPets.length > 0) {
         const names = ranAwayPets.map(p => {
             const def = PET_DEFINITIONS[p.petId];
-            const displayName = p.name || def?.name || p.petId;
-            return `${def?.emoji ?? '🐾'} **${displayName}**`;
+            return `${def?.emoji ?? '🐾'} **${p.name || def?.name || p.petId}**`;
         });
         await interaction.followUp({
             content: `💔 Your pet${ranAwayPets.length > 1 ? 's' : ''} ran away from starvation: ${names.join(', ')}`,
@@ -81,15 +77,82 @@ async function syncHungerAndRunaway(user, interaction) {
     }
 }
 
+// ── Pet status card helpers ───────────────────────────────────────────────────
+
+function buildPetEmbed(pet, index, total, ownerAvatarURL) {
+    const def         = PET_DEFINITIONS[pet.petId];
+    const displayName = pet.name || def?.name || pet.petId;
+    const bondDays    = Math.floor((Date.now() - new Date(pet.adoptedAt).getTime()) / 86400000);
+    const moodLine    = getMoodLine(pet);
+    const moodColor   = getMoodColor(pet.hunger);
+    const bonusActive = pet.hunger >= STARVING_THRESHOLD;
+    const bonusEmoji  = bonusActive ? '✅' : '❌';
+    const bonusLabel  = `+${def?.bonusPct ?? 0}% ${(def?.bonusType ?? '').replace(/_/g, ' ')}${bonusActive ? '' : ' *(inactive)*'}`;
+
+    const lastFedMs  = pet.lastFed ? Date.now() - new Date(pet.lastFed).getTime() : 0;
+    const lastFedH   = Math.floor(lastFedMs / 3600000);
+    const lastFedStr = lastFedH < 1
+        ? 'just now'
+        : lastFedH < 24
+        ? `${lastFedH}h ago`
+        : `${Math.floor(lastFedH / 24)}d ago`;
+
+    const isResting  = pet.restUntil && new Date(pet.restUntil).getTime() > Date.now();
+    const potwLine   = pet.potw     ? '\n🌟 **Pet of the Week**'               : '';
+    const restLine   = isResting    ? '\n🛏️ *Resting — hunger decays slower*' : '';
+
+    return new EmbedBuilder()
+        .setColor(moodColor)
+        .setAuthor({ name: `${displayName} • ${def?.name ?? pet.petId}`, iconURL: ownerAvatarURL })
+        .setDescription(`*${moodLine}*${potwLine}${restLine}`)
+        .addFields(
+            { name: '❤️ Bond',              value: `${heartBar(bondDays)} ${bondDays}d`, inline: false },
+            { name: '🍖 Hunger',            value: hungerBar(pet.hunger),                inline: false },
+            { name: `${bonusEmoji} Bonus`,  value: bonusLabel,                           inline: true  },
+            { name: '🐾 Species',           value: `${def?.emoji ?? ''} ${def?.name ?? pet.petId}`, inline: true },
+        )
+        .setFooter({ text: `Pet ${index + 1} of ${total} • Last fed ${lastFedStr}` })
+        .setTimestamp();
+}
+
+function buildNavComponents(userId, index, total) {
+    const rows = [];
+
+    if (total > 1) {
+        rows.push(
+            new ActionRowBuilder().addComponents(
+                new ButtonBuilder()
+                    .setCustomId(`pet_prev:${userId}:${index}`)
+                    .setLabel('◀ Prev')
+                    .setStyle(ButtonStyle.Secondary)
+                    .setDisabled(index === 0),
+                new ButtonBuilder()
+                    .setCustomId(`pet_next:${userId}:${index}`)
+                    .setLabel('Next ▶')
+                    .setStyle(ButtonStyle.Secondary)
+                    .setDisabled(index === total - 1),
+            )
+        );
+    }
+
+    rows.push(
+        new ActionRowBuilder().addComponents(
+            new ButtonBuilder().setCustomId(`pet_play:${userId}:${index}`)     .setLabel('🎾 Play')     .setStyle(ButtonStyle.Success),
+            new ButtonBuilder().setCustomId(`pet_rest:${userId}:${index}`)     .setLabel('🛏️ Rest')    .setStyle(ButtonStyle.Primary),
+            new ButtonBuilder().setCustomId(`pet_showcase:${userId}:${index}`) .setLabel('📷 Showcase') .setStyle(ButtonStyle.Secondary),
+        )
+    );
+
+    return rows;
+}
+
 // ── Subcommand handlers ───────────────────────────────────────────────────────
 
 async function executeAdopt(interaction) {
     const petId = interaction.options.getString('type');
-    const def = PET_DEFINITIONS[petId];
+    const def   = PET_DEFINITIONS[petId];
 
-    if (!def) {
-        return interaction.reply({ content: 'Unknown pet type.', ephemeral: true });
-    }
+    if (!def) return interaction.reply({ content: 'Unknown pet type.', ephemeral: true });
     if (!def.purchasable) {
         return interaction.reply({
             content: `${def.emoji} **${def.name}** can only be obtained as a legendary drop — it's not sold in any shop!`,
@@ -97,21 +160,13 @@ async function executeAdopt(interaction) {
         });
     }
 
-    const [user, guildSettings] = await Promise.all([
-        resolveUser(interaction),
-        Guild.findOne({ guildId: interaction.guild.id })
-    ]);
+    const [user, guildSettings] = await Promise.all([resolveUser(interaction), Guild.findOne({ guildId: interaction.guild.id })]);
 
-    if (guildSettings?.economy?.enabled === false) {
-        return interaction.reply({ content: 'The economy is disabled in this server.', ephemeral: true });
-    }
+    if (guildSettings?.economy?.enabled === false) return interaction.reply({ content: 'The economy is disabled in this server.', ephemeral: true });
+    if ((user.pets ?? []).some(p => p.petId === petId)) return interaction.reply({ content: `You already own a ${def.emoji} **${def.name}**!`, ephemeral: true });
 
-    if ((user.pets ?? []).some(p => p.petId === petId)) {
-        return interaction.reply({ content: `You already own a ${def.emoji} **${def.name}**!`, ephemeral: true });
-    }
-
+    const currency = guildSettings?.economy?.currency ?? '💰';
     if (user.balance < def.cost) {
-        const currency = guildSettings?.economy?.currency ?? '💰';
         return interaction.reply({
             content: `You need **${def.cost.toLocaleString()}** ${currency} to adopt this pet but only have **${user.balance.toLocaleString()}**.`,
             ephemeral: true
@@ -129,17 +184,16 @@ async function executeAdopt(interaction) {
         throw err;
     }
 
-    const currency = guildSettings?.economy?.currency ?? '💰';
     const embed = new EmbedBuilder()
         .setColor('#4caf50')
         .setTitle(`${def.emoji} New Pet Adopted!`)
         .setDescription(`Welcome your new **${def.name}**! Take good care of it.`)
         .addFields(
-            { name: 'Passive Bonus', value: `+${def.bonusPct}% ${def.bonusType.replace(/_/g, ' ')} (active when hunger ≥ 30%)`, inline: true },
-            { name: 'Favorite Food', value: `\`${def.favoriteMaterial}\` (restores 25 hunger)`, inline: true },
-            { name: 'Cost', value: `${def.cost.toLocaleString()} ${currency}`, inline: true }
+            { name: 'Passive Bonus',  value: `+${def.bonusPct}% ${def.bonusType.replace(/_/g, ' ')} (active when hunger ≥ 30%)`, inline: true },
+            { name: 'Favorite Food',  value: `\`${def.favoriteMaterial}\` (restores 25 hunger)`,                                  inline: true },
+            { name: 'Cost',           value: `${def.cost.toLocaleString()} ${currency}`,                                           inline: true },
         )
-        .setFooter({ text: 'Use /pet feed to keep it happy!' })
+        .setFooter({ text: 'Use /pet status to see your pet\'s mood, or /pet feed to keep it happy!' })
         .setTimestamp();
 
     return interaction.reply({ embeds: [embed] });
@@ -155,72 +209,170 @@ async function executeStatus(interaction) {
         return interaction.editReply('You have no pets. Use `/pet adopt` to get one!');
     }
 
-    const fields = user.pets.map(pet => {
-        const def = PET_DEFINITIONS[pet.petId];
-        const displayName = pet.name || def?.name || pet.petId;
-        const bonusActive = pet.hunger >= STARVING_THRESHOLD;
-        const daysOwned = Math.floor((Date.now() - new Date(pet.adoptedAt).getTime()) / 86400000);
-        const starvingDays = (pet.hunger === 0 && pet.starvingStartAt)
-            ? Math.floor((Date.now() - new Date(pet.starvingStartAt).getTime()) / 86400000)
-            : 0;
-        const runawayWarning = starvingDays > 0
-            ? `\n⚠️ Starving for ${starvingDays}/${RUNAWAY_DAYS} days — feed it!`
-            : '';
+    await user.save().catch(() => {});
 
-        return {
-            name: `${def?.emoji ?? '🐾'} ${displayName}`,
-            value: [
-                `Hunger: ${hungerBar(pet.hunger)}`,
-                `Bonus: +${def?.bonusPct ?? 0}% ${(def?.bonusType ?? '').replace(/_/g, ' ')} — ${bonusActive ? '✅ Active' : '❌ Inactive (feed me!)'}`,
-                `Days owned: ${daysOwned}${runawayWarning}`
-            ].join('\n'),
-            inline: false
-        };
+    let currentIndex = 0;
+    const ownerAvatarURL = interaction.user.displayAvatarURL({ dynamic: true });
+
+    const reply = await interaction.editReply({
+        embeds:     [buildPetEmbed(user.pets[currentIndex], currentIndex, user.pets.length, ownerAvatarURL)],
+        components: buildNavComponents(interaction.user.id, currentIndex, user.pets.length),
     });
 
-    const embed = new EmbedBuilder()
-        .setColor('#ff9800')
-        .setTitle('🐾 Your Pets')
-        .addFields(fields)
-        .setFooter({ text: 'Feed pets with /pet feed to keep bonuses active' })
-        .setTimestamp();
+    const collector = reply.createMessageComponentCollector({
+        filter: i => i.user.id === interaction.user.id,
+        time:   90_000,
+    });
 
-    await user.save().catch(() => {});
-    return interaction.editReply({ embeds: [embed] });
+    collector.on('collect', async (btn) => {
+        const parts  = btn.customId.split(':');
+        const action = parts[0];
+        const idx    = parseInt(parts[2], 10);
+
+        // Re-fetch user so mutations from concurrent actions are reflected
+        const freshUser = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+        if (!freshUser || !freshUser.pets[idx]) {
+            return btn.reply({ content: 'Pet not found.', ephemeral: true });
+        }
+
+        if (action === 'pet_prev') {
+            currentIndex = Math.max(0, idx - 1);
+            await btn.update({
+                embeds:     [buildPetEmbed(freshUser.pets[currentIndex], currentIndex, freshUser.pets.length, ownerAvatarURL)],
+                components: buildNavComponents(interaction.user.id, currentIndex, freshUser.pets.length),
+            });
+
+        } else if (action === 'pet_next') {
+            currentIndex = Math.min(freshUser.pets.length - 1, idx + 1);
+            await btn.update({
+                embeds:     [buildPetEmbed(freshUser.pets[currentIndex], currentIndex, freshUser.pets.length, ownerAvatarURL)],
+                components: buildNavComponents(interaction.user.id, currentIndex, freshUser.pets.length),
+            });
+
+        } else if (action === 'pet_play') {
+            const pet  = freshUser.pets[idx];
+            const def  = PET_DEFINITIONS[pet.petId];
+            const name = pet.name || def?.name || pet.petId;
+            const now  = Date.now();
+            const PLAY_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
+
+            if (pet.lastPlay && (now - new Date(pet.lastPlay).getTime()) < PLAY_COOLDOWN_MS) {
+                const remaining = Math.ceil((PLAY_COOLDOWN_MS - (now - new Date(pet.lastPlay).getTime())) / 60000);
+                return btn.reply({ content: `🎾 **${name}** is tired from playing! Try again in **${remaining}m**.`, ephemeral: true });
+            }
+
+            const xpGain = 15 + Math.floor(Math.random() * 11); // 15–25 XP
+            freshUser.xp = (freshUser.xp || 0) + xpGain;
+            freshUser.pets[idx].lastPlay            = new Date();
+            freshUser.pets[idx].weeklyInteractions  = (freshUser.pets[idx].weeklyInteractions || 0) + 1;
+            freshUser.markModified('pets');
+
+            try { await freshUser.save(); } catch { /* best effort */ }
+
+            await btn.reply({ content: `🎾 You played with **${name}**! They loved it.\n✨ **+${xpGain} XP** earned!`, ephemeral: true });
+            await interaction.editReply({
+                embeds:     [buildPetEmbed(freshUser.pets[idx], idx, freshUser.pets.length, ownerAvatarURL)],
+                components: buildNavComponents(interaction.user.id, idx, freshUser.pets.length),
+            }).catch(() => {});
+
+        } else if (action === 'pet_rest') {
+            const pet  = freshUser.pets[idx];
+            const def  = PET_DEFINITIONS[pet.petId];
+            const name = pet.name || def?.name || pet.petId;
+
+            if (pet.restUntil && new Date(pet.restUntil).getTime() > Date.now()) {
+                const remaining = Math.ceil((new Date(pet.restUntil).getTime() - Date.now()) / 60000);
+                return btn.reply({ content: `🛏️ **${name}** is already resting! ${remaining}m remaining.`, ephemeral: true });
+            }
+
+            freshUser.pets[idx].restUntil           = new Date(Date.now() + 2 * 60 * 60 * 1000);
+            freshUser.pets[idx].weeklyInteractions  = (freshUser.pets[idx].weeklyInteractions || 0) + 1;
+            freshUser.markModified('pets');
+
+            try { await freshUser.save(); } catch { /* best effort */ }
+
+            await btn.reply({ content: `🛏️ **${name}** is now resting! Hunger will decay at half speed for **2 hours**.`, ephemeral: true });
+            await interaction.editReply({
+                embeds:     [buildPetEmbed(freshUser.pets[idx], idx, freshUser.pets.length, ownerAvatarURL)],
+                components: buildNavComponents(interaction.user.id, idx, freshUser.pets.length),
+            }).catch(() => {});
+
+        } else if (action === 'pet_showcase') {
+            const pet      = freshUser.pets[idx];
+            const def      = PET_DEFINITIONS[pet.petId];
+            const name     = pet.name || def?.name || pet.petId;
+            const bondDays = Math.floor((Date.now() - new Date(pet.adoptedAt).getTime()) / 86400000);
+
+            freshUser.pets[idx].weeklyInteractions = (freshUser.pets[idx].weeklyInteractions || 0) + 1;
+            freshUser.markModified('pets');
+            await freshUser.save().catch(() => {});
+
+            const showcaseEmbed = new EmbedBuilder()
+                .setColor(getMoodColor(pet.hunger))
+                .setTitle(`${def?.emoji ?? '🐾'} ${name}`)
+                .setAuthor({ name: `Owned by ${interaction.user.username}`, iconURL: ownerAvatarURL })
+                .setDescription(`*${getMoodLine(pet)}*${pet.potw ? '\n🌟 **Pet of the Week**' : ''}`)
+                .addFields(
+                    { name: '❤️ Bond',    value: `${heartBar(bondDays)} ${bondDays}d`,               inline: true },
+                    { name: '🍖 Hunger', value: hungerBar(pet.hunger),                                inline: true },
+                    { name: `${pet.hunger >= STARVING_THRESHOLD ? '✅' : '❌'} Bonus`,
+                      value: `+${def?.bonusPct ?? 0}% ${(def?.bonusType ?? '').replace(/_/g, ' ')}`, inline: false },
+                )
+                .setFooter({ text: `${def?.name ?? pet.petId} • Use /pet status to check on yours!` })
+                .setTimestamp();
+
+            // Try to attach a pet sprite
+            let files = [];
+            try {
+                const spriteBuf = await generatePetSprite(pet.petId, 80);
+                if (spriteBuf) {
+                    showcaseEmbed.setThumbnail('attachment://pet_sprite.png');
+                    files = [new AttachmentBuilder(spriteBuf, { name: 'pet_sprite.png' })];
+                }
+            } catch { /* non-critical */ }
+
+            await btn.reply({ embeds: [showcaseEmbed], files });
+        }
+    });
+
+    collector.on('end', async () => {
+        try {
+            const disabled = buildNavComponents(interaction.user.id, currentIndex, user.pets.length)
+                .map(row => ActionRowBuilder.from(row).setComponents(
+                    row.components.map(b => ButtonBuilder.from(b).setDisabled(true))
+                ));
+            await interaction.editReply({ components: disabled });
+        } catch { /* non-critical */ }
+    });
 }
 
 async function executeFeed(interaction) {
     const materialId = interaction.options.getString('material');
-    const petIndex = interaction.options.getInteger('slot') ?? 0;
+    const petIndex   = interaction.options.getInteger('slot') ?? 0;
 
     await interaction.deferReply();
 
     const user = await resolveUser(interaction);
     await syncHungerAndRunaway(user, interaction);
 
-    if (!user.pets || user.pets.length === 0) {
-        return interaction.editReply('You have no pets to feed!');
-    }
-
+    if (!user.pets || user.pets.length === 0) return interaction.editReply('You have no pets to feed!');
     if (petIndex < 0 || petIndex >= user.pets.length) {
         return interaction.editReply(`Invalid pet slot. You have ${user.pets.length} pet(s) (slots 0–${user.pets.length - 1}).`);
     }
 
     const { total } = getMaterialSource(user, materialId);
-    if (total < 1) {
-        return interaction.editReply(`You don't have any \`${materialId}\` to feed your pet with.`);
-    }
+    if (total < 1) return interaction.editReply(`You don't have any \`${materialId}\` to feed your pet with.`);
 
-    const pet = user.pets[petIndex];
-    const def = PET_DEFINITIONS[pet.petId];
+    const pet    = user.pets[petIndex];
+    const def    = PET_DEFINITIONS[pet.petId];
     const result = feedPet(pet, materialId);
-
     if (!result) return interaction.editReply('Could not feed that pet.');
 
     decrementMaterial(user, materialId);
-    user.pets[petIndex].hunger = result.hunger;
-    user.pets[petIndex].lastFed = new Date();
-    user.pets[petIndex].starving = result.hunger < STARVING_THRESHOLD;
+    user.pets[petIndex].hunger          = result.hunger;
+    user.pets[petIndex].lastFed         = new Date();
+    user.pets[petIndex].starving        = result.hunger < STARVING_THRESHOLD;
+    user.pets[petIndex].weeklyInteractions = (user.pets[petIndex].weeklyInteractions || 0) + 1;
     if (result.hunger >= STARVING_THRESHOLD) user.pets[petIndex].starvingStartAt = null;
     user.markModified('pets');
 
@@ -231,16 +383,16 @@ async function executeFeed(interaction) {
         throw err;
     }
 
-    const displayName = pet.name || def?.name || pet.petId;
+    const displayName  = pet.name || def?.name || pet.petId;
     const favoriteNote = result.isFavorite ? ' *(favorite food — +25 hunger!)*' : ' *(not favorite — +10 hunger)*';
 
     const embed = new EmbedBuilder()
         .setColor(result.hunger >= STARVING_THRESHOLD ? '#4caf50' : '#ff5722')
         .setTitle(`${def?.emoji ?? '🐾'} ${displayName} fed!`)
         .addFields(
-            { name: 'Food', value: `\`${materialId}\`${favoriteNote}`, inline: true },
-            { name: 'Hunger', value: hungerBar(result.hunger), inline: false },
-            { name: 'Bonus', value: result.hunger >= STARVING_THRESHOLD ? '✅ Active' : '❌ Still inactive (need ≥ 30%)', inline: true }
+            { name: 'Food',   value: `\`${materialId}\`${favoriteNote}`,   inline: true  },
+            { name: 'Hunger', value: hungerBar(result.hunger),              inline: false },
+            { name: 'Bonus',  value: result.hunger >= STARVING_THRESHOLD ? '✅ Active' : '❌ Still inactive (need ≥ 30%)', inline: true },
         )
         .setTimestamp();
 
@@ -249,15 +401,15 @@ async function executeFeed(interaction) {
 
 async function executeRelease(interaction) {
     const petIndex = interaction.options.getInteger('slot');
-    const user = await resolveUser(interaction);
+    const user     = await resolveUser(interaction);
 
     if (!user.pets || petIndex < 0 || petIndex >= user.pets.length) {
         return interaction.reply({ content: 'Invalid pet slot.', ephemeral: true });
     }
 
-    const pet = user.pets[petIndex];
-    const def = PET_DEFINITIONS[pet.petId];
-    const displayName = pet.name || def?.name || pet.petId;
+    const pet  = user.pets[petIndex];
+    const def  = PET_DEFINITIONS[pet.petId];
+    const name = pet.name || def?.name || pet.petId;
 
     user.pets.splice(petIndex, 1);
     user.markModified('pets');
@@ -269,16 +421,13 @@ async function executeRelease(interaction) {
         throw err;
     }
 
-    return interaction.reply({
-        content: `${def?.emoji ?? '🐾'} **${displayName}** has been released. Goodbye, friend!`,
-        ephemeral: true
-    });
+    return interaction.reply({ content: `${def?.emoji ?? '🐾'} **${name}** has been released. Goodbye, friend!`, ephemeral: true });
 }
 
 async function executeRename(interaction) {
     const petIndex = interaction.options.getInteger('slot');
-    const newName = interaction.options.getString('name').trim().slice(0, 32);
-    const user = await resolveUser(interaction);
+    const newName  = interaction.options.getString('name').trim().slice(0, 32);
+    const user     = await resolveUser(interaction);
 
     if (!user.pets || petIndex < 0 || petIndex >= user.pets.length) {
         return interaction.reply({ content: 'Invalid pet slot.', ephemeral: true });
@@ -295,10 +444,7 @@ async function executeRename(interaction) {
     }
 
     const def = PET_DEFINITIONS[user.pets[petIndex].petId];
-    return interaction.reply({
-        content: `${def?.emoji ?? '🐾'} Pet renamed to **${newName}**!`,
-        ephemeral: true
-    });
+    return interaction.reply({ content: `${def?.emoji ?? '🐾'} Pet renamed to **${newName}**!`, ephemeral: true });
 }
 
 async function executeList(interaction) {
@@ -316,6 +462,44 @@ async function executeList(interaction) {
     return interaction.reply({ embeds: [embed] });
 }
 
+async function executeLeaderboard(interaction) {
+    await interaction.deferReply();
+
+    const users = await User.find(
+        { guildId: interaction.guild.id, 'pets.0': { $exists: true } },
+        'userId pets'
+    ).lean();
+
+    const entries = [];
+    for (const u of users) {
+        for (const pet of u.pets) {
+            const bondDays = Math.floor((Date.now() - new Date(pet.adoptedAt).getTime()) / 86400000);
+            entries.push({ userId: u.userId, pet, bondDays });
+        }
+    }
+
+    entries.sort((a, b) => b.bondDays - a.bondDays);
+    const top = entries.slice(0, 10);
+
+    const medals = ['🥇', '🥈', '🥉'];
+    const lines  = top.map((e, i) => {
+        const def  = PET_DEFINITIONS[e.pet.petId];
+        const name = e.pet.name || def?.name || e.pet.petId;
+        const rank = medals[i] ?? `${i + 1}.`;
+        const potw = e.pet.potw ? ' 🌟' : '';
+        return `${rank} ${def?.emoji ?? '🐾'} **${name}**${potw} — ${heartBar(e.bondDays)} ${e.bondDays}d — <@${e.userId}>`;
+    });
+
+    const embed = new EmbedBuilder()
+        .setColor('#ff9800')
+        .setTitle('🐾 Pet Leaderboard — Most Bonded Pets')
+        .setDescription(lines.length > 0 ? lines.join('\n') : '*No pets in this server yet!*')
+        .setFooter({ text: 'Pet of the Week is chosen weekly by most interactions • 🌟 = current POTW' })
+        .setTimestamp();
+
+    return interaction.editReply({ embeds: [embed] });
+}
+
 // ── Module export ─────────────────────────────────────────────────────────────
 
 module.exports = {
@@ -328,81 +512,58 @@ module.exports = {
             sub.setName('adopt')
                 .setDescription('Adopt a pet from the shop.')
                 .addStringOption(opt =>
-                    opt.setName('type')
-                        .setDescription('Pet type to adopt')
-                        .setRequired(true)
+                    opt.setName('type').setDescription('Pet type to adopt').setRequired(true)
                         .addChoices(
-                            { name: '🐶 Dog (2,000)', value: 'dog' },
-                            { name: '🐱 Cat (2,000)', value: 'cat' },
-                            { name: '🐦 Bird (3,000)', value: 'bird' },
-                            { name: '🐠 Fish (3,000)', value: 'fish' },
-                            { name: '🦊 Fox (5,000)', value: 'fox' },
-                            { name: '🐺 Wolf (8,000)', value: 'wolf' }
+                            { name: '🐶 Dog (2,000)',    value: 'dog'  },
+                            { name: '🐱 Cat (2,000)',    value: 'cat'  },
+                            { name: '🐦 Bird (3,000)',   value: 'bird' },
+                            { name: '🐠 Fish (3,000)',   value: 'fish' },
+                            { name: '🦊 Fox (5,000)',    value: 'fox'  },
+                            { name: '🐺 Wolf (8,000)',   value: 'wolf' },
                         )
                 )
         )
-        .addSubcommand(sub =>
-            sub.setName('status')
-                .setDescription('View your pets and their hunger levels.')
-        )
+        .addSubcommand(sub => sub.setName('status').setDescription('View your pets and their mood.'))
         .addSubcommand(sub =>
             sub.setName('feed')
                 .setDescription('Feed a pet using a hunt/fish/mine material.')
                 .addStringOption(opt =>
-                    opt.setName('material')
-                        .setDescription('Material to feed (e.g. rabbits_foot, fish_scale)')
-                        .setRequired(true)
+                    opt.setName('material').setDescription('Material to feed (e.g. rabbits_foot, fish_scale)').setRequired(true)
                 )
                 .addIntegerOption(opt =>
-                    opt.setName('slot')
-                        .setDescription('Pet slot number (0 = first pet, default 0)')
-                        .setRequired(false)
-                        .setMinValue(0)
-                        .setMaxValue(9)
+                    opt.setName('slot').setDescription('Pet slot number (0 = first pet, default 0)').setRequired(false).setMinValue(0).setMaxValue(9)
                 )
         )
         .addSubcommand(sub =>
             sub.setName('release')
                 .setDescription('Release a pet permanently.')
                 .addIntegerOption(opt =>
-                    opt.setName('slot')
-                        .setDescription('Pet slot number (0 = first pet)')
-                        .setRequired(true)
-                        .setMinValue(0)
-                        .setMaxValue(9)
+                    opt.setName('slot').setDescription('Pet slot number (0 = first pet)').setRequired(true).setMinValue(0).setMaxValue(9)
                 )
         )
         .addSubcommand(sub =>
             sub.setName('rename')
                 .setDescription('Give your pet a custom name.')
                 .addIntegerOption(opt =>
-                    opt.setName('slot')
-                        .setDescription('Pet slot number (0 = first pet)')
-                        .setRequired(true)
-                        .setMinValue(0)
-                        .setMaxValue(9)
+                    opt.setName('slot').setDescription('Pet slot number (0 = first pet)').setRequired(true).setMinValue(0).setMaxValue(9)
                 )
                 .addStringOption(opt =>
-                    opt.setName('name')
-                        .setDescription('New name (max 32 chars)')
-                        .setRequired(true)
-                        .setMaxLength(32)
+                    opt.setName('name').setDescription('New name (max 32 chars)').setRequired(true).setMaxLength(32)
                 )
         )
-        .addSubcommand(sub =>
-            sub.setName('list')
-                .setDescription('View all available pets in the shop.')
-        ),
+        .addSubcommand(sub => sub.setName('list').setDescription('View all available pets in the shop.'))
+        .addSubcommand(sub => sub.setName('leaderboard').setDescription('View the top bonded pets in this server.')),
 
     async execute(interaction) {
         const sub = interaction.options.getSubcommand();
         try {
-            if (sub === 'adopt')   return await executeAdopt(interaction);
-            if (sub === 'status')  return await executeStatus(interaction);
-            if (sub === 'feed')    return await executeFeed(interaction);
-            if (sub === 'release') return await executeRelease(interaction);
-            if (sub === 'rename')  return await executeRename(interaction);
-            if (sub === 'list')    return await executeList(interaction);
+            if (sub === 'adopt')       return await executeAdopt(interaction);
+            if (sub === 'status')      return await executeStatus(interaction);
+            if (sub === 'feed')        return await executeFeed(interaction);
+            if (sub === 'release')     return await executeRelease(interaction);
+            if (sub === 'rename')      return await executeRename(interaction);
+            if (sub === 'list')        return await executeList(interaction);
+            if (sub === 'leaderboard') return await executeLeaderboard(interaction);
         } catch (err) {
             console.error('[pet] error:', err);
             const msg = { content: 'Something went wrong with the pet command.', ephemeral: true };

--- a/src/commands/economy/pet.js
+++ b/src/commands/economy/pet.js
@@ -18,6 +18,7 @@ const {
     heartBar,
 } = require('../../services/petService');
 const { generatePetSprite } = require('../../utils/cardGenerator');
+const { applyXpGain, announceLevelUp } = require('../../utils/applyXpGain');
 
 const HUNGER_BAR_LENGTH = 10;
 
@@ -202,7 +203,10 @@ async function executeAdopt(interaction) {
 async function executeStatus(interaction) {
     await interaction.deferReply();
 
-    const user = await resolveUser(interaction);
+    const [user, guildSettings] = await Promise.all([
+        resolveUser(interaction),
+        Guild.findOne({ guildId: interaction.guild.id }),
+    ]);
     await syncHungerAndRunaway(user, interaction);
 
     if (!user.pets || user.pets.length === 0) {
@@ -212,7 +216,7 @@ async function executeStatus(interaction) {
     await user.save().catch(() => {});
 
     let currentIndex = 0;
-    const ownerAvatarURL = interaction.user.displayAvatarURL({ dynamic: true });
+    const ownerAvatarURL = interaction.user.displayAvatarURL();
 
     const reply = await interaction.editReply({
         embeds:     [buildPetEmbed(user.pets[currentIndex], currentIndex, user.pets.length, ownerAvatarURL)],
@@ -262,14 +266,27 @@ async function executeStatus(interaction) {
             }
 
             const xpGain = 15 + Math.floor(Math.random() * 11); // 15–25 XP
-            freshUser.xp = (freshUser.xp || 0) + xpGain;
-            freshUser.pets[idx].lastPlay            = new Date();
-            freshUser.pets[idx].weeklyInteractions  = (freshUser.pets[idx].weeklyInteractions || 0) + 1;
+            const { leveled } = applyXpGain(freshUser, xpGain);
+            freshUser.pets[idx].lastPlay           = new Date();
+            freshUser.pets[idx].weeklyInteractions = (freshUser.pets[idx].weeklyInteractions || 0) + 1;
             freshUser.markModified('pets');
 
-            try { await freshUser.save(); } catch { /* best effort */ }
+            try {
+                await freshUser.save();
+            } catch (err) {
+                if (err.name === 'VersionError') {
+                    return btn.reply({ content: '⚠️ Action conflict — please try again.', ephemeral: true });
+                }
+                console.error('[pet] play save error:', err);
+                return btn.reply({ content: '❌ Failed to save. Please try again.', ephemeral: true });
+            }
 
-            await btn.reply({ content: `🎾 You played with **${name}**! They loved it.\n✨ **+${xpGain} XP** earned!`, ephemeral: true });
+            if (leveled) {
+                announceLevelUp(freshUser, guildSettings, btn.member, btn.guild, interaction.channel).catch(() => {});
+            }
+
+            const levelNote = leveled ? `\n🎉 **Level up! You're now level ${freshUser.level}!**` : '';
+            await btn.reply({ content: `🎾 You played with **${name}**! They loved it.\n✨ **+${xpGain} XP** earned!${levelNote}`, ephemeral: true });
             await interaction.editReply({
                 embeds:     [buildPetEmbed(freshUser.pets[idx], idx, freshUser.pets.length, ownerAvatarURL)],
                 components: buildNavComponents(interaction.user.id, idx, freshUser.pets.length),
@@ -289,7 +306,15 @@ async function executeStatus(interaction) {
             freshUser.pets[idx].weeklyInteractions  = (freshUser.pets[idx].weeklyInteractions || 0) + 1;
             freshUser.markModified('pets');
 
-            try { await freshUser.save(); } catch { /* best effort */ }
+            try {
+                await freshUser.save();
+            } catch (err) {
+                if (err.name === 'VersionError') {
+                    return btn.reply({ content: '⚠️ Action conflict — please try again.', ephemeral: true });
+                }
+                console.error('[pet] rest save error:', err);
+                return btn.reply({ content: '❌ Failed to save. Please try again.', ephemeral: true });
+            }
 
             await btn.reply({ content: `🛏️ **${name}** is now resting! Hunger will decay at half speed for **2 hours**.`, ephemeral: true });
             await interaction.editReply({
@@ -305,7 +330,16 @@ async function executeStatus(interaction) {
 
             freshUser.pets[idx].weeklyInteractions = (freshUser.pets[idx].weeklyInteractions || 0) + 1;
             freshUser.markModified('pets');
-            await freshUser.save().catch(() => {});
+
+            try {
+                await freshUser.save();
+            } catch (err) {
+                if (err.name === 'VersionError') {
+                    return btn.reply({ content: '⚠️ Action conflict — please try again.', ephemeral: true });
+                }
+                console.error('[pet] showcase save error:', err);
+                return btn.reply({ content: '❌ Failed to save. Please try again.', ephemeral: true });
+            }
 
             const showcaseEmbed = new EmbedBuilder()
                 .setColor(getMoodColor(pet.hunger))
@@ -465,21 +499,16 @@ async function executeList(interaction) {
 async function executeLeaderboard(interaction) {
     await interaction.deferReply();
 
-    const users = await User.find(
-        { guildId: interaction.guild.id, 'pets.0': { $exists: true } },
-        'userId pets'
-    ).lean();
-
-    const entries = [];
-    for (const u of users) {
-        for (const pet of u.pets) {
-            const bondDays = Math.floor((Date.now() - new Date(pet.adoptedAt).getTime()) / 86400000);
-            entries.push({ userId: u.userId, pet, bondDays });
-        }
-    }
-
-    entries.sort((a, b) => b.bondDays - a.bondDays);
-    const top = entries.slice(0, 10);
+    const top = await User.aggregate([
+        { $match: { guildId: interaction.guild.id, 'pets.0': { $exists: true } } },
+        { $unwind: '$pets' },
+        { $addFields: {
+            bondDays: { $toInt: { $divide: [{ $subtract: [new Date(), '$pets.adoptedAt'] }, 86400000] } }
+        }},
+        { $sort: { bondDays: -1 } },
+        { $limit: 10 },
+        { $project: { _id: 0, userId: 1, pet: '$pets', bondDays: 1 } },
+    ]);
 
     const medals = ['🥇', '🥈', '🥉'];
     const lines  = top.map((e, i) => {

--- a/src/commands/fun/achievement.js
+++ b/src/commands/fun/achievement.js
@@ -1,34 +1,8 @@
+'use strict';
+
 const { SlashCommandBuilder, AttachmentBuilder } = require('discord.js');
-const { createCanvas } = require('canvas');
+const { createAchievementCard } = require('../../utils/cardGenerator');
 const { checkImageRateLimit } = require('../../utils/imageRateLimit');
-
-const W         = 420;
-const H         = 90;
-const ICON_SIZE = 58;
-const PAD       = 16;
-
-// Minimal diamond-sword-style icon drawn with canvas primitives
-function drawIcon(ctx, x, y, size) {
-    const s = size / 18;
-
-    // Blade — cyan/aqua pixels along the diagonal
-    ctx.fillStyle = '#5de0e6';
-    const blade = [
-        [9,1],[10,1],[8,2],[9,2],[7,3],[8,3],[6,4],[7,4],
-        [5,5],[6,5],[4,6],[5,6],[3,7],[4,7],[2,8],[3,8],
-    ];
-    for (const [bx, by] of blade) ctx.fillRect(x + bx * s, y + by * s, s, s);
-
-    // Guard — lighter blue horizontal bar
-    ctx.fillStyle = '#8aeef2';
-    const guard = [[1,8],[2,8],[3,8],[4,8],[5,8]];
-    for (const [gx, gy] of guard) ctx.fillRect(x + gx * s, y + gy * s, s, s);
-
-    // Handle — brown
-    ctx.fillStyle = '#8b5e3c';
-    const handle = [[2,9],[2,10],[2,11],[2,12],[1,10],[3,10]];
-    for (const [hx, hy] of handle) ctx.fillRect(x + hx * s, y + hy * s, s, s);
-}
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -50,67 +24,16 @@ module.exports = {
 
         try {
             await interaction.deferReply();
-            const canvas = createCanvas(W, H);
-            const ctx    = canvas.getContext('2d');
-
-            // Dark background
-            ctx.fillStyle = '#3c3c3c';
-            ctx.fillRect(0, 0, W, H);
-
-            // Minecraft-style bevel border
-            ctx.fillStyle = '#5a5a5a';
-            ctx.fillRect(0, 0, W, 3);       // top
-            ctx.fillRect(0, 0, 3, H);       // left
-            ctx.fillStyle = '#1a1a1a';
-            ctx.fillRect(0, H - 3, W, 3);   // bottom
-            ctx.fillRect(W - 3, 0, 3, H);   // right
-
-            // Icon background slot
-            const iconX = PAD;
-            const iconY = (H - ICON_SIZE) / 2;
-            ctx.fillStyle = '#2a2a2a';
-            ctx.fillRect(iconX, iconY, ICON_SIZE, ICON_SIZE);
-            ctx.strokeStyle = '#111111';
-            ctx.lineWidth   = 2;
-            ctx.strokeRect(iconX, iconY, ICON_SIZE, ICON_SIZE);
-            ctx.strokeStyle = '#555555';
-            ctx.lineWidth   = 1;
-            ctx.strokeRect(iconX + 2, iconY + 2, ICON_SIZE - 4, ICON_SIZE - 4);
-
-            drawIcon(ctx, iconX + 2, iconY + 2, ICON_SIZE - 4);
-
-            // Text
-            const textX = iconX + ICON_SIZE + 14;
-            ctx.textBaseline = 'top';
-
-            ctx.font      = 'bold 15px Arial, sans-serif';
-            ctx.fillStyle = '#ffdf00';
-            ctx.fillText('Achievement Unlocked!', textX, 20);
-
-            const maxTextWidth = W - textX - PAD;
-            let fontSize = 21;
-            ctx.font = `bold ${fontSize}px Arial, sans-serif`;
-            while (ctx.measureText(text).width > maxTextWidth && fontSize > 10) {
-                fontSize--;
-                ctx.font = `bold ${fontSize}px Arial, sans-serif`;
-            }
-            ctx.fillStyle = '#ffffff';
-            ctx.fillText(text, textX, 46);
-
-            const attachment = new AttachmentBuilder(canvas.toBuffer('image/png'), { name: 'achievement.png' });
+            const buf        = await createAchievementCard(text, null, null);
+            const attachment = new AttachmentBuilder(buf, { name: 'achievement.png' });
             await interaction.editReply({ files: [attachment] });
         } catch (err) {
             console.error('achievement: render failed', err);
             const msg = '❌ Could not generate the achievement. Please try again.';
             try {
-                if (interaction.deferred || interaction.replied) {
-                    await interaction.editReply(msg);
-                } else {
-                    await interaction.reply({ content: msg, ephemeral: true });
-                }
-            } catch (replyErr) {
-                console.error('achievement: failed to send error reply', replyErr);
-            }
+                if (interaction.deferred || interaction.replied) await interaction.editReply(msg);
+                else await interaction.reply({ content: msg, ephemeral: true });
+            } catch { /* ignore */ }
         }
     },
 };

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -45,7 +45,7 @@ async function trackQuestCommandUse(interaction) {
     const { completed, nearComplete } = await onCommandUse(user, guildSettings);
     await user.save();
 
-    await notifyQuestComplete(guildSettings, interaction.member, completed, interaction.channel);
+    await notifyQuestComplete(guildSettings, interaction.member, completed, interaction.channel, user);
     await notifyQuestNearComplete(guildSettings, interaction.member, nearComplete, interaction.channel);
 }
 

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -10,6 +10,7 @@ const { hasEffect, consumeEffect, getXpMultiplier, getServerXpMultiplier } = req
 const { checkRivalry } = require('../services/rivalryService');
 const { checkAndAward, announceAchievements } = require('../services/achievementService');
 const { checkAndBroadcastWealthMilestone } = require('../utils/wealthMilestone');
+const { applyXpGain, announceLevelUp } = require('../utils/applyXpGain');
 const BASE_BAD_WORDS = require('../data/profanityList');
 
 // Pre-compile base word regexes once at module load — avoids per-message regex construction
@@ -194,7 +195,7 @@ async function handleStreakAndQuests(message, guildSettings, existingUser = null
             announceAchievements(message.client, guildSettings, user, message.member, newlyEarned).catch(() => null);
         }
 
-        await notifyQuestComplete(guildSettings, message.member, completedQuests, message.channel);
+        await notifyQuestComplete(guildSettings, message.member, completedQuests, message.channel, user);
         await notifyQuestNearComplete(guildSettings, message.member, nearCompleteQuests, message.channel);
         if (assignedNewDaily) {
             await notifyDailyQuestReset(guildSettings, message.member, user, message.channel);
@@ -267,54 +268,11 @@ async function handleLeveling(message, guildSettings) {
     xpGain = Math.floor(xpGain);
 
     if (user) {
-        user.xp += xpGain;
+        const { leveled } = applyXpGain(user, xpGain);
         user.messages += 1;
         user.lastXpGain = new Date();
-
-        const requiredXp = user.level * 100 + 100;
-
-        if (user.xp >= requiredXp) {
-            user.level += 1;
-            user.xp = 0;
-
-            const userOptOut   = user.disableLevelUpAnnounce === true;
-            const guildOptOut  = guildSettings.leveling?.disableLevelUpAnnounce === true;
-            if (!userOptOut && !guildOptOut) {
-                const { EmbedBuilder } = require('discord.js');
-                const TIER_STYLES = [
-                    { min: 0,   color: '#cd7f32', label: 'Bronze',  glyph: '⬡' },
-                    { min: 10,  color: '#c0c0c0', label: 'Silver',  glyph: '◈' },
-                    { min: 25,  color: '#ffd700', label: 'Gold',    glyph: '◆' },
-                    { min: 50,  color: '#b9f2ff', label: 'Diamond', glyph: '◇' },
-                    { min: 100, color: '#ff6200', label: 'Mythic',  glyph: '✦' },
-                ];
-                const tierStyle = [...TIER_STYLES].reverse().find(t => user.level >= t.min) ?? TIER_STYLES[0];
-
-                const lvlEmbed = new EmbedBuilder()
-                    .setColor(tierStyle.color)
-                    .setTitle(`${tierStyle.glyph} TIER ${tierStyle.label.toUpperCase()} PROMOTION`)
-                    .setDescription(
-                        `<@${message.author.id}> has advanced to **Level ${user.level}**!\n\n` +
-                        `*${tierStyle.label} tier — keep climbing!*`
-                    )
-                    .setThumbnail(message.author.displayAvatarURL({ extension: 'png', size: 128 }))
-                    .setTimestamp();
-
-                const rewardChannelId = guildSettings.leveling.rewardChannelId || guildSettings.leveling.announceChannel;
-                if (guildSettings.leveling.announceInChannel && !rewardChannelId) {
-                    await message.channel.send({ embeds: [lvlEmbed] }).catch(console.error);
-                } else if (rewardChannelId) {
-                    const ch = message.guild.channels.cache.get(rewardChannelId);
-                    if (ch) await ch.send({ embeds: [lvlEmbed] }).catch(console.error);
-                }
-            }
-
-            if (guildSettings.levelRoles?.length) {
-                const reward = guildSettings.levelRoles
-                    .filter(lr => lr.level <= user.level)
-                    .sort((a, b) => b.level - a.level)[0];
-                if (reward) await message.member.roles.add(reward.roleId).catch(console.error);
-            }
+        if (leveled) {
+            await announceLevelUp(user, guildSettings, message.member, message.guild, message.channel);
         }
 
         await user.save();

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -578,6 +578,9 @@ const guildSchema = new Schema({
         endsAt:    { type: Date, default: null }
     },
 
+    // Scheduler claim timestamp for Pet of the Week job (prevents duplicate runs)
+    potwLastRunAt: { type: Date, default: null },
+
     createdAt: { type: Date, default: Date.now },
     updatedAt: { type: Date, default: Date.now }
 });

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -434,14 +434,22 @@ const userSchema = new Schema({
 
     // Pet system
     pets: [{
-        petId:     { type: String, required: true },
-        name:      { type: String, default: null },
-        hunger:    { type: Number, default: 100, min: 0, max: 100 },
-        lastFed:   { type: Date, default: Date.now },
-        adoptedAt: { type: Date, default: Date.now },
-        starving:  { type: Boolean, default: false },
-        starvingStartAt: { type: Date, default: null }
+        petId:              { type: String,  required: true },
+        name:               { type: String,  default: null },
+        hunger:             { type: Number,  default: 100, min: 0, max: 100 },
+        lastFed:            { type: Date,    default: Date.now },
+        adoptedAt:          { type: Date,    default: Date.now },
+        starving:           { type: Boolean, default: false },
+        starvingStartAt:    { type: Date,    default: null },
+        lastPlay:           { type: Date,    default: null },
+        restUntil:          { type: Date,    default: null },
+        potw:               { type: Boolean, default: false },
+        weeklyInteractions: { type: Number,  default: 0    },
     }],
+
+    // Pet of the Week tracking
+    petInteractionLog: { type: Date,    default: null },
+    petOfTheWeek:      { type: Boolean, default: false },
 
     // Season pass daily missions (reset at midnight UTC)
     seasonMissions: [{

--- a/src/services/achievementService.js
+++ b/src/services/achievementService.js
@@ -2,6 +2,7 @@
 
 const { ACHIEVEMENTS } = require('../data/achievements');
 const { delay } = require('../utils/delay');
+const { createAchievementCard } = require('../utils/cardGenerator');
 
 /**
  * Check all applicable achievements for a user and award any newly earned ones.
@@ -68,7 +69,7 @@ async function announceAchievements(client, guildSettings, user, member, achieve
     const channel = guild.channels.cache.get(channelId);
     if (!channel) return;
 
-    const { EmbedBuilder } = require('discord.js');
+    const { EmbedBuilder, AttachmentBuilder } = require('discord.js');
     const mention = member?.displayName ? `${member.displayName} (<@${user.userId}>)` : `<@${user.userId}>`;
 
     for (let i = 0; i < achievements.length; i++) {
@@ -88,7 +89,7 @@ async function announceAchievements(client, guildSettings, user, member, achieve
 
         await delay(800);
 
-        // Step 2 — reveal
+        // Step 2 — reveal with canvas image
         const separator = '━━━━━━━━━━━━━━━━━━━━━━━━━━';
         const rewards = [];
         if (ach.xpReward)   rewards.push(`+${ach.xpReward} XP`);
@@ -103,7 +104,15 @@ async function announceAchievements(client, guildSettings, user, member, achieve
             )
             .setFooter({ text: 'Use /achievements to view all achievements' });
 
-        await msg.edit({ embeds: [revealEmbed] }).catch(() => null);
+        // Attach the Minecraft-style canvas card
+        let files = [];
+        try {
+            const buf = await createAchievementCard(ach.name, ach.description, ach.xpReward);
+            revealEmbed.setImage('attachment://achievement.png');
+            files = [new AttachmentBuilder(buf, { name: 'achievement.png' })];
+        } catch { /* non-critical — send embed without card */ }
+
+        await msg.edit({ embeds: [revealEmbed], files }).catch(() => null);
     }
 }
 

--- a/src/services/petService.js
+++ b/src/services/petService.js
@@ -101,9 +101,16 @@ function applyHungerDecay(pets) {
         const daysPassed = Math.floor((now - lastFed) / MS_PER_DAY);
         if (daysPassed <= 0) return pet;
 
-        const isResting = pet.restUntil && new Date(pet.restUntil).getTime() > now;
-        const decayRate = isResting ? HUNGER_DECAY_RESTING : HUNGER_DECAY_PER_DAY;
-        const decay = daysPassed * decayRate;
+        // Prorate decay: compute overlap of the decay window with the rest window
+        const REST_WINDOW_MS  = 2 * 60 * 60 * 1000; // rest lasts 2 hours
+        const restUntilMs     = pet.restUntil ? new Date(pet.restUntil).getTime() : 0;
+        const restStartMs     = restUntilMs - REST_WINDOW_MS;
+        const restedMs        = restUntilMs > 0
+            ? Math.max(0, Math.min(restUntilMs, now) - Math.max(restStartMs, lastFed))
+            : 0;
+        const restedDays      = restedMs / MS_PER_DAY;
+        const normalDays      = Math.max(0, daysPassed - restedDays);
+        const decay           = restedDays * HUNGER_DECAY_RESTING + normalDays * HUNGER_DECAY_PER_DAY;
         const newHunger = Math.max(0, pet.hunger - decay);
         // Advance the decay cursor by the days processed so re-calls are no-ops
         const newLastFed = new Date(lastFed + daysPassed * MS_PER_DAY);

--- a/src/services/petService.js
+++ b/src/services/petService.js
@@ -12,11 +12,78 @@ const PET_DEFINITIONS = {
 };
 
 const HUNGER_DECAY_PER_DAY = 10;
+const HUNGER_DECAY_RESTING  = 5;   // half-speed decay while resting
 const HUNGER_RESTORE_FAVORITE = 25;
 const HUNGER_RESTORE_OTHER = 10;
 const STARVING_THRESHOLD = 30;
 const RUNAWAY_DAYS = 3;
 const MS_PER_DAY = 86400000;
+
+// ── Mood system ───────────────────────────────────────────────────────────────
+
+const MOOD_LINES = {
+    blissful: [
+        '"I could nap here forever... this is the life."',
+        '"You fed me so well — I might just purr until tomorrow."',
+        '"Life is good. Very good. *Extremely* good."',
+        '"I am completely and utterly content. Please don\'t move me."',
+        '"If happiness had a shape, it would be whatever snack I just had."',
+        '"This is peak existence and I refuse to acknowledge anything beyond this moment."',
+    ],
+    content: [
+        '"Thanks for checking in. I\'m doing okay."',
+        '"Life\'s pretty chill right now, honestly."',
+        '"A little hungry, but nothing to panic over."',
+        '"I\'m maintaining. Vibes are neutral-to-good."',
+        '"Not complaining. But a snack wouldn\'t hurt."',
+        '"I could do with a small treat if you\'re offering."',
+    ],
+    pleading: [
+        '"Excuse me... I hate to bring this up... but food?"',
+        '"I\'m not saying I\'m starving. I\'m saying my stomach is sad."',
+        '"A single crumb. That\'s all I ask."',
+        '"I keep looking at my bowl and it keeps being empty."',
+        '"If this is a test of loyalty, I\'m passing it hungry."',
+        '"Hello? Feed me? Pretty please? With a bow on top?"',
+    ],
+    concerning: [
+        '"...I don\'t have the energy for a full complaint. Please hurry."',
+        '"*stares at you with big, hollow eyes*"',
+        '"I\'m holding it together. Barely."',
+        '"Feed me before this becomes a dramatic backstory."',
+        '"I have decided to be disappointed in you. With love."',
+        '"This... is fine. Everything is fine. *It is not fine.*"',
+    ],
+};
+
+function getMoodBand(hunger) {
+    if (hunger >= 90) return 'blissful';
+    if (hunger >= 50) return 'content';
+    if (hunger >= 20) return 'pleading';
+    return 'concerning';
+}
+
+function getMoodLine(pet) {
+    const band = getMoodBand(pet.hunger);
+    const lines = MOOD_LINES[band];
+    const dayIndex = Math.floor(Date.now() / 86400000);
+    const petHash  = (pet.petId  || '').split('').reduce((a, c) => a + c.charCodeAt(0), 0);
+    const nameHash = (pet.name   || '').split('').reduce((a, c) => a + c.charCodeAt(0), 0);
+    return lines[(petHash + nameHash + dayIndex) % lines.length];
+}
+
+function getMoodColor(hunger) {
+    if (hunger >= 90) return '#4caf50'; // blissful — green
+    if (hunger >= 50) return '#ff9800'; // content  — orange
+    if (hunger >= 20) return '#f44336'; // pleading — red
+    return '#9c27b0';                   // concerning — purple
+}
+
+const HEART_BAR_LENGTH = 8;
+function heartBar(bondDays) {
+    const filled = Math.min(Math.floor(bondDays / 10), HEART_BAR_LENGTH);
+    return '❤️'.repeat(filled) + '🖤'.repeat(HEART_BAR_LENGTH - filled);
+}
 
 /**
  * Apply daily hunger decay to all pets. Call from a scheduled job or lazily on pet commands.
@@ -34,7 +101,9 @@ function applyHungerDecay(pets) {
         const daysPassed = Math.floor((now - lastFed) / MS_PER_DAY);
         if (daysPassed <= 0) return pet;
 
-        const decay = daysPassed * HUNGER_DECAY_PER_DAY;
+        const isResting = pet.restUntil && new Date(pet.restUntil).getTime() > now;
+        const decayRate = isResting ? HUNGER_DECAY_RESTING : HUNGER_DECAY_PER_DAY;
+        const decay = daysPassed * decayRate;
         const newHunger = Math.max(0, pet.hunger - decay);
         // Advance the decay cursor by the days processed so re-calls are no-ops
         const newLastFed = new Date(lastFed + daysPassed * MS_PER_DAY);
@@ -119,9 +188,13 @@ module.exports = {
     MS_PER_DAY,
     STARVING_THRESHOLD,
     RUNAWAY_DAYS,
+    MOOD_LINES,
     applyHungerDecay,
     checkRunaway,
     feedPet,
     getPetBonus,
-    getTotalBonus
+    getTotalBonus,
+    getMoodLine,
+    getMoodColor,
+    heartBar,
 };

--- a/src/services/questService.js
+++ b/src/services/questService.js
@@ -369,8 +369,20 @@ async function notifyDailyQuestReset(guildSettings, member, user, fallbackChanne
     ).catch(() => {});
 }
 
-// Send quest completion notification to the configured channel (or fallback channel)
-async function notifyQuestComplete(guild, member, rewards, fallbackChannel) {
+// Returns the next incomplete daily quest for a user, or null.
+function _nextQuest(user) {
+    const now  = new Date();
+    const active = (user?.quests ?? []).filter(q => !q.completedAt && q.expiresAt > now);
+    if (!active.length) return null;
+    const def = getDefById(active[0].questId);
+    if (!def) return null;
+    const pct = active[0].progress ? Math.floor((active[0].progress / def.target) * 100) : 0;
+    return { def, progress: active[0].progress ?? 0, pct };
+}
+
+// Send quest completion notification — includes QUEST COMPLETE banner + next-quest preview.
+// `user` is optional; pass it to include the "Up Next" teaser.
+async function notifyQuestComplete(guild, member, rewards, fallbackChannel, user) {
     if (!rewards?.length) return;
 
     const settings = guild.settings ?? guild;
@@ -383,19 +395,34 @@ async function notifyQuestComplete(guild, member, rewards, fallbackChannel) {
     const { EmbedBuilder } = require('discord.js');
     for (const reward of rewards) {
         if (!reward) continue;
-        const def        = reward.def;
-        const catEmoji   = CATEGORY_EMOJIS[def?.category] ?? '🗺️';
-        const diffColor  = DIFFICULTY_COLORS[def?.difficulty] ?? '🟢';
-        const diffName   = def?.difficulty ? (def.difficulty.charAt(0).toUpperCase() + def.difficulty.slice(1)) : 'Quest';
+        const def       = reward.def;
+        const catEmoji  = CATEGORY_EMOJIS[def?.category] ?? '🗺️';
+        const diffColor = DIFFICULTY_COLORS[def?.difficulty] ?? '🟢';
+        const diffName  = def?.difficulty ? (def.difficulty.charAt(0).toUpperCase() + def.difficulty.slice(1)) : 'Quest';
+
         const embed = new EmbedBuilder()
             .setColor(def?.difficulty === 'hard' ? 0xED4245 : def?.difficulty === 'medium' ? 0xFEE75C : 0x57F287)
             .setAuthor({ name: `${member.displayName} completed a quest!`, iconURL: member.displayAvatarURL({ dynamic: true }) })
-            .setDescription(`${catEmoji} **${def?.name ?? 'Quest'}** ${diffColor} ${diffName}\n${def?.description ?? ''}`)
+            .setTitle('✅ QUEST COMPLETE')
+            .setDescription(`${catEmoji} **${def?.name ?? 'Quest'}** ${diffColor} ${diffName}\n*${def?.description ?? ''}*`)
             .addFields(
-                { name: 'XP Earned',    value: `+${reward.xp} XP`,      inline: true },
-                { name: 'Coins Earned', value: `+${reward.coins} coins`, inline: true }
+                { name: '✨ XP Earned',    value: `+${reward.xp} XP`,       inline: true },
+                { name: '💰 Coins Earned', value: `+${reward.coins} coins`,  inline: true },
             )
             .setTimestamp();
+
+        // Next-quest teaser (anticipation loop)
+        const next = _nextQuest(user);
+        if (next) {
+            const nextCat = CATEGORY_EMOJIS[next.def.category] ?? '🗺️';
+            const bar     = next.pct > 0 ? ` (${next.pct}% done)` : '';
+            embed.addFields({
+                name:   '▶️ Up Next',
+                value:  `${nextCat} **${next.def.name}** — *${next.def.description}*${bar}`,
+                inline: false,
+            });
+        }
+
         await channel.send({ embeds: [embed] }).catch(() => {});
     }
 }

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -224,7 +224,9 @@ async function resolveOneSeason(client, guildDoc) {
     let announceChannelId  = null;
     try {
         seasonDiscordGuild = await client.guilds.fetch(guildId).catch(() => null);
-        announceChannelId  = seasonDiscordGuild?.systemChannelId ?? null;
+        announceChannelId  = guildDoc.economy?.announcementChannelId
+            ?? seasonDiscordGuild?.systemChannelId
+            ?? null;
     } catch {}
 
     let resolvedNames = {};
@@ -414,11 +416,20 @@ async function selectPetOfTheWeek(client) {
     const { EmbedBuilder, AttachmentBuilder } = require('discord.js');
     const { generatePetSprite } = require('../utils/cardGenerator');
 
-    const guilds = await Guild.find({}, 'guildId economy').lean();
+    const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const guilds  = await Guild.find({}, 'guildId economy potwLastRunAt').lean();
 
     for (const guildDoc of guilds) {
         const guildId = guildDoc.guildId;
         try {
+            // Atomic claim: only proceed if this guild hasn't been processed this week
+            const claimed = await Guild.findOneAndUpdate(
+                { guildId, $or: [{ potwLastRunAt: null }, { potwLastRunAt: { $lte: weekAgo } }] },
+                { $set: { potwLastRunAt: new Date() } },
+                { new: false }
+            );
+            if (!claimed) continue; // another worker already ran POTW for this guild this week
+
             const users = await User.find({ guildId, 'pets.0': { $exists: true } }, 'userId pets').lean();
             if (!users.length) continue;
 

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -1,7 +1,8 @@
 const Guild = require('../models/Guild');
-const User = require('../models/User');
+const User  = require('../models/User');
 const SeasonRecord = require('../models/SeasonRecord');
-const { createWarVictoryBanner } = require('../utils/cardGenerator');
+const { createWarVictoryBanner, createSeasonRecapCard } = require('../utils/cardGenerator');
+const { PET_DEFINITIONS, heartBar } = require('./petService');
 
 const WAR_BOOSTER_DURATION_MS = 24 * 60 * 60 * 1000;
 const WAR_BADGE_DURATION_MS   = 30 * 24 * 60 * 60 * 1000;
@@ -218,16 +219,21 @@ async function resolveOneSeason(client, guildDoc) {
         .select('userId seasonCoins')
         .lean();
 
-    let resolvedNames = {};
+    // Single guild fetch shared by name resolution, recap DMs, and announcement
+    let seasonDiscordGuild = null;
+    let announceChannelId  = null;
     try {
-        const discordGuild = await client.guilds.fetch(guildId).catch(() => null);
-        if (discordGuild) {
-            for (const u of topUsers.slice(0, 3)) {
-                const member = await discordGuild.members.fetch(u.userId).catch(() => null);
-                resolvedNames[u.userId] = member?.user?.username ?? 'Unknown';
-            }
-        }
+        seasonDiscordGuild = await client.guilds.fetch(guildId).catch(() => null);
+        announceChannelId  = seasonDiscordGuild?.systemChannelId ?? null;
     } catch {}
+
+    let resolvedNames = {};
+    if (seasonDiscordGuild) {
+        for (const u of topUsers.slice(0, 3)) {
+            const member = await seasonDiscordGuild.members.fetch(u.userId).catch(() => null);
+            resolvedNames[u.userId] = member?.user?.username ?? 'Unknown';
+        }
+    }
 
     // Freeze the leaderboard. Unique index on (guildId, seasonId) makes this idempotent.
     try {
@@ -248,9 +254,52 @@ async function resolveOneSeason(client, guildDoc) {
         if (err.code !== 11000) throw err;
     }
 
+    // Gather active participants for recap before resetting their coins
+    const activePlayers = await User.find(
+        { guildId, 'season.seasonId': season.id, 'season.xp': { $gt: 0 } },
+        'userId season duelWins duelLosses questsCompleted hunt fishing mining'
+    ).lean();
+
+    // Build a rank map by seasonCoins for the recap cards
+    const allRanked = await User.find(
+        { guildId, 'season.seasonId': season.id },
+        'userId seasonCoins'
+    ).sort({ seasonCoins: -1 }).lean();
+    const rankMap          = new Map(allRanked.map((u, i) => [u.userId, i + 1]));
+    const totalParticipants = allRanked.length;
+
     // Reset seasonCoins for everyone in the guild
     await User.updateMany({ guildId }, { $set: { seasonCoins: 0 } })
         .catch(err => console.error('[scheduler] seasonCoins reset failed:', err.message));
+
+    // DM each active player a personalised recap card (fire-and-forget)
+    if (activePlayers.length > 0 && seasonDiscordGuild) {
+        const { AttachmentBuilder } = require('discord.js');
+        const capturedChannelId = announceChannelId;
+        (async () => {
+            for (const u of activePlayers) {
+                try {
+                    const member = await seasonDiscordGuild.members.fetch(u.userId).catch(() => null);
+                    if (!member) continue;
+
+                    const rank = rankMap.get(u.userId) ?? null;
+                    const buf  = await createSeasonRecapCard(u, season.name ?? season.id, rank, totalParticipants);
+                    const file = new AttachmentBuilder(buf, { name: 'season_recap.png' });
+
+                    await member.send({
+                        content: `🏁 **Your ${season.name ?? season.id} recap is here!** Screenshot and share it — see you next season!`,
+                        files:   [file],
+                    }).catch(() => {});
+                } catch { /* non-critical per-user failure */ }
+            }
+
+            if (capturedChannelId) {
+                await postAnnouncement(client, guildId, capturedChannelId,
+                    `📸 **Season ended!** Check your DMs for your personalised recap card. Share it here and show off your season!`
+                );
+            }
+        })().catch(err => console.error('[scheduler] season recap DMs failed:', err.message));
+    }
 
     const { EmbedBuilder } = require('discord.js');
     const currency = guildDoc.economy?.currency ?? '💰';
@@ -265,14 +314,6 @@ async function resolveOneSeason(client, guildDoc) {
         .setDescription('The season leaderboard has been frozen and season coins have been reset.')
         .addFields({ name: '🏆 Final Top 3', value: winnerLines })
         .setTimestamp();
-
-    // Announcement channel: reuse the war channel only if set on the season; otherwise
-    // fall back to the system channel of the guild.
-    let announceChannelId = null;
-    try {
-        const discordGuild = await client.guilds.fetch(guildId).catch(() => null);
-        announceChannelId = discordGuild?.systemChannelId ?? null;
-    } catch {}
 
     await postAnnouncement(client, guildId, announceChannelId, embed);
     return true;
@@ -367,4 +408,79 @@ async function awardWeeklyLeaderboardBadges(client) {
     }
 }
 
-module.exports = { resolveExpiredWars, resolveExpiredSeasons, awardWeeklyLeaderboardBadges };
+// ── Pet of the Week ───────────────────────────────────────────────────────────
+
+async function selectPetOfTheWeek(client) {
+    const { EmbedBuilder, AttachmentBuilder } = require('discord.js');
+    const { generatePetSprite } = require('../utils/cardGenerator');
+
+    const guilds = await Guild.find({}, 'guildId economy').lean();
+
+    for (const guildDoc of guilds) {
+        const guildId = guildDoc.guildId;
+        try {
+            const users = await User.find({ guildId, 'pets.0': { $exists: true } }, 'userId pets').lean();
+            if (!users.length) continue;
+
+            // Find pet with most weekly interactions
+            let bestUser = null, bestPet = null, bestCount = 0;
+            for (const u of users) {
+                for (const pet of (u.pets ?? [])) {
+                    if ((pet.weeklyInteractions || 0) > bestCount) {
+                        bestCount = pet.weeklyInteractions;
+                        bestPet   = pet;
+                        bestUser  = u;
+                    }
+                }
+            }
+
+            // Reset weekly interaction counts + clear old POTW flags for all pets in guild
+            await User.updateMany({ guildId }, { $set: { 'pets.$[].potw': false, 'pets.$[].weeklyInteractions': 0 } });
+
+            if (!bestPet || bestCount === 0) continue;
+
+            // Set POTW on winning pet
+            await User.updateOne(
+                { guildId, userId: bestUser.userId, 'pets._id': bestPet._id },
+                { $set: { 'pets.$.potw': true } }
+            );
+
+            // Determine announcement channel
+            let channelId = guildDoc.economy?.announcementChannelId ?? null;
+            if (!channelId) {
+                const dg = await client.guilds.fetch(guildId).catch(() => null);
+                if (dg) channelId = dg.systemChannelId ?? null;
+            }
+            if (!channelId) continue;
+
+            const def      = PET_DEFINITIONS[bestPet.petId];
+            const name     = bestPet.name || def?.name || bestPet.petId;
+            const bondDays = Math.floor((Date.now() - new Date(bestPet.adoptedAt).getTime()) / 86400000);
+
+            const embed = new EmbedBuilder()
+                .setColor('#ffd700')
+                .setTitle('🌟 Pet of the Week!')
+                .setDescription(
+                    `This week's most beloved pet is:\n\n` +
+                    `${def?.emoji ?? '🐾'} **${name}** — owned by <@${bestUser.userId}>\n\n` +
+                    `_${bestCount} interaction${bestCount !== 1 ? 's' : ''} this week_`
+                )
+                .addFields({ name: '❤️ Bond', value: `${heartBar(bondDays)} ${bondDays} days`, inline: true })
+                .setFooter({ text: 'Earn the ribbon by feeding, playing with, or resting your pet!' })
+                .setTimestamp();
+
+            let files = [];
+            try {
+                const spriteBuf = await generatePetSprite(bestPet.petId, 80);
+                embed.setThumbnail('attachment://potw_sprite.png');
+                files = [new AttachmentBuilder(spriteBuf, { name: 'potw_sprite.png' })];
+            } catch { /* non-critical */ }
+
+            await postAnnouncement(client, guildId, channelId, { embeds: [embed], files });
+        } catch (err) {
+            console.error(`[scheduler] selectPetOfTheWeek failed for guild ${guildId}:`, err.message);
+        }
+    }
+}
+
+module.exports = { resolveExpiredWars, resolveExpiredSeasons, awardWeeklyLeaderboardBadges, selectPetOfTheWeek };

--- a/src/utils/applyXpGain.js
+++ b/src/utils/applyXpGain.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const TIER_STYLES = [
+    { min: 0,   color: '#cd7f32', label: 'Bronze',  glyph: '⬡' },
+    { min: 10,  color: '#c0c0c0', label: 'Silver',  glyph: '◈' },
+    { min: 25,  color: '#ffd700', label: 'Gold',    glyph: '◆' },
+    { min: 50,  color: '#b9f2ff', label: 'Diamond', glyph: '◇' },
+    { min: 100, color: '#ff6200', label: 'Mythic',  glyph: '✦' },
+];
+
+/**
+ * Apply XP in-memory, processing multi-level threshold crossings.
+ * Does NOT save the user. Returns { leveled, newLevel }.
+ */
+function applyXpGain(user, amount) {
+    user.xp = (user.xp || 0) + amount;
+    let leveled = false;
+    while (user.xp >= (user.level || 0) * 100 + 100) {
+        const threshold = (user.level || 0) * 100 + 100;
+        user.xp -= threshold;
+        user.level = (user.level || 0) + 1;
+        leveled = true;
+    }
+    return { leveled, newLevel: user.level };
+}
+
+/**
+ * Post a level-up embed to the configured channel (or fallbackChannel),
+ * then grant any earned level roles. Safe to fire-and-forget.
+ */
+async function announceLevelUp(user, guildSettings, member, guild, fallbackChannel) {
+    const userOptOut  = user.disableLevelUpAnnounce === true;
+    const guildOptOut = guildSettings?.leveling?.disableLevelUpAnnounce === true;
+
+    if (!userOptOut && !guildOptOut) {
+        const { EmbedBuilder } = require('discord.js');
+        const tierStyle = [...TIER_STYLES].reverse().find(t => user.level >= t.min) ?? TIER_STYLES[0];
+
+        const lvlEmbed = new EmbedBuilder()
+            .setColor(tierStyle.color)
+            .setTitle(`${tierStyle.glyph} TIER ${tierStyle.label.toUpperCase()} PROMOTION`)
+            .setDescription(
+                `<@${user.userId}> has advanced to **Level ${user.level}**!\n\n` +
+                `*${tierStyle.label} tier — keep climbing!*`
+            )
+            .setThumbnail(member?.user?.displayAvatarURL({ extension: 'png', size: 128 }) ?? null)
+            .setTimestamp();
+
+        const rewardChannelId = guildSettings?.leveling?.rewardChannelId || guildSettings?.leveling?.announceChannel;
+        if (guildSettings?.leveling?.announceInChannel && !rewardChannelId && fallbackChannel) {
+            await fallbackChannel.send({ embeds: [lvlEmbed] }).catch(console.error);
+        } else if (rewardChannelId && guild) {
+            const ch = guild.channels.cache.get(rewardChannelId);
+            if (ch) await ch.send({ embeds: [lvlEmbed] }).catch(console.error);
+        }
+    }
+
+    if (guildSettings?.levelRoles?.length && member) {
+        const reward = guildSettings.levelRoles
+            .filter(lr => lr.level <= user.level)
+            .sort((a, b) => b.level - a.level)[0];
+        if (reward) await member.roles.add(reward.roleId).catch(console.error);
+    }
+}
+
+module.exports = { applyXpGain, announceLevelUp };

--- a/src/utils/cardGenerator.js
+++ b/src/utils/cardGenerator.js
@@ -317,4 +317,217 @@ async function createWealthTierBanner(username, tierLabel, tierColor) {
     return canvas.toBuffer();
 }
 
-module.exports = { createWelcomeCard, createRankCard, createWarVictoryBanner, createWealthTierBanner };
+// ── Pet sprite generator ──────────────────────────────────────────────────────
+
+const PET_SPRITE_COLORS = {
+    dog:         { bg: '#c8a96e', ring: '#8b6914' },
+    cat:         { bg: '#b0b0b0', ring: '#555555' },
+    bird:        { bg: '#4fc3f7', ring: '#0277bd' },
+    fish:        { bg: '#ff7043', ring: '#bf360c' },
+    fox:         { bg: '#ef6c00', ring: '#bf360c' },
+    wolf:        { bg: '#546e7a', ring: '#263238' },
+    eagle:       { bg: '#795548', ring: '#4e342e' },
+    shark:       { bg: '#607d8b', ring: '#37474f' },
+    crystal_fox: { bg: '#7c4dff', ring: '#311b92' },
+};
+
+const PET_SPRITE_EMOJIS = {
+    dog: '🐶', cat: '🐱', bird: '🐦', fish: '🐠',
+    fox: '🦊', wolf: '🐺', eagle: '🦅', shark: '🦈', crystal_fox: '💎',
+};
+
+async function generatePetSprite(petId, size = 80) {
+    const canvas = createCanvas(size, size);
+    const ctx    = canvas.getContext('2d');
+    const colors = PET_SPRITE_COLORS[petId] ?? { bg: '#9e9e9e', ring: '#616161' };
+    const r      = size / 2;
+
+    ctx.beginPath();
+    ctx.arc(r, r, r, 0, Math.PI * 2);
+    ctx.fillStyle = colors.bg;
+    ctx.fill();
+
+    ctx.beginPath();
+    ctx.arc(r, r, r - 3, 0, Math.PI * 2);
+    ctx.strokeStyle = colors.ring;
+    ctx.lineWidth   = 4;
+    ctx.stroke();
+
+    const emoji    = PET_SPRITE_EMOJIS[petId] ?? '🐾';
+    const fontSize = Math.floor(size * 0.48);
+    ctx.font         = `${fontSize}px ${EMOJI_FONT}`;
+    ctx.textAlign    = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(emoji, r, r + fontSize * 0.05);
+    ctx.textAlign    = 'left';
+    ctx.textBaseline = 'alphabetic';
+
+    return canvas.toBuffer('image/png');
+}
+
+// ── Minecraft-style achievement card ─────────────────────────────────────────
+
+function _drawAchievementIcon(ctx, x, y, size) {
+    const s = size / 18;
+    ctx.fillStyle = '#5de0e6';
+    for (const [bx, by] of [[9,1],[10,1],[8,2],[9,2],[7,3],[8,3],[6,4],[7,4],[5,5],[6,5],[4,6],[5,6],[3,7],[4,7],[2,8],[3,8]]) {
+        ctx.fillRect(x + bx * s, y + by * s, s, s);
+    }
+    ctx.fillStyle = '#8aeef2';
+    for (const [gx, gy] of [[1,8],[2,8],[3,8],[4,8],[5,8]]) ctx.fillRect(x + gx * s, y + gy * s, s, s);
+    ctx.fillStyle = '#8b5e3c';
+    for (const [hx, hy] of [[2,9],[2,10],[2,11],[2,12],[1,10],[3,10]]) ctx.fillRect(x + hx * s, y + hy * s, s, s);
+}
+
+function _achTier(xpReward) {
+    if (!xpReward || xpReward <= 50)  return { label: 'Bronze',   color: '#cd7f32' };
+    if (xpReward <= 200)              return { label: 'Silver',   color: '#c0c0c0' };
+    if (xpReward <= 500)              return { label: 'Gold',     color: '#ffd700' };
+    return                                   { label: 'Platinum', color: '#e5e4e2' };
+}
+
+async function createAchievementCard(text, description, xpReward) {
+    const W = 520, H = 110, ICON_SIZE = 58, PAD = 16;
+    const canvas = createCanvas(W, H);
+    const ctx    = canvas.getContext('2d');
+    const tier   = _achTier(xpReward);
+
+    ctx.fillStyle = '#3c3c3c';
+    ctx.fillRect(0, 0, W, H);
+
+    // Tier colour strip at top
+    ctx.fillStyle = tier.color;
+    ctx.fillRect(0, 0, W, 5);
+
+    // Bevel border
+    ctx.fillStyle = '#5a5a5a';
+    ctx.fillRect(0, 5, W, 3);
+    ctx.fillRect(0, 5, 3, H - 5);
+    ctx.fillStyle = '#1a1a1a';
+    ctx.fillRect(0, H - 3, W, 3);
+    ctx.fillRect(W - 3, 5, 3, H - 5);
+
+    // Icon slot
+    const iconX = PAD, iconY = (H - ICON_SIZE) / 2;
+    ctx.fillStyle = '#2a2a2a';
+    ctx.fillRect(iconX, iconY, ICON_SIZE, ICON_SIZE);
+    ctx.strokeStyle = '#111111'; ctx.lineWidth = 2; ctx.strokeRect(iconX, iconY, ICON_SIZE, ICON_SIZE);
+    ctx.strokeStyle = '#555555'; ctx.lineWidth = 1; ctx.strokeRect(iconX + 2, iconY + 2, ICON_SIZE - 4, ICON_SIZE - 4);
+    _drawAchievementIcon(ctx, iconX + 2, iconY + 2, ICON_SIZE - 4);
+
+    // Text
+    const textX      = iconX + ICON_SIZE + 14;
+    const maxTextW   = W - textX - PAD;
+    ctx.textBaseline = 'top';
+
+    ctx.font      = 'bold 13px Arial, sans-serif';
+    ctx.fillStyle = '#ffdf00';
+    ctx.fillText('Achievement Unlocked!', textX, 14);
+
+    ctx.font      = 'bold 11px Arial, sans-serif';
+    ctx.fillStyle = tier.color;
+    ctx.textAlign = 'right';
+    ctx.fillText(`[${tier.label}]`, W - PAD, 14);
+    ctx.textAlign = 'left';
+
+    let fontSize = 21;
+    ctx.font = `bold ${fontSize}px Arial, sans-serif`;
+    while (ctx.measureText(text).width > maxTextW && fontSize > 10) {
+        fontSize--;
+        ctx.font = `bold ${fontSize}px Arial, sans-serif`;
+    }
+    ctx.fillStyle = '#ffffff';
+    ctx.fillText(text, textX, 36);
+
+    if (description) {
+        ctx.font      = 'italic 12px Arial, sans-serif';
+        ctx.fillStyle = '#aaaaaa';
+        ctx.fillText(truncateText(ctx, description, maxTextW), textX, 62);
+    }
+
+    return canvas.toBuffer('image/png');
+}
+
+// ── End-of-season recap card ──────────────────────────────────────────────────
+
+async function createSeasonRecapCard(user, seasonName, leaderboardRank, totalPlayers) {
+    const W = 700, H = 420;
+    const canvas = createCanvas(W, H);
+    const ctx    = canvas.getContext('2d');
+    const gold   = '#FFD700';
+
+    // Background
+    ctx.fillStyle = '#1a1a2e';
+    ctx.fillRect(0, 0, W, H);
+
+    // Gold accent bars
+    ctx.fillStyle = gold;
+    ctx.fillRect(0, 0, W, 8);
+    ctx.fillRect(0, H - 8, W, 8);
+
+    // Header
+    ctx.font = 'bold 30px "DejaVu Sans"';
+    ctx.fillStyle = gold;
+    ctx.fillText('YOUR SEASON', 30, 52);
+
+    ctx.font      = 'italic 17px "DejaVu Sans"';
+    ctx.fillStyle = '#aaaaaa';
+    ctx.fillText(truncateText(ctx, seasonName ?? 'Season Recap', W - 60), 30, 76);
+
+    // Divider
+    ctx.strokeStyle = '#333366'; ctx.lineWidth = 1;
+    ctx.beginPath(); ctx.moveTo(30, 90); ctx.lineTo(W - 30, 90); ctx.stroke();
+
+    // Stats grid (2 columns × 3 rows)
+    const biggestWin = Math.max(user.hunt?.bestPayout ?? 0, user.fishing?.bestPayout ?? 0, user.mining?.bestPayout ?? 0);
+    const stats = [
+        { label: 'Season Tier',    value: `Tier ${user.season?.tier ?? 0}`                    },
+        { label: 'Season XP',      value: `${(user.season?.xp ?? 0).toLocaleString()} XP`     },
+        { label: 'Best Win',       value: `${biggestWin.toLocaleString()} coins`               },
+        { label: 'Leaderboard',    value: leaderboardRank ? `#${leaderboardRank} / ${totalPlayers}` : 'Unranked' },
+        { label: 'Duel Record',    value: `${user.duelWins ?? 0}W / ${user.duelLosses ?? 0}L`  },
+        { label: 'Quests Done',    value: `${user.questsCompleted ?? 0}`                       },
+    ];
+
+    const colW = (W - 60) / 2;
+    const rowH = 65;
+    const startY = 110;
+
+    for (let i = 0; i < stats.length; i++) {
+        const col = i % 2, row = Math.floor(i / 2);
+        const x = 30 + col * colW, y = startY + row * rowH;
+
+        ctx.fillStyle = '#16213e';
+        ctx.fillRect(x, y, colW - 10, rowH - 8);
+
+        ctx.font = '13px "DejaVu Sans"'; ctx.fillStyle = '#888888';
+        ctx.fillText(stats[i].label, x + 10, y + 20);
+
+        ctx.font = 'bold 20px "DejaVu Sans"'; ctx.fillStyle = '#ffffff';
+        ctx.fillText(truncateText(ctx, stats[i].value, colW - 30), x + 10, y + 48);
+    }
+
+    // Tier progress ribbon bar
+    const tier      = user.season?.tier ?? 0;
+    const maxTiers  = 50;
+    const barX = 30, barY = startY + 3 * rowH + 10, barW = W - 60, barH = 20;
+    const topQuartile   = Math.max(1, Math.floor((totalPlayers ?? 1) * 0.25));
+    const inTopQuartile = leaderboardRank && leaderboardRank <= topQuartile;
+
+    ctx.fillStyle = '#222244';
+    ctx.fillRect(barX, barY, barW, barH);
+    const progress = Math.min((tier / maxTiers) * barW, barW);
+    ctx.fillStyle  = inTopQuartile ? gold : '#5865F2';
+    ctx.fillRect(barX, barY, progress, barH);
+
+    ctx.font = '13px "DejaVu Sans"'; ctx.fillStyle = '#dddddd';
+    ctx.fillText(`Tier ${tier} / ${maxTiers}${inTopQuartile ? ' — 🏆 Top 25%!' : ''}`, barX, barY + barH + 18);
+
+    // Next-season teaser
+    ctx.font = 'italic 14px "DejaVu Sans"'; ctx.fillStyle = '#555588';
+    ctx.fillText('New season coming soon — your next adventure awaits!', 30, H - 18);
+
+    return canvas.toBuffer('image/png');
+}
+
+module.exports = { createWelcomeCard, createRankCard, createWarVictoryBanner, createWealthTierBanner, generatePetSprite, createAchievementCard, createSeasonRecapCard };


### PR DESCRIPTION
Pet rewrite (Task 1):
- One-card-per-pet status embed cycleable via ◀/▶ buttons
- Embed shows rotating mood line (blissful/content/pleading/concerning
  based on hunger band), ❤️ bond bar (fills every 10 days), hunger bar,
  bonus status, and 🌟 POTW ribbon / 🛏️ rest indicator
- Action buttons: 🎾 Play (15–25 XP, 1-hour cooldown), 🛏️ Rest
  (halves hunger decay for 2 hours), 📷 Showcase (posts pet card with
  canvas sprite to the channel)
- MOOD_LINES pool of 24+ rotating entries across 4 hunger bands
- applyHungerDecay now respects pet.restUntil for half-speed decay

Pet-of-the-Week leaderboard (Task 2):
- New /pet leaderboard subcommand — top 10 pets by bond days with 🌟 ribbon
- selectPetOfTheWeek() scheduler job: picks highest weeklyInteractions pet
  per guild, sets potw flag, resets counters, announces with sprite card
- weeklyInteractions counter incremented on feed/play/rest/showcase

Quest ceremony (Task 3):
- notifyQuestComplete now posts a "✅ QUEST COMPLETE" titled embed
- "▶️ Up Next" field shows the next incomplete quest and % progress
  (anticipation loop); user param added as optional 5th argument

Achievement canvas on unlock (Task 3):
- createAchievementCard() extracted to cardGenerator.js with tier
  (Bronze/Silver/Gold/Platinum) colour strip and lore line
- /achievement command refactored to use shared helper
- announceAchievements() now attaches the Minecraft-style canvas image
  to the reveal step of every internal achievement unlock

End-of-season recap card (Task 4):
- createSeasonRecapCard() 700×420 canvas card: tier, XP, best win,
  leaderboard rank, duel record, quests done, tier progress ribbon,
  top-quartile highlight, next-season teaser footer
- resolveOneSeason() DMs each active participant their personalised card
  then posts a "Share your recap!" prompt in the announcement channel

Model changes:
- pets subdocument: lastPlay, restUntil, potw, weeklyInteractions
- user level: petInteractionLog, petOfTheWeek

https://claude.ai/code/session_01My5xEkNUCfCprRvBrpSZgK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pet leaderboard displaying top bonded pets in your server
  * Pet status now includes interactive buttons for play, rest, and showcase actions
  * Introduced pet rest mechanic that reduces hunger decay for 2 hours
  * Added pet mood indicators with visual styling
  * Implemented weekly Pet of the Week selection and announcements
  * Achievements now display as visual cards
  * Quest notifications now preview your next daily quest
  * Added personalized season recap cards sent via direct message

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheShield2594/clawdia/pull/306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->