### PR TITLE
Display guild shop item images in /shop view

### DIFF
--- a/src/commands/economy/shop.js
+++ b/src/commands/economy/shop.js
@@ -109,6 +109,7 @@ async function buildShopPages(guildSettings, currency, viewerPrestigeRank = 0) {
             const trendStr = dynamicEnabled ? ` ${trendBucket(item).arrow}` : '';
             return {
                 name:    item.name,
+                imageId: item.itemId,
                 emoji:   extractEmoji(item.description),
                 price:   ep,
                 badge,
@@ -147,6 +148,7 @@ async function buildShopPages(guildSettings, currency, viewerPrestigeRank = 0) {
             const ep = effectivePrice(item, dynamicEnabled);
             return {
                 name:    item.name,
+                imageId: item.itemId,
                 emoji:   extractEmoji(item.description),
                 price:   ep,
                 badge,
@@ -180,6 +182,7 @@ async function buildShopPages(guildSettings, currency, viewerPrestigeRank = 0) {
             const ep = effectivePrice(item, dynamicEnabled);
             return {
                 name:    item.name,
+                imageId: item.itemId,
                 emoji:   extractEmoji(item.description),
                 price:   ep,
                 badge:   'BLACK MARKET',
@@ -269,6 +272,7 @@ module.exports = {
                 title:    `${interaction.guild.name} Shop`,
                 currency,
                 footer:   balanceFooter,
+                guildId:  interaction.guild.id,
                 pages,
             });
         }

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -843,7 +843,7 @@
                                         <button class="btn btn-sm btn-danger" type="button" id="shop-img-clear-btn" onclick="clearShopItemImage()" style="display:none;width:fit-content">Remove image</button>
                                     </div>
                                 </div>
-                                <small>64×64 px PNG recommended. Shown as thumbnail when purchasing.</small>
+                                <small>64×64 px PNG recommended (max). Shown in <code>/shop view</code> tiles and on purchase confirmation.</small>
                             </div>
                         </div>
                         <div class="modal-actions">

--- a/src/utils/shopBrowse.js
+++ b/src/utils/shopBrowse.js
@@ -6,6 +6,7 @@ const {
 } = require('discord.js');
 
 const ItemImage = require('../models/ItemImage');
+const Guild = require('../models/Guild');
 const { renderCategoryBanner, getTheme } = require('./shopBanner');
 
 const COLOR_HEX = {
@@ -19,16 +20,37 @@ const COLOR_HEX = {
     shop_mythic:   '#e67e22',
 };
 
-async function loadImagesByItemIds(itemIds) {
+function toBuffer(raw) {
+    if (!raw) return null;
+    const buf = Buffer.isBuffer(raw) ? raw : Buffer.from(raw.buffer || raw);
+    return buf.length ? buf : null;
+}
+
+async function loadImagesByItemIds(itemIds, guildId = null) {
     const out = {};
     const ids = [...new Set(itemIds.filter(Boolean))];
     if (!ids.length) return out;
-    const docs = await ItemImage.find({ itemId: { $in: ids } });
-    for (const d of docs) {
-        const raw = d.imageData;
-        if (!raw) continue;
-        const buf = Buffer.isBuffer(raw) ? raw : Buffer.from(raw.buffer || raw);
-        if (buf.length) out[d.itemId] = buf;
+
+    // Guild shop items store their image on the shop sub-document itself.
+    // Check there first so dashboard-uploaded icons appear in /shop view.
+    if (guildId) {
+        const guild = await Guild.findOne({ guildId }, { shop: 1 }).lean();
+        if (guild?.shop) {
+            for (const item of guild.shop) {
+                if (!ids.includes(item.itemId)) continue;
+                const buf = toBuffer(item.imageData);
+                if (buf) out[item.itemId] = buf;
+            }
+        }
+    }
+
+    const missing = ids.filter(id => !out[id]);
+    if (missing.length) {
+        const docs = await ItemImage.find({ itemId: { $in: missing } });
+        for (const d of docs) {
+            const buf = toBuffer(d.imageData);
+            if (buf) out[d.itemId] = buf;
+        }
     }
     return out;
 }
@@ -55,7 +77,7 @@ async function loadImagesByItemIds(itemIds) {
  * }
  */
 async function runShopBrowse(interaction, config) {
-    const { activity, title, currency, pages, footer } = config;
+    const { activity, title, currency, pages, footer, guildId } = config;
     const colorHex = COLOR_HEX[activity] || '#f39c12';
 
     const imageCache = new Map();
@@ -63,7 +85,7 @@ async function runShopBrowse(interaction, config) {
         const wanted = page.items.map(it => it.imageId).filter(Boolean);
         const missing = wanted.filter(id => !imageCache.has(id));
         if (missing.length) {
-            const fetched = await loadImagesByItemIds(missing);
+            const fetched = await loadImagesByItemIds(missing, guildId);
             for (const id of missing) imageCache.set(id, fetched[id] || null);
         }
         return page.items.map(it => ({


### PR DESCRIPTION
## Summary
This PR enables guild shop item images (uploaded via the dashboard) to be displayed in the `/shop view` command, in addition to their existing use on purchase confirmations.

## Key Changes
- **shopBrowse.js**: 
  - Added `toBuffer()` utility function to standardize image data conversion
  - Modified `loadImagesByItemIds()` to accept an optional `guildId` parameter
  - Implemented priority-based image loading: checks guild shop items first (dashboard-uploaded icons), then falls back to the ItemImage collection
  - Updated `runShopBrowse()` to pass `guildId` from config to the image loader

- **shop.js**:
  - Added `imageId: item.itemId` to all three shop page builders (regular, prestige, black market)
  - Passed `guildId: interaction.guild.id` to the shop browse config

- **guild-settings.ejs**:
  - Updated help text to clarify that shop item images now appear in both `/shop view` tiles and purchase confirmations

## Implementation Details
The image loading now follows a two-stage approach:
1. First checks the guild's shop sub-document for dashboard-uploaded images
2. Falls back to the ItemImage collection for system/default images
This ensures dashboard customizations take precedence while maintaining backward compatibility with existing image storage.

https://claude.ai/code/session_01PKFQqv8nP1wzq6mxWYQh9E

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guild-specific custom images now display in shop tiles and purchase confirmations.

* **Documentation**
  * Updated image upload guidance to reflect where shop item images are shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->