### PR TITLE
fix: wire up Wilderness, Marketplace, and Bank district bonuses (#370)

### DIFF
--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -58,6 +58,8 @@ const { tryUpdateHourlyWinner, getCurrentHourlyLeader } = require('../../utils/h
 const { isDistrictActive } = require('../../services/districtService');
 
 // Rarity score for hourly fish competition (rarest catch wins)
+const WILDERNESS_YIELD_BONUS = 0.10;
+
 const FISH_TIER_SCORE = { common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5, event: 6 };
 
 const LOCATION_CHOICES = LOCATION_LIST.map(l => ({ name: l.name, value: l.id }));
@@ -615,10 +617,12 @@ async function handleCast(interaction) {
             result.featuredSpotBonus     = featBonus;
         }
     }
-    // Wilderness district: +10% fish yield
+    // Wilderness district: +10% fish yield (clamped to daily hard cap)
     const wildernessActive = isDistrictActive(guildSettings, 'wilderness');
     if (result.success && result.finalPayout > 0 && wildernessActive) {
-        const bonus = Math.round(result.finalPayout * 0.10);
+        const remaining = LIMITS.DAILY_HARD_CAP - user.fishing.dailyCoins;
+        const rawBonus  = Math.round(result.finalPayout * WILDERNESS_YIELD_BONUS);
+        const bonus     = Math.max(0, Math.min(rawBonus, remaining));
         if (bonus > 0) {
             user.balance               += bonus;
             user.fishing.totalEarned   += bonus;
@@ -1015,7 +1019,7 @@ function buildCastEmbed(result, user, location, rod, currency, discordUser) {
         if (isCrit)                          fishMultEntries.push({ emoji: '⚡', label: `${critMultiplier.toFixed(2)}x crit` });
         if (fishMultEntries.length > 0) {
             const fishCombined  = (result.streakMult ?? 1) * critMultiplier;
-            const preBonusPayout = finalPayout - (result.petYieldBonus ?? 0) - (result.featuredSpotBonus ?? 0);
+            const preBonusPayout = finalPayout - (result.petYieldBonus ?? 0) - (result.featuredSpotBonus ?? 0) - (result.wildernessBonus ?? 0);
             embed.addFields({ name: '📈 Multipliers', value: stackBar(fishMultEntries, fishCombined, Math.max(0, preBonusPayout), currency), inline: false });
         }
 

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -55,6 +55,7 @@ const { getDailyFeatured, FEATURED_PAYOUT_BONUS, FEATURED_RARE_BONUS } = require
 const { getTimeBand } = require('../../utils/timeBand');
 const { logBigWin } = require('../../utils/bigWinLogger');
 const { tryUpdateHourlyWinner, getCurrentHourlyLeader } = require('../../utils/hourlyWinner');
+const { isDistrictActive } = require('../../services/districtService');
 
 // Rarity score for hourly fish competition (rarest catch wins)
 const FISH_TIER_SCORE = { common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5, event: 6 };
@@ -582,7 +583,8 @@ async function handleCast(interaction) {
     const { getTotalBonus, PET_DEFINITIONS: PET_DEFS, STARVING_THRESHOLD: PET_STARVE, TRAIT_FLAVOR } = require('../../services/petService');
     const petFishYieldPct = getTotalBonus(user.pets || [], 'fish_yield');
 
-    const result = executeCast(user, locationId, { reactionFactor });
+    const marketplaceActive = isDistrictActive(guildSettings, 'marketplace');
+    const result = executeCast(user, locationId, { reactionFactor, marketplaceActive });
 
     // Pity counter: reset on rare+ success, increment otherwise
     if (result.success && ['rare', 'epic', 'legendary', 'event'].includes(result.tier)) {
@@ -611,6 +613,18 @@ async function handleCast(interaction) {
             user.fishing.dailyCoins     += featBonus;
             result.finalPayout          += featBonus;
             result.featuredSpotBonus     = featBonus;
+        }
+    }
+    // Wilderness district: +10% fish yield
+    const wildernessActive = isDistrictActive(guildSettings, 'wilderness');
+    if (result.success && result.finalPayout > 0 && wildernessActive) {
+        const bonus = Math.round(result.finalPayout * 0.10);
+        if (bonus > 0) {
+            user.balance               += bonus;
+            user.fishing.totalEarned   += bonus;
+            user.fishing.dailyCoins    += bonus;
+            result.finalPayout         += bonus;
+            result.wildernessBonus      = bonus;
         }
     }
     if (result.success && result.finalPayout > user.fishing.bestPayout) user.fishing.bestPayout = result.finalPayout;
@@ -660,6 +674,9 @@ async function handleCast(interaction) {
     }
     if (result.featuredSpotBonus > 0) {
         embed.addFields({ name: '🌟 Featured Spot Bonus', value: `+${result.featuredSpotBonus.toLocaleString()} coins (+${Math.round(FEATURED_PAYOUT_BONUS * 100)}%)`, inline: true });
+    }
+    if (result.wildernessBonus > 0) {
+        embed.addFields({ name: '🌲 Wilderness District', value: `+${result.wildernessBonus.toLocaleString()} coins (+10% yield)`, inline: true });
     }
 
     // Hourly leader footer

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -46,6 +46,7 @@ const { getDailyFeatured, FEATURED_PAYOUT_BONUS, FEATURED_RARE_BONUS } = require
 const { getTimeBand } = require('../../utils/timeBand');
 const { logBigWin } = require('../../utils/bigWinLogger');
 const { tryUpdateHourlyWinner, getCurrentHourlyLeader } = require('../../utils/hourlyWinner');
+const { isDistrictActive } = require('../../services/districtService');
 
 // ─── STEALTH APPROACH OPTIONS (per zone) ─────────────────────────────────────
 // Each zone has a hint about the animal's behaviour + 3 approach strategies.
@@ -624,7 +625,8 @@ async function executeStart(interaction) {
     const featured       = getDailyFeatured(interaction.guild.id);
     const isFeaturedZone = zoneId === featured.huntZone.id;
 
-    const result = executeHunt(user, zoneId, { stealthBonus, aimBonus });
+    const marketplaceActive = isDistrictActive(guildSettings, 'marketplace');
+    const result = executeHunt(user, zoneId, { stealthBonus, aimBonus, marketplaceActive });
 
     // Pity counter: reset on rare+ success, increment otherwise
     if (result.success && ['rare', 'epic', 'legendary', 'event'].includes(result.tier)) {
@@ -660,6 +662,18 @@ async function executeStart(interaction) {
             user.hunt.dailyCoins      += featBonus;
             result.finalPayout        += featBonus;
             result.featuredZoneBonus   = featBonus;
+        }
+    }
+    // Wilderness district: +10% hunt yield
+    const wildernessActive = isDistrictActive(guildSettings, 'wilderness');
+    if (result.success && result.finalPayout > 0 && wildernessActive) {
+        const bonus = Math.round(result.finalPayout * 0.10);
+        if (bonus > 0) {
+            user.balance           += bonus;
+            user.hunt.totalEarned  += bonus;
+            user.hunt.dailyCoins   += bonus;
+            result.finalPayout     += bonus;
+            result.wildernessBonus  = bonus;
         }
     }
     if (result.success && result.finalPayout > user.hunt.bestPayout) user.hunt.bestPayout = result.finalPayout;
@@ -711,6 +725,9 @@ async function executeStart(interaction) {
     }
     if (result.featuredZoneBonus > 0) {
         embed.addFields({ name: '🌟 Featured Zone Bonus', value: `+${result.featuredZoneBonus.toLocaleString()} coins (+${Math.round(FEATURED_PAYOUT_BONUS * 100)}%)`, inline: true });
+    }
+    if (result.wildernessBonus > 0) {
+        embed.addFields({ name: '🌲 Wilderness District', value: `+${result.wildernessBonus.toLocaleString()} coins (+10% yield)`, inline: true });
     }
 
     // Hourly leader footer

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -48,6 +48,8 @@ const { logBigWin } = require('../../utils/bigWinLogger');
 const { tryUpdateHourlyWinner, getCurrentHourlyLeader } = require('../../utils/hourlyWinner');
 const { isDistrictActive } = require('../../services/districtService');
 
+const WILDERNESS_YIELD_BONUS = 0.10;
+
 // ─── STEALTH APPROACH OPTIONS (per zone) ─────────────────────────────────────
 // Each zone has a hint about the animal's behaviour + 3 approach strategies.
 // One approach is correct; correct = stealthBonus, wrong = noise penalty.
@@ -664,10 +666,12 @@ async function executeStart(interaction) {
             result.featuredZoneBonus   = featBonus;
         }
     }
-    // Wilderness district: +10% hunt yield
+    // Wilderness district: +10% hunt yield (clamped to daily hard cap)
     const wildernessActive = isDistrictActive(guildSettings, 'wilderness');
     if (result.success && result.finalPayout > 0 && wildernessActive) {
-        const bonus = Math.round(result.finalPayout * 0.10);
+        const remaining = LIMITS.DAILY_HARD_CAP - user.hunt.dailyCoins;
+        const rawBonus  = Math.round(result.finalPayout * WILDERNESS_YIELD_BONUS);
+        const bonus     = Math.max(0, Math.min(rawBonus, remaining));
         if (bonus > 0) {
             user.balance           += bonus;
             user.hunt.totalEarned  += bonus;

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -45,6 +45,7 @@ const { getDailyFeatured, FEATURED_PAYOUT_BONUS } = require('../../data/featured
 const { getTimeBand } = require('../../utils/timeBand');
 const { logBigWin } = require('../../utils/bigWinLogger');
 const { tryUpdateHourlyWinner, getCurrentHourlyLeader } = require('../../utils/hourlyWinner');
+const { isDistrictActive } = require('../../services/districtService');
 
 const DEPTH_CHOICES    = DEPTH_LIST.map(d => ({ name: d.name, value: d.id }));
 const PICKAXE_CHOICES  = PICKAXE_TIERS.map(p => ({ name: `${p.emoji} ${p.name} — ${p.cost.toLocaleString()} coins`, value: p.slug }));
@@ -505,7 +506,8 @@ async function handleDig(interaction) {
     const { getTotalBonus, PET_DEFINITIONS: PET_DEFS, STARVING_THRESHOLD: PET_STARVE, TRAIT_FLAVOR } = require('../../services/petService');
     const petMineYieldPct = getTotalBonus(user.pets || [], 'mine_yield');
 
-    const result = executeMine(user, depthId, { intensity: chosenIntensity });
+    const marketplaceActive = isDistrictActive(guildSettings, 'marketplace');
+    const result = executeMine(user, depthId, { intensity: chosenIntensity, marketplaceActive });
 
     // Pity counter: reset on rare+ success, increment otherwise
     if (result.success && ['rare', 'epic', 'legendary', 'event'].includes(result.tier)) {
@@ -534,6 +536,19 @@ async function handleDig(interaction) {
             user.mining.dailyCoins    += bonus;
             result.finalPayout        += bonus;
             result.petYieldBonus       = bonus;
+        }
+    }
+
+    // Wilderness district: +10% mine yield
+    const wildernessActive = isDistrictActive(guildSettings, 'wilderness');
+    if (result.success && result.finalPayout > 0 && wildernessActive) {
+        const bonus = Math.round(result.finalPayout * 0.10);
+        if (bonus > 0) {
+            user.balance               += bonus;
+            user.mining.totalEarned    += bonus;
+            user.mining.dailyCoins     += bonus;
+            result.finalPayout         += bonus;
+            result.wildernessBonus      = bonus;
         }
     }
 
@@ -579,6 +594,9 @@ async function handleDig(interaction) {
     }
     if (result.petYieldBonus > 0) {
         embed.addFields({ name: '💎 Pet Bonus', value: `+${result.petYieldBonus.toLocaleString()} coins (${petMineYieldPct}% yield)`, inline: true });
+    }
+    if (result.wildernessBonus > 0) {
+        embed.addFields({ name: '🌲 Wilderness District', value: `+${result.wildernessBonus.toLocaleString()} coins (+10% yield)`, inline: true });
     }
 
     // Hourly leader footer

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -47,6 +47,8 @@ const { logBigWin } = require('../../utils/bigWinLogger');
 const { tryUpdateHourlyWinner, getCurrentHourlyLeader } = require('../../utils/hourlyWinner');
 const { isDistrictActive } = require('../../services/districtService');
 
+const WILDERNESS_YIELD_BONUS = 0.10;
+
 const DEPTH_CHOICES    = DEPTH_LIST.map(d => ({ name: d.name, value: d.id }));
 const PICKAXE_CHOICES  = PICKAXE_TIERS.map(p => ({ name: `${p.emoji} ${p.name} — ${p.cost.toLocaleString()} coins`, value: p.slug }));
 const ALL_ITEMS        = [...Object.values(CONSUMABLES), ...BLAST_PACKS];
@@ -539,10 +541,12 @@ async function handleDig(interaction) {
         }
     }
 
-    // Wilderness district: +10% mine yield
+    // Wilderness district: +10% mine yield (clamped to daily hard cap)
     const wildernessActive = isDistrictActive(guildSettings, 'wilderness');
     if (result.success && result.finalPayout > 0 && wildernessActive) {
-        const bonus = Math.round(result.finalPayout * 0.10);
+        const remaining = LIMITS.DAILY_HARD_CAP - user.mining.dailyCoins;
+        const rawBonus  = Math.round(result.finalPayout * WILDERNESS_YIELD_BONUS);
+        const bonus     = Math.max(0, Math.min(rawBonus, remaining));
         if (bonus > 0) {
             user.balance               += bonus;
             user.mining.totalEarned    += bonus;

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -6,7 +6,7 @@ const { checkGiveaways } = require('../services/giveawayService');
 const { checkTempVoice } = require('../services/tempVoiceService');
 const { checkBirthdays } = require('../services/birthdayService');
 const { checkSeasonalEvents } = require('../services/seasonalEventService');
-const { resolveExpiredWars, resolveExpiredSeasons, awardWeeklyLeaderboardBadges, announceHourlyWinners, recalcShopPrices, resolveRankedSeasons } = require('../services/schedulerService');
+const { resolveExpiredWars, resolveExpiredSeasons, awardWeeklyLeaderboardBadges, announceHourlyWinners, recalcShopPrices, resolveRankedSeasons, applyBankInterest } = require('../services/schedulerService');
 const { runJob } = require('../utils/jobRunner');
 const User = require('../models/User');
 const { logTransaction } = require('../utils/logTransaction');
@@ -68,6 +68,12 @@ module.exports = {
         // Award weekly leaderboard badges every Sunday at 23:59 UTC
         cron.schedule('59 23 * * 0', () =>
             runJob('schedulerService', 'awardWeeklyLeaderboardBadges', () => awardWeeklyLeaderboardBadges(client)),
+            { timezone: 'Etc/UTC' }
+        );
+
+        // Apply Bank district weekly interest every Monday at 00:01 UTC
+        cron.schedule('1 0 * * 1', () =>
+            runJob('schedulerService', 'applyBankInterest', () => applyBankInterest(client)),
             { timezone: 'Etc/UTC' }
         );
 

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -667,8 +667,9 @@ const guildSchema = new Schema({
         endsAt:    { type: Date, default: null }
     },
 
-    // Scheduler claim timestamp for Pet of the Week job (prevents duplicate runs)
-    potwLastRunAt: { type: Date, default: null },
+    // Scheduler claim timestamps — prevent duplicate runs across cron restarts
+    potwLastRunAt:          { type: Date, default: null },
+    bankInterestLastRunAt:  { type: Date, default: null },
 
     createdAt: { type: Date, default: Date.now },
     updatedAt: { type: Date, default: Date.now }

--- a/src/services/fishService.js
+++ b/src/services/fishService.js
@@ -678,8 +678,9 @@ function executeCast(user, locationId, options = {}) {
             // ── Special material drop ──────────────────────────────────────
             let specialDrop = null;
             let dropChance  = fish.specialDrop?.chance ?? 0;
-            if (isCrit)            dropChance *= 2;
-            if (traits.ancient)    dropChance *= 2; // ancient trait doubles mat chance
+            if (isCrit)                       dropChance *= 2;
+            if (traits.ancient)               dropChance *= 2; // ancient trait doubles mat chance
+            if (options.marketplaceActive)    dropChance *= 1.10;
             if (fish.specialDrop && Math.random() < dropChance) {
                 specialDrop = fish.specialDrop;
                 const matKey = fish.specialDrop.itemId;

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -736,7 +736,8 @@ function executeHunt(user, zoneId, options = {}) {
 
         // Special drop
         let specialDrop = null;
-        if (animal.specialDrop && Math.random() < (isCrit ? animal.specialDrop.chance * 2 : animal.specialDrop.chance)) {
+        const huntDropChance = (isCrit ? animal.specialDrop?.chance * 2 : animal.specialDrop?.chance ?? 0) * (options.marketplaceActive ? 1.10 : 1.0);
+        if (animal.specialDrop && Math.random() < huntDropChance) {
             specialDrop = animal.specialDrop;
             const matKey = animal.specialDrop.itemId;
             if (h.materials[matKey] != null) {

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -742,6 +742,8 @@ function executeHunt(user, zoneId, options = {}) {
             const matKey = animal.specialDrop.itemId;
             if (h.materials[matKey] != null) {
                 h.materials[matKey] += 1;
+            } else {
+                h.materials[matKey] = 1;
             }
         }
 

--- a/src/services/mineService.js
+++ b/src/services/mineService.js
@@ -512,7 +512,8 @@ function executeMine(user, depthId, options = {}) {
         const { adjustedPayout, cappedByHard } = applyPayoutModifiers(user, payoutBeforeMods, depth);
 
         let specialDrop = null;
-        if (ore.specialDrop && Math.random() < (isCrit ? ore.specialDrop.chance * 2 : ore.specialDrop.chance)) {
+        const mineDropChance = (isCrit ? ore.specialDrop?.chance * 2 : ore.specialDrop?.chance ?? 0) * (options.marketplaceActive ? 1.10 : 1.0);
+        if (ore.specialDrop && Math.random() < mineDropChance) {
             specialDrop = ore.specialDrop;
             const matKey = ore.specialDrop.itemId;
             if (m.materials[matKey] != null) {

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -782,4 +782,59 @@ async function resolveRankedSeasons(client) {
     }
 }
 
-module.exports = { resolveExpiredWars, resolveExpiredSeasons, awardWeeklyLeaderboardBadges, selectPetOfTheWeek, announceHourlyWinners, recalcShopPrices, resolveRankedSeasons };
+// ─── Bank district interest (issue #370) ─────────────────────────────────────
+// Credits 5% of each user's banked coins in guilds where the Bank district is active.
+// Intended to run once per week.
+async function applyBankInterest(client) {
+    const { EmbedBuilder } = require('discord.js');
+    const { isDistrictActive } = require('./districtService');
+    const { logTransaction } = require('../utils/logTransaction');
+
+    const now = new Date();
+    const guilds = await Guild.find({
+        'districts': { $elemMatch: { districtId: 'bank', activeUntil: { $gt: now } } }
+    }).lean();
+
+    for (const guildDoc of guilds) {
+        const guildId = guildDoc.guildId;
+        try {
+            if (!isDistrictActive(guildDoc, 'bank')) continue;
+
+            const users = await User.find({ guildId, bank: { $gt: 0 } });
+            let totalInterestPaid = 0;
+
+            for (const user of users) {
+                const interest = Math.floor(user.bank * 0.05);
+                if (interest <= 0) continue;
+                await User.findOneAndUpdate(
+                    { _id: user._id },
+                    { $inc: { bank: interest } }
+                );
+                logTransaction({ userId: user.userId, guildId, type: 'bank_interest', amount: interest, balance: user.balance, note: '5% weekly bank interest (Bank district active)' });
+                totalInterestPaid += interest;
+            }
+
+            if (totalInterestPaid <= 0) continue;
+
+            const channelId = guildDoc.economy?.announcementChannelId ?? null;
+            if (!channelId) continue;
+
+            const currency = guildDoc.economy?.currency ?? '💰';
+            const embed = new EmbedBuilder()
+                .setColor('#f1c40f')
+                .setTitle('🏦 Weekly Bank Interest Paid')
+                .setDescription(
+                    `The **Bank district** is active — all members with banked coins earned **5% weekly interest**.\n\n` +
+                    `Total interest distributed: **${currency}${totalInterestPaid.toLocaleString()}**`
+                )
+                .setFooter({ text: 'Deposit coins with /bank deposit to earn interest each week.' })
+                .setTimestamp();
+
+            await postAnnouncement(client, guildId, channelId, embed);
+        } catch (err) {
+            console.error(`[scheduler] applyBankInterest failed for guild ${guildId}:`, err.message);
+        }
+    }
+}
+
+module.exports = { resolveExpiredWars, resolveExpiredSeasons, awardWeeklyLeaderboardBadges, selectPetOfTheWeek, announceHourlyWinners, recalcShopPrices, resolveRankedSeasons, applyBankInterest };

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -790,14 +790,29 @@ async function applyBankInterest(client) {
     const { isDistrictActive } = require('./districtService');
     const { logTransaction } = require('../utils/logTransaction');
 
-    const now = new Date();
-    const guilds = await Guild.find({
+    const now     = new Date();
+    const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const guilds  = await Guild.find({
         'districts': { $elemMatch: { districtId: 'bank', activeUntil: { $gt: now } } }
     }).lean();
 
     for (const guildDoc of guilds) {
         const guildId = guildDoc.guildId;
         try {
+            // Atomic weekly claim — skip if already run within the last 7 days
+            const claimed = await Guild.findOneAndUpdate(
+                {
+                    guildId,
+                    $or: [
+                        { bankInterestLastRunAt: null },
+                        { bankInterestLastRunAt: { $lte: weekAgo } },
+                    ],
+                },
+                { $set: { bankInterestLastRunAt: now } },
+                { new: false }
+            );
+            if (!claimed) continue;
+
             if (!isDistrictActive(guildDoc, 'bank')) continue;
 
             const users = await User.find({ guildId, bank: { $gt: 0 } });


### PR DESCRIPTION
Wilderness (+10% hunt/fish/mine yield): import isDistrictActive in hunt.js,
fish.js, mine.js and apply a 1.10× multiplier to finalPayout when the
'wilderness' district is active, matching the existing pet-yield bonus pattern.
Embed fields surface the bonus to the user.

Marketplace (+10% item drop chance from activities): pass marketplaceActive
flag through executeHunt/executeCast/executeMine options; huntService,
fishService, and mineService multiply the specialDrop roll threshold by 1.10
when the flag is set.

Bank (+5% weekly interest on banked coins): add applyBankInterest() to
schedulerService — finds every guild with an active Bank district, credits
5% of each user's bank balance, logs each transaction, and posts an
announcement. Schedule the job every Monday at 00:01 UTC in ready.js.

https://claude.ai/code/session_01DqaRjWpME4F8n1kG7tkbBa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced district system affecting economy activities across fishing, hunting, and mining.
  * Added Wilderness District bonus: earn an extra 10% payout when district is active.
  * Added Marketplace District modifier: increases special item drop chances by 10%.
  * Implemented weekly bank interest: earn 5% interest on banked coins in guilds with Bank District active (runs Mondays at 00:01 UTC).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->