### PR TITLE
Implement Turn & River gameplay + endgame cosmetics + economy rebalance

### DIFF
--- a/src/commands/economy/daily.js
+++ b/src/commands/economy/daily.js
@@ -295,7 +295,7 @@ module.exports = {
                 starterKitResult = await claimStarterKit(interaction.user.id, interaction.guild.id);
             }
 
-            const dailyAmount  = guildSettings?.economy?.dailyAmount ?? 100;
+            const dailyAmount  = guildSettings?.economy?.dailyAmount ?? 2500;
             const streakMult   = getStreakMultiplier(user.streak?.current ?? 0);
             const coinMult     = getCoinMultiplier(user);
             const serverMult   = getServerCoinMultiplier(guildSettings);

--- a/src/commands/economy/rob.js
+++ b/src/commands/economy/rob.js
@@ -31,6 +31,7 @@ async function saveRobState(robber, victim, robberSnapshot, trapSnapshot, victim
             balance:        robber.balance,
             lastRob:        robber.lastRob,
             successfulRobs: robber.successfulRobs ?? 0,
+            failedRobs:     robber.failedRobs     ?? 0,
         },
     });
     if (!robberRes) {
@@ -80,6 +81,7 @@ async function saveRobState(robber, victim, robberSnapshot, trapSnapshot, victim
                     bank:            robberSnapshot.bank,
                     lastRob:         robberSnapshot.lastRob,
                     successfulRobs:  robberSnapshot.successfulRobs,
+                    failedRobs:      robberSnapshot.failedRobs,
                 } }
             );
         } catch (rollbackErr) {
@@ -170,6 +172,7 @@ module.exports = {
                 bank:           robber.bank,
                 lastRob:        robber.lastRob ?? null,
                 successfulRobs: robber.successfulRobs ?? 0,
+                failedRobs:     robber.failedRobs     ?? 0,
             };
             robber.lastRob = new Date();
 
@@ -365,6 +368,7 @@ module.exports = {
                         .setTimestamp();
                 } else {
                     robber.balance = Math.max(0, robber.balance - paid);
+                    robber.failedRobs = (robber.failedRobs || 0) + 1;
                     victim.balance += paid;
                     victim.lastRobbedAt = new Date();
                     await saveRobState(robber, victim, robberSnapshot, null, victimOrigBalance, victimOrigBank);

--- a/src/commands/economy/robstatus.js
+++ b/src/commands/economy/robstatus.js
@@ -47,7 +47,10 @@ module.exports = {
         statusCooldowns.set(cdKey, Date.now());
         setTimeout(() => statusCooldowns.delete(cdKey), STATUS_COOLDOWN_MS);
 
-        const victim = await User.findOne({ userId: target.id, guildId: interaction.guild.id });
+        const [victim, robber] = await Promise.all([
+            User.findOne({ userId: target.id,           guildId: interaction.guild.id }),
+            User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }),
+        ]);
 
         const lines = [];
 
@@ -76,10 +79,20 @@ module.exports = {
             }
         }
 
+        const mySuccesses = robber?.successfulRobs ?? 0;
+        const myFails     = robber?.failedRobs     ?? 0;
+        const myTotal     = mySuccesses + myFails;
+        const myRate      = myTotal > 0 ? `${Math.round((mySuccesses / myTotal) * 100)}%` : '—';
+
         const embed = new EmbedBuilder()
             .setColor('#9b59b6')
             .setTitle(`🔍 Rob Status: ${target.username}`)
             .setDescription(lines.join('\n'))
+            .addFields({
+                name: '📊 Your Heist Record',
+                value: `✅ ${mySuccesses} successful · ❌ ${myFails} failed · 🎯 ${myRate} success rate`,
+                inline: false,
+            })
             .setFooter({ text: 'Padlock status is not revealed. Cooldown: 2m' })
             .setTimestamp();
 

--- a/src/data/defaultShopItems.js
+++ b/src/data/defaultShopItems.js
@@ -27,6 +27,13 @@ const DEFAULT_SHOP_ITEMS = [
     { name: 'Permanent Stamina +1',   itemId: 'permanent_stamina',       rarity: 'Mythic', price: 100000, category: 'prestige', description: '⚡ Permanently increases your max hunt/fish/mine stamina by 1.',     lore: "The grind never ends. At least now you last a little longer." },
     { name: 'Prestige Accelerator',   itemId: 'prestige_accelerator',    rarity: 'Mythic', price: 200000, category: 'prestige', description: '🚀 -20% XP required for your next prestige (one-time use).',         lore: "The shortcut nobody talks about. Until they use it." },
 
+    // ── Endgame Cosmetics (high-value coin sinks, no gameplay advantage) ─────
+    { name: 'Diamond Profile Frame',  itemId: 'diamond_profile_frame',  rarity: 'Mythic', price: 1_000_000,  category: 'endgame', description: '💎 Animated diamond border on your /profile for 30 days.',                    lore: "Cut from something rarer than stone. Harder to earn." },
+    { name: 'Elite Title: Sovereign', itemId: 'title_sovereign',        rarity: 'Mythic', price: 5_000_000,  category: 'endgame', description: '👑 Displays the title "Sovereign" above your name in /profile for 30 days.',  lore: "The servers bow. Briefly. Then they keep grinding." },
+    { name: 'Prestige Aura',          itemId: 'prestige_aura',          rarity: 'Mythic', price: 10_000_000, category: 'endgame', description: '✨ Glowing aura effect on your /profile embed for 30 days.',                   lore: "Not everyone can see it. Everyone can feel it." },
+    { name: 'Grand Master Badge',     itemId: 'grand_master_badge',     rarity: 'Mythic', price: 25_000_000, category: 'endgame', description: '🏅 Permanent Grand Master badge shown on your /profile (no expiry).',          lore: "The number on your balance used to scare you. Now it just fuels you." },
+    { name: 'Apex Legend Title',      itemId: 'title_apex_legend',      rarity: 'Mythic', price: 50_000_000, category: 'endgame', description: '🌟 Displays "Apex Legend" — the rarest title — on your /profile permanently.', lore: "There are Diamond-prestige players. Then there is you." },
+
     // ── Black Market (Prestige I+ only) ──────────────────────────────────────
     { name: 'Phantom Token',          itemId: 'phantom_token',           rarity: 'Mythic', price: 120000, category: 'black_market', description: '👻 Skip the next /rob fine you would owe — undetectable.',         lore: "It wasn't you. It was never you." },
     { name: 'Silvered Talisman',      itemId: 'silvered_talisman',       rarity: 'Mythic', price: 180000, category: 'black_market', description: '🪙 Doubles coin yield from your next 5 hunts, fishes, or mines.',   lore: "Pawned by a stranger. Repurchased by you. The cycle continues." },
@@ -65,6 +72,11 @@ function isBlackMarketItem(itemId) {
     return DEFAULT_SHOP_ITEMS.find(i => i.itemId === itemId)?.category === 'black_market';
 }
 
+// Returns true if the item is in the endgame cosmetics category.
+function isEndgameItem(itemId) {
+    return DEFAULT_SHOP_ITEMS.find(i => i.itemId === itemId)?.category === 'endgame';
+}
+
 // Idempotent: appends any default items missing from the guild's shop and flips
 // the seeded flag so an admin can permanently remove items without them
 // reappearing. Returns true if the shop was modified (caller should save).
@@ -78,7 +90,7 @@ function ensureDefaultShopItems(guildSettings) {
 
     const existingIds   = new Set(guildSettings.shop.map(i => (i.itemId || '').toLowerCase()));
     const existingNames = new Set(guildSettings.shop.map(i => i.name.toLowerCase()));
-    const ALWAYS_BACKFILL_CATEGORIES = new Set(['black_market']);
+    const ALWAYS_BACKFILL_CATEGORIES = new Set(['black_market', 'endgame']);
     let changed = false;
 
     if (!guildSettings.shopDefaultsSeeded) {
@@ -107,4 +119,4 @@ function ensureDefaultShopItems(guildSettings) {
     return changed;
 }
 
-module.exports = { DEFAULT_SHOP_ITEMS, ensureDefaultShopItems, getItemLore, getItemRarity, isPrestigeItem, isBlackMarketItem, RARITY_ORDER };
+module.exports = { DEFAULT_SHOP_ITEMS, ensureDefaultShopItems, getItemLore, getItemRarity, isPrestigeItem, isBlackMarketItem, isEndgameItem, RARITY_ORDER };

--- a/src/games/casino/poker.js
+++ b/src/games/casino/poker.js
@@ -442,11 +442,252 @@ async function playPoker(interaction, bet) {
             return interaction.editReply({ embeds: [foldEmbed], components: [] });
         }
 
-        // ── Turn + River → Showdown ───────────────────────────────────────────
+        // ── Turn ─────────────────────────────────────────────────────────────
         await delay(400);
 
         const turnCard  = community[3];
+        const turnStr   = cardStr(turnCard);
+        const turnBoard = [...flop, turnCard];
+
+        const turnEquity      = dealerPostFlopEquity(dealerHole, playerHole, turnBoard);
+        const dTurnAction     = dealerPostFlopAction(turnEquity, pot, bet);
+        const dealerTurnLine  = dTurnAction === 'fold'
+            ? '🤖 **Dealer folds!** (not getting the right price)'
+            : dTurnAction === 'raise'
+            ? `🤖 **Dealer bets** — they like the turn! (${(turnEquity * 100).toFixed(0)}% equity)`
+            : `🤖 Dealer checks. (${(turnEquity * 100).toFixed(0)}% equity)`;
+
+        if (dTurnAction === 'fold') {
+            settled = true;
+            const coinMult   = getCoinMultiplier(debited);
+            const serverMult = getServerCoinMultiplier(guildSettings);
+            const totalMult  = coinMult * serverMult;
+            let winPayout    = pot;
+            if (totalMult > 1.0) winPayout = playerStake + Math.round((pot - playerStake) * totalMult);
+            await User.findOneAndUpdate(userFilter, { $inc: { balance: winPayout } }, { new: true });
+            return interaction.editReply({
+                embeds: [new EmbedBuilder()
+                    .setAuthor(embedAuthor(interaction))
+                    .setThumbnail(THUMB)
+                    .setColor('#2ecc71')
+                    .setTitle('♠ Poker — Dealer Folded on the Turn!')
+                    .setDescription(`**Turn:** ${turnStr}\n\nThe dealer couldn't justify calling. You win!\n\n**Dealer's hand:** ${handStr(dealerHole)} → *${bestHand([...dealerHole, ...turnBoard])?.name}*`)
+                    .addFields(
+                        { name: '🃏 Your Hand',  value: handStr(playerHole),           inline: true },
+                        { name: '🏆 Payout',     value: `**${winPayout.toLocaleString()}** coins`, inline: true },
+                        { name: '📊 Net',        value: `**+${(winPayout - playerStake).toLocaleString()}** coins`, inline: true },
+                    )
+                    .setFooter({ text: "Dealer's pot odds didn't justify calling the turn" })
+                    .setTimestamp()],
+                components: [],
+            });
+        }
+
+        if (dTurnAction === 'raise') pot += bet;
+
+        const turnRound = `turnround_${Date.now()}`;
+        const turnActions = dTurnAction === 'raise'
+            ? [
+                new ButtonBuilder().setCustomId(`pk_call_${turnRound}`).setLabel(`Call (${bet.toLocaleString()})`).setStyle(ButtonStyle.Primary),
+                new ButtonBuilder().setCustomId(`pk_fold_${turnRound}`).setLabel('Fold').setStyle(ButtonStyle.Danger),
+              ]
+            : [
+                new ButtonBuilder().setCustomId(`pk_check_${turnRound}`).setLabel('Check').setStyle(ButtonStyle.Secondary),
+                new ButtonBuilder().setCustomId(`pk_raise_${turnRound}`).setLabel(`Raise (${Math.min(bet, debited.balance).toLocaleString()})`).setStyle(ButtonStyle.Primary),
+                new ButtonBuilder().setCustomId(`pk_fold_${turnRound}`).setLabel('Fold').setStyle(ButtonStyle.Danger),
+              ];
+
+        await interaction.editReply({
+            embeds: [new EmbedBuilder()
+                .setAuthor(embedAuthor(interaction))
+                .setThumbnail(THUMB)
+                .setColor('#5865F2')
+                .setTitle('♠ Poker — The Turn')
+                .addFields(
+                    { name: '🃏 Your Hand',  value: handStr(playerHole),                     inline: false },
+                    { name: '🤖 Dealer',     value: dealerTurnLine,                           inline: false },
+                    { name: '🎴 Community',  value: `${flopStr}  ${turnStr}  🂠`,             inline: false },
+                    { name: '💰 Pot',        value: `**${pot.toLocaleString()}** coins`,      inline: true },
+                )
+                .setFooter({ text: 'Check or Raise · Fold to surrender' })],
+            components: [new ActionRowBuilder().addComponents(...turnActions)],
+        });
+        await delay(200);
+
+        const msg3 = await interaction.fetchReply();
+        let turnAction;
+        try {
+            const r = await msg3.awaitMessageComponent({
+                filter: i => i.user.id === interaction.user.id && i.customId.endsWith(turnRound),
+                time: 30_000,
+            });
+            await r.deferUpdate();
+            turnAction = r.customId.split('_')[1];
+        } catch {
+            settled = true;
+            await User.findOneAndUpdate(userFilter, { $inc: { balance: playerStake } });
+            return interaction.editReply({ content: '⏱️ Time\'s up! Bet refunded.', embeds: [], components: [] }).catch(() => {});
+        }
+
+        if (turnAction === 'fold') {
+            folded = true;
+        } else if (turnAction === 'call' || turnAction === 'raise') {
+            const raiseAmt = Math.min(bet, debited.balance);
+            if (raiseAmt > 0) {
+                const raised = await User.findOneAndUpdate(
+                    { ...userFilter, balance: { $gte: raiseAmt } },
+                    { $inc: { balance: -raiseAmt } },
+                    { new: true }
+                );
+                if (raised) {
+                    debited = raised;
+                    playerStake += raiseAmt;
+                    pot += raiseAmt * (turnAction === 'raise' ? 2 : 1);
+                } else if (turnAction === 'call') {
+                    folded = true;
+                }
+            } else if (turnAction === 'call') {
+                folded = true;
+            }
+        }
+
+        if (folded) {
+            settled = true;
+            const foldEmbed = new EmbedBuilder()
+                .setAuthor(embedAuthor(interaction))
+                .setThumbnail(THUMB)
+                .setColor('#e74c3c')
+                .setTitle('♠ Poker — Folded')
+                .setDescription(`You folded. The dealer had: **${handStr(dealerHole)}**\nCommunity: **${flopStr}  ${turnStr} (+ 1 more)**`)
+                .addFields({ name: '💰 Balance', value: `**${debited.balance.toLocaleString()}** coins` })
+                .setTimestamp();
+            return interaction.editReply({ embeds: [foldEmbed], components: [] });
+        }
+
+        // ── River ─────────────────────────────────────────────────────────────
+        await delay(400);
+
         const riverCard = community[4];
+        const riverStr  = cardStr(riverCard);
+        const riverBoard = [...turnBoard, riverCard];
+
+        const riverEquity      = dealerPostFlopEquity(dealerHole, playerHole, riverBoard);
+        const dRiverAction     = dealerPostFlopAction(riverEquity, pot, bet);
+        const dealerRiverLine  = dRiverAction === 'fold'
+            ? '🤖 **Dealer folds!** (river missed them)'
+            : dRiverAction === 'raise'
+            ? `🤖 **Dealer bets** — they like the river! (${(riverEquity * 100).toFixed(0)}% equity)`
+            : `🤖 Dealer checks. (${(riverEquity * 100).toFixed(0)}% equity)`;
+
+        if (dRiverAction === 'fold') {
+            settled = true;
+            const coinMult   = getCoinMultiplier(debited);
+            const serverMult = getServerCoinMultiplier(guildSettings);
+            const totalMult  = coinMult * serverMult;
+            let winPayout    = pot;
+            if (totalMult > 1.0) winPayout = playerStake + Math.round((pot - playerStake) * totalMult);
+            await User.findOneAndUpdate(userFilter, { $inc: { balance: winPayout } }, { new: true });
+            return interaction.editReply({
+                embeds: [new EmbedBuilder()
+                    .setAuthor(embedAuthor(interaction))
+                    .setThumbnail(THUMB)
+                    .setColor('#2ecc71')
+                    .setTitle('♠ Poker — Dealer Folded on the River!')
+                    .setDescription(`**River:** ${riverStr}\n\nThe dealer missed the river and folded. You win!\n\n**Dealer's hand:** ${handStr(dealerHole)} → *${bestHand([...dealerHole, ...riverBoard])?.name}*`)
+                    .addFields(
+                        { name: '🃏 Your Hand',  value: handStr(playerHole),           inline: true },
+                        { name: '🏆 Payout',     value: `**${winPayout.toLocaleString()}** coins`, inline: true },
+                        { name: '📊 Net',        value: `**+${(winPayout - playerStake).toLocaleString()}** coins`, inline: true },
+                    )
+                    .setFooter({ text: "Dealer missed the river — their loss, your gain" })
+                    .setTimestamp()],
+                components: [],
+            });
+        }
+
+        if (dRiverAction === 'raise') pot += bet;
+
+        const riverRound = `riverround_${Date.now()}`;
+        const riverActions = dRiverAction === 'raise'
+            ? [
+                new ButtonBuilder().setCustomId(`pk_call_${riverRound}`).setLabel(`Call (${bet.toLocaleString()})`).setStyle(ButtonStyle.Primary),
+                new ButtonBuilder().setCustomId(`pk_fold_${riverRound}`).setLabel('Fold').setStyle(ButtonStyle.Danger),
+              ]
+            : [
+                new ButtonBuilder().setCustomId(`pk_check_${riverRound}`).setLabel('Check').setStyle(ButtonStyle.Secondary),
+                new ButtonBuilder().setCustomId(`pk_raise_${riverRound}`).setLabel(`Raise (${Math.min(bet, debited.balance).toLocaleString()})`).setStyle(ButtonStyle.Primary),
+                new ButtonBuilder().setCustomId(`pk_fold_${riverRound}`).setLabel('Fold').setStyle(ButtonStyle.Danger),
+              ];
+
+        await interaction.editReply({
+            embeds: [new EmbedBuilder()
+                .setAuthor(embedAuthor(interaction))
+                .setThumbnail(THUMB)
+                .setColor('#5865F2')
+                .setTitle('♠ Poker — The River')
+                .addFields(
+                    { name: '🃏 Your Hand',  value: handStr(playerHole),                     inline: false },
+                    { name: '🤖 Dealer',     value: dealerRiverLine,                          inline: false },
+                    { name: '🎴 Community',  value: `${flopStr}  ${turnStr}  ${riverStr}`,   inline: false },
+                    { name: '💰 Pot',        value: `**${pot.toLocaleString()}** coins`,      inline: true },
+                )
+                .setFooter({ text: 'Last chance — Check, Raise, or Fold before showdown' })],
+            components: [new ActionRowBuilder().addComponents(...riverActions)],
+        });
+        await delay(200);
+
+        const msg4 = await interaction.fetchReply();
+        let riverAction;
+        try {
+            const r = await msg4.awaitMessageComponent({
+                filter: i => i.user.id === interaction.user.id && i.customId.endsWith(riverRound),
+                time: 30_000,
+            });
+            await r.deferUpdate();
+            riverAction = r.customId.split('_')[1];
+        } catch {
+            settled = true;
+            await User.findOneAndUpdate(userFilter, { $inc: { balance: playerStake } });
+            return interaction.editReply({ content: '⏱️ Time\'s up! Bet refunded.', embeds: [], components: [] }).catch(() => {});
+        }
+
+        if (riverAction === 'fold') {
+            folded = true;
+        } else if (riverAction === 'call' || riverAction === 'raise') {
+            const raiseAmt = Math.min(bet, debited.balance);
+            if (raiseAmt > 0) {
+                const raised = await User.findOneAndUpdate(
+                    { ...userFilter, balance: { $gte: raiseAmt } },
+                    { $inc: { balance: -raiseAmt } },
+                    { new: true }
+                );
+                if (raised) {
+                    debited = raised;
+                    playerStake += raiseAmt;
+                    pot += raiseAmt * (riverAction === 'raise' ? 2 : 1);
+                } else if (riverAction === 'call') {
+                    folded = true;
+                }
+            } else if (riverAction === 'call') {
+                folded = true;
+            }
+        }
+
+        if (folded) {
+            settled = true;
+            const foldEmbed = new EmbedBuilder()
+                .setAuthor(embedAuthor(interaction))
+                .setThumbnail(THUMB)
+                .setColor('#e74c3c')
+                .setTitle('♠ Poker — Folded')
+                .setDescription(`You folded on the river. The dealer had: **${handStr(dealerHole)}**\nCommunity: **${flopStr}  ${turnStr}  ${riverStr}**`)
+                .addFields({ name: '💰 Balance', value: `**${debited.balance.toLocaleString()}** coins` })
+                .setTimestamp();
+            return interaction.editReply({ embeds: [foldEmbed], components: [] });
+        }
+
+        // ── Showdown ──────────────────────────────────────────────────────────
+        await delay(400);
 
         const playerAll = [...playerHole, ...community];
         const dealerAll = [...dealerHole, ...community];
@@ -486,7 +727,7 @@ async function playPoker(interaction, bet) {
         else if (outcome === 'push') { color = '#f39c12'; title = '♠ Poker — Split Pot'; }
         else                         { color = '#e74c3c'; title = '♠ Poker — Dealer Wins'; }
 
-        const communityStr = `${flopStr}  ${cardStr(turnCard)}  ${cardStr(riverCard)}`;
+        const communityStr = `${flopStr}  ${turnStr}  ${riverStr}`;
         let boostNote = '';
         if (totalCoinMult > 1.0 && adjustedPayout > playerStake) boostNote = `\n> 🚀 *${totalCoinMult.toFixed(1)}x Coin Booster applied!*`;
 

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -149,7 +149,7 @@ const guildSchema = new Schema({
     economy: {
         enabled: { type: Boolean, default: true },
         currency: { type: String, default: '💰' },
-        dailyAmount: { type: Number, default: 100 },
+        dailyAmount: { type: Number, default: 2500 },
         workMin: { type: Number, default: 50 },
         workMax: { type: Number, default: 150 },
         shopEnabled: { type: Boolean, default: true },

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -580,6 +580,7 @@ const userSchema = new Schema({
     // Lifetime stats used for achievement checks
     lifetimeGambled: { type: Number, default: 0 },
     successfulRobs:  { type: Number, default: 0 },
+    failedRobs:      { type: Number, default: 0 },
     questsCompleted: { type: Number, default: 0 },
     lastWarnedAt:    { type: Date, default: null },
 

--- a/src/utils/streakMultiplier.js
+++ b/src/utils/streakMultiplier.js
@@ -7,9 +7,9 @@ const MULTIPLIER_LADDER = [
 ];
 
 const MILESTONES = [
-    { days:   7, coins:    500, badge: 'Week Warrior'   },
-    { days:  30, coins:  2_000, badge: 'Monthly Master' },
-    { days: 100, coins: 10_000, badge: 'Centurion'      },
+    { days:   7, coins:  12_500, badge: 'Week Warrior'   },
+    { days:  30, coins:  37_500, badge: 'Monthly Master' },
+    { days: 100, coins: 125_000, badge: 'Centurion'      },
 ];
 
 function getStreakMultiplier(streakDays) {


### PR DESCRIPTION
## Summary
This PR significantly expands the poker game with full Turn and River betting rounds, adds high-value cosmetic shop items for endgame coin sinks, rebalances economy rewards, and improves rob tracking with success/failure statistics.

## Key Changes

### Poker Game Enhancement
- **Turn & River Rounds**: Implemented complete Turn and River betting phases with dealer AI decision-making based on equity calculations
  - Dealer evaluates hand strength at each street and decides to fold, check, or raise
  - Players can check, raise, call, or fold on both streets
  - Proper pot management and player stake tracking across all betting rounds
  - Dealer fold scenarios on Turn and River with appropriate win payouts
- **Improved Game Flow**: Separated Turn and River logic from Showdown, with proper community card display and equity calculations

### Shop & Cosmetics System
- **Endgame Cosmetic Items**: Added 5 new Mythic-tier cosmetic items (1M - 50M coins) with no gameplay advantage:
  - Diamond Profile Frame (1M coins, 30-day duration)
  - Elite Title: Sovereign (5M coins, 30-day duration)
  - Prestige Aura (10M coins, 30-day duration)
  - Grand Master Badge (25M coins, permanent)
  - Apex Legend Title (50M coins, permanent)
- These serve as high-value coin sinks for endgame players

### Economy Rebalancing
- **Daily Reward**: Increased from 100 to 2,500 coins (25x multiplier)
- **Streak Milestones**: Significantly increased milestone rewards:
  - 7-day: 500 → 12,500 coins
  - 30-day: 2,000 → 37,500 coins
  - 100-day: 10,000 → 125,000 coins

### Rob System Improvements
- **Failed Robs Tracking**: Added `failedRobs` field to User model to track unsuccessful robbery attempts
- **Rob Status Command**: Enhanced `/robstatus` to display user's personal heist record:
  - Shows successful robs, failed robs, and success rate percentage
  - Fetches both victim and robber data in parallel for efficiency

## Implementation Details
- Turn and River rounds follow the same pattern as the Flop round with dealer equity-based decision making
- Proper error handling for timeouts on both new betting rounds
- Consistent embed styling and user feedback across all poker streets
- Database schema updates to support new tracking fields

https://claude.ai/code/session_013WTNgkWEB6i8zJdBWYX4xG