### PR TITLE
Fix shop item images getting wiped on settings re-save

### DIFF
--- a/src/dashboard/routes/api.js
+++ b/src/dashboard/routes/api.js
@@ -434,6 +434,25 @@ router.post('/guild/:guildId/settings', checkAuth, checkGuildAccess, checkWriteR
             return res.status(404).json({ error: 'Guild not found' });
         }
 
+        // Shop item images live inline at guild.shop[].imageData. The dashboard
+        // never round-trips those Buffers, so a naive replace of the shop array
+        // would wipe every saved image. Preserve imageData/imageType from the
+        // existing items, matched by itemId.
+        if (Array.isArray(updates.shop)) {
+            const existingImages = new Map();
+            for (const item of guildSettings.shop || []) {
+                if (item && item.itemId && item.imageData) {
+                    existingImages.set(item.itemId, { imageData: item.imageData, imageType: item.imageType });
+                }
+            }
+            updates.shop = updates.shop.map(item => {
+                if (!item || !item.itemId) return item;
+                const preserved = existingImages.get(item.itemId);
+                if (!preserved) return item;
+                return { ...item, imageData: preserved.imageData, imageType: preserved.imageType };
+            });
+        }
+
         Object.keys(updates).forEach(key => {
             guildSettings.set(key, updates[key]);
         });

--- a/src/dashboard/routes/dashboard.js
+++ b/src/dashboard/routes/dashboard.js
@@ -117,6 +117,9 @@ async function renderGuildSettings(req, res) {
         }));
 
         const safeSettings = guildSettings.toObject();
+        if (Array.isArray(safeSettings.shop)) {
+            safeSettings.shop = safeSettings.shop.map(({ imageData, imageType, ...rest }) => rest);
+        }
 
         // Pre-load the set of activity item images that actually exist so the
         // template can skip rendering <img> tags that would otherwise 404.


### PR DESCRIPTION
Shop item images are stored inline on guild.shop[].imageData. The
dashboard renders shop items without imageData/imageType (it loads
images out-of-band from /api/item-image/shop/:guildId/:itemId), so
when the user saves economy settings the entire shop array gets
replaced with image-less entries — turning every previously saved
image into a broken "?" thumbnail.

Preserve imageData/imageType on the backend by matching incoming
shop items to existing ones by itemId before applying the update.
Also strip the Buffers from the rendered settings payload so the
page doesn't ship binary data it never reads.

Hunt/fish/mine images live in a separate ItemImage collection and
aren't affected by this code path.