### PR TITLE
Center-align shop banner items for better visual balance

### DIFF
--- a/src/utils/shopBanner.js
+++ b/src/utils/shopBanner.js
@@ -30,10 +30,9 @@ async function renderCategoryBanner({ activity, title, subtitle, items, currency
     const theme = getTheme(activity);
     const safeItems = items.slice(0, 16);
     const count = Math.max(1, safeItems.length);
-    const cols  = Math.min(COLS, count);
     const rows  = Math.ceil(count / COLS);
 
-    const width  = cols * TILE_W + (cols + 1) * TILE_PAD;
+    const width  = COLS * TILE_W + (COLS + 1) * TILE_PAD;
     const height = HEADER_H + rows * TILE_H + (rows + 1) * TILE_PAD;
 
     const canvas = createCanvas(width, height);
@@ -63,7 +62,10 @@ async function renderCategoryBanner({ activity, title, subtitle, items, currency
     for (let i = 0; i < safeItems.length; i++) {
         const col = i % COLS;
         const row = Math.floor(i / COLS);
-        const x   = TILE_PAD + col * (TILE_W + TILE_PAD);
+        const itemsInRow = Math.min(COLS, safeItems.length - row * COLS);
+        const rowWidth   = itemsInRow * TILE_W + (itemsInRow - 1) * TILE_PAD;
+        const rowOffset  = Math.floor((width - rowWidth) / 2);
+        const x   = rowOffset + col * (TILE_W + TILE_PAD);
         const y   = HEADER_H + TILE_PAD + row * (TILE_H + TILE_PAD);
         await renderTile(ctx, safeItems[i], x, y, theme, currency);
     }


### PR DESCRIPTION
## Summary
Updated the shop banner rendering logic to center-align items within each row, improving the visual presentation when the number of items doesn't fill a complete row.

## Key Changes
- Removed unused `cols` variable that was calculating the minimum of `COLS` and `count`
- Changed width calculation to always use the constant `COLS` value instead of the computed `cols` variable
- Added row-based centering logic that:
  - Calculates the actual number of items in each row
  - Computes the total width of items in that row
  - Calculates an offset to center the row within the banner width
  - Applies this offset when positioning each tile

## Implementation Details
The centering is achieved by calculating `rowOffset` for each row based on the actual number of items present, allowing rows with fewer items than `COLS` to be centered rather than left-aligned. This provides a more balanced appearance when displaying incomplete rows of items.

https://claude.ai/code/session_017B3LydWGTBp9DaMCiqdPcg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved category banner tile alignment to horizontally center tiles within each row, ensuring consistent visual balance across all banner layouts, particularly when rows contain fewer items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->