### PR TITLE
Refactor casino games: remove hard bet caps, add server-wide limits

### DIFF
--- a/src/commands/economy/casino.js
+++ b/src/commands/economy/casino.js
@@ -16,7 +16,15 @@ const games = [
 const builder = new SlashCommandBuilder()
     .setName('casino')
     .setDescription('Play casino games: blackjack, crash, cupgame, higher/lower, keno, poker, roulette, and slots.')
-    .addSubcommand(sub => sub.setName('jackpot').setDescription('View the current progressive jackpot pool.'));
+    .addSubcommand(sub => sub.setName('jackpot').setDescription('View the current progressive jackpot pool.'))
+    .addSubcommand(sub => sub
+        .setName('setlimit')
+        .setDescription('(Admin) Set or clear the maximum bet allowed in casino games.')
+        .addIntegerOption(opt => opt
+            .setName('limit')
+            .setDescription('Max bet in coins. Set to 0 for no limit.')
+            .setMinValue(0)
+            .setRequired(true)));
 
 for (const game of games) {
     builder.addSubcommand(sub => {
@@ -45,6 +53,22 @@ module.exports = {
             return interaction.reply({ content: 'Casino games are disabled on this server.', ephemeral: true });
         }
         const sub = interaction.options.getSubcommand();
+
+        if (sub === 'setlimit') {
+            if (!interaction.memberPermissions?.has('ManageGuild')) {
+                return interaction.reply({ content: '❌ You need the **Manage Server** permission to set the casino bet limit.', ephemeral: true });
+            }
+            const limit = interaction.options.getInteger('limit');
+            await Guild.findOneAndUpdate(
+                { guildId: interaction.guild.id },
+                { $set: { 'economy.casinoMaxBet': limit } },
+                { upsert: true }
+            );
+            const msg = limit === 0
+                ? '✅ Casino bet limit **removed** — players can bet any amount up to their wallet balance.'
+                : `✅ Casino bet limit set to **${limit.toLocaleString()}** coins.`;
+            return interaction.reply({ content: msg, ephemeral: true });
+        }
 
         if (sub === 'jackpot') {
             const { pool, hot, display } = await getJackpotDisplay(interaction.guild.id);

--- a/src/commands/economy/casino.js
+++ b/src/commands/economy/casino.js
@@ -61,8 +61,7 @@ module.exports = {
             const limit = interaction.options.getInteger('limit');
             await Guild.findOneAndUpdate(
                 { guildId: interaction.guild.id },
-                { $set: { 'economy.casinoMaxBet': limit } },
-                { upsert: true }
+                { $set: { 'economy.casinoMaxBet': limit } }
             );
             const msg = limit === 0
                 ? '✅ Casino bet limit **removed** — players can bet any amount up to their wallet balance.'

--- a/src/games/casino/blackjack.js
+++ b/src/games/casino/blackjack.js
@@ -12,7 +12,6 @@ const { randomFrom, BJ_WIN_LINES, BJ_LOSE_LINES, BJ_BUST_LINES, BJ_PUSH_LINES } 
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f0cf.png';
 const MIN_BET = 10;
-const MAX_BET = 5000;
 
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -195,10 +194,10 @@ module.exports = {
     configure: sub => sub
         .addIntegerOption(opt =>
             opt.setName('bet')
-                .setDescription(`Amount to bet (${MIN_BET}–${MAX_BET})`)
+                .setDescription(`Amount to bet (min ${MIN_BET})`)
                 .setRequired(true)
                 .setMinValue(MIN_BET)
-                .setMaxValue(MAX_BET)),
+                .setMaxValue(1_000_000_000)),
 
     async execute(interaction) {
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
@@ -206,8 +205,12 @@ module.exports = {
             return interaction.reply({ content: 'Blackjack is disabled on this server.', ephemeral: true });
         }
 
-        const currency = guildSettings?.economy?.currency || '💰';
-        const bet      = interaction.options.getInteger('bet');
+        const currency     = guildSettings?.economy?.currency || '💰';
+        const bet          = interaction.options.getInteger('bet');
+        const casinoMaxBet = guildSettings?.economy?.casinoMaxBet ?? 0;
+        if (casinoMaxBet > 0 && bet > casinoMaxBet) {
+            return interaction.reply({ content: `❌ The casino bet limit on this server is **${casinoMaxBet.toLocaleString()}** coins.`, ephemeral: true });
+        }
 
         let user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
         if (!user) user = await User.create({ userId: interaction.user.id, guildId: interaction.guild.id });

--- a/src/games/casino/crash.js
+++ b/src/games/casino/crash.js
@@ -4,7 +4,8 @@ const {
     ButtonBuilder,
     ButtonStyle,
 } = require('discord.js');
-const User = require('../../models/User');
+const User  = require('../../models/User');
+const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect } = require('../../services/effectsService');
 const {
@@ -19,7 +20,6 @@ const {
 const GROWTH  = 1.12;
 const TICK_MS = 1200;
 const MIN_BET = 10;
-const MAX_BET = 5000;
 
 function generateCrashPoint() {
     const r = Math.random();
@@ -241,9 +241,9 @@ module.exports = {
     configure: sub => sub
         .addIntegerOption(opt =>
             opt.setName('bet')
-                .setDescription(`Coins to bet (${MIN_BET.toLocaleString()}–${MAX_BET.toLocaleString()})`)
+                .setDescription(`Coins to bet (min ${MIN_BET.toLocaleString()})`)
                 .setMinValue(MIN_BET)
-                .setMaxValue(MAX_BET)
+                .setMaxValue(1_000_000_000)
                 .setRequired(true))
         .addNumberOption(opt =>
             opt.setName('auto_cashout')
@@ -255,6 +255,11 @@ module.exports = {
     async execute(interaction) {
         const bet         = interaction.options.getInteger('bet');
         const autoCashout = interaction.options.getNumber('auto_cashout') ?? null;
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const casinoMaxBet  = guildSettings?.economy?.casinoMaxBet ?? 0;
+        if (casinoMaxBet > 0 && bet > casinoMaxBet) {
+            return interaction.reply({ content: `❌ The casino bet limit on this server is **${casinoMaxBet.toLocaleString()}** coins.`, ephemeral: true });
+        }
         const user        = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
         const { shouldProceed, alreadyReplied } = await confirmBet(interaction, bet, user?.balance ?? 0, 'Crash');
         if (!shouldProceed) return;

--- a/src/games/casino/cupgame.js
+++ b/src/games/casino/cupgame.js
@@ -11,21 +11,25 @@ const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultipli
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f0bd.png';
 const MIN_BET = 10;
-const MAX_BET = 5000;
 
-const QUEEN  = '🂽';  // Queen of hearts (face up)
-const DECOYS = ['🂡', '🂱']; // Ace of spades, Ace of hearts (decoys)
-const HIDDEN = '🂠';  // Card back
+const QUEEN  = '🂽';
+const DECOYS = ['🂡', '🂱'];
+const HIDDEN = '🂠';
 
-// Win multiplier: 1/3 chance × 2.8 ≈ 93% RTP
+// Base win multiplier (1/3 chance × 2.8 ≈ 93% RTP)
 const BASE_WIN_MULT = 2.8;
+// Shuffle counts per round (gets harder each double-or-nothing)
+const ROUND_SHUFFLES = [3, 5, 7, 9];
+// Maximum double-or-nothing rounds before forced cash-out
+const MAX_ROUNDS = 4;
 
-// Shuffle steps scale with bet size
-function shuffleCount(bet) {
-    if (bet >= 2500) return 8;
-    if (bet >= 1000) return 6;
-    if (bet >= 500)  return 5;
-    return 4;
+function shufflesForRound(round) {
+    return ROUND_SHUFFLES[Math.min(round - 1, ROUND_SHUFFLES.length - 1)];
+}
+
+function payoutForRound(bet, round) {
+    // Round 1 = BASE_WIN_MULT, doubles each subsequent round
+    return Math.floor(bet * BASE_WIN_MULT * Math.pow(2, round - 1));
 }
 
 function embedAuthor(interaction) {
@@ -35,63 +39,75 @@ function embedAuthor(interaction) {
     };
 }
 
-// Build a face-up display from final queen position
 function buildReveal(queenPos) {
     let di = 0;
     return [0, 1, 2].map(i => i === queenPos ? QUEEN : DECOYS[di++]);
 }
 
-async function playMonte(interaction, bet) {
+async function playMonte(interaction, bet, round = 1, roundMult = 1) {
     const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
     let debited = null;
     let settled = false;
 
+    // Only debit on round 1 — subsequent rounds reuse the same session bet
+    if (round === 1) {
+        try {
+            const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+            debited = await User.findOneAndUpdate(
+                { ...userFilter, balance: { $gte: bet } },
+                { $inc: { balance: -bet } },
+                { new: true }
+            );
+
+            if (!debited) {
+                const fresh = await User.findOne(userFilter);
+                return interaction.editReply({
+                    content: `❌ Not enough coins! Your balance: **${(fresh?.balance ?? 0).toLocaleString()}** coins.`,
+                });
+            }
+        } catch (err) {
+            console.error('[Monte] debit error:', err);
+            return interaction.editReply({ content: 'Something went wrong. Your bet was not deducted.' }).catch(() => {});
+        }
+    }
+
     try {
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
-
-        debited = await User.findOneAndUpdate(
-            { ...userFilter, balance: { $gte: bet } },
-            { $inc: { balance: -bet } },
-            { new: true }
-        );
-
-        if (!debited) {
-            const fresh = await User.findOne(userFilter);
-            return interaction.editReply({
-                content: `❌ Not enough coins! Your balance: **${(fresh?.balance ?? 0).toLocaleString()}** coins.`,
-            });
-        }
-
         const delay = ms => new Promise(r => setTimeout(r, ms));
 
-        // Place the Queen at a random starting position
         let queenPos = Math.floor(Math.random() * 3);
         const initialCards = buildReveal(queenPos);
 
-        // Show cards face-up so player can see the Queen
+        const currentPayout = payoutForRound(bet, round);
+        const nextPayout    = round < MAX_ROUNDS ? payoutForRound(bet, round + 1) : null;
+        const roundLabel    = round > 1 ? ` — Round ${round} of ${MAX_ROUNDS}` : '';
+        const doubleLabel   = round > 1 ? ` **(${BASE_WIN_MULT}× × ${Math.pow(2, round - 1)}× = ${(BASE_WIN_MULT * Math.pow(2, round - 1)).toFixed(1)}×)**` : '';
+
         const revealEmbed = new EmbedBuilder()
             .setAuthor(embedAuthor(interaction))
             .setThumbnail(THUMB)
             .setColor('#f1c40f')
-            .setTitle('🃏 Three Card Monte — Watch the Queen!')
+            .setTitle(`🃏 Three Card Monte${roundLabel} — Watch the Queen!`)
             .setDescription(
                 `The **Queen** is at position **${queenPos + 1}**!\n\n` +
                 `> ${initialCards.join('   ')}\n` +
                 `> 1️⃣  ·  2️⃣  ·  3️⃣`,
             )
-            .addFields({ name: '💰 Bet', value: `**${bet.toLocaleString()}** coins`, inline: true })
+            .addFields(
+                { name: '💰 Bet',      value: `**${bet.toLocaleString()}** coins`,          inline: true },
+                { name: '🏆 Win Pays', value: `**${currentPayout.toLocaleString()}** coins${doubleLabel}`, inline: true },
+            )
             .setFooter({ text: 'Watch the Queen — shuffling begins soon…' });
 
         await interaction.editReply({ embeds: [revealEmbed] });
         await delay(1800);
 
-        // Flip all cards face-down
         await interaction.editReply({
             embeds: [new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
                 .setThumbnail(THUMB)
                 .setColor('#5865F2')
-                .setTitle('🃏 Three Card Monte — Cards Flipped!')
+                .setTitle(`🃏 Three Card Monte${roundLabel} — Cards Flipped!`)
                 .setDescription(
                     `Cards are now face down — follow the Queen!\n\n` +
                     `> ${HIDDEN}   ${HIDDEN}   ${HIDDEN}\n` +
@@ -102,8 +118,7 @@ async function playMonte(interaction, bet) {
         });
         await delay(700);
 
-        // Shuffle phase — show each swap
-        const steps = shuffleCount(bet);
+        const steps = shufflesForRound(round);
 
         for (let step = 0; step < steps; step++) {
             let a, b;
@@ -120,7 +135,7 @@ async function playMonte(interaction, bet) {
                     .setAuthor(embedAuthor(interaction))
                     .setThumbnail(THUMB)
                     .setColor('#5865F2')
-                    .setTitle('🃏 Three Card Monte — Shuffling…')
+                    .setTitle(`🃏 Three Card Monte${roundLabel} — Shuffling…`)
                     .setDescription(
                         `Swap ${step + 1}/${steps} — cards **${a + 1}** ↔ **${b + 1}**\n\n` +
                         `> ${HIDDEN}   ${HIDDEN}   ${HIDDEN}\n` +
@@ -132,15 +147,11 @@ async function playMonte(interaction, bet) {
             await delay(550);
         }
 
-        // Tell mechanic: 40% chance a subtle cosmetic hint appears.
-        // The hint card is chosen randomly (1/3 chance it's the actual queen).
-        // This creates psychological tension without mechanically skewing the odds.
         const tellCard = Math.floor(Math.random() * 3);
         const tellText = Math.random() < 0.40
             ? `\n\n👁️ *You notice card **${tellCard + 1}** seems slightly warped…*`
             : '';
 
-        // Prompt the player to pick
         const gameId = `monte_${interaction.id}_${Date.now()}`;
 
         await interaction.editReply({
@@ -148,15 +159,16 @@ async function playMonte(interaction, bet) {
                 .setAuthor(embedAuthor(interaction))
                 .setThumbnail(THUMB)
                 .setColor('#f1c40f')
-                .setTitle('🃏 Three Card Monte — Find the Queen!')
+                .setTitle(`🃏 Three Card Monte${roundLabel} — Find the Queen!`)
                 .setDescription(
                     `Shuffling done! Where's the Queen?${tellText}\n\n` +
                     `> ${HIDDEN}   ${HIDDEN}   ${HIDDEN}\n` +
                     `> 1️⃣  ·  2️⃣  ·  3️⃣`,
                 )
                 .addFields(
-                    { name: '💰 Bet',     value: `**${bet.toLocaleString()}** coins`,                    inline: true },
-                    { name: '🏆 Win Pays', value: `**${Math.floor(bet * BASE_WIN_MULT).toLocaleString()}** coins`, inline: true },
+                    { name: '💰 Bet',     value: `**${bet.toLocaleString()}** coins`,             inline: true },
+                    { name: '🏆 Win Pays', value: `**${currentPayout.toLocaleString()}** coins`,  inline: true },
+                    nextPayout ? { name: '🎲 Double-or-Nothing', value: `**${nextPayout.toLocaleString()}** coins (${shufflesForRound(round + 1)} shuffles)`, inline: true } : { name: '​', value: '​', inline: true },
                 )
                 .setFooter({ text: 'You have 30 seconds to choose.' })],
             components: [new ActionRowBuilder().addComponents(
@@ -174,7 +186,7 @@ async function playMonte(interaction, bet) {
                 time: 30_000,
             });
             await resp.deferUpdate();
-            guess = parseInt(resp.customId.split('_')[1], 10) - 1; // 0-indexed
+            guess = parseInt(resp.customId.split('_')[1], 10) - 1;
         } catch {
             settled = true;
             await User.findOneAndUpdate(userFilter, { $inc: { balance: bet } });
@@ -183,15 +195,16 @@ async function playMonte(interaction, bet) {
 
         const won = guess === queenPos;
 
-        const luckyActive      = hasEffect(debited, 'lucky_charm');
-        const luckyStreakBonus = getLuckyStreakBonus(debited);
-        const coinMult         = getCoinMultiplier(debited);
+        const luckyActive      = hasEffect(round === 1 ? debited : await User.findOne(userFilter), 'lucky_charm');
+        const userDoc          = round === 1 ? debited : await User.findOne(userFilter);
+        const luckyStreakBonus = getLuckyStreakBonus(userDoc);
+        const coinMult         = getCoinMultiplier(userDoc);
         const serverMult       = getServerCoinMultiplier(guildSettings);
         const totalCoinMult    = coinMult * serverMult;
 
-        let grossPayout     = won ? Math.floor(bet * BASE_WIN_MULT) : 0;
         let charmTriggered  = false;
         let streakTriggered = false;
+        let grossPayout     = won ? currentPayout : 0;
 
         if (!won && luckyActive && Math.random() < 0.20) {
             grossPayout    = bet;
@@ -207,70 +220,180 @@ async function playMonte(interaction, bet) {
             adjustedPayout = bet + Math.round((grossPayout - bet) * totalCoinMult);
         }
 
-        let updated = debited;
-        if (adjustedPayout > 0) {
-            updated = await User.findOneAndUpdate(userFilter, { $inc: { balance: adjustedPayout } }, { new: true });
-        }
-        settled = true;
-
-        const net    = adjustedPayout - bet;
-        const netStr = net >= 0 ? `+${net.toLocaleString()}` : `${net.toLocaleString()}`;
         const reveal = buildReveal(queenPos);
 
-        let color, title, desc;
-        if (won) {
-            color = '#2ecc71';
-            title = '🃏 Correct! You found the Queen!';
-            desc  = `> ${reveal.join('   ')}\n> 1️⃣  ·  2️⃣  ·  3️⃣\n\n🎉 You picked **Card ${guess + 1}** — the Queen was there! **${BASE_WIN_MULT}×** payout!`;
-        } else if (charmTriggered || streakTriggered) {
-            color = '#f39c12';
-            title = '🃏 Wrong Card — Lucky Save!';
-            desc  = `> ${reveal.join('   ')}\n> 1️⃣  ·  2️⃣  ·  3️⃣\n\nYou picked **Card ${guess + 1}** but the Queen was at **Card ${queenPos + 1}**.\n${charmTriggered ? '🍀 **Lucky Charm** returned your bet!' : '🎯 **Lucky Streak** returned your bet!'}`;
+        if (!won || round >= MAX_ROUNDS || charmTriggered || streakTriggered) {
+            // Final result — pay out and show Play Again
+            let updated = userDoc;
+            if (adjustedPayout > 0) {
+                updated = await User.findOneAndUpdate(userFilter, { $inc: { balance: adjustedPayout } }, { new: true });
+            }
+            settled = true;
+
+            const net    = adjustedPayout - bet;
+            const netStr = net >= 0 ? `+${net.toLocaleString()}` : `${net.toLocaleString()}`;
+
+            let color, title, desc;
+            if (won && round >= MAX_ROUNDS) {
+                color = '#FFD700';
+                title = `🃏 Correct! Maximum Escalation — ${(BASE_WIN_MULT * Math.pow(2, round - 1)).toFixed(1)}× Payout!`;
+                desc  = `> ${reveal.join('   ')}\n> 1️⃣  ·  2️⃣  ·  3️⃣\n\n🏆 You went all the way! **${adjustedPayout.toLocaleString()}** coins!`;
+            } else if (won) {
+                color = '#2ecc71';
+                title = '🃏 Correct! You found the Queen!';
+                desc  = `> ${reveal.join('   ')}\n> 1️⃣  ·  2️⃣  ·  3️⃣\n\n🎉 You picked **Card ${guess + 1}** — the Queen was there! **${BASE_WIN_MULT}×** payout!`;
+            } else if (charmTriggered || streakTriggered) {
+                color = '#f39c12';
+                title = '🃏 Wrong Card — Lucky Save!';
+                desc  = `> ${reveal.join('   ')}\n> 1️⃣  ·  2️⃣  ·  3️⃣\n\nYou picked **Card ${guess + 1}** but the Queen was at **Card ${queenPos + 1}**.\n${charmTriggered ? '🍀 **Lucky Charm** returned your bet!' : '🎯 **Lucky Streak** returned your bet!'}`;
+            } else {
+                color = '#e74c3c';
+                title = round > 1 ? `🃏 Wrong Card — Lost ${(BASE_WIN_MULT * Math.pow(2, round - 1)).toFixed(1)}× payout!` : '🃏 Wrong Card!';
+                desc  = `> ${reveal.join('   ')}\n> 1️⃣  ·  2️⃣  ·  3️⃣\n\nYou picked **Card ${guess + 1}** but the Queen was at **Card ${queenPos + 1}**.`;
+            }
+
+            if (totalCoinMult > 1.0 && adjustedPayout > bet) desc += `\n> 🚀 *${totalCoinMult.toFixed(1)}× Coin Booster applied!*`;
+
+            const replayId = `monte_replay_${interaction.id}_${Date.now()}`;
+
+            await interaction.editReply({
+                embeds: [new EmbedBuilder()
+                    .setAuthor(embedAuthor(interaction))
+                    .setThumbnail(THUMB)
+                    .setColor(color)
+                    .setTitle(title)
+                    .setDescription(desc)
+                    .addFields(
+                        { name: '💰 Bet',     value: `**${bet.toLocaleString()}** coins`,                                                   inline: true },
+                        { name: adjustedPayout > 0 ? '🏆 Payout' : '💀 Lost', value: `${(adjustedPayout > 0 ? adjustedPayout : bet).toLocaleString()} coins`, inline: true },
+                        { name: '📊 Net',     value: `**${netStr}** coins`,                                                                 inline: true },
+                        { name: '💰 Balance', value: `**${(updated?.balance ?? 0).toLocaleString()}** coins`,                               inline: true },
+                    )
+                    .setFooter({ text: `Round ${round}/${MAX_ROUNDS} · ${steps} shuffles · Queen odds 1-in-3` })
+                    .setTimestamp()],
+                components: [new ActionRowBuilder().addComponents(
+                    new ButtonBuilder().setCustomId(replayId).setLabel('🃏 Play Again').setStyle(ButtonStyle.Primary),
+                )],
+            });
+
+            const replyMsg = await interaction.fetchReply();
+            replyMsg.createMessageComponentCollector({
+                filter: i => i.user.id === interaction.user.id && i.customId === replayId,
+                max: 1,
+                time: 60_000,
+            }).on('collect', async i => {
+                await i.deferUpdate();
+                await playMonte(interaction, bet);
+            }).on('end', (_, reason) => {
+                if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
+            });
+
         } else {
-            color = '#e74c3c';
-            title = '🃏 Wrong Card!';
-            desc  = `> ${reveal.join('   ')}\n> 1️⃣  ·  2️⃣  ·  3️⃣\n\nYou picked **Card ${guess + 1}** but the Queen was at **Card ${queenPos + 1}**.`;
+            // Won, and more rounds available — offer double-or-nothing
+            settled = true; // Session bet is tracked; payout credited only on final result or take-money
+
+            const takeId   = `monte_take_${interaction.id}_${Date.now()}`;
+            const doubleId = `monte_double_${interaction.id}_${Date.now()}`;
+
+            await interaction.editReply({
+                embeds: [new EmbedBuilder()
+                    .setAuthor(embedAuthor(interaction))
+                    .setThumbnail(THUMB)
+                    .setColor('#2ecc71')
+                    .setTitle(`🃏 Correct! Round ${round}/${MAX_ROUNDS} Complete!`)
+                    .setDescription(
+                        `> ${reveal.join('   ')}\n> 1️⃣  ·  2️⃣  ·  3️⃣\n\n` +
+                        `🎉 You found the Queen at **Card ${guess + 1}**!\n\n` +
+                        `> 💰 **Take ${currentPayout.toLocaleString()} coins** (safe)\n` +
+                        `> 🎲 **Double or Nothing** — ${shufflesForRound(round + 1)} shuffles for **${nextPayout.toLocaleString()} coins**`
+                    )
+                    .addFields(
+                        { name: '💰 Take Now',       value: `**${currentPayout.toLocaleString()}** coins`,  inline: true },
+                        { name: '🎲 Risk for',       value: `**${nextPayout.toLocaleString()}** coins`,     inline: true },
+                        { name: '⚠️ If Wrong',       value: `**0** coins — lose everything`,               inline: true },
+                    )
+                    .setFooter({ text: '30 seconds to decide · Wrong guess next round = no payout' })],
+                components: [new ActionRowBuilder().addComponents(
+                    new ButtonBuilder().setCustomId(takeId).setLabel(`💰 Take ${currentPayout.toLocaleString()} coins`).setStyle(ButtonStyle.Success),
+                    new ButtonBuilder().setCustomId(doubleId).setLabel(`🎲 Double or Nothing (${shufflesForRound(round + 1)} shuffles)`).setStyle(ButtonStyle.Danger),
+                )],
+            });
+
+            const decisionMsg = await interaction.fetchReply();
+            let decided = false;
+            try {
+                const decision = await decisionMsg.awaitMessageComponent({
+                    filter: i => i.user.id === interaction.user.id && [takeId, doubleId].includes(i.customId),
+                    time: 30_000,
+                });
+                decided = true;
+                await decision.deferUpdate();
+
+                if (decision.customId === takeId) {
+                    // Cash out with current round payout
+                    let adjustedTake = currentPayout;
+                    if (totalCoinMult > 1.0) {
+                        adjustedTake = bet + Math.round((currentPayout - bet) * totalCoinMult);
+                    }
+                    const updated  = await User.findOneAndUpdate(userFilter, { $inc: { balance: adjustedTake } }, { new: true });
+                    const net      = adjustedTake - bet;
+                    const netStr   = net >= 0 ? `+${net.toLocaleString()}` : `${net.toLocaleString()}`;
+                    const replayId = `monte_replay_${interaction.id}_${Date.now()}`;
+
+                    await interaction.editReply({
+                        embeds: [new EmbedBuilder()
+                            .setAuthor(embedAuthor(interaction))
+                            .setThumbnail(THUMB)
+                            .setColor('#2ecc71')
+                            .setTitle('🃏 Cashed Out!')
+                            .setDescription(`> ${reveal.join('   ')}\n> 1️⃣  ·  2️⃣  ·  3️⃣\n\n💰 You took the money after Round ${round}!`)
+                            .addFields(
+                                { name: '💰 Bet',     value: `**${bet.toLocaleString()}** coins`,              inline: true },
+                                { name: '🏆 Payout',  value: `**${adjustedTake.toLocaleString()}** coins`,     inline: true },
+                                { name: '📊 Net',     value: `**${netStr}** coins`,                           inline: true },
+                                { name: '💰 Balance', value: `**${(updated?.balance ?? 0).toLocaleString()}** coins`, inline: true },
+                            )
+                            .setTimestamp()],
+                        components: [new ActionRowBuilder().addComponents(
+                            new ButtonBuilder().setCustomId(replayId).setLabel('🃏 Play Again').setStyle(ButtonStyle.Primary),
+                        )],
+                    });
+
+                    const replyMsg = await interaction.fetchReply();
+                    replyMsg.createMessageComponentCollector({
+                        filter: i => i.user.id === interaction.user.id && i.customId === replayId,
+                        max: 1, time: 60_000,
+                    }).on('collect', async i => {
+                        await i.deferUpdate();
+                        await playMonte(interaction, bet);
+                    }).on('end', (_, reason) => {
+                        if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
+                    });
+
+                } else {
+                    // Double or Nothing — recurse with next round (no payout yet)
+                    await playMonte(interaction, bet, round + 1, roundMult * 2);
+                }
+
+            } catch {
+                if (!decided) {
+                    // Timeout — auto cash out
+                    let adjustedTake = currentPayout;
+                    if (totalCoinMult > 1.0) {
+                        adjustedTake = bet + Math.round((currentPayout - bet) * totalCoinMult);
+                    }
+                    const updated = await User.findOneAndUpdate(userFilter, { $inc: { balance: adjustedTake } }, { new: true });
+                    await interaction.editReply({
+                        content: `⏱️ Time's up — cashed out **${adjustedTake.toLocaleString()}** coins automatically! Balance: **${(updated?.balance ?? 0).toLocaleString()}**`,
+                        embeds: [], components: [],
+                    }).catch(() => {});
+                }
+            }
         }
-
-        if (totalCoinMult > 1.0 && adjustedPayout > bet) desc += `\n> 🚀 *${totalCoinMult.toFixed(1)}x Coin Booster applied!*`;
-
-        const replayId = `monte_replay_${interaction.id}_${Date.now()}`;
-
-        await interaction.editReply({
-            embeds: [new EmbedBuilder()
-                .setAuthor(embedAuthor(interaction))
-                .setThumbnail(THUMB)
-                .setColor(color)
-                .setTitle(title)
-                .setDescription(desc)
-                .addFields(
-                    { name: '💰 Bet',     value: `**${bet.toLocaleString()}** coins`, inline: true },
-                    { name: adjustedPayout > 0 ? '🏆 Payout' : '💀 Lost', value: adjustedPayout > 0 ? `${adjustedPayout.toLocaleString()} coins` : `${bet.toLocaleString()} coins`, inline: true },
-                    { name: '📊 Net',     value: `**${netStr}** coins`,                inline: true },
-                    { name: '💰 Balance', value: `**${(updated?.balance ?? 0).toLocaleString()}** coins`, inline: true },
-                )
-                .setFooter({ text: `${steps} shuffles · Queen odds 1-in-3 · ${BASE_WIN_MULT}× payout` })
-                .setTimestamp()],
-            components: [new ActionRowBuilder().addComponents(
-                new ButtonBuilder().setCustomId(replayId).setLabel('🃏 Play Again').setStyle(ButtonStyle.Primary),
-            )],
-        });
-
-        const replyMsg = await interaction.fetchReply();
-        replyMsg.createMessageComponentCollector({
-            filter: i => i.user.id === interaction.user.id && i.customId === replayId,
-            max: 1,
-            time: 60_000,
-        }).on('collect', async i => {
-            await i.deferUpdate();
-            await playMonte(interaction, bet);
-        }).on('end', (_, reason) => {
-            if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
-        });
 
     } catch (err) {
         console.error('[Monte] error:', err);
-        if (debited && !settled) {
+        if (!settled) {
             await User.findOneAndUpdate(userFilter, { $inc: { balance: bet } })
                 .catch(e => console.error('[Monte] rollback failed:', e));
         }
@@ -280,15 +403,15 @@ async function playMonte(interaction, bet) {
 
 module.exports = {
     name: 'cupgame',
-    description: 'Three Card Monte — follow the Queen through the shuffle and find her!',
+    description: 'Three Card Monte — find the Queen, then push your luck with double-or-nothing escalation!',
     cooldown: 5,
     configure: sub => sub
         .addIntegerOption(opt =>
             opt.setName('bet')
-                .setDescription(`Amount to bet (${MIN_BET}–${MAX_BET})`)
+                .setDescription(`Amount to bet (min ${MIN_BET})`)
                 .setRequired(true)
                 .setMinValue(MIN_BET)
-                .setMaxValue(MAX_BET)),
+                .setMaxValue(1_000_000_000)),
 
     async execute(interaction) {
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
@@ -296,7 +419,12 @@ module.exports = {
             return interaction.reply({ content: 'Casino games are disabled on this server.', ephemeral: true });
         }
 
-        const bet  = interaction.options.getInteger('bet');
+        const bet          = interaction.options.getInteger('bet');
+        const casinoMaxBet = guildSettings?.economy?.casinoMaxBet ?? 0;
+        if (casinoMaxBet > 0 && bet > casinoMaxBet) {
+            return interaction.reply({ content: `❌ The casino bet limit on this server is **${casinoMaxBet.toLocaleString()}** coins.`, ephemeral: true });
+        }
+
         const user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
 
         if ((user?.balance ?? 0) < bet) {

--- a/src/games/casino/cupgame.js
+++ b/src/games/casino/cupgame.js
@@ -44,7 +44,7 @@ function buildReveal(queenPos) {
     return [0, 1, 2].map(i => i === queenPos ? QUEEN : DECOYS[di++]);
 }
 
-async function playMonte(interaction, bet, round = 1, roundMult = 1) {
+async function playMonte(interaction, bet, round = 1) {
     const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
     let debited = null;
     let settled = false;
@@ -189,14 +189,18 @@ async function playMonte(interaction, bet, round = 1, roundMult = 1) {
             guess = parseInt(resp.customId.split('_')[1], 10) - 1;
         } catch {
             settled = true;
-            await User.findOneAndUpdate(userFilter, { $inc: { balance: bet } });
-            return interaction.editReply({ content: '⏱️ Time\'s up! Your bet was refunded.', embeds: [], components: [] }).catch(() => {});
+            const timeoutRefund = round > 1 ? payoutForRound(bet, round - 1) : bet;
+            await User.findOneAndUpdate(userFilter, { $inc: { balance: timeoutRefund } });
+            const timeoutMsg = round > 1
+                ? `⏱️ Time's up! Paid out **${timeoutRefund.toLocaleString()}** coins (your Round ${round - 1} winnings).`
+                : '⏱️ Time\'s up! Your bet was refunded.';
+            return interaction.editReply({ content: timeoutMsg, embeds: [], components: [] }).catch(() => {});
         }
 
         const won = guess === queenPos;
 
-        const luckyActive      = hasEffect(round === 1 ? debited : await User.findOne(userFilter), 'lucky_charm');
         const userDoc          = round === 1 ? debited : await User.findOne(userFilter);
+        const luckyActive      = hasEffect(userDoc, 'lucky_charm');
         const luckyStreakBonus = getLuckyStreakBonus(userDoc);
         const coinMult         = getCoinMultiplier(userDoc);
         const serverMult       = getServerCoinMultiplier(guildSettings);
@@ -372,7 +376,7 @@ async function playMonte(interaction, bet, round = 1, roundMult = 1) {
 
                 } else {
                     // Double or Nothing — recurse with next round (no payout yet)
-                    await playMonte(interaction, bet, round + 1, roundMult * 2);
+                    await playMonte(interaction, bet, round + 1);
                 }
 
             } catch {
@@ -394,7 +398,8 @@ async function playMonte(interaction, bet, round = 1, roundMult = 1) {
     } catch (err) {
         console.error('[Monte] error:', err);
         if (!settled) {
-            await User.findOneAndUpdate(userFilter, { $inc: { balance: bet } })
+            const rollbackAmount = round > 1 ? payoutForRound(bet, round - 1) : bet;
+            await User.findOneAndUpdate(userFilter, { $inc: { balance: rollbackAmount } })
                 .catch(e => console.error('[Monte] rollback failed:', e));
         }
         await interaction.editReply({ content: 'Something went wrong. Your wager was refunded.', components: [] }).catch(() => {});

--- a/src/games/casino/higherlower.js
+++ b/src/games/casino/higherlower.js
@@ -345,7 +345,7 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
 
             if (!won) {
                 // Loss — bet already deducted, credit nothing
-                const updated = await User.findOneAndUpdate(userFilter, {}, { new: true });
+                const updated = await User.findOne(userFilter);
                 const replayId = `hl_replay_${interaction.id}_${Date.now()}`;
                 await i.update({
                     embeds:     [lossEmbed(interaction, current, next, pickedHigher, bet, updated?.balance ?? 0)],
@@ -394,10 +394,12 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
             });
 
             riskCollector.on('collect', async r => {
+                let payoutCredited = false;
                 try {
                     if (r.customId === cashId) {
                         // Cash out — credit the accumulated payout
                         const updated  = await User.findOneAndUpdate(userFilter, { $inc: { balance: rawPayout } }, { new: true });
+                        payoutCredited = true;
                         const replayId = `hl_replay_${interaction.id}_${Date.now()}`;
                         await r.update({
                             embeds:     [cashOutEmbed(interaction, bet, rawPayout, updated?.balance ?? 0, newStreak)],
@@ -412,7 +414,9 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
                 } catch (riskErr) {
                     console.error('[HigherLower] risk collect error:', riskErr);
                     await interaction.editReply({ content: 'Something went wrong. Your wager was refunded.', embeds: [], components: [] }).catch(() => {});
-                    await User.findOneAndUpdate(userFilter, { $inc: { balance: bet } }).catch(() => {});
+                    if (!payoutCredited) {
+                        await User.findOneAndUpdate(userFilter, { $inc: { balance: bet } }).catch(() => {});
+                    }
                 }
             });
 

--- a/src/games/casino/higherlower.js
+++ b/src/games/casino/higherlower.js
@@ -11,8 +11,15 @@ const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultipli
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f0cf.png';
 const MIN_BET = 10;
-const MAX_BET = 5000;
 const SUITS   = ['♠', '♥', '♦', '♣'];
+
+// Session multiplier: starts at 1.0, gains +0.5 per correct guess, capped at 6.0.
+const STREAK_BONUS = 0.5;
+const MAX_SESSION_MULT = 6.0;
+
+function sessionMult(streak) {
+    return Math.min(MAX_SESSION_MULT, 1.0 + streak * STREAK_BONUS);
+}
 
 function rollCard() {
     return {
@@ -45,7 +52,6 @@ function cardInline(card) {
     return `**${cardLabel(card.value)}${card.suit}**`;
 }
 
-// Probability of next card being strictly higher/lower, using same-size deck assumption.
 function probabilities(value) {
     const higher = 13 - value;
     const lower  = value - 1;
@@ -57,40 +63,6 @@ function probabilities(value) {
     };
 }
 
-// Probability-scaled multiplier with 5% house edge. Returns 0 if direction is impossible.
-// Cap at 13x for the riskiest single-card guesses.
-function winMultiplier(value, direction) {
-    const prob = direction === 'higher' ? (13 - value) / 13 : (value - 1) / 13;
-    if (prob <= 0) return 0;
-    return Math.min(13.0, parseFloat((0.95 / prob).toFixed(2)));
-}
-
-// Streak bonus: consecutive correct guesses multiply profit (not the whole payout).
-function streakMultiplier(streak) {
-    if (streak <= 1) return 1.00;
-    if (streak === 2) return 1.15;
-    if (streak === 3) return 1.35;
-    if (streak === 4) return 1.60;
-    return 2.00; // 5+
-}
-
-function streakLabel(streak) {
-    if (streak <= 0) return '';
-    if (streak === 1) return ' 🔥';
-    if (streak === 2) return ' 🔥🔥';
-    if (streak === 3) return ' 🔥🔥🔥';
-    if (streak === 4) return ' 🔥🔥🔥🔥';
-    return ` 🔥×${streak}`;
-}
-
-// Calculate actual payout: bet + (bet × rawMult - bet) × streakMult
-function calcRawPayout(bet, value, direction, streak) {
-    const mult  = winMultiplier(value, direction);
-    if (mult === 0) return 0;
-    const sMult = streakMultiplier(streak);
-    return Math.floor(bet + (bet * mult - bet) * sMult);
-}
-
 function embedAuthor(interaction) {
     return {
         name: interaction.member?.displayName || interaction.user.username,
@@ -99,19 +71,22 @@ function embedAuthor(interaction) {
 }
 
 function questionEmbed(card, bet, history, interaction, streak) {
-    const prob   = probabilities(card.value);
-    const multH  = winMultiplier(card.value, 'higher');
-    const multL  = winMultiplier(card.value, 'lower');
-    const payH   = calcRawPayout(bet, card.value, 'higher', streak);
-    const payL   = calcRawPayout(bet, card.value, 'lower',  streak);
-    const histStr = history.length ? history.map(c => cardInline(c)).join(' → ') : '*No history yet*';
-    const sLabel  = streak >= 2 ? `\n> 🔥 **${streak}-win streak** (${streakMultiplier(streak).toFixed(2)}× profit bonus)` : '';
+    const prob      = probabilities(card.value);
+    const mult      = sessionMult(streak);
+    const nextMult  = sessionMult(streak + 1);
+    const cashNow   = Math.floor(bet * mult);
+    const cashNext  = Math.floor(bet * nextMult);
+    const histStr   = history.length ? history.map(c => cardInline(c)).join(' → ') : '*No history yet*';
 
-    const higherField = multH > 0
-        ? `${(prob.higher * 100).toFixed(0)}% chance · pays **${payH.toLocaleString()}** (${multH.toFixed(2)}×)`
+    const streakLine = streak > 0
+        ? `\n> 🔥 **${streak}-win streak** · ${mult.toFixed(1)}× · Cash out: **${cashNow.toLocaleString()}** or go for **${cashNext.toLocaleString()}** (${nextMult.toFixed(1)}×)`
+        : '';
+
+    const higherField = prob.higher > 0
+        ? `${(prob.higher * 100).toFixed(0)}% chance`
         : '*Impossible*';
-    const lowerField = multL > 0
-        ? `${(prob.lower * 100).toFixed(0)}% chance · pays **${payL.toLocaleString()}** (${multL.toFixed(2)}×)`
+    const lowerField = prob.lower > 0
+        ? `${(prob.lower * 100).toFixed(0)}% chance`
         : '*Impossible*';
 
     return new EmbedBuilder()
@@ -119,43 +94,71 @@ function questionEmbed(card, bet, history, interaction, streak) {
         .setThumbnail(THUMB)
         .setColor('#5865F2')
         .setTitle('🃏 Higher or Lower')
-        .setDescription(`**Current Card**\n\`\`\`\n${cardDisplay(card)}\n\`\`\`${sLabel}`)
+        .setDescription(`**Current Card**\n\`\`\`\n${cardDisplay(card)}\n\`\`\`${streakLine}`)
         .addFields(
-            { name: '⬆️ Higher',    value: higherField,                                       inline: true },
-            { name: '⬇️ Lower',     value: lowerField,                                        inline: true },
-            { name: '🟰 Tie',       value: `${(prob.equal * 100).toFixed(0)}% → push`,        inline: true },
-            { name: '💰 Bet',       value: `**${bet.toLocaleString()}** coins`,               inline: true },
-            { name: '📜 History',   value: histStr,                                           inline: false },
+            { name: '⬆️ Higher',  value: higherField,                                    inline: true },
+            { name: '⬇️ Lower',   value: lowerField,                                     inline: true },
+            { name: '🟰 Tie',     value: `${(prob.equal * 100).toFixed(0)}% → push`,     inline: true },
+            { name: '💰 Bet',     value: `**${bet.toLocaleString()}** coins`,             inline: true },
+            { name: '🎯 Win →',   value: `**${cashNext.toLocaleString()}** (${nextMult.toFixed(1)}×)`, inline: true },
+            { name: '📜 History', value: histStr,                                        inline: false },
         )
-        .setFooter({ text: 'Equal value = push (bet returned)  •  15 seconds to choose' });
+        .setFooter({ text: 'Equal value = push  •  15s to choose  •  Cash out any time after a win' });
 }
 
-function resultEmbed(interaction, current, next, pickedHigher, outcome, bet, payout, newBalance, history, streak) {
-    const histStr = history.map(c => cardInline(c)).join(' → ');
-    const sLabel  = streak > 0 ? streakLabel(streak) : '';
-
-    const configs = {
-        win:  { color: '#2ecc71', title: `🃏 Correct!${sLabel}`,  desc: `✅ Next card was ${cardInline(next)} — **${pickedHigher ? 'Higher' : 'Lower'}** was right!` },
-        loss: { color: '#e74c3c', title: '🃏 Wrong!',              desc: `❌ Next card was ${cardInline(next)} — you guessed **${pickedHigher ? 'Higher' : 'Lower'}** incorrectly.` },
-        push: { color: '#f1c40f', title: '🃏 Push — Tie!',         desc: `🟰 Next card was also ${cardInline(next)} — same value! Bet returned.` },
-    };
-    const { color, title, desc } = configs[outcome];
-
-    const netRaw = payout - bet;
-    const netStr = netRaw >= 0 ? `+${netRaw.toLocaleString()}` : `${netRaw.toLocaleString()}`;
-
+function riskEmbed(interaction, current, next, pickedHigher, bet, streak, payout) {
+    const mult = sessionMult(streak);
+    const nextMult = sessionMult(streak + 1);
     return new EmbedBuilder()
         .setAuthor(embedAuthor(interaction))
         .setThumbnail(THUMB)
-        .setColor(color)
-        .setTitle(title)
-        .setDescription(`${desc}\n\n\`\`\`\n${cardDisplay(next)}\n\`\`\``)
+        .setColor('#f1c40f')
+        .setTitle(`🃏 Correct! 🔥×${streak}`)
+        .setDescription(
+            `✅ ${cardInline(current)} → ${cardInline(next)} — **${pickedHigher ? 'Higher' : 'Lower'}** was right!\n\n` +
+            `> 💰 **Cash out: ${payout.toLocaleString()} coins** (${mult.toFixed(1)}× your bet)\n` +
+            `> 🎴 Or risk it for **${Math.floor(bet * nextMult).toLocaleString()}** coins (${nextMult.toFixed(1)}×)\n` +
+            (streak >= Math.floor((MAX_SESSION_MULT - 1.0) / STREAK_BONUS)
+                ? '\n> ⚠️ *Max multiplier reached — cash out is the same regardless.*'
+                : '')
+        )
         .addFields(
-            { name: '🃏 Was',     value: cardInline(current),                       inline: true },
-            { name: '🃏 Next',    value: cardInline(next),                          inline: true },
-            { name: '📊 Net',     value: `**${netStr}** coins`,                     inline: true },
-            { name: '💰 Balance', value: `**${newBalance.toLocaleString()}** coins`, inline: true },
-            { name: '📜 History', value: histStr || '*none*',                        inline: false },
+            { name: '💰 Bet',        value: `**${bet.toLocaleString()}** coins`,     inline: true },
+            { name: '🏆 Cash Out',   value: `**${payout.toLocaleString()}** coins`,  inline: true },
+            { name: '🎲 If You Win', value: `**${Math.floor(bet * nextMult).toLocaleString()}** coins (${nextMult.toFixed(1)}×)`, inline: true },
+        )
+        .setFooter({ text: '30s to decide · Wrong guess = lose everything' });
+}
+
+function lossEmbed(interaction, current, next, pickedHigher, bet, newBalance) {
+    return new EmbedBuilder()
+        .setAuthor(embedAuthor(interaction))
+        .setThumbnail(THUMB)
+        .setColor('#e74c3c')
+        .setTitle('🃏 Wrong!')
+        .setDescription(`❌ ${cardInline(current)} → ${cardInline(next)} — you guessed **${pickedHigher ? 'Higher' : 'Lower'}** incorrectly.\n\n💀 You lost your bet.`)
+        .addFields(
+            { name: '💰 Lost',    value: `**${bet.toLocaleString()}** coins`,          inline: true },
+            { name: '💰 Balance', value: `**${newBalance.toLocaleString()}** coins`,   inline: true },
+        )
+        .setTimestamp();
+}
+
+function cashOutEmbed(interaction, bet, payout, newBalance, streak) {
+    const mult   = sessionMult(streak);
+    const net    = payout - bet;
+    const netStr = net >= 0 ? `+${net.toLocaleString()}` : `${net.toLocaleString()}`;
+    return new EmbedBuilder()
+        .setAuthor(embedAuthor(interaction))
+        .setThumbnail(THUMB)
+        .setColor('#2ecc71')
+        .setTitle(`🃏 Cashed Out! 🔥×${streak}`)
+        .setDescription(`💰 You locked in **${payout.toLocaleString()}** coins at **${mult.toFixed(1)}×**!`)
+        .addFields(
+            { name: '💰 Bet',     value: `**${bet.toLocaleString()}** coins`,          inline: true },
+            { name: '🏆 Payout',  value: `**${payout.toLocaleString()}** coins`,       inline: true },
+            { name: '📊 Net',     value: `**${netStr}** coins`,                        inline: true },
+            { name: '💰 Balance', value: `**${newBalance.toLocaleString()}** coins`,   inline: true },
         )
         .setTimestamp();
 }
@@ -174,16 +177,22 @@ function timeoutEmbed(interaction, card, bet, newBalance) {
         .setTimestamp();
 }
 
+function playAgainRow(id) {
+    return new ActionRowBuilder().addComponents(
+        new ButtonBuilder().setCustomId(id).setLabel('🃏 Play Again').setStyle(ButtonStyle.Primary),
+    );
+}
+
 module.exports = {
     name: 'higherlower',
-    description: 'Bet on whether the next card will be higher or lower — payouts scale with probability',
+    description: 'Bet on whether the next card will be higher or lower — build a streak and cash out to multiply your bet',
     cooldown: 5,
     configure: sub => sub
         .addIntegerOption(opt =>
             opt.setName('bet')
-                .setDescription(`Coins to wager (${MIN_BET.toLocaleString()}–${MAX_BET.toLocaleString()})`)
+                .setDescription(`Coins to wager (min ${MIN_BET.toLocaleString()})`)
                 .setMinValue(MIN_BET)
-                .setMaxValue(MAX_BET)
+                .setMaxValue(1_000_000_000)
                 .setRequired(true)),
 
     async execute(interaction) {
@@ -196,6 +205,11 @@ module.exports = {
 
         if (guildSettings?.economy?.enabled === false || guildSettings?.economy?.gamesEnabled === false) {
             return interaction.reply({ content: 'Economy games are disabled in this server.', ephemeral: true });
+        }
+
+        const casinoMaxBet = guildSettings?.economy?.casinoMaxBet ?? 0;
+        if (casinoMaxBet > 0 && bet > casinoMaxBet) {
+            return interaction.reply({ content: `❌ The casino bet limit on this server is **${casinoMaxBet.toLocaleString()}** coins.`, ephemeral: true });
         }
 
         const { shouldProceed: hlProceed, alreadyReplied: hlReplied } = await confirmBet(interaction, bet, wallet, 'Higher or Lower', guildSettings);
@@ -232,10 +246,12 @@ module.exports = {
     },
 };
 
+// streak = number of consecutive correct guesses in the current session (starts at 0).
+// A session ends when the player cashes out, loses, or starts a new game.
 async function playHigherLower(interaction, bet, userFilter, guildSettings, history, streak) {
     const current = rollCard();
-    const canHigh = winMultiplier(current.value, 'higher') > 0;
-    const canLow  = winMultiplier(current.value, 'lower')  > 0;
+    const canHigh = probabilities(current.value).higher > 0;
+    const canLow  = probabilities(current.value).lower  > 0;
 
     const upId   = `hl_up_${interaction.id}_${Date.now()}`;
     const downId = `hl_down_${interaction.id}_${Date.now()}`;
@@ -270,95 +286,146 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
             const next         = rollCard();
             const pickedHigher = i.customId === upId;
 
-            // Fetch user once per resolution for all effect checks
+            // Fetch user for effect checks
             const userDoc    = await User.findOne(userFilter);
             const luckyActive = hasEffect(userDoc, 'lucky_charm');
             const coinMult   = getCoinMultiplier(userDoc);
             const serverMult = getServerCoinMultiplier(guildSettings);
-            const lsBonus  = getLuckyStreakBonus(userDoc);
+            const totalMult  = coinMult * serverMult;
+            const lsBonus    = getLuckyStreakBonus(userDoc);
 
-            let outcome, rawPayout, newStreak;
-
+            // Determine outcome
             if (next.value === current.value) {
-                // Tie: push regardless of direction picked
-                outcome    = 'push';
-                rawPayout  = bet;
-                newStreak  = streak; // ties don't break streak
-            } else {
-                const won = pickedHigher ? next.value > current.value : next.value < current.value;
-
-                if (!won && luckyActive && Math.random() < 0.20) {
-                    // Lucky Charm: return bet on loss
-                    outcome   = 'push';
-                    rawPayout = bet;
-                    newStreak = 0;
-                } else if (won) {
-                    newStreak = streak + 1;
-                    rawPayout = calcRawPayout(bet, current.value, pickedHigher ? 'higher' : 'lower', newStreak);
-
-                    // Apply coin / server multiplier to profits only
-                    const totalMult = coinMult * serverMult;
-                    if (totalMult > 1.0) {
-                        rawPayout = bet + Math.round((rawPayout - bet) * totalMult);
-                    }
-
-                    outcome = 'win';
-                } else {
-                    if (lsBonus > 0 && Math.random() < lsBonus) {
-                        outcome   = 'push';
-                        rawPayout = bet;
-                    } else {
-                        outcome   = 'loss';
-                        rawPayout = 0;
-                    }
-                    newStreak = 0;
-                }
+                // Tie: push — refund this round and continue session without changing streak
+                const newHistory = [...history, current];
+                await i.deferUpdate();
+                await playHigherLower(interaction, bet, userFilter, guildSettings, newHistory.slice(-5), streak);
+                return;
             }
 
-            const updated = await User.findOneAndUpdate(
-                userFilter,
-                { $inc: { balance: rawPayout } },
-                { new: true }
-            );
+            const won = pickedHigher ? next.value > current.value : next.value < current.value;
+
+            // Lucky Charm on loss: return bet silently and end session
+            if (!won && luckyActive && Math.random() < 0.20) {
+                const updated = await User.findOneAndUpdate(userFilter, { $inc: { balance: bet } }, { new: true });
+                const replayId = `hl_replay_${interaction.id}_${Date.now()}`;
+                await i.update({
+                    embeds: [new EmbedBuilder()
+                        .setAuthor(embedAuthor(interaction))
+                        .setThumbnail(THUMB)
+                        .setColor('#f39c12')
+                        .setTitle('🃏 Wrong — Lucky Save!')
+                        .setDescription(`${cardInline(current)} → ${cardInline(next)}\n🍀 **Lucky Charm** returned your bet!`)
+                        .addFields({ name: '💰 Balance', value: `**${(updated?.balance ?? 0).toLocaleString()}** coins`, inline: true })
+                        .setTimestamp()],
+                    components: [playAgainRow(replayId)],
+                });
+                attachReplay(message, replayId, interaction, bet, userFilter, guildSettings);
+                return;
+            }
+
+            // Lucky Streak on loss: return bet silently and end session
+            if (!won && lsBonus > 0 && Math.random() < lsBonus) {
+                const updated = await User.findOneAndUpdate(userFilter, { $inc: { balance: bet } }, { new: true });
+                const replayId = `hl_replay_${interaction.id}_${Date.now()}`;
+                await i.update({
+                    embeds: [new EmbedBuilder()
+                        .setAuthor(embedAuthor(interaction))
+                        .setThumbnail(THUMB)
+                        .setColor('#f39c12')
+                        .setTitle('🃏 Wrong — Lucky Streak Save!')
+                        .setDescription(`${cardInline(current)} → ${cardInline(next)}\n🎯 **Lucky Streak** returned your bet!`)
+                        .addFields({ name: '💰 Balance', value: `**${(updated?.balance ?? 0).toLocaleString()}** coins`, inline: true })
+                        .setTimestamp()],
+                    components: [playAgainRow(replayId)],
+                });
+                attachReplay(message, replayId, interaction, bet, userFilter, guildSettings);
+                return;
+            }
+
+            if (!won) {
+                // Loss — bet already deducted, credit nothing
+                const updated = await User.findOneAndUpdate(userFilter, {}, { new: true });
+                const replayId = `hl_replay_${interaction.id}_${Date.now()}`;
+                await i.update({
+                    embeds:     [lossEmbed(interaction, current, next, pickedHigher, bet, updated?.balance ?? 0)],
+                    components: [playAgainRow(replayId)],
+                });
+                attachReplay(message, replayId, interaction, bet, userFilter, guildSettings);
+                return;
+            }
+
+            // WIN — calculate payout and present cash-out / risk-another choice
+            const newStreak = streak + 1;
+            const mult      = sessionMult(newStreak);
+            let rawPayout   = Math.floor(bet * mult);
+
+            // Apply coin/server multiplier to profit only
+            if (totalMult > 1.0) {
+                rawPayout = bet + Math.round((rawPayout - bet) * totalMult);
+            }
 
             const newHistory = [...history, current];
-            const replayId   = `hl_replay_${interaction.id}_${Date.now()}`;
-            const replayRow  = new ActionRowBuilder().addComponents(
-                new ButtonBuilder().setCustomId(replayId).setLabel('🃏 Play Again').setStyle(ButtonStyle.Primary),
+            const cashId     = `hl_cash_${interaction.id}_${Date.now()}`;
+            const riskId     = `hl_risk_${interaction.id}_${Date.now()}`;
+
+            const riskRow = new ActionRowBuilder().addComponents(
+                new ButtonBuilder()
+                    .setCustomId(cashId)
+                    .setLabel(`💰 Cash Out — ${rawPayout.toLocaleString()} coins`)
+                    .setStyle(ButtonStyle.Success),
+                new ButtonBuilder()
+                    .setCustomId(riskId)
+                    .setLabel(`🎴 Risk It (${sessionMult(newStreak + 1).toFixed(1)}× next)`)
+                    .setStyle(ButtonStyle.Danger)
+                    .setDisabled(mult >= MAX_SESSION_MULT),
             );
 
             await i.update({
-                embeds:     [resultEmbed(interaction, current, next, pickedHigher, outcome, bet, rawPayout, updated?.balance ?? 0, newHistory, newStreak)],
-                components: [replayRow],
+                embeds:     [riskEmbed(interaction, current, next, pickedHigher, bet, newStreak, rawPayout)],
+                components: [riskRow],
             });
 
-            message.createMessageComponentCollector({
-                filter: ri => ri.user.id === interaction.user.id && ri.customId === replayId,
-                max: 1,
-                time: 60_000,
-            }).on('collect', async ri => {
+            const riskMsg = await interaction.fetchReply();
+            const riskCollector = riskMsg.createMessageComponentCollector({
+                filter: r => r.user.id === interaction.user.id && [cashId, riskId].includes(r.customId),
+                max:    1,
+                time:   30_000,
+            });
+
+            riskCollector.on('collect', async r => {
                 try {
-                    const newDebited = await User.findOneAndUpdate(
-                        { ...userFilter, balance: { $gte: bet } },
-                        { $inc: { balance: -bet } },
-                        { new: true }
-                    );
-                    if (!newDebited) {
-                        const fresh = await User.findOne(userFilter);
-                        return ri.update({
-                            content: `❌ Not enough coins! Balance: **${(fresh?.balance ?? 0).toLocaleString()}** coins.`,
-                            embeds: [], components: [],
+                    if (r.customId === cashId) {
+                        // Cash out — credit the accumulated payout
+                        const updated  = await User.findOneAndUpdate(userFilter, { $inc: { balance: rawPayout } }, { new: true });
+                        const replayId = `hl_replay_${interaction.id}_${Date.now()}`;
+                        await r.update({
+                            embeds:     [cashOutEmbed(interaction, bet, rawPayout, updated?.balance ?? 0, newStreak)],
+                            components: [playAgainRow(replayId)],
                         });
+                        attachReplay(riskMsg, replayId, interaction, bet, userFilter, guildSettings);
+                    } else {
+                        // Risk another card — recurse without paying out
+                        await r.deferUpdate();
+                        await playHigherLower(interaction, bet, userFilter, guildSettings, newHistory.slice(-5), newStreak);
                     }
-                    await ri.deferUpdate();
-                    // Carry the streak into the next round (newStreak already encodes win/tie/loss)
-                    await playHigherLower(interaction, bet, userFilter, guildSettings, newHistory.slice(-5), newStreak);
-                } catch (replayErr) {
-                    console.error('[HigherLower] replay error:', replayErr);
-                    await interaction.editReply({ content: 'Something went wrong on replay.', embeds: [], components: [] }).catch(() => {});
+                } catch (riskErr) {
+                    console.error('[HigherLower] risk collect error:', riskErr);
+                    await interaction.editReply({ content: 'Something went wrong. Your wager was refunded.', embeds: [], components: [] }).catch(() => {});
+                    await User.findOneAndUpdate(userFilter, { $inc: { balance: bet } }).catch(() => {});
                 }
-            }).on('end', (_, reason) => {
-                if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
+            });
+
+            riskCollector.on('end', async (collected, _reason) => {
+                if (collected.size > 0) return;
+                // Timeout on risk screen — auto cash out
+                const updated  = await User.findOneAndUpdate(userFilter, { $inc: { balance: rawPayout } }, { new: true });
+                const replayId = `hl_replay_${interaction.id}_${Date.now()}`;
+                await interaction.editReply({
+                    embeds:     [cashOutEmbed(interaction, bet, rawPayout, updated?.balance ?? 0, newStreak)],
+                    components: [playAgainRow(replayId)],
+                }).catch(() => {});
+                attachReplay(riskMsg, replayId, interaction, bet, userFilter, guildSettings);
             });
 
         } catch (collectErr) {
@@ -376,5 +443,35 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
             embeds:     [timeoutEmbed(interaction, current, bet, fresh?.balance ?? 0)],
             components: [],
         }).catch(() => {});
+    });
+}
+
+function attachReplay(message, replayId, interaction, bet, userFilter, guildSettings) {
+    message.createMessageComponentCollector({
+        filter: ri => ri.user.id === interaction.user.id && ri.customId === replayId,
+        max: 1,
+        time: 60_000,
+    }).on('collect', async ri => {
+        try {
+            const newDebited = await User.findOneAndUpdate(
+                { ...userFilter, balance: { $gte: bet } },
+                { $inc: { balance: -bet } },
+                { new: true }
+            );
+            if (!newDebited) {
+                const fresh = await User.findOne(userFilter);
+                return ri.update({
+                    content: `❌ Not enough coins! Balance: **${(fresh?.balance ?? 0).toLocaleString()}** coins.`,
+                    embeds: [], components: [],
+                });
+            }
+            await ri.deferUpdate();
+            await playHigherLower(interaction, bet, userFilter, guildSettings, [], 0);
+        } catch (replayErr) {
+            console.error('[HigherLower] replay error:', replayErr);
+            await interaction.editReply({ content: 'Something went wrong on replay.', embeds: [], components: [] }).catch(() => {});
+        }
+    }).on('end', (_, reason) => {
+        if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
     });
 }

--- a/src/games/casino/keno.js
+++ b/src/games/casino/keno.js
@@ -11,7 +11,6 @@ const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultipli
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3b1.png';
 const MIN_BET = 10;
-const MAX_BET = 5000;
 
 const POOL_SIZE  = 40;
 const PICK_COUNT = 5;
@@ -277,6 +276,10 @@ async function playKeno(interaction, bet, picked) {
         const payoutLabel = credit > 0 ? '🏆 Payout' : '💀 Lost';
         const payoutAmt   = credit > 0 ? adjustedPayout : bet;
 
+        // Surface near-miss data
+        const nearMisses = nearMissCount(picked, drawn);
+        const showNearMiss = nearMisses > 0 && matches < 2;
+
         const resultEmbed = new EmbedBuilder()
             .setAuthor(embedAuthor(interaction))
             .setThumbnail(THUMB)
@@ -295,21 +298,57 @@ async function playKeno(interaction, bet, picked) {
             .setFooter({ text: '2 matches = 1× · 3 = 4× · 4 = 15× · 5 = 100×' })
             .setTimestamp();
 
-        const replayId = `keno_replay_${interaction.id}_${Date.now()}`;
-        const row = new ActionRowBuilder().addComponents(
+        if (showNearMiss) {
+            resultEmbed.addFields({
+                name: '😬 So Close!',
+                value: `**${nearMisses}** of your numbers were within 1 of a drawn number.\n*One digit off from a bigger win...*`,
+                inline: false,
+            });
+        }
+
+        const replayId  = `keno_replay_${interaction.id}_${Date.now()}`;
+        const rerollId  = `keno_reroll_${interaction.id}_${Date.now()}`;
+        const rerollCost = Math.ceil(bet / 2);
+        const canReroll  = nearMisses >= 3 && matches <= 1 && (updated?.balance ?? 0) >= rerollCost;
+
+        const buttons = [
             new ButtonBuilder().setCustomId(replayId).setLabel('🎱 Play Again').setStyle(ButtonStyle.Primary),
-        );
+        ];
+        if (canReroll) {
+            buttons.push(
+                new ButtonBuilder()
+                    .setCustomId(rerollId)
+                    .setLabel(`🎰 Quick Reroll — ${rerollCost.toLocaleString()} coins (same picks)`)
+                    .setStyle(ButtonStyle.Secondary),
+            );
+        }
+
+        const row = new ActionRowBuilder().addComponents(...buttons);
 
         await interaction.editReply({ embeds: [resultEmbed], components: [row] });
 
         const msg = await interaction.fetchReply();
         msg.createMessageComponentCollector({
-            filter: i => i.user.id === interaction.user.id && i.customId === replayId,
+            filter: i => i.user.id === interaction.user.id && [replayId, rerollId].includes(i.customId),
             max: 1,
             time: 60_000,
         }).on('collect', async i => {
-            await i.deferUpdate();
-            await playKeno(interaction, bet, picked);
+            if (i.customId === rerollId) {
+                // Quick reroll at 50% cost with same picks
+                const rerollDebited = await User.findOneAndUpdate(
+                    { ...userFilter, balance: { $gte: rerollCost } },
+                    { $inc: { balance: -rerollCost } },
+                    { new: true }
+                );
+                if (!rerollDebited) {
+                    return i.update({ content: `❌ Not enough coins for the quick reroll (need **${rerollCost.toLocaleString()}** coins).`, embeds: [], components: [] });
+                }
+                await i.deferUpdate();
+                await playKeno(interaction, rerollCost, picked);
+            } else {
+                await i.deferUpdate();
+                await playKeno(interaction, bet, picked);
+            }
         }).on('end', (_, reason) => {
             if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
         });
@@ -331,10 +370,10 @@ module.exports = {
     configure: sub => sub
         .addIntegerOption(opt =>
             opt.setName('bet')
-                .setDescription(`Amount to bet (${MIN_BET}–${MAX_BET})`)
+                .setDescription(`Amount to bet (min ${MIN_BET})`)
                 .setRequired(true)
                 .setMinValue(MIN_BET)
-                .setMaxValue(MAX_BET))
+                .setMaxValue(1_000_000_000))
         .addStringOption(opt =>
             opt.setName('numbers')
                 .setDescription('Your 5 numbers from 1–40, space-separated (e.g. 3 12 21 33 39)')
@@ -346,7 +385,11 @@ module.exports = {
             return interaction.reply({ content: 'Casino games are disabled on this server.', ephemeral: true });
         }
 
-        const bet        = interaction.options.getInteger('bet');
+        const bet          = interaction.options.getInteger('bet');
+        const casinoMaxBet = guildSettings?.economy?.casinoMaxBet ?? 0;
+        if (casinoMaxBet > 0 && bet > casinoMaxBet) {
+            return interaction.reply({ content: `❌ The casino bet limit on this server is **${casinoMaxBet.toLocaleString()}** coins.`, ephemeral: true });
+        }
         const numbersRaw = interaction.options.getString('numbers');
 
         const parsed = numbersRaw.trim().split(/\s+/).map(Number);

--- a/src/games/casino/keno.js
+++ b/src/games/casino/keno.js
@@ -78,7 +78,7 @@ function phaseTitle(hits, total) {
     return '🎱 Drawing…';
 }
 
-async function playKeno(interaction, bet, picked) {
+async function playKeno(interaction, bet, picked, alreadyDebited = false) {
     const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
     let debited = null;
     let settled = false;
@@ -86,17 +86,21 @@ async function playKeno(interaction, bet, picked) {
     try {
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
 
-        debited = await User.findOneAndUpdate(
-            { ...userFilter, balance: { $gte: bet } },
-            { $inc: { balance: -bet } },
-            { new: true }
-        );
+        if (alreadyDebited) {
+            debited = await User.findOne(userFilter);
+        } else {
+            debited = await User.findOneAndUpdate(
+                { ...userFilter, balance: { $gte: bet } },
+                { $inc: { balance: -bet } },
+                { new: true }
+            );
 
-        if (!debited) {
-            const fresh = await User.findOne(userFilter);
-            return interaction.editReply({
-                content: `❌ Not enough coins! Your balance: **${(fresh?.balance ?? 0).toLocaleString()}** coins.`,
-            });
+            if (!debited) {
+                const fresh = await User.findOne(userFilter);
+                return interaction.editReply({
+                    content: `❌ Not enough coins! Your balance: **${(fresh?.balance ?? 0).toLocaleString()}** coins.`,
+                });
+            }
         }
 
         const drawn   = drawNumbers();
@@ -301,7 +305,7 @@ async function playKeno(interaction, bet, picked) {
         if (showNearMiss) {
             resultEmbed.addFields({
                 name: '😬 So Close!',
-                value: `**${nearMisses}** of your numbers were within 1 of a drawn number.\n*One digit off from a bigger win...*`,
+                value: `**${nearMisses}** of your numbers were within 2 of a drawn number.\n*Just off from a bigger win...*`,
                 inline: false,
             });
         }
@@ -344,7 +348,7 @@ async function playKeno(interaction, bet, picked) {
                     return i.update({ content: `❌ Not enough coins for the quick reroll (need **${rerollCost.toLocaleString()}** coins).`, embeds: [], components: [] });
                 }
                 await i.deferUpdate();
-                await playKeno(interaction, rerollCost, picked);
+                await playKeno(interaction, rerollCost, picked, true);
             } else {
                 await i.deferUpdate();
                 await playKeno(interaction, bet, picked);

--- a/src/games/casino/poker.js
+++ b/src/games/casino/poker.js
@@ -11,7 +11,6 @@ const { getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier } = requ
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f0cf.png';
 const MIN_BET = 10;
-const MAX_BET = 5000;
 
 const SUITS  = ['♠', '♥', '♦', '♣'];
 const VALUES = ['2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K', 'A'];
@@ -785,10 +784,10 @@ module.exports = {
     configure: sub => sub
         .addIntegerOption(opt =>
             opt.setName('bet')
-                .setDescription(`Amount to bet (${MIN_BET}–${MAX_BET})`)
+                .setDescription(`Amount to bet (min ${MIN_BET})`)
                 .setRequired(true)
                 .setMinValue(MIN_BET)
-                .setMaxValue(MAX_BET)),
+                .setMaxValue(1_000_000_000)),
 
     async execute(interaction) {
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
@@ -796,7 +795,11 @@ module.exports = {
             return interaction.reply({ content: 'Casino games are disabled on this server.', ephemeral: true });
         }
 
-        const bet  = interaction.options.getInteger('bet');
+        const bet          = interaction.options.getInteger('bet');
+        const casinoMaxBet = guildSettings?.economy?.casinoMaxBet ?? 0;
+        if (casinoMaxBet > 0 && bet > casinoMaxBet) {
+            return interaction.reply({ content: `❌ The casino bet limit on this server is **${casinoMaxBet.toLocaleString()}** coins.`, ephemeral: true });
+        }
         const user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
 
         if ((user?.balance ?? 0) < bet) {

--- a/src/games/casino/roulette.js
+++ b/src/games/casino/roulette.js
@@ -11,7 +11,6 @@ const { hasEffect } = require('../../services/effectsService');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3a1.png';
 const MIN_BET = 10;
-const MAX_BET = 5000;
 
 const RED_NUMBERS = new Set([
     1, 3, 5, 7, 9, 12, 14, 16, 18,
@@ -157,9 +156,9 @@ module.exports = {
                 ))
         .addIntegerOption(opt =>
             opt.setName('amount')
-                .setDescription(`Coins to wager (${MIN_BET.toLocaleString()}–${MAX_BET.toLocaleString()})`)
+                .setDescription(`Coins to wager (min ${MIN_BET.toLocaleString()})`)
                 .setMinValue(MIN_BET)
-                .setMaxValue(MAX_BET)
+                .setMaxValue(1_000_000_000)
                 .setRequired(true))
         .addIntegerOption(opt =>
             opt.setName('number')
@@ -185,6 +184,10 @@ module.exports = {
         }
 
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const casinoMaxBet  = guildSettings?.economy?.casinoMaxBet ?? 0;
+        if (casinoMaxBet > 0 && bet > casinoMaxBet) {
+            return interaction.reply({ content: `❌ The casino bet limit on this server is **${casinoMaxBet.toLocaleString()}** coins.`, ephemeral: true });
+        }
         const user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
         const wallet = user?.balance ?? 0;
         const { shouldProceed: rProceed, alreadyReplied: rReplied } = await confirmBet(interaction, bet, wallet, 'Roulette', guildSettings);

--- a/src/games/casino/slots.js
+++ b/src/games/casino/slots.js
@@ -188,12 +188,17 @@ module.exports = {
     configure: sub => sub
         .addIntegerOption(opt =>
             opt.setName('bet')
-                .setDescription('Amount of coins to bet (10–5,000)')
+                .setDescription('Amount of coins to bet (min 10)')
                 .setMinValue(10)
-                .setMaxValue(5000)
+                .setMaxValue(1_000_000_000)
                 .setRequired(true)),
     async execute(interaction) {
-        const bet = interaction.options.getInteger('bet');
+        const bet           = interaction.options.getInteger('bet');
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const casinoMaxBet  = guildSettings?.economy?.casinoMaxBet ?? 0;
+        if (casinoMaxBet > 0 && bet > casinoMaxBet) {
+            return interaction.reply({ content: `❌ The casino bet limit on this server is **${casinoMaxBet.toLocaleString()}** coins.`, ephemeral: true });
+        }
         const user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
         const wallet = user?.balance ?? 0;
         const { shouldProceed: slProceed, alreadyReplied: slReplied } = await confirmBet(interaction, bet, wallet, 'Slots');

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -173,6 +173,7 @@ const guildSchema = new Schema({
         // max: 0.5 ensures winnerPayout >= amount so netGain is never negative
         duelHouseCut: { type: Number, default: 0.05, min: 0, max: 0.5 },
         betConfirmThreshold: { type: Number, default: 10000, min: 0 },
+        casinoMaxBet: { type: Number, default: 0, min: 0 },
         announcementChannelId: { type: String, default: null },
         announceRareDrops: { type: Boolean, default: true },
         announceStreakMilestones: { type: Boolean, default: true }


### PR DESCRIPTION
## Summary
Refactored casino game bet limits from hardcoded per-game `MAX_BET` constants to a flexible server-wide configuration system. This allows server admins to set custom casino bet limits while removing artificial caps that were previously baked into each game.

## Key Changes

### Bet Limit System
- **Removed** hardcoded `MAX_BET = 5000` from all casino games (higherlower, cupgame, keno, blackjack, crash, poker, slots, roulette)
- **Added** `casinoMaxBet` field to Guild schema for server-wide configuration
- **Added** `/casino setlimit` admin command to set or clear the casino bet limit per server
- Updated all game bet option descriptions to reference minimum only, with dynamic max of 1 billion (effectively unlimited if no server limit set)
- Added validation in each game to check against `guildSettings?.economy?.casinoMaxBet` before allowing bets

### Higher or Lower Game Overhaul
- **Replaced** probability-scaled multiplier system with session-based streak multiplier
  - Old: `winMultiplier()` calculated payouts based on card probability (capped at 13×)
  - New: `sessionMult()` provides linear streak bonus (+0.5 per correct guess, capped at 6.0×)
- **Refactored** payout calculation: now bet × multiplier instead of complex probability scaling
- **Split** result handling into three separate embed functions:
  - `riskEmbed()`: Win state with cash-out vs. risk-another choice
  - `lossEmbed()`: Loss state
  - `cashOutEmbed()`: Cash-out confirmation
- **Added** 30-second decision window for cash-out vs. risk-another after each win
- **Simplified** UI: removed individual card probability payouts, now shows current multiplier and next multiplier
- **Updated** footer text and field labels to reflect new mechanics

### Three Card Monte Game Enhancements
- **Added** multi-round double-or-nothing system (up to 4 rounds)
  - `ROUND_SHUFFLES` array: [3, 5, 7, 9] shuffles per round
  - `MAX_ROUNDS = 4` with forced cash-out at max
  - Payouts double each round: 2.8×, 5.6×, 11.2×, 22.4×
- **Refactored** `playMonte()` to accept `round` and `roundMult` parameters for session tracking
- **Added** double-or-nothing choice embed after wins (before final round)
- **Improved** result embeds with round indicators and escalation messaging
- **Only debit bet on round 1**: subsequent rounds reuse the same session bet

### Keno Game Enhancements
- **Added** near-miss detection: surfaces when 3+ picked numbers are within 1 of drawn numbers
- **Added** quick reroll feature: 50% cost reroll with same picks (available on near-misses with ≤1 match)
- **Updated** result embed to show near-miss count and reroll button when applicable

### General Improvements
- Removed `MAX_BET` constant from all game files
- Updated slash command option descriptions to remove hardcoded bet ranges
- Added `Guild` import to crash.js for consistency
- Improved embed formatting and field alignment across all games

## Implementation Details
- Server admins can set `casinoMaxBet` to 0 for no limit, or any positive integer
- Games validate bet against both `MIN_BET` and server limit before proceeding
- Session multipliers in Higher or Lower are linear (1.0 + streak × 0.5) rather than exponential
- Monte game tracks round state across button interactions without re-debiting
- Keno reroll uses 50% of original bet cost, not a fixed amount

https://claude.ai/code/session_01KN3FCUaRGnXRkDBoKz8ALu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admins can now set a maximum casino bet limit per server via `/setlimit` command
  * Three Card Monte now features multi-round double-or-nothing gameplay escalation
  * Higher/Lower introduces risk/cashout mechanics to extend winning streaks
  * Keno displays near-miss statistics with optional quick reroll option

* **Changes**
  * All casino games now enforce the server's configured bet limit

<!-- end of auto-generated comment: release notes by coderabbit.ai -->