### PR TITLE
Expand weapon progression system from 5 to 12 tiers

### DIFF
--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -1224,7 +1224,7 @@ async function executeInv(interaction, sub) {
             ['iron_shot',       '🔶', 'Iron Shot        (T2–T3: Iron, Copper)'],
             ['steel_shot',      '⚫', 'Steel Shot       (T4–T5: Steel, Cobalt)'],
             ['composite_round', '🔵', 'Composite Round  (T6–T8: Gold, Platinum, Crimson)'],
-            ['titanium_round',  '💎', 'Titanium Round   (T9–T12: Admantine → Altair)']
+            ['titanium_round',  '💎', 'Titanium Round   (T9–T12: Adamantine → Altair)']
         ];
 
         const lines = allAmmo.map(([type, emoji, label]) => {

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -1221,10 +1221,10 @@ async function executeInv(interaction, sub) {
 
     if (sub === 'ammo') {
         const allAmmo = [
-            ['iron_shot',       '🔶', 'Iron Shot        (T2 Iron Rifle)'],
-            ['steel_shot',      '⚫', 'Steel Shot       (T3 Steel Rifle)'],
-            ['composite_round', '🔵', 'Composite Round  (T4 Composite Rifle)'],
-            ['titanium_round',  '💎', 'Titanium Round   (T5 Titanium Rifle)']
+            ['iron_shot',       '🔶', 'Iron Shot        (T2–T3: Iron, Copper)'],
+            ['steel_shot',      '⚫', 'Steel Shot       (T4–T5: Steel, Cobalt)'],
+            ['composite_round', '🔵', 'Composite Round  (T6–T8: Gold, Platinum, Crimson)'],
+            ['titanium_round',  '💎', 'Titanium Round   (T9–T12: Admantine → Altair)']
         ];
 
         const lines = allAmmo.map(([type, emoji, label]) => {

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -849,7 +849,7 @@
                     </div>
 
                     <div id="hunt-weapons" class="ai-inner-panel active">
-                        <p class="ai-inner-desc">Weapons used for hunting. Tier 1–5 progression.</p>
+                        <p class="ai-inner-desc">Weapons used for hunting. Tier 1–12 progression.</p>
                         <div class="game-items-grid">
                             <% huntItems.weapons.forEach(function(item){ %>
                             <%- include('partials/game-item-card', { item: item }) %>

--- a/src/data/huntData.js
+++ b/src/data/huntData.js
@@ -12,31 +12,80 @@ const WEAPON_TIERS = [
     },
     {
         tier: 2, slug: 'iron_rifle', name: 'Iron Rifle', emoji: '🔫',
-        cost: 2500, baseDurability: 120, successRate: 0.56, rarityBoost: 0.02,
+        cost: 2500, baseDurability: 110, successRate: 0.53, rarityBoost: 0.02,
         requiresAmmo: true, ammoType: 'iron_shot', ammoCost: 5,
         repairCostPer20: 180,
         description: 'A solid iron rifle with better accuracy and range.'
     },
     {
-        tier: 3, slug: 'steel_rifle', name: 'Steel Rifle', emoji: '🔫',
-        cost: 8000, baseDurability: 160, successRate: 0.65, rarityBoost: 0.05,
+        tier: 3, slug: 'copper_rifle', name: 'Copper Rifle', emoji: '🟤',
+        cost: 5500, baseDurability: 140, successRate: 0.59, rarityBoost: 0.04,
+        requiresAmmo: true, ammoType: 'iron_shot', ammoCost: 5,
+        repairCostPer20: 320,
+        description: 'A copper-forged rifle with improved precision.'
+    },
+    {
+        tier: 4, slug: 'steel_rifle', name: 'Steel Rifle', emoji: '🔫',
+        cost: 12000, baseDurability: 170, successRate: 0.65, rarityBoost: 0.06,
         requiresAmmo: true, ammoType: 'steel_shot', ammoCost: 10,
-        repairCostPer20: 400,
+        repairCostPer20: 550,
         description: 'A precision steel rifle for serious hunters.'
     },
     {
-        tier: 4, slug: 'composite_rifle', name: 'Composite Rifle', emoji: '🔫',
-        cost: 28000, baseDurability: 200, successRate: 0.74, rarityBoost: 0.09,
-        requiresAmmo: true, ammoType: 'composite_round', ammoCost: 15,
-        repairCostPer20: 900,
-        description: 'Military-grade composite rifle for elite hunters.'
+        tier: 5, slug: 'cobalt_rifle', name: 'Cobalt Rifle', emoji: '🔵',
+        cost: 30000, baseDurability: 200, successRate: 0.70, rarityBoost: 0.09,
+        requiresAmmo: true, ammoType: 'steel_shot', ammoCost: 10,
+        repairCostPer20: 1100,
+        description: 'A cobalt-alloy rifle favored by veteran hunters.'
     },
     {
-        tier: 5, slug: 'titanium_rifle', name: 'Titanium Rifle', emoji: '✨',
-        cost: 90000, baseDurability: 250, successRate: 0.80, rarityBoost: 0.14,
+        tier: 6, slug: 'gold_rifle', name: 'Gold Rifle', emoji: '🌟',
+        cost: 80000, baseDurability: 230, successRate: 0.74, rarityBoost: 0.12,
+        requiresAmmo: true, ammoType: 'composite_round', ammoCost: 15,
+        repairCostPer20: 2500,
+        description: 'A gilded rifle that commands respect in any hunting ground.'
+    },
+    {
+        tier: 7, slug: 'platinum_rifle', name: 'Platinum Rifle', emoji: '✨',
+        cost: 200000, baseDurability: 260, successRate: 0.78, rarityBoost: 0.16,
+        requiresAmmo: true, ammoType: 'composite_round', ammoCost: 15,
+        repairCostPer20: 5500,
+        description: 'A sleek platinum rifle engineered for elite hunters.'
+    },
+    {
+        tier: 8, slug: 'crimson_rifle', name: 'Crimson Rifle', emoji: '🔴',
+        cost: 500000, baseDurability: 290, successRate: 0.81, rarityBoost: 0.20,
+        requiresAmmo: true, ammoType: 'composite_round', ammoCost: 15,
+        repairCostPer20: 12000,
+        description: 'A blood-red enchanted rifle that draws out rare prey.'
+    },
+    {
+        tier: 9, slug: 'admantine_rifle', name: 'Admantine Rifle', emoji: '💜',
+        cost: 1200000, baseDurability: 325, successRate: 0.84, rarityBoost: 0.25,
         requiresAmmo: true, ammoType: 'titanium_round', ammoCost: 20,
-        repairCostPer20: 2000,
-        description: 'The pinnacle of hunting weaponry. Near-mythical accuracy.'
+        repairCostPer20: 28000,
+        description: 'Forged from the hardest known metal. Near-indestructible.'
+    },
+    {
+        tier: 10, slug: 'fateful_rifle', name: 'Fateful Rifle', emoji: '🌑',
+        cost: 3000000, baseDurability: 360, successRate: 0.87, rarityBoost: 0.30,
+        requiresAmmo: true, ammoType: 'titanium_round', ammoCost: 20,
+        repairCostPer20: 60000,
+        description: 'A rifle imbued with the power of fate itself.'
+    },
+    {
+        tier: 11, slug: 'angelic_rifle', name: 'Angelic Rifle', emoji: '💛',
+        cost: 7500000, baseDurability: 400, successRate: 0.90, rarityBoost: 0.36,
+        requiresAmmo: true, ammoType: 'titanium_round', ammoCost: 20,
+        repairCostPer20: 130000,
+        description: 'A divine weapon blessed by celestial forces.'
+    },
+    {
+        tier: 12, slug: 'altair_rifle', name: 'Altair Rifle', emoji: '⭐',
+        cost: 20000000, baseDurability: 450, successRate: 0.93, rarityBoost: 0.44,
+        requiresAmmo: true, ammoType: 'titanium_round', ammoCost: 20,
+        repairCostPer20: 280000,
+        description: 'The star-forged pinnacle of hunting. Mythical in every sense.'
     }
 ];
 
@@ -73,22 +122,22 @@ const AMMO_PACKS = [
     {
         id: 'iron_shot_pack', name: 'Iron Shot (20)', emoji: '🔶',
         cost: 90, ammoType: 'iron_shot', quantity: 20,
-        description: 'Ammunition for Iron Rifle'
+        description: 'Ammunition for Iron & Copper Rifles (T2–T3)'
     },
     {
         id: 'steel_shot_pack', name: 'Steel Shot (20)', emoji: '⚫',
         cost: 180, ammoType: 'steel_shot', quantity: 20,
-        description: 'Ammunition for Steel Rifle'
+        description: 'Ammunition for Steel & Cobalt Rifles (T4–T5)'
     },
     {
         id: 'composite_round_pack', name: 'Composite Rounds (20)', emoji: '🔵',
         cost: 270, ammoType: 'composite_round', quantity: 20,
-        description: 'Ammunition for Composite Rifle'
+        description: 'Ammunition for Gold, Platinum & Crimson Rifles (T6–T8)'
     },
     {
         id: 'titanium_round_pack', name: 'Titanium Rounds (20)', emoji: '💎',
         cost: 360, ammoType: 'titanium_round', quantity: 20,
-        description: 'Ammunition for Titanium Rifle'
+        description: 'Ammunition for Admantine through Altair Rifles (T9–T12)'
     }
 ];
 

--- a/src/data/huntData.js
+++ b/src/data/huntData.js
@@ -60,7 +60,7 @@ const WEAPON_TIERS = [
         description: 'A blood-red enchanted rifle that draws out rare prey.'
     },
     {
-        tier: 9, slug: 'admantine_rifle', name: 'Admantine Rifle', emoji: '💜',
+        tier: 9, slug: 'admantine_rifle', name: 'Adamantine Rifle', emoji: '💜',
         cost: 1200000, baseDurability: 325, successRate: 0.84, rarityBoost: 0.25,
         requiresAmmo: true, ammoType: 'titanium_round', ammoCost: 20,
         repairCostPer20: 28000,
@@ -137,7 +137,7 @@ const AMMO_PACKS = [
     {
         id: 'titanium_round_pack', name: 'Titanium Rounds (20)', emoji: '💎',
         cost: 360, ammoType: 'titanium_round', quantity: 20,
-        description: 'Ammunition for Admantine through Altair Rifles (T9–T12)'
+        description: 'Ammunition for Adamantine through Altair Rifles (T9–T12)'
     }
 ];
 

--- a/src/data/huntData.js
+++ b/src/data/huntData.js
@@ -60,7 +60,7 @@ const WEAPON_TIERS = [
         description: 'A blood-red enchanted rifle that draws out rare prey.'
     },
     {
-        tier: 9, slug: 'admantine_rifle', name: 'Adamantine Rifle', emoji: '💜',
+        tier: 9, slug: 'adamantine_rifle', name: 'Adamantine Rifle', emoji: '💜',
         cost: 1200000, baseDurability: 325, successRate: 0.84, rarityBoost: 0.25,
         requiresAmmo: true, ammoType: 'titanium_round', ammoCost: 20,
         repairCostPer20: 28000,


### PR DESCRIPTION
## Summary
This PR significantly expands the hunting weapon progression system from 5 tiers to 12 tiers, introducing new weapons with increasing power, cost, and rarity bonuses. The changes create a more granular progression path for players while maintaining balanced scaling.

## Key Changes

- **Weapon Tier Expansion**: Extended weapon progression from tiers 1-5 to tiers 1-12
  - Tier 2: Iron Rifle (adjusted stats)
  - Tier 3: New Copper Rifle (5500 cost, 0.59 success rate)
  - Tier 4: Steel Rifle (repositioned from tier 3, increased cost to 12000)
  - Tier 5: New Cobalt Rifle (30000 cost, 0.70 success rate)
  - Tiers 6-12: New weapons including Gold, Platinum, Crimson, Admantine, Fateful, Angelic, and Altair Rifles with escalating costs (80K-20M) and stats

- **Stat Adjustments**: 
  - Iron Rifle: Reduced baseDurability (120→110) and successRate (0.56→0.53)
  - Steel Rifle: Increased baseDurability (160→170) and rarityBoost (0.05→0.06)
  - All new weapons follow a consistent scaling curve with increasing durability, success rates, and rarity boosts

- **Ammo System Updates**: Updated ammunition descriptions to reflect new weapon tier ranges
  - Iron Shot: Now covers T2-T3 (Iron, Copper)
  - Steel Shot: Now covers T4-T5 (Steel, Cobalt)
  - Composite Rounds: Now covers T6-T8 (Gold, Platinum, Crimson)
  - Titanium Rounds: Now covers T9-T12 (Admantine through Altair)

- **UI/Documentation Updates**:
  - Updated guild settings description from "Tier 1–5 progression" to "Tier 1–12 progression"
  - Updated inventory ammo display to show new tier ranges

## Implementation Details

The new weapons maintain consistent progression with:
- Exponential cost scaling (from 2500 to 20M)
- Linear durability increases (110 to 450)
- Gradual success rate improvements (0.53 to 0.93)
- Rarity boost scaling (0.02 to 0.44)
- Thematic naming and emoji assignments for visual distinction

https://claude.ai/code/session_01P2naida5ktcfscTvm1UuwF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Balance Updates**
  * Extended weapon tier progression from Tier 1–5 to Tier 1–12 with revised stats and costs
  * Updated ammo stock display labels to show applicable tier ranges instead of individual weapon names
  * Clarified ammo pack descriptions to specify which weapon tiers they apply to

<!-- end of auto-generated comment: release notes by coderabbit.ai -->