### PR TITLE
Implement issues #339, #342, #354: ranked duel ladder, account prestige, dynamic shop pricing

### DIFF
--- a/src/commands/economy/duel.js
+++ b/src/commands/economy/duel.js
@@ -9,6 +9,7 @@ const { randomInt } = require('crypto');
 const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { isDistrictActive } = require('../../services/districtService');
+const { RANK_TIERS, START_ELO, tierFor, applyElo, makeSeasonId } = require('../../utils/duelElo');
 
 const DUEL_COOLDOWN_MS = 5 * 60_000;
 const ACCEPT_TIMEOUT_MS = 60_000;
@@ -88,7 +89,7 @@ function buildRpsRow(role, duelId) {
     );
 }
 
-async function finalizeDuel({ interaction, targetUser, challengerId, opponentId, amount, currency, houseCut, challengerWins, tie, game, gameResult }) {
+async function finalizeDuel({ interaction, targetUser, challengerId, opponentId, amount, currency, houseCut, challengerWins, tie, game, gameResult, isRanked = false }) {
     const guildId = interaction.guild.id;
     // Escrow already deducted both stakes; compute payout from pot
     const guildDoc = await Guild.findOne({ guildId }).lean();
@@ -101,6 +102,7 @@ async function finalizeDuel({ interaction, targetUser, challengerId, opponentId,
     const netGain      = winnerPayout - amount; // winner's profit above their own stake
 
     let description;
+    let eloLine = '';
     if (tie) {
         // Refund both stakes and record cooldown
         await Promise.all([
@@ -112,12 +114,48 @@ async function finalizeDuel({ interaction, targetUser, challengerId, opponentId,
         const winnerId   = challengerWins ? challengerId : opponentId;
         const loserId    = challengerWins ? opponentId   : challengerId;
         const winnerName = challengerWins ? interaction.user.username : targetUser.username;
+
+        const baseWinnerInc = { $inc: { balance: winnerPayout, duelWins: 1 }, $set: { lastDuel: new Date() } };
+        const baseLoserInc  = { $inc: { duelLosses: 1 }, $set: { lastDuel: new Date() } };
+
+        if (isRanked) {
+            // Apply ELO changes — read current ratings, compute deltas, persist atomically.
+            const [winnerDoc, loserDoc] = await Promise.all([
+                User.findOne({ userId: winnerId, guildId }).select('ranked').lean(),
+                User.findOne({ userId: loserId,  guildId }).select('ranked').lean(),
+            ]);
+            const kFactor = guildDoc?.rankedDuels?.kFactor ?? 32;
+            const seasonId = guildDoc?.rankedDuels?.currentSeasonId
+                ?? makeSeasonId(guildDoc?.rankedDuels?.seasonNumber ?? 1);
+            const wElo = winnerDoc?.ranked?.elo ?? START_ELO;
+            const lElo = loserDoc?.ranked?.elo  ?? START_ELO;
+            const { winnerNewElo, loserNewElo, winnerDelta, loserDelta } = applyElo(wElo, lElo, kFactor);
+
+            baseWinnerInc.$inc['ranked.rankedWins']       = 1;
+            baseWinnerInc.$inc['ranked.seasonRankedWins'] = 1;
+            baseWinnerInc.$set['ranked.elo']              = winnerNewElo;
+            baseWinnerInc.$set['ranked.peakElo']         = Math.max(winnerDoc?.ranked?.peakElo ?? START_ELO, winnerNewElo);
+            baseWinnerInc.$set['ranked.seasonPeakElo']   = Math.max(winnerDoc?.ranked?.seasonPeakElo ?? START_ELO, winnerNewElo);
+            baseWinnerInc.$set['ranked.currentSeasonId'] = seasonId;
+
+            baseLoserInc.$inc['ranked.rankedLosses']       = 1;
+            baseLoserInc.$inc['ranked.seasonRankedLosses'] = 1;
+            baseLoserInc.$set['ranked.elo']                = loserNewElo;
+            baseLoserInc.$set['ranked.currentSeasonId']    = seasonId;
+
+            const winnerTier = tierFor(winnerNewElo);
+            const loserTier  = tierFor(loserNewElo);
+            eloLine = `\n\n📊 **Ranked update** · ${seasonId}\n` +
+                `Winner: ${winnerTier.icon} ${winnerNewElo} (+${winnerDelta})\n` +
+                `Loser:  ${loserTier.icon} ${loserNewElo} (${loserDelta})`;
+        }
+
         await Promise.all([
-            User.updateOne({ userId: winnerId, guildId }, { $inc: { balance: winnerPayout, duelWins: 1 }, $set: { lastDuel: new Date() } }),
-            User.updateOne({ userId: loserId,  guildId }, { $inc: { duelLosses: 1 }, $set: { lastDuel: new Date() } }),
+            User.updateOne({ userId: winnerId, guildId }, baseWinnerInc),
+            User.updateOne({ userId: loserId,  guildId }, baseLoserInc),
         ]);
         const arenaStr = arenaActive ? ` + ⚔️ Arena bonus: ${currency}${arenaBonus.toLocaleString()}` : '';
-        description = `${gameResult}\n\n**${winnerName}** wins **${currency}${netGain.toLocaleString()}** net (${Math.round(houseCut * 100)}% house cut${arenaStr})!`;
+        description = `${gameResult}\n\n**${winnerName}** wins **${currency}${netGain.toLocaleString()}** net (${Math.round(houseCut * 100)}% house cut${arenaStr})!${eloLine}`;
     }
 
     const [challenger, opponent] = await Promise.all([
@@ -177,7 +215,7 @@ function errorEmbed(title, description) {
     return new EmbedBuilder().setColor('#e74c3c').setTitle(title).setDescription(description).setTimestamp();
 }
 
-async function runInstantGame(interaction, targetUser, amount, currency, houseCut, game) {
+async function runInstantGame(interaction, targetUser, amount, currency, houseCut, game, isRanked = false) {
     let challengerWins = false;
     let tie = false;
     let gameResult = '';
@@ -201,7 +239,7 @@ async function runInstantGame(interaction, targetUser, amount, currency, houseCu
     }
 
     try {
-        await finalizeDuel({ interaction, targetUser, challengerId: interaction.user.id, opponentId: targetUser.id, amount, currency, houseCut, challengerWins, tie, game, gameResult });
+        await finalizeDuel({ interaction, targetUser, challengerId: interaction.user.id, opponentId: targetUser.id, amount, currency, houseCut, challengerWins, tie, game, gameResult, isRanked });
     } catch (err) {
         console.error('Duel finalizeDuel error:', err);
         await refundEscrow(interaction.user.id, targetUser.id, interaction.guild.id, amount).catch(console.error);
@@ -209,7 +247,7 @@ async function runInstantGame(interaction, targetUser, amount, currency, houseCu
     }
 }
 
-async function runRPS(interaction, msg, targetUser, amount, currency, houseCut, duelId) {
+async function runRPS(interaction, msg, targetUser, amount, currency, houseCut, duelId, isRanked = false) {
     // settled prevents double-refund if both a collect error and a timeout fire
     let settled = false;
     const guildId = interaction.guild.id;
@@ -276,7 +314,7 @@ async function runRPS(interaction, msg, targetUser, amount, currency, houseCut, 
 
                     await settle(async () => {
                         try {
-                            await finalizeDuel({ interaction, targetUser, challengerId: interaction.user.id, opponentId: targetUser.id, amount, currency, houseCut, challengerWins, tie, game: 'rps', gameResult });
+                            await finalizeDuel({ interaction, targetUser, challengerId: interaction.user.id, opponentId: targetUser.id, amount, currency, houseCut, challengerWins, tie, game: 'rps', gameResult, isRanked });
                         } catch (err) {
                             console.error('Duel RPS finalizeDuel error:', err);
                             await refundEscrow(interaction.user.id, targetUser.id, guildId, amount).catch(console.error);
@@ -325,159 +363,270 @@ async function runRPS(interaction, msg, targetUser, amount, currency, houseCut, 
     });
 }
 
+async function runChallenge(interaction, isRanked) {
+    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+
+    if (guildSettings?.economy?.enabled === false) {
+        return interaction.reply({ content: 'The economy is disabled on this server.', ephemeral: true });
+    }
+    if (guildSettings?.economy?.duelEnabled === false) {
+        return interaction.reply({ content: 'Duels are disabled on this server.', ephemeral: true });
+    }
+    if (isRanked && guildSettings?.rankedDuels?.enabled === false) {
+        return interaction.reply({ content: 'Ranked duels are disabled on this server.', ephemeral: true });
+    }
+
+    const currency = guildSettings?.economy?.currency    || '💰';
+    const maxBet   = guildSettings?.economy?.duelMaxBet  ?? 10000;
+    const houseCut = guildSettings?.economy?.duelHouseCut ?? 0.05;
+    const minBet   = isRanked ? (guildSettings?.rankedDuels?.minBet ?? 100) : 1;
+
+    const target    = interaction.options.getUser('user');
+    const amount    = interaction.options.getInteger('amount');
+    const gameChoice = interaction.options.getString('game') ?? 'random';
+
+    if (target.id === interaction.user.id) {
+        return interaction.reply({ content: "You can't duel yourself.", ephemeral: true });
+    }
+    if (target.bot) {
+        return interaction.reply({ content: "You can't duel a bot.", ephemeral: true });
+    }
+    if (amount > maxBet) {
+        return interaction.reply({ content: `The maximum bet on this server is **${currency}${maxBet.toLocaleString()}**.`, ephemeral: true });
+    }
+    if (amount < minBet) {
+        return interaction.reply({ content: `Ranked duels require a minimum bet of **${currency}${minBet.toLocaleString()}**.`, ephemeral: true });
+    }
+
+    const [challenger, opponent] = await Promise.all([
+        User.findOneAndUpdate({ userId: interaction.user.id, guildId: interaction.guild.id }, {}, { upsert: true, new: true }),
+        User.findOneAndUpdate({ userId: target.id,           guildId: interaction.guild.id }, {}, { upsert: true, new: true }),
+    ]);
+
+    if (challenger.lastDuel && Date.now() - new Date(challenger.lastDuel).getTime() < DUEL_COOLDOWN_MS) {
+        const mins = Math.ceil((DUEL_COOLDOWN_MS - (Date.now() - new Date(challenger.lastDuel).getTime())) / 60_000);
+        return interaction.reply({ content: `You're cooling down from your last duel. Try again in **${mins} min**.`, ephemeral: true });
+    }
+    if (opponent.lastDuel && Date.now() - new Date(opponent.lastDuel).getTime() < DUEL_COOLDOWN_MS) {
+        const mins = Math.ceil((DUEL_COOLDOWN_MS - (Date.now() - new Date(opponent.lastDuel).getTime())) / 60_000);
+        return interaction.reply({ content: `**${target.username}** is still on duel cooldown. Try again in **${mins} min**.`, ephemeral: true });
+    }
+
+    if (challenger.balance < amount) {
+        return interaction.reply({ content: `You don't have enough ${currency}. Wallet: **${currency}${challenger.balance.toLocaleString()}**`, ephemeral: true });
+    }
+
+    const duelId = `${interaction.user.id}_${Date.now()}`;
+    const modeLabel = isRanked ? '🏆 Ranked Duel' : '⚔️ Duel Challenge!';
+    let rankedFooter = '';
+    if (isRanked) {
+        const cTier = tierFor(challenger.ranked?.elo ?? START_ELO);
+        const oTier = tierFor(opponent.ranked?.elo  ?? START_ELO);
+        rankedFooter = `\n\nELO: ${cTier.icon} ${challenger.ranked?.elo ?? START_ELO}  vs  ${oTier.icon} ${opponent.ranked?.elo ?? START_ELO}`;
+    }
+
+    const challengeEmbed = new EmbedBuilder()
+        .setColor(isRanked ? '#9b59b6' : '#f39c12')
+        .setTitle(modeLabel)
+        .setDescription(
+            `**${interaction.user.username}** challenges <@${target.id}> to a${isRanked ? ' **ranked**' : ''} duel!\n\n` +
+            `Bet: **${currency}${amount.toLocaleString()}** each\n` +
+            `House cut: **${Math.round(houseCut * 100)}%**\n` +
+            `Game: **${gameChoice === 'random' ? '🎲 Random' : GAME_NAMES[gameChoice]}**${rankedFooter}\n\n` +
+            `<@${target.id}>, do you accept?`
+        )
+        .setFooter({ text: 'Challenge expires in 60 seconds' })
+        .setTimestamp();
+
+    const row = new ActionRowBuilder().addComponents(
+        new ButtonBuilder().setCustomId(`duel_accept_${duelId}`).setLabel('Accept').setStyle(ButtonStyle.Success),
+        new ButtonBuilder().setCustomId(`duel_decline_${duelId}`).setLabel('Decline').setStyle(ButtonStyle.Danger),
+    );
+
+    await interaction.reply({ embeds: [challengeEmbed], components: [row] });
+    const msg = await interaction.fetchReply();
+
+    const acceptCollector = msg.createMessageComponentCollector({
+        filter: i => i.user.id === target.id && (i.customId === `duel_accept_${duelId}` || i.customId === `duel_decline_${duelId}`),
+        time: ACCEPT_TIMEOUT_MS,
+        max: 1,
+    });
+
+    acceptCollector.on('collect', async i => {
+        let escrowTaken = false;
+        try {
+            await i.deferUpdate();
+
+            if (i.customId === `duel_decline_${duelId}`) {
+                return interaction.editReply({
+                    embeds: [new EmbedBuilder().setColor('#e74c3c').setTitle('⚔️ Duel Declined').setDescription(`**${target.username}** declined the challenge.`).setTimestamp()],
+                    components: [],
+                });
+            }
+
+            const escrow = await takeEscrow(interaction.user.id, target.id, interaction.guild.id, amount);
+            if (!escrow.success) {
+                const who = escrow.reason === 'challenger' ? interaction.user.username : target.username;
+                return interaction.editReply({
+                    embeds: [new EmbedBuilder().setColor('#e74c3c').setTitle('⚔️ Duel Cancelled').setDescription(`**${who}** no longer has enough ${currency}.`).setTimestamp()],
+                    components: [],
+                });
+            }
+            escrowTaken = true;
+
+            const game = (gameChoice === 'random')
+                ? MINI_GAMES[randomInt(MINI_GAMES.length)]
+                : gameChoice;
+            if (game === 'rps') {
+                await runRPS(interaction, msg, target, amount, currency, houseCut, duelId, isRanked);
+            } else {
+                await runInstantGame(interaction, target, amount, currency, houseCut, game, isRanked);
+            }
+        } catch (err) {
+            console.error('Duel accept collect error:', err);
+            if (escrowTaken) {
+                await refundEscrow(interaction.user.id, target.id, interaction.guild.id, amount).catch(console.error);
+            }
+            await interaction.editReply({ embeds: [errorEmbed('⚔️ Duel Error', 'Something went wrong. Any escrowed bets have been refunded.')], components: [] }).catch(() => {});
+        }
+    });
+
+    acceptCollector.on('end', async (collected, reason) => {
+        if (reason === 'time' && collected.size === 0) {
+            await interaction.editReply({
+                embeds: [new EmbedBuilder().setColor('#95a5a6').setTitle('⚔️ Duel Expired').setDescription(`The duel challenge to **${target.username}** expired.`).setTimestamp()],
+                components: [],
+            }).catch(() => {});
+        }
+    });
+}
+
+async function runRankView(interaction) {
+    const target  = interaction.options.getUser('user') ?? interaction.user;
+    const guildId = interaction.guild.id;
+    const userDoc = await User.findOne({ userId: target.id, guildId }).select('ranked duelWins duelLosses').lean();
+    const elo     = userDoc?.ranked?.elo ?? START_ELO;
+    const tier    = tierFor(elo);
+    const peak    = userDoc?.ranked?.peakElo ?? elo;
+    const peakTier= tierFor(peak);
+    const rW = userDoc?.ranked?.rankedWins ?? 0;
+    const rL = userDoc?.ranked?.rankedLosses ?? 0;
+    const sW = userDoc?.ranked?.seasonRankedWins ?? 0;
+    const sL = userDoc?.ranked?.seasonRankedLosses ?? 0;
+    const titles = userDoc?.ranked?.seasonalTitles ?? [];
+
+    // Server rank (1-indexed) based on current ELO
+    const higher = await User.countDocuments({ guildId, 'ranked.elo': { $gt: elo } });
+    const rankPosition = higher + 1;
+
+    const guildSettings = await Guild.findOne({ guildId }, 'rankedDuels').lean();
+    const seasonId = guildSettings?.rankedDuels?.currentSeasonId
+        ?? makeSeasonId(guildSettings?.rankedDuels?.seasonNumber ?? 1);
+
+    const embed = new EmbedBuilder()
+        .setColor('#9b59b6')
+        .setTitle(`${tier.icon} ${target.username} — ${tier.label}`)
+        .setThumbnail(target.displayAvatarURL({ dynamic: true }))
+        .setDescription(`Current **${elo}** ELO · Server rank **#${rankPosition}**`)
+        .addFields(
+            { name: 'Peak Rating',  value: `${peakTier.icon} ${peak} (${peakTier.label})`, inline: true },
+            { name: 'Season',       value: `${seasonId} · ${sW}W / ${sL}L`,                inline: true },
+            { name: 'All-Time',     value: `${rW}W / ${rL}L (Ranked)`,                     inline: true },
+        );
+    if (titles.length) {
+        embed.addFields({ name: 'Earned Titles', value: titles.map(t => `🏷️ ${t}`).join('\n'), inline: false });
+    }
+    embed.setTimestamp();
+    return interaction.reply({ embeds: [embed], ephemeral: false });
+}
+
+async function runLeaderboard(interaction) {
+    const guildId = interaction.guild.id;
+    const top = await User.find({ guildId, 'ranked.rankedWins': { $gt: 0 } })
+        .sort({ 'ranked.elo': -1 })
+        .limit(10)
+        .select('userId ranked')
+        .lean();
+
+    if (!top.length) {
+        return interaction.reply({ content: 'No one has played a ranked duel yet on this server.', ephemeral: true });
+    }
+
+    const lines = await Promise.all(top.map(async (row, idx) => {
+        const elo = row.ranked?.elo ?? START_ELO;
+        const tier = tierFor(elo);
+        const u = await interaction.client.users.fetch(row.userId).catch(() => null);
+        const name = u?.username ?? row.userId;
+        const wl = `${row.ranked?.rankedWins ?? 0}W/${row.ranked?.rankedLosses ?? 0}L`;
+        const medal = idx === 0 ? '🥇' : idx === 1 ? '🥈' : idx === 2 ? '🥉' : `\`#${String(idx + 1).padStart(2, ' ')}\``;
+        return `${medal}  ${tier.icon} **${name}** — ${elo} ELO · ${wl}`;
+    }));
+
+    const guildSettings = await Guild.findOne({ guildId }, 'rankedDuels').lean();
+    const seasonId = guildSettings?.rankedDuels?.currentSeasonId
+        ?? makeSeasonId(guildSettings?.rankedDuels?.seasonNumber ?? 1);
+    const seasonEnds = guildSettings?.rankedDuels?.seasonEndsAt
+        ? `\n\nSeason ends <t:${Math.floor(new Date(guildSettings.rankedDuels.seasonEndsAt).getTime() / 1000)}:R>`
+        : '';
+
+    const embed = new EmbedBuilder()
+        .setColor('#9b59b6')
+        .setTitle(`🏆 Ranked Duel Ladder — ${seasonId}`)
+        .setDescription(lines.join('\n') + seasonEnds)
+        .setFooter({ text: 'Top 3 at season end earn coins, a title, and bragging rights.' })
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
 module.exports = {
     cooldown: 5,
     data: new SlashCommandBuilder()
         .setName('duel')
         .setDescription('Challenge another user to a coin-bet duel')
         .setDMPermission(false)
-        .addUserOption(opt =>
-            opt.setName('user')
-                .setDescription('The user to challenge')
-                .setRequired(true))
-        .addIntegerOption(opt =>
-            opt.setName('amount')
-                .setDescription('Amount to bet from your wallet')
-                .setRequired(true)
-                .setMinValue(1))
-        .addStringOption(opt =>
-            opt.setName('game')
-                .setDescription('Minigame to play (default: random)')
-                .setRequired(false)
-                .addChoices(
-                    { name: '🪙 Coin Flip',           value: 'coinflip'   },
-                    { name: '🎲 Dice Roll',            value: 'dice'       },
-                    { name: '🃏 Higher Card',          value: 'highercard' },
-                    { name: '✊ Rock Paper Scissors',  value: 'rps'        },
-                    { name: '🎲 Random',               value: 'random'     }
-                )),
+        .addSubcommand(sub =>
+            sub.setName('casual')
+                .setDescription('Unranked duel — wager coins without affecting your ELO.')
+                .addUserOption(o => o.setName('user').setDescription('The user to challenge').setRequired(true))
+                .addIntegerOption(o => o.setName('amount').setDescription('Amount to bet from your wallet').setRequired(true).setMinValue(1))
+                .addStringOption(o => o.setName('game').setDescription('Minigame to play (default: random)').setRequired(false)
+                    .addChoices(
+                        { name: '🪙 Coin Flip',           value: 'coinflip'   },
+                        { name: '🎲 Dice Roll',            value: 'dice'       },
+                        { name: '🃏 Higher Card',          value: 'highercard' },
+                        { name: '✊ Rock Paper Scissors',  value: 'rps'        },
+                        { name: '🎲 Random',               value: 'random'     }
+                    )))
+        .addSubcommand(sub =>
+            sub.setName('ranked')
+                .setDescription('Rated duel — updates your ELO and seasonal record.')
+                .addUserOption(o => o.setName('user').setDescription('The user to challenge').setRequired(true))
+                .addIntegerOption(o => o.setName('amount').setDescription('Amount to bet (server-configured minimum)').setRequired(true).setMinValue(1))
+                .addStringOption(o => o.setName('game').setDescription('Minigame to play (default: random)').setRequired(false)
+                    .addChoices(
+                        { name: '🪙 Coin Flip',           value: 'coinflip'   },
+                        { name: '🎲 Dice Roll',            value: 'dice'       },
+                        { name: '🃏 Higher Card',          value: 'highercard' },
+                        { name: '✊ Rock Paper Scissors',  value: 'rps'        },
+                        { name: '🎲 Random',               value: 'random'     }
+                    )))
+        .addSubcommand(sub =>
+            sub.setName('rank')
+                .setDescription('Show your (or another user\'s) ranked duel rating and tier.')
+                .addUserOption(o => o.setName('user').setDescription('User to inspect (defaults to yourself).').setRequired(false)))
+        .addSubcommand(sub =>
+            sub.setName('leaderboard')
+                .setDescription('Show the top 10 ranked duelists on this server.')),
 
     async execute(interaction) {
         if (!interaction.guild) {
             return interaction.reply({ content: 'This command can only be used in a server.', ephemeral: true });
         }
-
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
-
-        if (guildSettings?.economy?.enabled === false) {
-            return interaction.reply({ content: 'The economy is disabled on this server.', ephemeral: true });
-        }
-        if (guildSettings?.economy?.duelEnabled === false) {
-            return interaction.reply({ content: 'Duels are disabled on this server.', ephemeral: true });
-        }
-
-        const currency = guildSettings?.economy?.currency    || '💰';
-        const maxBet   = guildSettings?.economy?.duelMaxBet  ?? 10000;
-        const houseCut = guildSettings?.economy?.duelHouseCut ?? 0.05;
-
-        const target    = interaction.options.getUser('user');
-        const amount    = interaction.options.getInteger('amount');
-        const gameChoice = interaction.options.getString('game') ?? 'random';
-
-        if (target.id === interaction.user.id) {
-            return interaction.reply({ content: "You can't duel yourself.", ephemeral: true });
-        }
-        if (target.bot) {
-            return interaction.reply({ content: "You can't duel a bot.", ephemeral: true });
-        }
-        if (amount > maxBet) {
-            return interaction.reply({ content: `The maximum bet on this server is **${currency}${maxBet.toLocaleString()}**.`, ephemeral: true });
-        }
-
-        const [challenger, opponent] = await Promise.all([
-            User.findOneAndUpdate({ userId: interaction.user.id, guildId: interaction.guild.id }, {}, { upsert: true, new: true }),
-            User.findOneAndUpdate({ userId: target.id,           guildId: interaction.guild.id }, {}, { upsert: true, new: true }),
-        ]);
-
-        if (challenger.lastDuel && Date.now() - new Date(challenger.lastDuel).getTime() < DUEL_COOLDOWN_MS) {
-            const mins = Math.ceil((DUEL_COOLDOWN_MS - (Date.now() - new Date(challenger.lastDuel).getTime())) / 60_000);
-            return interaction.reply({ content: `You're cooling down from your last duel. Try again in **${mins} min**.`, ephemeral: true });
-        }
-        if (opponent.lastDuel && Date.now() - new Date(opponent.lastDuel).getTime() < DUEL_COOLDOWN_MS) {
-            const mins = Math.ceil((DUEL_COOLDOWN_MS - (Date.now() - new Date(opponent.lastDuel).getTime())) / 60_000);
-            return interaction.reply({ content: `**${target.username}** is still on duel cooldown. Try again in **${mins} min**.`, ephemeral: true });
-        }
-
-        if (challenger.balance < amount) {
-            return interaction.reply({ content: `You don't have enough ${currency}. Wallet: **${currency}${challenger.balance.toLocaleString()}**`, ephemeral: true });
-        }
-
-        const duelId = `${interaction.user.id}_${Date.now()}`;
-
-        const challengeEmbed = new EmbedBuilder()
-            .setColor('#f39c12')
-            .setTitle('⚔️ Duel Challenge!')
-            .setDescription(
-                `**${interaction.user.username}** challenges <@${target.id}> to a duel!\n\n` +
-                `Bet: **${currency}${amount.toLocaleString()}** each\n` +
-                `House cut: **${Math.round(houseCut * 100)}%**\n` +
-                `Game: **${gameChoice === 'random' ? '🎲 Random' : GAME_NAMES[gameChoice]}**\n\n` +
-                `<@${target.id}>, do you accept?`
-            )
-            .setFooter({ text: 'Challenge expires in 60 seconds' })
-            .setTimestamp();
-
-        const row = new ActionRowBuilder().addComponents(
-            new ButtonBuilder().setCustomId(`duel_accept_${duelId}`).setLabel('Accept').setStyle(ButtonStyle.Success),
-            new ButtonBuilder().setCustomId(`duel_decline_${duelId}`).setLabel('Decline').setStyle(ButtonStyle.Danger),
-        );
-
-        await interaction.reply({ embeds: [challengeEmbed], components: [row] });
-        const msg = await interaction.fetchReply();
-
-        const acceptCollector = msg.createMessageComponentCollector({
-            filter: i => i.user.id === target.id && (i.customId === `duel_accept_${duelId}` || i.customId === `duel_decline_${duelId}`),
-            time: ACCEPT_TIMEOUT_MS,
-            max: 1,
-        });
-
-        acceptCollector.on('collect', async i => {
-            let escrowTaken = false;
-            try {
-                await i.deferUpdate();
-
-                if (i.customId === `duel_decline_${duelId}`) {
-                    return interaction.editReply({
-                        embeds: [new EmbedBuilder().setColor('#e74c3c').setTitle('⚔️ Duel Declined').setDescription(`**${target.username}** declined the challenge.`).setTimestamp()],
-                        components: [],
-                    });
-                }
-
-                // Atomically escrow wagers; re-validates live balances at deduction time
-                const escrow = await takeEscrow(interaction.user.id, target.id, interaction.guild.id, amount);
-                if (!escrow.success) {
-                    const who = escrow.reason === 'challenger' ? interaction.user.username : target.username;
-                    return interaction.editReply({
-                        embeds: [new EmbedBuilder().setColor('#e74c3c').setTitle('⚔️ Duel Cancelled').setDescription(`**${who}** no longer has enough ${currency}.`).setTimestamp()],
-                        components: [],
-                    });
-                }
-                escrowTaken = true;
-
-                const game = (gameChoice === 'random')
-                    ? MINI_GAMES[randomInt(MINI_GAMES.length)]
-                    : gameChoice;
-                if (game === 'rps') {
-                    await runRPS(interaction, msg, target, amount, currency, houseCut, duelId);
-                } else {
-                    await runInstantGame(interaction, target, amount, currency, houseCut, game);
-                }
-            } catch (err) {
-                console.error('Duel accept collect error:', err);
-                if (escrowTaken) {
-                    await refundEscrow(interaction.user.id, target.id, interaction.guild.id, amount).catch(console.error);
-                }
-                await interaction.editReply({ embeds: [errorEmbed('⚔️ Duel Error', 'Something went wrong. Any escrowed bets have been refunded.')], components: [] }).catch(() => {});
-            }
-        });
-
-        acceptCollector.on('end', async (collected, reason) => {
-            if (reason === 'time' && collected.size === 0) {
-                await interaction.editReply({
-                    embeds: [new EmbedBuilder().setColor('#95a5a6').setTitle('⚔️ Duel Expired').setDescription(`The duel challenge to **${target.username}** expired.`).setTimestamp()],
-                    components: [],
-                }).catch(() => {});
-            }
-        });
+        const sub = interaction.options.getSubcommand();
+        if (sub === 'casual')      return runChallenge(interaction, false);
+        if (sub === 'ranked')      return runChallenge(interaction, true);
+        if (sub === 'rank')        return runRankView(interaction);
+        if (sub === 'leaderboard') return runLeaderboard(interaction);
     },
 };

--- a/src/commands/economy/duel.js
+++ b/src/commands/economy/duel.js
@@ -89,6 +89,55 @@ function buildRpsRow(role, duelId) {
     );
 }
 
+// Atomically re-check and claim cooldown for both players at duel-accept time.
+// Returns { ok, reason } — reason ∈ { 'challenger' | 'opponent' } on failure.
+// Both player updates are performed only if both pass the cooldown check; if
+// the second claim fails the first is reverted.
+async function claimDuelCooldown(challengerId, opponentId, guildId, lastDuelBefore) {
+    const claimedChallenger = await User.findOneAndUpdate(
+        {
+            userId: challengerId,
+            guildId,
+            $or: [
+                { lastDuel: null },
+                { lastDuel: { $lt: lastDuelBefore } },
+            ],
+        },
+        { $set: { lastDuel: new Date() } },
+        { new: false }
+    );
+    if (!claimedChallenger) return { ok: false, reason: 'challenger' };
+
+    const claimedOpponent = await User.findOneAndUpdate(
+        {
+            userId: opponentId,
+            guildId,
+            $or: [
+                { lastDuel: null },
+                { lastDuel: { $lt: lastDuelBefore } },
+            ],
+        },
+        { $set: { lastDuel: new Date() } },
+        { new: false }
+    );
+    if (!claimedOpponent) {
+        // Revert challenger's claim to its previous value
+        await User.updateOne(
+            { userId: challengerId, guildId },
+            { $set: { lastDuel: claimedChallenger.lastDuel } }
+        ).catch(console.error);
+        return { ok: false, reason: 'opponent' };
+    }
+    return { ok: true, prevChallengerLastDuel: claimedChallenger.lastDuel, prevOpponentLastDuel: claimedOpponent.lastDuel };
+}
+
+async function revertDuelCooldown(challengerId, opponentId, guildId, prevChallenger, prevOpponent) {
+    await Promise.all([
+        User.updateOne({ userId: challengerId, guildId }, { $set: { lastDuel: prevChallenger ?? null } }),
+        User.updateOne({ userId: opponentId,   guildId }, { $set: { lastDuel: prevOpponent   ?? null } }),
+    ]).catch(console.error);
+}
+
 async function finalizeDuel({ interaction, targetUser, challengerId, opponentId, amount, currency, houseCut, challengerWins, tie, game, gameResult, isRanked = false }) {
     const guildId = interaction.guild.id;
     // Escrow already deducted both stakes; compute payout from pot
@@ -125,23 +174,47 @@ async function finalizeDuel({ interaction, targetUser, challengerId, opponentId,
                 User.findOne({ userId: loserId,  guildId }).select('ranked').lean(),
             ]);
             const kFactor = guildDoc?.rankedDuels?.kFactor ?? 32;
-            const seasonId = guildDoc?.rankedDuels?.currentSeasonId
+            // Detect if the stored season is already past its end date. When that
+            // happens (the scheduler hasn't yet rolled the season over) we tag this
+            // match against the *next* season id and initialize the season-scoped
+            // counters with $set rather than $inc, so an in-flight match never
+            // bumps a counter from the prior season.
+            const storedSeasonId = guildDoc?.rankedDuels?.currentSeasonId
                 ?? makeSeasonId(guildDoc?.rankedDuels?.seasonNumber ?? 1);
+            const seasonExpired  = guildDoc?.rankedDuels?.seasonEndsAt
+                && new Date(guildDoc.rankedDuels.seasonEndsAt).getTime() <= Date.now();
+            const seasonId       = seasonExpired
+                ? makeSeasonId((guildDoc?.rankedDuels?.seasonNumber ?? 1) + 1)
+                : storedSeasonId;
             const wElo = winnerDoc?.ranked?.elo ?? START_ELO;
             const lElo = loserDoc?.ranked?.elo  ?? START_ELO;
             const { winnerNewElo, loserNewElo, winnerDelta, loserDelta } = applyElo(wElo, lElo, kFactor);
 
-            baseWinnerInc.$inc['ranked.rankedWins']       = 1;
-            baseWinnerInc.$inc['ranked.seasonRankedWins'] = 1;
-            baseWinnerInc.$set['ranked.elo']              = winnerNewElo;
-            baseWinnerInc.$set['ranked.peakElo']         = Math.max(winnerDoc?.ranked?.peakElo ?? START_ELO, winnerNewElo);
-            baseWinnerInc.$set['ranked.seasonPeakElo']   = Math.max(winnerDoc?.ranked?.seasonPeakElo ?? START_ELO, winnerNewElo);
+            baseWinnerInc.$inc['ranked.rankedWins']  = 1;
+            baseWinnerInc.$set['ranked.elo']         = winnerNewElo;
+            baseWinnerInc.$set['ranked.peakElo']     = Math.max(winnerDoc?.ranked?.peakElo ?? START_ELO, winnerNewElo);
             baseWinnerInc.$set['ranked.currentSeasonId'] = seasonId;
 
-            baseLoserInc.$inc['ranked.rankedLosses']       = 1;
-            baseLoserInc.$inc['ranked.seasonRankedLosses'] = 1;
-            baseLoserInc.$set['ranked.elo']                = loserNewElo;
-            baseLoserInc.$set['ranked.currentSeasonId']    = seasonId;
+            baseLoserInc.$inc['ranked.rankedLosses'] = 1;
+            baseLoserInc.$set['ranked.elo']          = loserNewElo;
+            baseLoserInc.$set['ranked.currentSeasonId'] = seasonId;
+
+            if (seasonExpired) {
+                // First match of a new season — initialize seasonal counters rather
+                // than carrying over the prior season's totals via $inc.
+                baseWinnerInc.$set['ranked.seasonRankedWins']   = 1;
+                baseWinnerInc.$set['ranked.seasonRankedLosses'] = 0;
+                baseWinnerInc.$set['ranked.seasonPeakElo']      = winnerNewElo;
+
+                baseLoserInc.$set['ranked.seasonRankedWins']    = 0;
+                baseLoserInc.$set['ranked.seasonRankedLosses']  = 1;
+                baseLoserInc.$set['ranked.seasonPeakElo']       = loserNewElo;
+            } else {
+                baseWinnerInc.$inc['ranked.seasonRankedWins']   = 1;
+                baseWinnerInc.$set['ranked.seasonPeakElo']      = Math.max(winnerDoc?.ranked?.seasonPeakElo ?? START_ELO, winnerNewElo);
+
+                baseLoserInc.$inc['ranked.seasonRankedLosses']  = 1;
+            }
 
             const winnerTier = tierFor(winnerNewElo);
             const loserTier  = tierFor(loserNewElo);
@@ -454,6 +527,7 @@ async function runChallenge(interaction, isRanked) {
 
     acceptCollector.on('collect', async i => {
         let escrowTaken = false;
+        let cooldownClaim = null;
         try {
             await i.deferUpdate();
 
@@ -464,8 +538,24 @@ async function runChallenge(interaction, isRanked) {
                 });
             }
 
+            // Re-check + atomically claim the cooldown for both players at accept time.
+            // Each player must either have no recorded lastDuel or one older than
+            // (now - DUEL_COOLDOWN_MS). Both claims must succeed or both are reverted.
+            const cooldownBefore = new Date(Date.now() - DUEL_COOLDOWN_MS);
+            cooldownClaim = await claimDuelCooldown(interaction.user.id, target.id, interaction.guild.id, cooldownBefore);
+            if (!cooldownClaim.ok) {
+                const who = cooldownClaim.reason === 'challenger' ? interaction.user.username : target.username;
+                return interaction.editReply({
+                    embeds: [new EmbedBuilder().setColor('#e74c3c').setTitle('⚔️ Duel Cancelled').setDescription(`**${who}** is on duel cooldown.`).setTimestamp()],
+                    components: [],
+                });
+            }
+
             const escrow = await takeEscrow(interaction.user.id, target.id, interaction.guild.id, amount);
             if (!escrow.success) {
+                // Cooldown was claimed but escrow failed — revert the claim
+                await revertDuelCooldown(interaction.user.id, target.id, interaction.guild.id, cooldownClaim.prevChallengerLastDuel, cooldownClaim.prevOpponentLastDuel);
+                cooldownClaim = null;
                 const who = escrow.reason === 'challenger' ? interaction.user.username : target.username;
                 return interaction.editReply({
                     embeds: [new EmbedBuilder().setColor('#e74c3c').setTitle('⚔️ Duel Cancelled').setDescription(`**${who}** no longer has enough ${currency}.`).setTimestamp()],
@@ -486,6 +576,9 @@ async function runChallenge(interaction, isRanked) {
             console.error('Duel accept collect error:', err);
             if (escrowTaken) {
                 await refundEscrow(interaction.user.id, target.id, interaction.guild.id, amount).catch(console.error);
+            }
+            if (cooldownClaim?.ok) {
+                await revertDuelCooldown(interaction.user.id, target.id, interaction.guild.id, cooldownClaim.prevChallengerLastDuel, cooldownClaim.prevOpponentLastDuel);
             }
             await interaction.editReply({ embeds: [errorEmbed('⚔️ Duel Error', 'Something went wrong. Any escrowed bets have been refunded.')], components: [] }).catch(() => {});
         }
@@ -542,7 +635,14 @@ async function runRankView(interaction) {
 
 async function runLeaderboard(interaction) {
     const guildId = interaction.guild.id;
-    const top = await User.find({ guildId, 'ranked.rankedWins': { $gt: 0 } })
+    // Include anyone who has touched the ladder (wins OR losses), not just winners.
+    const top = await User.find({
+        guildId,
+        $or: [
+            { 'ranked.rankedWins':   { $gt: 0 } },
+            { 'ranked.rankedLosses': { $gt: 0 } },
+        ],
+    })
         .sort({ 'ranked.elo': -1 })
         .limit(10)
         .select('userId ranked')

--- a/src/commands/economy/prestige.js
+++ b/src/commands/economy/prestige.js
@@ -5,7 +5,7 @@ const {
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
 const {
-    PRESTIGE_TIERS, UNLOCK_LABELS, tierFor, nextTierAfter, badgeFor, roman,
+    PRESTIGE_TIERS, UNLOCK_LABELS, tierFor, titleForExactRank, nextTierAfter, badgeFor, roman,
 } = require('../../utils/prestige');
 
 const CONFIRM_TIMEOUT_MS = 30_000;
@@ -58,9 +58,10 @@ async function handleStatus(interaction) {
         ? tier.unlocks.map(u => `• ${UNLOCK_LABELS[u] || u}`).join('\n')
         : '_None yet — reach Prestige I to unlock the Black Market._';
 
+    const exactTitle = titleForExactRank(rank);
     const embed = new EmbedBuilder()
         .setColor(rank >= 5 ? '#f1c40f' : '#9b59b6')
-        .setTitle(`${badgeFor(rank) || '⟦P0⟧'} ${target.username} — ${tier.title || 'No prestige yet'}`)
+        .setTitle(`${badgeFor(rank) || '⟦P0⟧'} ${target.username} — ${exactTitle || 'No prestige yet'}`)
         .setThumbnail(target.displayAvatarURL({ dynamic: true }))
         .setDescription(
             `Current level: **${userDoc?.level ?? 0}** · Prestige rank: **${rank}**\n` +
@@ -152,8 +153,16 @@ async function handleUp(interaction) {
 
         // Atomically apply prestige: increment rank, reset level/xp, set unlocks, stamp prestigedAt.
         // Guard with rank match so concurrent runs only succeed once.
+        // Treat a missing accountPrestige.rank field as 0 so legacy users (created
+        // before the schema introduced this subdoc) can prestige without a
+        // pre-migration. $expr + $ifNull normalizes the comparison at the DB.
         const updated = await User.findOneAndUpdate(
-            { userId: interaction.user.id, guildId, 'accountPrestige.rank': oldRank, level: { $gte: minLevel } },
+            {
+                userId: interaction.user.id,
+                guildId,
+                level: { $gte: minLevel },
+                $expr: { $eq: [{ $ifNull: ['$accountPrestige.rank', 0] }, oldRank] },
+            },
             {
                 $inc: { 'accountPrestige.rank': 1, 'accountPrestige.lifetimePrestigeXp': userDoc.xp ?? 0 },
                 $set: {

--- a/src/commands/economy/prestige.js
+++ b/src/commands/economy/prestige.js
@@ -1,0 +1,250 @@
+const {
+    SlashCommandBuilder, EmbedBuilder,
+    ActionRowBuilder, ButtonBuilder, ButtonStyle, ComponentType,
+} = require('discord.js');
+const User  = require('../../models/User');
+const Guild = require('../../models/Guild');
+const {
+    PRESTIGE_TIERS, UNLOCK_LABELS, tierFor, nextTierAfter, badgeFor, roman,
+} = require('../../utils/prestige');
+
+const CONFIRM_TIMEOUT_MS = 30_000;
+
+async function postAnnouncement(client, guildId, channelId, payload) {
+    if (!channelId) return;
+    try {
+        const g = await client.guilds.fetch(guildId).catch(() => null);
+        if (!g) return;
+        const ch = await g.channels.fetch(channelId).catch(() => null);
+        if (!ch?.isTextBased?.()) return;
+        await ch.send(payload).catch(() => {});
+    } catch (err) {
+        console.error(`[prestige] announce failed:`, err.message);
+    }
+}
+
+function bonusSummary(bonuses) {
+    const parts = [];
+    if (bonuses.yieldPct)        parts.push(`+${Math.round(bonuses.yieldPct * 100)}% all yields`);
+    if (bonuses.xpPct)           parts.push(`+${Math.round(bonuses.xpPct * 100)}% XP gain`);
+    if (bonuses.staminaRegenPct) parts.push(`+${Math.round(bonuses.staminaRegenPct * 100)}% stamina regen`);
+    if (bonuses.crimeSuccessPct) parts.push(`+${Math.round(bonuses.crimeSuccessPct * 100)}% crime success`);
+    return parts.length ? parts.join(' · ') : '—';
+}
+
+function describeTier(tier) {
+    const title  = tier.title || `Rank ${tier.rank}`;
+    const bonus  = bonusSummary(tier.bonuses || {});
+    const unlock = (tier.unlocks?.length)
+        ? tier.unlocks.map(u => UNLOCK_LABELS[u] || u).join('\n  • ')
+        : 'None';
+    return `**P${tier.rank} — ${title}**\n  • Bonuses: ${bonus}\n  • Unlocks:\n  • ${unlock}`;
+}
+
+async function handleStatus(interaction) {
+    const target = interaction.options.getUser('user') || interaction.user;
+    const userDoc = await User.findOne(
+        { userId: target.id, guildId: interaction.guild.id },
+        'level xp accountPrestige'
+    ).lean();
+
+    const rank = userDoc?.accountPrestige?.rank ?? 0;
+    const tier = tierFor(rank);
+    const next = nextTierAfter(rank);
+    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id }, 'accountPrestige').lean();
+    const minLevel = guildSettings?.accountPrestige?.minLevelToPrestige ?? 50;
+
+    const unlocks = tier.unlocks?.length
+        ? tier.unlocks.map(u => `• ${UNLOCK_LABELS[u] || u}`).join('\n')
+        : '_None yet — reach Prestige I to unlock the Black Market._';
+
+    const embed = new EmbedBuilder()
+        .setColor(rank >= 5 ? '#f1c40f' : '#9b59b6')
+        .setTitle(`${badgeFor(rank) || '⟦P0⟧'} ${target.username} — ${tier.title || 'No prestige yet'}`)
+        .setThumbnail(target.displayAvatarURL({ dynamic: true }))
+        .setDescription(
+            `Current level: **${userDoc?.level ?? 0}** · Prestige rank: **${rank}**\n` +
+            (rank > 0 ? `Active bonuses: ${bonusSummary(tier.bonuses || {})}` : '_No bonuses active yet._')
+        )
+        .addFields(
+            { name: 'Unlocks', value: unlocks, inline: false },
+            { name: `Next rank (P${next.rank} — ${next.title})`,
+              value: `Bonuses: ${bonusSummary(next.bonuses || {})}\nRequires: level **${minLevel}** (resets to 0 on prestige)`,
+              inline: false },
+        )
+        .setFooter({ text: 'Use /prestige up when ready to ascend. Use /prestige info to see all tiers.' })
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+async function handleInfo(interaction) {
+    const lines = PRESTIGE_TIERS.filter(t => t.rank > 0).map(describeTier).join('\n\n');
+    const embed = new EmbedBuilder()
+        .setColor('#9b59b6')
+        .setTitle('✨ Prestige Tiers')
+        .setDescription(lines)
+        .setFooter({ text: 'Each prestige resets your level to 0 but grants permanent bonuses and exclusive content.' })
+        .setTimestamp();
+    return interaction.reply({ embeds: [embed], ephemeral: true });
+}
+
+async function handleUp(interaction) {
+    const guildId = interaction.guild.id;
+    const guildSettings = await Guild.findOne({ guildId }, 'accountPrestige economy').lean();
+
+    if (guildSettings?.accountPrestige?.enabled === false) {
+        return interaction.reply({ content: 'Account prestige is disabled on this server.', ephemeral: true });
+    }
+    const minLevel = guildSettings?.accountPrestige?.minLevelToPrestige ?? 50;
+
+    const userDoc = await User.findOneAndUpdate(
+        { userId: interaction.user.id, guildId },
+        { $setOnInsert: { userId: interaction.user.id, guildId } },
+        { upsert: true, new: true }
+    );
+
+    if ((userDoc.level ?? 0) < minLevel) {
+        return interaction.reply({
+            content: `You need to reach **level ${minLevel}** before you can prestige. (You're level ${userDoc.level ?? 0}.)`,
+            ephemeral: true,
+        });
+    }
+
+    const oldRank  = userDoc.accountPrestige?.rank ?? 0;
+    const newRank  = oldRank + 1;
+    const newTier  = nextTierAfter(oldRank);
+    const newUnlocks = newTier.unlocks ?? [];
+
+    // Confirmation prompt — prestige is irreversible.
+    const confirmEmbed = new EmbedBuilder()
+        .setColor('#f39c12')
+        .setTitle('✨ Confirm Prestige')
+        .setDescription(
+            `You're about to **prestige to ${newTier.title || `Rank ${newRank}`}**.\n\n` +
+            `This will:\n` +
+            `• Reset your level and XP to **0**\n` +
+            `• Grant permanent bonuses: **${bonusSummary(newTier.bonuses || {})}**\n` +
+            `• Unlock: ${(newUnlocks.filter(u => !(tierFor(oldRank).unlocks || []).includes(u)).map(u => UNLOCK_LABELS[u] || u).join(', ')) || 'no new unlocks at this tier'}\n\n` +
+            `This **cannot be undone**.`
+        )
+        .setFooter({ text: 'Confirmation expires in 30 seconds.' });
+
+    const row = new ActionRowBuilder().addComponents(
+        new ButtonBuilder().setCustomId('prestige_confirm').setLabel('Ascend').setStyle(ButtonStyle.Success),
+        new ButtonBuilder().setCustomId('prestige_cancel').setLabel('Cancel').setStyle(ButtonStyle.Secondary),
+    );
+
+    const msg = await interaction.reply({ embeds: [confirmEmbed], components: [row], ephemeral: true, fetchReply: true });
+
+    const collector = msg.createMessageComponentCollector({
+        componentType: ComponentType.Button,
+        filter: i => i.user.id === interaction.user.id,
+        time: CONFIRM_TIMEOUT_MS,
+        max: 1,
+    });
+
+    collector.on('collect', async btn => {
+        if (btn.customId === 'prestige_cancel') {
+            return btn.update({ content: 'Prestige cancelled.', embeds: [], components: [] });
+        }
+        await btn.deferUpdate();
+
+        // Atomically apply prestige: increment rank, reset level/xp, set unlocks, stamp prestigedAt.
+        // Guard with rank match so concurrent runs only succeed once.
+        const updated = await User.findOneAndUpdate(
+            { userId: interaction.user.id, guildId, 'accountPrestige.rank': oldRank, level: { $gte: minLevel } },
+            {
+                $inc: { 'accountPrestige.rank': 1, 'accountPrestige.lifetimePrestigeXp': userDoc.xp ?? 0 },
+                $set: {
+                    level: 0,
+                    xp:    0,
+                    'accountPrestige.prestigedAt': new Date(),
+                    'accountPrestige.unlocks':     newUnlocks,
+                },
+            },
+            { new: true }
+        );
+
+        if (!updated) {
+            return interaction.editReply({ content: 'Could not complete prestige — your level may have changed. Try again.', embeds: [], components: [] });
+        }
+
+        // Public reset ceremony — only announce if rank exceeds previous announced peak.
+        const announcedRank = updated.accountPrestige.announcedRank ?? 0;
+        const announceChannelId = guildSettings?.accountPrestige?.announceChannelId
+            ?? guildSettings?.economy?.announcementChannelId
+            ?? null;
+        if (newRank > announcedRank && announceChannelId) {
+            const ceremony = new EmbedBuilder()
+                .setColor('#FFD700')
+                .setTitle('✨ A New Ascension')
+                .setDescription(
+                    `<@${interaction.user.id}> has ascended to **${newTier.title || `Rank ${newRank}`}** ` +
+                    `${badgeFor(newRank)}\n\n` +
+                    `**Unlocks this tier:** ${newUnlocks.map(u => UNLOCK_LABELS[u] || u).join(' · ') || '—'}\n` +
+                    `**Permanent bonuses:** ${bonusSummary(newTier.bonuses || {})}`
+                )
+                .setThumbnail(interaction.user.displayAvatarURL({ dynamic: true }))
+                .setTimestamp();
+            await postAnnouncement(interaction.client, guildId, announceChannelId, { embeds: [ceremony] });
+            await User.updateOne(
+                { userId: interaction.user.id, guildId },
+                { $set: { 'accountPrestige.announcedRank': newRank } }
+            ).catch(() => {});
+        }
+
+        // Optional elite role
+        const eliteRoleId = guildSettings?.accountPrestige?.eliteRoleId;
+        const eliteMin    = guildSettings?.accountPrestige?.eliteRoleMinRank ?? 5;
+        if (eliteRoleId && newRank >= eliteMin) {
+            await interaction.member.roles.add(eliteRoleId).catch(() => {});
+        }
+
+        const doneEmbed = new EmbedBuilder()
+            .setColor('#FFD700')
+            .setTitle(`${badgeFor(newRank)} Welcome to ${newTier.title || `Rank ${newRank}`}`)
+            .setDescription(
+                `Your level has been reset, but you carry forward:\n\n` +
+                `• **Bonuses:** ${bonusSummary(newTier.bonuses || {})}\n` +
+                `• **Unlocks:** ${newUnlocks.map(u => UNLOCK_LABELS[u] || u).join(', ') || '—'}\n\n` +
+                `The climb starts again — at a new altitude.`
+            );
+
+        return interaction.editReply({ embeds: [doneEmbed], components: [] });
+    });
+
+    collector.on('end', (collected, reason) => {
+        if (reason === 'time' && collected.size === 0) {
+            interaction.editReply({ content: 'Prestige confirmation timed out.', embeds: [], components: [] }).catch(() => {});
+        }
+    });
+}
+
+module.exports = {
+    cooldown: 5,
+    data: new SlashCommandBuilder()
+        .setName('prestige')
+        .setDescription('Account-level prestige — reset your level for permanent rewards and unlocks.')
+        .setDMPermission(false)
+        .addSubcommand(sub =>
+            sub.setName('status')
+                .setDescription("Show your (or someone else's) prestige rank, bonuses, and unlocks.")
+                .addUserOption(o => o.setName('user').setDescription('User to inspect (defaults to yourself).').setRequired(false)))
+        .addSubcommand(sub =>
+            sub.setName('info')
+                .setDescription('Show every prestige tier and what each one unlocks.'))
+        .addSubcommand(sub =>
+            sub.setName('up')
+                .setDescription('Prestige your account (requires the server-configured level threshold).')),
+
+    async execute(interaction) {
+        if (!interaction.guild) {
+            return interaction.reply({ content: 'This command can only be used in a server.', ephemeral: true });
+        }
+        const sub = interaction.options.getSubcommand();
+        if (sub === 'status') return handleStatus(interaction);
+        if (sub === 'info')   return handleInfo(interaction);
+        if (sub === 'up')     return handleUp(interaction);
+    },
+};

--- a/src/commands/economy/shop.js
+++ b/src/commands/economy/shop.js
@@ -9,10 +9,12 @@ const {
 const Guild = require('../../models/Guild');
 const User = require('../../models/User');
 const Transaction = require('../../models/Transaction');
-const { ensureDefaultShopItems, getItemLore, getItemRarity, isPrestigeItem, RARITY_ORDER } = require('../../data/defaultShopItems');
+const { ensureDefaultShopItems, getItemLore, getItemRarity, isPrestigeItem, isBlackMarketItem, RARITY_ORDER } = require('../../data/defaultShopItems');
 const { getItemImageAttachment } = require('../../utils/itemImageHelper');
 const { runShopBrowse } = require('../../utils/shopBrowse');
 const { logTransaction } = require('../../utils/logTransaction');
+const { ensurePricingFields, trendBucket } = require('../../utils/dynamicPricing');
+const { hasUnlock } = require('../../utils/prestige');
 
 const CONFIRM_THRESHOLD = 500;
 const NEW_ITEM_TTL_MS   = 48 * 3_600_000; // 48 hours
@@ -43,27 +45,42 @@ async function getTrendingItemIds(guildId) {
     return new Set(rows.map(r => r._id));
 }
 
+// Returns effective price for an item — currentPrice if dynamic pricing is enabled and set,
+// otherwise the static price.
+function effectivePrice(item, dynamicEnabled) {
+    if (dynamicEnabled && item.currentPrice != null) return item.currentPrice;
+    return item.price;
+}
+
 // Build the runShopBrowse page descriptors from the guild's shop items
-async function buildShopPages(guildSettings, currency) {
+async function buildShopPages(guildSettings, currency, viewerPrestigeRank = 0) {
     const trending = await getTrendingItemIds(guildSettings.guildId);
     const now = Date.now();
+    const dynamicEnabled = !!guildSettings.dynamicPricing?.enabled;
+    const showBlackMarket = hasUnlock(viewerPrestigeRank, 'black_market');
 
     // Group items by rarity
     const byRarity = {};
     for (const item of guildSettings.shop) {
-        const rarity = getItemRarity(item.itemId, item.price);
+        // Hide black-market items from users who haven't unlocked them yet
+        if (isBlackMarketItem(item.itemId) && !showBlackMarket) continue;
+        const ep = effectivePrice(item, dynamicEnabled);
+        const rarity = getItemRarity(item.itemId, ep);
         if (!byRarity[rarity]) byRarity[rarity] = [];
         byRarity[rarity].push(item);
     }
 
-    // Separate prestige items into their own page
+    // Separate prestige + black-market items into their own pages
     const prestigeItems = [];
+    const blackMarketItems = [];
     const standardByRarity = {};
     for (const rarity of RARITY_ORDER) {
         const items = byRarity[rarity];
         if (!items) continue;
         for (const item of items) {
-            if (isPrestigeItem(item.itemId)) {
+            if (isBlackMarketItem(item.itemId)) {
+                blackMarketItems.push(item);
+            } else if (isPrestigeItem(item.itemId)) {
                 prestigeItems.push(item);
             } else {
                 if (!standardByRarity[rarity]) standardByRarity[rarity] = [];
@@ -88,18 +105,22 @@ async function buildShopPages(guildSettings, currency) {
                 badge = 'TRENDING';
             }
             const stock = item.stock === -1 ? '∞' : String(item.stock);
+            const ep = effectivePrice(item, dynamicEnabled);
+            const trendStr = dynamicEnabled ? ` ${trendBucket(item).arrow}` : '';
             return {
                 name:    item.name,
                 emoji:   extractEmoji(item.description),
-                price:   item.price,
+                price:   ep,
                 badge,
-                subline: `Stock: ${stock}${item.roleId ? ' · Role reward' : ''}`,
+                subline: `Stock: ${stock}${item.roleId ? ' · Role reward' : ''}${trendStr}`,
             };
         });
 
         const listText = items.map((item, i) => {
             const stock = item.stock === -1 ? '∞' : item.stock;
-            return `**${i + 1}. ${item.name}** — ${currency}${item.price.toLocaleString()} (Stock: ${stock})`;
+            const ep = effectivePrice(item, dynamicEnabled);
+            const trendStr = dynamicEnabled ? ` ${trendBucket(item).arrow}` : '';
+            return `**${i + 1}. ${item.name}** — ${currency}${ep.toLocaleString()}${trendStr} (Stock: ${stock})`;
         }).join('\n') + `\n\n*Use /shop buy <item name> to purchase*`;
 
         pages.push({
@@ -123,10 +144,11 @@ async function buildShopPages(guildSettings, currency) {
                 badge = 'TRENDING';
             }
             const stock = item.stock === -1 ? '∞' : String(item.stock);
+            const ep = effectivePrice(item, dynamicEnabled);
             return {
                 name:    item.name,
                 emoji:   extractEmoji(item.description),
-                price:   item.price,
+                price:   ep,
                 badge,
                 subline: `Stock: ${stock} · Prestige`,
             };
@@ -136,7 +158,8 @@ async function buildShopPages(guildSettings, currency) {
             `*Save up and make a statement.*\n\n` +
             prestigeItems.map((item, i) => {
                 const stock = item.stock === -1 ? '∞' : item.stock;
-                return `**${i + 1}. ${item.name}** — ${currency}${item.price.toLocaleString()} (Stock: ${stock})`;
+                const ep = effectivePrice(item, dynamicEnabled);
+                return `**${i + 1}. ${item.name}** — ${currency}${ep.toLocaleString()} (Stock: ${stock})`;
             }).join('\n') +
             `\n\n*Use /shop buy <item name> to purchase*`;
 
@@ -145,6 +168,39 @@ async function buildShopPages(guildSettings, currency) {
             label:    'Prestige',
             emoji:    '✨',
             subtitle: `${prestigeItems.length} aspirational item${prestigeItems.length !== 1 ? 's' : ''}`,
+            items:    pageItems,
+            listText,
+        });
+    }
+
+    // Black market — only visible to viewers with the unlock
+    if (blackMarketItems.length > 0) {
+        const pageItems = blackMarketItems.map(item => {
+            const stock = item.stock === -1 ? '∞' : String(item.stock);
+            const ep = effectivePrice(item, dynamicEnabled);
+            return {
+                name:    item.name,
+                emoji:   extractEmoji(item.description),
+                price:   ep,
+                badge:   'BLACK MARKET',
+                subline: `Stock: ${stock} · Prestige I+ only`,
+            };
+        });
+        const listText =
+            `**🏴 Black Market** — exclusive contraband only available to prestige holders.\n` +
+            `*No questions asked. No receipts given.*\n\n` +
+            blackMarketItems.map((item, i) => {
+                const stock = item.stock === -1 ? '∞' : item.stock;
+                const ep = effectivePrice(item, dynamicEnabled);
+                return `**${i + 1}. ${item.name}** — ${currency}${ep.toLocaleString()} (Stock: ${stock})`;
+            }).join('\n') +
+            `\n\n*Use /shop buy <item name> to purchase*`;
+
+        pages.push({
+            id:       'black_market',
+            label:    'Black Market',
+            emoji:    '🏴',
+            subtitle: `${blackMarketItems.length} contraband item${blackMarketItems.length !== 1 ? 's' : ''}`,
             items:    pageItems,
             listText,
         });
@@ -164,6 +220,9 @@ module.exports = {
             sub.setName('buy')
                 .setDescription('Purchase an item from the shop')
                 .addStringOption(o => o.setName('item').setDescription('Exact name of the item to buy (see /shop view for the full list)').setRequired(true)))
+        .addSubcommand(sub =>
+            sub.setName('trends')
+                .setDescription('Show price movement on shop items (dynamic pricing must be enabled).'))
         .setDefaultMemberPermissions(null),
 
     async execute(interaction) {
@@ -175,11 +234,20 @@ module.exports = {
             { upsert: true, new: true }
         );
 
-        if (ensureDefaultShopItems(guildSettings)) {
+        const seededDefaults = ensureDefaultShopItems(guildSettings);
+        const seededPrices   = ensurePricingFields(guildSettings.shop);
+        if (seededDefaults || seededPrices) {
             await guildSettings.save();
         }
 
         const currency = guildSettings.economy.currency;
+
+        // Viewer's prestige rank (used to gate Black Market and other unlock-tabs)
+        const viewer = await User.findOne(
+            { userId: interaction.user.id, guildId: interaction.guild.id },
+            'accountPrestige'
+        ).lean();
+        const viewerPrestigeRank = viewer?.accountPrestige?.rank ?? 0;
 
         // ── VIEW ──────────────────────────────────────────────────────────────
         if (sub === 'view') {
@@ -187,7 +255,7 @@ module.exports = {
                 return interaction.reply({ content: 'The shop is empty. Admins can add items via the dashboard.', ephemeral: true });
             }
 
-            const pages = await buildShopPages(guildSettings, currency);
+            const pages = await buildShopPages(guildSettings, currency, viewerPrestigeRank);
             if (!pages.length) {
                 return interaction.reply({ content: 'The shop is empty.', ephemeral: true });
             }
@@ -205,6 +273,42 @@ module.exports = {
             });
         }
 
+        // ── TRENDS ────────────────────────────────────────────────────────────
+        if (sub === 'trends') {
+            if (!guildSettings.dynamicPricing?.enabled) {
+                return interaction.reply({ content: 'Dynamic pricing is disabled on this server.', ephemeral: true });
+            }
+            const movers = guildSettings.shop
+                .filter(item => !isBlackMarketItem(item.itemId) || hasUnlock(viewerPrestigeRank, 'black_market'))
+                .map(item => {
+                    const tb = trendBucket(item);
+                    return { item, pct: tb.pct, arrow: tb.arrow };
+                })
+                .sort((a, b) => Math.abs(b.pct) - Math.abs(a.pct))
+                .slice(0, 12);
+
+            const lines = movers.map(({ item, pct, arrow }) => {
+                const base = item.basePrice ?? item.price;
+                const cur  = item.currentPrice ?? base;
+                const sign = pct >= 0 ? '+' : '';
+                return `${arrow} **${item.name}** — ${currency}${cur.toLocaleString()} (base ${currency}${base.toLocaleString()}, ${sign}${pct.toFixed(1)}%)`;
+            });
+
+            const lastRecalc = guildSettings.dynamicPricing.lastRecalcAt;
+            const recalcStr = lastRecalc
+                ? `Last recalc <t:${Math.floor(new Date(lastRecalc).getTime() / 1000)}:R>`
+                : 'No recalcs yet — pricing will adjust on the next scheduled run.';
+
+            const embed = new EmbedBuilder()
+                .setColor('#3498db')
+                .setTitle('📊 Market Trends')
+                .setDescription(lines.length ? lines.join('\n') : 'No price movement yet.')
+                .setFooter({ text: `${recalcStr} · Volatility: ${guildSettings.dynamicPricing.volatility}` })
+                .setTimestamp();
+
+            return interaction.reply({ embeds: [embed] });
+        }
+
         // ── BUY ───────────────────────────────────────────────────────────────
         if (sub === 'buy') {
             const itemName = interaction.options.getString('item').toLowerCase();
@@ -214,9 +318,20 @@ module.exports = {
                 return interaction.reply({ content: `Item \`${itemName}\` not found. Use \`/shop view\` to see available items.`, ephemeral: true });
             }
 
+            // Gate Black Market behind prestige unlock
+            if (isBlackMarketItem(item.itemId) && !hasUnlock(viewerPrestigeRank, 'black_market')) {
+                return interaction.reply({
+                    content: 'That item is sold on the Black Market — reach **Prestige I** to unlock it.',
+                    ephemeral: true,
+                });
+            }
+
             if (item.stock === 0) {
                 return interaction.reply({ content: 'That item is out of stock!', ephemeral: true });
             }
+
+            const dynamicEnabled = !!guildSettings.dynamicPricing?.enabled;
+            const itemPrice = effectivePrice(item, dynamicEnabled);
 
             const userData = await User.findOneAndUpdate(
                 { userId: interaction.user.id, guildId: interaction.guild.id },
@@ -224,9 +339,9 @@ module.exports = {
                 { upsert: true, new: true }
             );
 
-            if (userData.balance < item.price) {
+            if (userData.balance < itemPrice) {
                 return interaction.reply({
-                    content: `You need ${currency}${item.price.toLocaleString()} but only have ${currency}${userData.balance.toLocaleString()}.`,
+                    content: `You need ${currency}${itemPrice.toLocaleString()} but only have ${currency}${userData.balance.toLocaleString()}.`,
                     ephemeral: true
                 });
             }
@@ -242,17 +357,18 @@ module.exports = {
                 if (!freshItem || freshItem.stock === 0) {
                     return reply({ content: 'That item is no longer available.', embeds: [], components: [] });
                 }
-                if (!freshUser || freshUser.balance < freshItem.price) {
+                const freshPrice = effectivePrice(freshItem, !!freshGuild.dynamicPricing?.enabled);
+                if (!freshUser || freshUser.balance < freshPrice) {
                     return reply({
-                        content: `You need ${currency}${freshItem.price.toLocaleString()} but only have ${currency}${(freshUser?.balance ?? 0).toLocaleString()}.`,
+                        content: `You need ${currency}${freshPrice.toLocaleString()} but only have ${currency}${(freshUser?.balance ?? 0).toLocaleString()}.`,
                         embeds: [], components: []
                     });
                 }
 
                 // Atomically deduct balance — prevents double-spend if balance changed between checks
                 const chargedUser = await User.findOneAndUpdate(
-                    { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: freshItem.price } },
-                    { $inc: { balance: -freshItem.price } },
+                    { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: freshPrice } },
+                    { $inc: { balance: -freshPrice } },
                     { new: true }
                 );
                 if (!chargedUser) {
@@ -269,7 +385,7 @@ module.exports = {
                         try {
                             await User.findOneAndUpdate(
                                 { userId: interaction.user.id, guildId: interaction.guild.id },
-                                { $inc: { balance: freshItem.price } }
+                                { $inc: { balance: freshPrice } }
                             );
                             return reply({ content: 'That item just sold out. Your coins have been refunded.', embeds: [], components: [] });
                         } catch (refundErr) {
@@ -277,6 +393,14 @@ module.exports = {
                             return reply({ content: 'That item just sold out and the automatic refund failed — please contact support.', embeds: [], components: [] });
                         }
                     }
+                }
+
+                // Bump demand score so the next price recalc moves this item's price up.
+                if (freshGuild.dynamicPricing?.enabled) {
+                    await Guild.updateOne(
+                        { guildId: interaction.guild.id, 'shop._id': freshItem._id },
+                        { $inc: { 'shop.$.demandScore': 1 } }
+                    ).catch(err => console.error('[shop] demand bump failed:', err));
                 }
 
                 // Use the item's canonical itemId if set, otherwise fall back to its name
@@ -304,15 +428,15 @@ module.exports = {
                     userId:  interaction.user.id,
                     guildId: interaction.guild.id,
                     type:    'shop_buy',
-                    amount:  -freshItem.price,
+                    amount:  -freshPrice,
                     balance: chargedUser.balance,
                     note:    inventoryId,
                 });
 
                 const successLore = getItemLore(freshItem.itemId);
                 const successDesc = successLore
-                    ? `You bought **${freshItem.name}** for ${currency}${freshItem.price.toLocaleString()}.\n\n*${successLore}*`
-                    : `You bought **${freshItem.name}** for ${currency}${freshItem.price.toLocaleString()}.`;
+                    ? `You bought **${freshItem.name}** for ${currency}${freshPrice.toLocaleString()}.\n\n*${successLore}*`
+                    : `You bought **${freshItem.name}** for ${currency}${freshPrice.toLocaleString()}.`;
                 const successEmbed = new EmbedBuilder()
                     .setColor('#00ff00')
                     .setTitle('Purchase Successful')
@@ -330,7 +454,7 @@ module.exports = {
                 return reply(successPayload);
             };
 
-            if (item.price >= CONFIRM_THRESHOLD) {
+            if (itemPrice >= CONFIRM_THRESHOLD) {
                 const row = new ActionRowBuilder().addComponents(
                     new ButtonBuilder().setCustomId('shop_confirm').setLabel('Confirm Purchase').setStyle(ButtonStyle.Success),
                     new ButtonBuilder().setCustomId('shop_cancel').setLabel('Cancel').setStyle(ButtonStyle.Secondary)
@@ -338,15 +462,15 @@ module.exports = {
 
                 const confirmLore = getItemLore(item.itemId);
                 const confirmDesc = confirmLore
-                    ? `Buy **${item.name}** for **${currency}${item.price.toLocaleString()}**?\n\n*${confirmLore}*`
-                    : `Buy **${item.name}** for **${currency}${item.price.toLocaleString()}**?`;
+                    ? `Buy **${item.name}** for **${currency}${itemPrice.toLocaleString()}**?\n\n*${confirmLore}*`
+                    : `Buy **${item.name}** for **${currency}${itemPrice.toLocaleString()}**?`;
                 const confirmEmbed = new EmbedBuilder()
                     .setColor('#f39c12')
                     .setTitle('Confirm Purchase')
                     .setDescription(confirmDesc)
                     .addFields(
                         { name: 'Your Balance', value: `${currency}${userData.balance.toLocaleString()}`, inline: true },
-                        { name: 'After Purchase', value: `${currency}${(userData.balance - item.price).toLocaleString()}`, inline: true }
+                        { name: 'After Purchase', value: `${currency}${(userData.balance - itemPrice).toLocaleString()}`, inline: true }
                     )
                     .setFooter({ text: 'This confirmation expires in 30 seconds' });
 

--- a/src/commands/economy/shop.js
+++ b/src/commands/economy/shop.js
@@ -375,10 +375,16 @@ module.exports = {
                     return reply({ content: `You no longer have enough ${currency} for this purchase.`, embeds: [], components: [] });
                 }
 
-                // Atomically decrement stock if limited; refund on sell-out race
+                // Atomically decrement stock if limited; refund on sell-out race.
+                // $elemMatch binds both predicates to the SAME array element so
+                // the positional update can't accidentally decrement a different
+                // item just because some other item happens to have stock > 0.
                 if (freshItem.stock > 0) {
                     const stockResult = await Guild.findOneAndUpdate(
-                        { guildId: interaction.guild.id, 'shop._id': freshItem._id, 'shop.stock': { $gt: 0 } },
+                        {
+                            guildId: interaction.guild.id,
+                            shop: { $elemMatch: { _id: freshItem._id, stock: { $gt: 0 } } },
+                        },
                         { $inc: { 'shop.$.stock': -1 } }
                     );
                     if (!stockResult) {
@@ -406,19 +412,41 @@ module.exports = {
                 // Use the item's canonical itemId if set, otherwise fall back to its name
                 const inventoryId = freshItem.itemId || freshItem.name;
 
-                // Update inventory atomically: increment if entry exists, otherwise push
-                const incResult = await User.updateOne(
-                    { userId: interaction.user.id, guildId: interaction.guild.id, 'inventory.itemId': inventoryId },
-                    { $inc: { 'inventory.$.quantity': 1 } }
+                // Inventory upsert in a single atomic aggregation-pipeline update:
+                // when the itemId exists, bump its quantity by 1; otherwise append
+                // a new entry. Done in one call so concurrent buys can't race
+                // between an unsuccessful $inc and a guarded $push and lose a unit.
+                await User.updateOne(
+                    { userId: interaction.user.id, guildId: interaction.guild.id },
+                    [{
+                        $set: {
+                            inventory: {
+                                $cond: {
+                                    if: { $in: [inventoryId, { $ifNull: ['$inventory.itemId', []] }] },
+                                    then: {
+                                        $map: {
+                                            input: '$inventory',
+                                            as: 'slot',
+                                            in: {
+                                                $cond: [
+                                                    { $eq: ['$$slot.itemId', inventoryId] },
+                                                    { itemId: '$$slot.itemId', quantity: { $add: ['$$slot.quantity', 1] } },
+                                                    '$$slot'
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    else: {
+                                        $concatArrays: [
+                                            { $ifNull: ['$inventory', []] },
+                                            [{ itemId: inventoryId, quantity: 1 }]
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }]
                 );
-                if (incResult.modifiedCount === 0) {
-                    // No existing entry — push a new one; $ne guard makes this a no-op if a
-                    // concurrent request already inserted the entry between these two operations
-                    await User.updateOne(
-                        { userId: interaction.user.id, guildId: interaction.guild.id, 'inventory.itemId': { $ne: inventoryId } },
-                        { $push: { inventory: { itemId: inventoryId, quantity: 1 } } }
-                    );
-                }
 
                 if (freshItem.roleId) {
                     await interaction.member.roles.add(freshItem.roleId).catch(console.error);

--- a/src/commands/leveling/rank.js
+++ b/src/commands/leveling/rank.js
@@ -3,7 +3,7 @@ const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { createRankCard } = require('../../utils/cardGenerator');
 const { pruneEffects, EFFECT_CONFIGS, timeRemaining, getServerCoinMultiplier, getServerXpMultiplier } = require('../../services/effectsService');
-const { badgeFor, tierFor: prestigeTierFor } = require('../../utils/prestige');
+const { badgeFor, titleForExactRank: prestigeTitle } = require('../../utils/prestige');
 const { tierFor: eloTierFor, START_ELO } = require('../../utils/duelElo');
 
 const BOOSTER_TYPES  = new Set(['coin_booster_2x', 'xp_booster_2x', 'lucky_streak', 'salary_raise']);
@@ -78,14 +78,13 @@ module.exports = {
 
             // Prestige + ranked summary lines (appended to whichever embed we send)
             const prestigeRank = user.accountPrestige?.rank ?? 0;
-            const prestigeTier = prestigeTierFor(prestigeRank);
             const eloVal       = user.ranked?.elo ?? START_ELO;
             const eloTier      = eloTierFor(eloVal);
             const showRanked   = (user.ranked?.rankedWins ?? 0) + (user.ranked?.rankedLosses ?? 0) > 0;
             const identityField = (() => {
                 const parts = [];
                 if (prestigeRank > 0) {
-                    parts.push(`${badgeFor(prestigeRank)} **${prestigeTier.title}**`);
+                    parts.push(`${badgeFor(prestigeRank)} **${prestigeTitle(prestigeRank)}**`);
                 }
                 if (showRanked) {
                     parts.push(`${eloTier.icon} **${eloTier.label}** (${eloVal} ELO)`);

--- a/src/commands/leveling/rank.js
+++ b/src/commands/leveling/rank.js
@@ -3,6 +3,8 @@ const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { createRankCard } = require('../../utils/cardGenerator');
 const { pruneEffects, EFFECT_CONFIGS, timeRemaining, getServerCoinMultiplier, getServerXpMultiplier } = require('../../services/effectsService');
+const { badgeFor, tierFor: prestigeTierFor } = require('../../utils/prestige');
+const { tierFor: eloTierFor, START_ELO } = require('../../utils/duelElo');
 
 const BOOSTER_TYPES  = new Set(['coin_booster_2x', 'xp_booster_2x', 'lucky_streak', 'salary_raise']);
 const BOOST_TYPES    = new Set(['coin_booster_2x', 'xp_booster_2x']);
@@ -74,6 +76,24 @@ module.exports = {
                 ? '💡 Some channels or roles may not earn XP. Use /xpinfo to see details.'
                 : null;
 
+            // Prestige + ranked summary lines (appended to whichever embed we send)
+            const prestigeRank = user.accountPrestige?.rank ?? 0;
+            const prestigeTier = prestigeTierFor(prestigeRank);
+            const eloVal       = user.ranked?.elo ?? START_ELO;
+            const eloTier      = eloTierFor(eloVal);
+            const showRanked   = (user.ranked?.rankedWins ?? 0) + (user.ranked?.rankedLosses ?? 0) > 0;
+            const identityField = (() => {
+                const parts = [];
+                if (prestigeRank > 0) {
+                    parts.push(`${badgeFor(prestigeRank)} **${prestigeTier.title}**`);
+                }
+                if (showRanked) {
+                    parts.push(`${eloTier.icon} **${eloTier.label}** (${eloVal} ELO)`);
+                }
+                if (!parts.length) return null;
+                return { name: '🪪 Identity', value: parts.join('\n'), inline: false };
+            })();
+
             if (activeBoosters.length || hasServerBoost) {
                 const lines = [];
                 if (hasServerBoost) {
@@ -88,8 +108,13 @@ module.exports = {
                 const boosterEmbed = new EmbedBuilder()
                     .setColor('#f39c12')
                     .addFields({ name: '🚀 Active Boosters', value: lines.join('\n'), inline: false });
+                if (identityField) boosterEmbed.addFields(identityField);
                 if (xpHint) boosterEmbed.setFooter({ text: xpHint });
                 await interaction.reply({ files: [attachment], embeds: [boosterEmbed] });
+            } else if (identityField) {
+                const idEmbed = new EmbedBuilder().setColor('#9b59b6').addFields(identityField);
+                if (xpHint) idEmbed.setFooter({ text: xpHint });
+                await interaction.reply({ files: [attachment], embeds: [idEmbed] });
             } else if (xpHint) {
                 const hintEmbed = new EmbedBuilder()
                     .setColor('#95a5a6')

--- a/src/data/defaultShopItems.js
+++ b/src/data/defaultShopItems.js
@@ -26,6 +26,11 @@ const DEFAULT_SHOP_ITEMS = [
     { name: 'Pet Slot Expansion',     itemId: 'pet_slot_expansion',      rarity: 'Epic',   price: 60000,  category: 'prestige', description: '🐾 Allows owning one additional pet simultaneously (stackable ×3).', lore: "More companions. More chaos. Entirely worth it." },
     { name: 'Permanent Stamina +1',   itemId: 'permanent_stamina',       rarity: 'Mythic', price: 100000, category: 'prestige', description: '⚡ Permanently increases your max hunt/fish/mine stamina by 1.',     lore: "The grind never ends. At least now you last a little longer." },
     { name: 'Prestige Accelerator',   itemId: 'prestige_accelerator',    rarity: 'Mythic', price: 200000, category: 'prestige', description: '🚀 -20% XP required for your next prestige (one-time use).',         lore: "The shortcut nobody talks about. Until they use it." },
+
+    // ── Black Market (Prestige I+ only) ──────────────────────────────────────
+    { name: 'Phantom Token',          itemId: 'phantom_token',           rarity: 'Mythic', price: 120000, category: 'black_market', description: '👻 Skip the next /rob fine you would owe — undetectable.',         lore: "It wasn't you. It was never you." },
+    { name: 'Silvered Talisman',      itemId: 'silvered_talisman',       rarity: 'Mythic', price: 180000, category: 'black_market', description: '🪙 Doubles coin yield from your next 5 hunts, fishes, or mines.',   lore: "Pawned by a stranger. Repurchased by you. The cycle continues." },
+    { name: 'Black Market Contract',  itemId: 'black_market_contract',   rarity: 'Mythic', price: 350000, category: 'black_market', description: '📜 Grants +1 permanent crime success roll bonus (stackable ×3).',    lore: "Don't ask who signed the other side." },
 ];
 
 const ITEM_LORE_BY_ID = Object.fromEntries(
@@ -55,22 +60,47 @@ function isPrestigeItem(itemId) {
     return DEFAULT_SHOP_ITEMS.find(i => i.itemId === itemId)?.category === 'prestige';
 }
 
+// Returns true if the item lives in the Black Market tab (unlocked at account prestige 1+).
+function isBlackMarketItem(itemId) {
+    return DEFAULT_SHOP_ITEMS.find(i => i.itemId === itemId)?.category === 'black_market';
+}
+
 // Idempotent: appends any default items missing from the guild's shop and flips
 // the seeded flag so an admin can permanently remove items without them
 // reappearing. Returns true if the shop was modified (caller should save).
+//
+// New top-level item categories (e.g. 'black_market' added with the prestige
+// system) are backfilled even on already-seeded guilds so existing servers pick
+// them up without a manual reseed.
 function ensureDefaultShopItems(guildSettings) {
-    if (!guildSettings || guildSettings.shopDefaultsSeeded) return false;
-
+    if (!guildSettings) return false;
     if (!Array.isArray(guildSettings.shop)) guildSettings.shop = [];
+
+    const existingIds   = new Set(guildSettings.shop.map(i => (i.itemId || '').toLowerCase()));
     const existingNames = new Set(guildSettings.shop.map(i => i.name.toLowerCase()));
-    let added = false;
-    for (const item of DEFAULT_SHOP_ITEMS) {
-        if (existingNames.has(item.name.toLowerCase())) continue;
-        guildSettings.shop.push({ ...item, roleId: null, stock: -1, imageUrl: '' });
-        added = true;
+    const ALWAYS_BACKFILL_CATEGORIES = new Set(['black_market']);
+    let changed = false;
+
+    if (!guildSettings.shopDefaultsSeeded) {
+        for (const item of DEFAULT_SHOP_ITEMS) {
+            if (existingNames.has(item.name.toLowerCase())) continue;
+            guildSettings.shop.push({ ...item, roleId: null, stock: -1, imageUrl: '' });
+            existingIds.add(item.itemId.toLowerCase());
+            existingNames.add(item.name.toLowerCase());
+            changed = true;
+        }
+        guildSettings.shopDefaultsSeeded = true;
+        return true;
     }
-    guildSettings.shopDefaultsSeeded = true;
-    return added || true;
+
+    // For seeded guilds, only top up categories that are new to the schema.
+    for (const item of DEFAULT_SHOP_ITEMS) {
+        if (!ALWAYS_BACKFILL_CATEGORIES.has(item.category)) continue;
+        if (existingIds.has(item.itemId.toLowerCase()) || existingNames.has(item.name.toLowerCase())) continue;
+        guildSettings.shop.push({ ...item, roleId: null, stock: -1, imageUrl: '' });
+        changed = true;
+    }
+    return changed;
 }
 
-module.exports = { DEFAULT_SHOP_ITEMS, ensureDefaultShopItems, getItemLore, getItemRarity, isPrestigeItem, RARITY_ORDER };
+module.exports = { DEFAULT_SHOP_ITEMS, ensureDefaultShopItems, getItemLore, getItemRarity, isPrestigeItem, isBlackMarketItem, RARITY_ORDER };

--- a/src/data/defaultShopItems.js
+++ b/src/data/defaultShopItems.js
@@ -83,9 +83,13 @@ function ensureDefaultShopItems(guildSettings) {
 
     if (!guildSettings.shopDefaultsSeeded) {
         for (const item of DEFAULT_SHOP_ITEMS) {
-            if (existingNames.has(item.name.toLowerCase())) continue;
+            // Match either canonical itemId or display name — an admin-created
+            // item that shares the canonical id must not be duplicated even
+            // when its display name differs.
+            const id = (item.itemId || '').toLowerCase();
+            if (existingIds.has(id) || existingNames.has(item.name.toLowerCase())) continue;
             guildSettings.shop.push({ ...item, roleId: null, stock: -1, imageUrl: '' });
-            existingIds.add(item.itemId.toLowerCase());
+            existingIds.add(id);
             existingNames.add(item.name.toLowerCase());
             changed = true;
         }

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -6,7 +6,7 @@ const { checkGiveaways } = require('../services/giveawayService');
 const { checkTempVoice } = require('../services/tempVoiceService');
 const { checkBirthdays } = require('../services/birthdayService');
 const { checkSeasonalEvents } = require('../services/seasonalEventService');
-const { resolveExpiredWars, resolveExpiredSeasons, awardWeeklyLeaderboardBadges, announceHourlyWinners } = require('../services/schedulerService');
+const { resolveExpiredWars, resolveExpiredSeasons, awardWeeklyLeaderboardBadges, announceHourlyWinners, recalcShopPrices, resolveRankedSeasons } = require('../services/schedulerService');
 const { runJob } = require('../utils/jobRunner');
 const User = require('../models/User');
 const { logTransaction } = require('../utils/logTransaction');
@@ -74,6 +74,16 @@ module.exports = {
         // Announce last hour's micro-competition winners and reset at the top of every hour
         cron.schedule('0 * * * *', () =>
             runJob('schedulerService', 'announceHourlyWinners', () => announceHourlyWinners(client))
+        );
+
+        // Dynamic shop pricing recalculation — per-guild gated by lastRecalcAt + recalcMinutes
+        cron.schedule('*/15 * * * *', () =>
+            runJob('schedulerService', 'recalcShopPrices', () => recalcShopPrices(client))
+        );
+
+        // Ranked duel season rollover — check every 10 minutes for expired seasons
+        cron.schedule('*/10 * * * *', () =>
+            runJob('schedulerService', 'resolveRankedSeasons', () => resolveRankedSeasons(client))
         );
 
         // Refund any bets that were deducted during a crash game that was interrupted by a restart

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -301,10 +301,58 @@ const guildSchema = new Schema({
         stock:     { type: Number, default: -1 },
         imageData: { type: Buffer, default: null },
         imageType: { type: String, default: 'image/png' },
-        createdAt: { type: Date, default: null }
+        createdAt: { type: Date, default: null },
+        // ── Dynamic pricing (issue #354) ──
+        // basePrice is the canonical anchor; currentPrice is what buyers actually pay.
+        // demandScore drifts up on buys and down on idle ticks / market listings.
+        basePrice:     { type: Number, default: null },
+        currentPrice:  { type: Number, default: null },
+        demandScore:   { type: Number, default: 0 },
+        priceHistory:  [{
+            at:    { type: Date,   required: true },
+            price: { type: Number, required: true },
+            demandScore: { type: Number, default: 0 }
+        }]
     }],
 
     shopDefaultsSeeded: { type: Boolean, default: false },
+
+    // Dynamic pricing config for shop items
+    dynamicPricing: {
+        enabled:         { type: Boolean, default: false },
+        volatility:      { type: String, enum: ['low', 'medium', 'high'], default: 'medium' },
+        // ±band as a fraction of basePrice; capped here at recalc time
+        priceBand:       { type: Number, default: 0.5, min: 0.05, max: 0.9 },
+        // How often the scheduled job recalculates prices (minutes)
+        recalcMinutes:   { type: Number, default: 60, min: 15, max: 1440 },
+        lastRecalcAt:    { type: Date, default: null }
+    },
+
+    // Ranked duel ladder (issue #339)
+    rankedDuels: {
+        enabled:           { type: Boolean, default: true },
+        minBet:            { type: Number, default: 100, min: 1 },
+        kFactor:           { type: Number, default: 32, min: 8, max: 64 },
+        seasonDurationDays:{ type: Number, default: 60, min: 7, max: 365 },
+        currentSeasonId:   { type: String, default: null },
+        seasonStartedAt:   { type: Date,   default: null },
+        seasonEndsAt:      { type: Date,   default: null },
+        seasonNumber:      { type: Number, default: 1, min: 1 },
+        // Top-3 reward at season end
+        topReward:         { type: Number, default: 50_000, min: 0 },
+        announceChannelId: { type: String, default: null }
+    },
+
+    // Account prestige settings (issue #342)
+    accountPrestige: {
+        enabled:              { type: Boolean, default: true },
+        minLevelToPrestige:   { type: Number, default: 50, min: 5 },
+        softPrestigeAt:       { type: Number, default: 25, min: 5 },  // optional soft prestige threshold
+        announceChannelId:    { type: String, default: null },
+        // Server role granted to high-prestige users (optional)
+        eliteRoleId:          { type: String, default: null },
+        eliteRoleMinRank:     { type: Number, default: 5, min: 1 }
+    },
 
     // Server investment districts — cooperative money sink
     districts: {

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -500,6 +500,30 @@ const userSchema = new Schema({
     duelWins:   { type: Number, default: 0 },
     duelLosses: { type: Number, default: 0 },
 
+    // Ranked duel ladder (per-guild ELO + seasonal records)
+    ranked: {
+        elo:                  { type: Number, default: 1000 },
+        peakElo:              { type: Number, default: 1000 },
+        seasonPeakElo:        { type: Number, default: 1000 },
+        rankedWins:           { type: Number, default: 0 },
+        rankedLosses:         { type: Number, default: 0 },
+        seasonRankedWins:     { type: Number, default: 0 },
+        seasonRankedLosses:   { type: Number, default: 0 },
+        currentSeasonId:      { type: String, default: null },
+        peakSeasonTitle:      { type: String, default: null },  // best peak tier label across all seasons
+        seasonalTitles:       [{ type: String }],               // earned end-of-season titles (e.g. "S1 Champion")
+        lastSeasonId:         { type: String, default: null }
+    },
+
+    // Top-level (account) prestige — separate from per-skill hunt/fish/mine prestige
+    accountPrestige: {
+        rank:           { type: Number, default: 0, min: 0 },
+        prestigedAt:    { type: Date,   default: null },
+        unlocks:        [{ type: String }],   // ordered list of feature unlock ids
+        lifetimePrestigeXp: { type: Number, default: 0 },
+        announcedRank:  { type: Number, default: 0 }   // highest rank announced server-wide
+    },
+
     // Transient social badges (war victor, leaderboard #1, etc.) with optional expiry
     badges: [{
         id:        { type: String, required: true },
@@ -551,6 +575,8 @@ userSchema.index({ userId: 1, guildId: 1 }, { unique: true });
 userSchema.index({ guildId: 1, 'streak.current': -1 });
 userSchema.index({ guildId: 1, 'streak.longest': -1 });
 userSchema.index({ guildId: 1, duelWins: -1 });
+userSchema.index({ guildId: 1, 'ranked.elo': -1 });
+userSchema.index({ guildId: 1, 'accountPrestige.rank': -1 });
 userSchema.index({ guildId: 1, achievementsCount: -1 });
 userSchema.index({ guildId: 1, seasonCoins: -1 }); // used by executeLeaderboard / executeSeasonMe
 

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -577,19 +577,34 @@ async function recalcShopPrices(client) {
     const { EmbedBuilder } = require('discord.js');
     const guilds = await Guild.find({ 'dynamicPricing.enabled': true });
 
-    for (const guildDoc of guilds) {
+    for (const guildSummary of guilds) {
         try {
-            const recalcMs = (guildDoc.dynamicPricing?.recalcMinutes ?? 60) * 60_000;
-            const last = guildDoc.dynamicPricing?.lastRecalcAt
-                ? new Date(guildDoc.dynamicPricing.lastRecalcAt).getTime()
-                : 0;
-            if (Date.now() - last < recalcMs) continue;
+            const recalcMs = (guildSummary.dynamicPricing?.recalcMinutes ?? 60) * 60_000;
+            const now      = new Date();
+            const leaseCutoff = new Date(now.getTime() - recalcMs);
+
+            // Atomically claim this guild's recalc window. The update only
+            // succeeds when lastRecalcAt is null or older than the lease window,
+            // ensuring concurrent workers (multi-instance deployments) don't
+            // both run the recalc for the same guild.
+            const guildDoc = await Guild.findOneAndUpdate(
+                {
+                    guildId: guildSummary.guildId,
+                    'dynamicPricing.enabled': true,
+                    $or: [
+                        { 'dynamicPricing.lastRecalcAt': null },
+                        { 'dynamicPricing.lastRecalcAt': { $lte: leaseCutoff } },
+                    ],
+                },
+                { $set: { 'dynamicPricing.lastRecalcAt': now } },
+                { new: true }
+            );
+            if (!guildDoc) continue; // another worker already claimed this window
 
             ensurePricingFields(guildDoc.shop);
 
             const band       = guildDoc.dynamicPricing.priceBand ?? 0.5;
             const volatility = guildDoc.dynamicPricing.volatility ?? 'medium';
-            const now        = new Date();
             const changedMovers = [];
 
             for (const item of guildDoc.shop) {
@@ -601,9 +616,7 @@ async function recalcShopPrices(client) {
                     changedMovers.push({ name: item.name, prev, next: item.currentPrice, item });
                 }
             }
-            guildDoc.dynamicPricing.lastRecalcAt = now;
             guildDoc.markModified('shop');
-            guildDoc.markModified('dynamicPricing');
             await guildDoc.save();
 
             const channelId = guildDoc.economy?.announcementChannelId;
@@ -625,7 +638,7 @@ async function recalcShopPrices(client) {
                 await postAnnouncement(client, guildDoc.guildId, channelId, embed);
             }
         } catch (err) {
-            console.error(`[scheduler] recalcShopPrices failed for guild ${guildDoc.guildId}:`, err);
+            console.error(`[scheduler] recalcShopPrices failed for guild ${guildSummary.guildId}:`, err);
         }
     }
 }
@@ -685,7 +698,17 @@ async function resolveRankedSeasons(client) {
             );
             if (!claimed) continue;
 
-            const top = await User.find({ guildId, 'ranked.rankedWins': { $gt: 0 } })
+            // Only count users active *this* season so that prior-season
+            // winners (whose seasonPeakElo lingers until the next soft-reset
+            // ticks them) don't reclaim a top-3 slot without playing.
+            const top = await User.find({
+                guildId,
+                $or: [
+                    { 'ranked.seasonRankedWins':   { $gt: 0 } },
+                    { 'ranked.seasonRankedLosses': { $gt: 0 } },
+                ],
+                'ranked.currentSeasonId': seasonId,
+            })
                 .sort({ 'ranked.seasonPeakElo': -1 })
                 .limit(3)
                 .select('userId ranked')

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -3,6 +3,8 @@ const User  = require('../models/User');
 const SeasonRecord = require('../models/SeasonRecord');
 const { createWarVictoryBanner, createSeasonRecapCard } = require('../utils/cardGenerator');
 const { PET_DEFINITIONS, heartBar } = require('./petService');
+const { ensurePricingFields, nextPrice, decayDemand, pushHistory, trendBucket } = require('../utils/dynamicPricing');
+const { softResetElo, tierFor, makeSeasonId } = require('../utils/duelElo');
 
 const WAR_BOOSTER_DURATION_MS = 24 * 60 * 60 * 1000;
 const WAR_BADGE_DURATION_MS   = 30 * 24 * 60 * 60 * 1000;
@@ -570,4 +572,191 @@ async function announceHourlyWinners(client) {
     }
 }
 
-module.exports = { resolveExpiredWars, resolveExpiredSeasons, awardWeeklyLeaderboardBadges, selectPetOfTheWeek, announceHourlyWinners };
+// ─── Dynamic shop pricing recalculation (issue #354) ─────────────────────────
+async function recalcShopPrices(client) {
+    const { EmbedBuilder } = require('discord.js');
+    const guilds = await Guild.find({ 'dynamicPricing.enabled': true });
+
+    for (const guildDoc of guilds) {
+        try {
+            const recalcMs = (guildDoc.dynamicPricing?.recalcMinutes ?? 60) * 60_000;
+            const last = guildDoc.dynamicPricing?.lastRecalcAt
+                ? new Date(guildDoc.dynamicPricing.lastRecalcAt).getTime()
+                : 0;
+            if (Date.now() - last < recalcMs) continue;
+
+            ensurePricingFields(guildDoc.shop);
+
+            const band       = guildDoc.dynamicPricing.priceBand ?? 0.5;
+            const volatility = guildDoc.dynamicPricing.volatility ?? 'medium';
+            const now        = new Date();
+            const changedMovers = [];
+
+            for (const item of guildDoc.shop) {
+                const prev = item.currentPrice ?? item.basePrice ?? item.price;
+                item.currentPrice = nextPrice(item, band, volatility);
+                item.demandScore  = decayDemand(item, volatility);
+                pushHistory(item, now);
+                if (Math.abs(item.currentPrice - prev) / Math.max(1, prev) > 0.05) {
+                    changedMovers.push({ name: item.name, prev, next: item.currentPrice, item });
+                }
+            }
+            guildDoc.dynamicPricing.lastRecalcAt = now;
+            guildDoc.markModified('shop');
+            guildDoc.markModified('dynamicPricing');
+            await guildDoc.save();
+
+            const channelId = guildDoc.economy?.announcementChannelId;
+            if (channelId && changedMovers.length) {
+                const currency = guildDoc.economy?.currency ?? '💰';
+                const top = changedMovers
+                    .sort((a, b) => Math.abs(b.next - b.prev) - Math.abs(a.next - a.prev))
+                    .slice(0, 5);
+                const lines = top.map(m => {
+                    const tb = trendBucket(m.item);
+                    return `${tb.arrow} **${m.name}** — ${currency}${m.prev.toLocaleString()} → ${currency}${m.next.toLocaleString()}`;
+                });
+                const embed = new EmbedBuilder()
+                    .setColor('#3498db')
+                    .setTitle('📊 Market Update')
+                    .setDescription(lines.join('\n'))
+                    .setFooter({ text: 'Supply and demand shifted shop prices. Use /shop trends for the full board.' })
+                    .setTimestamp();
+                await postAnnouncement(client, guildDoc.guildId, channelId, embed);
+            }
+        } catch (err) {
+            console.error(`[scheduler] recalcShopPrices failed for guild ${guildDoc.guildId}:`, err);
+        }
+    }
+}
+
+// ─── Ranked duel season rollover (issue #339) ────────────────────────────────
+// Resolves and rolls over expired ranked-duel seasons:
+//  1. Awards top-3 prizes (coins + seasonal title)
+//  2. Soft-decays all ELO toward 1200
+//  3. Resets season counters and starts the next season
+async function resolveRankedSeasons(client) {
+    const { EmbedBuilder } = require('discord.js');
+    const now = new Date();
+    // Initialize the first season for any guild that has ranked enabled but no season yet
+    const uninitialized = await Guild.find({
+        'rankedDuels.enabled': true,
+        $or: [
+            { 'rankedDuels.currentSeasonId': null },
+            { 'rankedDuels.seasonEndsAt': null },
+        ]
+    });
+    for (const g of uninitialized) {
+        const seasonNumber = g.rankedDuels.seasonNumber ?? 1;
+        const days = g.rankedDuels.seasonDurationDays ?? 60;
+        g.rankedDuels.currentSeasonId = makeSeasonId(seasonNumber);
+        g.rankedDuels.seasonStartedAt = now;
+        g.rankedDuels.seasonEndsAt    = new Date(now.getTime() + days * 86_400_000);
+        await g.save().catch(err => console.error('[scheduler] ranked season init failed:', err.message));
+    }
+
+    const expired = await Guild.find({
+        'rankedDuels.enabled': true,
+        'rankedDuels.seasonEndsAt': { $ne: null, $lte: now },
+    });
+
+    for (const guildDoc of expired) {
+        try {
+            const guildId  = guildDoc.guildId;
+            const seasonId = guildDoc.rankedDuels.currentSeasonId;
+            const seasonNumber = guildDoc.rankedDuels.seasonNumber ?? 1;
+            const reward   = guildDoc.rankedDuels.topReward ?? 50_000;
+            const currency = guildDoc.economy?.currency ?? '💰';
+
+            // Atomically claim this season-end so concurrent sweeps no-op
+            const days = guildDoc.rankedDuels.seasonDurationDays ?? 60;
+            const newSeasonNumber = seasonNumber + 1;
+            const claimed = await Guild.findOneAndUpdate(
+                { guildId, 'rankedDuels.currentSeasonId': seasonId },
+                {
+                    $set: {
+                        'rankedDuels.currentSeasonId': makeSeasonId(newSeasonNumber),
+                        'rankedDuels.seasonNumber':    newSeasonNumber,
+                        'rankedDuels.seasonStartedAt': now,
+                        'rankedDuels.seasonEndsAt':    new Date(now.getTime() + days * 86_400_000),
+                    }
+                },
+                { new: false }
+            );
+            if (!claimed) continue;
+
+            const top = await User.find({ guildId, 'ranked.rankedWins': { $gt: 0 } })
+                .sort({ 'ranked.seasonPeakElo': -1 })
+                .limit(3)
+                .select('userId ranked')
+                .lean();
+
+            const rewards = [reward, Math.floor(reward * 0.6), Math.floor(reward * 0.3)];
+            const medals  = ['🥇', '🥈', '🥉'];
+
+            for (let i = 0; i < top.length; i++) {
+                const u = top[i];
+                const titleLabel = `${seasonId} ${i === 0 ? 'Champion' : i === 1 ? 'Runner-Up' : 'Third Place'}`;
+                const peakTier   = tierFor(u.ranked?.seasonPeakElo ?? 1000);
+                await User.updateOne(
+                    { userId: u.userId, guildId },
+                    {
+                        $inc: { balance: rewards[i] },
+                        $addToSet: { 'ranked.seasonalTitles': titleLabel },
+                        $set: {
+                            'ranked.peakSeasonTitle': peakTier.label,
+                            'ranked.lastSeasonId':   seasonId,
+                        },
+                    },
+                ).catch(err => console.error('[scheduler] ranked reward update failed:', err.message));
+            }
+
+            // Soft-reset ELO toward 1200 for every participant
+            const participants = await User.find({
+                guildId,
+                $or: [
+                    { 'ranked.rankedWins': { $gt: 0 } },
+                    { 'ranked.rankedLosses': { $gt: 0 } },
+                ]
+            }).select('_id ranked').lean();
+            const bulk = participants.map(u => ({
+                updateOne: {
+                    filter: { _id: u._id },
+                    update: {
+                        $set: {
+                            'ranked.elo':                softResetElo(u.ranked?.elo ?? 1000),
+                            'ranked.seasonPeakElo':      softResetElo(u.ranked?.elo ?? 1000),
+                            'ranked.seasonRankedWins':   0,
+                            'ranked.seasonRankedLosses': 0,
+                            'ranked.currentSeasonId':    makeSeasonId(newSeasonNumber),
+                        }
+                    }
+                }
+            }));
+            if (bulk.length) {
+                await User.bulkWrite(bulk, { ordered: false })
+                    .catch(err => console.error('[scheduler] ranked soft reset failed:', err.message));
+            }
+
+            const channelId = guildDoc.rankedDuels.announceChannelId
+                ?? guildDoc.economy?.announcementChannelId
+                ?? null;
+            if (channelId) {
+                const lines = top.length
+                    ? top.map((u, i) => `${medals[i]} <@${u.userId}> — ${u.ranked?.seasonPeakElo ?? 1000} ELO · earned **${currency}${rewards[i].toLocaleString()}** + title *"${seasonId} ${i === 0 ? 'Champion' : i === 1 ? 'Runner-Up' : 'Third Place'}"*`).join('\n')
+                    : '_No ranked games played this season._';
+                const embed = new EmbedBuilder()
+                    .setColor('#9b59b6')
+                    .setTitle(`🏆 Ranked Season Ended — ${seasonId}`)
+                    .setDescription(lines)
+                    .setFooter({ text: `Season ${newSeasonNumber} starts now — ELO soft-reset toward 1200.` })
+                    .setTimestamp();
+                await postAnnouncement(client, guildId, channelId, embed);
+            }
+        } catch (err) {
+            console.error(`[scheduler] resolveRankedSeasons failed for guild ${guildDoc.guildId}:`, err);
+        }
+    }
+}
+
+module.exports = { resolveExpiredWars, resolveExpiredSeasons, awardWeeklyLeaderboardBadges, selectPetOfTheWeek, announceHourlyWinners, recalcShopPrices, resolveRankedSeasons };

--- a/src/utils/duelElo.js
+++ b/src/utils/duelElo.js
@@ -1,0 +1,59 @@
+// Ranked duel ELO helpers (issue #339)
+
+const RANK_TIERS = [
+    { id: 'bronze',    label: 'Bronze',    icon: '🥉', min: 0,    max: 1099 },
+    { id: 'silver',    label: 'Silver',    icon: '🥈', min: 1100, max: 1299 },
+    { id: 'gold',      label: 'Gold',      icon: '🥇', min: 1300, max: 1499 },
+    { id: 'platinum',  label: 'Platinum',  icon: '💎', min: 1500, max: 1699 },
+    { id: 'diamond',   label: 'Diamond',   icon: '💠', min: 1700, max: 1899 },
+    { id: 'champion',  label: 'Champion',  icon: '👑', min: 1900, max: Infinity },
+];
+
+const START_ELO = 1000;
+const SOFT_RESET_TARGET = 1200;
+const SOFT_RESET_PULL   = 0.5;  // decay halfway toward the target
+
+function tierFor(elo) {
+    const n = Number(elo) || 0;
+    return RANK_TIERS.find(t => n >= t.min && n <= t.max) || RANK_TIERS[0];
+}
+
+// Standard ELO expected score
+function expectedScore(rA, rB) {
+    return 1 / (1 + 10 ** ((rB - rA) / 400));
+}
+
+// Returns { winnerNewElo, loserNewElo, winnerDelta, loserDelta }
+function applyElo(winnerElo, loserElo, kFactor = 32) {
+    const eW = expectedScore(winnerElo, loserElo);
+    const eL = 1 - eW;
+    const winnerDelta = Math.round(kFactor * (1 - eW));
+    const loserDelta  = Math.round(kFactor * (0 - eL));
+    return {
+        winnerNewElo: winnerElo + winnerDelta,
+        loserNewElo:  Math.max(0, loserElo + loserDelta),
+        winnerDelta,
+        loserDelta,
+    };
+}
+
+// Decays an ELO value toward SOFT_RESET_TARGET (used at season end).
+function softResetElo(elo) {
+    return Math.round(elo + (SOFT_RESET_TARGET - elo) * SOFT_RESET_PULL);
+}
+
+// Generate a deterministic season id like "S3"
+function makeSeasonId(seasonNumber) {
+    return `S${seasonNumber}`;
+}
+
+module.exports = {
+    RANK_TIERS,
+    START_ELO,
+    SOFT_RESET_TARGET,
+    tierFor,
+    expectedScore,
+    applyElo,
+    softResetElo,
+    makeSeasonId,
+};

--- a/src/utils/duelElo.js
+++ b/src/utils/duelElo.js
@@ -24,14 +24,19 @@ function expectedScore(rA, rB) {
 }
 
 // Returns { winnerNewElo, loserNewElo, winnerDelta, loserDelta }
+// Deltas remain zero-sum even when the loser would dip below 0 — we clamp
+// loserNewElo at 0 and reduce the reported winnerDelta to match the actual
+// loser change so the embed reads correctly.
 function applyElo(winnerElo, loserElo, kFactor = 32) {
     const eW = expectedScore(winnerElo, loserElo);
     const eL = 1 - eW;
-    const winnerDelta = Math.round(kFactor * (1 - eW));
-    const loserDelta  = Math.round(kFactor * (0 - eL));
+    const tentativeLoserDelta = Math.round(kFactor * (0 - eL));
+    const loserNewElo  = Math.max(0, loserElo + tentativeLoserDelta);
+    const loserDelta   = loserNewElo - loserElo;
+    const winnerDelta  = -loserDelta;
     return {
         winnerNewElo: winnerElo + winnerDelta,
-        loserNewElo:  Math.max(0, loserElo + loserDelta),
+        loserNewElo,
         winnerDelta,
         loserDelta,
     };

--- a/src/utils/dynamicPricing.js
+++ b/src/utils/dynamicPricing.js
@@ -1,0 +1,85 @@
+// Dynamic supply & demand pricing for shop items (issue #354)
+
+const VOLATILITY_FACTORS = {
+    low:    { adjust: 0.10, decay: 0.05 },
+    medium: { adjust: 0.18, decay: 0.10 },
+    high:   { adjust: 0.28, decay: 0.15 },
+};
+
+const HISTORY_CAP = 30;
+
+// Ensure pricing fields are populated for every shop item. Returns true if mutated.
+function ensurePricingFields(shopItems) {
+    let changed = false;
+    for (const item of shopItems) {
+        if (item.basePrice == null) {
+            item.basePrice = item.price;
+            changed = true;
+        }
+        if (item.currentPrice == null) {
+            item.currentPrice = item.price;
+            changed = true;
+        }
+        if (item.demandScore == null) {
+            item.demandScore = 0;
+            changed = true;
+        }
+    }
+    return changed;
+}
+
+// Compute next price based on demand, clamped to ±band of basePrice.
+function nextPrice(item, band, volatility = 'medium') {
+    const cfg = VOLATILITY_FACTORS[volatility] || VOLATILITY_FACTORS.medium;
+    const base = item.basePrice ?? item.price;
+    const demand = item.demandScore ?? 0;
+    // Sigmoid-ish curve so extreme demand asymptotes
+    const swing = Math.tanh(demand * cfg.adjust / 10) * (band || 0.5);
+    const target = Math.max(1, Math.round(base * (1 + swing)));
+    // Step toward target instead of jumping; smooths price chart
+    const cur = item.currentPrice ?? base;
+    return Math.round(cur + (target - cur) * 0.6);
+}
+
+// Decay demand toward zero (oversupply if negative, demand if positive).
+function decayDemand(item, volatility = 'medium') {
+    const cfg = VOLATILITY_FACTORS[volatility] || VOLATILITY_FACTORS.medium;
+    return (item.demandScore ?? 0) * (1 - cfg.decay);
+}
+
+// Record a price-history entry and trim to cap.
+function pushHistory(item, at = new Date()) {
+    if (!Array.isArray(item.priceHistory)) item.priceHistory = [];
+    item.priceHistory.push({
+        at,
+        price: item.currentPrice ?? item.basePrice ?? item.price,
+        demandScore: item.demandScore ?? 0,
+    });
+    if (item.priceHistory.length > HISTORY_CAP) {
+        item.priceHistory.splice(0, item.priceHistory.length - HISTORY_CAP);
+    }
+}
+
+// Convenience: % change between currentPrice and basePrice for /market trends display.
+function trendBucket(item) {
+    const base = item.basePrice ?? item.price;
+    const cur  = item.currentPrice ?? base;
+    if (!base) return { pct: 0, arrow: '·' };
+    const pct = ((cur - base) / base) * 100;
+    let arrow = '·';
+    if (pct >= 15) arrow = '🔥';
+    else if (pct >= 5) arrow = '📈';
+    else if (pct <= -15) arrow = '🧊';
+    else if (pct <= -5) arrow = '📉';
+    return { pct, arrow };
+}
+
+module.exports = {
+    VOLATILITY_FACTORS,
+    HISTORY_CAP,
+    ensurePricingFields,
+    nextPrice,
+    decayDemand,
+    pushHistory,
+    trendBucket,
+};

--- a/src/utils/prestige.js
+++ b/src/utils/prestige.js
@@ -32,6 +32,17 @@ function tierFor(rank) {
     return best;
 }
 
+// Returns the exact display title for a rank — uses the explicit PRESTIGE_TIERS
+// entry when one exists, otherwise synthesizes `Prestige <roman>` so P6–P9
+// don't render as the floored "Prestige V" label.
+function titleForExactRank(rank) {
+    const r = Math.max(0, Number(rank) || 0);
+    if (r === 0) return null;
+    const explicit = PRESTIGE_TIERS.find(t => t.rank === r);
+    if (explicit?.title) return explicit.title;
+    return `Prestige ${roman(r)}`;
+}
+
 // Returns the explicit definition for the upcoming rank (used in /prestige confirmation).
 function nextTierAfter(rank) {
     const r = Math.max(0, Number(rank) || 0);
@@ -84,6 +95,7 @@ module.exports = {
     UNLOCK_LABELS,
     SOFT_PRESTIGE_BONUS,
     tierFor,
+    titleForExactRank,
     nextTierAfter,
     getBonusMultipliers,
     hasUnlock,

--- a/src/utils/prestige.js
+++ b/src/utils/prestige.js
@@ -1,0 +1,92 @@
+// Account-level prestige system (issue #342)
+
+// Each tier unlocks new content + grants a global bonus stack.
+const PRESTIGE_TIERS = [
+    { rank: 0,  title: null,                    bonuses: {},                                                              unlocks: []                                                                                          },
+    { rank: 1,  title: 'Prestige I',            bonuses: { yieldPct: 0.03 },                                              unlocks: ['black_market']                                                                            },
+    { rank: 2,  title: 'Prestige II',           bonuses: { yieldPct: 0.03, staminaRegenPct: 0.05 },                       unlocks: ['black_market', 'legendary_zones']                                                         },
+    { rank: 3,  title: 'Prestige III',          bonuses: { yieldPct: 0.03, staminaRegenPct: 0.05, crimeSuccessPct: 0.05 },unlocks: ['black_market', 'legendary_zones', 'syndicate_leader']                                     },
+    { rank: 4,  title: 'Prestige IV',           bonuses: { yieldPct: 0.03, staminaRegenPct: 0.05, crimeSuccessPct: 0.05, xpPct: 0.05 }, unlocks: ['black_market', 'legendary_zones', 'syndicate_leader', 'exclusive_pets']    },
+    { rank: 5,  title: 'Prestige V ⭐',          bonuses: { yieldPct: 0.08, staminaRegenPct: 0.05, crimeSuccessPct: 0.05, xpPct: 0.05 }, unlocks: ['black_market', 'legendary_zones', 'syndicate_leader', 'exclusive_pets', 'prestige_v_badge'] },
+    { rank: 10, title: 'The Ascended ✨',        bonuses: { yieldPct: 0.10, staminaRegenPct: 0.10, crimeSuccessPct: 0.10, xpPct: 0.10 }, unlocks: ['black_market', 'legendary_zones', 'syndicate_leader', 'exclusive_pets', 'prestige_v_badge', 'ascended'] },
+];
+
+const UNLOCK_LABELS = {
+    black_market:      '🏴 Black Market shop tab',
+    legendary_zones:   '🗺️ Legendary hunt / fish / mine zones',
+    syndicate_leader:  '🕴️ Crime syndicate leadership',
+    exclusive_pets:    '🦝 Exclusive pets',
+    prestige_v_badge:  '⭐ Prestige V star + animated badge',
+    ascended:          '✨ "The Ascended" title + animated profile accent',
+};
+
+const SOFT_PRESTIGE_BONUS = { yieldPct: 0.02, xpPct: 0.02 };
+
+// Returns the tier definition for a given rank (largest rank ≤ requested).
+function tierFor(rank) {
+    const r = Math.max(0, Number(rank) || 0);
+    let best = PRESTIGE_TIERS[0];
+    for (const tier of PRESTIGE_TIERS) {
+        if (tier.rank <= r) best = tier;
+    }
+    return best;
+}
+
+// Returns the explicit definition for the upcoming rank (used in /prestige confirmation).
+function nextTierAfter(rank) {
+    const r = Math.max(0, Number(rank) || 0);
+    const target = r + 1;
+    // If we have an explicit entry for this rank, return it; otherwise interpolate from PRESTIGE_TIERS[5] for ranks 6-9, etc.
+    const explicit = PRESTIGE_TIERS.find(t => t.rank === target);
+    if (explicit) return explicit;
+    // Fallback: use prior tier definition with target rank
+    const prior = tierFor(target);
+    return { ...prior, rank: target, title: `Prestige ${roman(target)}` };
+}
+
+function roman(n) {
+    if (n <= 0) return '0';
+    const map = [['M',1000],['CM',900],['D',500],['CD',400],['C',100],['XC',90],['L',50],['XL',40],['X',10],['IX',9],['V',5],['IV',4],['I',1]];
+    let out = '';
+    for (const [r, v] of map) {
+        while (n >= v) { out += r; n -= v; }
+    }
+    return out;
+}
+
+// Aggregate active bonus multipliers from prestige rank.
+// Returns { yieldMult, xpMult, staminaRegenMult, crimeSuccessMult }
+function getBonusMultipliers(rank) {
+    const tier = tierFor(rank);
+    const b = tier.bonuses || {};
+    return {
+        yieldMult:        1 + (b.yieldPct        ?? 0),
+        xpMult:           1 + (b.xpPct           ?? 0),
+        staminaRegenMult: 1 + (b.staminaRegenPct ?? 0),
+        crimeSuccessMult: 1 + (b.crimeSuccessPct ?? 0),
+    };
+}
+
+function hasUnlock(rank, unlockId) {
+    return tierFor(rank).unlocks.includes(unlockId);
+}
+
+function badgeFor(rank) {
+    if (!rank) return '';
+    if (rank >= 10) return '✨';
+    if (rank >= 5)  return '⭐';
+    if (rank >= 1)  return `⟦P${rank}⟧`;
+    return '';
+}
+
+module.exports = {
+    PRESTIGE_TIERS,
+    UNLOCK_LABELS,
+    SOFT_PRESTIGE_BONUS,
+    tierFor,
+    nextTierAfter,
+    getBonusMultipliers,
+    hasUnlock,
+    badgeFor,
+    roman,
+};

--- a/tests/duelElo.test.js
+++ b/tests/duelElo.test.js
@@ -1,0 +1,53 @@
+const { tierFor, applyElo, softResetElo, RANK_TIERS, START_ELO } = require('../src/utils/duelElo');
+
+describe('duelElo', () => {
+    test('tierFor returns correct tier for boundary ELO values', () => {
+        expect(tierFor(0).id).toBe('bronze');
+        expect(tierFor(1099).id).toBe('bronze');
+        expect(tierFor(1100).id).toBe('silver');
+        expect(tierFor(1500).id).toBe('platinum');
+        expect(tierFor(1899).id).toBe('diamond');
+        expect(tierFor(1900).id).toBe('champion');
+        expect(tierFor(5000).id).toBe('champion');
+    });
+
+    test('tierFor handles invalid input gracefully', () => {
+        expect(tierFor(undefined).id).toBe('bronze');
+        expect(tierFor(NaN).id).toBe('bronze');
+        expect(tierFor(null).id).toBe('bronze');
+    });
+
+    test('applyElo: equal opponents trade roughly K/2', () => {
+        const { winnerDelta, loserDelta } = applyElo(1500, 1500, 32);
+        expect(winnerDelta).toBe(16);
+        expect(loserDelta).toBe(-16);
+    });
+
+    test('applyElo: beating a higher-rated opponent yields more ELO than beating a lower-rated one', () => {
+        const upset    = applyElo(1200, 1800, 32);
+        const expected = applyElo(1800, 1200, 32);
+        expect(upset.winnerDelta).toBeGreaterThan(expected.winnerDelta);
+    });
+
+    test('applyElo: loser cannot go below 0', () => {
+        const { loserNewElo } = applyElo(2000, 5, 32);
+        expect(loserNewElo).toBeGreaterThanOrEqual(0);
+    });
+
+    test('softResetElo pulls toward 1200', () => {
+        expect(softResetElo(1800)).toBe(1500);
+        expect(softResetElo(800)).toBe(1000);
+        expect(softResetElo(1200)).toBe(1200);
+    });
+
+    test('RANK_TIERS form a contiguous ladder starting at 0', () => {
+        expect(RANK_TIERS[0].min).toBe(0);
+        for (let i = 0; i < RANK_TIERS.length - 1; i++) {
+            expect(RANK_TIERS[i + 1].min).toBe(RANK_TIERS[i].max + 1);
+        }
+    });
+
+    test('START_ELO maps to a known tier', () => {
+        expect(tierFor(START_ELO).id).toBe('bronze');
+    });
+});

--- a/tests/duelElo.test.js
+++ b/tests/duelElo.test.js
@@ -34,6 +34,17 @@ describe('duelElo', () => {
         expect(loserNewElo).toBeGreaterThanOrEqual(0);
     });
 
+    test('applyElo: deltas stay zero-sum even when loser would clamp at 0', () => {
+        // 100 vs 5 — close enough that the loser's "expected loss" would
+        // push them below zero. Winner gain should match loser's actual drop.
+        const { winnerNewElo, loserNewElo, winnerDelta, loserDelta } = applyElo(100, 5, 32);
+        expect(loserNewElo).toBe(0);
+        expect(loserDelta).toBe(-5);
+        expect(winnerDelta).toBe(5);
+        expect(winnerNewElo - 100).toBe(winnerDelta);
+        expect(winnerDelta + loserDelta).toBe(0);
+    });
+
     test('softResetElo pulls toward 1200', () => {
         expect(softResetElo(1800)).toBe(1500);
         expect(softResetElo(800)).toBe(1000);

--- a/tests/dynamicPricing.test.js
+++ b/tests/dynamicPricing.test.js
@@ -1,0 +1,56 @@
+const { ensurePricingFields, nextPrice, decayDemand, pushHistory, trendBucket, HISTORY_CAP } = require('../src/utils/dynamicPricing');
+
+describe('dynamicPricing', () => {
+    test('ensurePricingFields fills in missing fields once', () => {
+        const items = [
+            { itemId: 'a', price: 100 },
+            { itemId: 'b', price: 500, basePrice: 500, currentPrice: 600, demandScore: 3 },
+        ];
+        expect(ensurePricingFields(items)).toBe(true);
+        expect(items[0].basePrice).toBe(100);
+        expect(items[0].currentPrice).toBe(100);
+        expect(items[0].demandScore).toBe(0);
+        expect(items[1].currentPrice).toBe(600);
+        expect(ensurePricingFields(items)).toBe(false); // idempotent
+    });
+
+    test('nextPrice rises when demand is positive, falls when negative', () => {
+        const item = { basePrice: 1000, currentPrice: 1000, demandScore: 50 };
+        const up = nextPrice(item, 0.5, 'medium');
+        expect(up).toBeGreaterThan(item.currentPrice);
+
+        const item2 = { basePrice: 1000, currentPrice: 1000, demandScore: -50 };
+        const down = nextPrice(item2, 0.5, 'medium');
+        expect(down).toBeLessThan(item2.currentPrice);
+    });
+
+    test('nextPrice respects the price band', () => {
+        const item = { basePrice: 1000, currentPrice: 1000, demandScore: 999 };
+        const high = nextPrice(item, 0.5, 'high');
+        // Should not exceed base * (1 + band)
+        expect(high).toBeLessThanOrEqual(1500);
+        expect(high).toBeGreaterThanOrEqual(1);
+    });
+
+    test('decayDemand moves demand toward zero', () => {
+        expect(decayDemand({ demandScore: 100 }, 'medium')).toBeLessThan(100);
+        expect(decayDemand({ demandScore: 100 }, 'medium')).toBeGreaterThan(0);
+        expect(decayDemand({ demandScore: -100 }, 'medium')).toBeGreaterThan(-100);
+    });
+
+    test('pushHistory trims to cap', () => {
+        const item = { basePrice: 100, currentPrice: 100, demandScore: 0 };
+        for (let i = 0; i < HISTORY_CAP + 10; i++) pushHistory(item, new Date(i));
+        expect(item.priceHistory.length).toBe(HISTORY_CAP);
+        // Oldest dropped first
+        expect(item.priceHistory[0].at.getTime()).toBe(10);
+    });
+
+    test('trendBucket classifies movement', () => {
+        expect(trendBucket({ basePrice: 100, currentPrice: 130 }).arrow).toBe('🔥');
+        expect(trendBucket({ basePrice: 100, currentPrice: 108 }).arrow).toBe('📈');
+        expect(trendBucket({ basePrice: 100, currentPrice: 100 }).arrow).toBe('·');
+        expect(trendBucket({ basePrice: 100, currentPrice: 92 }).arrow).toBe('📉');
+        expect(trendBucket({ basePrice: 100, currentPrice: 70 }).arrow).toBe('🧊');
+    });
+});

--- a/tests/prestige.test.js
+++ b/tests/prestige.test.js
@@ -1,0 +1,67 @@
+const { tierFor, nextTierAfter, getBonusMultipliers, hasUnlock, badgeFor, roman, PRESTIGE_TIERS } = require('../src/utils/prestige');
+
+describe('prestige', () => {
+    test('tierFor returns floor of requested rank', () => {
+        expect(tierFor(0).rank).toBe(0);
+        expect(tierFor(1).rank).toBe(1);
+        expect(tierFor(2).rank).toBe(2);
+        expect(tierFor(5).rank).toBe(5);
+        expect(tierFor(6).rank).toBe(5);  // between P5 and P10 → uses P5 tier definition
+        expect(tierFor(10).rank).toBe(10);
+        expect(tierFor(15).rank).toBe(10); // above max defined tier
+    });
+
+    test('tierFor handles invalid input', () => {
+        expect(tierFor(undefined).rank).toBe(0);
+        expect(tierFor(-5).rank).toBe(0);
+        expect(tierFor(NaN).rank).toBe(0);
+    });
+
+    test('nextTierAfter returns next explicit tier when defined', () => {
+        expect(nextTierAfter(0).rank).toBe(1);
+        expect(nextTierAfter(4).rank).toBe(5);
+        expect(nextTierAfter(5).rank).toBe(6); // synthesized
+        expect(nextTierAfter(9).rank).toBe(10);
+    });
+
+    test('getBonusMultipliers always returns ≥1.0', () => {
+        const m = getBonusMultipliers(0);
+        expect(m.yieldMult).toBe(1);
+        expect(m.xpMult).toBe(1);
+
+        const m3 = getBonusMultipliers(3);
+        expect(m3.yieldMult).toBeGreaterThan(1);
+        expect(m3.crimeSuccessMult).toBeGreaterThan(1);
+
+        const m10 = getBonusMultipliers(10);
+        expect(m10.yieldMult).toBeGreaterThan(m3.yieldMult);
+    });
+
+    test('hasUnlock follows the tier table', () => {
+        expect(hasUnlock(0, 'black_market')).toBe(false);
+        expect(hasUnlock(1, 'black_market')).toBe(true);
+        expect(hasUnlock(2, 'legendary_zones')).toBe(true);
+        expect(hasUnlock(10, 'ascended')).toBe(true);
+        expect(hasUnlock(5, 'ascended')).toBe(false);
+    });
+
+    test('badgeFor renders rank visually', () => {
+        expect(badgeFor(0)).toBe('');
+        expect(badgeFor(3)).toBe('⟦P3⟧');
+        expect(badgeFor(5)).toBe('⭐');
+        expect(badgeFor(10)).toBe('✨');
+    });
+
+    test('roman converts integers correctly', () => {
+        expect(roman(1)).toBe('I');
+        expect(roman(4)).toBe('IV');
+        expect(roman(9)).toBe('IX');
+        expect(roman(50)).toBe('L');
+        expect(roman(14)).toBe('XIV');
+    });
+
+    test('PRESTIGE_TIERS includes the required milestones from the issue', () => {
+        const ranks = PRESTIGE_TIERS.map(t => t.rank);
+        expect(ranks).toEqual(expect.arrayContaining([0, 1, 2, 3, 4, 5, 10]));
+    });
+});

--- a/tests/prestige.test.js
+++ b/tests/prestige.test.js
@@ -1,4 +1,4 @@
-const { tierFor, nextTierAfter, getBonusMultipliers, hasUnlock, badgeFor, roman, PRESTIGE_TIERS } = require('../src/utils/prestige');
+const { tierFor, titleForExactRank, nextTierAfter, getBonusMultipliers, hasUnlock, badgeFor, roman, PRESTIGE_TIERS } = require('../src/utils/prestige');
 
 describe('prestige', () => {
     test('tierFor returns floor of requested rank', () => {
@@ -63,5 +63,14 @@ describe('prestige', () => {
     test('PRESTIGE_TIERS includes the required milestones from the issue', () => {
         const ranks = PRESTIGE_TIERS.map(t => t.rank);
         expect(ranks).toEqual(expect.arrayContaining([0, 1, 2, 3, 4, 5, 10]));
+    });
+
+    test('titleForExactRank renders explicit tiers verbatim and synthesizes P6-P9', () => {
+        expect(titleForExactRank(0)).toBeNull();
+        expect(titleForExactRank(1)).toBe('Prestige I');
+        expect(titleForExactRank(5)).toBe('Prestige V ⭐');
+        expect(titleForExactRank(6)).toBe('Prestige VI');   // synthesized, NOT "Prestige V ⭐"
+        expect(titleForExactRank(9)).toBe('Prestige IX');
+        expect(titleForExactRank(10)).toBe('The Ascended ✨');
     });
 });


### PR DESCRIPTION
#339 — Ranked duel ladder with ELO + seasons
- Add User.ranked subdocument (elo, peakElo, seasonPeakElo, W/L, seasonal titles)
- Refactor /duel into subcommands: casual, ranked, rank, leaderboard
- Apply ELO updates on ranked wins via standard formula (configurable K-factor)
- Add Guild.rankedDuels config (enabled, minBet, season duration, top reward)
- Scheduler: resolveRankedSeasons rolls over expired seasons, soft-resets
  ELO toward 1200, awards top-3 coins + seasonal titles
- New utility: src/utils/duelElo.js (tier table, expectedScore, applyElo)

#342 — Account prestige overhaul
- Add User.accountPrestige (rank, unlocks, lifetimePrestigeXp, announcedRank)
- New /prestige command with status, info, up subcommands
- Tier table grants permanent bonuses (yield, XP, stamina regen, crime success)
  AND content unlocks (Black Market shop tab, legendary zones, syndicate
  leadership, exclusive pets, "Prestige V" badge, "The Ascended" title)
- Public ascension announcement embed posted on rank-up
- Optional configurable elite role assignment at threshold
- Identity line in /rank shows prestige badge + ranked tier
- New utility: src/utils/prestige.js (tiers, unlocks, badges, bonus mults)

#354 — Dynamic supply/demand pricing
- Add basePrice, currentPrice, demandScore, priceHistory to shop schema
- Add Guild.dynamicPricing (enabled, volatility, band, recalcMinutes)
- Shop buy now charges currentPrice and bumps demandScore atomically
- New /shop trends subcommand shows biggest price movers
- Scheduler: recalcShopPrices runs every 15min, gated per-guild by
  recalcMinutes; emits a market-update embed when items shift >5%
- New utility: src/utils/dynamicPricing.js (sigmoid-clamped price curve,
  demand decay, history trim, trend bucket arrows)

Cross-cutting
- Black Market items seeded into existing guilds via a one-time category
  backfill (existing shopDefaultsSeeded guilds pick up the new tab)
- /shop view hides Black Market tab unless viewer has the prestige unlock
- /shop buy refuses Black Market purchases without the unlock
- Indexes on ranked.elo and accountPrestige.rank for leaderboard queries
- Tests for all three new utility modules (22 new assertions)

https://claude.ai/code/session_01YQ6qXsjSbC3zyHozSLGxyW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ranked duel system with ELO-based rankings and seasonal competition
  * Added account prestige system with tier progression and bonus unlocks
  * Added dynamic shop pricing driven by market supply and demand
  * Added Black Market shop category with prestige-restricted items
  * Enhanced rank cards to display prestige and ranked duel statistics

* **Improvements**
  * Background services now handle shop price recalculation and ranked season management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->