### PR TITLE
Implement trap system, achievement broadcasts, and multiplier breakdowns

### DIFF
--- a/src/commands/economy/crime.js
+++ b/src/commands/economy/crime.js
@@ -7,6 +7,7 @@ const { clampMultiplier } = require('../../config/economy');
 const { logTransaction } = require('../../utils/logTransaction');
 const { getTotalBonus } = require('../../services/petService');
 const { randomFrom, CRIME_WIN_LINES, CRIME_BUST_LINES, getCrimeFlavorText } = require('../../utils/copyLines');
+const { stackBar } = require('../../utils/rewardReveal');
 const { delay } = require('../../utils/delay');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
 const { getDailyFeatured, FEATURED_PAYOUT_BONUS } = require('../../data/featuredRotation');
@@ -186,8 +187,12 @@ module.exports = {
                 if (luckyActive) desc += `\n> 🍀 *Lucky Charm boosted your success chance!*`;
                 if (petCrimeBonus > 0) desc += `\n> 🐱 *Cat pet boosted your success chance!*`;
                 if (isFeaturedCrime) desc += `\n> 🌟 *Featured job — +${Math.round(FEATURED_PAYOUT_BONUS * 100)}% payout applied!*`;
-                desc += `\n\n────────────────────\n  ${currency} Earned: ${earned.toLocaleString()} coins`;
-                if (streakMult > 1.0) desc += `\n  🔥 Streak bonus: ${streakMult}x applied`;
+                const crimeMultEntries = [];
+                if (streakMult > 1.0) crimeMultEntries.push({ emoji: '🔥', label: `${streakMult.toFixed(2)}x` });
+                if (isFeaturedCrime)  crimeMultEntries.push({ emoji: '🌟', label: `+${Math.round(FEATURED_PAYOUT_BONUS * 100)}%` });
+                const crimeBar = stackBar(crimeMultEntries, streakMult * (isFeaturedCrime ? 1 + FEATURED_PAYOUT_BONUS : 1), earned, currency);
+                desc += `\n\n────────────────────\n  ${currency} Earned: **${earned.toLocaleString()} coins**`;
+                if (crimeBar) desc += `\n  ${crimeBar}`;
                 desc += `\n────────────────────\n  Balance: ${updated.balance.toLocaleString()} coins`;
 
                 embed = new EmbedBuilder()

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -995,10 +995,11 @@ function buildCastEmbed(result, user, location, rod, currency, discordUser) {
 
         const fishMultEntries = [];
         if ((result.streakMult ?? 1) > 1.0) fishMultEntries.push({ emoji: '🔥', label: `${(result.streakMult).toFixed(2)}x` });
-        if (isCrit)                          fishMultEntries.push({ emoji: '⚡', label: `${critMultiplier}x crit` });
+        if (isCrit)                          fishMultEntries.push({ emoji: '⚡', label: `${critMultiplier.toFixed(2)}x crit` });
         if (fishMultEntries.length > 0) {
-            const fishCombined = (result.streakMult ?? 1) * critMultiplier;
-            embed.addFields({ name: '📈 Multipliers', value: stackBar(fishMultEntries, fishCombined, finalPayout, currency), inline: false });
+            const fishCombined  = (result.streakMult ?? 1) * critMultiplier;
+            const preBonusPayout = finalPayout - (result.petYieldBonus ?? 0) - (result.featuredSpotBonus ?? 0);
+            embed.addFields({ name: '📈 Multipliers', value: stackBar(fishMultEntries, fishCombined, Math.max(0, preBonusPayout), currency), inline: false });
         }
 
         // Fish traits display

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -49,6 +49,7 @@ const { ensureHuntData } = require('../../services/huntService');
 const { TIER_NUM, TIER_RIBBON } = require('../../data/materialRarity');
 const { randomFrom, FISH_MISS_POOL } = require('../../utils/copyLines');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
+const { stackBar } = require('../../utils/rewardReveal');
 const { submitCatch: submitTournamentCatch, getActiveTournament, buildLeaderboardEmbed, endTournament, buildWinnersEmbed } = require('../../services/tournamentService');
 const { getDailyFeatured, FEATURED_PAYOUT_BONUS, FEATURED_RARE_BONUS } = require('../../data/featuredRotation');
 const { getTimeBand } = require('../../utils/timeBand');
@@ -992,7 +993,13 @@ function buildCastEmbed(result, user, location, rod, currency, discordUser) {
                 { name: 'Stamina',  value: buildStaminaLine(user),                   inline: true }
             );
 
-        if (isCrit) embed.addFields({ name: 'Crit Multiplier', value: `×${critMultiplier}`, inline: true });
+        const fishMultEntries = [];
+        if ((result.streakMult ?? 1) > 1.0) fishMultEntries.push({ emoji: '🔥', label: `${(result.streakMult).toFixed(2)}x` });
+        if (isCrit)                          fishMultEntries.push({ emoji: '⚡', label: `${critMultiplier}x crit` });
+        if (fishMultEntries.length > 0) {
+            const fishCombined = (result.streakMult ?? 1) * critMultiplier;
+            embed.addFields({ name: '📈 Multipliers', value: stackBar(fishMultEntries, fishCombined, finalPayout, currency), inline: false });
+        }
 
         // Fish traits display
         if (result.traitEffects?.length) {

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -41,6 +41,7 @@ const {
     applyXp
 } = require('../../services/huntService');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
+const { stackBar } = require('../../utils/rewardReveal');
 const { getDailyFeatured, FEATURED_PAYOUT_BONUS, FEATURED_RARE_BONUS } = require('../../data/featuredRotation');
 const { getTimeBand } = require('../../utils/timeBand');
 const { logBigWin } = require('../../utils/bigWinLogger');
@@ -797,8 +798,13 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
                 { name: 'Stamina',  value: buildStaminaLine(user),                inline: true }
             );
 
-        if (isCrit) {
-            embed.addFields({ name: 'Crit Multiplier', value: `×${critMultiplier}`, inline: true });
+        const huntMultEntries = [];
+        if ((result.streakMult ?? 1) > 1.0) huntMultEntries.push({ emoji: '🔥', label: `${(result.streakMult).toFixed(2)}x` });
+        if (isCrit)                          huntMultEntries.push({ emoji: '⚡', label: `${critMultiplier}x crit` });
+        if (trophyQuality && trophyQuality.multiplier > 1.0) huntMultEntries.push({ emoji: trophyQuality.emoji, label: `${trophyQuality.multiplier.toFixed(2)}x` });
+        if (huntMultEntries.length > 0) {
+            const combined = (result.streakMult ?? 1) * critMultiplier * (trophyQuality?.multiplier ?? 1);
+            embed.addFields({ name: '📈 Multipliers', value: stackBar(huntMultEntries, combined, finalPayout, currency), inline: false });
         }
 
         if (traits && traits.length > 0) {

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -800,7 +800,7 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
 
         const huntMultEntries = [];
         if ((result.streakMult ?? 1) > 1.0) huntMultEntries.push({ emoji: '🔥', label: `${(result.streakMult).toFixed(2)}x` });
-        if (isCrit)                          huntMultEntries.push({ emoji: '⚡', label: `${critMultiplier}x crit` });
+        if (isCrit)                          huntMultEntries.push({ emoji: '⚡', label: `${critMultiplier.toFixed(2)}x crit` });
         if (trophyQuality && trophyQuality.multiplier > 1.0) huntMultEntries.push({ emoji: trophyQuality.emoji, label: `${trophyQuality.multiplier.toFixed(2)}x` });
         if (huntMultEntries.length > 0) {
             const combined = (result.streakMult ?? 1) * critMultiplier * (trophyQuality?.multiplier ?? 1);

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -40,6 +40,7 @@ const {
     activateMineLock
 } = require('../../services/mineService');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
+const { stackBar } = require('../../utils/rewardReveal');
 const { getDailyFeatured, FEATURED_PAYOUT_BONUS } = require('../../data/featuredRotation');
 const { getTimeBand } = require('../../utils/timeBand');
 const { logBigWin } = require('../../utils/bigWinLogger');
@@ -1430,8 +1431,12 @@ function buildMineEmbed(result, user, depth, pickaxe, currency, discordUser) {
                 { name: 'Stamina',  value: buildStaminaLine(user),                  inline: true }
             );
 
-        if (isCrit) {
-            embed.addFields({ name: 'Crit Multiplier', value: `×${critMultiplier}`, inline: true });
+        const mineMultEntries = [];
+        if ((result.streakMult ?? 1) > 1.0) mineMultEntries.push({ emoji: '🔥', label: `${(result.streakMult).toFixed(2)}x` });
+        if (isCrit)                          mineMultEntries.push({ emoji: '⚡', label: `${critMultiplier}x crit` });
+        if (mineMultEntries.length > 0) {
+            const mineCombined = (result.streakMult ?? 1) * critMultiplier;
+            embed.addFields({ name: '📈 Multipliers', value: stackBar(mineMultEntries, mineCombined, finalPayout, currency), inline: false });
         }
 
         if (specialDrop) {

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -1433,7 +1433,7 @@ function buildMineEmbed(result, user, depth, pickaxe, currency, discordUser) {
 
         const mineMultEntries = [];
         if ((result.streakMult ?? 1) > 1.0) mineMultEntries.push({ emoji: '🔥', label: `${(result.streakMult).toFixed(2)}x` });
-        if (isCrit)                          mineMultEntries.push({ emoji: '⚡', label: `${critMultiplier}x crit` });
+        if (isCrit)                          mineMultEntries.push({ emoji: '⚡', label: `${critMultiplier.toFixed(2)}x crit` });
         if (mineMultEntries.length > 0) {
             const mineCombined = (result.streakMult ?? 1) * critMultiplier;
             embed.addFields({ name: '📈 Multipliers', value: stackBar(mineMultEntries, mineCombined, finalPayout, currency), inline: false });

--- a/src/commands/economy/rob.js
+++ b/src/commands/economy/rob.js
@@ -8,11 +8,12 @@ const { randomFrom, ROB_WIN_LINES, ROB_FAIL_LINES } = require('../../utils/copyL
 const { delay } = require('../../utils/delay');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
 
-const ROBBER_COOLDOWN_MS = 1 * 3_600_000; // 1 hour
-const VICTIM_IMMUNITY_MS = 30 * 60_000;   // 30 minutes
+const ROBBER_COOLDOWN_MS  = 1 * 3_600_000; // 1 hour
+const VICTIM_IMMUNITY_MS  = 30 * 60_000;   // 30 minutes
 const BASE_SUCCESS_CHANCE = 0.40;
-const ROB_STEAL_MIN = 0.10;
-const ROB_STEAL_MAX = 0.40;
+const ROB_STEAL_MIN       = 0.10;
+const ROB_STEAL_MAX       = 0.40;
+const TRAP_FINE_MULTIPLIER = 2;            // trap doubles the normal fine
 
 // Standalone MongoDB deployments don't support multi-doc transactions, so
 // persist both balances sequentially. If the victim save fails after the
@@ -184,6 +185,21 @@ module.exports = {
                 }
                 victim.lastRobbedAt = new Date();
                 if (padlockActive) consumeEffect(victim, 'padlock');
+
+                // ── Trap check ────────────────────────────────────────────────
+                const trapActive = victim.trap?.expiresAt && victim.trap.expiresAt > new Date();
+                let trapFine = 0;
+                if (trapActive) {
+                    // Compute doubled fine and apply it
+                    const normalFine = Math.floor(robber.balance * failFineRate);
+                    trapFine = Math.min(normalFine * TRAP_FINE_MULTIPLIER, robber.balance);
+                    robber.balance = Math.max(0, robber.balance - trapFine);
+                    victim.balance += trapFine;
+                    // Consume the trap
+                    victim.trap.setAt     = null;
+                    victim.trap.expiresAt = null;
+                }
+
                 const robAchievements = await checkAndAward(robber, guildSettings).catch(() => []);
                 await saveRobState(robber, victim, robberSnapshot);
                 if (robAchievements.length) {
@@ -191,19 +207,64 @@ module.exports = {
                 }
 
                 const bagNote = hasEffect(robber, 'robbery_bag') ? '\n> 💼 *Robbery Bag boosted your haul by 10%!*' : '';
-                embed = new EmbedBuilder()
-                    .setColor('#f39c12')
-                    .setTitle('🦹 Successful Heist!')
-                    .setDescription(`${randomFrom(ROB_WIN_LINES)} You took **${currency}${stolen.toLocaleString()}** from **${target.username}**.${bagNote}`)
-                    .addFields(
-                        { name: 'Your Balance', value: `${currency}${robber.balance.toLocaleString()}`, inline: true },
-                        { name: 'Their Balance', value: `${currency}${victim.balance.toLocaleString()}`, inline: true }
-                    )
-                    .setFooter({ text: 'Cooldown: 1h' })
-                    .setTimestamp();
 
-                if (padlockActive) {
-                    embed.addFields({ name: '🔒 Padlock Broken!', value: `${target.username}'s bank was protected, but their padlock is now gone!`, inline: false });
+                if (trapActive) {
+                    // Trap triggered: suspense then reveal the trap
+                    await interaction.editReply({
+                        embeds: [new EmbedBuilder()
+                            .setColor('#f39c12')
+                            .setTitle('🦹 Successful Heist!')
+                            .setDescription(`${randomFrom(ROB_WIN_LINES)} You took **${currency}${stolen.toLocaleString()}** from **${target.username}**.${bagNote}`)]
+                    });
+                    await delay(900);
+
+                    embed = new EmbedBuilder()
+                        .setColor('#e74c3c')
+                        .setTitle('💥 TRAP TRIGGERED!')
+                        .setDescription(
+                            `**${target.username}** set a **Tripwire**!\n\n` +
+                            `You stole **${currency}${stolen.toLocaleString()}** — but walked straight into their trap.\n` +
+                            `You paid a **2× fine** of **${currency}${trapFine.toLocaleString()}** back to them.`
+                        )
+                        .addFields(
+                            { name: 'Robber Balance', value: `${currency}${robber.balance.toLocaleString()}`,  inline: true },
+                            { name: 'Victim Balance', value: `${currency}${victim.balance.toLocaleString()}`, inline: true },
+                            { name: 'Fine Paid',      value: `${currency}${trapFine.toLocaleString()}`,       inline: true }
+                        )
+                        .setFooter({ text: 'Cooldown: 1h' })
+                        .setTimestamp();
+
+                    // Server-wide announcement
+                    const announceChannelId = guildSettings?.economy?.announcementChannelId;
+                    const announceChannel   = announceChannelId
+                        ? interaction.guild.channels.cache.get(announceChannelId)
+                        : null;
+                    if (announceChannel?.isTextBased()) {
+                        const trapAnnounce = new EmbedBuilder()
+                            .setColor('#e74c3c')
+                            .setTitle('🪤 Trap Sprung!')
+                            .setDescription(
+                                `<@${target.id}>'s trap just caught <@${interaction.user.id}> red-handed!\n\n` +
+                                `The robber paid **${currency}${trapFine.toLocaleString()}** for their trouble.`
+                            )
+                            .setTimestamp();
+                        announceChannel.send({ embeds: [trapAnnounce] }).catch(() => null);
+                    }
+                } else {
+                    embed = new EmbedBuilder()
+                        .setColor('#f39c12')
+                        .setTitle('🦹 Successful Heist!')
+                        .setDescription(`${randomFrom(ROB_WIN_LINES)} You took **${currency}${stolen.toLocaleString()}** from **${target.username}**.${bagNote}`)
+                        .addFields(
+                            { name: 'Your Balance', value: `${currency}${robber.balance.toLocaleString()}`, inline: true },
+                            { name: 'Their Balance', value: `${currency}${victim.balance.toLocaleString()}`, inline: true }
+                        )
+                        .setFooter({ text: 'Cooldown: 1h' })
+                        .setTimestamp();
+
+                    if (padlockActive) {
+                        embed.addFields({ name: '🔒 Padlock Broken!', value: `${target.username}'s bank was protected, but their padlock is now gone!`, inline: false });
+                    }
                 }
             } else {
                 const fine = Math.floor(robber.balance * failFineRate);

--- a/src/commands/economy/trap.js
+++ b/src/commands/economy/trap.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { logTransaction } = require('../../utils/logTransaction');
@@ -53,40 +53,49 @@ module.exports = {
             return interaction.reply({ embeds: [embed], ephemeral: true });
         }
 
-        // sub === 'set'
-        const trapActive = user.trap?.expiresAt && user.trap.expiresAt > new Date();
-        if (trapActive) {
-            const remaining = Math.ceil((user.trap.expiresAt - Date.now()) / 60_000);
-            return interaction.reply({
-                content: `You already have a trap set! It expires in **${remaining} min**. You can only have one active trap at a time.`,
-                ephemeral: true,
-            });
-        }
-
-        if (user.balance < TRAP_COST) {
-            return interaction.reply({
-                content: `You need **${currency}${TRAP_COST.toLocaleString()}** to set a trap but only have **${currency}${user.balance.toLocaleString()}**.`,
-                ephemeral: true,
-            });
-        }
-
+        // sub === 'set' — atomic: check balance + no active trap, deduct, arm in one query
         const now       = new Date();
         const expiresAt = new Date(Date.now() + TRAP_DURATION);
 
-        await User.findOneAndUpdate(
-            { userId: interaction.user.id, guildId: interaction.guild.id },
+        const updated = await User.findOneAndUpdate(
+            {
+                userId: interaction.user.id,
+                guildId: interaction.guild.id,
+                balance: { $gte: TRAP_COST },
+                $or: [
+                    { 'trap.expiresAt': null },
+                    { 'trap.expiresAt': { $lte: now } }
+                ]
+            },
             {
                 $inc: { balance: -TRAP_COST },
                 $set: { 'trap.setAt': now, 'trap.expiresAt': expiresAt }
-            }
+            },
+            { new: true }
         );
+
+        if (!updated) {
+            // Determine which guard failed for a helpful message
+            const trapActive = user.trap?.expiresAt && user.trap.expiresAt > new Date();
+            if (trapActive) {
+                const remaining = Math.ceil((user.trap.expiresAt - Date.now()) / 60_000);
+                return interaction.reply({
+                    content: `You already have a trap set! It expires in **${remaining} min**. You can only have one active trap at a time.`,
+                    flags: MessageFlags.Ephemeral,
+                });
+            }
+            return interaction.reply({
+                content: `You need **${currency}${TRAP_COST.toLocaleString()}** to set a trap but only have **${currency}${user.balance.toLocaleString()}**.`,
+                flags: MessageFlags.Ephemeral,
+            });
+        }
 
         logTransaction({
             userId: interaction.user.id,
             guildId: interaction.guild.id,
             type: 'trap_set',
             amount: -TRAP_COST,
-            balance: user.balance - TRAP_COST,
+            balance: updated.balance,
             note: 'tripwire set (12h)',
         });
 
@@ -103,13 +112,13 @@ module.exports = {
                 `Expires in **12 hours**.`
             )
             .addFields(
-                { name: 'Cost',    value: `${currency}${TRAP_COST.toLocaleString()}`,          inline: true },
-                { name: 'Balance', value: `${currency}${(user.balance - TRAP_COST).toLocaleString()}`, inline: true },
-                { name: 'Expires', value: `<t:${Math.floor(expiresAt.getTime() / 1000)}:R>`,   inline: true }
+                { name: 'Cost',    value: `${currency}${TRAP_COST.toLocaleString()}`,   inline: true },
+                { name: 'Balance', value: `${currency}${updated.balance.toLocaleString()}`, inline: true },
+                { name: 'Expires', value: `<t:${Math.floor(expiresAt.getTime() / 1000)}:R>`, inline: true }
             )
             .setFooter({ text: 'Only one trap at a time. Use /trap status to check.' })
             .setTimestamp();
 
-        return interaction.reply({ embeds: [embed] });
+        return interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
     }
 };

--- a/src/commands/economy/trap.js
+++ b/src/commands/economy/trap.js
@@ -1,0 +1,115 @@
+'use strict';
+
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const User  = require('../../models/User');
+const Guild = require('../../models/Guild');
+const { logTransaction } = require('../../utils/logTransaction');
+
+const TRAP_COST     = 6_000;
+const TRAP_DURATION = 12 * 3_600_000; // 12 hours
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('trap')
+        .setDescription('Set a hidden tripwire on your wallet. Triggers if someone successfully robs you.')
+        .addSubcommand(sub =>
+            sub.setName('set')
+               .setDescription(`Set a trap on your wallet for ${TRAP_COST.toLocaleString()} coins. Lasts 12 hours.`))
+        .addSubcommand(sub =>
+            sub.setName('status')
+               .setDescription('Check whether your trap is currently armed.')),
+
+    async execute(interaction) {
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        if (guildSettings?.economy?.enabled === false) {
+            return interaction.reply({ content: 'The economy is disabled on this server.', ephemeral: true });
+        }
+        if (guildSettings?.economy?.robEnabled === false) {
+            return interaction.reply({ content: 'Robbing is disabled on this server — traps have no purpose here.', ephemeral: true });
+        }
+
+        const currency = guildSettings?.economy?.currency || '💰';
+        const sub      = interaction.options.getSubcommand();
+
+        const user = await User.findOneAndUpdate(
+            { userId: interaction.user.id, guildId: interaction.guild.id },
+            { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
+            { upsert: true, new: true }
+        );
+
+        if (sub === 'status') {
+            const trapActive = user.trap?.expiresAt && user.trap.expiresAt > new Date();
+            const embed = new EmbedBuilder()
+                .setColor(trapActive ? '#f39c12' : '#95a5a6')
+                .setTitle('🪤 Trap Status')
+                .setTimestamp();
+
+            if (trapActive) {
+                const remaining = Math.ceil((user.trap.expiresAt - Date.now()) / 60_000);
+                embed.setDescription(`Your tripwire is **armed** and waiting.\n\nExpires in **${remaining} min**.\nAny robber who succeeds against you will pay double the fine.`);
+            } else {
+                embed.setDescription(`You have **no active trap**.\n\nUse \`/trap set\` to arm one for **${currency}${TRAP_COST.toLocaleString()}**.`);
+            }
+            return interaction.reply({ embeds: [embed], ephemeral: true });
+        }
+
+        // sub === 'set'
+        const trapActive = user.trap?.expiresAt && user.trap.expiresAt > new Date();
+        if (trapActive) {
+            const remaining = Math.ceil((user.trap.expiresAt - Date.now()) / 60_000);
+            return interaction.reply({
+                content: `You already have a trap set! It expires in **${remaining} min**. You can only have one active trap at a time.`,
+                ephemeral: true,
+            });
+        }
+
+        if (user.balance < TRAP_COST) {
+            return interaction.reply({
+                content: `You need **${currency}${TRAP_COST.toLocaleString()}** to set a trap but only have **${currency}${user.balance.toLocaleString()}**.`,
+                ephemeral: true,
+            });
+        }
+
+        const now       = new Date();
+        const expiresAt = new Date(Date.now() + TRAP_DURATION);
+
+        await User.findOneAndUpdate(
+            { userId: interaction.user.id, guildId: interaction.guild.id },
+            {
+                $inc: { balance: -TRAP_COST },
+                $set: { 'trap.setAt': now, 'trap.expiresAt': expiresAt }
+            }
+        );
+
+        logTransaction({
+            userId: interaction.user.id,
+            guildId: interaction.guild.id,
+            type: 'trap_set',
+            amount: -TRAP_COST,
+            balance: user.balance - TRAP_COST,
+            note: 'tripwire set (12h)',
+        });
+
+        const embed = new EmbedBuilder()
+            .setColor('#f39c12')
+            .setTitle('🪤 Trap Set!')
+            .setDescription(
+                `You\'ve armed a **Tripwire** on your wallet.\n\n` +
+                `The trap is **invisible** — any robber has no way to know it\'s there.\n\n` +
+                `> **If a rob attempt succeeds:**\n` +
+                `> The robber pays **2× the normal fine** — straight to you.\n\n` +
+                `> **If a rob attempt fails:**\n` +
+                `> The trap is preserved (not consumed).\n\n` +
+                `Expires in **12 hours**.`
+            )
+            .addFields(
+                { name: 'Cost',    value: `${currency}${TRAP_COST.toLocaleString()}`,          inline: true },
+                { name: 'Balance', value: `${currency}${(user.balance - TRAP_COST).toLocaleString()}`, inline: true },
+                { name: 'Expires', value: `<t:${Math.floor(expiresAt.getTime() / 1000)}:R>`,   inline: true }
+            )
+            .setFooter({ text: 'Only one trap at a time. Use /trap status to check.' })
+            .setTimestamp();
+
+        return interaction.reply({ embeds: [embed] });
+    }
+};

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -567,10 +567,8 @@ const guildSchema = new Schema({
     achievements: {
         enabled: { type: Boolean, default: false },
         announcementChannelId: { type: String, default: null },
-        // Channel for server-wide broadcasts (rare/legendary/secret unlocks)
-        achievementAnnounceChannelId: { type: String, default: null },
-        // Minimum tier to broadcast: 'rare' | 'secret' | 'legendary'
-        achievementAnnounceThreshold: { type: String, default: 'rare' },
+        // Minimum tier to broadcast server-wide: 'rare' | 'secret' | 'legendary'
+        achievementAnnounceThreshold: { type: String, enum: ['rare', 'secret', 'legendary'], default: 'rare' },
         disabledAchievements: [{ type: String }],
         customAchievements: [{
             id:          { type: String, required: true },

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -567,6 +567,10 @@ const guildSchema = new Schema({
     achievements: {
         enabled: { type: Boolean, default: false },
         announcementChannelId: { type: String, default: null },
+        // Channel for server-wide broadcasts (rare/legendary/secret unlocks)
+        achievementAnnounceChannelId: { type: String, default: null },
+        // Minimum tier to broadcast: 'rare' | 'secret' | 'legendary'
+        achievementAnnounceThreshold: { type: String, default: 'rare' },
         disabledAchievements: [{ type: String }],
         customAchievements: [{
             id:          { type: String, required: true },

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -418,6 +418,12 @@ const userSchema = new Schema({
     },
     // ─────────────────────────────────────────────────────────────────────────
 
+    // Rob trap — set via /trap set; triggers on successful rob against this user
+    trap: {
+        setAt:     { type: Date, default: null },
+        expiresAt: { type: Date, default: null }
+    },
+
     // Active item effects (populated by /use; pruned on read)
     activeEffects: [{
         type:      { type: String, required: true },

--- a/src/services/achievementService.js
+++ b/src/services/achievementService.js
@@ -63,23 +63,30 @@ function getAnnounceTier(def) {
     return 'legendary';
 }
 
-// Minimum tier order (for threshold config)
-const ANNOUNCE_TIER_ORDER = { none: 0, rare: 1, secret: 2, legendary: 3 };
+// Rank order for non-secret tiers only (secret is handled orthogonally)
+const ANNOUNCE_TIER_ORDER = { none: 0, rare: 1, legendary: 2 };
 
 function tierMeetsThreshold(tier, threshold) {
-    const min = ANNOUNCE_TIER_ORDER[threshold] ?? 1;
-    return ANNOUNCE_TIER_ORDER[tier] >= min;
+    // Secret achievements always broadcast regardless of threshold
+    if (tier === 'secret') return true;
+    const min = ANNOUNCE_TIER_ORDER[threshold] ?? ANNOUNCE_TIER_ORDER['rare'];
+    return (ANNOUNCE_TIER_ORDER[tier] ?? 0) >= min;
 }
 
 /**
  * Send a server-wide announcement for notable achievement unlocks.
  * Tiers: rare = brief mention, secret = redacted, legendary = fancy bordered.
- * Respects `achievementAnnounceChannel` and `achievementAnnounceThreshold` guild settings.
+ * Uses the same announcementChannelId as the per-user reveal to avoid needing
+ * a separate dashboard field; skips broadcast if both channels are identical
+ * (prevent duplicate when the reveal channel IS the announce channel).
+ * Respects `achievementAnnounceThreshold` guild setting ('rare'|'secret'|'legendary').
  */
-async function broadcastAchievementUnlock(client, guildSettings, member, def) {
-    const channelId = guildSettings.achievements?.achievementAnnounceChannelId
-        ?? guildSettings.economy?.announcementChannelId;
+async function broadcastAchievementUnlock(client, guildSettings, mention, def, revealChannelId) {
+    const channelId = guildSettings.achievements?.announcementChannelId;
     if (!channelId) return;
+
+    // Skip broadcast if it would post to the same channel as the per-user reveal
+    if (channelId === revealChannelId) return;
 
     const tier = getAnnounceTier(def);
     const threshold = guildSettings.achievements?.achievementAnnounceThreshold ?? 'rare';
@@ -91,7 +98,6 @@ async function broadcastAchievementUnlock(client, guildSettings, member, def) {
     if (!channel?.isTextBased()) return;
 
     const { EmbedBuilder } = require('discord.js');
-    const mention = `<@${member?.id ?? member?.user?.id}>`;
 
     let embed;
     if (tier === 'legendary') {
@@ -185,8 +191,8 @@ async function announceAchievements(client, guildSettings, user, member, achieve
 
         await msg.edit({ embeds: [revealEmbed], files }).catch(() => null);
 
-        // Server-wide broadcast for notable unlocks (fire-and-forget)
-        broadcastAchievementUnlock(client, guildSettings, member, ach).catch(() => null);
+        // Server-wide broadcast for notable unlocks (fire-and-forget, skips if same channel)
+        broadcastAchievementUnlock(client, guildSettings, mention, ach, channelId).catch(() => null);
     }
 }
 

--- a/src/services/achievementService.js
+++ b/src/services/achievementService.js
@@ -54,6 +54,77 @@ function getTierColor(xpReward) {
     return 0xFFD700;                                    // legendary
 }
 
+// XP + secret flag → announcement tier
+// Returns 'none' | 'rare' | 'secret' | 'legendary'
+function getAnnounceTier(def) {
+    if (def.secret)                           return 'secret';
+    if (!def.xpReward || def.xpReward <= 200) return 'none';     // common/uncommon
+    if (def.xpReward <= 999)                  return 'rare';
+    return 'legendary';
+}
+
+// Minimum tier order (for threshold config)
+const ANNOUNCE_TIER_ORDER = { none: 0, rare: 1, secret: 2, legendary: 3 };
+
+function tierMeetsThreshold(tier, threshold) {
+    const min = ANNOUNCE_TIER_ORDER[threshold] ?? 1;
+    return ANNOUNCE_TIER_ORDER[tier] >= min;
+}
+
+/**
+ * Send a server-wide announcement for notable achievement unlocks.
+ * Tiers: rare = brief mention, secret = redacted, legendary = fancy bordered.
+ * Respects `achievementAnnounceChannel` and `achievementAnnounceThreshold` guild settings.
+ */
+async function broadcastAchievementUnlock(client, guildSettings, member, def) {
+    const channelId = guildSettings.achievements?.achievementAnnounceChannelId
+        ?? guildSettings.economy?.announcementChannelId;
+    if (!channelId) return;
+
+    const tier = getAnnounceTier(def);
+    const threshold = guildSettings.achievements?.achievementAnnounceThreshold ?? 'rare';
+    if (!tierMeetsThreshold(tier, threshold)) return;
+
+    const guild = client.guilds.cache.get(guildSettings.guildId);
+    if (!guild) return;
+    const channel = guild.channels.cache.get(channelId);
+    if (!channel?.isTextBased()) return;
+
+    const { EmbedBuilder } = require('discord.js');
+    const mention = `<@${member?.id ?? member?.user?.id}>`;
+
+    let embed;
+    if (tier === 'legendary') {
+        const bar = '⚡ ════════════════════════ ⚡';
+        embed = new EmbedBuilder()
+            .setColor(0xFFD700)
+            .setTitle(`${bar}`)
+            .setDescription(
+                `${bar}\n👑 ${mention} just achieved the legendary\n\n` +
+                `**${def.emoji || '🏆'} ${def.name.toUpperCase()}**\n\n` +
+                `${def.description}\n${bar}`
+            )
+            .setTimestamp();
+    } else if (tier === 'secret') {
+        embed = new EmbedBuilder()
+            .setColor(0x9c27b0)
+            .setTitle('✨ Secret Achievement Discovered!')
+            .setDescription(
+                `${mention} just discovered a **secret achievement**…\n\n🔒 *"[REDACTED]"*\n\nCan you find it too?`
+            )
+            .setTimestamp();
+    } else {
+        // rare
+        embed = new EmbedBuilder()
+            .setColor(getTierColor(def.xpReward))
+            .setTitle('🏆 Achievement Unlocked')
+            .setDescription(`${def.emoji || '🏆'} ${mention} just unlocked **${def.name}** — ${def.description}`)
+            .setTimestamp();
+    }
+
+    channel.send({ embeds: [embed] }).catch(() => null);
+}
+
 /**
  * Post achievement unlock announcements to the configured channel.
  * Each achievement is revealed in two steps (mystery → reveal) with an 800ms gap,
@@ -113,6 +184,9 @@ async function announceAchievements(client, guildSettings, user, member, achieve
         } catch { /* non-critical — send embed without card */ }
 
         await msg.edit({ embeds: [revealEmbed], files }).catch(() => null);
+
+        // Server-wide broadcast for notable unlocks (fire-and-forget)
+        broadcastAchievementUnlock(client, guildSettings, member, ach).catch(() => null);
     }
 }
 

--- a/src/services/fishService.js
+++ b/src/services/fishService.js
@@ -573,7 +573,8 @@ function executeCast(user, locationId, options = {}) {
 
             Object.assign(result, {
                 junkItem: junk, finalPayout: adjustedPayout,
-                xpEarned: xpGain, levelUp: lvResult.leveledUp ? lvResult : null, cappedByHard
+                xpEarned: xpGain, levelUp: lvResult.leveledUp ? lvResult : null, cappedByHard,
+                streakMult
             });
             f.successfulCasts += 1;
             f.consecutiveFails = 0;
@@ -598,7 +599,8 @@ function executeCast(user, locationId, options = {}) {
 
             Object.assign(result, {
                 treasureItem: treasure, finalPayout: adjustedPayout,
-                xpEarned: xpGain, levelUp: lvResult.leveledUp ? lvResult : null, cappedByHard
+                xpEarned: xpGain, levelUp: lvResult.leveledUp ? lvResult : null, cappedByHard,
+                streakMult
             });
             f.successfulCasts += 1;
             f.consecutiveFails = 0;

--- a/src/services/fishService.js
+++ b/src/services/fishService.js
@@ -735,7 +735,8 @@ function executeCast(user, locationId, options = {}) {
                 sizeLabel, sizeTierId, weightLbs, specialDrop, xpEarned: xpGain,
                 levelUp: lvResult.leveledUp ? lvResult : null, cappedByHard,
                 traitEffects: Object.keys(traits).filter(t => traits[t]),
-                isPersonalBest, newRecord
+                isPersonalBest, newRecord,
+                streakMult
             });
 
             // ── Boss encounter check (Issue #154) ──────────────────────────

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -801,7 +801,8 @@ function executeHunt(user, zoneId, options = {}) {
             trophyQuality,
             specialDrop, xpEarned: xpGain,
             levelUp: lvResult.leveledUp ? lvResult : null,
-            cappedByHard
+            cappedByHard,
+            streakMult
         });
 
         if (weapon.currentDurability <= 0) result.weaponBroke = true;

--- a/src/services/mineService.js
+++ b/src/services/mineService.js
@@ -547,7 +547,8 @@ function executeMine(user, depthId, options = {}) {
             isCrit, critMultiplier: parseFloat(critMultiplier.toFixed(2)),
             specialDrop, xpEarned: xpGain,
             levelUp: lvResult.leveledUp ? lvResult : null,
-            cappedByHard
+            cappedByHard,
+            streakMult
         });
 
         if (pickaxe.currentDurability <= 0) result.pickaxeBroke = true;


### PR DESCRIPTION
Issue #338 – Trap system: new /trap command (set/status) costs 6,000 coins
and arms a 12-hour hidden tripwire. When a rob attempt succeeds against a
trapped user, the success animation plays then the trap triggers — robber
pays 2× the normal fine to the victim and the trap is consumed. A server
announcement fires to the economy channel. Failed rob attempts leave the
trap intact.

Issue #343 – Achievement server-wide announcements: broadcastAchievementUnlock
tiers announcements by rarity (rare=brief, secret=redacted, legendary=fancy
bordered). Fires after every unlock in announceAchievements. Respects new
achievementAnnounceChannelId and achievementAnnounceThreshold guild settings.

Issue #329 – Multiplier breakdown in reward embeds: crime now uses stackBar
for streak/featured multipliers. hunt/fish/mine services now return streakMult
in the result object; buildHuntEmbed, buildCastEmbed, and buildMineEmbed each
show a 📈 Multipliers field when any multiplier is active.

https://claude.ai/code/session_01D4VRcyMcdt2ZfNnrHJWJWC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added robbery trap mechanic—users can arm traps to catch robbers and impose doubled fines
  * New `/trap` command with `set` and `status` subcommands
  * New "Multipliers" section in fish, hunt, and mine activities showing combined gameplay effects
  * New server-wide achievement broadcast system with configurable tier thresholds

* **Changes**
  * Updated crime reward display with improved "stack bar" visualization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->