### PR TITLE
Fix invest command: save districts and validate active status

### DIFF
--- a/src/commands/economy/invest.js
+++ b/src/commands/economy/invest.js
@@ -107,6 +107,9 @@ module.exports = {
         }
 
         ensureDistricts(guildSettings);
+        if (guildSettings.isModified('districts')) {
+            await guildSettings.save();
+        }
 
         const currency = guildSettings.economy.currency || '💰';
         const sub = interaction.options.getSubcommand();
@@ -153,6 +156,15 @@ module.exports = {
         const distMeta   = DISTRICTS.find(d => d.id === districtId);
         if (!distMeta) {
             return interaction.reply({ content: 'Unknown district.', ephemeral: true });
+        }
+
+        // Check district is not already active before touching the user's balance
+        const distEntryCheck = guildSettings.districts.find(x => x.districtId === districtId);
+        if (distEntryCheck && isActive(distEntryCheck)) {
+            return interaction.reply({
+                content: `The **${distMeta.name}** district is already active!`,
+                ephemeral: true,
+            });
         }
 
         const userDoc = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });


### PR DESCRIPTION
## Summary
This PR fixes two issues in the invest command to improve data persistence and prevent duplicate active district investments.

## Key Changes
- **Save districts after initialization**: Added a check to persist `guildSettings` to the database after `ensureDistricts()` is called, ensuring newly created district entries are saved.
- **Validate district is not already active**: Added an early validation check before deducting user balance to prevent investing in a district that is already active. This check uses the existing `isActive()` function to determine status.

## Implementation Details
- The districts save operation is conditional (`if (guildSettings.isModified('districts'))`) to avoid unnecessary database writes.
- The active district check is performed after validating the district exists but before any balance modifications, following the fail-fast principle to avoid side effects on invalid requests.

https://claude.ai/code/session_01GZaQDNQrDMMcTmdBPQphfo