### PR TITLE
feat(ai): token usage tracking + larger prompt editors (#433, #427)

### DIFF
--- a/src/dashboard/public/styles.css
+++ b/src/dashboard/public/styles.css
@@ -889,7 +889,7 @@ textarea.auto-resize {
 }
 .ai-usage-stat {
     padding: .75rem .9rem;
-    background: var(--bg);
+    background: var(--bg-1);
     border: 1px solid var(--border);
     border-radius: 8px;
 }
@@ -902,7 +902,7 @@ textarea.auto-resize {
 .ai-usage-stat-sub { font-size: .78rem; color: var(--text-mute); margin-top: .15rem; }
 .ai-usage-sparkline {
     width: 100%; height: 60px;
-    background: var(--bg);
+    background: var(--bg-1);
     border: 1px solid var(--border);
     border-radius: 6px;
     display: block;

--- a/src/dashboard/public/styles.css
+++ b/src/dashboard/public/styles.css
@@ -832,6 +832,93 @@ textarea { resize: vertical; min-height: 80px; }
     padding: 1rem 1.5rem; border-top: 1px solid var(--border);
 }
 
+/* Prompt editor with header (label + char counter + fullscreen button) */
+.prompt-field-head {
+    display: flex; align-items: baseline; justify-content: space-between;
+    gap: 1rem; margin-bottom: .35rem;
+}
+.prompt-field-meta {
+    display: flex; align-items: center; gap: .75rem;
+    font-size: .78rem; color: var(--text-mute);
+}
+.prompt-char-count.over { color: var(--danger, #e05a5a); font-weight: 600; }
+.prompt-expand-btn {
+    background: none; border: 1px solid var(--border);
+    color: var(--text-mute); cursor: pointer;
+    font-size: .75rem; padding: .15rem .55rem; border-radius: 4px;
+    transition: all .12s ease;
+}
+.prompt-expand-btn:hover { color: var(--text); border-color: var(--border-strong); }
+
+/* Auto-resizing textareas — modern browsers grow with content; older ones
+   fall back to the rows attribute set on the element. */
+textarea.auto-resize {
+    field-sizing: content;
+    min-height: 9rem;
+    max-height: 30rem;
+}
+
+/* Full-screen prompt editor modal */
+.modal-box.modal-box-wide { max-width: 900px; }
+.prompt-editor-modal textarea {
+    width: 100%;
+    min-height: 60vh;
+    font-family: ui-monospace, 'JetBrains Mono', monospace;
+    font-size: .92rem;
+    line-height: 1.5;
+    resize: vertical;
+}
+
+/* AI Usage stats card */
+.ai-usage-card {
+    margin-top: 1.5rem;
+    padding: 1.25rem 1.5rem;
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+}
+.ai-usage-card-head {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 1rem;
+}
+.ai-usage-card-head h3 { font-size: 1rem; font-weight: 700; margin: 0; }
+.ai-usage-card-head .muted { font-size: .8rem; color: var(--text-mute); }
+.ai-usage-stats {
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: .75rem;
+    margin-bottom: 1rem;
+}
+.ai-usage-stat {
+    padding: .75rem .9rem;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+}
+.ai-usage-stat-label {
+    font-size: .72rem; text-transform: uppercase;
+    letter-spacing: .04em; color: var(--text-mute);
+    margin-bottom: .3rem;
+}
+.ai-usage-stat-value { font-size: 1.15rem; font-weight: 700; }
+.ai-usage-stat-sub { font-size: .78rem; color: var(--text-mute); margin-top: .15rem; }
+.ai-usage-sparkline {
+    width: 100%; height: 60px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    display: block;
+}
+.ai-usage-breakdown {
+    margin-top: 1rem;
+    font-size: .82rem;
+    color: var(--text-mute);
+}
+.ai-usage-breakdown table { width: 100%; border-collapse: collapse; }
+.ai-usage-breakdown th, .ai-usage-breakdown td {
+    text-align: left; padding: .35rem .5rem;
+    border-bottom: 1px solid var(--border);
+}
+.ai-usage-breakdown th { font-weight: 600; color: var(--text); }
+.ai-usage-breakdown td.num { text-align: right; font-variant-numeric: tabular-nums; }
 
 /* ================================================================
    NEW HOME PAGE — cream/ink palette

--- a/src/dashboard/routes/api.js
+++ b/src/dashboard/routes/api.js
@@ -1116,6 +1116,32 @@ router.delete('/guild/:guildId/persona/:channelId', checkAuth, checkGuildAccess,
     }
 });
 
+// ── AI Usage ───────────────────────────────────────────────────────────────
+
+router.get('/guild/:guildId/ai/usage', checkAuth, checkGuildAccess, async (req, res) => {
+    const { guildId } = req.params;
+    const days = Math.min(90, Math.max(1, parseInt(req.query.days, 10) || 14));
+
+    try {
+        const { getUsageStats } = require('../../services/aiService');
+        const guildSettings = await Guild.findOne({ guildId }).lean();
+        const stats = await getUsageStats(guildId, days);
+
+        const ai = guildSettings?.ai || {};
+        res.json({
+            ...stats,
+            rateLimit: {
+                perUser: ai.rateLimitPerUser ?? 0,
+                perChannel: ai.rateLimitPerChannel ?? 0,
+                windowMin: ai.rateLimitWindowMin ?? 10
+            }
+        });
+    } catch (error) {
+        console.error('AI usage stats error:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
 // ── Achievements ────────────────────────────────────────────────────────────
 
 router.post('/guild/:guildId/achievements/grant', checkAuth, checkGuildAccess, checkWriteRateLimit, async (req, res) => {

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -2907,6 +2907,15 @@
                     'commandPolicies.cooldownOverrides': _cpCooldowns
                 };
             } else if (section === 'ai') {
+                // EJS renders the saved systemPrompt verbatim, so pre-existing values
+                // can exceed the textarea's maxlength (e.g. set via the API).
+                // Validate here so we never POST an oversized prompt.
+                var aiPromptVal = document.getElementById('ai-prompt').value;
+                if (aiPromptVal.length > 4000) {
+                    updatePromptCount('ai-prompt');
+                    toast('System prompt is ' + aiPromptVal.length + ' chars — maximum is 4000.', 'error');
+                    return;
+                }
                 data = {
                     'ai.enabled': document.getElementById('ai-enabled').checked,
                     'ai.provider': document.getElementById('ai-provider').value,
@@ -2917,7 +2926,7 @@
                     ...(document.getElementById('ai-openrouter-key').value ? {'ai.openrouterKey': document.getElementById('ai-openrouter-key').value} : {}),
                     'ai.ollamaBaseUrl': document.getElementById('ai-ollama-url').value.trim(),
                     'ai.channelId': document.getElementById('ai-channel').value,
-                    'ai.systemPrompt': document.getElementById('ai-prompt').value,
+                    'ai.systemPrompt': aiPromptVal,
                     'ai.temperature': parseFloat(document.getElementById('ai-temperature').value),
                     'ai.maxTokens': parseInt(document.getElementById('ai-max-tokens').value, 10),
                     'ai.maxHistory': parseInt(document.getElementById('ai-max-history').value, 10),
@@ -4101,6 +4110,15 @@
         }
 
         var _promptEditorTarget = null;
+        function _promptEditorKeydown(e) {
+            if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                e.preventDefault();
+                closePromptEditor(true);
+            } else if (e.key === 'Escape') {
+                e.preventDefault();
+                closePromptEditor(false);
+            }
+        }
         function openPromptEditor(textareaId, title) {
             var ta = document.getElementById(textareaId);
             if (!ta) return;
@@ -4111,6 +4129,7 @@
             editor.setAttribute('maxlength', ta.getAttribute('maxlength') || 4000);
             document.getElementById('prompt-editor-modal').style.display = 'flex';
             updatePromptEditorCount();
+            document.addEventListener('keydown', _promptEditorKeydown);
             setTimeout(function() { editor.focus(); }, 50);
         }
         function updatePromptEditorCount() {
@@ -4131,18 +4150,9 @@
                 }
             }
             modal.style.display = 'none';
+            document.removeEventListener('keydown', _promptEditorKeydown);
             _promptEditorTarget = null;
         }
-        // Cmd/Ctrl+Enter inside the full-screen editor commits changes
-        document.getElementById('prompt-editor-textarea').addEventListener('keydown', function(e) {
-            if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-                e.preventDefault();
-                closePromptEditor(true);
-            } else if (e.key === 'Escape') {
-                e.preventDefault();
-                closePromptEditor(false);
-            }
-        });
         // Initialize counters on load
         updatePromptCount('ai-prompt');
         updatePromptCount('persona-prompt');
@@ -4239,21 +4249,25 @@
             } catch (e) {
                 console.error('Failed to load AI usage:', e);
                 statusEl.textContent = 'Failed to load usage';
+                throw e;
             }
         }
         // Lazy-load AI usage stats the first time the AI panel becomes visible.
-        // Polls the AI panel's `.active` class — works for nav clicks, hash routing,
-        // and initial page load without coupling to the nav implementation.
+        // Watches the AI panel's `.active` class so it works for nav clicks, hash
+        // routing, and initial page load without coupling to the nav implementation.
         (function() {
             var aiPanel = document.getElementById('ai');
             if (!aiPanel) return;
             var loaded = false;
+            var inFlight = false;
             function check() {
-                if (loaded) return;
-                if (aiPanel.classList.contains('active')) {
-                    loaded = true;
-                    loadAiUsage();
-                }
+                if (loaded || inFlight) return;
+                if (!aiPanel.classList.contains('active')) return;
+                inFlight = true;
+                loadAiUsage()
+                    .then(function() { loaded = true; })
+                    .catch(function() { /* leave `loaded` false so a later view retries */ })
+                    .finally(function() { inFlight = false; });
             }
             check();
             var obs = new MutationObserver(check);

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -2020,8 +2020,14 @@
                             </select>
                         </div>
                         <div class="field">
-                            <label class="field-label" for="ai-prompt">System prompt</label>
-                            <textarea id="ai-prompt" rows="3"><%= settings.ai.systemPrompt %></textarea>
+                            <div class="prompt-field-head">
+                                <label class="field-label" for="ai-prompt" style="margin:0;">System prompt</label>
+                                <div class="prompt-field-meta">
+                                    <span class="prompt-char-count" id="ai-prompt-count">0 / 4000</span>
+                                    <button type="button" class="prompt-expand-btn" onclick="openPromptEditor('ai-prompt', 'System prompt')">⛶ Full-screen</button>
+                                </div>
+                            </div>
+                            <textarea id="ai-prompt" class="auto-resize" rows="8" maxlength="4000" oninput="updatePromptCount('ai-prompt')"><%= settings.ai.systemPrompt %></textarea>
                         </div>
                         <div class="field">
                             <label class="field-label" for="ai-temperature">Temperature (<span id="ai-temp-display"><%= settings.ai.temperature ?? 0.7 %></span>)</label>
@@ -2047,6 +2053,37 @@
                         <p style="font-size:.8rem;opacity:.65;margin:.25rem 0 1rem;">Users can type <code>!reset</code> in the AI channel to clear their conversation history.</p>
                         <div class="actions-row">
                             <button class="btn btn-primary" onclick="saveSettings('ai')">Save changes</button>
+                        </div>
+
+                        <!-- Token Usage Stats -->
+                        <div class="ai-usage-card" id="ai-usage-card">
+                            <div class="ai-usage-card-head">
+                                <h3>📊 Token usage</h3>
+                                <span class="muted" id="ai-usage-status">Loading…</span>
+                            </div>
+                            <div class="ai-usage-stats">
+                                <div class="ai-usage-stat">
+                                    <div class="ai-usage-stat-label">Today</div>
+                                    <div class="ai-usage-stat-value" id="ai-usage-today-tokens">—</div>
+                                    <div class="ai-usage-stat-sub" id="ai-usage-today-cost"></div>
+                                </div>
+                                <div class="ai-usage-stat">
+                                    <div class="ai-usage-stat-label">This week</div>
+                                    <div class="ai-usage-stat-value" id="ai-usage-week-tokens">—</div>
+                                    <div class="ai-usage-stat-sub" id="ai-usage-week-cost"></div>
+                                </div>
+                                <div class="ai-usage-stat">
+                                    <div class="ai-usage-stat-label">This month</div>
+                                    <div class="ai-usage-stat-value" id="ai-usage-month-tokens">—</div>
+                                    <div class="ai-usage-stat-sub" id="ai-usage-month-cost"></div>
+                                </div>
+                            </div>
+                            <div style="font-size:.78rem;color:var(--text-mute);margin-bottom:.35rem;">Tokens per day — last 14 days</div>
+                            <svg class="ai-usage-sparkline" id="ai-usage-sparkline" viewBox="0 0 280 60" preserveAspectRatio="none"></svg>
+                            <div class="ai-usage-breakdown" id="ai-usage-breakdown"></div>
+                            <p style="font-size:.74rem;color:var(--text-mute);margin:.75rem 0 0;">
+                                Costs are estimates based on published per-token pricing for known models; OpenRouter and unknown models show no cost. Self-hosted Ollama is always $0.
+                            </p>
                         </div>
                     </div>
 
@@ -2145,11 +2182,37 @@
                             <input type="text" id="persona-name" placeholder="e.g. Support Bot">
                         </div>
                         <div class="field">
-                            <label class="field-label" for="persona-prompt">System prompt</label>
-                            <textarea id="persona-prompt" rows="4" placeholder="You are a helpful support assistant…"></textarea>
+                            <div class="prompt-field-head">
+                                <label class="field-label" for="persona-prompt" style="margin:0;">System prompt</label>
+                                <div class="prompt-field-meta">
+                                    <span class="prompt-char-count" id="persona-prompt-count">0 / 4000</span>
+                                    <button type="button" class="prompt-expand-btn" onclick="openPromptEditor('persona-prompt', 'Persona system prompt')">⛶ Full-screen</button>
+                                </div>
+                            </div>
+                            <textarea id="persona-prompt" class="auto-resize" rows="8" maxlength="4000" placeholder="You are a helpful support assistant…" oninput="updatePromptCount('persona-prompt')"></textarea>
                         </div>
                         <div class="actions-row">
                             <button class="btn btn-primary" onclick="addPersona()">Save persona</button>
+                        </div>
+                    </div>
+
+                    <!-- Full-screen prompt editor (shared by ai-prompt and persona-prompt) -->
+                    <div id="prompt-editor-modal" class="modal-overlay prompt-editor-modal" style="display:none;" onclick="if(event.target===this)closePromptEditor(false)">
+                        <div class="modal-box modal-box-wide">
+                            <div class="modal-head">
+                                <h3 id="prompt-editor-title">Edit prompt</h3>
+                                <button class="modal-close" onclick="closePromptEditor(false)">&times;</button>
+                            </div>
+                            <div class="modal-body">
+                                <textarea id="prompt-editor-textarea" maxlength="4000" oninput="updatePromptEditorCount()"></textarea>
+                                <div style="display:flex;justify-content:flex-end;margin-top:.5rem;font-size:.78rem;color:var(--text-mute);">
+                                    <span id="prompt-editor-count">0 / 4000</span>
+                                </div>
+                            </div>
+                            <div class="modal-actions">
+                                <button class="btn" onclick="closePromptEditor(false)">Cancel</button>
+                                <button class="btn btn-primary" onclick="closePromptEditor(true)">Done</button>
+                            </div>
                         </div>
                     </div>
                 </section>
@@ -4025,6 +4088,177 @@
 
         // Initialize personas on page load (data already available from template)
         renderPersonas();
+
+        // ── Prompt editor: char counter + full-screen modal ─────────────────
+        function updatePromptCount(textareaId) {
+            var ta = document.getElementById(textareaId);
+            var counter = document.getElementById(textareaId + '-count');
+            if (!ta || !counter) return;
+            var max = parseInt(ta.getAttribute('maxlength'), 10) || 4000;
+            var len = ta.value.length;
+            counter.textContent = len + ' / ' + max;
+            counter.classList.toggle('over', len >= max);
+        }
+
+        var _promptEditorTarget = null;
+        function openPromptEditor(textareaId, title) {
+            var ta = document.getElementById(textareaId);
+            if (!ta) return;
+            _promptEditorTarget = textareaId;
+            document.getElementById('prompt-editor-title').textContent = title || 'Edit prompt';
+            var editor = document.getElementById('prompt-editor-textarea');
+            editor.value = ta.value;
+            editor.setAttribute('maxlength', ta.getAttribute('maxlength') || 4000);
+            document.getElementById('prompt-editor-modal').style.display = 'flex';
+            updatePromptEditorCount();
+            setTimeout(function() { editor.focus(); }, 50);
+        }
+        function updatePromptEditorCount() {
+            var editor = document.getElementById('prompt-editor-textarea');
+            var counter = document.getElementById('prompt-editor-count');
+            var max = parseInt(editor.getAttribute('maxlength'), 10) || 4000;
+            var len = editor.value.length;
+            counter.textContent = len + ' / ' + max;
+            counter.classList.toggle('over', len >= max);
+        }
+        function closePromptEditor(commit) {
+            var modal = document.getElementById('prompt-editor-modal');
+            if (commit && _promptEditorTarget) {
+                var ta = document.getElementById(_promptEditorTarget);
+                if (ta) {
+                    ta.value = document.getElementById('prompt-editor-textarea').value;
+                    updatePromptCount(_promptEditorTarget);
+                }
+            }
+            modal.style.display = 'none';
+            _promptEditorTarget = null;
+        }
+        // Cmd/Ctrl+Enter inside the full-screen editor commits changes
+        document.getElementById('prompt-editor-textarea').addEventListener('keydown', function(e) {
+            if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                e.preventDefault();
+                closePromptEditor(true);
+            } else if (e.key === 'Escape') {
+                e.preventDefault();
+                closePromptEditor(false);
+            }
+        });
+        // Initialize counters on load
+        updatePromptCount('ai-prompt');
+        updatePromptCount('persona-prompt');
+
+        // ── AI Token Usage ──────────────────────────────────────────────────
+        function formatTokens(n) {
+            if (n == null) return '—';
+            if (n >= 1_000_000) return (n / 1_000_000).toFixed(2) + 'M';
+            if (n >= 1_000) return (n / 1_000).toFixed(1) + 'k';
+            return String(n);
+        }
+        function formatCost(n, costKnown) {
+            if (n == null) return '';
+            if (!costKnown && n === 0) return 'cost unavailable';
+            var prefix = costKnown ? '' : '≥ ';
+            if (n < 0.01 && n > 0) return prefix + '< $0.01';
+            return prefix + '$' + n.toFixed(2);
+        }
+        function renderSparkline(daily) {
+            var svg = document.getElementById('ai-usage-sparkline');
+            if (!svg) return;
+            var W = 280, H = 60, pad = 4;
+            var values = daily.map(function(d) { return d.inputTokens + d.outputTokens; });
+            var max = Math.max.apply(null, values.concat([1]));
+            if (max <= 0) max = 1;
+            var n = values.length;
+            var stepX = (W - pad * 2) / Math.max(1, n - 1);
+            // Build bars instead of a line — easier to read for small token counts
+            var barW = Math.max(2, (W - pad * 2) / n - 2);
+            var bars = '';
+            for (var i = 0; i < n; i++) {
+                var v = values[i];
+                var h = max > 0 ? (v / max) * (H - pad * 2) : 0;
+                var x = pad + i * ((W - pad * 2) / n);
+                var y = H - pad - h;
+                bars += '<rect x="' + x.toFixed(1) + '" y="' + y.toFixed(1) +
+                        '" width="' + barW.toFixed(1) + '" height="' + h.toFixed(1) +
+                        '" fill="currentColor" opacity="' + (v > 0 ? 0.7 : 0.2) + '">' +
+                        '<title>' + daily[i].day + ': ' + formatTokens(v) + ' tokens</title></rect>';
+            }
+            svg.innerHTML = bars;
+            svg.style.color = 'var(--accent, #7aa7ff)';
+        }
+        function renderUsageBreakdown(byModel) {
+            var el = document.getElementById('ai-usage-breakdown');
+            if (!el) return;
+            if (!byModel.length) { el.innerHTML = ''; return; }
+            var rows = byModel
+                .sort(function(a, b) { return (b.inputTokens + b.outputTokens) - (a.inputTokens + a.outputTokens); })
+                .map(function(m) {
+                    var total = m.inputTokens + m.outputTokens;
+                    var costStr = m.costKnown ? '$' + (m.cost || 0).toFixed(4) : '—';
+                    return '<tr>' +
+                        '<td>' + escHtml(m.provider) + '</td>' +
+                        '<td>' + escHtml(m.model) + '</td>' +
+                        '<td class="num">' + m.requestCount + '</td>' +
+                        '<td class="num">' + formatTokens(total) + '</td>' +
+                        '<td class="num">' + costStr + '</td>' +
+                    '</tr>';
+                }).join('');
+            el.innerHTML =
+                '<div style="margin-bottom:.4rem;color:var(--text);font-weight:600;">This month, by model</div>' +
+                '<table><thead><tr>' +
+                    '<th>Provider</th><th>Model</th>' +
+                    '<th style="text-align:right;">Reqs</th>' +
+                    '<th style="text-align:right;">Tokens</th>' +
+                    '<th style="text-align:right;">Est. cost</th>' +
+                '</tr></thead><tbody>' + rows + '</tbody></table>';
+        }
+        async function loadAiUsage() {
+            var guildId = '<%= guild.id %>';
+            var statusEl = document.getElementById('ai-usage-status');
+            try {
+                var resp = await fetch('/api/guild/' + guildId + '/ai/usage?days=14');
+                if (!resp.ok) throw new Error('HTTP ' + resp.status);
+                var data = await resp.json();
+                document.getElementById('ai-usage-today-tokens').textContent = formatTokens(data.today.tokens);
+                document.getElementById('ai-usage-week-tokens').textContent  = formatTokens(data.week.tokens);
+                document.getElementById('ai-usage-month-tokens').textContent = formatTokens(data.month.tokens);
+                document.getElementById('ai-usage-today-cost').textContent = formatCost(data.today.cost, data.costKnown);
+                document.getElementById('ai-usage-week-cost').textContent  = formatCost(data.week.cost, data.costKnown);
+                document.getElementById('ai-usage-month-cost').textContent = formatCost(data.month.cost, data.costKnown);
+                renderSparkline(data.daily || []);
+                renderUsageBreakdown(data.byModel || []);
+
+                var rl = data.rateLimit || {};
+                var rlParts = [];
+                if (rl.perUser)    rlParts.push(rl.perUser + '/user');
+                if (rl.perChannel) rlParts.push(rl.perChannel + '/channel');
+                var rlStr = rlParts.length
+                    ? 'Limit: ' + rlParts.join(', ') + ' per ' + (rl.windowMin || 10) + 'm'
+                    : 'No rate limit set';
+                statusEl.textContent = rlStr;
+            } catch (e) {
+                console.error('Failed to load AI usage:', e);
+                statusEl.textContent = 'Failed to load usage';
+            }
+        }
+        // Lazy-load AI usage stats the first time the AI panel becomes visible.
+        // Polls the AI panel's `.active` class — works for nav clicks, hash routing,
+        // and initial page load without coupling to the nav implementation.
+        (function() {
+            var aiPanel = document.getElementById('ai');
+            if (!aiPanel) return;
+            var loaded = false;
+            function check() {
+                if (loaded) return;
+                if (aiPanel.classList.contains('active')) {
+                    loaded = true;
+                    loadAiUsage();
+                }
+            }
+            check();
+            var obs = new MutationObserver(check);
+            obs.observe(aiPanel, { attributes: true, attributeFilter: ['class'] });
+        })();
 
         // ── Leveling: No-XP role tag-input ──────────────────────────────────
         function addLevelNoXpRole() {

--- a/src/models/AIUsage.js
+++ b/src/models/AIUsage.js
@@ -1,0 +1,20 @@
+const { Schema, model } = require('mongoose');
+
+const aiUsageSchema = new Schema({
+    guildId:      { type: String, required: true, index: true },
+    provider:     { type: String, required: true },
+    model:        { type: String, required: true },
+    // ISO date string (YYYY-MM-DD, UTC) — one row per guild/provider/model/day.
+    day:          { type: String, required: true },
+    inputTokens:  { type: Number, default: 0 },
+    outputTokens: { type: Number, default: 0 },
+    requestCount: { type: Number, default: 0 },
+    updatedAt:    { type: Date, default: Date.now }
+});
+
+aiUsageSchema.index(
+    { guildId: 1, day: 1, provider: 1, model: 1 },
+    { unique: true }
+);
+
+module.exports = model('AIUsage', aiUsageSchema);

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -5,6 +5,7 @@ const axios = require('axios');
 const Conversation = require('../models/Conversation');
 const KnowledgeBase = require('../models/KnowledgeBase');
 const Reminder = require('../models/Reminder');
+const AIUsage = require('../models/AIUsage');
 const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 
 const DEFAULT_MODELS = {
@@ -281,8 +282,13 @@ async function executeAction(action, message) {
 }
 
 // ---------- Provider implementations ----------
+//
+// Streaming functions yield text deltas (strings). If a `usageOut` ref object
+// is passed, the function will set `usageOut.usage = { inputTokens, outputTokens }`
+// when the provider reports usage (typically at end-of-stream).
+// Non-streaming functions return { text, usage|null }.
 
-async function* streamOpenAI({ apiKey, model, systemPrompt, history, prompt, temperature, maxTokens, baseURL, defaultHeaders }) {
+async function* streamOpenAI({ apiKey, model, systemPrompt, history, prompt, temperature, maxTokens, baseURL, defaultHeaders, usageOut }) {
     const client = new OpenAI({ apiKey, baseURL, defaultHeaders });
     const messages = [
         { role: 'system', content: systemPrompt },
@@ -290,11 +296,18 @@ async function* streamOpenAI({ apiKey, model, systemPrompt, history, prompt, tem
         { role: 'user', content: prompt }
     ];
     const stream = await client.chat.completions.create({
-        model, messages, temperature, max_tokens: maxTokens, stream: true
+        model, messages, temperature, max_tokens: maxTokens, stream: true,
+        stream_options: { include_usage: true }
     });
     for await (const chunk of stream) {
         const delta = chunk.choices?.[0]?.delta?.content;
         if (delta) yield delta;
+        if (usageOut && chunk.usage) {
+            usageOut.usage = {
+                inputTokens: chunk.usage.prompt_tokens || 0,
+                outputTokens: chunk.usage.completion_tokens || 0
+            };
+        }
     }
 }
 
@@ -308,10 +321,15 @@ async function callOpenAINonStream({ apiKey, model, systemPrompt, history, promp
     const completion = await client.chat.completions.create({
         model, messages, temperature, max_tokens: maxTokens
     });
-    return completion.choices[0].message.content || '';
+    const text = completion.choices[0].message.content || '';
+    const usage = completion.usage ? {
+        inputTokens: completion.usage.prompt_tokens || 0,
+        outputTokens: completion.usage.completion_tokens || 0
+    } : null;
+    return { text, usage };
 }
 
-async function* streamGemini({ apiKey, model, systemPrompt, history, prompt, temperature, maxTokens }) {
+async function* streamGemini({ apiKey, model, systemPrompt, history, prompt, temperature, maxTokens, usageOut }) {
     const client = new GoogleGenerativeAI(apiKey);
     const generative = client.getGenerativeModel({
         model,
@@ -329,15 +347,44 @@ async function* streamGemini({ apiKey, model, systemPrompt, history, prompt, tem
         const text = chunk.text();
         if (text) yield text;
     }
+    if (usageOut) {
+        try {
+            const final = await result.response;
+            const meta = final?.usageMetadata;
+            if (meta) {
+                usageOut.usage = {
+                    inputTokens: meta.promptTokenCount || 0,
+                    outputTokens: meta.candidatesTokenCount || 0
+                };
+            }
+        } catch { /* usage metadata unavailable — leave unset */ }
+    }
 }
 
-async function callGeminiNonStream(args) {
-    let out = '';
-    for await (const piece of streamGemini(args)) out += piece;
-    return out;
+async function callGeminiNonStream({ apiKey, model, systemPrompt, history, prompt, temperature, maxTokens }) {
+    const client = new GoogleGenerativeAI(apiKey);
+    const generative = client.getGenerativeModel({
+        model,
+        systemInstruction: systemPrompt,
+        generationConfig: { temperature, maxOutputTokens: maxTokens }
+    });
+    const chat = generative.startChat({
+        history: history.map(h => ({
+            role: h.role === 'assistant' ? 'model' : 'user',
+            parts: [{ text: h.content }]
+        }))
+    });
+    const result = await chat.sendMessage(prompt);
+    const text = result.response.text();
+    const meta = result.response.usageMetadata;
+    const usage = meta ? {
+        inputTokens: meta.promptTokenCount || 0,
+        outputTokens: meta.candidatesTokenCount || 0
+    } : null;
+    return { text, usage };
 }
 
-async function* streamAnthropic({ apiKey, model, systemPrompt, history, prompt, temperature, maxTokens }) {
+async function* streamAnthropic({ apiKey, model, systemPrompt, history, prompt, temperature, maxTokens, usageOut }) {
     const client = new Anthropic({ apiKey });
     const messages = [
         ...history.map(h => ({ role: h.role, content: h.content })),
@@ -352,20 +399,49 @@ async function* streamAnthropic({ apiKey, model, systemPrompt, history, prompt, 
         ],
         messages
     });
+    let inputTokens = 0;
+    let outputTokens = 0;
     for await (const event of stream) {
         if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
             yield event.delta.text;
+        } else if (event.type === 'message_start' && event.message?.usage) {
+            inputTokens = event.message.usage.input_tokens || 0;
+            outputTokens = event.message.usage.output_tokens || 0;
+        } else if (event.type === 'message_delta' && event.usage) {
+            // Final cumulative output_tokens arrive in message_delta
+            outputTokens = event.usage.output_tokens || outputTokens;
         }
     }
+    if (usageOut) usageOut.usage = { inputTokens, outputTokens };
 }
 
-async function callAnthropicNonStream(args) {
-    let out = '';
-    for await (const piece of streamAnthropic(args)) out += piece;
-    return out;
+async function callAnthropicNonStream({ apiKey, model, systemPrompt, history, prompt, temperature, maxTokens }) {
+    const client = new Anthropic({ apiKey });
+    const messages = [
+        ...history.map(h => ({ role: h.role, content: h.content })),
+        { role: 'user', content: prompt }
+    ];
+    const response = await client.messages.create({
+        model,
+        max_tokens: maxTokens,
+        temperature,
+        system: [
+            { type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }
+        ],
+        messages
+    });
+    const text = response.content
+        .filter(b => b.type === 'text')
+        .map(b => b.text)
+        .join('');
+    const usage = response.usage ? {
+        inputTokens: response.usage.input_tokens || 0,
+        outputTokens: response.usage.output_tokens || 0
+    } : null;
+    return { text, usage };
 }
 
-async function* streamOllama({ baseUrl, model, systemPrompt, history, prompt, temperature, maxTokens }) {
+async function* streamOllama({ baseUrl, model, systemPrompt, history, prompt, temperature, maxTokens, usageOut }) {
     const url = `${(baseUrl || 'http://localhost:11434').replace(/\/$/, '')}/api/chat`;
     const messages = [
         { role: 'system', content: systemPrompt },
@@ -390,16 +466,39 @@ async function* streamOllama({ baseUrl, model, systemPrompt, history, prompt, te
             try {
                 const json = JSON.parse(line);
                 if (json.message?.content) yield json.message.content;
-                if (json.done) return;
+                if (json.done) {
+                    if (usageOut) {
+                        usageOut.usage = {
+                            inputTokens: json.prompt_eval_count || 0,
+                            outputTokens: json.eval_count || 0
+                        };
+                    }
+                    return;
+                }
             } catch { /* skip malformed line */ }
         }
     }
 }
 
-async function callOllamaNonStream(args) {
-    let out = '';
-    for await (const piece of streamOllama(args)) out += piece;
-    return out;
+async function callOllamaNonStream({ baseUrl, model, systemPrompt, history, prompt, temperature, maxTokens }) {
+    const url = `${(baseUrl || 'http://localhost:11434').replace(/\/$/, '')}/api/chat`;
+    const messages = [
+        { role: 'system', content: systemPrompt },
+        ...history,
+        { role: 'user', content: prompt }
+    ];
+    const response = await axios.post(url, {
+        model,
+        messages,
+        stream: false,
+        options: { temperature, num_predict: maxTokens }
+    }, { timeout: 120000 });
+    const text = response.data?.message?.content || '';
+    const usage = (response.data?.prompt_eval_count != null || response.data?.eval_count != null) ? {
+        inputTokens: response.data.prompt_eval_count || 0,
+        outputTokens: response.data.eval_count || 0
+    } : null;
+    return { text, usage };
 }
 
 // OpenRouter is OpenAI-compatible
@@ -446,8 +545,8 @@ function resolveProviderConfig(aiSettings) {
     return { provider, model, temperature, maxTokens, apiKey, baseUrl };
 }
 
-async function* streamCompletion({ provider, model, apiKey, baseUrl, systemPrompt, history, prompt, temperature, maxTokens }) {
-    const common = { model, systemPrompt, history, prompt, temperature, maxTokens };
+async function* streamCompletion({ provider, model, apiKey, baseUrl, systemPrompt, history, prompt, temperature, maxTokens, usageOut, guildId }) {
+    const common = { model, systemPrompt, history, prompt, temperature, maxTokens, usageOut };
     if (provider === 'openai') {
         yield* streamOpenAI({ apiKey, ...common });
     } else if (provider === 'gemini') {
@@ -461,17 +560,179 @@ async function* streamCompletion({ provider, model, apiKey, baseUrl, systemPromp
     } else {
         throw new Error(`Unknown provider: ${provider}`);
     }
+    if (guildId && usageOut?.usage) {
+        recordUsage(guildId, provider, model, usageOut.usage).catch(err =>
+            console.error('[AI usage] record error:', err.message));
+    }
 }
 
-async function getCompletion({ provider, model, apiKey, baseUrl, systemPrompt, history, prompt, temperature, maxTokens }) {
+async function getCompletion({ provider, model, apiKey, baseUrl, systemPrompt, history, prompt, temperature, maxTokens, guildId }) {
     const common = { model, systemPrompt, history, prompt, temperature, maxTokens };
-    if (provider === 'openai') return callOpenAINonStream({ apiKey, ...common });
-    if (provider === 'gemini') return callGeminiNonStream({ apiKey, ...common });
-    if (provider === 'anthropic') return callAnthropicNonStream({ apiKey, ...common });
-    if (provider === 'ollama') return callOllamaNonStream({ baseUrl, ...common });
-    if (provider === 'openrouter') return callOpenAINonStream(openRouterArgs({ apiKey, ...common }));
-    throw new Error(`Unknown provider: ${provider}`);
+    let result;
+    if (provider === 'openai') result = await callOpenAINonStream({ apiKey, ...common });
+    else if (provider === 'gemini') result = await callGeminiNonStream({ apiKey, ...common });
+    else if (provider === 'anthropic') result = await callAnthropicNonStream({ apiKey, ...common });
+    else if (provider === 'ollama') result = await callOllamaNonStream({ baseUrl, ...common });
+    else if (provider === 'openrouter') result = await callOpenAINonStream(openRouterArgs({ apiKey, ...common }));
+    else throw new Error(`Unknown provider: ${provider}`);
+
+    if (guildId && result.usage) {
+        recordUsage(guildId, provider, model, result.usage).catch(err =>
+            console.error('[AI usage] record error:', err.message));
+    }
+    return result.text;
 }
+
+// ---------- Usage tracking ----------
+
+// USD per 1M tokens for common models (input, output). Prefix-matched.
+// Unknown models report null cost.
+const PRICING = {
+    openai: [
+        { match: /^gpt-4o-mini/i,   in: 0.15,  out: 0.60 },
+        { match: /^gpt-4o/i,        in: 2.50,  out: 10.00 },
+        { match: /^gpt-4\.1-mini/i, in: 0.40,  out: 1.60 },
+        { match: /^gpt-4\.1-nano/i, in: 0.10,  out: 0.40 },
+        { match: /^gpt-4\.1/i,      in: 2.00,  out: 8.00 },
+        { match: /^o3-mini/i,       in: 1.10,  out: 4.40 },
+        { match: /^o3/i,            in: 2.00,  out: 8.00 },
+        { match: /^o1-mini/i,       in: 1.10,  out: 4.40 },
+        { match: /^o1/i,            in: 15.00, out: 60.00 }
+    ],
+    anthropic: [
+        { match: /haiku-4/i,    in: 1.00,  out: 5.00 },
+        { match: /sonnet-4/i,   in: 3.00,  out: 15.00 },
+        { match: /opus-4/i,     in: 15.00, out: 75.00 },
+        { match: /haiku-3-5/i,  in: 0.80,  out: 4.00 },
+        { match: /sonnet-3-5/i, in: 3.00,  out: 15.00 },
+        { match: /haiku/i,      in: 0.25,  out: 1.25 },
+        { match: /sonnet/i,     in: 3.00,  out: 15.00 },
+        { match: /opus/i,       in: 15.00, out: 75.00 }
+    ],
+    gemini: [
+        { match: /flash-lite/i, in: 0.075, out: 0.30 },
+        { match: /2\.0-flash/i, in: 0.10,  out: 0.40 },
+        { match: /1\.5-flash/i, in: 0.075, out: 0.30 },
+        { match: /1\.5-pro/i,   in: 1.25,  out: 5.00 },
+        { match: /pro/i,        in: 1.25,  out: 5.00 },
+        { match: /flash/i,      in: 0.10,  out: 0.40 }
+    ],
+    openrouter: [], // variable per-model; we don't know without an API call
+    ollama: [{ match: /.*/, in: 0, out: 0 }]
+};
+
+function estimateCost(provider, model, inputTokens, outputTokens) {
+    const table = PRICING[provider] || [];
+    const row = table.find(r => r.match.test(model || ''));
+    if (!row) return null;
+    return (inputTokens * row.in + outputTokens * row.out) / 1_000_000;
+}
+
+function utcDayString(date = new Date()) {
+    return date.toISOString().slice(0, 10);
+}
+
+async function recordUsage(guildId, provider, model, usage) {
+    if (!guildId || !usage) return;
+    const inputTokens = Math.max(0, Math.floor(usage.inputTokens || 0));
+    const outputTokens = Math.max(0, Math.floor(usage.outputTokens || 0));
+    if (inputTokens === 0 && outputTokens === 0) return;
+    const day = utcDayString();
+    await AIUsage.updateOne(
+        { guildId, day, provider, model: model || 'unknown' },
+        {
+            $inc: { inputTokens, outputTokens, requestCount: 1 },
+            $set: { updatedAt: new Date() }
+        },
+        { upsert: true }
+    );
+}
+
+async function getUsageStats(guildId, days = 14) {
+    const todayDay = utcDayString();
+    const start = new Date();
+    start.setUTCDate(start.getUTCDate() - (days - 1));
+    const startDay = utcDayString(start);
+
+    const rows = await AIUsage.find({ guildId, day: { $gte: startDay } }).lean();
+
+    // Aggregate per-day totals across providers/models
+    const byDay = new Map();
+    for (let i = 0; i < days; i++) {
+        const d = new Date();
+        d.setUTCDate(d.getUTCDate() - (days - 1 - i));
+        const key = utcDayString(d);
+        byDay.set(key, { day: key, inputTokens: 0, outputTokens: 0, requestCount: 0, cost: 0 });
+    }
+
+    const monthStart = todayDay.slice(0, 7) + '-01';
+    const weekStart = (() => {
+        const d = new Date();
+        d.setUTCDate(d.getUTCDate() - 6);
+        return utcDayString(d);
+    })();
+
+    let todayTokens = 0, weekTokens = 0, monthTokens = 0;
+    let todayCost = 0, weekCost = 0, monthCost = 0;
+    let costKnown = true;
+
+    for (const row of rows) {
+        const cost = estimateCost(row.provider, row.model, row.inputTokens, row.outputTokens);
+        if (cost == null) costKnown = false;
+        const totalTokens = row.inputTokens + row.outputTokens;
+
+        const bucket = byDay.get(row.day);
+        if (bucket) {
+            bucket.inputTokens += row.inputTokens;
+            bucket.outputTokens += row.outputTokens;
+            bucket.requestCount += row.requestCount;
+            bucket.cost += cost || 0;
+        }
+
+        if (row.day === todayDay) {
+            todayTokens += totalTokens;
+            todayCost += cost || 0;
+        }
+        if (row.day >= weekStart) {
+            weekTokens += totalTokens;
+            weekCost += cost || 0;
+        }
+        if (row.day >= monthStart) {
+            monthTokens += totalTokens;
+            monthCost += cost || 0;
+        }
+    }
+
+    // Per-model breakdown for the current month
+    const byModel = {};
+    for (const row of rows.filter(r => r.day >= monthStart)) {
+        const key = `${row.provider}/${row.model}`;
+        if (!byModel[key]) {
+            byModel[key] = {
+                provider: row.provider, model: row.model,
+                inputTokens: 0, outputTokens: 0, requestCount: 0, cost: 0, costKnown: true
+            };
+        }
+        const m = byModel[key];
+        m.inputTokens += row.inputTokens;
+        m.outputTokens += row.outputTokens;
+        m.requestCount += row.requestCount;
+        const c = estimateCost(row.provider, row.model, row.inputTokens, row.outputTokens);
+        if (c == null) m.costKnown = false;
+        else m.cost += c;
+    }
+
+    return {
+        today:  { tokens: todayTokens, cost: round4(todayCost) },
+        week:   { tokens: weekTokens,  cost: round4(weekCost) },
+        month:  { tokens: monthTokens, cost: round4(monthCost) },
+        costKnown,
+        daily: Array.from(byDay.values()).map(d => ({ ...d, cost: round4(d.cost) })),
+        byModel: Object.values(byModel).map(m => ({ ...m, cost: round4(m.cost) }))
+    };
+}
+
+function round4(n) { return Math.round(n * 10000) / 10000; }
 
 async function handleAIChat(message, aiSettings) {
     const { provider, model, temperature, maxTokens, apiKey, baseUrl } = resolveProviderConfig(aiSettings);
@@ -518,7 +779,12 @@ async function handleAIChat(message, aiSettings) {
             message.guild.id, message.channel.id, message.author.id, maxHistory
         );
 
-        const callArgs = { provider, model, apiKey, baseUrl, systemPrompt, history, prompt: content, temperature, maxTokens };
+        const usageOut = {};
+        const callArgs = {
+            provider, model, apiKey, baseUrl, systemPrompt, history,
+            prompt: content, temperature, maxTokens,
+            guildId: message.guild.id, usageOut
+        };
 
         let fullResponse = '';
 
@@ -624,5 +890,8 @@ module.exports = {
     retrieveKnowledge,
     checkRateLimit,
     checkChannelRateLimit,
+    recordUsage,
+    getUsageStats,
+    estimateCost,
     DEFAULT_MODELS
 };

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -638,14 +638,23 @@ async function recordUsage(guildId, provider, model, usage) {
     const outputTokens = Math.max(0, Math.floor(usage.outputTokens || 0));
     if (inputTokens === 0 && outputTokens === 0) return;
     const day = utcDayString();
-    await AIUsage.updateOne(
-        { guildId, day, provider, model: model || 'unknown' },
-        {
-            $inc: { inputTokens, outputTokens, requestCount: 1 },
-            $set: { updatedAt: new Date() }
-        },
-        { upsert: true }
-    );
+    const filter = { guildId, day, provider, model: model || 'unknown' };
+    const update = {
+        $inc: { inputTokens, outputTokens, requestCount: 1 },
+        $set: { updatedAt: new Date() }
+    };
+    try {
+        await AIUsage.updateOne(filter, update, { upsert: true });
+    } catch (err) {
+        // Concurrent upserts on the same key can race: one succeeds, the other
+        // throws E11000. Retry without upsert — the row exists now, so $inc
+        // will hit it and we don't drop the token count.
+        if (err && (err.code === 11000 || err.codeName === 'DuplicateKey')) {
+            await AIUsage.updateOne(filter, update, { upsert: false });
+        } else {
+            throw err;
+        }
+    }
 }
 
 async function getUsageStats(guildId, days = 14) {
@@ -654,9 +663,19 @@ async function getUsageStats(guildId, days = 14) {
     start.setUTCDate(start.getUTCDate() - (days - 1));
     const startDay = utcDayString(start);
 
-    const rows = await AIUsage.find({ guildId, day: { $gte: startDay } }).lean();
+    const monthStart = todayDay.slice(0, 7) + '-01';
+    const weekStart = (() => {
+        const d = new Date();
+        d.setUTCDate(d.getUTCDate() - 6);
+        return utcDayString(d);
+    })();
 
-    // Aggregate per-day totals across providers/models
+    // Fetch enough to cover both the sparkline window AND the current calendar
+    // month so the "this month" KPI is accurate when `days` < day-of-month.
+    const queryStart = monthStart < startDay ? monthStart : startDay;
+    const rows = await AIUsage.find({ guildId, day: { $gte: queryStart } }).lean();
+
+    // Aggregate per-day totals across providers/models for the sparkline window
     const byDay = new Map();
     for (let i = 0; i < days; i++) {
         const d = new Date();
@@ -664,13 +683,6 @@ async function getUsageStats(guildId, days = 14) {
         const key = utcDayString(d);
         byDay.set(key, { day: key, inputTokens: 0, outputTokens: 0, requestCount: 0, cost: 0 });
     }
-
-    const monthStart = todayDay.slice(0, 7) + '-01';
-    const weekStart = (() => {
-        const d = new Date();
-        d.setUTCDate(d.getUTCDate() - 6);
-        return utcDayString(d);
-    })();
 
     let todayTokens = 0, weekTokens = 0, monthTokens = 0;
     let todayCost = 0, weekCost = 0, monthCost = 0;

--- a/src/services/newspaperService.js
+++ b/src/services/newspaperService.js
@@ -173,7 +173,8 @@ async function generateNewspaper(client, guildDoc, preloadedGuild) {
                         `Write this week's server newspaper for "${guildDoc.name || 'our server'}".\n\n` +
                         `Date: ${dateStr}\n\nServer stats this week:\n${dataSummary}\n\n` +
                         `Include a fun headline, a brief intro paragraph, and highlight the sections above. ` +
-                        quoteInstruction
+                        quoteInstruction,
+                    guildId: guildDoc.guildId
                 });
             }
         } catch (err) {

--- a/src/services/summaryService.js
+++ b/src/services/summaryService.js
@@ -32,7 +32,8 @@ async function runSummaryJob(job, client) {
         ...config,
         systemPrompt: 'You are a helpful assistant that creates concise summaries of Discord channel activity.',
         history: [],
-        prompt: `Summarize the key topics, decisions, and highlights from these Discord messages as bullet points:\n\n${transcript}`
+        prompt: `Summarize the key topics, decisions, and highlights from these Discord messages as bullet points:\n\n${transcript}`,
+        guildId: job.guildId
     });
 
     const dstChannel = guild.channels.cache.get(job.targetChannelId)


### PR DESCRIPTION
#433 — Token usage tracking
- New AIUsage model: per-guild/provider/model daily aggregates (upsert/$inc).
- aiService captures usage from every provider (OpenAI/Anthropic/Gemini/
  OpenRouter via stream_options.include_usage; Ollama via prompt_eval_count/
  eval_count) and records it through the existing handleAIChat path, plus
  the summary and newspaper services.
- Pricing table (USD / 1M tokens) for common OpenAI / Anthropic / Gemini
  models; OpenRouter and unknown models report no cost; Ollama is $0.
- GET /api/guild/:guildId/ai/usage returns today/week/month tokens + cost,
  a 14-day daily series, and a per-model month breakdown.
- Usage Stats card in the AI Chat panel: three KPI tiles, SVG sparkline
  (lazy-loaded the first time the AI panel becomes active), per-model
  table, and the configured rate-limit summary.

#427 — Bigger prompt editor
- ai-prompt and persona-prompt textareas now rows=8 with field-sizing:
  content for auto-grow and a 30rem cap.
- 4000-char counter under each (turns red at the cap), full-screen modal
  editor shared by both fields (Cmd/Ctrl+Enter commits, Esc cancels).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full-screen prompt editor with live character counter and keyboard shortcuts.
  * AI token-usage analytics: daily/weekly/monthly totals, estimated costs, sparkline and per-model breakdown; stats lazy-load when the AI panel is viewed.
  * Server-side usage tracking and cost estimation to power the analytics.

* **Bug Fixes**
  * Client-side validation blocks saving prompts over the 4,000-character limit and shows an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->