### PR TITLE
Fix trap consumption race condition and improve error handling

### DIFF
--- a/src/commands/economy/crime.js
+++ b/src/commands/economy/crime.js
@@ -299,6 +299,8 @@ module.exports = {
             console.error('Crime command error:', error);
             if (!interaction.replied && !interaction.deferred) {
                 await interaction.reply({ content: 'Something went wrong.', ephemeral: true });
+            } else {
+                await interaction.editReply({ content: 'Something went wrong. Try again.' }).catch(() => {});
             }
         }
     }

--- a/src/commands/economy/rob.js
+++ b/src/commands/economy/rob.js
@@ -20,7 +20,7 @@ const TRAP_FINE_MULTIPLIER = 2;            // trap doubles the normal fine
 // robber has already been persisted, restore the robber's prior balance from
 // the snapshot before re-throwing, so partial heists don't leave the robber
 // with stolen coins the victim never lost.
-async function saveRobState(robber, victim, robberSnapshot) {
+async function saveRobState(robber, victim, robberSnapshot, trapSnapshot) {
     await robber.save();
     try {
         await victim.save();
@@ -37,6 +37,16 @@ async function saveRobState(robber, victim, robberSnapshot) {
             );
         } catch (rollbackErr) {
             console.error('[rob] rollback failed; balances may be inconsistent:', rollbackErr);
+        }
+        if (trapSnapshot) {
+            try {
+                await User.updateOne(
+                    { userId: victim.userId, guildId: victim.guildId },
+                    { $set: { 'trap.setAt': trapSnapshot.setAt, 'trap.expiresAt': trapSnapshot.expiresAt } }
+                );
+            } catch (trapRollbackErr) {
+                console.error('[rob] trap rollback failed; trap may be permanently consumed:', trapRollbackErr);
+            }
         }
         throw victimErr;
     }
@@ -194,18 +204,23 @@ module.exports = {
                     { new: false }
                 );
                 const trapActive = !!trapConsumed;
+                const trapSnapshot = trapActive
+                    ? { setAt: trapConsumed.trap?.setAt ?? null, expiresAt: trapConsumed.trap?.expiresAt ?? null }
+                    : null;
                 let trapFine = 0;
                 if (trapActive) {
                     const normalFine = Math.floor(preRobBalance * failFineRate);
                     trapFine = Math.min(normalFine * TRAP_FINE_MULTIPLIER, robber.balance);
                     robber.balance = Math.max(0, robber.balance - trapFine);
                     victim.balance += trapFine;
-                    victim.trap.setAt     = null;
-                    victim.trap.expiresAt = null;
+                    if (victim.trap) {
+                        victim.trap.setAt     = null;
+                        victim.trap.expiresAt = null;
+                    }
                 }
 
                 const robAchievements = await checkAndAward(robber, guildSettings).catch(() => []);
-                await saveRobState(robber, victim, robberSnapshot);
+                await saveRobState(robber, victim, robberSnapshot, trapSnapshot);
                 if (robAchievements.length) {
                     announceAchievements(interaction.client, guildSettings, robber, interaction.member, robAchievements).catch(() => null);
                 }

--- a/src/commands/economy/rob.js
+++ b/src/commands/economy/rob.js
@@ -173,6 +173,7 @@ module.exports = {
                 // Robbery Bag: +10% stolen
                 if (hasEffect(robber, 'robbery_bag')) stolen = Math.floor(stolen * 1.10);
 
+                const preRobBalance = robber.balance;
                 robber.balance += stolen;
                 robber.successfulRobs = (robber.successfulRobs || 0) + 1;
 
@@ -186,16 +187,19 @@ module.exports = {
                 victim.lastRobbedAt = new Date();
                 if (padlockActive) consumeEffect(victim, 'padlock');
 
-                // ── Trap check ────────────────────────────────────────────────
-                const trapActive = victim.trap?.expiresAt && victim.trap.expiresAt > new Date();
+                // ── Trap check (atomic consume to prevent double-trigger) ─────
+                const trapConsumed = await User.findOneAndUpdate(
+                    { userId: victim.userId, guildId: interaction.guild.id, 'trap.expiresAt': { $gt: new Date() } },
+                    { $unset: { 'trap.expiresAt': '', 'trap.setAt': '' } },
+                    { new: false }
+                );
+                const trapActive = !!trapConsumed;
                 let trapFine = 0;
                 if (trapActive) {
-                    // Compute doubled fine and apply it
-                    const normalFine = Math.floor(robber.balance * failFineRate);
+                    const normalFine = Math.floor(preRobBalance * failFineRate);
                     trapFine = Math.min(normalFine * TRAP_FINE_MULTIPLIER, robber.balance);
                     robber.balance = Math.max(0, robber.balance - trapFine);
                     victim.balance += trapFine;
-                    // Consume the trap
                     victim.trap.setAt     = null;
                     victim.trap.expiresAt = null;
                 }


### PR DESCRIPTION
## Summary
This PR addresses a critical race condition in the robbery trap mechanic and improves error handling in the crime command.

## Key Changes

### Rob Command (`src/commands/economy/rob.js`)
- **Atomic trap consumption**: Replaced non-atomic trap check with a database-level `findOneAndUpdate` operation to prevent double-triggering of traps in concurrent robbery scenarios
- **Trap fine calculation fix**: Changed trap fine calculation to use `preRobBalance` (balance before robbery) instead of current balance, ensuring the fine is computed correctly and preventing exploits where stolen amount affects the penalty
- **Balance tracking**: Added `preRobBalance` variable to capture the robber's balance before the robbery amount is added

### Crime Command (`src/commands/economy/crime.js`)
- **Improved error handling**: Added fallback error response when interaction has already been replied to or deferred, preventing silent failures and improving user experience

## Implementation Details
The trap consumption now uses MongoDB's atomic update operation with a query filter (`'trap.expiresAt': { $gt: new Date() }`), ensuring that only one concurrent robbery can consume a trap. The operation returns the document state before the update, allowing us to verify if a trap existed without a separate read operation.

https://claude.ai/code/session_01F4pzihsWKHwTw3tUUSuqBd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in the crime command with improved fallback error messages
  * Strengthened trap mechanics in the rob command for more reliable and accurate processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->