### PR TITLE
Reorganize economy settings with tabbed interface and add game toggles

### DIFF
--- a/src/commands/economy/casino.js
+++ b/src/commands/economy/casino.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
+const Guild = require('../../models/Guild');
 
 const games = [
     require('../../games/casino/blackjack'),
@@ -31,6 +32,13 @@ module.exports = {
         return game?.cooldown ?? 3;
     },
     async execute(interaction) {
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        if (guildSettings?.economy?.enabled === false) {
+            return interaction.reply({ content: 'The economy is disabled on this server.', ephemeral: true });
+        }
+        if (guildSettings?.economy?.casinoEnabled === false) {
+            return interaction.reply({ content: 'Casino games are disabled on this server.', ephemeral: true });
+        }
         const sub = interaction.options.getSubcommand();
         const game = games.find(g => g.name === sub);
         if (!game) {

--- a/src/commands/economy/casino.js
+++ b/src/commands/economy/casino.js
@@ -36,6 +36,9 @@ module.exports = {
         if (guildSettings?.economy?.enabled === false) {
             return interaction.reply({ content: 'The economy is disabled on this server.', ephemeral: true });
         }
+        if (guildSettings?.economy?.gamesEnabled === false) {
+            return interaction.reply({ content: 'Economy games are disabled on this server.', ephemeral: true });
+        }
         if (guildSettings?.economy?.casinoEnabled === false) {
             return interaction.reply({ content: 'Casino games are disabled on this server.', ephemeral: true });
         }

--- a/src/commands/economy/crime.js
+++ b/src/commands/economy/crime.js
@@ -45,6 +45,9 @@ module.exports = {
         if (guildSettings?.economy?.enabled === false) {
             return interaction.reply({ content: 'The economy is disabled on this server.', ephemeral: true });
         }
+        if (guildSettings?.economy?.crimeEnabled === false) {
+            return interaction.reply({ content: 'The crime command is disabled on this server.', ephemeral: true });
+        }
 
         const currency = guildSettings?.economy?.currency || '💰';
 

--- a/src/commands/economy/quiz.js
+++ b/src/commands/economy/quiz.js
@@ -9,6 +9,7 @@ const {
 } = require('discord.js');
 const axios = require('axios');
 const User  = require('../../models/User');
+const Guild = require('../../models/Guild');
 const FALLBACK_QUESTIONS = require('../../data/quizFallback');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
 
@@ -199,6 +200,13 @@ module.exports = {
     cooldown: 20,
 
     async execute(interaction) {
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        if (guildSettings?.economy?.enabled === false) {
+            return interaction.reply({ content: 'The economy is disabled on this server.', ephemeral: true });
+        }
+        if (guildSettings?.economy?.quizEnabled === false) {
+            return interaction.reply({ content: 'The quiz command is disabled on this server.', ephemeral: true });
+        }
         const diffChoice = interaction.options.getString('difficulty') ?? 'any';
         await interaction.deferReply();
         await runQuiz(interaction, diffChoice);

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -637,96 +637,158 @@
                         <p>Tune currency rewards, manage the store, games, and jobs.</p>
                     </div>
 
-                    <!-- General -->
-                    <label class="toggle">
-                        <span class="toggle-text"><strong>Enable economy</strong><span>Allow members to earn and spend currency</span></span>
-                        <span class="switch"><input type="checkbox" id="economy-enabled" <%= settings.economy.enabled ? 'checked' : '' %>><span class="slider"></span></span>
-                    </label>
-                    <div class="field">
-                        <label class="field-label" for="economy-currency">Currency symbol</label>
-                        <input type="text" id="economy-currency" value="<%= settings.economy.currency %>">
-                    </div>
-                    <div class="field">
-                        <label class="field-label" for="economy-daily">Daily reward amount</label>
-                        <input type="text" id="economy-daily" value="<%= settings.economy.dailyAmount %>">
-                    </div>
-                    <div class="field" style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;">
-                        <div><label class="field-label" for="economy-work-min">Work payout (min)</label><input type="text" id="economy-work-min" value="<%= settings.economy.workMin %>"></div>
-                        <div><label class="field-label" for="economy-work-max">Work payout (max)</label><input type="text" id="economy-work-max" value="<%= settings.economy.workMax %>"></div>
-                    </div>
-                    <div class="field">
-                        <label class="field-label" for="economy-announcement-channel">Announcements channel</label>
-                        <select id="economy-announcement-channel">
-                            <option value="">None (no announcements)</option>
-                            <% channels.forEach(channel => { %>
-                                <option value="<%= channel.id %>" <%= settings.economy.announcementChannelId === channel.id ? 'selected' : '' %>>#<%= channel.name %></option>
-                            <% }); %>
-                        </select>
-                        <small>Channel where shop purchases and economy events are announced</small>
+                    <div class="ai-inner-tabs">
+                        <button class="ai-inner-tab eco-inner-tab active" data-eco-tab="eco-tab-settings">⚙️ Settings &amp; Store</button>
+                        <button class="ai-inner-tab eco-inner-tab" data-eco-tab="eco-tab-games">🎮 Games</button>
+                        <button class="ai-inner-tab eco-inner-tab" data-eco-tab="eco-tab-careers">💼 Careers</button>
                     </div>
 
-                    <!-- Store -->
-                    <div class="eco-section-head">
-                        <label class="toggle" style="margin:0;flex:1">
-                            <span class="toggle-text"><strong>Store</strong><span>Items available for purchase with /shop buy</span></span>
-                            <span class="switch"><input type="checkbox" id="economy-shop-enabled" <%= settings.economy.shopEnabled !== false ? 'checked' : '' %>><span class="slider"></span></span>
+                    <!-- Settings & Store -->
+                    <div id="eco-tab-settings" class="ai-inner-panel active">
+                        <label class="toggle">
+                            <span class="toggle-text"><strong>Enable economy</strong><span>Allow members to earn and spend currency</span></span>
+                            <span class="switch"><input type="checkbox" id="economy-enabled" <%= settings.economy.enabled ? 'checked' : '' %>><span class="slider"></span></span>
                         </label>
-                        <button class="btn btn-sm btn-primary" onclick="openItemModal(-1)">+ Add item</button>
+                        <div class="field">
+                            <label class="field-label" for="economy-currency">Currency symbol</label>
+                            <input type="text" id="economy-currency" value="<%= settings.economy.currency %>">
+                        </div>
+                        <div class="field">
+                            <label class="field-label" for="economy-daily">Daily reward amount</label>
+                            <input type="text" id="economy-daily" value="<%= settings.economy.dailyAmount %>">
+                        </div>
+                        <div class="field" style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;">
+                            <div><label class="field-label" for="economy-work-min">Work payout (min)</label><input type="text" id="economy-work-min" value="<%= settings.economy.workMin %>"></div>
+                            <div><label class="field-label" for="economy-work-max">Work payout (max)</label><input type="text" id="economy-work-max" value="<%= settings.economy.workMax %>"></div>
+                        </div>
+                        <div class="field">
+                            <label class="field-label" for="economy-announcement-channel">Announcements channel</label>
+                            <select id="economy-announcement-channel">
+                                <option value="">None (no announcements)</option>
+                                <% channels.forEach(channel => { %>
+                                    <option value="<%= channel.id %>" <%= settings.economy.announcementChannelId === channel.id ? 'selected' : '' %>>#<%= channel.name %></option>
+                                <% }); %>
+                            </select>
+                            <small>Channel where shop purchases and economy events are announced</small>
+                        </div>
+
+                        <!-- Store -->
+                        <div class="eco-section-head" style="margin-top:1.5rem">
+                            <label class="toggle" style="margin:0;flex:1">
+                                <span class="toggle-text"><strong>Store</strong><span>Items available for purchase with /shop buy</span></span>
+                                <span class="switch"><input type="checkbox" id="economy-shop-enabled" <%= settings.economy.shopEnabled !== false ? 'checked' : '' %>><span class="slider"></span></span>
+                            </label>
+                            <button class="btn btn-sm btn-primary" onclick="openItemModal(-1)">+ Add item</button>
+                        </div>
+                        <div id="store-items-grid" class="store-grid"></div>
+
+                        <div class="actions-row">
+                            <button class="btn btn-primary" onclick="saveSettings('economy')">Save changes</button>
+                        </div>
                     </div>
-                    <div id="store-items-grid" class="store-grid"></div>
 
                     <!-- Games -->
-                    <div class="eco-section-head" style="margin-top:1.75rem">
-                        <label class="toggle" style="margin:0;flex:1">
-                            <span class="toggle-text"><strong>Games</strong><span>Economy mini-games members can play for coins</span></span>
-                            <span class="switch"><input type="checkbox" id="economy-games-enabled" <%= settings.economy.gamesEnabled !== false ? 'checked' : '' %>><span class="slider"></span></span>
-                        </label>
-                    </div>
-                    <div class="games-grid">
-                        <div class="game-card">
-                            <div class="game-card-icon">🪙</div>
-                            <div class="game-card-info">
-                                <span class="game-card-name">Coinflip</span>
-                                <span class="game-card-desc">Bet coins — heads or tails wins double</span>
-                            </div>
-                            <label class="switch"><input type="checkbox" id="economy-coinflip-enabled" <%= settings.economy.coinflipEnabled !== false ? 'checked' : '' %>><span class="slider"></span></label>
+                    <div id="eco-tab-games" class="ai-inner-panel">
+                        <p class="ai-inner-desc">Toggle individual economy games on or off for your server.</p>
+                        <div class="eco-section-head" style="margin-bottom:.75rem">
+                            <label class="toggle" style="margin:0;flex:1">
+                                <span class="toggle-text"><strong>Enable all games</strong><span>Master switch for all economy games</span></span>
+                                <span class="switch"><input type="checkbox" id="economy-games-enabled" <%= settings.economy.gamesEnabled !== false ? 'checked' : '' %>><span class="slider"></span></span>
+                            </label>
                         </div>
-                        <div class="game-card">
-                            <div class="game-card-icon">🎲</div>
-                            <div class="game-card-info">
-                                <span class="game-card-name">Dice Roll</span>
-                                <span class="game-card-desc">Roll dice and multiply your wager</span>
+                        <div class="games-grid">
+                            <div class="game-card">
+                                <div class="game-card-icon">🪙</div>
+                                <div class="game-card-info">
+                                    <span class="game-card-name">Coinflip</span>
+                                    <span class="game-card-desc">Bet coins — heads or tails wins double</span>
+                                </div>
+                                <label class="switch"><input type="checkbox" id="economy-coinflip-enabled" <%= settings.economy.coinflipEnabled !== false ? 'checked' : '' %>><span class="slider"></span></label>
                             </div>
-                            <label class="switch"><input type="checkbox" id="economy-roll-enabled" <%= settings.economy.rollEnabled !== false ? 'checked' : '' %>><span class="slider"></span></label>
+                            <div class="game-card">
+                                <div class="game-card-icon">🎲</div>
+                                <div class="game-card-info">
+                                    <span class="game-card-name">Dice Roll</span>
+                                    <span class="game-card-desc">Roll dice and multiply your wager</span>
+                                </div>
+                                <label class="switch"><input type="checkbox" id="economy-roll-enabled" <%= settings.economy.rollEnabled !== false ? 'checked' : '' %>><span class="slider"></span></label>
+                            </div>
+                            <div class="game-card">
+                                <div class="game-card-icon">🃏</div>
+                                <div class="game-card-info">
+                                    <span class="game-card-name">Blackjack</span>
+                                    <span class="game-card-desc">Beat the dealer to win your bet</span>
+                                </div>
+                                <label class="switch"><input type="checkbox" id="economy-blackjack-enabled" <%= settings.economy.blackjackEnabled !== false ? 'checked' : '' %>><span class="slider"></span></label>
+                            </div>
+                            <div class="game-card">
+                                <div class="game-card-icon">🎰</div>
+                                <div class="game-card-info">
+                                    <span class="game-card-name">Casino</span>
+                                    <span class="game-card-desc">Slots, roulette, poker, crash and more</span>
+                                </div>
+                                <label class="switch"><input type="checkbox" id="economy-casino-enabled" <%= settings.economy.casinoEnabled !== false ? 'checked' : '' %>><span class="slider"></span></label>
+                            </div>
+                            <div class="game-card">
+                                <div class="game-card-icon">⚔️</div>
+                                <div class="game-card-info">
+                                    <span class="game-card-name">Duel</span>
+                                    <span class="game-card-desc">Challenge another member to a coin wager</span>
+                                </div>
+                                <label class="switch"><input type="checkbox" id="economy-duel-enabled" <%= settings.economy.duelEnabled !== false ? 'checked' : '' %>><span class="slider"></span></label>
+                            </div>
+                            <div class="game-card">
+                                <div class="game-card-icon">🦹</div>
+                                <div class="game-card-info">
+                                    <span class="game-card-name">Crime</span>
+                                    <span class="game-card-desc">Attempt a heist for a chance at big coins</span>
+                                </div>
+                                <label class="switch"><input type="checkbox" id="economy-crime-enabled" <%= settings.economy.crimeEnabled !== false ? 'checked' : '' %>><span class="slider"></span></label>
+                            </div>
+                            <div class="game-card">
+                                <div class="game-card-icon">🥷</div>
+                                <div class="game-card-info">
+                                    <span class="game-card-name">Rob</span>
+                                    <span class="game-card-desc">Steal coins from another member's wallet</span>
+                                </div>
+                                <label class="switch"><input type="checkbox" id="economy-rob-enabled" <%= settings.economy.robEnabled !== false ? 'checked' : '' %>><span class="slider"></span></label>
+                            </div>
+                            <div class="game-card">
+                                <div class="game-card-icon">🎓</div>
+                                <div class="game-card-info">
+                                    <span class="game-card-name">Quiz</span>
+                                    <span class="game-card-desc">Answer trivia questions to earn coins</span>
+                                </div>
+                                <label class="switch"><input type="checkbox" id="economy-quiz-enabled" <%= settings.economy.quizEnabled !== false ? 'checked' : '' %>><span class="slider"></span></label>
+                            </div>
                         </div>
-                        <div class="game-card">
-                            <div class="game-card-icon">🃏</div>
-                            <div class="game-card-info">
-                                <span class="game-card-name">Blackjack</span>
-                                <span class="game-card-desc">Beat the dealer to win your bet</span>
-                            </div>
-                            <label class="switch"><input type="checkbox" id="economy-blackjack-enabled" <%= settings.economy.blackjackEnabled !== false ? 'checked' : '' %>><span class="slider"></span></label>
+
+                        <div class="actions-row">
+                            <button class="btn btn-primary" onclick="saveSettings('economy')">Save changes</button>
                         </div>
                     </div>
 
-                    <!-- Career Tiers -->
-                    <div class="eco-section-head" style="margin-top:1.75rem">
-                        <span class="toggle-text"><strong>Career Tiers</strong><span>Rename tiers and set how many shifts unlock each one</span></span>
-                    </div>
-                    <div id="job-tiers-grid" class="job-tiers-grid"></div>
+                    <!-- Careers -->
+                    <div id="eco-tab-careers" class="ai-inner-panel">
+                        <!-- Career Tiers -->
+                        <div class="eco-section-head">
+                            <span class="toggle-text"><strong>Career Tiers</strong><span>Rename tiers and set how many shifts unlock each one</span></span>
+                        </div>
+                        <div id="job-tiers-grid" class="job-tiers-grid"></div>
 
-                    <!-- Jobs -->
-                    <div class="eco-section-head" style="margin-top:1.5rem">
-                        <label class="toggle" style="margin:0;flex:1">
-                            <span class="toggle-text"><strong>Jobs</strong><span>Jobs shown when members use /work</span></span>
-                            <span class="switch"><input type="checkbox" id="economy-jobs-enabled" <%= settings.economy.jobsEnabled !== false ? 'checked' : '' %>><span class="slider"></span></span>
-                        </label>
-                        <button class="btn btn-sm btn-primary" onclick="openJobModal(-1)">+ Add job</button>
-                    </div>
-                    <div id="jobs-list" class="jobs-list"></div>
+                        <!-- Jobs -->
+                        <div class="eco-section-head" style="margin-top:1.5rem">
+                            <label class="toggle" style="margin:0;flex:1">
+                                <span class="toggle-text"><strong>Jobs</strong><span>Jobs shown when members use /work</span></span>
+                                <span class="switch"><input type="checkbox" id="economy-jobs-enabled" <%= settings.economy.jobsEnabled !== false ? 'checked' : '' %>><span class="slider"></span></span>
+                            </label>
+                            <button class="btn btn-sm btn-primary" onclick="openJobModal(-1)">+ Add job</button>
+                        </div>
+                        <div id="jobs-list" class="jobs-list"></div>
 
-                    <div class="actions-row">
-                        <button class="btn btn-primary" onclick="saveSettings('economy')">Save changes</button>
+                        <div class="actions-row">
+                            <button class="btn btn-primary" onclick="saveSettings('economy')">Save changes</button>
+                        </div>
                     </div>
                 </section>
 
@@ -2061,6 +2123,8 @@
                 if (panel) panel.classList.add('active');
             };
         }
+        const switchEcoTab = makeGameTabSwitcher('eco-inner-tab', '#economy .ai-inner-panel', 'eco-tab');
+        document.querySelectorAll('.eco-inner-tab').forEach(tab => tab.addEventListener('click', () => switchEcoTab(tab.dataset.ecoTab)));
         const switchHuntTab = makeGameTabSwitcher('hunt-inner-tab', '#hunt .ai-inner-panel', 'hunt-tab');
         const switchFishTab = makeGameTabSwitcher('fish-inner-tab', '#fish .ai-inner-panel', 'fish-tab');
         const switchMineTab = makeGameTabSwitcher('mine-inner-tab', '#mine .ai-inner-panel', 'mine-tab');
@@ -2441,6 +2505,11 @@
                     'economy.coinflipEnabled': document.getElementById('economy-coinflip-enabled').checked,
                     'economy.rollEnabled': document.getElementById('economy-roll-enabled').checked,
                     'economy.blackjackEnabled': document.getElementById('economy-blackjack-enabled').checked,
+                    'economy.casinoEnabled': document.getElementById('economy-casino-enabled').checked,
+                    'economy.duelEnabled': document.getElementById('economy-duel-enabled').checked,
+                    'economy.crimeEnabled': document.getElementById('economy-crime-enabled').checked,
+                    'economy.robEnabled': document.getElementById('economy-rob-enabled').checked,
+                    'economy.quizEnabled': document.getElementById('economy-quiz-enabled').checked,
                     'economy.jobsEnabled': document.getElementById('economy-jobs-enabled').checked,
                     'economy.announcementChannelId': document.getElementById('economy-announcement-channel').value || null,
                     shop: storeItems,

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -2085,7 +2085,7 @@
 
         // AI inner tab navigation
         function switchAiInnerTab(tabId) {
-            document.querySelectorAll('.ai-inner-tab:not(.rss-inner-tab)').forEach(t => t.classList.remove('active'));
+            document.querySelectorAll('#ai .ai-inner-tab').forEach(t => t.classList.remove('active'));
             document.querySelectorAll('#ai .ai-inner-panel').forEach(p => p.classList.remove('active'));
             const btn = document.querySelector(`.ai-inner-tab[data-ai-tab="${tabId}"]`);
             const panel = document.getElementById(tabId);

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -165,6 +165,9 @@ const guildSchema = new Schema({
         // wheelExtraSpinCost: { type: Number, default: 200, min: 1 },
         duelEnabled: { type: Boolean, default: true },
         duelMaxBet: { type: Number, default: 10000, min: 1 },
+        casinoEnabled: { type: Boolean, default: true },
+        crimeEnabled: { type: Boolean, default: true },
+        quizEnabled: { type: Boolean, default: true },
         // max: 0.5 ensures winnerPayout >= amount so netGain is never negative
         duelHouseCut: { type: Number, default: 0.05, min: 0, max: 0.5 },
         betConfirmThreshold: { type: Number, default: 10000, min: 0 },


### PR DESCRIPTION
## Summary
Refactored the economy settings section in the guild settings dashboard to use a tabbed interface for better organization, and added individual toggle controls for additional economy games (Casino, Crime, Quiz, Duel, Rob).

## Key Changes

- **Tabbed Interface**: Reorganized economy settings into three tabs:
  - ⚙️ Settings & Store: General economy config and shop management
  - 🎮 Games: Game toggles and master games switch
  - 💼 Careers: Job tiers and job management

- **New Game Toggles**: Added database schema and UI controls for:
  - `casinoEnabled` - Toggle for casino games (slots, roulette, poker, crash)
  - `crimeEnabled` - Toggle for crime command
  - `quizEnabled` - Toggle for quiz command
  - Existing toggles for duel and rob games now properly integrated

- **Command Validation**: Updated economy commands to check both global economy status and individual game toggles:
  - `casino.js`: Checks `economy.enabled` and `economy.casinoEnabled`
  - `quiz.js`: Checks `economy.enabled` and `economy.quizEnabled`
  - `crime.js`: Checks `economy.enabled` and `economy.crimeEnabled`

- **Settings Persistence**: Added form field mappings to save all new game toggle states when settings are saved

- **UI Improvements**: 
  - Added descriptive text for games tab
  - Reorganized game cards with consistent styling
  - Added margin adjustments for better visual hierarchy
  - Moved save buttons to each tab panel for clarity

## Implementation Details

The tabbed interface uses the existing `makeGameTabSwitcher` utility function, following the same pattern as hunt, fish, and mine tabs. Each tab is independently saveable, and the settings are persisted to the Guild model with appropriate defaults (all games enabled by default for backward compatibility).

https://claude.ai/code/session_01QTPH4fq6VVDTtJJttdeAUD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server admins can now individually enable or disable specific economy games (casino, crime, quiz) per server
  * Economy settings dashboard reorganized into separate tabs: Settings & Store, Games, and Careers for improved navigation
  * Commands now respect per-game enable/disable settings with appropriate error messages when games are disabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->