### PR TITLE
Improve AI chat: typing refresh, faster streaming, missing dashboard fields

### DIFF
--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -1838,10 +1838,16 @@
                             <span class="toggle-text"><strong>Stream responses</strong><span>Edit messages in real-time as the model generates</span></span>
                             <span class="switch"><input type="checkbox" id="ai-streaming" <%= settings.ai.streaming !== false ? 'checked' : '' %>><span class="slider"></span></span>
                         </label>
-                        <div class="field" style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;">
+                        <div class="field" style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:.75rem;">
                             <div><label class="field-label" for="ai-rate-limit">Rate limit (requests / user)</label><input type="number" id="ai-rate-limit" min="0" value="<%= settings.ai.rateLimitPerUser ?? 20 %>"><small>0 disables</small></div>
+                            <div><label class="field-label" for="ai-rate-channel">Rate limit (requests / channel)</label><input type="number" id="ai-rate-channel" min="0" value="<%= settings.ai.rateLimitPerChannel ?? 0 %>"><small>0 disables</small></div>
                             <div><label class="field-label" for="ai-rate-window">Rate-limit window (minutes)</label><input type="number" id="ai-rate-window" min="1" value="<%= settings.ai.rateLimitWindowMin ?? 10 %>"></div>
                         </div>
+                        <label class="toggle">
+                            <span class="toggle-text"><strong>Enable AI actions</strong><span>Let the AI create polls, set reminders, and suggest mod actions</span></span>
+                            <span class="switch"><input type="checkbox" id="ai-actions-enabled" <%= settings.ai.actionsEnabled ? 'checked' : '' %>><span class="slider"></span></span>
+                        </label>
+                        <p style="font-size:.8rem;opacity:.65;margin:.25rem 0 1rem;">Users can type <code>!reset</code> in the AI channel to clear their conversation history.</p>
                         <div class="actions-row">
                             <button class="btn btn-primary" onclick="saveSettings('ai')">Save changes</button>
                         </div>
@@ -2162,8 +2168,8 @@
 
         const AI_MODEL_DEFAULTS = {
             openai: 'gpt-4o-mini',
-            anthropic: 'claude-haiku-4-5-20251001',
-            gemini: 'gemini-1.5-flash',
+            anthropic: 'claude-haiku-4-5',
+            gemini: 'gemini-2.0-flash',
             openrouter: 'openai/gpt-4o-mini',
             ollama: 'llama3.2'
         };
@@ -2654,7 +2660,9 @@
                     'ai.maxHistory': parseInt(document.getElementById('ai-max-history').value, 10),
                     'ai.streaming': document.getElementById('ai-streaming').checked,
                     'ai.rateLimitPerUser': parseInt(document.getElementById('ai-rate-limit').value, 10),
-                    'ai.rateLimitWindowMin': parseInt(document.getElementById('ai-rate-window').value, 10)
+                    'ai.rateLimitPerChannel': parseInt(document.getElementById('ai-rate-channel').value, 10),
+                    'ai.rateLimitWindowMin': parseInt(document.getElementById('ai-rate-window').value, 10),
+                    'ai.actionsEnabled': document.getElementById('ai-actions-enabled').checked
                 };
             } else if (section === 'tempvoice') {
                 data = {

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -9,14 +9,16 @@ const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('
 
 const DEFAULT_MODELS = {
     openai: 'gpt-4o-mini',
-    gemini: 'gemini-1.5-flash',
-    anthropic: 'claude-haiku-4-5-20251001',
+    gemini: 'gemini-2.0-flash',
+    anthropic: 'claude-haiku-4-5',
     ollama: 'llama3.2',
     openrouter: 'openai/gpt-4o-mini'
 };
 
 const DISCORD_MAX_LEN = 2000;
-const STREAM_EDIT_INTERVAL_MS = 1200;
+const STREAM_EDIT_INTERVAL_MS = 800;
+// Discord typing indicator expires after 10s — refresh every 8s during long generations
+const TYPING_REFRESH_INTERVAL_MS = 8000;
 
 // userId -> [timestamps] and channelId -> [timestamps] for sliding-window rate limiting (in-memory)
 const rateLimits = new Map();
@@ -527,6 +529,9 @@ async function handleAIChat(message, aiSettings) {
             let currentBuf = '';
             const sentMessages = [placeholder]; // all Discord messages emitted during streaming
 
+            // Keep the typing indicator alive for long generations
+            const typingInterval = setInterval(() => message.channel.sendTyping().catch(() => {}), TYPING_REFRESH_INTERVAL_MS);
+
             await withRetry(async () => {
                 fullResponse = '';
                 currentBuf = '';
@@ -550,6 +555,7 @@ async function handleAIChat(message, aiSettings) {
                 }
                 if (currentBuf) await currentMsg.edit(currentBuf).catch(() => {});
             });
+            clearInterval(typingInterval);
 
             // Post-process: reconcile sentMessages against the canonical cleanText chunks
             if (aiSettings.actionsEnabled) {
@@ -600,7 +606,11 @@ async function handleAIChat(message, aiSettings) {
         }
     } catch (error) {
         console.error(`[AI:${provider}] error:`, error?.message || error);
-        const detail = error?.status ? ` (HTTP ${error.status})` : '';
+        const status = error?.status || error?.response?.status;
+        let detail = status ? ` (HTTP ${status})` : '';
+        if (status === 401) detail += ' — check your API key';
+        else if (status === 429) detail += ' — rate limit exceeded';
+        else if (status === 503) detail += ' — provider unavailable';
         await message.reply(`Sorry, I hit an error talking to ${providerLabel}${detail}.`).catch(() => {});
     }
 }


### PR DESCRIPTION
- Keep Discord typing indicator alive every 8s during long streams (previously expired after 10s with no refresh)
- Reduce stream edit interval from 1200ms to 800ms for more responsive feel
- Update default models: gemini-2.0-flash (replaces deprecated 1.5-flash), claude-haiku-4-5 (cleaner ID)
- Add actionsEnabled toggle to dashboard AI settings (was in the model but had no UI)
- Add rateLimitPerChannel field to dashboard and save logic (was silently ignored)
- Add !reset command hint in dashboard so users can discover conversation history reset
- More descriptive error messages for 401/429/503 responses

https://claude.ai/code/session_01WJQ5vZ41dpTrfL2fsrW1wN