### PR TITLE
Add multi-phase boss encounters and fishing tournaments

### DIFF
--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -16,7 +16,8 @@ const {
     ROD_UPGRADES, MATERIAL_NAMES, BAIT_PACKS, CONSUMABLES,
     ROD_TIERS, ROD_BY_SLUG,
     FISHER_LEVELS, PRESTIGE_BONUSES,
-    FISH_QUEST_TEMPLATES, FISH_CRAFT_RECIPES
+    FISH_QUEST_TEMPLATES, FISH_CRAFT_RECIPES,
+    BOSS_TYPES
 } = require('../../data/fishData');
 const { MATERIAL_NAMES: HUNT_MATERIAL_NAMES } = require('../../data/huntData');
 const { checkAndAward, announceAchievements } = require('../../services/achievementService');
@@ -29,6 +30,7 @@ const {
     calculateSuccessChance,
     executeCast,
     resolveBossEncounter,
+    rollBossType,
     assignDailyFishQuests,
     updateFishQuestProgress,
     formatMs,
@@ -47,6 +49,7 @@ const { ensureHuntData } = require('../../services/huntService');
 const { TIER_NUM, TIER_RIBBON } = require('../../data/materialRarity');
 const { randomFrom, FISH_MISS_POOL } = require('../../utils/copyLines');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
+const { submitCatch: submitTournamentCatch, getActiveTournament, buildLeaderboardEmbed, endTournament, buildWinnersEmbed } = require('../../services/tournamentService');
 const { getDailyFeatured, FEATURED_PAYOUT_BONUS, FEATURED_RARE_BONUS } = require('../../data/featuredRotation');
 const { getTimeBand } = require('../../utils/timeBand');
 const { logBigWin } = require('../../utils/bigWinLogger');
@@ -246,7 +249,32 @@ module.exports = {
                             o.setName('location')
                                 .setDescription('Location to fish at')
                                 .setRequired(true)
-                                .addChoices(...LOCATION_LIST.map(l => ({ name: `${l.emoji} ${l.name}`, value: l.id })))))),
+                                .addChoices(...LOCATION_LIST.map(l => ({ name: `${l.emoji} ${l.name}`, value: l.id }))))))
+        .addSubcommandGroup(group =>
+            group.setName('tournament')
+                .setDescription('Fishing tournament commands')
+                .addSubcommand(sub =>
+                    sub.setName('status')
+                        .setDescription('View the current tournament leaderboard'))
+                .addSubcommand(sub =>
+                    sub.setName('start')
+                        .setDescription('Start a fishing tournament (admin only)')
+                        .addIntegerOption(o =>
+                            o.setName('duration')
+                                .setDescription('Tournament duration in minutes (default 60)')
+                                .setMinValue(15)
+                                .setMaxValue(180)
+                                .setRequired(false))
+                        .addIntegerOption(o =>
+                            o.setName('prize_pool')
+                                .setDescription('Starting prize pool (coins to seed)')
+                                .setMinValue(0)
+                                .setRequired(false))
+                        .addIntegerOption(o =>
+                            o.setName('entry_fee')
+                                .setDescription('Entry fee per participant (0 = free)')
+                                .setMinValue(0)
+                                .setRequired(false)))),
 
     async execute(interaction) {
         const group = interaction.options.getSubcommandGroup(false);
@@ -259,11 +287,12 @@ module.exports = {
             return;
         }
 
-        if (group === 'inv')      return handleInv(interaction, sub);
-        if (group === 'quests')   return handleQuests(interaction, sub);
-        if (group === 'shop')     return handleShop(interaction, sub);
-        if (group === 'craft')    return handleCraft(interaction, sub);
-        if (group === 'location') return handleLocation(interaction, sub);
+        if (group === 'inv')         return handleInv(interaction, sub);
+        if (group === 'quests')      return handleQuests(interaction, sub);
+        if (group === 'shop')        return handleShop(interaction, sub);
+        if (group === 'craft')       return handleCraft(interaction, sub);
+        if (group === 'location')    return handleLocation(interaction, sub);
+        if (group === 'tournament')  return handleTournament(interaction, sub);
     }
 };
 
@@ -602,6 +631,18 @@ async function handleCast(interaction) {
         return interaction.editReply({ content: 'Something went wrong saving your catch. Please try again.' });
     }
 
+    // Submit to active tournament if fish catch (not junk/treasure)
+    if (result.success && result.catchType === 'fish' && result.fish && result.finalPayout > 0) {
+        submitTournamentCatch(interaction.guild.id, {
+            userId:    interaction.user.id,
+            username:  interaction.user.username,
+            fishName:  result.fish.name,
+            fishEmoji: result.fish.emoji ?? '🐟',
+            tier:      result.tier,
+            score:     result.finalPayout
+        }).catch(() => null);
+    }
+
     // Await hourly winner update then re-fetch for accurate footer
     if (result.success) {
         const tierScore = FISH_TIER_SCORE[result.tier] ?? 0;
@@ -647,101 +688,160 @@ async function handleCast(interaction) {
         }
     }
 
-    // Boss encounter — present choices if triggered
+    // Boss encounter — multi-phase fight
     if (result.bossEncounter) {
-        const bossRow = new ActionRowBuilder().addComponents(
-            new ButtonBuilder().setCustomId('boss_fight').setLabel('⚔️ Fight').setStyle(ButtonStyle.Danger),
-            new ButtonBuilder().setCustomId('boss_loosen').setLabel('〰️ Loosen Line').setStyle(ButtonStyle.Primary),
-            new ButtonBuilder().setCustomId('boss_cut').setLabel('✂️ Cut Line').setStyle(ButtonStyle.Secondary)
-        );
-        const bossEmbed = new EmbedBuilder()
-            .setColor('#1C0A00')
-            .setTitle(`${result.bossEncounter.fish.emoji} Something monstrous grabs your line!`)
-            .setDescription(
-                `━━━━━━━━━━━━━━━━━━━━━━━━━━\n` +
-                `  ${result.bossEncounter.fish.emoji}  **${result.bossEncounter.fish.name}**  [⭐⭐⭐⭐⭐]\n` +
-                `━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n` +
-                `*The rod bends nearly double. Your hands shake. This is no ordinary catch.*\n\n` +
-                `**Choose your response — NOW:**\n\n` +
-                `⚔️ **Fight** — hold on and reel hard. Maximum reward, maximum rod damage.\n` +
-                `〰️ **Loosen Line** — let it tire itself out. Safer, partial payout.\n` +
-                `✂️ **Cut Line** — retreat clean. No reward, no damage.`
-            )
-            .setFooter({ text: '⏱️ 30 seconds to decide — or the creature vanishes into the deep.' });
+        const bossType     = rollBossType();
+        const choicesMade  = [];
+        const phaseCount   = bossType.phases.length;
 
-        await interaction.editReply({ embeds: [embed, bossEmbed], components: [bossRow] });
+        const buildBossPhaseEmbed = (phaseIndex, prevResults) => {
+            const phase      = bossType.phases[phaseIndex];
+            const integrity  = 3 - prevResults.filter(p => !p.correct && p.chosen !== 'safe').length;
+            const intBar     = '❤️'.repeat(integrity) + '🖤'.repeat(3 - integrity);
+            const histLines  = prevResults.map((p, i) => {
+                const icon = p.correct ? '✅' : p.chosen === 'safe' ? '🛡️' : '❌';
+                return `Phase ${i + 1}: ${icon}`;
+            }).join('  ');
 
-        const bossReply = await interaction.fetchReply();
-        const bossCollector = bossReply.createMessageComponentCollector({
-            filter: i => i.user.id === interaction.user.id && ['boss_fight', 'boss_loosen', 'boss_cut'].includes(i.customId),
-            time: 30_000, max: 1
-        });
-
-        bossCollector.on('collect', async btn => {
-            const choiceMap = { boss_fight: 'fight', boss_loosen: 'loosen', boss_cut: 'cut' };
-            const choice    = choiceMap[btn.customId];
-
-            const freshUser = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
-            ensureFishingData(freshUser);
-            const bossResult = resolveBossEncounter(freshUser, result.bossEncounter.fish, result.bossEncounter.tier, choice);
-
-            if (bossResult.bonusPayout > 0) {
-                const bossLocation = LOCATIONS[freshUser.fishing.activeLocation] ?? location;
-                const { adjustedPayout } = applyPayoutModifiers(freshUser, bossResult.bonusPayout, bossLocation);
-                bossResult.bonusPayout = adjustedPayout;
-                freshUser.balance                 += adjustedPayout;
-                freshUser.fishing.totalEarned     += adjustedPayout;
-                freshUser.fishing.dailyCoins      += adjustedPayout;
-                if (adjustedPayout > freshUser.fishing.bestPayout) freshUser.fishing.bestPayout = adjustedPayout;
-            }
-            freshUser.markModified('fishing');
-            try {
-                await freshUser.save();
-            } catch (saveErr) {
-                console.error('[fish boss] save error:', saveErr);
-                return btn.update({ content: 'Something went wrong saving your boss result. Please try again.', embeds: [], components: [] });
-            }
-
-            // Log big win for boss payout
-            if (bossResult.bonusPayout > 0) {
-                const bigWinThreshold = guildSettings?.economy?.bigWinThreshold ?? 50000;
-                if (bossResult.bonusPayout >= bigWinThreshold) {
-                    logBigWin({ guildId: interaction.guild.id, userId: interaction.user.id, username: interaction.user.username, amount: bossResult.bonusPayout, source: 'fish', details: `${result.bossEncounter.fish.emoji ?? ''} ${result.bossEncounter.fish.name} [boss]`.trim() });
-                }
-            }
-
-            const freshCurrency = currency;
-            const bossResultEmbed = new EmbedBuilder()
-                .setColor(
-                    bossResult.outcome === 'win'    ? '#FFD700' :
-                    bossResult.outcome === 'loosen' ? '#3498db' :
-                    bossResult.outcome === 'loss'   ? '#1C0A00' : '#95a5a6'
-                )
-                .setTitle(
-                    bossResult.outcome === 'win'    ? `🏆 ${result.bossEncounter.fish.emoji} Defeated!` :
-                    bossResult.outcome === 'loss'   ? `💀 ${result.bossEncounter.fish.emoji} Escaped into the Deep…` :
-                    bossResult.outcome === 'loosen' ? `〰️ Partial Victory — ${result.bossEncounter.fish.emoji} Tired Out` :
-                    `✂️ Line Cut — Retreat`
-                )
+            return new EmbedBuilder()
+                .setColor('#1C0A00')
+                .setTitle(`${bossType.emoji} ${bossType.name} — Phase ${phaseIndex + 1}/${phaseCount}`)
                 .setDescription(
-                    bossResult.outcome === 'win'
-                        ? `**You landed the ${result.bossEncounter.fish.emoji} ${result.bossEncounter.fish.name}.**\n\n${bossResult.message}`
-                        : bossResult.message
+                    `━━━━━━━━━━━━━━━━━━━━━━━━━━\n` +
+                    `  ${result.bossEncounter.fish.emoji}  **${result.bossEncounter.fish.name}**\n` +
+                    `  Line Integrity: ${intBar}\n` +
+                    `━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n` +
+                    `${phase.hint}\n\n` +
+                    (histLines ? `${histLines}\n\n` : '') +
+                    `**Choose your response — NOW:**`
                 )
-                .addFields(
-                    { name: 'Bonus Payout',   value: bossResult.bonusPayout > 0 ? `${freshCurrency}${bossResult.bonusPayout.toLocaleString()}` : 'None', inline: true },
-                    { name: 'Rod Damage',     value: `-${bossResult.durabilityLost} durability`, inline: true }
-                )
-                .setTimestamp();
+                .setFooter({ text: `⏱️ 30 seconds per phase • Outcomes: 3/3=Full legendary payout | 2/3=Rare | 1/3=Common | 0/3=Nothing` });
+        };
 
-            await btn.update({ embeds: [embed, bossResultEmbed], components: [] });
-        });
+        const buildPhaseRow = (phaseIndex) => {
+            const phase   = bossType.phases[phaseIndex];
+            const choices = phase.choices;
+            return new ActionRowBuilder().addComponents(
+                new ButtonBuilder().setCustomId('boss_match').setLabel(choices.match.label).setStyle(ButtonStyle.Danger),
+                new ButtonBuilder().setCustomId('boss_hold').setLabel(choices.hold.label).setStyle(ButtonStyle.Primary),
+                new ButtonBuilder().setCustomId('boss_safe').setLabel(choices.safe.label).setStyle(ButtonStyle.Secondary)
+            );
+        };
 
-        bossCollector.on('end', (collected, reason) => {
-            if (reason === 'time' && collected.size === 0) {
+        const validIds = ['boss_match', 'boss_hold', 'boss_safe'];
+        const idToKey  = { boss_match: 'match', boss_hold: 'hold', boss_safe: 'safe' };
+
+        // Phase 1
+        await interaction.editReply({ embeds: [embed, buildBossPhaseEmbed(0, [])], components: [buildPhaseRow(0)] });
+
+        const runPhase = async (phaseIndex, prevResults, prevBtn) => {
+            const responder  = prevBtn ?? interaction;
+            const fetchReply = prevBtn ? await prevBtn.fetchReply() : await interaction.fetchReply();
+
+            return new Promise(resolve => {
+                const collector = fetchReply.createMessageComponentCollector({
+                    filter: i => i.user.id === interaction.user.id && validIds.includes(i.customId),
+                    time: 30_000, max: 1
+                });
+                collector.on('collect', async btn => {
+                    const chosen    = idToKey[btn.customId];
+                    const phase     = bossType.phases[phaseIndex];
+                    const correct   = chosen === phase.correct;
+                    const results   = [...prevResults, { correct, chosen, correctChoice: phase.correct }];
+                    choicesMade.push(chosen);
+
+                    if (phaseIndex < phaseCount - 1) {
+                        // More phases ahead
+                        await btn.update({ embeds: [embed, buildBossPhaseEmbed(phaseIndex + 1, results)], components: [buildPhaseRow(phaseIndex + 1)] });
+                        resolve({ btn, results });
+                    } else {
+                        resolve({ btn, results, done: true });
+                    }
+                });
+                collector.on('end', (collected, reason) => {
+                    if (reason === 'time' && collected.size === 0) {
+                        // Timeout — treat as safe choice for remaining phases
+                        resolve({ btn: null, results: prevResults, timedOut: true });
+                    }
+                });
+            });
+        };
+
+        // Run all 3 phases sequentially
+        let state = { btn: null, results: [], done: false, timedOut: false };
+        for (let i = 0; i < phaseCount; i++) {
+            state = await runPhase(i, state.results, state.btn);
+            if (state.timedOut) {
                 interaction.editReply({ embeds: [embed], components: [] }).catch(() => {});
+                return;
             }
-        });
+        }
+
+        // Resolve outcome
+        const freshUser = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+        ensureFishingData(freshUser);
+        const bossResult = resolveBossEncounter(freshUser, result.bossEncounter.fish, result.bossEncounter.tier, choicesMade, bossType);
+
+        if (bossResult.bonusPayout > 0) {
+            const bossLocation = LOCATIONS[freshUser.fishing.activeLocation] ?? location;
+            const { adjustedPayout } = applyPayoutModifiers(freshUser, bossResult.bonusPayout, bossLocation);
+            bossResult.bonusPayout = adjustedPayout;
+            freshUser.balance                 += adjustedPayout;
+            freshUser.fishing.totalEarned     += adjustedPayout;
+            freshUser.fishing.dailyCoins      += adjustedPayout;
+            if (adjustedPayout > freshUser.fishing.bestPayout) freshUser.fishing.bestPayout = adjustedPayout;
+        }
+        freshUser.markModified('fishing');
+        try {
+            await freshUser.save();
+        } catch (saveErr) {
+            console.error('[fish boss] save error:', saveErr);
+            return state.btn.update({ content: 'Something went wrong saving your boss result. Please try again.', embeds: [], components: [] });
+        }
+
+        if (bossResult.bonusPayout > 0) {
+            const bigWinThreshold = guildSettings?.economy?.bigWinThreshold ?? 50000;
+            if (bossResult.bonusPayout >= bigWinThreshold) {
+                logBigWin({ guildId: interaction.guild.id, userId: interaction.user.id, username: interaction.user.username, amount: bossResult.bonusPayout, source: 'fish', details: `${result.bossEncounter.fish.emoji ?? ''} ${result.bossEncounter.fish.name} [boss]`.trim() });
+            }
+            // Submit boss win to active tournament with multiplier bonus
+            const tournamentScore = Math.round(bossResult.bonusPayout * (bossResult.tournamentMultiplier ?? 1));
+            submitTournamentCatch(interaction.guild.id, {
+                userId:    interaction.user.id,
+                username:  interaction.user.username,
+                fishName:  result.bossEncounter.fish.name,
+                fishEmoji: result.bossEncounter.fish.emoji ?? '🐉',
+                tier:      result.bossEncounter.tier,
+                score:     tournamentScore,
+                isBossKill: ['perfect', 'win'].includes(bossResult.outcome)
+            }).catch(() => null);
+        }
+
+        const phaseScoreLine = bossResult.phaseResults.map((p, i) => {
+            const icon = p.correct ? '✅' : p.chosen === 'safe' ? '🛡️' : '❌';
+            return `Phase ${i + 1}: ${icon}`;
+        }).join('  ');
+
+        const outcomeColors = { perfect: '#FFD700', win: '#2ecc71', survived: '#3498db', escaped: '#1C0A00' };
+        const outcomeTitles = {
+            perfect:  `🏆 ${result.bossEncounter.fish.emoji} PERFECT — ${bossType.name} Mastered!`,
+            win:      `✅ ${result.bossEncounter.fish.emoji} ${bossType.name} Subdued`,
+            survived: `😓 ${result.bossEncounter.fish.emoji} Barely Survived`,
+            escaped:  `💀 ${result.bossEncounter.fish.emoji} ${bossType.name} Escaped!`
+        };
+
+        const bossResultEmbed = new EmbedBuilder()
+            .setColor(outcomeColors[bossResult.outcome] ?? '#95a5a6')
+            .setTitle(outcomeTitles[bossResult.outcome] ?? '❓ Boss Result')
+            .setDescription(`${phaseScoreLine}\n\n${bossResult.message}`)
+            .addFields(
+                { name: 'Score',        value: `${bossResult.correctCount}/3 correct`, inline: true },
+                { name: 'Bonus Payout', value: bossResult.bonusPayout > 0 ? `${currency}${bossResult.bonusPayout.toLocaleString()}` : 'None', inline: true },
+                { name: 'Rod Damage',   value: `-${bossResult.durabilityLost} durability`, inline: true }
+            )
+            .setTimestamp();
+
+        await state.btn.update({ embeds: [embed, bossResultEmbed], components: [] });
         return;
     }
 
@@ -2497,4 +2597,91 @@ function formatTierWeights(weights) {
         .filter(([, w]) => w > 0)
         .map(([tier, w]) => `${tier} ${Math.round((w / total) * 100)}%`)
         .join(', ');
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TOURNAMENT
+// ═══════════════════════════════════════════════════════════════════════════════
+
+async function handleTournament(interaction, sub) {
+    if (sub === 'status') return handleTournamentStatus(interaction);
+    if (sub === 'start')  return handleTournamentStart(interaction);
+}
+
+async function handleTournamentStatus(interaction) {
+    await interaction.deferReply();
+    const tournament = await getActiveTournament(interaction.guild.id);
+    if (!tournament) {
+        return interaction.editReply({
+            embeds: [
+                new EmbedBuilder()
+                    .setColor('#95a5a6')
+                    .setTitle('🎣 No Active Tournament')
+                    .setDescription('There is no fishing tournament running right now.\n\nAdmins can start one with `/fish tournament start`.')
+                    .setTimestamp()
+            ]
+        });
+    }
+
+    // Auto-end if expired
+    if (new Date() > tournament.endsAt) {
+        const ended = await endTournament(tournament._id);
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const currency = guildSettings?.economy?.currency ?? '💰';
+        return interaction.editReply({ embeds: [buildWinnersEmbed(ended, currency)] });
+    }
+
+    return interaction.editReply({ embeds: [buildLeaderboardEmbed(tournament)] });
+}
+
+async function handleTournamentStart(interaction) {
+    const member = interaction.guild.members.cache.get(interaction.user.id);
+    if (!member?.permissions.has('ManageGuild')) {
+        return interaction.reply({ content: '❌ You need the **Manage Server** permission to start a tournament.', ephemeral: true });
+    }
+
+    await interaction.deferReply();
+
+    const durationMins = interaction.options.getInteger('duration') ?? 60;
+    const seedAmount   = interaction.options.getInteger('prize_pool') ?? 0;
+    const entryFee     = interaction.options.getInteger('entry_fee') ?? 0;
+    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const announceChannelId = guildSettings?.economy?.announcementChannelId ?? null;
+
+    let tournament;
+    try {
+        tournament = await startTournament(interaction.guild.id, {
+            durationMs: durationMins * 60_000,
+            seedAmount,
+            entryFee,
+            announceChannelId
+        });
+    } catch (err) {
+        return interaction.editReply({ content: `❌ ${err.message}` });
+    }
+
+    const currency = guildSettings?.economy?.currency ?? '💰';
+    const announceEmbed = new EmbedBuilder()
+        .setColor('#1e90ff')
+        .setTitle('🎣 A Fishing Tournament Has Begun!')
+        .setDescription(
+            `**Duration:** ${durationMins} minutes\n` +
+            `**Ends:** <t:${Math.floor(tournament.endsAt.getTime() / 1000)}:R>\n` +
+            `**Goal:** Catch the highest-value single fish!\n` +
+            (entryFee > 0 ? `**Entry Fee:** ${currency}${entryFee.toLocaleString()} (auto-deducted on first catch)\n` : `**Entry:** Free\n`) +
+            (seedAmount > 0 ? `**Prize Pool:** ${currency}${seedAmount.toLocaleString()} to start\n` : '') +
+            `\nUse \`/fish cast\` to participate. Use \`/fish tournament status\` to see the live leaderboard!\n\n` +
+            `🐉 **Tip:** Boss encounters during the tournament give a score multiplier!`
+        )
+        .setTimestamp();
+
+    // Announce in the announcement channel if configured
+    if (announceChannelId) {
+        const ch = interaction.guild.channels.cache.get(announceChannelId);
+        if (ch?.isTextBased()) {
+            ch.send({ embeds: [announceEmbed] }).catch(() => null);
+        }
+    }
+
+    return interaction.editReply({ embeds: [announceEmbed] });
 }

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -835,6 +835,10 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
         const balanceLine = `${currency}${user.balance.toLocaleString()}`;
         const xpLine = buildXpLine(user);
         embed.addFields({ name: 'Balance', value: balanceLine, inline: true }, { name: 'Hunter XP', value: xpLine, inline: true });
+
+        const sinceRareNow = user.hunt.sinceRare ?? 0;
+        if (sinceRareNow >= 5) embed.addFields(buildPityField(user));
+
         embed.setFooter({ text: `Cooldown: 45s • ${buildActiveConsumablesLine(user)}` });
         embed.setTimestamp();
         return embed;
@@ -889,6 +893,9 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
         embed.addFields({ name: '❌ Weapon Broke!', value: `Your **${weapon.name}** has broken! Use \`/hunt shop repair\` before hunting again.`, inline: false });
     }
 
+    const sinceRareNow = user.hunt.sinceRare ?? 0;
+    if (sinceRareNow >= 5) embed.addFields(buildPityField(user));
+
     embed.setFooter({ text: 'Tip: Use consumables from /hunt shop to boost your success chance' });
     embed.setTimestamp();
     return embed;
@@ -896,6 +903,32 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
 
 function buildFailureTitle(severityId) {
     return { clean_miss: '💨 Miss!', spooked: '😰 Spooked!', jammed: '🔧 Jammed!', injured: '🤕 Injured!' }[severityId] ?? '❌ Failed Hunt';
+}
+
+function buildPityField(user) {
+    const sinceRare  = user.hunt.sinceRare ?? 0;
+    const threshold  = LIMITS.RARE_PITY_GUARANTEE;
+    const filled     = Math.min(sinceRare, threshold);
+    const barLen     = 16;
+    const filledLen  = Math.round((filled / threshold) * barLen);
+    const bar        = '█'.repeat(filledLen) + '░'.repeat(barLen - filledLen);
+
+    let heat, label;
+    if (sinceRare >= threshold) {
+        heat  = '⚡';
+        label = `**GUARANTEED NEXT HUNT**`;
+    } else if (sinceRare >= 41) {
+        heat  = '🔥';
+        label = `Getting hot — ~${threshold - sinceRare} more`;
+    } else if (sinceRare >= 26) {
+        heat  = '🌡️';
+        label = `Warming up — ~${threshold - sinceRare} more`;
+    } else {
+        heat  = '❄️';
+        label = `~${threshold - sinceRare} more for guaranteed Rare+`;
+    }
+
+    return { name: `${heat} Rare Pity: ${sinceRare}/${threshold}`, value: `\`${bar}\`\n${label}`, inline: false };
 }
 
 function buildStaminaLine(user) {

--- a/src/data/fishData.js
+++ b/src/data/fishData.js
@@ -1155,6 +1155,115 @@ const FAILURE_SEVERITIES = [
       msg: 'You slipped on the bank and fell in! You need a moment to dry off.' }
 ];
 
+// ─── BOSS TYPES ───────────────────────────────────────────────────────────────
+// Each boss type has 3 phases. Each phase has hint text and 3 choices.
+// correctChoice: which choice wins the phase ('match'|'hold'|'safe')
+// strategy: how to play it (exposed to players indirectly through hints)
+const BOSS_TYPES = {
+    leviathan: {
+        name: 'Abyssal Leviathan',
+        emoji: '🐉',
+        strategy: 'match', // correct: match direction, wrong: hold, neutral: safe
+        phases: [
+            {
+                hint: '**THE ABYSSAL LEVIATHAN** pulls hard to the right!',
+                choices: {
+                    match: { label: '🎯 Match its pull — reel RIGHT', risk: 'high' },
+                    hold:  { label: '⚡ Hold your ground',             risk: 'high' },
+                    safe:  { label: '🔄 Slack the line',              risk: 'none' }
+                },
+                correct: 'match'
+            },
+            {
+                hint: 'It surges LEFT with tremendous force!',
+                choices: {
+                    match: { label: '🎯 Match its pull — reel LEFT',  risk: 'high' },
+                    hold:  { label: '⚡ Brace and hold',              risk: 'high' },
+                    safe:  { label: '🔄 Give it line',                risk: 'none' }
+                },
+                correct: 'match'
+            },
+            {
+                hint: '**The creature is weakening** — one strong pull should do it.',
+                choices: {
+                    match: { label: '💪 Reel with everything you have', risk: 'high' },
+                    hold:  { label: '⚡ Steady, controlled reeling',    risk: 'high' },
+                    safe:  { label: '🔄 Wait for the right moment',    risk: 'none' }
+                },
+                correct: 'match'
+            }
+        ]
+    },
+    ghost_eel: {
+        name: 'Ghost Eel',
+        emoji: '👻',
+        strategy: 'safe', // correct: safe option, unpredictable
+        phases: [
+            {
+                hint: 'The **Ghost Eel** thrashes erratically — you can\'t predict it!',
+                choices: {
+                    match: { label: '🎯 Try to match its movements', risk: 'high' },
+                    hold:  { label: '⚡ Fight it directly',          risk: 'high' },
+                    safe:  { label: '🔄 Let it tire itself out',     risk: 'none' }
+                },
+                correct: 'safe'
+            },
+            {
+                hint: 'It goes still… then suddenly darts in an unknown direction.',
+                choices: {
+                    match: { label: '🎯 React to the movement',     risk: 'high' },
+                    hold:  { label: '⚡ Hold your position',        risk: 'high' },
+                    safe:  { label: '🔄 Maintain steady tension',   risk: 'none' }
+                },
+                correct: 'safe'
+            },
+            {
+                hint: 'The eel circles the boat — completely unpredictable.',
+                choices: {
+                    match: { label: '🎯 Chase its direction',       risk: 'high' },
+                    hold:  { label: '⚡ Lock the reel',             risk: 'high' },
+                    safe:  { label: '🔄 Patient tension — wait it out', risk: 'none' }
+                },
+                correct: 'safe'
+            }
+        ]
+    },
+    iron_marlin: {
+        name: 'Iron Marlin',
+        emoji: '⚔️',
+        strategy: 'hold', // correct: hold ground, methodical
+        phases: [
+            {
+                hint: 'The **Iron Marlin** runs in a straight line — methodical, powerful.',
+                choices: {
+                    match: { label: '🎯 Follow its run',            risk: 'high' },
+                    hold:  { label: '⚡ Lock the drag and hold',    risk: 'high' },
+                    safe:  { label: '🔄 Give it some slack',        risk: 'none' }
+                },
+                correct: 'hold'
+            },
+            {
+                hint: 'It turns back — a predictable arc. You can anticipate it.',
+                choices: {
+                    match: { label: '🎯 Mirror its arc',            risk: 'high' },
+                    hold:  { label: '⚡ Counter-reel on the turn',  risk: 'high' },
+                    safe:  { label: '🔄 Maintain even tension',     risk: 'none' }
+                },
+                correct: 'hold'
+            },
+            {
+                hint: 'The Marlin makes its final run — straight and predictable.',
+                choices: {
+                    match: { label: '🎯 Follow its path',           risk: 'high' },
+                    hold:  { label: '⚡ Full drag — reel it in!',   risk: 'high' },
+                    safe:  { label: '🔄 Careful steady pressure',   risk: 'none' }
+                },
+                correct: 'hold'
+            }
+        ]
+    }
+};
+
 module.exports = {
     ROD_TIERS,
     ROD_BY_SLUG,
@@ -1178,6 +1287,7 @@ module.exports = {
     FISH_QUEST_TEMPLATES,
     FAILURE_SEVERITIES,
     FISH_TRAITS,
+    BOSS_TYPES,
     SIZE_TIERS,
     FISH_BASE_WEIGHTS,
     WEATHER_TYPES,

--- a/src/data/huntData.js
+++ b/src/data/huntData.js
@@ -824,7 +824,8 @@ const LIMITS = {
     MAX_CRIT_CHANCE:         0.25,          // 25% hard cap on crit
     STAMINA_TONICS_PER_DAY:  2,
     PITY_CONSECUTIVE_FAILS:  4,             // after N fails, +15% success (stacks 4×)
-    PITY_BONUS_PER_STACK:    0.15
+    PITY_BONUS_PER_STACK:    0.15,
+    RARE_PITY_GUARANTEE:     50             // sinceRare threshold for guaranteed rare+
 };
 
 // ─── PRESTIGE BONUSES ────────────────────────────────────────────────────────

--- a/src/models/FishingTournament.js
+++ b/src/models/FishingTournament.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const { Schema, model } = require('mongoose');
+
+const entrySchema = new Schema({
+    userId:      { type: String, required: true },
+    username:    { type: String, required: true },
+    fishName:    { type: String, required: true },
+    fishEmoji:   { type: String, default: '🐟' },
+    tier:        { type: String, required: true },
+    score:       { type: Number, required: true },  // coin value used for ranking
+    caughtAt:    { type: Date,   required: true },
+    isBossKill:  { type: Boolean, default: false }  // boss encounter win during tournament
+}, { _id: false });
+
+const tournamentSchema = new Schema({
+    guildId: { type: String, required: true, index: true },
+
+    status:    { type: String, enum: ['scheduled', 'active', 'ended'], default: 'scheduled' },
+    startedAt: { type: Date, default: null },
+    endsAt:    { type: Date, required: true },
+
+    prizePool:    { type: Number, default: 0 },
+    entryFee:     { type: Number, default: 0 },
+    seedAmount:   { type: Number, default: 0 },
+
+    announceChannelId:   { type: String, default: null },
+    leaderboardMessageId: { type: String, default: null },
+
+    entries: [entrySchema],
+
+    prizes: [{
+        place:   { type: Number },
+        userId:  { type: String },
+        amount:  { type: Number },
+        paidOut: { type: Boolean, default: false }
+    }],
+
+    winnersAnnouncedAt: { type: Date, default: null }
+}, { timestamps: true });
+
+module.exports = model('FishingTournament', tournamentSchema);

--- a/src/services/fishService.js
+++ b/src/services/fishService.js
@@ -18,6 +18,7 @@ const {
     SIZE_TIERS,
     FISH_BASE_WEIGHTS,
     TIME_OF_DAY_BONUSES,
+    BOSS_TYPES,
     getTimeOfDay
 } = require('../data/fishData');
 const { getCurrentWeather } = require('./weatherService');
@@ -880,45 +881,79 @@ function updateFishQuestProgress(user, result, locationId) {
     user.markModified('quests');
 }
 
-// ─── BOSS ENCOUNTER RESOLUTION (Issue #154) ───────────────────────────────────
+// ─── BOSS ENCOUNTER RESOLUTION ────────────────────────────────────────────────
 
 /**
- * Resolves a boss encounter. choice: 'fight' | 'loosen' | 'cut'
- * Returns { outcome, bonusPayout, durabilityLost, message }
+ * Pick a random boss type for this encounter.
  */
-function resolveBossEncounter(user, fish, tier, choice) {
+function rollBossType() {
+    const keys = Object.keys(BOSS_TYPES);
+    return BOSS_TYPES[keys[Math.floor(Math.random() * keys.length)]];
+}
+
+/**
+ * Resolve a single phase of the multi-phase boss fight.
+ * choices: array of 'match'|'hold'|'safe' strings, one per phase played so far
+ * Returns { phaseResults: [{correct, chosen}], correct, lineIntegrity }
+ */
+function resolveBossPhases(bossType, choicesMade) {
+    let lineIntegrity = 3; // 3 strikes before line snaps
+    const phaseResults = [];
+    for (let i = 0; i < choicesMade.length; i++) {
+        const phase   = bossType.phases[i];
+        const chosen  = choicesMade[i];
+        const correct = chosen === phase.correct;
+        if (!correct && chosen !== 'safe') {
+            lineIntegrity = Math.max(0, lineIntegrity - 1);
+        }
+        phaseResults.push({ correct, chosen, correctChoice: phase.correct });
+    }
+    return { phaseResults, lineIntegrity };
+}
+
+/**
+ * Resolve the final boss outcome after all phases.
+ * Returns { outcome, bonusPayout, durabilityLost, correctCount, message, tournamentMultiplier }
+ */
+function resolveBossEncounter(user, fish, tier, choicesMade, bossType) {
     const rod = user.fishing?.rods[user.fishing.equippedRodIndex];
+    const bt  = bossType ?? rollBossType();
+    const { phaseResults, lineIntegrity } = resolveBossPhases(bt, choicesMade);
+
+    const correctCount = phaseResults.filter(p => p.correct).length;
+    const lineSnapped  = lineIntegrity <= 0;
+
     let bonusPayout = 0, durabilityLost = 0, outcome = '';
 
-    if (choice === 'fight') {
-        const winChance = tier === 'legendary' ? 0.40 : tier === 'epic' ? 0.60 : 0.75;
-        if (Math.random() < winChance) {
-            bonusPayout   = Math.round(randInt(fish.payoutMin, fish.payoutMax) * 1.5);
-            outcome       = 'win';
-            if (rod) { applyDurabilityLoss(rod, 3); durabilityLost = 3; }
-        } else {
-            outcome       = 'loss';
-            if (rod) { applyDurabilityLoss(rod, 6); durabilityLost = 6; }
-        }
-    } else if (choice === 'loosen') {
-        bonusPayout   = Math.round(randInt(fish.payoutMin, fish.payoutMax) * 0.5);
-        outcome       = 'loosen';
-        if (rod) { applyDurabilityLoss(rod, 1); durabilityLost = 1; }
+    if (lineSnapped || correctCount === 0) {
+        outcome = 'escaped';
+        if (rod) { applyDurabilityLoss(rod, 4); durabilityLost = 4; }
+    } else if (correctCount === 1) {
+        outcome = 'survived';
+        bonusPayout = Math.round(randInt(fish.payoutMin, fish.payoutMax) * 0.4);
+        if (rod) { applyDurabilityLoss(rod, 3); durabilityLost = 3; }
+    } else if (correctCount === 2) {
+        outcome = 'win';
+        bonusPayout = Math.round(randInt(fish.payoutMin, fish.payoutMax) * 1.0);
+        if (rod) { applyDurabilityLoss(rod, 2); durabilityLost = 2; }
     } else {
-        // Cut line — safe, no reward
-        outcome = 'cut';
+        // 3/3 correct
+        outcome = 'perfect';
+        bonusPayout = Math.round(randInt(fish.payoutMin, fish.payoutMax) * 1.5);
         if (rod) { applyDurabilityLoss(rod, 1); durabilityLost = 1; }
     }
 
+    const tournamentMultiplier = outcome === 'perfect' ? 1.5 : outcome === 'win' ? 1.2 : 1.0;
+
     const messages = {
-        win:    `⚔️ You fought hard and landed the ${fish.name}! Bonus payout earned!`,
-        loss:   `💥 The ${fish.name} snapped your line and escaped! Your rod took heavy damage.`,
-        loosen: `〰️ You loosened the drag — the ${fish.name} tired itself out. Partial reward.`,
-        cut:    `✂️ You cut the line to safety. No reward, but your gear is intact.`
+        perfect:  `🏆 **FLAWLESS** — You read the ${bt.name} perfectly. Maximum reward!`,
+        win:      `✅ You wrestled the ${bt.name} under control. Solid payout earned.`,
+        survived: `😓 Barely held on — the ${bt.name} nearly escaped. Partial reward.`,
+        escaped:  `💀 The ${bt.name} snapped your line and vanished into the deep!`
     };
 
     if (rod) user.markModified('fishing');
-    return { outcome, bonusPayout, durabilityLost, message: messages[outcome] };
+    return { outcome, bonusPayout, durabilityLost, correctCount, phaseResults, bossType: bt, tournamentMultiplier, message: messages[outcome] };
 }
 
 // ─── FORMATTING HELPERS ───────────────────────────────────────────────────────
@@ -966,6 +1001,7 @@ module.exports = {
     tickConsumables,
     executeCast,
     resolveBossEncounter,
+    rollBossType,
     assignDailyFishQuests,
     updateFishQuestProgress,
     formatMs,

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -339,6 +339,15 @@ function rollTier(user, zone) {
         w.rare  += shift;
     }
 
+    // Pity guarantee: at sinceRare threshold, force rare+ by zeroing out common/uncommon
+    if ((user.hunt.sinceRare ?? 0) >= LIMITS.RARE_PITY_GUARANTEE) {
+        w.common   = 0;
+        w.uncommon = 0;
+        if ((w.rare ?? 0) + (w.epic ?? 0) + (w.legendary ?? 0) + (w.event ?? 0) === 0) {
+            w.rare = 1;
+        }
+    }
+
     const tiers = ['common', 'uncommon', 'rare', 'epic', 'legendary', 'event'];
     const items = tiers.map(t => ({ tier: t, weight: w[t] ?? 0 })).filter(i => i.weight > 0);
     return weightedRoll(items).tier;

--- a/src/services/tournamentService.js
+++ b/src/services/tournamentService.js
@@ -1,0 +1,168 @@
+'use strict';
+
+const FishingTournament = require('../models/FishingTournament');
+const { EmbedBuilder } = require('discord.js');
+
+const PRIZE_SPLITS = [0.60, 0.25, 0.15];
+
+/**
+ * Get the active tournament for a guild, or null.
+ */
+async function getActiveTournament(guildId) {
+    return FishingTournament.findOne({ guildId, status: 'active' });
+}
+
+/**
+ * Start a new tournament. durationMs defaults to 1 hour.
+ */
+async function startTournament(guildId, { durationMs = 60 * 60_000, seedAmount = 0, entryFee = 0, announceChannelId = null } = {}) {
+    const existing = await FishingTournament.findOne({ guildId, status: { $in: ['scheduled', 'active'] } });
+    if (existing) throw new Error('A tournament is already running or scheduled.');
+
+    const now = new Date();
+    return FishingTournament.create({
+        guildId,
+        status: 'active',
+        startedAt: now,
+        endsAt: new Date(now.getTime() + durationMs),
+        prizePool: seedAmount,
+        seedAmount,
+        entryFee,
+        announceChannelId
+    });
+}
+
+/**
+ * Submit a catch to the active tournament.
+ * Returns the updated tournament doc, or null if no active tournament.
+ * Only keeps the user's best catch (highest score).
+ */
+async function submitCatch(guildId, { userId, username, fishName, fishEmoji, tier, score, isBossKill = false }) {
+    const tournament = await FishingTournament.findOne({ guildId, status: 'active' });
+    if (!tournament) return null;
+
+    // Check if tournament has expired
+    if (new Date() > tournament.endsAt) {
+        await endTournament(tournament._id);
+        return null;
+    }
+
+    const existing = tournament.entries.find(e => e.userId === userId);
+    if (existing) {
+        if (score > existing.score) {
+            existing.fishName  = fishName;
+            existing.fishEmoji = fishEmoji;
+            existing.tier      = tier;
+            existing.score     = score;
+            existing.caughtAt  = new Date();
+            existing.isBossKill = isBossKill;
+        }
+    } else {
+        if (tournament.entryFee > 0) {
+            tournament.prizePool += tournament.entryFee;
+        }
+        tournament.entries.push({ userId, username, fishName, fishEmoji, tier, score, caughtAt: new Date(), isBossKill });
+    }
+    await tournament.save();
+    return tournament;
+}
+
+/**
+ * Get sorted leaderboard entries (best score first, tie-break by earliest caughtAt).
+ */
+function getSortedEntries(tournament) {
+    return [...tournament.entries].sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score;
+        return a.caughtAt - b.caughtAt;
+    });
+}
+
+/**
+ * End a tournament, calculate prizes, return winner data.
+ */
+async function endTournament(tournamentId) {
+    const tournament = await FishingTournament.findById(tournamentId);
+    if (!tournament || tournament.status === 'ended') return tournament;
+
+    tournament.status = 'ended';
+    tournament.winnersAnnouncedAt = new Date();
+
+    const sorted = getSortedEntries(tournament);
+    const pool   = tournament.prizePool;
+
+    tournament.prizes = [];
+    for (let i = 0; i < Math.min(3, sorted.length); i++) {
+        const pct    = PRIZE_SPLITS[i];
+        const amount = Math.round(pool * pct);
+        if (amount > 0) {
+            tournament.prizes.push({ place: i + 1, userId: sorted[i].userId, amount, paidOut: false });
+        }
+    }
+
+    await tournament.save();
+    return tournament;
+}
+
+/**
+ * Build the live leaderboard embed.
+ */
+function buildLeaderboardEmbed(tournament, client) {
+    const sorted   = getSortedEntries(tournament);
+    const now      = new Date();
+    const msLeft   = Math.max(0, tournament.endsAt - now);
+    const minsLeft = Math.floor(msLeft / 60_000);
+    const secsLeft = Math.floor((msLeft % 60_000) / 1000);
+    const timeStr  = msLeft <= 0 ? 'Ended' : minsLeft > 0 ? `${minsLeft}m ${secsLeft}s remaining` : `${secsLeft}s remaining`;
+
+    const medals = ['🥇', '🥈', '🥉'];
+    const lines  = sorted.slice(0, 10).map((e, i) => {
+        const medal = medals[i] ?? `**${i + 1}.**`;
+        const boss  = e.isBossKill ? ' 🐉' : '';
+        return `${medal} <@${e.userId}> — ${e.fishEmoji} ${e.fishName} (${e.score.toLocaleString()} pts)${boss}`;
+    });
+
+    const desc = lines.length
+        ? lines.join('\n') + (sorted.length > 10 ? `\n…and ${sorted.length - 10} more participants` : '')
+        : '*No catches yet — be the first!*';
+
+    const embed = new EmbedBuilder()
+        .setColor('#1e90ff')
+        .setTitle(`🎣 FISHING TOURNAMENT — ${timeStr}`)
+        .setDescription(desc)
+        .setTimestamp();
+
+    if (tournament.prizePool > 0) {
+        embed.addFields({ name: '💰 Prize Pool', value: tournament.prizePool.toLocaleString(), inline: true });
+    }
+
+    return embed;
+}
+
+/**
+ * Build the tournament ended / winners embed.
+ */
+function buildWinnersEmbed(tournament, currency = '💰') {
+    const sorted  = getSortedEntries(tournament);
+    const medals  = ['🥇', '🥈', '🥉'];
+    const lines   = sorted.slice(0, 3).map((e, i) => {
+        const prize = tournament.prizes.find(p => p.place === i + 1);
+        const pStr  = prize ? ` — wins **${currency}${prize.amount.toLocaleString()}**` : '';
+        return `${medals[i]} <@${e.userId}> — ${e.fishEmoji} ${e.fishName} (${e.score.toLocaleString()} pts)${pStr}`;
+    });
+
+    return new EmbedBuilder()
+        .setColor('#FFD700')
+        .setTitle('🏆 Fishing Tournament Results!')
+        .setDescription(lines.length ? lines.join('\n') : '*No participants.*')
+        .setTimestamp();
+}
+
+module.exports = {
+    getActiveTournament,
+    startTournament,
+    submitCatch,
+    getSortedEntries,
+    endTournament,
+    buildLeaderboardEmbed,
+    buildWinnersEmbed
+};


### PR DESCRIPTION
## Summary
This PR introduces two major features to the fishing system: a redesigned multi-phase boss encounter mechanic and a new guild-wide fishing tournament system with leaderboards and prize pools.

## Key Changes

### Boss Encounter Redesign
- **Multi-phase boss fights**: Boss encounters now consist of 3 sequential phases instead of a single choice. Each phase presents a hint and three tactical options (match, hold, safe)
- **Three boss types**: Added `BOSS_TYPES` data structure with Abyssal Leviathan (match strategy), Ghost Eel (safe strategy), and Iron Marlin (hold strategy), each with unique phase hints and correct answers
- **New `rollBossType()` function**: Randomly selects a boss type for each encounter
- **Outcome-based rewards**: Payout and durability loss now scale based on correct answers (0/3 = escaped, 1/3 = survived, 2/3 = win, 3/3 = perfect) rather than simple fight/loosen/cut choices
- **Tournament multiplier**: Boss wins grant a 1.5x multiplier for perfect outcomes and 1.2x for regular wins when submitting to tournaments

### Fishing Tournament System
- **New `FishingTournament` model**: Tracks active tournaments with entries, prize pools, entry fees, and winner payouts
- **Tournament service** (`tournamentService.js`): Handles tournament lifecycle (start, submit catches, end, calculate prizes)
- **Leaderboard tracking**: Keeps only each player's best catch (highest score) and sorts by score with tie-breaking by earliest catch time
- **Prize distribution**: Automatic 60/25/15 split for 1st/2nd/3rd place from the prize pool
- **New subcommand group**: `/fish tournament status` (view live leaderboard) and `/fish tournament start` (admin-only, with configurable duration, seed amount, and entry fee)
- **Auto-submission**: Regular fish catches and boss wins automatically submit to active tournaments with appropriate scoring

### Integration Points
- Fish catches now submit to active tournaments with their payout as the score
- Boss encounters submit with a tournament multiplier applied to the bonus payout
- Tournament leaderboard embeds display catch details (emoji, fish name, score) and boss kill indicators
- Expired tournaments auto-end when status is checked

### Hunt System Pity Guarantee
- Added pity guarantee mechanic: at 50 consecutive hunts without a rare+ drop, the next hunt is guaranteed to be rare or better
- Visual pity meter in hunt embeds shows progress toward guarantee threshold

## Notable Implementation Details
- Boss phase resolution uses a sequential collector pattern, awaiting each phase before moving to the next
- Tournament entries are stored as subdocuments with catch metadata for leaderboard display
- Boss type selection is randomized per encounter, making each boss fight unpredictable
- Tournament scoring uses the same currency system as regular payouts for consistency

https://claude.ai/code/session_01FtS35LZSZWVuMqB6DeKdZv