### PR TITLE
Add autocomplete support for craft command recipes

### DIFF
--- a/src/commands/economy/craft.js
+++ b/src/commands/economy/craft.js
@@ -13,7 +13,7 @@ const { ensureFishingData } = require('../../services/fishService');
 
 const ALL_RECIPES   = { ...HUNT_RECIPES, ...MINE_RECIPES, ...FISH_CRAFT_RECIPES, ...CROSS_CRAFT_RECIPES };
 const ALL_MAT_NAMES = { ...HUNT_MAT_NAMES, ...MINE_MAT_NAMES, ...FISH_MAT_NAMES };
-const RECIPE_CHOICES = Object.values(ALL_RECIPES).map(r => ({ name: r.name, value: r.id }));
+const RECIPE_LIST = Object.values(ALL_RECIPES).map(r => ({ name: r.name, value: r.id }));
 
 module.exports = {
     cooldown: 3,
@@ -31,7 +31,17 @@ module.exports = {
                     o.setName('recipe')
                         .setDescription('Recipe to craft')
                         .setRequired(true)
-                        .addChoices(...RECIPE_CHOICES))),
+                        .setAutocomplete(true))),
+
+    async autocomplete(interaction) {
+        const focused = interaction.options.getFocused()?.toLowerCase() ?? '';
+        const matches = focused
+            ? RECIPE_LIST.filter(r =>
+                r.name.toLowerCase().includes(focused) ||
+                r.value.toLowerCase().includes(focused))
+            : RECIPE_LIST;
+        await interaction.respond(matches.slice(0, 25));
+    },
 
     async execute(interaction) {
         const sub = interaction.options.getSubcommand();

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -160,6 +160,17 @@ module.exports = {
             return;
         }
 
+        if (interaction.isAutocomplete()) {
+            const command = client.commands.get(interaction.commandName);
+            if (!command?.autocomplete) return;
+            try {
+                await command.autocomplete(interaction, client);
+            } catch (error) {
+                console.error(`Autocomplete error in ${interaction.commandName}:`, error);
+            }
+            return;
+        }
+
         if (!interaction.isChatInputCommand()) return;
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
 

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -162,11 +162,19 @@ module.exports = {
 
         if (interaction.isAutocomplete()) {
             const command = client.commands.get(interaction.commandName);
-            if (!command?.autocomplete) return;
+            const safeRespondEmpty = async () => {
+                if (interaction.responded) return;
+                try { await interaction.respond([]); } catch (_) { /* interaction expired */ }
+            };
+            if (!command?.autocomplete) {
+                await safeRespondEmpty();
+                return;
+            }
             try {
                 await command.autocomplete(interaction, client);
             } catch (error) {
                 console.error(`Autocomplete error in ${interaction.commandName}:`, error);
+                await safeRespondEmpty();
             }
             return;
         }


### PR DESCRIPTION
## Summary
Implemented autocomplete functionality for the craft command's recipe selection, replacing the static choice list with dynamic filtering based on user input.

## Key Changes
- **craft.js**: 
  - Renamed `RECIPE_CHOICES` to `RECIPE_LIST` for clarity since it's now used for autocomplete filtering rather than static choices
  - Changed recipe option from `.addChoices()` to `.setAutocomplete(true)` to enable dynamic autocomplete
  - Added new `autocomplete()` handler that filters recipes by name or ID, returning up to 25 matches

- **interactionCreate.js**:
  - Added autocomplete interaction handler that routes autocomplete requests to the appropriate command's `autocomplete()` method
  - Includes error handling to log any autocomplete errors without crashing the bot

## Implementation Details
The autocomplete handler performs case-insensitive filtering on both recipe names and IDs, allowing users to search by either field. Results are limited to 25 items per Discord's autocomplete constraints.

https://claude.ai/code/session_013HsTLiEHDpwboEDvMpQgTS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `/craft make` command's recipe selection now features dynamic autocomplete, enabling real-time search and filtering of recipes as you type, with up to 25 matching results displayed per search.

* **Improvements**
  * Enhanced the recipe selection interface with autocomplete functionality instead of a fixed predefined list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->