### PR TITLE
Add mine raiding system and persistent mine map visualization

### DIFF
--- a/src/commands/economy/craft.js
+++ b/src/commands/economy/craft.js
@@ -3,17 +3,21 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
-const { CRAFT_RECIPES, CONSUMABLES, MATERIAL_NAMES } = require('../../data/huntData');
+const { CRAFT_RECIPES: HUNT_RECIPES, CONSUMABLES: HUNT_CONSUMABLES, MATERIAL_NAMES: HUNT_MATERIAL_NAMES } = require('../../data/huntData');
+const { CRAFT_RECIPES: MINE_RECIPES, CONSUMABLES: MINE_CONSUMABLES, MATERIAL_NAMES: MINE_MATERIAL_NAMES } = require('../../data/mineData');
 const { ensureHuntData } = require('../../services/huntService');
+const { ensureMineData, activateMineLock } = require('../../services/mineService');
 
-const RECIPE_CHOICES = Object.values(CRAFT_RECIPES).map(r => ({ name: r.name, value: r.id }));
+const ALL_RECIPES     = { ...HUNT_RECIPES, ...MINE_RECIPES };
+const ALL_MAT_NAMES   = { ...HUNT_MATERIAL_NAMES, ...MINE_MATERIAL_NAMES };
+const RECIPE_CHOICES  = Object.values(ALL_RECIPES).map(r => ({ name: r.name, value: r.id }));
 
 module.exports = {
     cooldown: 3,
 
     data: new SlashCommandBuilder()
         .setName('craft')
-        .setDescription('Craft items from hunting materials')
+        .setDescription('Craft items from hunting or mining materials')
         .addSubcommand(sub =>
             sub.setName('list')
                 .setDescription('Browse all available crafting recipes'))
@@ -40,27 +44,52 @@ module.exports = {
             { upsert: true, new: true }
         );
         ensureHuntData(user);
+        ensureMineData(user);
         const h = user.hunt;
+        const m = user.mining;
+
+        // Helper: get material qty from either skill
+        function getMat(matId) {
+            return (h.materials[matId] ?? 0) + (m.materials[matId] ?? 0);
+        }
+        // Helper: consume material from hunt first, then mine
+        function consumeMat(matId, qty) {
+            const huntHas = h.materials[matId] ?? 0;
+            const fromHunt = Math.min(huntHas, qty);
+            h.materials[matId] = huntHas - fromHunt;
+            const fromMine = qty - fromHunt;
+            if (fromMine > 0) m.materials[matId] = (m.materials[matId] ?? 0) - fromMine;
+        }
 
         // ── LIST ───────────────────────────────────────────────────────────
         if (sub === 'list') {
-            const lines = Object.values(CRAFT_RECIPES).map(r => {
+            const huntLines = Object.values(HUNT_RECIPES).map(r => {
                 const ingredientStr = r.ingredients
-                    .map(ing => `${MATERIAL_NAMES[ing.material] ?? ing.material} ×${ing.qty}`)
+                    .map(ing => `${ALL_MAT_NAMES[ing.material] ?? ing.material} ×${ing.qty}`)
                     .join(', ');
-
-                const canCraft = r.ingredients.every(ing => (h.materials[ing.material] ?? 0) >= ing.qty);
+                const canCraft  = r.ingredients.every(ing => getMat(ing.material) >= ing.qty);
                 const uniqueDone = r.unique && r.output.id === 'luckyPaw' && h.luckyPaw;
                 const status = uniqueDone ? '✅ **[OWNED]**' : canCraft ? '✅' : '❌';
+                return `${status} **${r.emoji} ${r.name}**\n> ${r.description}\n> Requires: ${ingredientStr}`;
+            });
 
+            const mineLines = Object.values(MINE_RECIPES).map(r => {
+                const ingredientStr = r.ingredients
+                    .map(ing => `${ALL_MAT_NAMES[ing.material] ?? ing.material} ×${ing.qty}`)
+                    .join(', ');
+                const canCraft = r.ingredients.every(ing => getMat(ing.material) >= ing.qty);
+                const status = canCraft ? '✅' : '❌';
                 return `${status} **${r.emoji} ${r.name}**\n> ${r.description}\n> Requires: ${ingredientStr}`;
             });
 
             const embed = new EmbedBuilder()
                 .setColor('#1abc9c')
                 .setTitle('🔨 Crafting Recipes')
-                .setDescription(lines.join('\n\n'))
-                .setFooter({ text: '✅ = you can craft now  •  Use /craft make <recipe> to craft  •  /hunt inv materials to check stock' });
+                .addFields(
+                    { name: '🏹 Hunting Recipes', value: huntLines.join('\n\n') || 'None', inline: false },
+                    { name: '⛏️ Mining Recipes',  value: mineLines.join('\n\n') || 'None', inline: false }
+                )
+                .setFooter({ text: '✅ = you can craft now  •  Use /craft make <recipe> to craft' });
 
             return interaction.reply({ embeds: [embed] });
         }
@@ -68,7 +97,7 @@ module.exports = {
         // ── MAKE ───────────────────────────────────────────────────────────
         if (sub === 'make') {
             const recipeId = interaction.options.getString('recipe');
-            const recipe   = CRAFT_RECIPES[recipeId];
+            const recipe   = ALL_RECIPES[recipeId];
 
             if (!recipe) {
                 return interaction.reply({
@@ -77,7 +106,7 @@ module.exports = {
                 });
             }
 
-            // Unique upgrade guard
+            // Unique upgrade guard (hunt)
             if (recipe.unique && recipe.output.id === 'luckyPaw' && h.luckyPaw) {
                 return interaction.reply({
                     content: 'You already have the **🐾 Lucky Paw** upgrade!',
@@ -85,9 +114,9 @@ module.exports = {
                 });
             }
 
-            // Stack limit guard for consumables
+            // Stack limit guard for hunt consumables
             if (recipe.output.type === 'consumable') {
-                const def          = CONSUMABLES[recipe.output.id];
+                const def          = HUNT_CONSUMABLES[recipe.output.id];
                 const currentStock = h.consumables[recipe.output.id] ?? 0;
                 if (def && currentStock + recipe.output.qty > def.maxStack) {
                     return interaction.reply({
@@ -98,10 +127,23 @@ module.exports = {
                 }
             }
 
-            // Check ingredients
+            // Stack limit guard for mine consumables
+            if (recipe.output.type === 'mine_consumable') {
+                const def          = MINE_CONSUMABLES[recipe.output.id];
+                const currentStock = m.consumables[recipe.output.id] ?? 0;
+                if (def && currentStock + recipe.output.qty > def.maxStack) {
+                    return interaction.reply({
+                        content: `You can only hold **${def.maxStack}× ${def.name}** (you have ${currentStock}). ` +
+                                 `Free up space before crafting more.`,
+                        ephemeral: true
+                    });
+                }
+            }
+
+            // Check ingredients across both material pools
             const missing = recipe.ingredients
-                .filter(ing => (h.materials[ing.material] ?? 0) < ing.qty)
-                .map(ing => `**${MATERIAL_NAMES[ing.material] ?? ing.material}** (need ${ing.qty}, have ${h.materials[ing.material] ?? 0})`);
+                .filter(ing => getMat(ing.material) < ing.qty)
+                .map(ing => `**${ALL_MAT_NAMES[ing.material] ?? ing.material}** (need ${ing.qty}, have ${getMat(ing.material)})`);
 
             if (missing.length) {
                 return interaction.reply({
@@ -112,14 +154,14 @@ module.exports = {
 
             // Consume materials
             for (const ing of recipe.ingredients) {
-                h.materials[ing.material] -= ing.qty;
+                consumeMat(ing.material, ing.qty);
             }
 
             // Apply output
             let outputDesc = '';
             if (recipe.output.type === 'consumable') {
                 h.consumables[recipe.output.id] = (h.consumables[recipe.output.id] ?? 0) + recipe.output.qty;
-                const def = CONSUMABLES[recipe.output.id];
+                const def = HUNT_CONSUMABLES[recipe.output.id];
                 outputDesc = `${def?.emoji ?? '📦'} **${recipe.output.qty}× ${def?.name ?? recipe.output.id}**`;
             } else if (recipe.output.type === 'ammo') {
                 h.ammo[recipe.output.id] = (h.ammo[recipe.output.id] ?? 0) + recipe.output.qty;
@@ -129,22 +171,37 @@ module.exports = {
                     h.luckyPaw = true;
                     outputDesc = '🐾 **Lucky Paw** — permanently +1% critical hit chance!';
                 }
+            } else if (recipe.output.type === 'mine_consumable') {
+                if (recipe.output.id === 'mine_lock') {
+                    // Activate the mine lock immediately (last-write wins)
+                    activateMineLock(user);
+                    outputDesc = '🔒 **Mine Lock** — your mine is now protected from the next raid!';
+                } else {
+                    m.consumables[recipe.output.id] = (m.consumables[recipe.output.id] ?? 0) + recipe.output.qty;
+                    const def = MINE_CONSUMABLES[recipe.output.id];
+                    outputDesc = `${def?.emoji ?? '📦'} **${recipe.output.qty}× ${def?.name ?? recipe.output.id}**`;
+                }
+            } else if (recipe.output.type === 'mine_charge') {
+                m.charges[recipe.output.id] = (m.charges[recipe.output.id] ?? 0) + recipe.output.qty;
+                outputDesc = `💥 **${recipe.output.qty}× ${recipe.output.id.replace(/_/g, ' ')}** (mine charge)`;
             }
 
             user.markModified('hunt');
+            user.markModified('mining');
             await user.save();
 
-            const usedLines = recipe.ingredients.map(ing =>
-                `• ${MATERIAL_NAMES[ing.material] ?? ing.material} ×${ing.qty}` +
-                `  (remaining: ${h.materials[ing.material]})`
-            ).join('\n');
+            const usedLines = recipe.ingredients.map(ing => {
+                const remaining = getMat(ing.material);
+                return `• ${ALL_MAT_NAMES[ing.material] ?? ing.material} ×${ing.qty}  (remaining: ${remaining})`;
+            }).join('\n');
 
+            const isMineRecipe = Object.hasOwn(MINE_RECIPES, recipeId);
             const embed = new EmbedBuilder()
                 .setColor('#2ecc71')
                 .setTitle(`${recipe.emoji} Crafted: ${recipe.name}`)
                 .setDescription(`You crafted ${outputDesc}!`)
                 .addFields({ name: 'Materials Consumed', value: usedLines, inline: false })
-                .setFooter({ text: 'Use /hunt inv materials to check your remaining stock' })
+                .setFooter({ text: isMineRecipe ? 'Use /mine inv view to check mining stock' : 'Use /hunt inv materials to check your remaining stock' })
                 .setTimestamp();
 
             return interaction.reply({ embeds: [embed] });

--- a/src/commands/economy/craft.js
+++ b/src/commands/economy/craft.js
@@ -6,7 +6,7 @@ const Guild = require('../../models/Guild');
 const { CRAFT_RECIPES: HUNT_RECIPES, CONSUMABLES: HUNT_CONSUMABLES, MATERIAL_NAMES: HUNT_MATERIAL_NAMES } = require('../../data/huntData');
 const { CRAFT_RECIPES: MINE_RECIPES, CONSUMABLES: MINE_CONSUMABLES, MATERIAL_NAMES: MINE_MATERIAL_NAMES } = require('../../data/mineData');
 const { ensureHuntData } = require('../../services/huntService');
-const { ensureMineData, activateMineLock } = require('../../services/mineService');
+const { ensureMineData } = require('../../services/mineService');
 
 const ALL_RECIPES     = { ...HUNT_RECIPES, ...MINE_RECIPES };
 const ALL_MAT_NAMES   = { ...HUNT_MATERIAL_NAMES, ...MINE_MATERIAL_NAMES };
@@ -172,15 +172,16 @@ module.exports = {
                     outputDesc = '🐾 **Lucky Paw** — permanently +1% critical hit chance!';
                 }
             } else if (recipe.output.type === 'mine_consumable') {
-                if (recipe.output.id === 'mine_lock') {
-                    // Activate the mine lock immediately (last-write wins)
-                    activateMineLock(user);
-                    outputDesc = '🔒 **Mine Lock** — your mine is now protected from the next raid!';
-                } else {
-                    m.consumables[recipe.output.id] = (m.consumables[recipe.output.id] ?? 0) + recipe.output.qty;
-                    const def = MINE_CONSUMABLES[recipe.output.id];
-                    outputDesc = `${def?.emoji ?? '📦'} **${recipe.output.qty}× ${def?.name ?? recipe.output.id}**`;
+                // Guard: can't craft a mine_lock while one is already active
+                if (recipe.output.id === 'mine_lock' && m.mineLockActive) {
+                    return interaction.reply({
+                        content: 'Your mine already has an active **Mine Lock**. Use it up before crafting another.',
+                        ephemeral: true
+                    });
                 }
+                m.consumables[recipe.output.id] = (m.consumables[recipe.output.id] ?? 0) + recipe.output.qty;
+                const def = MINE_CONSUMABLES[recipe.output.id];
+                outputDesc = `${def?.emoji ?? '📦'} **${recipe.output.qty}× ${def?.name ?? recipe.output.id}**`;
             } else if (recipe.output.type === 'mine_charge') {
                 m.charges[recipe.output.id] = (m.charges[recipe.output.id] ?? 0) + recipe.output.qty;
                 outputDesc = `💥 **${recipe.output.qty}× ${recipe.output.id.replace(/_/g, ' ')}** (mine charge)`;

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -10,8 +10,7 @@ const {
     MATERIAL_NAMES, CONSUMABLES, BLAST_PACKS,
     PICKAXE_TIERS, PICKAXE_BY_SLUG, PICKAXE_UPGRADES,
     MINER_LEVELS, PRESTIGE_BONUSES, MINE_QUEST_TEMPLATES,
-    RAID_COOLDOWN_MS, RAID_SHIELD_MS, RAID_STEAL_MIN, RAID_STEAL_MAX,
-    MINE_LOCK_DURATION_MS
+    RAID_COOLDOWN_MS, RAID_SHIELD_MS, RAID_STEAL_MIN, RAID_STEAL_MAX
 } = require('../../data/mineData');
 const { checkAndAward, announceAchievements } = require('../../services/achievementService');
 const { TIER_NUM, TIER_RIBBON } = require('../../data/materialRarity');
@@ -1681,10 +1680,12 @@ async function handleRaid(interaction) {
 
     // Mine Lock: defender is protected
     if (defender.mining.mineLockActive) {
-        // Consume the lock on first raid attempt
+        // Consume the lock on first raid attempt; enforce cooldown on raider
         defender.mining.mineLockActive = false;
         defender.markModified('mining');
-        await defender.save().catch(() => null);
+        raider.mining.lastRaidSent = new Date();
+        raider.markModified('mining');
+        await Promise.all([defender.save(), raider.save()]).catch(() => null);
         return interaction.reply({
             embeds: [new EmbedBuilder()
                 .setColor('#e74c3c')

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -9,7 +9,9 @@ const {
     DEPTHS, DEPTH_LIST, TIER_COLORS, LIMITS, PICKAXE_BY_TIER,
     MATERIAL_NAMES, CONSUMABLES, BLAST_PACKS,
     PICKAXE_TIERS, PICKAXE_BY_SLUG, PICKAXE_UPGRADES,
-    MINER_LEVELS, PRESTIGE_BONUSES, MINE_QUEST_TEMPLATES
+    MINER_LEVELS, PRESTIGE_BONUSES, MINE_QUEST_TEMPLATES,
+    RAID_COOLDOWN_MS, RAID_SHIELD_MS, RAID_STEAL_MIN, RAID_STEAL_MAX,
+    MINE_LOCK_DURATION_MS
 } = require('../../data/mineData');
 const { checkAndAward, announceAchievements } = require('../../services/achievementService');
 const { TIER_NUM, TIER_RIBBON } = require('../../data/materialRarity');
@@ -31,7 +33,12 @@ const {
     activateConsumable,
     applyRepair,
     updatePickaxeStatus,
-    applyXp
+    applyXp,
+    updateMineMap,
+    renderMineMap,
+    getOreStashSummary,
+    isOreStashEmpty,
+    activateMineLock
 } = require('../../services/mineService');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
 const { getDailyFeatured, FEATURED_PAYOUT_BONUS } = require('../../data/featuredRotation');
@@ -107,6 +114,16 @@ module.exports = {
                                 .setDescription('Quest to claim')
                                 .setRequired(true)
                                 .addChoices(...MINE_QUEST_TEMPLATES.map(t => ({ name: t.name, value: t.id }))))))
+        .addSubcommand(sub =>
+            sub.setName('map')
+                .setDescription('View your persistent mine map — see every cell you have excavated.'))
+        .addSubcommand(sub =>
+            sub.setName('raid')
+                .setDescription('Raid another miner\'s mine and steal unprocessed ore (requires pickaxe equipped)')
+                .addUserOption(o =>
+                    o.setName('target')
+                        .setDescription('The miner to raid')
+                        .setRequired(true)))
         .addSubcommandGroup(group =>
             group.setName('shop')
                 .setDescription('Browse and purchase all mining gear, charges, and supplies')
@@ -183,6 +200,8 @@ module.exports = {
         if (!group) {
             if (sub === 'dig')     return handleDig(interaction);
             if (sub === 'profile') return handleProfile(interaction);
+            if (sub === 'map')     return handleMap(interaction);
+            if (sub === 'raid')    return handleRaid(interaction);
         }
         if (group === 'inv')    return handleInv(interaction, sub);
         if (group === 'quests') return handleQuests(interaction, sub);
@@ -520,6 +539,9 @@ async function handleDig(interaction) {
 
     updateMineQuestProgress(user, result, depthId);
 
+    // Update the persistent mine map with this dig's result
+    updateMineMap(user, result);
+
     const mineAchievements = await checkAndAward(user, guildSettings).catch(() => []);
 
     try {
@@ -598,6 +620,23 @@ async function handleDig(interaction) {
             )
             .setTimestamp();
         announceChannel.send({ embeds: [announcementEmbed] }).catch(() => null);
+    }
+
+    // Catastrophic cave-in server announcement (Deep or Abyss intensity, pickaxe destroyed)
+    if (result.caveIn && result.pickaxeBroke && chosenIntensity.level >= 4 && guildSettings?.economy?.announceRareDrops !== false) {
+        const announceChannelId = guildSettings?.economy?.announcementChannelId;
+        const resolved = announceChannelId ? interaction.guild.channels.cache.get(announceChannelId) : null;
+        const announceChannel = resolved?.isTextBased() ? resolved : interaction.channel;
+        const caveEmbed = new EmbedBuilder()
+            .setColor('#b5651d')
+            .setTitle('💥 Catastrophic Cave-in!')
+            .setDescription(
+                `<@${interaction.user.id}> just suffered a **catastrophic cave-in** at Depth **${chosenIntensity.name}** (${depth.name})!\n` +
+                `Their **${pickaxe.name}** has been destroyed.\n\n` +
+                `*Others are warned: the tunnel grows less stable the deeper you go.*`
+            )
+            .setTimestamp();
+        announceChannel.send({ embeds: [caveEmbed] }).catch(() => null);
     }
 }
 
@@ -1514,3 +1553,206 @@ function formatExpiry(ms) {
     if (hrs > 0) return `${hrs}h ${mins}m`;
     return `${mins}m`;
 }
+
+// ─── MAP ──────────────────────────────────────────────────────────────────────
+
+async function handleMap(interaction) {
+    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    if (guildSettings?.economy?.enabled === false) {
+        return interaction.reply({ content: 'The economy is disabled on this server.', ephemeral: true });
+    }
+
+    const user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+    if (!user) {
+        return interaction.reply({
+            content: "You haven't started mining yet! Use `/mine dig` to begin.",
+            ephemeral: true
+        });
+    }
+    ensureMineData(user);
+    const m = user.mining;
+
+    const grid     = renderMineMap(user);
+    const depth    = DEPTHS[m.activeDepth];
+    const mapSize  = 10;
+    const explored = (m.mineMap ?? []).filter(c => c !== 0).length;
+    const total    = mapSize * mapSize;
+
+    // Compute depth level proxy from miner level for the yield multiplier hint
+    const intensityHint = m.level >= 40 ? '2.0×–3.0×' : m.level >= 20 ? '1.4×–2.0×' : '1.0×–1.4×';
+
+    const stashLines = getOreStashSummary(user).map(([id, qty]) => `${MATERIAL_NAMES[id] ?? id}: **${qty}**`);
+
+    const embed = new EmbedBuilder()
+        .setColor('#8B4513')
+        .setTitle(`🗺️ ${interaction.user.username}'s Mine Map`)
+        .setDescription(`\`\`\`\n${grid}\n\`\`\`\n` +
+            `${depth ? `**Depth:** ${depth.emoji} ${depth.name}` : ''} | **Yield range:** ${intensityHint}`)
+        .addFields(
+            {
+                name: '📊 Excavation Progress',
+                value: `${explored}/${total} cells explored`,
+                inline: true
+            },
+            {
+                name: '📦 Unprocessed Ore Stash',
+                value: stashLines.length
+                    ? stashLines.join('\n') + '\n*Can be stolen by raiders!*'
+                    : 'Empty — ore stash fills as you mine veins.',
+                inline: true
+            },
+            {
+                name: '🔑 Legend',
+                value: '🪨 Unexplored  ⬛ Excavated  💎 Ore Vein  💥 Cave-in  ⛏️ You',
+                inline: false
+            }
+        )
+        .setFooter({ text: 'Mine more to expand your map • Use /mine raid to steal from others' })
+        .setTimestamp();
+
+    if (m.mineLockActive) {
+        embed.addFields({ name: '🔒 Mine Lock', value: 'Active — your mine is protected from raiders.', inline: true });
+    }
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+// ─── RAID ─────────────────────────────────────────────────────────────────────
+
+async function handleRaid(interaction) {
+    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    if (guildSettings?.economy?.enabled === false) {
+        return interaction.reply({ content: 'The economy is disabled on this server.', ephemeral: true });
+    }
+
+    const targetUser = interaction.options.getUser('target');
+    if (targetUser.id === interaction.user.id) {
+        return interaction.reply({ content: "You can't raid your own mine.", ephemeral: true });
+    }
+
+    const [raider, defender] = await Promise.all([
+        User.findOneAndUpdate(
+            { userId: interaction.user.id, guildId: interaction.guild.id },
+            { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
+            { upsert: true, new: true }
+        ),
+        User.findOne({ userId: targetUser.id, guildId: interaction.guild.id })
+    ]);
+
+    ensureMineData(raider);
+
+    if (!defender) {
+        return interaction.reply({
+            content: `${targetUser.username} hasn't started mining yet — nothing to raid.`,
+            ephemeral: true
+        });
+    }
+    ensureMineData(defender);
+
+    // Raider cooldown
+    const now = Date.now();
+    if (raider.mining.lastRaidSent && now - raider.mining.lastRaidSent.getTime() < RAID_COOLDOWN_MS) {
+        const nextAt = new Date(raider.mining.lastRaidSent.getTime() + RAID_COOLDOWN_MS);
+        const remaining = formatMs(nextAt.getTime() - now);
+        return interaction.reply({
+            content: `You need to wait **${remaining}** before raiding again.`,
+            ephemeral: true
+        });
+    }
+
+    // Defender shield (recently raided)
+    if (defender.mining.lastRaidReceived && now - defender.mining.lastRaidReceived.getTime() < RAID_SHIELD_MS) {
+        const shieldEnds = new Date(defender.mining.lastRaidReceived.getTime() + RAID_SHIELD_MS);
+        const remaining  = formatMs(shieldEnds.getTime() - now);
+        return interaction.reply({
+            content: `**${targetUser.username}**'s mine is still recovering from a recent raid. Wait **${remaining}**.`,
+            ephemeral: true
+        });
+    }
+
+    // Raider must have a pickaxe equipped
+    const rm = raider.mining;
+    if (rm.equippedPickaxeIndex < 0 || !rm.pickaxes[rm.equippedPickaxeIndex]) {
+        return interaction.reply({
+            content: "You need a pickaxe equipped to raid! Use `/mine inv equip`.",
+            ephemeral: true
+        });
+    }
+
+    // Mine Lock: defender is protected
+    if (defender.mining.mineLockActive) {
+        // Consume the lock on first raid attempt
+        defender.mining.mineLockActive = false;
+        defender.markModified('mining');
+        await defender.save().catch(() => null);
+        return interaction.reply({
+            embeds: [new EmbedBuilder()
+                .setColor('#e74c3c')
+                .setTitle('🔒 Mine Lock Triggered!')
+                .setDescription(
+                    `**${targetUser.username}**'s mine was protected by a **Mine Lock**.\n` +
+                    `The lock absorbed your raid attempt and has now been consumed.`
+                )
+                .setTimestamp()
+            ]
+        });
+    }
+
+    // Check if there's anything to steal
+    if (isOreStashEmpty(defender)) {
+        return interaction.reply({
+            content: `**${targetUser.username}**'s ore stash is empty — nothing worth raiding.`,
+            ephemeral: true
+        });
+    }
+
+    // Execute the raid: steal RAID_STEAL_MIN–RAID_STEAL_MAX of each stash material
+    const stealFraction = RAID_STEAL_MIN + Math.random() * (RAID_STEAL_MAX - RAID_STEAL_MIN);
+    const stolen = {};
+    const dm = defender.mining;
+
+    for (const [matId, qty] of Object.entries(dm.oreStash ?? {})) {
+        if (qty <= 0) continue;
+        const take = Math.max(1, Math.floor(qty * stealFraction));
+        stolen[matId] = take;
+        dm.oreStash[matId] = qty - take;
+        // Transfer to raider's materials
+        if (!rm.materials[matId]) rm.materials[matId] = 0;
+        rm.materials[matId] += take;
+    }
+    defender.markModified('mining');
+    raider.mining.lastRaidSent = new Date();
+    defender.mining.lastRaidReceived = new Date();
+    raider.markModified('mining');
+
+    await Promise.all([raider.save(), defender.save()]).catch(err => console.error('[mine raid] save error:', err));
+
+    const stolenLines = Object.entries(stolen).map(([id, qty]) => `• ${MATERIAL_NAMES[id] ?? id} ×${qty}`).join('\n');
+    const pct = Math.round(stealFraction * 100);
+
+    const embed = new EmbedBuilder()
+        .setColor('#e67e22')
+        .setTitle('⚔️ Mine Raided!')
+        .setDescription(
+            `You broke into **${targetUser.username}**'s mine and made off with **${pct}%** of their ore stash!\n\n` +
+            `**Stolen:**\n${stolenLines}`
+        )
+        .setFooter({ text: `${targetUser.username} now has a 1-hour raid shield • Use /mine map to see your stash` })
+        .setTimestamp();
+
+    await interaction.reply({ embeds: [embed] });
+
+    // Notify defender if possible
+    const dmEmbed = new EmbedBuilder()
+        .setColor('#e74c3c')
+        .setTitle('⚠️ Your Mine Was Raided!')
+        .setDescription(
+            `**${interaction.user.username}** broke into your mine on **${interaction.guild.name}** ` +
+            `and stole **${pct}%** of your ore stash!\n\n` +
+            `**Lost:**\n${stolenLines}\n\n` +
+            `Craft a **Mine Lock** (\`/craft make mine_lock_from_obsidian\`) to protect yourself next time.`
+        )
+        .setTimestamp();
+    targetUser.send({ embeds: [dmEmbed] }).catch(() => null);
+}
+

--- a/src/data/mineData.js
+++ b/src/data/mineData.js
@@ -146,6 +146,12 @@ const CONSUMABLES = {
         effect: { xpMultiplier: 0.50 },
         description: '+50% XP on next mine',
         maxStack: 10
+    },
+    mine_lock: {
+        id: 'mine_lock', name: 'Mine Lock', emoji: '🔒',
+        cost: 400, type: 'defense',
+        description: 'Protects your mine from being raided for 24 hours',
+        maxStack: 3
     }
 };
 
@@ -550,6 +556,51 @@ const CRAFT_RECIPES = {
             { material: 'amethyst_chip', qty: 2 }
         ],
         output: { type: 'consumable', id: 'miners_instinct', qty: 3 }
+    },
+    repair_kit_from_iron: {
+        id: 'repair_kit_from_iron', name: 'Repair Kit (Small)', emoji: '🔧',
+        description: 'Forge a Repair Kit from Iron Ore filings',
+        ingredients: [
+            { material: 'iron_filing', qty: 3 },
+            { material: 'rock_fragment', qty: 2 }
+        ],
+        output: { type: 'consumable', id: 'repair_kit_small', qty: 1 }
+    },
+    lucky_charm_from_gold: {
+        id: 'lucky_charm_from_gold', name: 'Premium Magnet (Lucky Charm)', emoji: '🍀',
+        description: 'Craft a Premium Magnet from Gold Nuggets — a miner\'s lucky charm',
+        ingredients: [
+            { material: 'gold_nugget', qty: 3 },
+            { material: 'quartz_shard', qty: 2 }
+        ],
+        output: { type: 'consumable', id: 'premium_magnet', qty: 1 }
+    },
+    xp_booster_from_crystal: {
+        id: 'xp_booster_from_crystal', name: 'XP Booster (Scroll)', emoji: '🔮',
+        description: 'Infuse Crystal Slivers into an XP Scroll for double gains',
+        ingredients: [
+            { material: 'crystal_sliver', qty: 2 },
+            { material: 'raw_sapphire',   qty: 1 }
+        ],
+        output: { type: 'consumable', id: 'xp_scroll', qty: 2 }
+    },
+    void_charge_from_mythril: {
+        id: 'void_charge_from_mythril', name: 'Void Charge Pack (Mythril)', emoji: '🔷',
+        description: 'Forge exclusive Void Charges from rare Mythril Dust — not sold in shop',
+        ingredients: [
+            { material: 'mythril_dust',  qty: 2 },
+            { material: 'void_essence',  qty: 1 }
+        ],
+        output: { type: 'mine_charge', id: 'void_charge', qty: 5 }
+    },
+    mine_lock_from_obsidian: {
+        id: 'mine_lock_from_obsidian', name: 'Mine Lock', emoji: '🔒',
+        description: 'Craft a Mine Lock from Obsidian to protect your mine from raiders',
+        ingredients: [
+            { material: 'obsidian_chip', qty: 2 },
+            { material: 'iron_filing',   qty: 3 }
+        ],
+        output: { type: 'mine_consumable', id: 'mine_lock', qty: 1 }
     }
 };
 
@@ -671,5 +722,22 @@ module.exports = {
     PRESTIGE_BONUSES,
     MATERIAL_NAMES,
     CRAFT_RECIPES,
-    MINE_QUEST_TEMPLATES
+    MINE_QUEST_TEMPLATES,
+
+    // Map cell visual constants (exported for use in mine.js)
+    MAP_CELL: {
+        ROCK:    0,  // unexplored: 🪨
+        DUG:     1,  // excavated:  ⬛
+        ORE:     2,  // ore vein:   💎
+        CAVE_IN: 3,  // cave-in:    💥
+    },
+    MAP_EMOJI: ['🪨', '⬛', '💎', '💥'],
+    MAP_SIZE:  10,
+
+    // Raid constants
+    RAID_COOLDOWN_MS:       30 * 60_000,  // 30 min between raids sent
+    RAID_SHIELD_MS:         60 * 60_000,  // 1 hr immunity after being raided
+    RAID_STEAL_MIN:         0.05,
+    RAID_STEAL_MAX:         0.20,
+    MINE_LOCK_DURATION_MS:  24 * 3_600_000
 };

--- a/src/data/mineData.js
+++ b/src/data/mineData.js
@@ -150,7 +150,7 @@ const CONSUMABLES = {
     mine_lock: {
         id: 'mine_lock', name: 'Mine Lock', emoji: '🔒',
         cost: 400, type: 'defense',
-        description: 'Protects your mine from being raided for 24 hours',
+        description: 'Blocks the next raid attempt on your mine; consumed on first use',
         maxStack: 3
     }
 };
@@ -735,9 +735,8 @@ module.exports = {
     MAP_SIZE:  10,
 
     // Raid constants
-    RAID_COOLDOWN_MS:       30 * 60_000,  // 30 min between raids sent
-    RAID_SHIELD_MS:         60 * 60_000,  // 1 hr immunity after being raided
-    RAID_STEAL_MIN:         0.05,
-    RAID_STEAL_MAX:         0.20,
-    MINE_LOCK_DURATION_MS:  24 * 3_600_000
+    RAID_COOLDOWN_MS:  30 * 60_000,  // 30 min between raids sent
+    RAID_SHIELD_MS:    60 * 60_000,  // 1 hr immunity after being raided
+    RAID_STEAL_MIN:    0.05,
+    RAID_STEAL_MAX:    0.20
 };

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -401,7 +401,20 @@ const userSchema = new Schema({
 
         dailyCoins:       { type: Number, default: 0 },
         dailyMines:       { type: Number, default: 0 },
-        dailyWindowStart: { type: Date,   default: null }
+        dailyWindowStart: { type: Date,   default: null },
+
+        // Persistent mine map (10×10 grid stored as flat array of 100 cell codes)
+        // Cell codes: 0=unexplored, 1=excavated, 2=ore-vein, 3=cave-in
+        mineMap:          [{ type: Number, default: 0 }],
+        mineMapRow:       { type: Number, default: 5 },
+        mineMapCol:       { type: Number, default: 5 },
+        // Unprocessed ore stash — stolen during raids (material id → quantity map)
+        oreStash:         { type: Object, default: {} },
+        // Raid cooldowns
+        lastRaidSent:     { type: Date, default: null },
+        lastRaidReceived: { type: Date, default: null },
+        // Mine Lock consumable stock
+        mineLockActive:   { type: Boolean, default: false }
     },
     // ─────────────────────────────────────────────────────────────────────────
 

--- a/src/services/mineService.js
+++ b/src/services/mineService.js
@@ -61,6 +61,17 @@ function ensureMineData(user) {
     if (!m.unlockedDepths.includes('surface_quarry')) {
         m.unlockedDepths.push('surface_quarry');
     }
+
+    // Mine map: 10×10 flat array; initialise once then persist
+    const MAP_SIZE = 10;
+    if (!Array.isArray(m.mineMap) || m.mineMap.length !== MAP_SIZE * MAP_SIZE) {
+        m.mineMap = new Array(MAP_SIZE * MAP_SIZE).fill(0);
+    }
+    if (m.mineMapRow == null) m.mineMapRow = 5;
+    if (m.mineMapCol == null) m.mineMapCol = 5;
+    if (!m.oreStash)          m.oreStash = {};
+    if (m.mineLockActive == null) m.mineLockActive = false;
+
     user.markModified('mining');
 }
 
@@ -730,6 +741,90 @@ function durabilityBar(current, max, length = 10) {
     return '█'.repeat(filled) + '░'.repeat(length - filled);
 }
 
+// ─── MINE MAP ─────────────────────────────────────────────────────────────────
+
+const MAP_SIZE = 10;
+// Cell codes
+const CELL = { ROCK: 0, DUG: 1, ORE: 2, CAVE_IN: 3 };
+
+function updateMineMap(user, result) {
+    const m = user.mining;
+    if (!Array.isArray(m.mineMap) || m.mineMap.length !== MAP_SIZE * MAP_SIZE) {
+        m.mineMap = new Array(MAP_SIZE * MAP_SIZE).fill(0);
+    }
+
+    const row = m.mineMapRow ?? 5;
+    const col = m.mineMapCol ?? 5;
+    const idx = row * MAP_SIZE + col;
+
+    if (result.caveIn) {
+        m.mineMap[idx] = CELL.CAVE_IN;
+    } else if (result.success && result.ore) {
+        m.mineMap[idx] = CELL.ORE;
+        // Accumulate ore stash for raiding
+        const matId = result.specialDrop?.itemId;
+        if (matId) {
+            if (!m.oreStash) m.oreStash = {};
+            m.oreStash[matId] = (m.oreStash[matId] ?? 0) + 1;
+        }
+    } else {
+        m.mineMap[idx] = CELL.DUG;
+    }
+
+    // Move miner to an adjacent unexplored cell if possible; otherwise wander freely
+    const adjacent = [
+        { r: row - 1, c: col }, { r: row + 1, c: col },
+        { r: row, c: col - 1 }, { r: row, c: col + 1 }
+    ].filter(({ r, c }) => r >= 0 && r < MAP_SIZE && c >= 0 && c < MAP_SIZE);
+
+    const unexplored = adjacent.filter(({ r, c }) => m.mineMap[r * MAP_SIZE + c] === CELL.ROCK);
+    const candidates = unexplored.length ? unexplored : adjacent;
+    const next = candidates[Math.floor(Math.random() * candidates.length)];
+    m.mineMapRow = next.r;
+    m.mineMapCol = next.c;
+
+    user.markModified('mining');
+}
+
+function renderMineMap(user) {
+    const m = user.mining;
+    const EMOJI = ['🪨', '⬛', '💎', '💥'];
+    const rows = [];
+    const row = m.mineMapRow ?? 5;
+    const col = m.mineMapCol ?? 5;
+
+    for (let r = 0; r < MAP_SIZE; r++) {
+        let line = '';
+        for (let c = 0; c < MAP_SIZE; c++) {
+            if (r === row && c === col) {
+                line += '⛏️';
+            } else {
+                line += EMOJI[m.mineMap[r * MAP_SIZE + c] ?? 0];
+            }
+        }
+        rows.push(line);
+    }
+    return rows.join('\n');
+}
+
+// ─── ORE STASH ────────────────────────────────────────────────────────────────
+
+function getOreStashSummary(user) {
+    const stash = user.mining?.oreStash ?? {};
+    return Object.entries(stash).filter(([, qty]) => qty > 0);
+}
+
+function isOreStashEmpty(user) {
+    return getOreStashSummary(user).length === 0;
+}
+
+// ─── MINE LOCK ────────────────────────────────────────────────────────────────
+
+function activateMineLock(user) {
+    user.mining.mineLockActive = true;
+    user.markModified('mining');
+}
+
 module.exports = {
     ensureMineData,
     getMaxStamina,
@@ -756,5 +851,10 @@ module.exports = {
     updateMineQuestProgress,
     formatMs,
     pickaxeStatusEmoji,
-    durabilityBar
+    durabilityBar,
+    updateMineMap,
+    renderMineMap,
+    getOreStashSummary,
+    isOreStashEmpty,
+    activateMineLock
 };


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive raiding system for the mining economy, allowing players to steal ore from other miners' stashes. It also adds a persistent mine map that visualizes excavation progress and tracks unprocessed ore inventory vulnerable to raids.

## Key Changes

### Mine Raiding System (`/mine raid`)
- New subcommand to raid another player's mine and steal unprocessed ore (5–20% of their stash)
- Raider cooldown: 30 minutes between raids
- Defender shield: 1-hour immunity after being raided
- Requires equipped pickaxe to raid
- **Mine Lock consumable** provides one-time protection against raids (consumed on first raid attempt)
- Raid notifications sent to defender via DM
- Catastrophic cave-in announcements for Deep/Abyss intensity pickaxe destruction

### Mine Map System (`/mine map`)
- New subcommand displaying a 10×10 persistent grid of excavation progress
- Visual cell states: 🪨 (unexplored), ⬛ (excavated), 💎 (ore vein), 💥 (cave-in), ⛏️ (current position)
- Tracks unprocessed ore stash with raid vulnerability warning
- Shows excavation progress (cells explored / total)
- Displays active Mine Lock status
- Miner position updates after each dig, preferring unexplored adjacent cells

### Crafting Integration
- **Mine Lock recipe** (`mine_lock_from_obsidian`): 2× Obsidian Chip + 3× Iron Filing → 1× Mine Lock
- Unified crafting system now supports both hunt and mine materials/consumables
- Mine consumables and charges integrated into `/craft` command
- Material consumption prioritizes hunt inventory first, then mine inventory

### Data Model Updates
- Added `mineMap` (100-cell flat array), `mineMapRow`, `mineMapCol` to track persistent grid state
- Added `oreStash` object to store unprocessed ore by material ID
- Added `lastRaidSent`, `lastRaidReceived` timestamps for cooldown tracking
- Added `mineLockActive` boolean flag for raid protection status
- New raid constants: `RAID_COOLDOWN_MS`, `RAID_SHIELD_MS`, `RAID_STEAL_MIN/MAX`, `MINE_LOCK_DURATION_MS`

### Service Layer Enhancements
- `updateMineMap()`: Updates grid cell state and moves miner to adjacent unexplored cells
- `renderMineMap()`: Generates ASCII visualization of the mine grid
- `getOreStashSummary()` / `isOreStashEmpty()`: Query ore stash state
- `activateMineLock()`: Activates raid protection on a user

## Notable Implementation Details
- Mine map uses a flat 100-element array (10×10) with cell codes for efficient storage
- Ore stash accumulates only from successful ore vein digs (not rock excavations)
- Raider position advances intelligently: prefers unexplored adjacent cells, falls back to any adjacent cell
- Raid steal fraction is randomized per raid (5–20%), applied uniformly to all materials in stash
- Mine Lock is a consumable that activates immediately upon crafting (last-write-wins pattern)
- Unified material pool across hunt and mine skills for crafting ingredient checks

https://claude.ai/code/session_01DzGqWCt5hbnfX2j6KkKNMq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Craft command now unified: hunting and mining recipes available together with combined material inventory.
  * New mine map feature displaying persistent excavation grid and ore stash summary.
  * Raid system enables stealing ore from other miners with cooldown protection.
  * Mine lock consumable provides 24-hour stash protection.
  * Catastrophic cave-in announcements when pickaxe is destroyed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->