### PR TITLE
Add math challenges, starter kit, and onboarding improvements

### DIFF
--- a/src/commands/economy/balance.js
+++ b/src/commands/economy/balance.js
@@ -3,6 +3,7 @@ const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { pruneEffects, EFFECT_CONFIGS, timeRemaining, getServerCoinMultiplier, getServerXpMultiplier } = require('../../services/effectsService');
 const { getStreakMultiplier } = require('../../utils/streakMultiplier');
+const { claimStarterKit } = require('../../utils/starterKit');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -24,6 +25,16 @@ module.exports = {
             let user = user_raw;
             if (!user) {
                 user = await User.create({ userId: targetUser.id, guildId: interaction.guild.id });
+            }
+
+            // Grant starter kit to new users on first economy command use (self only)
+            const isSelfCheck = targetUser.id === interaction.user.id;
+            let starterKitResult = null;
+            if (isSelfCheck && !user.onboarding?.starterKitClaimed) {
+                starterKitResult = await claimStarterKit(interaction.user.id, interaction.guild.id);
+                if (starterKitResult) {
+                    user.balance = (user.balance || 0) + starterKitResult.coins;
+                }
             }
 
             // Prune expired effects before displaying
@@ -87,6 +98,30 @@ module.exports = {
                 if (protectors.length) {
                     embed.addFields({ name: '🔮 Active Effects', value: protectors.join('\n'), inline: false });
                 }
+            }
+
+            // Economy reference benchmarks for context
+            const walletCoins = user.balance || 0;
+            if (isSelf && walletCoins < 10000) {
+                const padlockCost = 5000;
+                const avgHuntEarn = 350;
+                const avgWorkEarn = 200;
+                const coinsNeeded = Math.max(0, padlockCost - walletCoins);
+                const workRunsNeeded = coinsNeeded > 0 ? Math.ceil(coinsNeeded / avgWorkEarn) : 0;
+                const referenceLines = [
+                    `🔒 Padlock costs **5,000** — you're **${walletCoins >= padlockCost ? 'there!' : `${coinsNeeded.toLocaleString()} away`}**${workRunsNeeded > 0 ? ` (~${workRunsNeeded} work runs)` : ''}`,
+                    `⛏️ Average \`/hunt\` earns ~**${avgHuntEarn}**/run`,
+                    `💼 Average \`/work\` earns ~**${avgWorkEarn}**/shift`,
+                ];
+                embed.addFields({ name: '📊 Economy Reference', value: referenceLines.join('\n'), inline: false });
+            }
+
+            if (starterKitResult) {
+                embed.addFields({
+                    name: '🎁 Welcome to Clawdia!',
+                    value: `You received a starter kit: **+${starterKitResult.coins.toLocaleString()} coins** · 🛟 Lifesaver · 🍀 Lucky Charm\nUse \`/daily\` every day to build your streak and multiply earnings!`,
+                    inline: false,
+                });
             }
 
             await interaction.reply({ embeds: [embed] });

--- a/src/commands/economy/daily.js
+++ b/src/commands/economy/daily.js
@@ -10,6 +10,7 @@ const { DROP_TABLE, RARE_DROP_TABLE, DROP_MILESTONES, DROP_BASE_CHANCE, weighted
 const { stackBar } = require('../../utils/rewardReveal');
 const { buildCooldownEmbed, getNextStreakMilestone } = require('../../utils/cooldownEmbed');
 const { getTimeBand } = require('../../utils/timeBand');
+const { claimStarterKit } = require('../../utils/starterKit');
 
 function getStreakColor(streak) {
     if (streak >= 100) return '#9b59b6';
@@ -254,6 +255,12 @@ module.exports = {
             }
             // ─────────────────────────────────────────────────────────────────────
 
+            // Grant starter kit on first economy command use
+            let starterKitResult = null;
+            if (!user.onboarding?.starterKitClaimed) {
+                starterKitResult = await claimStarterKit(interaction.user.id, interaction.guild.id);
+            }
+
             const dailyAmount  = guildSettings?.economy?.dailyAmount ?? 100;
             const streakMult   = getStreakMultiplier(user.streak?.current ?? 0);
             const coinMult     = getCoinMultiplier(user);
@@ -348,11 +355,22 @@ module.exports = {
             }
             // ─────────────────────────────────────────────────────────────────────
 
+            const isFirstDaily = !user.onboarding?.firstDailyClaimed;
+            if (isFirstDaily) {
+                User.findOneAndUpdate(
+                    { userId: interaction.user.id, guildId: interaction.guild.id },
+                    { $set: { 'onboarding.firstDailyClaimed': true } }
+                ).catch(() => {});
+            }
+
             const rankMedals = { 1: '🥇', 2: '🥈', 3: '🥉' };
             const rankMedal = streakRank && rankMedals[streakRank] ? `${rankMedals[streakRank]} ` : '';
-            const rankText = streakRank
+            const baseRankText = streakRank
                 ? `🔥 Your ${streakCurrent}-day streak · ${rankMedal}Ranked #${streakRank} on this server  •  Cooldown: 24h`
                 : 'Cooldown: 24h';
+            const rankText = isFirstDaily
+                ? 'Tip: Claim daily every day to build your streak — streaks multiply your earnings!'
+                : baseRankText;
 
             const rewardEmbed = new EmbedBuilder()
                 .setColor(streakColor)
@@ -372,6 +390,14 @@ module.exports = {
             const milestoneTeaser = getNextStreakMilestone(streakCurrent);
             if (milestoneTeaser) {
                 rewardEmbed.addFields({ name: '📊 Streak Progress', value: milestoneTeaser, inline: false });
+            }
+
+            if (starterKitResult) {
+                rewardEmbed.addFields({
+                    name: '🎁 Welcome to Clawdia!',
+                    value: `Starter kit claimed: **+${starterKitResult.coins.toLocaleString()} coins** · 🛟 Lifesaver · 🍀 Lucky Charm`,
+                    inline: false,
+                });
             }
 
             const challenge = generateDailyChallenge();

--- a/src/commands/economy/work.js
+++ b/src/commands/economy/work.js
@@ -173,8 +173,8 @@ module.exports = {
                 finalEarned = Math.max(0, earned + specialEvent.coinDelta);
             }
 
-            // Challenge fires only when no special event is active (avoids embed conflicts)
-            const challengeFires = !specialEvent && Math.random() < 0.15;
+            // Challenge fires on every run
+            const challengeFires = true;
 
             // Atomic update — cooldown condition in query prevents double-credit on concurrent requests
             const updated = await User.findOneAndUpdate(
@@ -245,18 +245,32 @@ module.exports = {
 
             if (challengeFires) {
                 const challenge = generateWorkChallenge(job.name);
+                const isFirstWork = !updated.onboarding?.firstWorkDone;
+                const footerText = isFirstWork
+                    ? 'Tip: Higher job tiers unlock as you work more shifts. Keep grinding!'
+                    : 'Answer correctly for a bonus · Cooldown: 1h';
+
                 const challengeEmbed = new EmbedBuilder()
                     .setColor(performance.color)
                     .setTitle(challenge.title)
                     .setDescription(`*${scenario}*\n\n${challenge.description}`)
-                    .addFields({ name: '💡 Bonus', value: 'Answer correctly for a **+40% bonus** on this shift!' })
-                    .setFooter({ text: 'You have 20 seconds to answer' })
+                    .addFields({ name: '💡 Bonus', value: 'Fast correct answer: **+55%** · Correct answer: **+40%**' })
+                    .setFooter({ text: footerText })
                     .setTimestamp();
 
                 const reply = await interaction.reply({ embeds: [challengeEmbed], components: [challenge.row], fetchReply: true });
 
+                // Mark first work done (non-blocking)
+                if (isFirstWork) {
+                    User.findOneAndUpdate(
+                        { userId: interaction.user.id, guildId: interaction.guild.id },
+                        { $set: { 'onboarding.firstWorkDone': true } }
+                    ).catch(() => {});
+                }
+
                 let bonusEarned = 0;
                 let responseRef = null;
+                let exceptionalChallenge = false;
 
                 try {
                     const response = await reply.awaitMessageComponent({
@@ -267,7 +281,10 @@ module.exports = {
                     await responseRef.deferUpdate();
 
                     if (response.customId === challenge.correctId) {
-                        bonusEarned = Math.round(earned * 0.4);
+                        const elapsed = Date.now() - challenge.startedAt;
+                        exceptionalChallenge = elapsed <= 5000;
+                        const bonusRate = exceptionalChallenge ? 0.55 : 0.40;
+                        bonusEarned = Math.round(earned * bonusRate);
                         await User.findOneAndUpdate(
                             { userId: interaction.user.id, guildId: interaction.guild.id },
                             { $inc: { balance: bonusEarned } }
@@ -278,7 +295,7 @@ module.exports = {
                             type: 'work_challenge_bonus',
                             amount: bonusEarned,
                             balance: updated.balance + bonusEarned,
-                            note: `work challenge bonus (${challenge.type}) for ${job.name}`,
+                            note: `work challenge bonus (${challenge.type}${exceptionalChallenge ? ', fast' : ''}) for ${job.name}`,
                         });
                     }
                 } catch {
@@ -307,9 +324,16 @@ module.exports = {
                 }
 
                 if (bonusEarned > 0) {
-                    workEmbed.addFields({ name: '🎯 Challenge Bonus!', value: `✅ Correct! You earned an extra **+${bonusEarned.toLocaleString()}** coins!` });
+                    const bonusLabel = exceptionalChallenge
+                        ? `⚡ Lightning fast! You earned an extra **+${bonusEarned.toLocaleString()}** coins! (+55%)`
+                        : `✅ Correct! You earned an extra **+${bonusEarned.toLocaleString()}** coins! (+40%)`;
+                    workEmbed.addFields({ name: exceptionalChallenge ? '🎯 Exceptional Challenge!' : '🎯 Challenge Bonus!', value: bonusLabel });
                 } else {
                     workEmbed.addFields({ name: '🎯 Challenge Result', value: responseRef ? '❌ Wrong answer — no bonus this time.' : '⏱️ Time\'s up — no bonus this time.' });
+                }
+
+                if (specialEvent) {
+                    workEmbed.addFields(specialEvent.embedField);
                 }
 
                 if (promotedTo && promotedTo.minShifts > 0) {

--- a/src/commands/economy/work.js
+++ b/src/commands/economy/work.js
@@ -11,7 +11,6 @@ const { generateWorkChallenge } = require('../../utils/workChallenge');
 const { getTotalBonus } = require('../../services/petService');
 const { randomFrom, WORK_ROUGH_LINES, WORK_EXCEPTIONAL_LINES } = require('../../utils/copyLines');
 const { stackBar } = require('../../utils/rewardReveal');
-const { delay } = require('../../utils/delay');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
 
 function resolveTiers(guildSettings) {
@@ -346,49 +345,6 @@ module.exports = {
                     await interaction.editReply({ embeds: [workEmbed], components: [] }).catch(() => {});
                 }
                 return;
-            }
-
-            // Normal (no challenge) path
-            const normalDescription = performance.exceptional
-                ? `${scenario}\n\n────────────────────\n  ${currency} **${finalEarned.toLocaleString()} coins**  ·  🔥 ${performance.multiplier}x performance\n────────────────────\n${careerValueIndented}\n────────────────────\n  Balance: ${currency} ${updated.balance.toLocaleString()} coins`
-                : `${scenario}\n\n────────────────────\n  💰 **${finalEarned.toLocaleString()} coins**${bonusStr}\n  Balance: ${currency} ${updated.balance.toLocaleString()} coins\n────────────────────`;
-
-            const embed = new EmbedBuilder()
-                .setColor(performance.color)
-                .setTitle(performance.title)
-                .setDescription(normalDescription)
-                .setFooter({ text: 'Cooldown: 1h' })
-                .setTimestamp();
-
-            if (!performance.exceptional) {
-                embed.addFields(
-                    { name: '📊 Performance', value: performance.label, inline: false },
-                    { name: '📈 Career',      value: careerValue,       inline: false }
-                );
-            }
-
-            if (specialEvent) {
-                embed.addFields(specialEvent.embedField);
-            }
-
-            if (promotedTo && promotedTo.minShifts > 0) {
-                embed.addFields({
-                    name: '🎉 Promotion!',
-                    value: `You've been promoted to **${promotedTo.name}** — new jobs and higher pay are now available!`
-                });
-            }
-
-            if (specialEvent) {
-                // Suspense reveal for special work events
-                const suspenseEmbed = new EmbedBuilder()
-                    .setColor(performance.color)
-                    .setTitle('💼 Shift Update…')
-                    .setDescription(`*${scenario}*`);
-                await interaction.reply({ embeds: [suspenseEmbed] });
-                await delay(900);
-                await interaction.editReply({ embeds: [embed] });
-            } else {
-                await interaction.reply({ embeds: [embed] });
             }
         } catch (error) {
             console.error('Work error:', error);

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -508,6 +508,14 @@ const userSchema = new Schema({
         allTimeBest:  { type: Number, default: 0 },
     },
 
+    // New user onboarding state
+    onboarding: {
+        starterKitClaimed: { type: Boolean, default: false },
+        firstDailyClaimed: { type: Boolean, default: false },
+        firstWorkDone:     { type: Boolean, default: false },
+        firstHuntDone:     { type: Boolean, default: false },
+    },
+
     // Lifetime stats used for achievement checks
     lifetimeGambled: { type: Number, default: 0 },
     successfulRobs:  { type: Number, default: 0 },

--- a/src/utils/starterKit.js
+++ b/src/utils/starterKit.js
@@ -1,0 +1,39 @@
+const User = require('../models/User');
+const { logTransaction } = require('./logTransaction');
+
+const STARTER_COINS = 500;
+const STARTER_ITEMS = [
+    { itemId: 'lifesaver',    quantity: 1 },
+    { itemId: 'lucky_charm',  quantity: 1 },
+];
+
+/**
+ * Atomically claims the starter kit for a new user.
+ * Returns { coins } on success, or null if already claimed.
+ */
+async function claimStarterKit(userId, guildId) {
+    const updated = await User.findOneAndUpdate(
+        { userId, guildId, 'onboarding.starterKitClaimed': { $ne: true } },
+        {
+            $inc: { balance: STARTER_COINS },
+            $set: { 'onboarding.starterKitClaimed': true },
+            $push: { inventory: { $each: STARTER_ITEMS } },
+        },
+        { new: true }
+    );
+
+    if (!updated) return null;
+
+    logTransaction({
+        userId,
+        guildId,
+        type: 'starter_kit',
+        amount: STARTER_COINS,
+        balance: updated.balance,
+        note: 'new user starter kit: 500 coins + lifesaver + lucky_charm',
+    });
+
+    return { coins: STARTER_COINS };
+}
+
+module.exports = { claimStarterKit };

--- a/src/utils/workChallenge.js
+++ b/src/utils/workChallenge.js
@@ -163,10 +163,17 @@ function generateWorkChallenge(jobName = 'your job') {
     // math_problem
     const problem = MATH_PROBLEMS[Math.floor(Math.random() * MATH_PROBLEMS.length)];
     const wrongNums = new Set();
-    while (wrongNums.size < 2) {
+    let iterations = 0;
+    while (wrongNums.size < 2 && iterations < 50) {
+        iterations++;
         const delta = Math.floor(Math.random() * 6) + 1;
         const candidate = problem.answer + (Math.random() < 0.5 ? delta : -delta);
         if (candidate !== problem.answer && candidate > 0) wrongNums.add(candidate);
+    }
+    // Deterministic fallback if loop exhausted
+    for (let fallback = 1; wrongNums.size < 2; fallback++) {
+        const candidate = problem.answer + fallback;
+        if (candidate !== problem.answer) wrongNums.add(candidate);
     }
     const mathWrong = [...wrongNums];
     const mathButtons = shuffle([

--- a/src/utils/workChallenge.js
+++ b/src/utils/workChallenge.js
@@ -47,6 +47,19 @@ const COUNT_PAIRS = [
     { target: '🐱', decoy: '🐶' },
 ];
 
+const MATH_PROBLEMS = [
+    { a: 14, b: 8,  op: '+', answer: 22 },
+    { a: 37, b: 15, op: '+', answer: 52 },
+    { a: 9,  b: 6,  op: '×', answer: 54 },
+    { a: 8,  b: 7,  op: '×', answer: 56 },
+    { a: 63, b: 27, op: '-', answer: 36 },
+    { a: 48, b: 19, op: '-', answer: 29 },
+    { a: 7,  b: 8,  op: '×', answer: 56 },
+    { a: 25, b: 13, op: '+', answer: 38 },
+    { a: 72, b: 36, op: '-', answer: 36 },
+    { a: 6,  b: 9,  op: '×', answer: 54 },
+];
+
 function shuffle(arr) {
     const a = [...arr];
     for (let i = a.length - 1; i > 0; i--) {
@@ -68,13 +81,16 @@ function scrambleWord(word) {
 
 /**
  * Returns a challenge descriptor for the /work bonus mini-game.
- * Types: 'word_scramble', 'crisis_decision', 'quick_count'
+ * Types: 'word_scramble', 'crisis_decision', 'quick_count', 'math_problem'
  *
  * Returned object shape:
- *   type, title, description (string), row (ActionRowBuilder), correctId, timeLimit (ms)
+ *   type, title, description, row, correctId, timeLimit (ms), startedAt (ms)
+ *
+ * Fast-answer window: if the user answers within 5s of startedAt, work.js
+ * awards the "exceptional challenge" bonus (+55%) instead of the standard (+40%).
  */
 function generateWorkChallenge(jobName = 'your job') {
-    const types = ['word_scramble', 'crisis_decision', 'quick_count'];
+    const types = ['word_scramble', 'crisis_decision', 'quick_count', 'math_problem'];
     const type = types[Math.floor(Math.random() * types.length)];
 
     if (type === 'word_scramble') {
@@ -87,11 +103,12 @@ function generateWorkChallenge(jobName = 'your job') {
         ]);
         return {
             type,
-            title: `🔡 Work Crisis — Word Scramble!`,
+            title: `🔡 Work Challenge — Word Scramble!`,
             description: `Unscramble this word from your ${jobName} shift:\n\`\`\`${scrambled}\`\`\``,
             row: new ActionRowBuilder().addComponents(...buttons),
             correctId: 'work_challenge_correct',
-            timeLimit: 20_000,
+            timeLimit: 15_000,
+            startedAt: Date.now(),
         };
     }
 
@@ -104,41 +121,67 @@ function generateWorkChallenge(jobName = 'your job') {
         ]);
         return {
             type,
-            title: `⚠️ Work Crisis — Situation!`,
+            title: `⚠️ Work Challenge — Situation!`,
             description: entry.question,
             row: new ActionRowBuilder().addComponents(...buttons),
             correctId: 'work_challenge_correct',
-            timeLimit: 20_000,
+            timeLimit: 15_000,
+            startedAt: Date.now(),
         };
     }
 
-    // quick_count
-    const pair = COUNT_PAIRS[Math.floor(Math.random() * COUNT_PAIRS.length)];
-    const targetCount = 2 + Math.floor(Math.random() * 4); // 2-5 targets
-    const decoyCount  = 2 + Math.floor(Math.random() * 4); // 2-5 decoys
-    const emojiStr = shuffle([
-        ...Array(targetCount).fill(pair.target),
-        ...Array(decoyCount).fill(pair.decoy),
-    ]).join('');
-
-    const wrong = new Set();
-    while (wrong.size < 2) {
-        const candidate = targetCount + Math.floor(Math.random() * 5) - 2;
-        if (candidate !== targetCount && candidate >= 0) wrong.add(candidate);
+    if (type === 'quick_count') {
+        const pair = COUNT_PAIRS[Math.floor(Math.random() * COUNT_PAIRS.length)];
+        const targetCount = 2 + Math.floor(Math.random() * 4); // 2-5 targets
+        const decoyCount  = 2 + Math.floor(Math.random() * 4); // 2-5 decoys
+        const emojiStr = shuffle([
+            ...Array(targetCount).fill(pair.target),
+            ...Array(decoyCount).fill(pair.decoy),
+        ]).join('');
+        const wrong = new Set();
+        while (wrong.size < 2) {
+            const candidate = targetCount + Math.floor(Math.random() * 5) - 2;
+            if (candidate !== targetCount && candidate >= 0) wrong.add(candidate);
+        }
+        const wrongArr = [...wrong];
+        const buttons = shuffle([
+            new ButtonBuilder().setCustomId('work_challenge_correct').setLabel(String(targetCount)).setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('work_challenge_wrong1').setLabel(String(wrongArr[0])).setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('work_challenge_wrong2').setLabel(String(wrongArr[1])).setStyle(ButtonStyle.Secondary),
+        ]);
+        return {
+            type,
+            title: `🔢 Work Challenge — Quick Count!`,
+            description: `How many **${pair.target}** do you see?\n${emojiStr}`,
+            row: new ActionRowBuilder().addComponents(...buttons),
+            correctId: 'work_challenge_correct',
+            timeLimit: 12_000,
+            startedAt: Date.now(),
+        };
     }
-    const wrongArr = [...wrong];
-    const buttons = shuffle([
-        new ButtonBuilder().setCustomId('work_challenge_correct').setLabel(String(targetCount)).setStyle(ButtonStyle.Secondary),
-        new ButtonBuilder().setCustomId('work_challenge_wrong1').setLabel(String(wrongArr[0])).setStyle(ButtonStyle.Secondary),
-        new ButtonBuilder().setCustomId('work_challenge_wrong2').setLabel(String(wrongArr[1])).setStyle(ButtonStyle.Secondary),
+
+    // math_problem
+    const problem = MATH_PROBLEMS[Math.floor(Math.random() * MATH_PROBLEMS.length)];
+    const wrongNums = new Set();
+    while (wrongNums.size < 2) {
+        const delta = Math.floor(Math.random() * 6) + 1;
+        const candidate = problem.answer + (Math.random() < 0.5 ? delta : -delta);
+        if (candidate !== problem.answer && candidate > 0) wrongNums.add(candidate);
+    }
+    const mathWrong = [...wrongNums];
+    const mathButtons = shuffle([
+        new ButtonBuilder().setCustomId('work_challenge_correct').setLabel(String(problem.answer)).setStyle(ButtonStyle.Secondary),
+        new ButtonBuilder().setCustomId('work_challenge_wrong1').setLabel(String(mathWrong[0])).setStyle(ButtonStyle.Secondary),
+        new ButtonBuilder().setCustomId('work_challenge_wrong2').setLabel(String(mathWrong[1])).setStyle(ButtonStyle.Secondary),
     ]);
     return {
         type,
-        title: `🔢 Work Crisis — Quick Count!`,
-        description: `How many **${pair.target}** do you see?\n${emojiStr}`,
-        row: new ActionRowBuilder().addComponents(...buttons),
+        title: `🧮 Work Challenge — Quick Math!`,
+        description: `Solve this fast:\n\`\`\`${problem.a} ${problem.op} ${problem.b} = ?\`\`\``,
+        row: new ActionRowBuilder().addComponents(...mathButtons),
         correctId: 'work_challenge_correct',
-        timeLimit: 20_000,
+        timeLimit: 12_000,
+        startedAt: Date.now(),
     };
 }
 


### PR DESCRIPTION
## Summary
This PR enhances the economy system with new challenge types, a starter kit for new users, and improved onboarding tracking. It introduces math problems as a fourth work challenge type, implements an atomic starter kit claim system, and adds onboarding state tracking to guide new players.

## Key Changes

**Work Challenge System**
- Added `MATH_PROBLEMS` array with 10 math problems (addition, subtraction, multiplication)
- Introduced new `math_problem` challenge type alongside existing word scramble, crisis decision, and quick count
- Reduced time limits: word scramble (20s → 15s), crisis decision (20s → 15s), quick count (20s → 12s), math (new 12s)
- Added `startedAt` timestamp to all challenges to enable fast-answer detection
- Implemented "exceptional challenge" bonus: +55% for answers within 5 seconds, +40% for standard correct answers
- Changed challenge fire rate from 15% to 100% (fires on every work run)
- Updated challenge titles from "Work Crisis" to "Work Challenge" for consistency
- Enhanced challenge result messaging to distinguish between fast and standard correct answers

**Starter Kit System**
- Created new `starterKit.js` utility with atomic `claimStarterKit()` function
- Starter kit grants: 500 coins, 1 lifesaver, 1 lucky charm
- Uses MongoDB atomic update with `$ne` condition to prevent double-claiming
- Integrated into `/balance` and `/daily` commands for first-time economy users
- Displays welcome message with starter kit details on claim

**Onboarding Tracking**
- Added `onboarding` schema to User model with four boolean flags:
  - `starterKitClaimed`: tracks starter kit claim status
  - `firstDailyClaimed`: marks first daily claim
  - `firstWorkDone`: marks first work shift
  - `firstHuntDone`: placeholder for future hunt tracking
- Updated `/balance` command to show economy reference benchmarks (padlock cost, average earnings) for users under 10k coins
- Updated `/daily` command to show onboarding tip on first claim instead of streak ranking
- Updated `/work` command to show onboarding tip on first shift instead of standard footer
- Non-blocking async updates for onboarding flags to avoid blocking response

**UI/UX Improvements**
- Added special event field display in work command results
- Enhanced challenge bonus messaging with emoji indicators (⚡ for exceptional, 🎯 for standard)
- Added economy reference section in balance command for new players
- Improved footer text contextuality based on onboarding state

https://claude.ai/code/session_01PPmdXv2duGFSwrtSMgypZd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Starter kit (500 coins + items) awarded on first economy command use
  * New math problem challenge type added to work shifts
  * Economy reference guide displays when wallet is below 10,000 coins
  * Onboarding welcome messages for new users

* **Improvements**
  * Work challenges now consistently trigger on every shift
  * Response time now affects bonus multipliers—faster completions earn higher rewards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->