### PR TITLE
Add crime syndicate system with cooperative heists

### DIFF
--- a/src/commands/economy/syndicate.js
+++ b/src/commands/economy/syndicate.js
@@ -1,0 +1,911 @@
+const {
+    SlashCommandBuilder,
+    EmbedBuilder,
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+} = require('discord.js');
+const Guild = require('../../models/Guild');
+const User = require('../../models/User');
+const Syndicate = require('../../models/Syndicate');
+const { logTransaction } = require('../../utils/logTransaction');
+const { buildSkillCheck } = require('../../services/heistService');
+const {
+    activeSyndicateHeists,
+    SYNDICATE_TARGETS,
+    SYNDICATE_ROLES,
+    createSyndicateLobby,
+    joinSyndicateLobby,
+    endSyndicateLobby,
+    clearSyndicateHeist,
+    getSyndicateHeist,
+    getEffectiveHeat,
+    computeSyndicateOutcome,
+} = require('../../services/syndicateService');
+
+const CREATION_COST    = 50_000;
+const MAX_MEMBERS      = 10;
+const HEIST_COOLDOWN_H = 4;
+const LOBBY_DURATION_S = 60;
+const SKILL_TIMEOUT_MS = 30_000;
+const SABOTAGE_HEAT_COST = 20;
+
+// ── UI helpers ─────────────────────────────────────────────────────────────
+
+function escapeRegex(str) {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function heatBar(heat) {
+    const filled = Math.round(Math.min(100, Math.max(0, heat)) / 10);
+    return `${'🟥'.repeat(filled)}${'⬛'.repeat(10 - filled)} ${heat}/100`;
+}
+
+function buildLobbyEmbed(heist, synName, target) {
+    const secondsLeft = Math.max(0, Math.floor((heist.lobbyEndsAt - Date.now()) / 1000));
+    const roleLines = Object.entries(SYNDICATE_ROLES).map(([key, r]) => {
+        const player = [...heist.players.entries()].find(([, p]) => p.role === key);
+        return `${r.emoji} **${r.label}** — ${player ? `✅ ${player[1].username}` : '_open_'}`;
+    });
+    const highHeat = heist.heatAtStart > 50;
+
+    return new EmbedBuilder()
+        .setColor('#9b59b6')
+        .setTitle(`${target.emoji} Syndicate Heist — ${target.label}`)
+        .setDescription(
+            `**Syndicate:** ${synName}\n` +
+            `**Min. Crew Required:** ${target.minPlayers}\n` +
+            (highHeat ? '⚠️ **High heat** — +20% payout, but extra risk!\n' : '') +
+            '\n' + roleLines.join('\n')
+        )
+        .addFields(
+            { name: '⏳ Lobby closes in', value: `${secondsLeft}s`, inline: true },
+            { name: '👥 Crew so far',      value: `${heist.players.size}`, inline: true },
+            { name: '🌡️ Heat',              value: heatBar(heist.heatAtStart), inline: false }
+        )
+        .setFooter({ text: 'Only syndicate members can join · one player per role' })
+        .setTimestamp();
+}
+
+function buildLobbyRows(heistId, heist) {
+    const roleEntries = Object.entries(SYNDICATE_ROLES);
+    const rows = [];
+    for (let i = 0; i < roleEntries.length; i += 5) {
+        const row = new ActionRowBuilder();
+        for (const [key, r] of roleEntries.slice(i, i + 5)) {
+            const taken = [...heist.players.values()].some(p => p.role === key);
+            row.addComponents(
+                new ButtonBuilder()
+                    .setCustomId(`syn_join_${heistId}_${key}`)
+                    .setLabel(`${r.emoji} ${r.label}`)
+                    .setStyle(taken ? ButtonStyle.Secondary : ButtonStyle.Primary)
+                    .setDisabled(taken)
+            );
+        }
+        rows.push(row);
+    }
+    return rows;
+}
+
+// ── Skill check DM helpers ─────────────────────────────────────────────────
+
+function makeSkillRow(heistId, userId, check) {
+    const row = new ActionRowBuilder();
+    for (const choice of check.choices) {
+        row.addComponents(
+            new ButtonBuilder()
+                .setCustomId(`syn_skill_${heistId}_${userId}_${String(choice)}`)
+                .setLabel(String(choice))
+                .setStyle(ButtonStyle.Primary)
+        );
+    }
+    return row;
+}
+
+async function sendSkillCheck(member, heistId, role) {
+    const roleMeta = SYNDICATE_ROLES[role];
+    const check = buildSkillCheck(roleMeta.skillType);
+
+    const embed = new EmbedBuilder()
+        .setColor('#9b59b6')
+        .setTitle(`🔒 Syndicate Heist — ${roleMeta.emoji} ${roleMeta.label} Check`)
+        .setDescription(
+            `**Your role:** ${roleMeta.label}\n${roleMeta.desc}\n\n` +
+            `**Your challenge:**\n${check.question}\n\n` +
+            `⏳ You have **30 seconds** to answer!`
+        )
+        .setFooter({ text: 'This is your private skill check — only you can see this.' });
+
+    try {
+        const dm = await member.send({ embeds: [embed], components: [makeSkillRow(heistId, member.id, check)] });
+        return { dm, check };
+    } catch {
+        return { dm: null, check };
+    }
+}
+
+// ── Heist resolution ───────────────────────────────────────────────────────
+
+async function resolveHeist(client, heist) {
+    if (heist.resolving) return;
+    heist.resolving = true;
+
+    const target = SYNDICATE_TARGETS[heist.target];
+    const { outcome, payout, perPlayer, passedCount } = computeSyndicateOutcome(heist);
+
+    const guildDoc = await Guild.findOne({ guildId: heist.guildId }, 'economy').lean();
+    const currency = guildDoc?.economy?.currency ?? '💰';
+
+    const players = [...heist.players.entries()];
+    const resultLines = [];
+
+    for (const [userId, player] of players) {
+        const roleMeta = SYNDICATE_ROLES[player.role];
+        const passed   = player.skillPassed === true;
+        resultLines.push(`${roleMeta.emoji} **${player.username}** (${roleMeta.label}) — ${passed ? '✅ Passed' : '❌ Failed'}`);
+
+        const wins = (outcome === 'full_success') || (outcome === 'partial_success' && passed);
+        if (wins && perPlayer > 0) {
+            await User.findOneAndUpdate(
+                { userId, guildId: heist.guildId },
+                { $inc: { balance: perPlayer } }
+            ).catch(() => {});
+            const u = await User.findOne({ userId, guildId: heist.guildId }, 'balance').lean();
+            logTransaction({
+                userId,
+                guildId: heist.guildId,
+                type:    'syndicate_heist',
+                amount:  perPlayer,
+                balance: u?.balance ?? perPlayer,
+                note:    `Syndicate heist: ${target.label}`,
+            });
+        }
+    }
+
+    // Persist heist results to the Syndicate document
+    try {
+        const synDoc = await Syndicate.findOne({ syndicateId: heist.syndicateId, guildId: heist.guildId });
+        if (synDoc) {
+            const heatGain = outcome !== 'bust' ? target.heatGain : 0;
+            synDoc.lifetimeEarnings = (synDoc.lifetimeEarnings || 0) + payout;
+            synDoc.heistCount       = (synDoc.heistCount || 0) + 1;
+            synDoc.lastHeistAt      = new Date();
+            synDoc.heat             = Math.min(100, Math.max(0, heist.heatAtStart + heatGain));
+            await synDoc.save();
+        }
+    } catch (err) {
+        console.error('[syndicate] Failed to update syndicate after heist:', err.message);
+    }
+
+    // Build result embed
+    let title, desc, color;
+    if (outcome === 'bust') {
+        title = `🚨 ${target.label} — Busted!`;
+        desc  = `Intelligence was wrong — enforcement was waiting. The crew escaped empty-handed.`;
+        color = '#e74c3c';
+    } else if (outcome === 'full_success') {
+        title = `🎉 ${target.label} — Complete Success!`;
+        desc  = `Flawless execution. Every crew member delivered.\n\n**Share:** ${currency}${perPlayer.toLocaleString()} each\n**Total haul:** ${currency}${payout.toLocaleString()}`;
+        color = '#2ecc71';
+    } else if (outcome === 'partial_success') {
+        title = `⚠️ ${target.label} — Partial Success`;
+        desc  = `The job got done, but some crew slipped up. Survivors collect their cut.\n\n**Survivors earn:** ${currency}${perPlayer.toLocaleString()} each`;
+        color = '#f39c12';
+    } else {
+        title = `💀 ${target.label} — Operation Failed`;
+        desc  = `Not enough crew completed their tasks. Nothing was collected.`;
+        color = '#e74c3c';
+    }
+
+    const embed = new EmbedBuilder()
+        .setColor(color)
+        .setTitle(title)
+        .setDescription(desc)
+        .addFields({ name: '👥 Crew Results', value: resultLines.join('\n') || '*No players*' })
+        .setTimestamp();
+
+    if (heist.sabotageCount > 0) {
+        embed.addFields({
+            name: '⚡ Sabotaged',
+            value: `This heist was sabotaged **${heist.sabotageCount}** time(s) — success chance was reduced!`,
+        });
+    }
+
+    try {
+        const dg = await client.guilds.fetch(heist.guildId).catch(() => null);
+        if (dg) {
+            const ch = await dg.channels.fetch(heist.channelId).catch(() => null);
+            if (ch?.isTextBased?.()) await ch.send({ embeds: [embed] });
+        }
+    } catch {}
+
+    clearSyndicateHeist(heist.guildId);
+}
+
+// ── Button handler (exported for interactionCreate) ────────────────────────
+
+async function handleSyndicateButton(interaction, client) {
+    const id = interaction.customId;
+
+    // syn_join_{heistId}_{role}
+    // heistId = syn-{guildId}-{ts} — uses hyphens only, no underscores
+    if (id.startsWith('syn_join_')) {
+        const afterPrefix = id.slice('syn_join_'.length);
+        const parts = afterPrefix.split('_');
+        if (parts.length < 2) {
+            return interaction.reply({ content: 'Malformed button ID.', ephemeral: true });
+        }
+        const heistId = parts[0];
+        const role    = parts[1];
+
+        if (!SYNDICATE_ROLES[role]) {
+            return interaction.reply({ content: 'Invalid role.', ephemeral: true });
+        }
+
+        const guildId = interaction.guildId;
+        const heist   = getSyndicateHeist(guildId);
+        if (!heist || heist.heistId !== heistId || heist.phase !== 'lobby') {
+            return interaction.reply({ content: 'This heist lobby is no longer active.', ephemeral: true });
+        }
+
+        // Only syndicate members may join
+        const userDoc = await User.findOne({ userId: interaction.user.id, guildId }, 'syndicateId').lean();
+        if (!userDoc?.syndicateId || userDoc.syndicateId !== heist.syndicateId) {
+            return interaction.reply({ content: 'Only members of this syndicate can join.', ephemeral: true });
+        }
+
+        const result = joinSyndicateLobby(guildId, interaction.user.id, interaction.user.username, role);
+        if (!result.ok) {
+            return interaction.reply({ content: result.reason, ephemeral: true });
+        }
+
+        const synDoc = await Syndicate.findOne({ syndicateId: heist.syndicateId, guildId }, 'name').lean();
+        const target = SYNDICATE_TARGETS[heist.target];
+
+        await interaction.update({
+            embeds:     [buildLobbyEmbed(heist, synDoc?.name ?? 'Unknown', target)],
+            components: buildLobbyRows(heistId, heist),
+        }).catch(() => {});
+        return;
+    }
+
+    // syn_skill_{heistId}_{userId}_{answer}
+    if (id.startsWith('syn_skill_')) {
+        const afterPrefix = id.slice('syn_skill_'.length);
+        const parts = afterPrefix.split('_');
+        // parts[0] = heistId (syn-guildId-ts, no underscores)
+        // parts[1] = userId
+        // parts[2] = answer
+        if (parts.length < 3) {
+            return interaction.reply({ content: 'Malformed skill-check button.', ephemeral: true }).catch(() => {});
+        }
+        const heistId = parts[0];
+        const userId  = parts[1];
+        const answer  = parts[2];
+
+        // DM interactions have no guildId — find by heistId scan
+        let heist = null;
+        for (const [, h] of activeSyndicateHeists) {
+            if (h.heistId === heistId) { heist = h; break; }
+        }
+
+        if (!heist || !heist.players.has(userId)) {
+            return interaction.reply({ content: 'This skill check has expired.', ephemeral: true }).catch(() => {});
+        }
+
+        const player = heist.players.get(userId);
+        if (player.skillPassed !== null) {
+            return interaction.reply({ content: 'You already submitted your answer.', ephemeral: true }).catch(() => {});
+        }
+
+        const check  = heist._skillChecks?.[userId];
+        const passed = check ? String(answer) === String(check.correct) : false;
+        player.skillPassed = passed;
+
+        if (heist.skillTimers?.[userId]) {
+            clearTimeout(heist.skillTimers[userId]);
+            delete heist.skillTimers[userId];
+        }
+
+        await interaction.update({
+            embeds: [
+                new EmbedBuilder()
+                    .setColor(passed ? '#2ecc71' : '#e74c3c')
+                    .setTitle(passed ? '✅ Check Passed!' : '❌ Check Failed')
+                    .setDescription(passed
+                        ? 'You executed your role perfectly. Waiting for the rest of the crew…'
+                        : `Wrong answer. The correct answer was **${check?.correct}**.\nThe overall outcome depends on how many others pass.`)
+                    .setTimestamp(),
+            ],
+            components: [],
+        }).catch(() => {});
+
+        const allDone = [...heist.players.values()].every(p => p.skillPassed !== null);
+        if (allDone) await resolveHeist(client, heist);
+    }
+}
+
+// ── Subcommand handlers ────────────────────────────────────────────────────
+
+async function executeCreate(interaction, guildDoc) {
+    const name      = interaction.options.getString('name');
+    const rawTag    = interaction.options.getString('tag');
+    const openToJoin = interaction.options.getBoolean('open') ?? false;
+    const currency  = guildDoc?.economy?.currency ?? '💰';
+
+    if (name.length < 2 || name.length > 32) {
+        return interaction.reply({ content: 'Syndicate name must be 2–32 characters.', ephemeral: true });
+    }
+    if (rawTag && (rawTag.length < 2 || rawTag.length > 5)) {
+        return interaction.reply({ content: 'Syndicate tag must be 2–5 characters.', ephemeral: true });
+    }
+
+    const userDoc = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }, 'balance syndicateId').lean();
+    if (userDoc?.syndicateId) {
+        return interaction.reply({ content: 'You are already in a syndicate. Leave it first.', ephemeral: true });
+    }
+
+    const balance = userDoc?.balance ?? 0;
+    if (balance < CREATION_COST) {
+        return interaction.reply({
+            content: `Creating a syndicate costs ${currency}${CREATION_COST.toLocaleString()}. You only have ${currency}${balance.toLocaleString()}.`,
+            ephemeral: true,
+        });
+    }
+
+    const existing = await Syndicate.findOne({
+        guildId: interaction.guild.id,
+        name: { $regex: new RegExp(`^${escapeRegex(name)}$`, 'i') },
+    }).lean();
+    if (existing) {
+        return interaction.reply({ content: `A syndicate named **${name}** already exists on this server.`, ephemeral: true });
+    }
+
+    const tag         = rawTag ? rawTag.toUpperCase() : null;
+    const syndicateId = `${interaction.guild.id}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+
+    await User.findOneAndUpdate(
+        { userId: interaction.user.id, guildId: interaction.guild.id },
+        { $inc: { balance: -CREATION_COST }, $set: { syndicateId } },
+        { upsert: true }
+    );
+
+    await Syndicate.create({
+        syndicateId,
+        guildId: interaction.guild.id,
+        name,
+        tag,
+        leaderId:  interaction.user.id,
+        memberIds: [interaction.user.id],
+        openToJoin,
+    });
+
+    logTransaction({
+        userId:  interaction.user.id,
+        guildId: interaction.guild.id,
+        type:    'syndicate_create',
+        amount:  -CREATION_COST,
+        balance: balance - CREATION_COST,
+        note:    `Founded syndicate: ${name}`,
+    });
+
+    const embed = new EmbedBuilder()
+        .setColor('#9b59b6')
+        .setTitle('🦹 Syndicate Founded!')
+        .setDescription(
+            `**${name}**${tag ? ` [${tag}]` : ''} is now operational.\n\n` +
+            `You spent ${currency}${CREATION_COST.toLocaleString()} to establish it.\n` +
+            `Invite members with \`/syndicate invite @user\`, or enable open joining.`
+        )
+        .addFields(
+            { name: 'Membership', value: openToJoin ? 'Open' : 'Invite-only', inline: true },
+            { name: 'Members',    value: `1 / ${MAX_MEMBERS}`,                inline: true }
+        )
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+async function executeJoin(interaction) {
+    const name    = interaction.options.getString('name');
+    const userDoc = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }, 'syndicateId').lean();
+    if (userDoc?.syndicateId) {
+        return interaction.reply({ content: 'You are already in a syndicate. Leave it first.', ephemeral: true });
+    }
+
+    const synDoc = await Syndicate.findOne({
+        guildId: interaction.guild.id,
+        name: { $regex: new RegExp(`^${escapeRegex(name)}$`, 'i') },
+    });
+    if (!synDoc) {
+        return interaction.reply({ content: `No syndicate named **${name}** was found on this server.`, ephemeral: true });
+    }
+
+    if (synDoc.memberIds.length >= MAX_MEMBERS) {
+        return interaction.reply({ content: `**${synDoc.name}** is full (${MAX_MEMBERS} members).`, ephemeral: true });
+    }
+
+    const inInvites = synDoc.pendingInvites.includes(interaction.user.id);
+    if (!synDoc.openToJoin && !inInvites) {
+        return interaction.reply({ content: `**${synDoc.name}** is invite-only. Ask the leader to send you an invite.`, ephemeral: true });
+    }
+
+    synDoc.memberIds.push(interaction.user.id);
+    if (inInvites) synDoc.pendingInvites = synDoc.pendingInvites.filter(id => id !== interaction.user.id);
+    await synDoc.save();
+
+    await User.findOneAndUpdate(
+        { userId: interaction.user.id, guildId: interaction.guild.id },
+        { $set: { syndicateId: synDoc.syndicateId } },
+        { upsert: true }
+    );
+
+    const embed = new EmbedBuilder()
+        .setColor('#9b59b6')
+        .setTitle('🦹 Joined Syndicate')
+        .setDescription(`You've joined **${synDoc.name}**${synDoc.tag ? ` [${synDoc.tag}]` : ''}! You are member ${synDoc.memberIds.length} of ${MAX_MEMBERS}.`)
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+async function executeLeave(interaction) {
+    const userDoc = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }, 'syndicateId').lean();
+    if (!userDoc?.syndicateId) {
+        return interaction.reply({ content: 'You are not in a syndicate.', ephemeral: true });
+    }
+
+    const synDoc = await Syndicate.findOne({ syndicateId: userDoc.syndicateId, guildId: interaction.guild.id });
+    if (!synDoc) {
+        await User.findOneAndUpdate({ userId: interaction.user.id, guildId: interaction.guild.id }, { $set: { syndicateId: null } });
+        return interaction.reply({ content: 'Your syndicate no longer exists. Membership cleared.', ephemeral: true });
+    }
+
+    if (synDoc.leaderId === interaction.user.id) {
+        if (synDoc.memberIds.length > 1) {
+            return interaction.reply({
+                content: `You are the leader of **${synDoc.name}**. Kick all other members first, or use \`/syndicate disband\`.`,
+                ephemeral: true,
+            });
+        }
+        // Last member — auto-disband
+        await Syndicate.deleteOne({ syndicateId: synDoc.syndicateId });
+        await User.findOneAndUpdate({ userId: interaction.user.id, guildId: interaction.guild.id }, { $set: { syndicateId: null } });
+        return interaction.reply({ content: `**${synDoc.name}** has been disbanded.`, ephemeral: true });
+    }
+
+    synDoc.memberIds = synDoc.memberIds.filter(id => id !== interaction.user.id);
+    await synDoc.save();
+    await User.findOneAndUpdate({ userId: interaction.user.id, guildId: interaction.guild.id }, { $set: { syndicateId: null } });
+
+    return interaction.reply({ content: `You have left **${synDoc.name}**.`, ephemeral: true });
+}
+
+async function executeInvite(interaction) {
+    const target  = interaction.options.getUser('user');
+    const userDoc = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }, 'syndicateId').lean();
+    if (!userDoc?.syndicateId) {
+        return interaction.reply({ content: 'You are not in a syndicate.', ephemeral: true });
+    }
+
+    const synDoc = await Syndicate.findOne({ syndicateId: userDoc.syndicateId, guildId: interaction.guild.id });
+    if (!synDoc) return interaction.reply({ content: 'Your syndicate no longer exists.', ephemeral: true });
+
+    if (synDoc.leaderId !== interaction.user.id) {
+        return interaction.reply({ content: 'Only the syndicate leader can invite members.', ephemeral: true });
+    }
+    if (target.id === interaction.user.id) {
+        return interaction.reply({ content: "You can't invite yourself.", ephemeral: true });
+    }
+    if (synDoc.memberIds.includes(target.id)) {
+        return interaction.reply({ content: `<@${target.id}> is already a member.`, ephemeral: true });
+    }
+    if (synDoc.pendingInvites.includes(target.id)) {
+        return interaction.reply({ content: `<@${target.id}> already has a pending invite.`, ephemeral: true });
+    }
+    if (synDoc.memberIds.length >= MAX_MEMBERS) {
+        return interaction.reply({ content: `Your syndicate is full (${MAX_MEMBERS} members).`, ephemeral: true });
+    }
+
+    const targetDoc = await User.findOne({ userId: target.id, guildId: interaction.guild.id }, 'syndicateId').lean();
+    if (targetDoc?.syndicateId) {
+        return interaction.reply({ content: `<@${target.id}> is already in a syndicate.`, ephemeral: true });
+    }
+
+    synDoc.pendingInvites.push(target.id);
+    await synDoc.save();
+
+    return interaction.reply({
+        content: `<@${target.id}> has been invited to **${synDoc.name}**. They can accept with \`/syndicate join ${synDoc.name}\`.`,
+    });
+}
+
+async function executeKick(interaction) {
+    const target  = interaction.options.getUser('user');
+    const userDoc = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }, 'syndicateId').lean();
+    if (!userDoc?.syndicateId) return interaction.reply({ content: 'You are not in a syndicate.', ephemeral: true });
+
+    const synDoc = await Syndicate.findOne({ syndicateId: userDoc.syndicateId, guildId: interaction.guild.id });
+    if (!synDoc) return interaction.reply({ content: 'Your syndicate no longer exists.', ephemeral: true });
+
+    if (synDoc.leaderId !== interaction.user.id) {
+        return interaction.reply({ content: 'Only the syndicate leader can kick members.', ephemeral: true });
+    }
+    if (target.id === interaction.user.id) {
+        return interaction.reply({ content: "Use `/syndicate leave` to leave your own syndicate.", ephemeral: true });
+    }
+    if (!synDoc.memberIds.includes(target.id)) {
+        return interaction.reply({ content: `<@${target.id}> is not a member of your syndicate.`, ephemeral: true });
+    }
+
+    synDoc.memberIds = synDoc.memberIds.filter(id => id !== target.id);
+    await synDoc.save();
+
+    await User.findOneAndUpdate(
+        { userId: target.id, guildId: interaction.guild.id },
+        { $set: { syndicateId: null } }
+    );
+
+    return interaction.reply({ content: `<@${target.id}> has been kicked from **${synDoc.name}**.` });
+}
+
+async function executeOpen(interaction) {
+    const userDoc = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }, 'syndicateId').lean();
+    if (!userDoc?.syndicateId) return interaction.reply({ content: 'You are not in a syndicate.', ephemeral: true });
+
+    const synDoc = await Syndicate.findOne({ syndicateId: userDoc.syndicateId, guildId: interaction.guild.id });
+    if (!synDoc) return interaction.reply({ content: 'Your syndicate no longer exists.', ephemeral: true });
+
+    if (synDoc.leaderId !== interaction.user.id) {
+        return interaction.reply({ content: 'Only the syndicate leader can change membership settings.', ephemeral: true });
+    }
+
+    synDoc.openToJoin = !synDoc.openToJoin;
+    await synDoc.save();
+
+    return interaction.reply({
+        content: `**${synDoc.name}** is now **${synDoc.openToJoin ? 'open — anyone can join' : 'invite-only'}**.`,
+        ephemeral: true,
+    });
+}
+
+async function executeInfo(interaction, guildDoc) {
+    const nameOpt = interaction.options.getString('name');
+    const currency = guildDoc?.economy?.currency ?? '💰';
+
+    let synDoc;
+    if (nameOpt) {
+        synDoc = await Syndicate.findOne({
+            guildId: interaction.guild.id,
+            name: { $regex: new RegExp(`^${escapeRegex(nameOpt)}$`, 'i') },
+        });
+        if (!synDoc) return interaction.reply({ content: `No syndicate named **${nameOpt}** was found.`, ephemeral: true });
+    } else {
+        const userDoc = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }, 'syndicateId').lean();
+        if (!userDoc?.syndicateId) {
+            return interaction.reply({ content: 'You are not in a syndicate. Provide a name to look one up.', ephemeral: true });
+        }
+        synDoc = await Syndicate.findOne({ syndicateId: userDoc.syndicateId, guildId: interaction.guild.id });
+        if (!synDoc) return interaction.reply({ content: 'Your syndicate no longer exists.', ephemeral: true });
+    }
+
+    const effectiveHeat = getEffectiveHeat(synDoc);
+    const activeHeist   = getSyndicateHeist(interaction.guild.id);
+    const hasActiveHeist = activeHeist?.syndicateId === synDoc.syndicateId;
+
+    const memberLines = synDoc.memberIds.slice(0, MAX_MEMBERS).map((id, i) =>
+        id === synDoc.leaderId ? `👑 <@${id}>` : `${i + 1}. <@${id}>`
+    );
+
+    const embed = new EmbedBuilder()
+        .setColor('#9b59b6')
+        .setTitle(`🦹 ${synDoc.name}${synDoc.tag ? ` [${synDoc.tag}]` : ''}`)
+        .addFields(
+            { name: '🌡️ Heat',              value: heatBar(effectiveHeat),                                                  inline: false },
+            { name: '💰 Lifetime Earnings', value: `${currency}${(synDoc.lifetimeEarnings || 0).toLocaleString()}`,         inline: true },
+            { name: '🎯 Heists Pulled',     value: String(synDoc.heistCount || 0),                                          inline: true },
+            { name: '👥 Members',           value: `${synDoc.memberIds.length} / ${MAX_MEMBERS}`,                           inline: true },
+            { name: '🚪 Membership',        value: synDoc.openToJoin ? 'Open' : 'Invite-only',                              inline: true },
+            { name: '⚡ Active Heist',      value: hasActiveHeist ? 'In progress' : 'None',                                 inline: true },
+            { name: '👤 Crew',              value: memberLines.join('\n') || '*none*',                                       inline: false }
+        )
+        .setFooter({ text: `Founded ${synDoc.createdAt.toLocaleDateString()}` })
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+async function executeLeaderboard(interaction, guildDoc) {
+    const currency = guildDoc?.economy?.currency ?? '💰';
+    const top = await Syndicate.find({ guildId: interaction.guild.id })
+        .sort({ lifetimeEarnings: -1 })
+        .limit(10)
+        .lean();
+
+    if (!top.length) {
+        return interaction.reply({ content: 'No syndicates have been founded on this server yet.', ephemeral: true });
+    }
+
+    const medals = ['🥇', '🥈', '🥉'];
+    const lines = top.map((syn, i) => {
+        const rank = medals[i] ?? `${i + 1}.`;
+        const tag  = syn.tag ? ` [${syn.tag}]` : '';
+        return `${rank} **${syn.name}**${tag} — ${currency}${(syn.lifetimeEarnings || 0).toLocaleString()} · ${syn.memberIds.length} members · Heat ${syn.heat || 0}`;
+    });
+
+    const embed = new EmbedBuilder()
+        .setColor('#f39c12')
+        .setTitle('🏆 Syndicate Leaderboard')
+        .setDescription(lines.join('\n'))
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+async function executeHeist(interaction, guildDoc, client) {
+    const targetKey = interaction.options.getString('target');
+    const target    = SYNDICATE_TARGETS[targetKey];
+    if (!target) return interaction.reply({ content: 'Invalid heist target.', ephemeral: true });
+
+    const userDoc = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }, 'syndicateId').lean();
+    if (!userDoc?.syndicateId) return interaction.reply({ content: 'You are not in a syndicate.', ephemeral: true });
+
+    const synDoc = await Syndicate.findOne({ syndicateId: userDoc.syndicateId, guildId: interaction.guild.id });
+    if (!synDoc) return interaction.reply({ content: 'Your syndicate no longer exists.', ephemeral: true });
+
+    if (synDoc.leaderId !== interaction.user.id) {
+        return interaction.reply({ content: 'Only the syndicate leader can initiate a heist.', ephemeral: true });
+    }
+    if (synDoc.memberIds.length < target.minPlayers) {
+        return interaction.reply({
+            content: `**${target.label}** requires at least ${target.minPlayers} syndicate members. You only have ${synDoc.memberIds.length}.`,
+            ephemeral: true,
+        });
+    }
+    if (getSyndicateHeist(interaction.guild.id)) {
+        return interaction.reply({ content: 'A syndicate heist is already active on this server.', ephemeral: true });
+    }
+
+    const cooldownMs = HEIST_COOLDOWN_H * 60 * 60 * 1000;
+    if (synDoc.lastHeistAt && (Date.now() - synDoc.lastHeistAt.getTime()) < cooldownMs) {
+        const ts = Math.floor((synDoc.lastHeistAt.getTime() + cooldownMs) / 1000);
+        return interaction.reply({
+            content: `**${synDoc.name}** is on cooldown. Next heist available <t:${ts}:R>.`,
+            ephemeral: true,
+        });
+    }
+
+    const currentHeat = getEffectiveHeat(synDoc);
+    const heist = createSyndicateLobby({
+        guildId:             interaction.guild.id,
+        channelId:           interaction.channelId,
+        syndicateId:         synDoc.syndicateId,
+        leaderId:            interaction.user.id,
+        target:              targetKey,
+        lobbyDurationSeconds: LOBBY_DURATION_S,
+        currentHeat,
+    });
+
+    const embed = buildLobbyEmbed(heist, synDoc.name, target);
+    const rows  = buildLobbyRows(heist.heistId, heist);
+    const msg   = await interaction.reply({ embeds: [embed], components: rows, fetchReply: true });
+    heist.lobbyMessage = msg;
+
+    // Periodic countdown refresh
+    const refreshTimer = setInterval(async () => {
+        if (heist.phase !== 'lobby') { clearInterval(refreshTimer); return; }
+        await msg.edit({
+            embeds:     [buildLobbyEmbed(heist, synDoc.name, target)],
+            components: buildLobbyRows(heist.heistId, heist),
+        }).catch(() => {});
+    }, 5_000);
+
+    // Lobby expiry
+    setTimeout(async () => {
+        clearInterval(refreshTimer);
+        if (heist.phase !== 'lobby') return;
+
+        if (heist.players.size < target.minPlayers) {
+            await msg.edit({
+                embeds: [new EmbedBuilder()
+                    .setColor('#e74c3c')
+                    .setTitle('❌ Heist Cancelled')
+                    .setDescription(`Not enough crew joined (need ${target.minPlayers}, got ${heist.players.size}). **${synDoc.name}**'s operation is called off.`)
+                    .setTimestamp()],
+                components: [],
+            }).catch(() => {});
+            clearSyndicateHeist(heist.guildId);
+            return;
+        }
+
+        endSyndicateLobby(heist.guildId);
+        await msg.edit({
+            embeds: [new EmbedBuilder()
+                .setColor('#9b59b6')
+                .setTitle('🔓 Heist Underway!')
+                .setDescription('Lobby closed. Skill checks are being sent to each crew member via DM.\nResults will post here when everyone responds or time runs out.')
+                .setTimestamp()],
+            components: [],
+        }).catch(() => {});
+
+        const dg = await client.guilds.fetch(heist.guildId).catch(() => null);
+        heist._skillChecks = {};
+
+        for (const [userId, player] of heist.players) {
+            const member = dg ? await dg.members.fetch(userId).catch(() => null) : null;
+            if (!member) {
+                player.skillPassed = false;
+                continue;
+            }
+            const { dm, check } = await sendSkillCheck(member, heist.heistId, player.role);
+            heist._skillChecks[userId] = check;
+
+            if (!dm) {
+                player.skillPassed = false;
+            } else {
+                heist.skillTimers[userId] = setTimeout(async () => {
+                    if (player.skillPassed !== null) return;
+                    player.skillPassed = false;
+                    await dm.edit({
+                        embeds: [new EmbedBuilder()
+                            .setColor('#e74c3c')
+                            .setTitle("⏰ Time's up!")
+                            .setDescription(`You ran out of time. The correct answer was **${check.correct}**.`)
+                            .setTimestamp()],
+                        components: [],
+                    }).catch(() => {});
+                    const allDone = [...heist.players.values()].every(p => p.skillPassed !== null);
+                    if (allDone) await resolveHeist(client, heist);
+                }, SKILL_TIMEOUT_MS);
+            }
+        }
+
+        const allDone = [...heist.players.values()].every(p => p.skillPassed !== null);
+        if (allDone) await resolveHeist(client, heist);
+
+    }, LOBBY_DURATION_S * 1000);
+}
+
+async function executeSabotage(interaction, guildDoc) {
+    const userDoc = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }, 'syndicateId').lean();
+    if (!userDoc?.syndicateId) return interaction.reply({ content: 'You are not in a syndicate.', ephemeral: true });
+
+    const synDoc = await Syndicate.findOne({ syndicateId: userDoc.syndicateId, guildId: interaction.guild.id });
+    if (!synDoc) return interaction.reply({ content: 'Your syndicate no longer exists.', ephemeral: true });
+
+    const activeHeist = getSyndicateHeist(interaction.guild.id);
+    if (!activeHeist) {
+        return interaction.reply({ content: 'There is no active syndicate heist on this server to sabotage.', ephemeral: true });
+    }
+    if (activeHeist.syndicateId === synDoc.syndicateId) {
+        return interaction.reply({ content: "You can't sabotage your own heist.", ephemeral: true });
+    }
+
+    const effectiveHeat = getEffectiveHeat(synDoc);
+    if (effectiveHeat < SABOTAGE_HEAT_COST) {
+        return interaction.reply({
+            content: `Sabotage costs **${SABOTAGE_HEAT_COST} heat**. **${synDoc.name}** only has **${effectiveHeat}** heat. Run more heists to build it up.`,
+            ephemeral: true,
+        });
+    }
+
+    const rivalDoc = await Syndicate.findOne({ syndicateId: activeHeist.syndicateId, guildId: interaction.guild.id }, 'name').lean();
+    const rivalName = rivalDoc?.name ?? 'Unknown Syndicate';
+
+    // Deduct heat from saboteur's syndicate
+    synDoc.heat = Math.max(0, effectiveHeat - SABOTAGE_HEAT_COST);
+    await synDoc.save();
+
+    // Apply sabotage to the rival heist
+    activeHeist.sabotageCount++;
+
+    const embed = new EmbedBuilder()
+        .setColor('#e74c3c')
+        .setTitle('⚡ Sabotage Deployed!')
+        .setDescription(
+            `**${synDoc.name}** has compromised **${rivalName}**'s ongoing heist!\n\n` +
+            `Their success chance has been reduced by **15%**.\n` +
+            `Cost to you: **${SABOTAGE_HEAT_COST} heat** (${effectiveHeat} → ${synDoc.heat})`
+        )
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+// ── Command definition ─────────────────────────────────────────────────────
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('syndicate')
+        .setDescription('Crime syndicate system — cooperative heists, territory, and rivalry.')
+        .addSubcommand(sub => sub
+            .setName('create')
+            .setDescription(`Found a new syndicate (costs ${CREATION_COST.toLocaleString()} coins).`)
+            .addStringOption(opt => opt.setName('name').setDescription('Syndicate name (2–32 chars)').setRequired(true))
+            .addStringOption(opt => opt.setName('tag').setDescription('Short tag shown on the leaderboard (2–5 chars)').setRequired(false))
+            .addBooleanOption(opt => opt.setName('open').setDescription('Allow anyone to join without an invite (default: false)').setRequired(false))
+        )
+        .addSubcommand(sub => sub
+            .setName('join')
+            .setDescription('Join an open syndicate or accept an invite.')
+            .addStringOption(opt => opt.setName('name').setDescription('Syndicate name').setRequired(true))
+        )
+        .addSubcommand(sub => sub
+            .setName('leave')
+            .setDescription('Leave your current syndicate (leaders must kick all members first).')
+        )
+        .addSubcommand(sub => sub
+            .setName('invite')
+            .setDescription('Invite a player to your syndicate (leader only).')
+            .addUserOption(opt => opt.setName('user').setDescription('User to invite').setRequired(true))
+        )
+        .addSubcommand(sub => sub
+            .setName('kick')
+            .setDescription('Kick a member from your syndicate (leader only).')
+            .addUserOption(opt => opt.setName('user').setDescription('Member to kick').setRequired(true))
+        )
+        .addSubcommand(sub => sub
+            .setName('open')
+            .setDescription('Toggle open / invite-only membership for your syndicate (leader only).')
+        )
+        .addSubcommand(sub => sub
+            .setName('info')
+            .setDescription('View syndicate details.')
+            .addStringOption(opt => opt.setName('name').setDescription('Syndicate name (defaults to your own)').setRequired(false))
+        )
+        .addSubcommand(sub => sub
+            .setName('leaderboard')
+            .setDescription('Top syndicates on this server by lifetime heist earnings.')
+        )
+        .addSubcommand(sub => sub
+            .setName('heist')
+            .setDescription('Plan and initiate a cooperative syndicate heist (leader only, 3+ members required).')
+            .addStringOption(opt => opt
+                .setName('target')
+                .setDescription('The target to hit.')
+                .setRequired(true)
+                .addChoices(
+                    { name: 'Bank Job (3 players, 45% base, 10k–25k)', value: 'bank_job' },
+                    { name: 'Museum Heist (5 players, 30% base, 30k–80k)', value: 'museum_heist' },
+                    { name: 'City Hall Con (7 players, 20% base, 100k–200k)', value: 'city_hall_con' }
+                )
+            )
+        )
+        .addSubcommand(sub => sub
+            .setName('sabotage')
+            .setDescription(`Sabotage an active rival heist (costs ${SABOTAGE_HEAT_COST} heat from your syndicate).`)
+        ),
+
+    cooldownKey:    (interaction) => `syndicate:${interaction.options.getSubcommand()}`,
+    cooldownAmount: () => 5,
+
+    async execute(interaction, client) {
+        const guildDoc = await Guild.findOne({ guildId: interaction.guild.id }, 'economy syndicates').lean();
+
+        if (!guildDoc?.economy?.enabled) {
+            return interaction.reply({ content: 'The economy is disabled on this server.', ephemeral: true });
+        }
+
+        const sub = interaction.options.getSubcommand();
+
+        // Info and leaderboard are read-only — no syndicates.enabled gate
+        if (!['info', 'leaderboard'].includes(sub) && !guildDoc?.syndicates?.enabled) {
+            return interaction.reply({ content: 'The syndicate system is not enabled on this server. An admin can enable it in server settings.', ephemeral: true });
+        }
+
+        switch (sub) {
+            case 'create':      return executeCreate(interaction, guildDoc);
+            case 'join':        return executeJoin(interaction);
+            case 'leave':       return executeLeave(interaction);
+            case 'invite':      return executeInvite(interaction);
+            case 'kick':        return executeKick(interaction);
+            case 'open':        return executeOpen(interaction);
+            case 'info':        return executeInfo(interaction, guildDoc);
+            case 'leaderboard': return executeLeaderboard(interaction, guildDoc);
+            case 'heist':       return executeHeist(interaction, guildDoc, client);
+            case 'sabotage':    return executeSabotage(interaction, guildDoc);
+        }
+    },
+
+    handleSyndicateButton,
+};

--- a/src/commands/economy/syndicate.js
+++ b/src/commands/economy/syndicate.js
@@ -5,6 +5,7 @@ const {
     ButtonBuilder,
     ButtonStyle,
 } = require('discord.js');
+const mongoose = require('mongoose');
 const Guild = require('../../models/Guild');
 const User = require('../../models/User');
 const Syndicate = require('../../models/Syndicate');
@@ -364,21 +365,40 @@ async function executeCreate(interaction, guildDoc) {
     const tag         = rawTag ? rawTag.toUpperCase() : null;
     const syndicateId = `${interaction.guild.id}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
 
-    await User.findOneAndUpdate(
-        { userId: interaction.user.id, guildId: interaction.guild.id },
-        { $inc: { balance: -CREATION_COST }, $set: { syndicateId } },
-        { upsert: true }
-    );
-
-    await Syndicate.create({
-        syndicateId,
-        guildId: interaction.guild.id,
-        name,
-        tag,
-        leaderId:  interaction.user.id,
-        memberIds: [interaction.user.id],
-        openToJoin,
-    });
+    // Atomic: debit coins + enroll user + create syndicate in one transaction
+    const session = await mongoose.startSession();
+    try {
+        await session.withTransaction(async () => {
+            const updated = await User.findOneAndUpdate(
+                { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: CREATION_COST }, syndicateId: null },
+                { $inc: { balance: -CREATION_COST }, $set: { syndicateId } },
+                { upsert: false, session, new: true }
+            );
+            if (!updated) {
+                throw new Error('PRECONDITION_FAILED');
+            }
+            await Syndicate.create([{
+                syndicateId,
+                guildId: interaction.guild.id,
+                name,
+                nameLower: name.toLowerCase(),
+                tag,
+                leaderId:  interaction.user.id,
+                memberIds: [interaction.user.id],
+                openToJoin,
+            }], { session });
+        });
+    } catch (err) {
+        await session.endSession();
+        if (err.message === 'PRECONDITION_FAILED') {
+            return interaction.reply({
+                content: 'Could not create the syndicate — your balance or membership status changed. Please try again.',
+                ephemeral: true,
+            });
+        }
+        throw err;
+    }
+    await session.endSession();
 
     logTransaction({
         userId:  interaction.user.id,
@@ -464,7 +484,7 @@ async function executeLeave(interaction) {
     if (synDoc.leaderId === interaction.user.id) {
         if (synDoc.memberIds.length > 1) {
             return interaction.reply({
-                content: `You are the leader of **${synDoc.name}**. Kick all other members first, or use \`/syndicate disband\`.`,
+                content: `You are the leader of **${synDoc.name}**. Kick all other members first with \`/syndicate kick\`, then \`/syndicate leave\` to disband.`,
                 ephemeral: true,
             });
         }
@@ -773,12 +793,19 @@ async function executeSabotage(interaction, guildDoc) {
     const synDoc = await Syndicate.findOne({ syndicateId: userDoc.syndicateId, guildId: interaction.guild.id });
     if (!synDoc) return interaction.reply({ content: 'Your syndicate no longer exists.', ephemeral: true });
 
+    if (synDoc.leaderId !== interaction.user.id) {
+        return interaction.reply({ content: 'Only the syndicate leader can perform a sabotage.', ephemeral: true });
+    }
+
     const activeHeist = getSyndicateHeist(interaction.guild.id);
     if (!activeHeist) {
         return interaction.reply({ content: 'There is no active syndicate heist on this server to sabotage.', ephemeral: true });
     }
     if (activeHeist.syndicateId === synDoc.syndicateId) {
         return interaction.reply({ content: "You can't sabotage your own heist.", ephemeral: true });
+    }
+    if (activeHeist.phase === 'lobby') {
+        return interaction.reply({ content: 'The rival heist is still in the lobby phase. Sabotage can only be used once it has started.', ephemeral: true });
     }
 
     const effectiveHeat = getEffectiveHeat(synDoc);

--- a/src/commands/economy/syndicate.js
+++ b/src/commands/economy/syndicate.js
@@ -147,19 +147,33 @@ async function resolveHeist(client, heist) {
 
         const wins = (outcome === 'full_success') || (outcome === 'partial_success' && passed);
         if (wins && perPlayer > 0) {
-            await User.findOneAndUpdate(
-                { userId, guildId: heist.guildId },
-                { $inc: { balance: perPlayer } }
-            ).catch(() => {});
-            const u = await User.findOne({ userId, guildId: heist.guildId }, 'balance').lean();
-            logTransaction({
-                userId,
-                guildId: heist.guildId,
-                type:    'syndicate_heist',
-                amount:  perPlayer,
-                balance: u?.balance ?? perPlayer,
-                note:    `Syndicate heist: ${target.label}`,
-            });
+            let credited = false;
+            for (let attempt = 1; attempt <= 3; attempt++) {
+                try {
+                    await User.findOneAndUpdate(
+                        { userId, guildId: heist.guildId },
+                        { $inc: { balance: perPlayer } }
+                    );
+                    credited = true;
+                    break;
+                } catch (err) {
+                    console.error(`[syndicate] Credit attempt ${attempt}/3 failed for userId=${userId} guildId=${heist.guildId} amount=${perPlayer}:`, err.message);
+                    if (attempt < 3) await new Promise(r => setTimeout(r, attempt * 200));
+                }
+            }
+            if (!credited) {
+                console.error(`[syndicate] CRITICAL: all credit attempts failed — userId=${userId} guildId=${heist.guildId} amount=${perPlayer} heistId=${heist.heistId}`);
+            } else {
+                const u = await User.findOne({ userId, guildId: heist.guildId }, 'balance').lean();
+                logTransaction({
+                    userId,
+                    guildId: heist.guildId,
+                    type:    'syndicate_heist',
+                    amount:  perPlayer,
+                    balance: u?.balance ?? perPlayer,
+                    note:    `Syndicate heist: ${target.label}`,
+                });
+            }
         }
     }
 

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -2,6 +2,7 @@ const Guild = require('../models/Guild');
 const User = require('../models/User');
 const { handlePollVote } = require('../commands/utility/poll');
 const { handleHeistButton } = require('../commands/economy/heist');
+const { handleSyndicateButton } = require('../commands/economy/syndicate');
 const { ensureQuests, onCommandUse, notifyQuestComplete, notifyQuestNearComplete } = require('../services/questService');
 async function logCommandMetric(interaction, success, reason = null) {
     try {
@@ -128,6 +129,13 @@ module.exports = {
             if (interaction.customId.startsWith('heist_join_') || interaction.customId.startsWith('heist_skill_')) {
                 await handleHeistButton(interaction, client).catch(err => {
                     console.error('[heist] button handler error:', err);
+                });
+                return;
+            }
+
+            if (interaction.customId.startsWith('syn_join_') || interaction.customId.startsWith('syn_skill_')) {
+                await handleSyndicateButton(interaction, client).catch(err => {
+                    console.error('[syndicate] button handler error:', err);
                 });
                 return;
             }

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -687,6 +687,12 @@ const guildSchema = new Schema({
         lastRunAt:        { type: Date, default: null }
     },
 
+    // Crime Syndicate System (issue #341)
+    syndicates: {
+        enabled:            { type: Boolean, default: false },
+        heistCooldownHours: { type: Number,  default: 4, min: 1, max: 48 },
+    },
+
     // Strategic Heist System (issue #358)
     heist: {
         enabled:               { type: Boolean, default: false },

--- a/src/models/Syndicate.js
+++ b/src/models/Syndicate.js
@@ -4,6 +4,7 @@ const syndicateSchema = new Schema({
     syndicateId:      { type: String, required: true },
     guildId:          { type: String, required: true },
     name:             { type: String, required: true, maxlength: 32 },
+    nameLower:        { type: String, required: true },  // lowercase of name; used for unique index
     tag:              { type: String, default: null, maxlength: 5 },
     leaderId:         { type: String, required: true },
     memberIds:        [{ type: String }],
@@ -17,11 +18,13 @@ const syndicateSchema = new Schema({
     updatedAt:        { type: Date, default: Date.now },
 });
 
+// Case-insensitive unique name enforcement via normalized field
 syndicateSchema.index({ syndicateId: 1 }, { unique: true });
-syndicateSchema.index({ guildId: 1, name: 1 }, { unique: true });
+syndicateSchema.index({ guildId: 1, nameLower: 1 }, { unique: true });
 syndicateSchema.index({ guildId: 1, lifetimeEarnings: -1 });
 
 syndicateSchema.pre('save', function(next) {
+    this.nameLower = this.name.toLowerCase();
     this.updatedAt = Date.now();
     next();
 });

--- a/src/models/Syndicate.js
+++ b/src/models/Syndicate.js
@@ -1,0 +1,29 @@
+const { Schema, model } = require('mongoose');
+
+const syndicateSchema = new Schema({
+    syndicateId:      { type: String, required: true },
+    guildId:          { type: String, required: true },
+    name:             { type: String, required: true, maxlength: 32 },
+    tag:              { type: String, default: null, maxlength: 5 },
+    leaderId:         { type: String, required: true },
+    memberIds:        [{ type: String }],
+    heat:             { type: Number, default: 0, min: 0, max: 100 },
+    lastHeistAt:      { type: Date, default: null },
+    lifetimeEarnings: { type: Number, default: 0 },
+    heistCount:       { type: Number, default: 0 },
+    openToJoin:       { type: Boolean, default: false },
+    pendingInvites:   [{ type: String }],
+    createdAt:        { type: Date, default: Date.now },
+    updatedAt:        { type: Date, default: Date.now },
+});
+
+syndicateSchema.index({ syndicateId: 1 }, { unique: true });
+syndicateSchema.index({ guildId: 1, name: 1 }, { unique: true });
+syndicateSchema.index({ guildId: 1, lifetimeEarnings: -1 });
+
+syndicateSchema.pre('save', function(next) {
+    this.updatedAt = Date.now();
+    next();
+});
+
+module.exports = model('Syndicate', syndicateSchema);

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -543,6 +543,9 @@ const userSchema = new Schema({
     dailyGiftSent:  { type: Number, default: 0 },
     dailyGiftReset: { type: Date,   default: null },
 
+    // Crime syndicate membership
+    syndicateId: { type: String, default: null },
+
     // Crash game: bet amount deducted but not yet resolved (cleared on cash out or crash end)
     pendingCrashRefund: { type: Number, default: 0 },
 

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -584,6 +584,7 @@ userSchema.index({ guildId: 1, 'ranked.elo': -1 });
 userSchema.index({ guildId: 1, 'accountPrestige.rank': -1 });
 userSchema.index({ guildId: 1, achievementsCount: -1 });
 userSchema.index({ guildId: 1, seasonCoins: -1 }); // used by executeLeaderboard / executeSeasonMe
+userSchema.index({ guildId: 1, syndicateId: 1 });  // used by syndicate member lookups
 
 userSchema.pre('save', function(next) {
     this.updatedAt = Date.now();

--- a/src/services/syndicateService.js
+++ b/src/services/syndicateService.js
@@ -1,0 +1,164 @@
+// In-memory state for active syndicate heist lobbies, keyed by guildId.
+// Only one syndicate heist can run per guild at a time.
+
+const activeSyndicateHeists = new Map();
+
+const SYNDICATE_TARGETS = {
+    bank_job: {
+        label:             'Bank Job',
+        emoji:             '🏦',
+        minPlayers:        3,
+        baseSuccessChance: 0.45,
+        minPayout:         10_000,
+        maxPayout:         25_000,
+        heatGain:          8,
+    },
+    museum_heist: {
+        label:             'Museum Heist',
+        emoji:             '🏛️',
+        minPlayers:        5,
+        baseSuccessChance: 0.30,
+        minPayout:         30_000,
+        maxPayout:         80_000,
+        heatGain:          15,
+    },
+    city_hall_con: {
+        label:             'City Hall Con',
+        emoji:             '🏙️',
+        minPlayers:        7,
+        baseSuccessChance: 0.20,
+        minPayout:         100_000,
+        maxPayout:         200_000,
+        heatGain:          25,
+    },
+};
+
+// Each role has an emoji, label, and a skillType that maps to heistService's buildSkillCheck
+const SYNDICATE_ROLES = {
+    driver:   { emoji: '🚗', label: 'Driver',   skillType: 'driver',  desc: 'Plans the getaway — pick the safe escape route.' },
+    hacker:   { emoji: '💻', label: 'Hacker',   skillType: 'hacker',  desc: 'Bypasses security — solve the logic puzzle.' },
+    lookout:  { emoji: '👀', label: 'Lookout',  skillType: 'lookout', desc: 'Monitors guards — spot the duplicate number.' },
+    muscle:   { emoji: '💪', label: 'Muscle',   skillType: 'muscle',  desc: 'Handles threats — guess higher or lower.' },
+    grifter:  { emoji: '🎭', label: 'Grifter',  skillType: 'hacker',  desc: 'Creates a diversion — crack the misdirection code.' },
+    courier:  { emoji: '📦', label: 'Courier',  skillType: 'driver',  desc: 'Moves the goods — choose the fastest delivery path.' },
+    scout:    { emoji: '🔭', label: 'Scout',    skillType: 'lookout', desc: 'Gathers intel — identify the surveillance anomaly.' },
+};
+
+function generateSyndicateHeistId(guildId) {
+    return `syn-${guildId}-${Date.now()}`;
+}
+
+function createSyndicateLobby({ guildId, channelId, syndicateId, leaderId, target, lobbyDurationSeconds, currentHeat }) {
+    const heistId = generateSyndicateHeistId(guildId);
+    const state = {
+        heistId,
+        guildId,
+        channelId,
+        syndicateId,
+        leaderId,
+        target,
+        lobbyEndsAt: new Date(Date.now() + lobbyDurationSeconds * 1000),
+        phase: 'lobby',
+        players: new Map(),  // userId -> { role, username, skillPassed: null }
+        skillTimers: {},
+        sabotageCount: 0,
+        heatAtStart: currentHeat,
+        resolving: false,
+        _skillChecks: {},
+    };
+    activeSyndicateHeists.set(guildId, state);
+    return state;
+}
+
+function joinSyndicateLobby(guildId, userId, username, role) {
+    const heist = activeSyndicateHeists.get(guildId);
+    if (!heist || heist.phase !== 'lobby') return { ok: false, reason: 'No active lobby.' };
+    if (!SYNDICATE_ROLES[role]) return { ok: false, reason: 'Invalid role.' };
+    for (const [pid, p] of heist.players) {
+        if (p.role === role) return { ok: false, reason: `The ${SYNDICATE_ROLES[role].label} role is already taken.` };
+        if (pid === userId) return { ok: false, reason: 'You already joined this heist.' };
+    }
+    heist.players.set(userId, { role, username, skillPassed: null });
+    return { ok: true };
+}
+
+function endSyndicateLobby(guildId) {
+    const heist = activeSyndicateHeists.get(guildId);
+    if (!heist) return null;
+    heist.phase = 'active';
+    return heist;
+}
+
+function clearSyndicateHeist(guildId) {
+    const heist = activeSyndicateHeists.get(guildId);
+    if (heist) {
+        for (const timer of Object.values(heist.skillTimers || {})) clearTimeout(timer);
+    }
+    activeSyndicateHeists.delete(guildId);
+}
+
+function getSyndicateHeist(guildId) {
+    return activeSyndicateHeists.get(guildId) ?? null;
+}
+
+// Computes current heat accounting for passive decay (10 per 24h without a heist)
+function getEffectiveHeat(syndicateDoc) {
+    if (!syndicateDoc.lastHeistAt) return Math.max(0, syndicateDoc.heat);
+    const hoursSince = (Date.now() - syndicateDoc.lastHeistAt.getTime()) / (1000 * 60 * 60);
+    const daysSince = Math.floor(hoursSince / 24);
+    return Math.max(0, syndicateDoc.heat - daysSince * 10);
+}
+
+// Determines outcome and payouts for a resolved syndicate heist.
+// High heat (>50) adds +20% payout but -15% success chance.
+// Each sabotage reduces success chance by an additional 15%.
+function computeSyndicateOutcome(heist) {
+    const target = SYNDICATE_TARGETS[heist.target];
+    const players = [...heist.players.values()];
+    const total = players.length;
+    if (!total) return { outcome: 'bust', payout: 0, perPlayer: 0, passedCount: 0, totalCount: 0 };
+
+    const highHeat = heist.heatAtStart > 50;
+    const adjustedChance = Math.max(0.05,
+        target.baseSuccessChance
+        + (highHeat ? -0.15 : 0)
+        - (heist.sabotageCount * 0.15)
+    );
+
+    if (Math.random() >= adjustedChance) {
+        return { outcome: 'bust', payout: 0, perPlayer: 0, passedCount: 0, totalCount: total };
+    }
+
+    const passedCount = players.filter(p => p.skillPassed === true).length;
+    const ratio = passedCount / total;
+    const heatMultiplier = highHeat ? 1.2 : 1.0;
+    const basePayout = Math.floor(target.minPayout + Math.random() * (target.maxPayout - target.minPayout + 1));
+
+    let outcome, payoutPool;
+    if (ratio >= 1.0) {
+        outcome = 'full_success';
+        payoutPool = Math.floor(basePayout * heatMultiplier);
+    } else if (ratio >= 0.5) {
+        outcome = 'partial_success';
+        payoutPool = Math.floor(basePayout * heatMultiplier * 0.5);
+    } else {
+        outcome = 'failure';
+        payoutPool = 0;
+    }
+
+    const perPlayer = (passedCount > 0 && payoutPool > 0) ? Math.floor(payoutPool / passedCount) : 0;
+    return { outcome, payout: payoutPool, perPlayer, passedCount, totalCount: total };
+}
+
+module.exports = {
+    activeSyndicateHeists,
+    SYNDICATE_TARGETS,
+    SYNDICATE_ROLES,
+    createSyndicateLobby,
+    joinSyndicateLobby,
+    endSyndicateLobby,
+    clearSyndicateHeist,
+    getSyndicateHeist,
+    getEffectiveHeat,
+    computeSyndicateOutcome,
+};

--- a/src/services/syndicateService.js
+++ b/src/services/syndicateService.js
@@ -49,6 +49,14 @@ function generateSyndicateHeistId(guildId) {
 }
 
 function createSyndicateLobby({ guildId, channelId, syndicateId, leaderId, target, lobbyDurationSeconds, currentHeat }) {
+    // Clear any orphaned lobby so timers don't double-fire if the caller somehow
+    // calls this without first checking getSyndicateHeist.
+    const existing = activeSyndicateHeists.get(guildId);
+    if (existing) {
+        for (const timer of Object.values(existing.skillTimers || {})) clearTimeout(timer);
+        activeSyndicateHeists.delete(guildId);
+    }
+
     const heistId = generateSyndicateHeistId(guildId);
     const state = {
         heistId,
@@ -114,6 +122,11 @@ function getEffectiveHeat(syndicateDoc) {
 // Each sabotage reduces success chance by an additional 15%.
 function computeSyndicateOutcome(heist) {
     const target = SYNDICATE_TARGETS[heist.target];
+    if (!target) {
+        console.error(`[syndicateService] computeSyndicateOutcome: unknown target "${heist.target}"`);
+        return { outcome: 'bust', payout: 0, perPlayer: 0, passedCount: 0, totalCount: 0 };
+    }
+
     const players = [...heist.players.values()];
     const total = players.length;
     if (!total) return { outcome: 'bust', payout: 0, perPlayer: 0, passedCount: 0, totalCount: 0 };


### PR DESCRIPTION
## Summary
Implements a comprehensive crime syndicate system enabling players to form organizations, plan cooperative heists, and engage in rival sabotage mechanics. This adds a new layer of cooperative gameplay to the economy system with skill-based challenges and dynamic heat/risk mechanics.

## Key Changes

### New Command: `/syndicate`
- **Management subcommands**: `create`, `join`, `leave`, `invite`, `kick`, `open` — full lifecycle management of syndicate organizations
- **Information subcommands**: `info`, `leaderboard` — view syndicate details and top earners
- **Heist subcommands**: `heist`, `sabotage` — initiate cooperative heists and interfere with rival operations
- Syndicates support up to 10 members with leader-based permissions
- Creation costs 50,000 coins; optional tags and open/invite-only membership modes

### Heist System
- Three heist targets with escalating difficulty and payouts:
  - Bank Job (3 players, 10k–25k coins, 45% base success)
  - Museum Heist (5 players, 30k–80k coins, 30% base success)
  - City Hall Con (7 players, 100k–200k coins, 20% base success)
- 60-second lobby phase where crew members select roles (Driver, Hacker, Lookout, Muscle, Grifter, Courier, Scout)
- Skill checks sent via DM with 30-second timeout; each role has unique challenge type
- Outcome determination: full success (all pass), partial success (≥50% pass), failure, or bust
- High heat (>50) increases payout by 20% but reduces success chance by 15%
- 4-hour cooldown between heists per syndicate

### Heat & Sabotage Mechanics
- Syndicates accumulate heat (0–100) based on heist outcomes
- Heat decays passively at 10 points per 24 hours without activity
- Rival syndicates can spend 20 heat to sabotage active heists, reducing success chance by 15%
- Multiple sabotages stack their effects

### Data Models
- **Syndicate**: Stores organization data (members, heat, earnings, heist history, invites)
- **User**: Extended with `syndicateId` field for membership tracking
- **Guild**: Extended with `syndicates.enabled` configuration flag

### Integration
- Button handlers for lobby role selection and skill check responses
- Transaction logging for all heist payouts
- Embeds with heat bars, countdown timers, and detailed result reporting
- Proper cleanup of timers and in-memory heist state

## Notable Implementation Details
- In-memory heist state (`activeSyndicateHeists` Map) allows only one active heist per guild
- Skill checks are role-specific and leverage existing `heistService.buildSkillCheck()` infrastructure
- Outcome computation accounts for high heat multipliers, sabotage penalties, and partial success scenarios
- DM-based skill checks with fallback handling for users with closed DMs
- Regex-based case-insensitive syndicate name lookups with proper escaping

https://claude.ai/code/session_01Juc1QbPzQh9Wg3jq4pJJ9D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Crime Syndicate System: create and manage syndicates with roles, invites, join/leave, and leader controls
  * Heist Lobby & UI: lobby join buttons, countdowns, per-member DM skill checks, and results posts
  * Heist Mechanics: cooperative heists with dynamic outcomes, payouts, sabotage actions, and cooldowns
  * Syndicate Info & Leaderboard: view syndicate stats, members, heat, earnings, and top syndicates
  * Guild Configuration: server toggle and configurable heist cooldown settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->