### PR TITLE
Add Pet of the Week scheduler and fix duplicate payouts

### DIFF
--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -102,29 +102,59 @@ module.exports = {
         try {
             const Guild = require('../models/Guild');
             const Transaction = require('../models/Transaction');
-            const guildsWithUnpaid = await Guild.find({
-                'casinoJackpot.lastWinnerId':  { $ne: null },
-                'casinoJackpot.lastWonAmount': { $gt: 0 },
-            }).lean();
-            for (const g of guildsWithUnpaid) {
-                const { lastWinnerId, lastWonAmount, lastWonAt } = g.casinoJackpot;
-                const credited = await Transaction.findOne({
-                    userId:  lastWinnerId,
-                    guildId: g.guildId,
-                    type:    'casino_jackpot',
-                    amount:  lastWonAmount,
-                    ...(lastWonAt ? { createdAt: { $gte: lastWonAt } } : {}),
-                }).lean();
-                if (!credited) {
-                    const updatedUser = await User.findOneAndUpdate(
-                        { userId: lastWinnerId, guildId: g.guildId },
-                        { $inc: { balance: lastWonAmount } },
-                        { new: true }
-                    );
-                    logTransaction({ userId: lastWinnerId, guildId: g.guildId, type: 'casino_jackpot', amount: lastWonAmount, balance: updatedUser?.balance ?? 0, note: 'jackpot reconciliation on restart' });
-                    console.log(`[READY] Reconciled jackpot payout of ${lastWonAmount} to ${lastWinnerId} in guild ${g.guildId}`);
+            const claimToken = `${process.pid}-${Date.now()}`;
+            let candidateGuild;
+            // Process one guild at a time; re-query each iteration to avoid stale data
+            while ((candidateGuild = await Guild.findOneAndUpdate(
+                {
+                    'casinoJackpot.lastWinnerId':  { $ne: null },
+                    'casinoJackpot.lastWonAmount': { $gt: 0 },
+                    'casinoJackpot.claimToken':    { $in: [null, claimToken] },
+                },
+                { $set: { 'casinoJackpot.claimToken': claimToken } },
+                { new: true }
+            )) !== null) {
+                const { lastWinnerId, lastWonAmount, lastWonAt } = candidateGuild.casinoJackpot;
+                const guildId = candidateGuild.guildId;
+                let creditSucceeded = false;
+                try {
+                    const credited = await Transaction.findOne({
+                        userId:  lastWinnerId,
+                        guildId,
+                        type:    'casino_jackpot',
+                        amount:  lastWonAmount,
+                        ...(lastWonAt ? { createdAt: { $gte: lastWonAt } } : {}),
+                    }).lean();
+                    if (!credited) {
+                        const updatedUser = await User.findOneAndUpdate(
+                            { userId: lastWinnerId, guildId },
+                            { $inc: { balance: lastWonAmount } },
+                            { new: true }
+                        );
+                        if (updatedUser) {
+                            logTransaction({ userId: lastWinnerId, guildId, type: 'casino_jackpot', amount: lastWonAmount, balance: updatedUser.balance, note: 'jackpot reconciliation on restart' });
+                            console.log(`[READY] Reconciled jackpot payout of ${lastWonAmount} to ${lastWinnerId} in guild ${guildId}`);
+                            creditSucceeded = true;
+                        }
+                    } else {
+                        creditSucceeded = true; // already paid, just clear
+                    }
+                } catch (innerErr) {
+                    console.error(`[READY] Jackpot credit failed for guild ${guildId}:`, innerErr);
                 }
-                await Guild.updateOne({ _id: g._id }, { $set: { 'casinoJackpot.lastWinnerId': null, 'casinoJackpot.lastWonAmount': null } });
+                if (creditSucceeded) {
+                    await Guild.updateOne(
+                        { _id: candidateGuild._id },
+                        { $set: { 'casinoJackpot.lastWinnerId': null, 'casinoJackpot.lastWonAmount': null, 'casinoJackpot.claimToken': null } }
+                    );
+                } else {
+                    // Release lock without clearing recovery fields so next restart can retry
+                    await Guild.updateOne(
+                        { _id: candidateGuild._id },
+                        { $set: { 'casinoJackpot.claimToken': null } }
+                    );
+                    break; // avoid spinning on a persistently failing guild
+                }
             }
         } catch (err) {
             console.error('[READY] Jackpot reconciliation failed:', err);

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -6,7 +6,7 @@ const { checkGiveaways } = require('../services/giveawayService');
 const { checkTempVoice } = require('../services/tempVoiceService');
 const { checkBirthdays } = require('../services/birthdayService');
 const { checkSeasonalEvents } = require('../services/seasonalEventService');
-const { resolveExpiredWars, resolveExpiredSeasons, awardWeeklyLeaderboardBadges, announceHourlyWinners, recalcShopPrices, resolveRankedSeasons, applyBankInterest } = require('../services/schedulerService');
+const { resolveExpiredWars, resolveExpiredSeasons, awardWeeklyLeaderboardBadges, selectPetOfTheWeek, announceHourlyWinners, recalcShopPrices, resolveRankedSeasons, applyBankInterest } = require('../services/schedulerService');
 const { runJob } = require('../utils/jobRunner');
 const User = require('../models/User');
 const { logTransaction } = require('../utils/logTransaction');
@@ -71,6 +71,12 @@ module.exports = {
             { timezone: 'Etc/UTC' }
         );
 
+        // Select Pet of the Week every Monday at midnight UTC
+        cron.schedule('0 0 * * 1', () =>
+            runJob('schedulerService', 'selectPetOfTheWeek', () => selectPetOfTheWeek(client)),
+            { timezone: 'Etc/UTC' }
+        );
+
         // Apply Bank district weekly interest every Monday at 00:01 UTC
         cron.schedule('1 0 * * 1', () =>
             runJob('schedulerService', 'applyBankInterest', () => applyBankInterest(client)),
@@ -91,6 +97,38 @@ module.exports = {
         cron.schedule('*/10 * * * *', () =>
             runJob('schedulerService', 'resolveRankedSeasons', () => resolveRankedSeasons(client))
         );
+
+        // Reconcile any jackpot wins where pool was reset but winner was never credited
+        try {
+            const Guild = require('../models/Guild');
+            const Transaction = require('../models/Transaction');
+            const guildsWithUnpaid = await Guild.find({
+                'casinoJackpot.lastWinnerId':  { $ne: null },
+                'casinoJackpot.lastWonAmount': { $gt: 0 },
+            }).lean();
+            for (const g of guildsWithUnpaid) {
+                const { lastWinnerId, lastWonAmount, lastWonAt } = g.casinoJackpot;
+                const credited = await Transaction.findOne({
+                    userId:  lastWinnerId,
+                    guildId: g.guildId,
+                    type:    'casino_jackpot',
+                    amount:  lastWonAmount,
+                    ...(lastWonAt ? { createdAt: { $gte: lastWonAt } } : {}),
+                }).lean();
+                if (!credited) {
+                    const updatedUser = await User.findOneAndUpdate(
+                        { userId: lastWinnerId, guildId: g.guildId },
+                        { $inc: { balance: lastWonAmount } },
+                        { new: true }
+                    );
+                    logTransaction({ userId: lastWinnerId, guildId: g.guildId, type: 'casino_jackpot', amount: lastWonAmount, balance: updatedUser?.balance ?? 0, note: 'jackpot reconciliation on restart' });
+                    console.log(`[READY] Reconciled jackpot payout of ${lastWonAmount} to ${lastWinnerId} in guild ${g.guildId}`);
+                }
+                await Guild.updateOne({ _id: g._id }, { $set: { 'casinoJackpot.lastWinnerId': null, 'casinoJackpot.lastWonAmount': null } });
+            }
+        } catch (err) {
+            console.error('[READY] Jackpot reconciliation failed:', err);
+        }
 
         // Refund any bets that were deducted during a crash game that was interrupted by a restart
         try {

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -670,6 +670,7 @@ const guildSchema = new Schema({
     // Scheduler claim timestamps — prevent duplicate runs across cron restarts
     potwLastRunAt:          { type: Date, default: null },
     bankInterestLastRunAt:  { type: Date, default: null },
+    badgesLastAwardedAt:    { type: Date, default: null },
 
     createdAt: { type: Date, default: Date.now },
     updatedAt: { type: Date, default: Date.now }

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -197,6 +197,7 @@ const guildSchema = new Schema({
         lastWinnerName:       { type: String,  default: null },
         lastWonAmount:        { type: Number,  default: null },
         lastWonAt:            { type: Date,    default: null },
+        claimToken:           { type: String,  default: null },
     },
 
     rssFeeds: [{
@@ -671,6 +672,7 @@ const guildSchema = new Schema({
     potwLastRunAt:          { type: Date, default: null },
     bankInterestLastRunAt:  { type: Date, default: null },
     badgesLastAwardedAt:    { type: Date, default: null },
+    badgesAwardLeaseAt:     { type: Date, default: null },
 
     createdAt: { type: Date, default: Date.now },
     updatedAt: { type: Date, default: Date.now }

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -349,12 +349,18 @@ async function awardWeeklyLeaderboardBadges(client) {
     for (const guildDoc of guilds) {
         const guildId = guildDoc.guildId;
         try {
-            const claimed = await Guild.findOneAndUpdate(
-                { guildId, $or: [{ badgesLastAwardedAt: null }, { badgesLastAwardedAt: { $lte: weekAgo } }] },
-                { $set: { badgesLastAwardedAt: new Date() } },
+            // Atomically acquire a short-lived lease; badgesLastAwardedAt is only written on success
+            const leaseUntil = new Date(Date.now() + 5 * 60 * 1000); // 5-minute lease window
+            const leased = await Guild.findOneAndUpdate(
+                {
+                    guildId,
+                    $or: [{ badgesLastAwardedAt: null }, { badgesLastAwardedAt: { $lte: weekAgo } }],
+                    $or: [{ badgesAwardLeaseAt: null }, { badgesAwardLeaseAt: { $lte: new Date() } }],
+                },
+                { $set: { badgesAwardLeaseAt: leaseUntil } },
                 { new: false }
             );
-            if (!claimed) continue;
+            if (!leased) continue;
 
             const categories = [
                 { key: 'levels',       sort: { level: -1, xp: -1 },            label: '📈 Top Level' },
@@ -394,14 +400,20 @@ async function awardWeeklyLeaderboardBadges(client) {
                 champLines.push(`${cat.label}: ${username}`);
             }
 
-            if (!champLines.length) continue;
+            if (!champLines.length) {
+                await Guild.updateOne({ guildId }, { $set: { badgesLastAwardedAt: new Date(), badgesAwardLeaseAt: null } });
+                continue;
+            }
 
             // Find announcement channel: economy.announcementChannelId or systemChannel
             let announceChannelId = guildDoc.economy?.announcementChannelId ?? null;
             if (!announceChannelId && discordGuild) {
                 announceChannelId = discordGuild.systemChannelId ?? null;
             }
-            if (!announceChannelId) continue;
+            if (!announceChannelId) {
+                await Guild.updateOne({ guildId }, { $set: { badgesLastAwardedAt: new Date(), badgesAwardLeaseAt: null } });
+                continue;
+            }
 
             const embed = new EmbedBuilder()
                 .setColor('#ffd700')
@@ -414,8 +426,12 @@ async function awardWeeklyLeaderboardBadges(client) {
                 .setTimestamp();
 
             await postAnnouncement(client, guildId, announceChannelId, embed);
+            // All work succeeded — commit the run timestamp and release lease
+            await Guild.updateOne({ guildId }, { $set: { badgesLastAwardedAt: new Date(), badgesAwardLeaseAt: null } });
         } catch (err) {
             console.error(`[scheduler] weeklyLeaderboardBadges failed for guild ${guildId}:`, err.message);
+            // Release lease so this guild is eligible for retry on the next cron tick
+            await Guild.updateOne({ guildId }, { $set: { badgesAwardLeaseAt: null } }).catch(() => {});
         }
     }
 }

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -344,10 +344,18 @@ async function awardWeeklyLeaderboardBadges(client) {
     const { EmbedBuilder } = require('discord.js');
 
     const guilds = await Guild.find({}, 'guildId name economy').lean();
+    const weekAgo = new Date(Date.now() - LEADERBOARD_BADGE_DURATION_MS);
 
     for (const guildDoc of guilds) {
         const guildId = guildDoc.guildId;
         try {
+            const claimed = await Guild.findOneAndUpdate(
+                { guildId, $or: [{ badgesLastAwardedAt: null }, { badgesLastAwardedAt: { $lte: weekAgo } }] },
+                { $set: { badgesLastAwardedAt: new Date() } },
+                { new: false }
+            );
+            if (!claimed) continue;
+
             const categories = [
                 { key: 'levels',       sort: { level: -1, xp: -1 },            label: '📈 Top Level' },
                 { key: 'economy',      sort: { balance: -1 },                   label: '💰 Wealthiest' },

--- a/src/services/tournamentService.js
+++ b/src/services/tournamentService.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const FishingTournament = require('../models/FishingTournament');
+const User = require('../models/User');
+const { logTransaction } = require('../utils/logTransaction');
 const { EmbedBuilder } = require('discord.js');
 
 const PRIZE_SPLITS = [0.60, 0.25, 0.15];
@@ -100,6 +102,26 @@ async function endTournament(tournamentId) {
     }
 
     await tournament.save();
+
+    // Pay out each winner and mark paidOut
+    for (const prize of tournament.prizes) {
+        const updatedUser = await User.findOneAndUpdate(
+            { userId: prize.userId, guildId: tournament.guildId },
+            { $inc: { balance: prize.amount } },
+            { new: true }
+        );
+        prize.paidOut = true;
+        logTransaction({
+            userId:  prize.userId,
+            guildId: tournament.guildId,
+            type:    'tournament_prize',
+            amount:  prize.amount,
+            balance: updatedUser?.balance ?? 0,
+            note:    `Tournament place #${prize.place}`,
+        });
+    }
+    await tournament.save();
+
     return tournament;
 }
 

--- a/src/services/tournamentService.js
+++ b/src/services/tournamentService.js
@@ -83,11 +83,16 @@ function getSortedEntries(tournament) {
  * End a tournament, calculate prizes, return winner data.
  */
 async function endTournament(tournamentId) {
-    const tournament = await FishingTournament.findById(tournamentId);
-    if (!tournament || tournament.status === 'ended') return tournament;
-
-    tournament.status = 'ended';
-    tournament.winnersAnnouncedAt = new Date();
+    // Atomically claim the tournament; returns null if already ended or claimed by another caller
+    const tournament = await FishingTournament.findOneAndUpdate(
+        { _id: tournamentId, status: 'active' },
+        { $set: { status: 'ended', winnersAnnouncedAt: new Date() } },
+        { new: true }
+    );
+    if (!tournament) {
+        // Already ended — return the existing doc for embed building
+        return FishingTournament.findById(tournamentId);
+    }
 
     const sorted = getSortedEntries(tournament);
     const pool   = tournament.prizePool;
@@ -101,27 +106,27 @@ async function endTournament(tournamentId) {
         }
     }
 
-    await tournament.save();
-
-    // Pay out each winner and mark paidOut
+    // Pay out each winner; only mark paidOut when the credit succeeded
     for (const prize of tournament.prizes) {
         const updatedUser = await User.findOneAndUpdate(
             { userId: prize.userId, guildId: tournament.guildId },
             { $inc: { balance: prize.amount } },
             { new: true }
         );
-        prize.paidOut = true;
-        logTransaction({
-            userId:  prize.userId,
-            guildId: tournament.guildId,
-            type:    'tournament_prize',
-            amount:  prize.amount,
-            balance: updatedUser?.balance ?? 0,
-            note:    `Tournament place #${prize.place}`,
-        });
+        if (updatedUser) {
+            prize.paidOut = true;
+            logTransaction({
+                userId:  prize.userId,
+                guildId: tournament.guildId,
+                type:    'tournament_prize',
+                amount:  prize.amount,
+                balance: updatedUser.balance,
+                note:    `Tournament place #${prize.place}`,
+            });
+        }
     }
-    await tournament.save();
 
+    await tournament.save();
     return tournament;
 }
 


### PR DESCRIPTION
## Summary
This PR adds a new "Pet of the Week" scheduled task and implements several critical fixes to prevent duplicate payouts in tournaments and casino jackpots, along with improvements to the weekly leaderboard badge system.

## Key Changes

- **New Pet of the Week Feature**: Added `selectPetOfTheWeek` scheduler that runs every Monday at midnight UTC, imported from schedulerService
- **Tournament Payout Logic**: Implemented actual payout execution in `endTournament()` that credits winners' balances and logs transactions, with `paidOut` flag to track completion
- **Casino Jackpot Reconciliation**: Added startup reconciliation in the ready event to detect and credit any jackpot wins where the pool was reset but the winner was never paid, preventing loss of funds on bot restarts
- **Leaderboard Badge Deduplication**: Enhanced `awardWeeklyLeaderboardBadges()` with a claim-based locking mechanism using `badgesLastAwardedAt` timestamp to prevent duplicate badge awards across cron restarts
- **Database Schema**: Added `badgesLastAwardedAt` field to Guild model to track the last time badges were awarded

## Implementation Details

- The Pet of the Week scheduler follows the same pattern as other weekly tasks (Monday at midnight UTC)
- Tournament payouts now properly increment user balances and create transaction logs with tournament place information
- Jackpot reconciliation queries for unpaid wins by checking if a corresponding transaction exists, then credits the user and clears the jackpot state
- Badge awarding uses atomic `findOneAndUpdate` with a query condition to ensure only one instance processes badges per week, even if multiple bot instances restart simultaneously

https://claude.ai/code/session_019eXfrm6G6a5qidyhpfpVhJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic weekly Pet of the Week selection now runs every Monday.

* **Bug Fixes**
  * Added startup reconciliation to ensure jackpot winners are properly credited if transactions were missed.
  * Prevented duplicate badge awards during concurrent scheduler runs.
  * Tournament prize payouts are now properly recorded and tracked with transaction logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->