### PR TITLE
fix(overview): correct module count KPI; add economy/leveling/AI KPIs; resolve Discord user IDs to usernames in tables and admin inputs

### DIFF
--- a/src/dashboard/public/styles.css
+++ b/src/dashboard/public/styles.css
@@ -1403,3 +1403,14 @@ textarea.auto-resize {
 .eco-kpi-tile { background: var(--surface-2, #1a1510); border: 1px solid var(--border); border-radius: 8px; padding: .75rem 1.1rem; min-width: 140px; }
 .eco-kpi-label { font-size: .75rem; color: var(--text-dim); font-weight: 600; text-transform: uppercase; letter-spacing: .04em; }
 .eco-kpi-value { font-size: 1.4rem; font-weight: 700; color: var(--cream-50, #faf5f0); margin-top: .2rem; }
+
+/* ── User search widget ───────────────────────────────────────── */
+.user-search-widget { position: relative; }
+.user-tag-list { display: flex; flex-wrap: wrap; gap: .35rem; margin-bottom: .4rem; min-height: 0; }
+.user-id-tag { display: inline-flex; align-items: center; background: rgba(255,255,255,.08); border: 1px solid rgba(255,255,255,.12); border-radius: 4px; padding: .15rem .45rem; font-size: .8em; gap: .25rem; }
+.user-id-tag button { background: none; border: none; color: inherit; opacity: .55; cursor: pointer; padding: 0 .1rem; font-size: 1.1em; line-height: 1; }
+.user-id-tag button:hover { opacity: 1; }
+.user-search-input { width: 100%; }
+.user-search-dropdown { position: absolute; left: 0; right: 0; top: calc(100% + 2px); background: var(--bg-card, #1e1a15); border: 1px solid var(--border); border-radius: 6px; z-index: 200; max-height: 200px; overflow-y: auto; box-shadow: 0 4px 16px rgba(0,0,0,.4); }
+.user-search-item { display: flex; align-items: center; padding: .4rem .65rem; cursor: pointer; font-size: .875rem; gap: .5rem; }
+.user-search-item:hover { background: rgba(255,255,255,.06); }

--- a/src/dashboard/routes/api.js
+++ b/src/dashboard/routes/api.js
@@ -1206,6 +1206,24 @@ router.get('/guild/:guildId/members/search', checkAuth, checkGuildAccess, async 
     }
 });
 
+router.get('/guild/:guildId/members/resolve', checkAuth, checkGuildAccess, async (req, res) => {
+    const ids = (req.query.ids || '').split(',').map(s => s.trim()).filter(s => /^\d{17,20}$/.test(s)).slice(0, 50);
+    if (!ids.length) return res.json({});
+    try {
+        const result = {};
+        await Promise.all(ids.map(async id => {
+            try {
+                const user = await req.client.users.fetch(id, { force: false });
+                result[id] = { id, username: user.username, displayName: user.globalName || user.username, avatarURL: user.displayAvatarURL({ size: 32, extension: 'webp' }) };
+            } catch { result[id] = null; }
+        }));
+        res.json(result);
+    } catch (err) {
+        console.error('Member resolve error:', err);
+        res.status(500).json({ error: 'Resolve failed' });
+    }
+});
+
 // ── Achievements ────────────────────────────────────────────────────────────
 
 router.post('/guild/:guildId/achievements/grant', checkAuth, checkGuildAccess, checkWriteRateLimit, async (req, res) => {
@@ -1382,7 +1400,25 @@ router.get('/guild/:guildId/cases', checkAuth, checkGuildAccess, async (req, res
             Case.find(query).sort({ createdAt: -1 }).skip((page - 1) * limit).limit(limit).lean(),
             Case.countDocuments(query)
         ]);
-        res.json({ cases, total, page, pages: Math.ceil(total / limit) });
+
+        const uniqueIds = [...new Set(cases.flatMap(c => [c.targetUserId, c.moderatorId].filter(Boolean)))];
+        const userMap = {};
+        await Promise.all(uniqueIds.map(async id => {
+            try {
+                const u = await req.client.users.fetch(id, { force: false });
+                userMap[id] = { tag: u.tag, avatarUrl: u.displayAvatarURL({ size: 32, extension: 'webp' }) };
+            } catch { /* user not resolvable */ }
+        }));
+
+        res.json({
+            cases: cases.map(c => ({
+                ...c,
+                targetUserTag: userMap[c.targetUserId]?.tag || null,
+                targetAvatarUrl: userMap[c.targetUserId]?.avatarUrl || null,
+                moderatorTag: userMap[c.moderatorId]?.tag || null,
+            })),
+            total, page, pages: Math.ceil(total / limit)
+        });
     } catch (error) {
         console.error('Cases list error:', error);
         res.status(500).json({ error: 'Internal server error' });
@@ -1535,10 +1571,24 @@ router.get('/guild/:guildId/economy/stats', checkAuth, checkGuildAccess, async (
             }
         }
 
+        const ecoUserMap = {};
+        await Promise.all(topEarners.map(async u => {
+            try {
+                const user = await req.client.users.fetch(u.userId, { force: false });
+                ecoUserMap[u.userId] = { tag: user.tag, avatarUrl: user.displayAvatarURL({ size: 32, extension: 'webp' }) };
+            } catch { /* user not resolvable */ }
+        }));
+
         res.json({
             totalCoins: totalCoinsAgg[0]?.total || 0,
             activeUsers: activeUsersCount,
-            topEarners: topEarners.map(u => ({ userId: u.userId, balance: u.balance, bank: u.bank, total: (u.balance || 0) + (u.bank || 0) })),
+            topEarners: topEarners.map(u => ({
+                userId: u.userId,
+                userTag: ecoUserMap[u.userId]?.tag || null,
+                avatarUrl: ecoUserMap[u.userId]?.avatarUrl || null,
+                balance: u.balance, bank: u.bank,
+                total: (u.balance || 0) + (u.bank || 0)
+            })),
             commandFrequency: Object.entries(commandFrequency).sort((a, b) => b[1] - a[1]).slice(0, 10).map(([cmd, count]) => ({ cmd, count }))
         });
     } catch (error) {

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -220,24 +220,67 @@
                         Modules on
                     </div>
                     <%
-                    var moduleCount = 0;
-                    if (settings.welcome && settings.welcome.enabled) moduleCount++;
-                    if (settings.leveling && settings.leveling.enabled) moduleCount++;
-                    if (settings.economy && settings.economy.enabled) moduleCount++;
-                    if (settings.moderation && settings.moderation.enabled) moduleCount++;
-                    if (settings.ai && settings.ai.enabled) moduleCount++;
-                    if (settings.rss?.enabled || settings.rssFeeds?.length > 0 || settings.dailyNews?.enabled || settings.dailyNewsProfiles?.length > 0) moduleCount++;
+                    var _moduleChecks = [
+                        !!(settings.welcome?.enabled),
+                        !!(settings.farewell?.enabled),
+                        !!(settings.birthdays?.enabled),
+                        !!(settings.moderation?.enabled),
+                        !!(settings.leveling?.enabled),
+                        !!(settings.economy?.enabled),
+                        !!(settings.heist?.enabled),
+                        !!(settings.achievements?.enabled),
+                        !!(settings.raidDetection?.enabled),
+                        !!(settings.antiNuke?.enabled),
+                        !!(settings.starboard?.enabled),
+                        !!(settings.eventLog?.enabled),
+                        !!(settings.quests?.enabled),
+                        !!(settings.newspaper?.enabled),
+                        !!(settings.season?.enabled),
+                        !!(settings.progressionTracks?.enabled),
+                        !!(settings.suggestions?.enabled),
+                        !!(settings.dailyNews?.enabled || settings.rss?.enabled || settings.rssFeeds?.length > 0 || settings.dailyNewsProfiles?.length > 0),
+                        !!(settings.tempVoice?.enabled),
+                        !!(settings.commandPolicies?.enabled),
+                        !!(settings.ai?.enabled),
+                        !!(settings.bibleVerse?.enabled),
+                    ];
+                    var moduleCount = _moduleChecks.filter(Boolean).length;
+                    var totalModules = _moduleChecks.length;
                     %>
                     <div class="dash-kpi-value"><%= moduleCount %></div>
-                    <div class="dash-kpi-meta"><span class="dash-kpi-foot">of 7 modules</span></div>
+                    <div class="dash-kpi-meta"><span class="dash-kpi-foot">of <%= totalModules %> features on</span></div>
                 </div>
                 <div class="dash-kpi feature">
                     <div class="dash-kpi-label">
                         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2L4 14h6l-1 8 9-12h-6l1-8z"/></svg>
                         Bot Status
                     </div>
-                    <div class="dash-kpi-value" style="font-size:34px;">Online</div>
-                    <div class="dash-kpi-meta"><span style="color:var(--good);font-size:12px;font-family:'JetBrains Mono',monospace;">● Active</span></div>
+                    <div class="dash-kpi-value" style="font-size:34px;" id="kpi-bot-value">—</div>
+                    <div class="dash-kpi-meta"><span id="kpi-bot-foot" style="font-size:12px;font-family:'JetBrains Mono',monospace;">checking…</span></div>
+                </div>
+                <div class="dash-kpi" id="kpi-economy-overview">
+                    <div class="dash-kpi-label">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8"/><path d="M10 9h3a2 2 0 0 1 0 4h-3v-4zM10 13v3"/></svg>
+                        Economy
+                    </div>
+                    <div class="dash-kpi-value" id="kpi-eco-value">—</div>
+                    <div class="dash-kpi-meta"><span class="dash-kpi-foot" id="kpi-eco-foot">active users (7d)</span></div>
+                </div>
+                <div class="dash-kpi" id="kpi-leveling-overview">
+                    <div class="dash-kpi-label">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 18l5-5 4 4 5-7 4 3"/></svg>
+                        Leveling
+                    </div>
+                    <div class="dash-kpi-value" id="kpi-level-value">—</div>
+                    <div class="dash-kpi-meta"><span class="dash-kpi-foot" id="kpi-level-foot">top level</span></div>
+                </div>
+                <div class="dash-kpi" id="kpi-ai-overview">
+                    <div class="dash-kpi-label">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l1.6 4.6L18 9l-4.4 1.4L12 15l-1.6-4.6L6 9l4.4-1.4z"/></svg>
+                        AI
+                    </div>
+                    <div class="dash-kpi-value" id="kpi-ai-value">—</div>
+                    <div class="dash-kpi-meta"><span class="dash-kpi-foot" id="kpi-ai-foot">requests (total)</span></div>
                 </div>
             </div>
 
@@ -1057,7 +1100,7 @@
                             <button class="btn btn-sm" onclick="loadEcoHealth()">Retry</button>
                         </div>
                         <table id="eco-top-earners-table" class="cases-table" style="display:none">
-                            <thead><tr><th>Rank</th><th>User ID</th><th>Wallet</th><th>Bank</th><th>Total</th></tr></thead>
+                            <thead><tr><th>Rank</th><th>User</th><th>Wallet</th><th>Bank</th><th>Total</th></tr></thead>
                             <tbody id="eco-top-earners-tbody"></tbody>
                         </table>
 
@@ -1587,7 +1630,17 @@
                     </div>
                     <div class="field-label" style="margin-top:1rem;margin-bottom:.4rem;font-weight:600;">Whitelist <small style="font-weight:400;color:var(--text-dim)">— one ID per line</small></div>
                     <div style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;">
-                        <div><label class="field-label" for="an-whitelist-users">User IDs</label><textarea id="an-whitelist-users" rows="3" placeholder="One user ID per line"><%= (settings.antiNuke?.whitelistUserIds||[]).join('\n') %></textarea></div>
+                        <div>
+                            <label class="field-label">Whitelisted users</label>
+                            <div class="user-search-widget">
+                                <div class="user-tag-list" id="an-whitelist-users-tags"></div>
+                                <div style="position:relative">
+                                    <input type="text" class="user-search-input" placeholder="Search member by name…" autocomplete="off" data-widget="an-whitelist-users">
+                                    <div class="user-search-dropdown" id="an-whitelist-users-dropdown" style="display:none"></div>
+                                </div>
+                                <textarea id="an-whitelist-users" style="display:none"><%= (settings.antiNuke?.whitelistUserIds||[]).join('\n') %></textarea>
+                            </div>
+                        </div>
                         <div><label class="field-label" for="an-whitelist-roles">Role IDs</label><textarea id="an-whitelist-roles" rows="3" placeholder="One role ID per line"><%= (settings.antiNuke?.whitelistRoleIds||[]).join('\n') %></textarea></div>
                     </div>
                     <div class="actions-row"><button class="btn btn-primary" onclick="saveSettings('antinuke')">Save changes</button></div>
@@ -2107,8 +2160,15 @@
                             </div>
                         </div>
                         <div>
-                            <label class="field-label">Exempt user IDs <small>(one per line)</small></label>
-                            <textarea id="cp-exc-users" rows="3" placeholder="One user ID per line"><%= (settings.commandPolicies?.exceptions?.userIds||[]).join('\n') %></textarea>
+                            <label class="field-label">Exempt users</label>
+                            <div class="user-search-widget">
+                                <div class="user-tag-list" id="cp-exc-users-tags"></div>
+                                <div style="position:relative">
+                                    <input type="text" class="user-search-input" placeholder="Search member by name…" autocomplete="off" data-widget="cp-exc-users">
+                                    <div class="user-search-dropdown" id="cp-exc-users-dropdown" style="display:none"></div>
+                                </div>
+                                <textarea id="cp-exc-users" style="display:none"><%= (settings.commandPolicies?.exceptions?.userIds||[]).join('\n') %></textarea>
+                            </div>
                         </div>
                     </div>
                     <div class="eco-section-head" style="margin-top:1.25rem;">
@@ -5147,6 +5207,12 @@
                 if (memberFoot) memberFoot.textContent = `${joins7} joined · ${leaves7} left (7d)`;
                 if (memberVal) memberVal.style.color = net7 >= 0 ? 'var(--good)' : 'var(--danger, #e05)';
 
+                // Bot Status KPI
+                const botVal = document.getElementById('kpi-bot-value');
+                const botFoot = document.getElementById('kpi-bot-foot');
+                if (botVal) { botVal.textContent = 'Online'; botVal.style.fontSize = '34px'; }
+                if (botFoot) { botFoot.textContent = '● Active'; botFoot.style.color = 'var(--good)'; }
+
                 // Moderation KPI
                 const modCmds = ['warn','mute','kick','ban','timeout','unmute','unban'];
                 const modTotal = modCmds.reduce((sum, cmd) => sum + (a.commandUsage?.[cmd]?.total || 0), 0);
@@ -5154,6 +5220,26 @@
                 const modFoot = document.getElementById('kpi-mod-foot');
                 if (modVal) modVal.textContent = modTotal;
                 if (modFoot) modFoot.textContent = modTotal === 1 ? 'action this week' : 'actions this week';
+
+                // Economy KPI
+                const ecoActive = a.economyStats?.activeUsers ?? 0;
+                const ecoVal = document.getElementById('kpi-eco-value');
+                if (ecoVal) ecoVal.textContent = ecoActive.toLocaleString();
+
+                // Leveling KPI
+                const topLevel = stats.topLevels?.[0]?.level ?? 0;
+                const levelVal = document.getElementById('kpi-level-value');
+                const levelFoot = document.getElementById('kpi-level-foot');
+                if (levelVal) levelVal.textContent = topLevel;
+                if (levelFoot) levelFoot.textContent = topLevel ? 'highest member level' : 'no levels yet';
+
+                // AI KPI
+                const aiCmds = ['ask', 'ai', 'chat', 'aiask', 'clawdia'];
+                const aiTotal = aiCmds.reduce((sum, cmd) => sum + (a.commandUsage?.[cmd]?.total || 0), 0);
+                const aiVal = document.getElementById('kpi-ai-value');
+                const aiFoot = document.getElementById('kpi-ai-foot');
+                if (aiVal) aiVal.textContent = aiTotal.toLocaleString();
+                if (aiFoot) aiFoot.textContent = aiTotal === 1 ? 'AI request' : 'AI requests';
 
                 // Ask Clawdia recommendations
                 const recs = a.recommendations || [];
@@ -5211,8 +5297,12 @@
                 if (actionsEl) actionsEl.innerHTML = `<button class="dash-bot-btn" onclick="document.querySelector('.nav-item[data-tab=analytics]').click()">Open Analytics →</button>`;
                 const memberVal = document.getElementById('kpi-members-value');
                 const modVal = document.getElementById('kpi-mod-value');
+                const botVal2 = document.getElementById('kpi-bot-value');
+                const botFoot2 = document.getElementById('kpi-bot-foot');
                 if (memberVal) memberVal.textContent = '—';
                 if (modVal) modVal.textContent = '—';
+                if (botVal2) { botVal2.textContent = 'Online'; botVal2.style.fontSize = '34px'; }
+                if (botFoot2) { botFoot2.textContent = '● Active'; botFoot2.style.color = 'var(--good)'; }
                 const feed = document.getElementById('overview-activity-feed');
                 if (feed) feed.innerHTML = '<span style="opacity:.4;font-size:.85em">Could not load activity data.</span>';
             }
@@ -5631,11 +5721,17 @@
                 tbody.innerHTML = '';
                 for (const c of cases) {
                     const date = new Date(c.createdAt).toLocaleDateString();
+                    const targetCell = c.targetUserTag
+                        ? `<span title="${escHtml(c.targetUserId)}">${c.targetAvatarUrl ? `<img src="${escHtml(c.targetAvatarUrl)}" style="width:16px;height:16px;border-radius:50%;margin-right:4px;vertical-align:middle" onerror="this.style.display='none'">` : ''}${escHtml(c.targetUserTag)}</span>`
+                        : `<span style="font-size:.8em">${escHtml(c.targetUserId)}</span>`;
+                    const modCell = c.moderatorTag
+                        ? `<span title="${escHtml(c.moderatorId)}">${escHtml(c.moderatorTag)}</span>`
+                        : `<span style="font-size:.8em">${escHtml(c.moderatorId)}</span>`;
                     tbody.insertAdjacentHTML('beforeend', `<tr>
                         <td>#${c.caseId}</td>
-                        <td style="font-size:.8em">${c.targetUserId}</td>
+                        <td>${targetCell}</td>
                         <td><span class="case-type-badge type-${c.type}">${c.type}</span></td>
-                        <td style="font-size:.8em">${c.moderatorId}</td>
+                        <td>${modCell}</td>
                         <td>${date}</td>
                         <td><span class="case-status-badge status-${c.status}">${c.status}</span></td>
                         <td style="display:flex;gap:.35rem;flex-wrap:wrap">
@@ -5723,7 +5819,10 @@
                 tbody.innerHTML = '';
                 for (let i = 0; i < (stats.topEarners || []).length; i++) {
                     const u = stats.topEarners[i];
-                    tbody.insertAdjacentHTML('beforeend', `<tr><td>#${i+1}</td><td style="font-size:.8em">${u.userId}</td><td>${(u.balance||0).toLocaleString()}</td><td>${(u.bank||0).toLocaleString()}</td><td>${(u.total||0).toLocaleString()}</td></tr>`);
+                    const userCell = u.userTag
+                        ? `<span title="${escHtml(u.userId)}">${u.avatarUrl ? `<img src="${escHtml(u.avatarUrl)}" style="width:16px;height:16px;border-radius:50%;margin-right:4px;vertical-align:middle" onerror="this.style.display='none'">` : ''}${escHtml(u.userTag)}</span>`
+                        : `<span style="font-size:.8em">${escHtml(u.userId)}</span>`;
+                    tbody.insertAdjacentHTML('beforeend', `<tr><td>#${i+1}</td><td>${userCell}</td><td>${(u.balance||0).toLocaleString()}</td><td>${(u.bank||0).toLocaleString()}</td><td>${(u.total||0).toLocaleString()}</td></tr>`);
                 }
                 document.getElementById('eco-top-earners-table').style.display = '';
                 // Command frequency chart
@@ -5793,6 +5892,95 @@
                 document.querySelectorAll('#eco-tab-health .btn').forEach(b => b.disabled = false);
             }
         }
+
+        // ── User search widget ────────────────────────────────────────────────
+        (function() {
+            const _gId = '<%= guild.id %>';
+
+            function initUserSearchWidget(widgetId) {
+                const textarea = document.getElementById(widgetId);
+                const tagsEl   = document.getElementById(widgetId + '-tags');
+                const dropdown = document.getElementById(widgetId + '-dropdown');
+                const input    = document.querySelector(`.user-search-input[data-widget="${widgetId}"]`);
+                if (!textarea || !tagsEl || !input || !dropdown) return;
+
+                const existingIds = textarea.value.split('\n').map(s => s.trim()).filter(Boolean);
+                if (existingIds.length) {
+                    fetch(`/api/guild/${_gId}/members/resolve?ids=${existingIds.join(',')}`)
+                        .then(r => r.json())
+                        .then(map => {
+                            for (const id of existingIds) {
+                                const info = map[id];
+                                _addUserTag(widgetId, id, info?.displayName || info?.username || id, info?.avatarURL || null);
+                            }
+                        })
+                        .catch(() => { for (const id of existingIds) _addUserTag(widgetId, id, id, null); });
+                }
+
+                let _debounce;
+                input.addEventListener('input', function() {
+                    clearTimeout(_debounce);
+                    const q = this.value.trim();
+                    if (q.length < 2) { dropdown.style.display = 'none'; return; }
+                    _debounce = setTimeout(async () => {
+                        try {
+                            const results = await fetch(`/api/guild/${_gId}/members/search?q=${encodeURIComponent(q)}`).then(r => r.json());
+                            if (!Array.isArray(results) || !results.length) { dropdown.style.display = 'none'; return; }
+                            dropdown.innerHTML = results.map(u => {
+                                const name = escHtml(u.displayName || u.username);
+                                const id   = escHtml(u.id);
+                                const av   = u.avatarURL ? escHtml(u.avatarURL) : '';
+                                return `<div class="user-search-item" data-id="${id}" data-name="${name}" data-avatar="${av}">
+                                    ${av ? `<img src="${av}" style="width:20px;height:20px;border-radius:50%" onerror="this.style.display='none'">` : ''}
+                                    <span>${name}</span>
+                                    <span style="opacity:.5;font-size:.75em;margin-left:auto">${escHtml(u.username)}</span>
+                                </div>`;
+                            }).join('');
+                            dropdown.style.display = '';
+                            dropdown.querySelectorAll('.user-search-item').forEach(el => {
+                                el.addEventListener('mousedown', function(e) {
+                                    e.preventDefault();
+                                    _addUserTag(widgetId, this.dataset.id, this.dataset.name, this.dataset.avatar || null);
+                                    input.value = '';
+                                    dropdown.style.display = 'none';
+                                });
+                            });
+                        } catch { dropdown.style.display = 'none'; }
+                    }, 280);
+                });
+
+                input.addEventListener('blur', () => setTimeout(() => { dropdown.style.display = 'none'; }, 150));
+            }
+
+            function _addUserTag(widgetId, id, name, avatarUrl) {
+                const textarea = document.getElementById(widgetId);
+                const tagsEl   = document.getElementById(widgetId + '-tags');
+                if (!textarea || !tagsEl) return;
+                const existing = textarea.value.split('\n').map(s => s.trim()).filter(Boolean);
+                if (existing.includes(id)) return;
+                const tag = document.createElement('span');
+                tag.className = 'user-id-tag';
+                tag.dataset.userId = id;
+                const safeId   = escHtml(id);
+                const safeName = escHtml(name);
+                const safeAv   = avatarUrl ? escHtml(avatarUrl) : '';
+                tag.innerHTML  = `${safeAv ? `<img src="${safeAv}" style="width:16px;height:16px;border-radius:50%" onerror="this.style.display='none'">` : ''}<span title="${safeId}">${safeName}</span><button type="button" title="Remove">&times;</button>`;
+                tag.querySelector('button').addEventListener('click', function() {
+                    const ta = document.getElementById(widgetId);
+                    if (ta) ta.value = ta.value.split('\n').map(s => s.trim()).filter(s => s && s !== id).join('\n');
+                    tag.remove();
+                });
+                tagsEl.appendChild(tag);
+                textarea.value = [...existing, id].join('\n');
+            }
+
+            window._initUserSearchWidgets = function() {
+                initUserSearchWidget('an-whitelist-users');
+                initUserSearchWidget('cp-exc-users');
+            };
+            // Init when DOM is ready (script runs at end of body)
+            _initUserSearchWidgets();
+        })();
 
     </script>
 </body>


### PR DESCRIPTION
Closes #455, #456

- Module count KPI now checks all 22 toggleable features dynamically
  instead of hardcoding "of 7 modules"
- Bot Status KPI value is now set by JS (no longer static HTML)
- Three new overview KPI tiles: Economy active users (7d), top member
  level, and AI request count — all sourced from the existing stats API
- Cases table: /api/guild/:guildId/cases now resolves targetUserId and
  moderatorId to Discord usernames (avatar + tag) server-side; raw IDs
  shown as title tooltip fallback
- Economy Top 10 table: /api/guild/:guildId/economy/stats now resolves
  userId to username + avatar; table header changed from "User ID" to "User"
- New GET /api/guild/:guildId/members/resolve endpoint for batch-resolving
  up to 50 Discord user IDs to display names
- Anti-nuke whitelist and Command Policies exempt-users fields replaced
  with member-search tag widgets: type a name, pick from dropdown, IDs
  stored in hidden textarea so existing save logic is unchanged

https://claude.ai/code/session_01TK6JGX2cdScozxN63umgaz