### PR TITLE
fix(ai): upgrade @google/generative-ai so Gemini system prompt works

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",
-        "@google/generative-ai": "^0.2.1",
+        "@google/generative-ai": "^0.24.1",
         "axios": "^1.6.2",
         "canvas": "^2.11.2",
         "connect-mongo": "^5.1.0",
@@ -724,9 +724,9 @@
       }
     },
     "node_modules/@google/generative-ai": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.2.1.tgz",
-      "integrity": "sha512-gNmMFadfwi7qf/6M9gImgyGJXY1jKQ/de8vGOqgJ0PPYgQ7WwzZDavbKrIuXS2zdqZZaYtxW3EFN6aG9x5wtFw==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.1",
-    "@google/generative-ai": "^0.2.1",
+    "@google/generative-ai": "^0.24.1",
     "axios": "^1.6.2",
     "canvas": "^2.11.2",
     "connect-mongo": "^5.1.0",


### PR DESCRIPTION
The pinned ^0.2.1 predated the `systemInstruction` parameter on
`getGenerativeModel`, so it was silently dropped on every Gemini call.
Persona prompts (Clawdia, etc.) never reached the model, which is why
Gemini introduced itself as "a large language model trained by Google"
instead of staying in character. Bumping to ^0.24.0 — the existing
aiService.js call sites are already compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to the latest versions for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->