### PR TITLE
Fix include paths in economy panel template

### DIFF
--- a/src/dashboard/views/partials/panels/economy.ejs
+++ b/src/dashboard/views/partials/panels/economy.ejs
@@ -225,7 +225,7 @@
                             <p class="ai-inner-desc">Weapons used for hunting. Tier 1–12 progression.</p>
                             <div class="game-items-grid">
                                 <% huntItems.weapons.forEach(function(item){ %>
-                                <%- include('partials/game-item-card', { item: item }) %>
+                                <%- include('../game-item-card', { item: item }) %>
                                 <% }); %>
                             </div>
                         </div>
@@ -233,7 +233,7 @@
                             <p class="ai-inner-desc">Permanent module upgrades installed on weapons.</p>
                             <div class="game-items-grid">
                                 <% huntItems.upgrades.forEach(function(item){ %>
-                                <%- include('partials/game-item-card', { item: item }) %>
+                                <%- include('../game-item-card', { item: item }) %>
                                 <% }); %>
                             </div>
                         </div>
@@ -241,7 +241,7 @@
                             <p class="ai-inner-desc">Ammunition packs consumed during hunts.</p>
                             <div class="game-items-grid">
                                 <% huntItems.ammo.forEach(function(item){ %>
-                                <%- include('partials/game-item-card', { item: item }) %>
+                                <%- include('../game-item-card', { item: item }) %>
                                 <% }); %>
                             </div>
                         </div>
@@ -249,7 +249,7 @@
                             <p class="ai-inner-desc">One-time use consumables for hunt boosts.</p>
                             <div class="game-items-grid">
                                 <% huntItems.consumables.forEach(function(item){ %>
-                                <%- include('partials/game-item-card', { item: item }) %>
+                                <%- include('../game-item-card', { item: item }) %>
                                 <% }); %>
                             </div>
                         </div>
@@ -271,7 +271,7 @@
                             <p class="ai-inner-desc">Fishing rods used to catch fish. Tier 1–5 progression.</p>
                             <div class="game-items-grid">
                                 <% fishItems.rods.forEach(function(item){ %>
-                                <%- include('partials/game-item-card', { item: item }) %>
+                                <%- include('../game-item-card', { item: item }) %>
                                 <% }); %>
                             </div>
                         </div>
@@ -279,7 +279,7 @@
                             <p class="ai-inner-desc">Permanent module upgrades for rods.</p>
                             <div class="game-items-grid">
                                 <% fishItems.upgrades.forEach(function(item){ %>
-                                <%- include('partials/game-item-card', { item: item }) %>
+                                <%- include('../game-item-card', { item: item }) %>
                                 <% }); %>
                             </div>
                         </div>
@@ -287,7 +287,7 @@
                             <p class="ai-inner-desc">Bait packs used when fishing.</p>
                             <div class="game-items-grid">
                                 <% fishItems.bait.forEach(function(item){ %>
-                                <%- include('partials/game-item-card', { item: item }) %>
+                                <%- include('../game-item-card', { item: item }) %>
                                 <% }); %>
                             </div>
                         </div>
@@ -295,7 +295,7 @@
                             <p class="ai-inner-desc">One-time use consumables for fishing boosts.</p>
                             <div class="game-items-grid">
                                 <% fishItems.consumables.forEach(function(item){ %>
-                                <%- include('partials/game-item-card', { item: item }) %>
+                                <%- include('../game-item-card', { item: item }) %>
                                 <% }); %>
                             </div>
                         </div>
@@ -317,7 +317,7 @@
                             <p class="ai-inner-desc">Pickaxes used for mining. Tier 1–5 progression.</p>
                             <div class="game-items-grid">
                                 <% mineItems.pickaxes.forEach(function(item){ %>
-                                <%- include('partials/game-item-card', { item: item }) %>
+                                <%- include('../game-item-card', { item: item }) %>
                                 <% }); %>
                             </div>
                         </div>
@@ -325,7 +325,7 @@
                             <p class="ai-inner-desc">Permanent module upgrades for pickaxes.</p>
                             <div class="game-items-grid">
                                 <% mineItems.upgrades.forEach(function(item){ %>
-                                <%- include('partials/game-item-card', { item: item }) %>
+                                <%- include('../game-item-card', { item: item }) %>
                                 <% }); %>
                             </div>
                         </div>
@@ -333,7 +333,7 @@
                             <p class="ai-inner-desc">Blast charge packs used when mining.</p>
                             <div class="game-items-grid">
                                 <% mineItems.blasts.forEach(function(item){ %>
-                                <%- include('partials/game-item-card', { item: item }) %>
+                                <%- include('../game-item-card', { item: item }) %>
                                 <% }); %>
                             </div>
                         </div>
@@ -341,7 +341,7 @@
                             <p class="ai-inner-desc">One-time use consumables for mining boosts.</p>
                             <div class="game-items-grid">
                                 <% mineItems.consumables.forEach(function(item){ %>
-                                <%- include('partials/game-item-card', { item: item }) %>
+                                <%- include('../game-item-card', { item: item }) %>
                                 <% }); %>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
Corrected relative include paths in the economy dashboard panel template to properly reference the game-item-card partial component.

## Changes
- Updated 12 include statements from `'partials/game-item-card'` to `'../game-item-card'` across hunting, fishing, and mining item sections
- Fixes incorrect relative path references that were looking for the partial in a non-existent subdirectory

## Details
The original paths attempted to include `partials/game-item-card` from within the panels directory, but the actual file structure requires going up one level (`../`) to access the game-item-card partial. This change ensures all item card renders in the economy panel correctly locate and include the shared component.

https://claude.ai/code/session_01Cr7e2pY9VkBSnFULEiorkj