### PR TITLE
Add World Exploration system: /explore, /map, regions, secrets, and dashboard panel

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -183,7 +183,8 @@ Set a moderation log channel to track:
 Narrated expeditions in Clawdia's voice. Players set out into distinct regions, each with its own weighted event table — encounters, discoveries, traps, treasure, lore fragments, and rare secrets.
 
 **Commands:**
-```
+
+```text
 /explore go [region]   - Set out on an expedition (1 stamina, 60s cooldown)
 /explore travel        - Unlock and move between regions
 /explore regions       - Browse every region, requirements, and progress

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -178,6 +178,35 @@ Set a moderation log channel to track:
 - Work reward range (min-max)
 - Wheel of Fortune: enable/disable, cooldown hours, extra spin cost
 
+### World Exploration
+
+Narrated expeditions in Clawdia's voice. Players set out into distinct regions, each with its own weighted event table — encounters, discoveries, traps, treasure, lore fragments, and rare secrets.
+
+**Commands:**
+```
+/explore go [region]   - Set out on an expedition (1 stamina, 60s cooldown)
+/explore travel        - Unlock and move between regions
+/explore regions       - Browse every region, requirements, and progress
+/explore journal       - Reread your most recent finds
+/explore profile       - Explorer level, stamina, and field record
+/explore map  or  /map - Unroll your persistent Explorer's Map
+```
+
+**Regions:**
+- Core: Whispering Forest → Crumbling Ruins → Crystal Caves → Sunken Docks (level + coin gated, rising payouts)
+- Seasonal: Frostveil Pass (winter), Hollowgrave Lane (spooky), Scorchglass Shore (summer), The Velvet Arcade (Valentine's) — open only while their seasonal event runs and they drop event currency for the event shop
+
+**Integration:**
+- Treasure coins feed the economy (transaction-logged, daily-capped); relics land in `/inventory`
+- Expeditions grant Explorer XP and mirror guild leveling XP
+- Rare finds unlock exploration achievements (including secret ones)
+- The Explorer's Map persists per player: landmarks, lore, and secrets charted per region
+
+**Dashboard Settings:**
+- Enable/disable exploration, per-region toggles
+- Payout multiplier and rare-event bonus knobs
+- Secret discovery announcements
+
 ## 👋 Welcome System
 
 ### Features

--- a/src/commands/community/achievements.js
+++ b/src/commands/community/achievements.js
@@ -5,7 +5,7 @@ const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { ACHIEVEMENTS, CATEGORY_LABELS, CATEGORY_EMOJIS } = require('../../data/achievements');
 
-const CATEGORY_ORDER = ['economy', 'leveling', 'hunt', 'fishing', 'community', 'moderation', 'custom'];
+const CATEGORY_ORDER = ['economy', 'leveling', 'hunt', 'fishing', 'exploration', 'community', 'moderation', 'custom'];
 
 module.exports = {
     data: new SlashCommandBuilder()

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -32,6 +32,7 @@ const {
     getEventXpMultiplier, getEventCoinMultiplier,
     hasActiveEvent, getEventCurrencyId, addEventCurrency,
 } = require('../../services/seasonalEventService');
+const { SEASONAL_EVENTS } = require('../../data/seasonalEvents');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
 const { logTransaction } = require('../../utils/logTransaction');
 const { logBigWin } = require('../../utils/bigWinLogger');
@@ -405,8 +406,7 @@ function buildResultEmbed(result, region, user, currency, eventDrop, mainXp, fir
     if (result.xp > 0)      gains.push(`+${result.xp} Explorer XP`);
     if (mainXp > 0)         gains.push(`+${mainXp} XP`);
     if (eventDrop) {
-        const ev = require('../../data/seasonalEvents').SEASONAL_EVENTS;
-        const def = Object.values(ev).find(s => s.currency?.id === eventDrop.currencyId);
+        const def = Object.values(SEASONAL_EVENTS).find(s => s.currency?.id === eventDrop.currencyId);
         gains.push(`+${eventDrop.amount} ${def?.currency?.emoji ?? '🎟️'} ${def?.currency?.name ?? eventDrop.currencyId}`);
     }
     if (gains.length) embed.addFields({ name: '🎒 The Haul', value: gains.join('  ·  '), inline: false });

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -1,0 +1,669 @@
+'use strict';
+
+const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const User  = require('../../models/User');
+const Guild = require('../../models/Guild');
+const {
+    LIMITS, EXPLORER_LEVELS, TIER_COLORS, REGIONS, REGION_LIST,
+    FOOTER_LINES, INJURY_LINES,
+} = require('../../data/exploreData');
+const {
+    ensureExploreData,
+    applyStaminaRegen,
+    applyDailyReset,
+    msUntilNextStamina,
+    getLevelData,
+    xpToNextLevel,
+    getRegionProgress,
+    isRegionInSeason,
+    isRegionEnabled,
+    getAvailableRegions,
+    executeExplore,
+    resolveEncounter,
+    addJournalEntry,
+    regionCompletion,
+    renderMap,
+    randomFrom,
+    formatMs,
+} = require('../../services/exploreService');
+const { checkAndAward, announceAchievements } = require('../../services/achievementService');
+const { applyXpGain, announceLevelUp } = require('../../utils/applyXpGain');
+const {
+    getEventXpMultiplier, getEventCoinMultiplier,
+    hasActiveEvent, getEventCurrencyId, addEventCurrency,
+} = require('../../services/seasonalEventService');
+const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
+const { logTransaction } = require('../../utils/logTransaction');
+const { logBigWin } = require('../../utils/bigWinLogger');
+const { progressBar } = require('../../utils/progressBar');
+
+const REGION_CHOICES = REGION_LIST.map(r => ({
+    name: `${r.emoji} ${r.name}${r.seasonalEventId ? ' (seasonal)' : ''}`,
+    value: r.id,
+}));
+
+const EVENT_TYPE_EMOJI = {
+    discovery: '🗿', lore: '📜', secret: '✨', treasure: '🪙',
+    trap: '🪤', encounter: '👁️', quiet: '🌫️',
+};
+
+module.exports = {
+    cooldown: 5,
+
+    data: new SlashCommandBuilder()
+        .setName('explore')
+        .setDescription('World exploration: set out into the wilds, chart your map, and find what hides there.')
+        .addSubcommand(sub =>
+            sub.setName('go')
+                .setDescription('Set out on an expedition. Uses 1 stamina. Cooldown: 60s.')
+                .addStringOption(o =>
+                    o.setName('region')
+                        .setDescription('Region to explore (defaults to your active region)')
+                        .setRequired(false)
+                        .addChoices(...REGION_CHOICES)))
+        .addSubcommand(sub =>
+            sub.setName('map')
+                .setDescription("View your Explorer's Map — every region, landmark, and secret you've charted."))
+        .addSubcommand(sub =>
+            sub.setName('travel')
+                .setDescription('Travel to a region (unlocking it first if needed) and make it your active region.')
+                .addStringOption(o =>
+                    o.setName('region')
+                        .setDescription('Destination region')
+                        .setRequired(true)
+                        .addChoices(...REGION_CHOICES)))
+        .addSubcommand(sub =>
+            sub.setName('regions')
+                .setDescription('Browse every known region — requirements, season windows, and your progress.'))
+        .addSubcommand(sub =>
+            sub.setName('journal')
+                .setDescription('Reread your expedition journal — your most recent finds, in order.'))
+        .addSubcommand(sub =>
+            sub.setName('profile')
+                .setDescription("View your or another wanderer's explorer profile")
+                .addUserOption(o =>
+                    o.setName('user')
+                        .setDescription('Explorer to inspect')
+                        .setRequired(false))),
+
+    async execute(interaction) {
+        const sub = interaction.options.getSubcommand();
+        if (sub === 'go')      return handleGo(interaction);
+        if (sub === 'map')     return handleMap(interaction);
+        if (sub === 'travel')  return handleTravel(interaction);
+        if (sub === 'regions') return handleRegions(interaction);
+        if (sub === 'journal') return handleJournal(interaction);
+        if (sub === 'profile') return handleProfile(interaction);
+    },
+
+    // Exposed so /map can render the same Explorer's Map
+    handleMap,
+};
+
+// ─── Shared guards ────────────────────────────────────────────────────────────
+
+async function loadContext(interaction) {
+    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    if (guildSettings?.economy?.enabled === false) {
+        await interaction.reply({ content: 'The economy is disabled on this server.', ephemeral: true });
+        return null;
+    }
+    if (guildSettings?.exploration?.enabled === false) {
+        await interaction.reply({ content: 'Exploration is switched off on this server. The wilds will wait — they\'re good at it.', ephemeral: true });
+        return null;
+    }
+    const user = await User.findOneAndUpdate(
+        { userId: interaction.user.id, guildId: interaction.guild.id },
+        { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
+        { upsert: true, new: true }
+    );
+    ensureExploreData(user);
+    return { guildSettings, user, currency: guildSettings?.economy?.currency ?? '💰' };
+}
+
+// Region gate shared by go/travel: returns an error string or null
+function regionGateError(user, region, guildSettings) {
+    const e = user.exploration;
+    if (!region) {
+        return 'I don\'t have that place on any map, and I have several maps.';
+    }
+    if (!isRegionEnabled(region, guildSettings)) {
+        return `**${region.name}** is closed by decree of the server staff. Even the wilds answer to someone.`;
+    }
+    if (region.seasonalEventId && !isRegionInSeason(region, guildSettings)) {
+        return `**${region.emoji} ${region.name}** is out of season. It will be back — that kind of place always comes back. Keep an eye on \`/event status\`.`;
+    }
+    if (!region.seasonalEventId && !e.unlockedRegions.includes(region.id)) {
+        return `You haven't opened the way to **${region.emoji} ${region.name}** yet. Use \`/explore travel\` — it costs **${region.unlockCost.toLocaleString()}** coins and Explorer Level **${region.unlockLevel}**.`;
+    }
+    if (!region.seasonalEventId && e.level < region.unlockLevel) {
+        return `**${region.emoji} ${region.name}** requires Explorer Level **${region.unlockLevel}**. The place isn't going anywhere. You should be, though — go level up.`;
+    }
+    return null;
+}
+
+// ─── GO ───────────────────────────────────────────────────────────────────────
+
+async function handleGo(interaction) {
+    const ctx = await loadContext(interaction);
+    if (!ctx) return;
+    const { guildSettings, user, currency } = ctx;
+
+    applyStaminaRegen(user);
+    applyDailyReset(user);
+    if (user.isModified()) {
+        await user.save().catch(e => console.error('[explore] pre-check save error:', e));
+    }
+
+    const e = user.exploration;
+    const regionId = interaction.options.getString('region') ?? e.activeRegion;
+    const region = REGIONS[regionId];
+
+    const gateError = regionGateError(user, region, guildSettings);
+    if (gateError) return interaction.reply({ content: gateError, ephemeral: true });
+
+    if (e.injuryUntil && Date.now() < e.injuryUntil.getTime()) {
+        return interaction.reply({
+            embeds: [buildCooldownEmbed({
+                title: '🤕 Patching Yourself Up',
+                description: 'The last trap left a mark. The wilds will still be wild when you can walk straight.',
+                color: '#2e7d32',
+                nextAt: new Date(e.injuryUntil.getTime()),
+            })],
+            ephemeral: true,
+        });
+    }
+
+    if (e.lastExplore && Date.now() - e.lastExplore.getTime() < LIMITS.EXPLORE_COOLDOWN_MS) {
+        return interaction.reply({
+            embeds: [buildCooldownEmbed({
+                title: '🥾 Catching Your Breath',
+                description: 'You just got back. Shake the dust off, check your boots for stowaways, then go again.',
+                color: '#2e7d32',
+                nextAt: new Date(e.lastExplore.getTime() + LIMITS.EXPLORE_COOLDOWN_MS),
+                nextRewardPreview: e.sinceSecret >= 10
+                    ? `It's been ${e.sinceSecret} expeditions since your last secret. Something is overdue to find you.`
+                    : 'The map never fills itself in.',
+            })],
+            ephemeral: true,
+        });
+    }
+
+    if (e.stamina <= 0) {
+        return interaction.reply({
+            embeds: [buildCooldownEmbed({
+                title: '😮‍💨 Out of Stamina',
+                description: 'Even legends sleep. Your legs have unionized and their demands are reasonable.',
+                color: '#2e7d32',
+                nextAt: new Date(Date.now() + msUntilNextStamina(user)),
+                nextRewardPreview: 'Stamina regenerates 1 every 5 minutes.',
+            })],
+            ephemeral: true,
+        });
+    }
+
+    // ── Run the expedition ────────────────────────────────────────────────────
+    const coinMultiplier = getEventCoinMultiplier(guildSettings);
+    const result = executeExplore(user, region, guildSettings, { coinMultiplier });
+    const firstVisit = result.firstVisit;
+
+    // Staged narration: the setting-out beat, then the find
+    const delay = ms => new Promise(r => setTimeout(r, ms));
+    await interaction.reply({
+        embeds: [new EmbedBuilder()
+            .setColor(region.color)
+            .setTitle(`${region.emoji} Setting out — ${region.name}`)
+            .setDescription(`*${result.intro}*`)
+            .setFooter({ text: region.tagline })],
+    });
+    await delay(2000);
+
+    // ── Encounter choice ──────────────────────────────────────────────────────
+    if (result.pendingChoice) {
+        const enc = result.encounter;
+        const encId = `explore_${interaction.id}`;
+        const row = new ActionRowBuilder().addComponents(
+            new ButtonBuilder().setCustomId(`${encId}_approach`).setLabel('🤝 Approach').setStyle(ButtonStyle.Primary),
+            new ButtonBuilder().setCustomId(`${encId}_observe`).setLabel('🌿 Keep Your Distance').setStyle(ButtonStyle.Secondary),
+        );
+        await interaction.editReply({
+            embeds: [new EmbedBuilder()
+                .setColor(region.color)
+                .setTitle(`${enc.emoji} ${enc.name}`)
+                .setDescription(`*${enc.intro}*\n\nApproach it, or watch from a safe distance? Bold pays better. Careful always pays.`)
+                .setFooter({ text: '20 seconds to decide. Hesitation counts as keeping your distance, which is honest of it.' })],
+            components: [row],
+        });
+        const msg = await interaction.fetchReply();
+        const choice = await new Promise(resolve => {
+            const col = msg.createMessageComponentCollector({
+                filter: i => i.user.id === interaction.user.id && i.customId.startsWith(encId),
+                time: 20_000,
+                max: 1,
+            });
+            col.on('collect', async i => { await i.deferUpdate(); resolve(i.customId.endsWith('_approach') ? 'approach' : 'observe'); });
+            col.on('end', (_, reason) => { if (reason !== 'limit') resolve(null); });
+        });
+        resolveEncounter(user, region, guildSettings, result, choice);
+    }
+
+    // ── Cross-system rewards ──────────────────────────────────────────────────
+    // Seasonal event currency: a real handful in the seasonal region, loose
+    // change anywhere else while an event runs.
+    let eventDrop = null;
+    const currencyId = getEventCurrencyId(guildSettings);
+    if (currencyId && hasActiveEvent(guildSettings)) {
+        const range = region.eventCurrency ?? { min: 1, max: 2 };
+        const amount = Math.floor(Math.random() * (range.max - range.min + 1)) + range.min;
+        addEventCurrency(user, currencyId, amount);
+        eventDrop = { currencyId, amount };
+    }
+
+    // Guild leveling XP mirrors half the explorer XP
+    const mainXp = Math.floor((result.xp ?? 0) * 0.5 * getEventXpMultiplier(guildSettings));
+    let leveledUp = false;
+    if (mainXp > 0) {
+        ({ leveled: leveledUp } = applyXpGain(user, mainXp));
+    }
+
+    // Journal
+    addJournalEntry(user, region.id, result.type, summarizeResult(result, currency));
+
+    // Achievements (checked against the freshly mutated user doc)
+    const newAchievements = await checkAndAward(user, guildSettings).catch(() => []);
+
+    try {
+        await user.save();
+    } catch (err) {
+        if (err.name === 'VersionError') {
+            return interaction.editReply({ content: 'A simultaneous request tangled your expedition log. Try `/explore go` again.', embeds: [], components: [] });
+        }
+        console.error('[explore] save error:', err);
+        return interaction.editReply({ content: 'Something went wrong writing your expedition down. Try again.', embeds: [], components: [] });
+    }
+
+    if (newAchievements.length) {
+        announceAchievements(interaction.client, guildSettings, user, interaction.member, newAchievements).catch(() => null);
+    }
+    if (leveledUp) {
+        announceLevelUp(user, guildSettings, interaction.member, interaction.guild, interaction.channel).catch(() => null);
+    }
+
+    // Transaction audit log
+    if (result.payout > 0) {
+        logTransaction({ userId: user.userId, guildId: user.guildId, type: 'explore', amount: result.payout, balance: user.balance, note: `${region.name} · ${result.type}` });
+    } else if (result.penalty > 0) {
+        logTransaction({ userId: user.userId, guildId: user.guildId, type: 'explore', amount: -result.penalty, balance: user.balance, note: `${region.name} · ${result.type}` });
+    }
+
+    // Big-win feed for legendary treasure and secrets
+    if (result.payout > 0 && (result.treasureTier?.tier === 'legendary' || result.type === 'secret')) {
+        logBigWin({ guildId: interaction.guild.id, userId: interaction.user.id, username: interaction.user.username, amount: result.payout, source: 'explore', details: result.secret?.name ?? `${region.name} legendary treasure` });
+    }
+
+    // ── Result embed ──────────────────────────────────────────────────────────
+    const embed = buildResultEmbed(result, region, user, currency, eventDrop, mainXp, firstVisit);
+    await interaction.editReply({ embeds: [embed], components: [] });
+
+    // Server-wide whisper for secrets
+    if (result.type === 'secret' && guildSettings?.exploration?.announceSecrets !== false) {
+        const channelId = guildSettings?.economy?.announcementChannelId;
+        const resolved = channelId ? interaction.guild.channels.cache.get(channelId) : null;
+        const announceChannel = resolved?.isTextBased() ? resolved : interaction.channel;
+        announceChannel.send({
+            embeds: [new EmbedBuilder()
+                .setColor('#FFD700')
+                .setTitle('✨ A Secret Has Been Found')
+                .setDescription(
+                    `<@${interaction.user.id}> just uncovered **${result.secret.name}** in ${region.emoji} **${region.name}**.\n\n` +
+                    `*The map has fewer blank spaces tonight. The blank spaces are taking it personally.*`
+                )
+                .setTimestamp()],
+        }).catch(() => null);
+    }
+}
+
+function summarizeResult(result, currency) {
+    switch (result.type) {
+        case 'discovery': return `Charted ${result.landmark.name}`;
+        case 'lore':      return `Recovered a lore fragment`;
+        case 'secret':    return `Uncovered the secret: ${result.secret.name}`;
+        case 'treasure':  return `${result.relic ? `Recovered ${result.relic.itemId} and ` : ''}hauled ${currency}${result.payout.toLocaleString()} in treasure`;
+        case 'trap':      return `Sprang ${result.trap.name} (−${currency}${(result.penalty ?? 0).toLocaleString()})`;
+        case 'encounter': return result.outcome === 'win'
+            ? `Faced ${result.encounter.name} and came out ahead`
+            : result.outcome === 'safe'
+                ? `Watched ${result.encounter.name} from a respectful distance`
+                : `Faced ${result.encounter.name} and paid the tuition`;
+        default:          return 'A long, quiet walk';
+    }
+}
+
+function buildResultEmbed(result, region, user, currency, eventDrop, mainXp, firstVisit) {
+    const e = user.exploration;
+    const embed = new EmbedBuilder().setTimestamp();
+    const lines = [];
+
+    switch (result.type) {
+        case 'discovery':
+            embed.setColor(region.color).setTitle(`🗿 Landmark Charted — ${result.landmark.name}`);
+            lines.push(`*${result.landmark.line}*`);
+            break;
+        case 'lore':
+            embed.setColor('#b39ddb').setTitle('📜 Lore Fragment Recovered');
+            lines.push(`*You find words someone meant to be found:*`, '', `> ${result.lore.text}`);
+            break;
+        case 'secret':
+            embed.setColor('#FFD700').setTitle(`✨ SECRET UNCOVERED — ${result.secret.name}`);
+            lines.push(`*${result.secret.reveal}*`);
+            break;
+        case 'treasure': {
+            const tier = result.treasureTier;
+            embed.setColor(TIER_COLORS[tier.tier] ?? region.color)
+                .setTitle(`🪙 Treasure — ${tier.tier.charAt(0).toUpperCase() + tier.tier.slice(1)} ${tier.stars}`);
+            lines.push(`*${result.treasureLine}*`);
+            if (result.relic) {
+                lines.push('', `🏺 **Relic recovered: ${result.relic.itemId}**`, `> *${result.relic.lore}*`, `> It's in your \`/inventory\` now. It was always going to end up there.`);
+            }
+            break;
+        }
+        case 'trap':
+            embed.setColor('#b5651d').setTitle(`🪤 Trap — ${result.trap.name}`);
+            lines.push(`*${result.trap.line}*`);
+            if (result.injured) lines.push('', `🤕 *${randomFrom(INJURY_LINES)}* (10 min)`);
+            break;
+        case 'encounter': {
+            const enc = result.encounter;
+            if (result.outcome === 'win') {
+                embed.setColor('#00CC55').setTitle(`${enc.emoji} ${enc.name} — Well Played`);
+                lines.push(`*${enc.winLine}*`);
+            } else if (result.outcome === 'safe') {
+                embed.setColor(region.color).setTitle(`${enc.emoji} ${enc.name} — Watched From the Ferns`);
+                lines.push(`*${enc.safeLine}*`);
+            } else {
+                embed.setColor('#CC4400').setTitle(`${enc.emoji} ${enc.name} — That Went Differently`);
+                lines.push(`*${enc.loseLine}*`);
+                if (result.injured) lines.push('', `🤕 *${randomFrom(INJURY_LINES)}* (10 min)`);
+            }
+            break;
+        }
+        default:
+            embed.setColor('#78909c').setTitle('🌫️ A Quiet Expedition');
+            lines.push(`*${result.quietLine}*`);
+            break;
+    }
+
+    if (firstVisit) {
+        lines.push('', `🗺️ **New region charted: ${region.emoji} ${region.name}** — it has a place on your map now. So do its blank spaces.`);
+    }
+
+    embed.setDescription(lines.join('\n'));
+
+    const gains = [];
+    if (result.payout > 0)  gains.push(`+${currency}${result.payout.toLocaleString()}`);
+    if (result.penalty > 0) gains.push(`−${currency}${result.penalty.toLocaleString()}`);
+    if (result.xp > 0)      gains.push(`+${result.xp} Explorer XP`);
+    if (mainXp > 0)         gains.push(`+${mainXp} XP`);
+    if (eventDrop) {
+        const ev = require('../../data/seasonalEvents').SEASONAL_EVENTS;
+        const def = Object.values(ev).find(s => s.currency?.id === eventDrop.currencyId);
+        gains.push(`+${eventDrop.amount} ${def?.currency?.emoji ?? '🎟️'} ${def?.currency?.name ?? eventDrop.currencyId}`);
+    }
+    if (gains.length) embed.addFields({ name: '🎒 The Haul', value: gains.join('  ·  '), inline: false });
+
+    embed.setFooter({ text: `⚡ ${e.stamina}/${LIMITS.MAX_STAMINA} stamina · ${randomFrom(FOOTER_LINES)}` });
+    return embed;
+}
+
+// ─── MAP ──────────────────────────────────────────────────────────────────────
+
+async function handleMap(interaction) {
+    const [userData, guildSettings] = await Promise.all([
+        User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }),
+        Guild.findOne({ guildId: interaction.guild.id }),
+    ]);
+
+    if (!userData?.exploration?.totalExpeditions) {
+        return interaction.reply({
+            content: 'Your map is a blank page with your name on it. Poetic, but useless. `/explore go` fixes that.',
+            ephemeral: true,
+        });
+    }
+
+    ensureExploreData(userData);
+    const e = userData.exploration;
+    const lines = renderMap(userData, guildSettings);
+    const levelData = getLevelData(e.level);
+
+    const embed = new EmbedBuilder()
+        .setColor('#2e7d32')
+        .setTitle(`🗺️ The Explorer's Map — ${interaction.user.username}`)
+        .setDescription(
+            `*Every line on this map cost somebody shoe leather. These lines cost yours.*\n\n` +
+            lines.join('\n\n')
+        )
+        .addFields({
+            name: '🧭 The Tally',
+            value: [
+                `**${levelData.title}** — Explorer Lv ${e.level}`,
+                `🗿 ${e.landmarksDiscovered} landmarks · 📜 ${e.loreCollected} lore · ✨ ${e.secretsFound} secrets · 🏺 ${e.relicsRecovered} relics`,
+                `${e.totalExpeditions.toLocaleString()} expeditions logged`,
+            ].join('\n'),
+            inline: false,
+        })
+        .setFooter({ text: 'The blank spaces aren\'t empty. They\'re waiting.' })
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+// ─── TRAVEL ───────────────────────────────────────────────────────────────────
+
+async function handleTravel(interaction) {
+    const ctx = await loadContext(interaction);
+    if (!ctx) return;
+    const { guildSettings, user, currency } = ctx;
+    const e = user.exploration;
+
+    const region = REGIONS[interaction.options.getString('region')];
+    if (!region) {
+        return interaction.reply({ content: 'I don\'t have that place on any map, and I have several maps.', ephemeral: true });
+    }
+    if (!isRegionEnabled(region, guildSettings)) {
+        return interaction.reply({ content: `**${region.name}** is closed by decree of the server staff.`, ephemeral: true });
+    }
+    if (region.seasonalEventId && !isRegionInSeason(region, guildSettings)) {
+        return interaction.reply({ content: `**${region.emoji} ${region.name}** is out of season. It will return when the calendar does its part.`, ephemeral: true });
+    }
+
+    let unlockLine = '';
+    if (!region.seasonalEventId && !e.unlockedRegions.includes(region.id)) {
+        if (e.level < region.unlockLevel) {
+            return interaction.reply({
+                content: `The way to **${region.emoji} ${region.name}** needs Explorer Level **${region.unlockLevel}**. You're Level **${e.level}**. The road respects experience; go collect some.`,
+                ephemeral: true,
+            });
+        }
+        if (user.balance < region.unlockCost) {
+            return interaction.reply({
+                content: `Opening the route to **${region.emoji} ${region.name}** costs **${currency}${region.unlockCost.toLocaleString()}** — guides, bribes, one very specific key. You have ${currency}${user.balance.toLocaleString()}.`,
+                ephemeral: true,
+            });
+        }
+        user.balance -= region.unlockCost;
+        e.unlockedRegions.push(region.id);
+        unlockLine = `\n\n🔓 Route opened for **${currency}${region.unlockCost.toLocaleString()}**. Money well buried.`;
+        logTransaction({ userId: user.userId, guildId: user.guildId, type: 'explore_unlock', amount: -region.unlockCost, balance: user.balance, note: region.name });
+    }
+
+    e.activeRegion = region.id;
+    user.markModified('exploration');
+    await user.save();
+
+    return interaction.reply({
+        embeds: [new EmbedBuilder()
+            .setColor(region.color)
+            .setTitle(`${region.emoji} Now Exploring: ${region.name}`)
+            .setDescription(`*${region.description}*${unlockLine}`)
+            .setFooter({ text: region.tagline })],
+    });
+}
+
+// ─── REGIONS ──────────────────────────────────────────────────────────────────
+
+async function handleRegions(interaction) {
+    const ctx = await loadContext(interaction);
+    if (!ctx) return;
+    const { guildSettings, user, currency } = ctx;
+    const e = user.exploration;
+
+    const sections = REGION_LIST
+        .filter(r => isRegionEnabled(r, guildSettings))
+        .map(region => {
+            const progress = e.regions.find(r => r.regionId === region.id) ?? null;
+            const pct = progress ? regionCompletion(region, progress) : 0;
+            const active = e.activeRegion === region.id ? ' 🧭 *(active)*' : '';
+
+            let status;
+            if (region.seasonalEventId) {
+                status = isRegionInSeason(region, guildSettings)
+                    ? '🟢 **In season** — open to everyone, free entry, limited time'
+                    : '⚪ Out of season — returns with its event';
+            } else if (e.unlockedRegions.includes(region.id)) {
+                status = e.level >= region.unlockLevel ? '🟢 Open to you' : `🟡 Unlocked, needs Explorer Lv ${region.unlockLevel}`;
+            } else {
+                status = `🔒 Explorer Lv ${region.unlockLevel} + ${currency}${region.unlockCost.toLocaleString()} via \`/explore travel\``;
+            }
+
+            return [
+                `${region.emoji} **${region.name}**${active} — *${region.tagline}*`,
+                `> ${status}`,
+                `> ${progress ? `${pct}% charted · ${progress.expeditions} expeditions` : 'Uncharted'}`,
+            ].join('\n');
+        });
+
+    const embed = new EmbedBuilder()
+        .setColor('#2e7d32')
+        .setTitle('🧭 Known Regions')
+        .setDescription(sections.join('\n\n'))
+        .setFooter({ text: 'Seasonal regions come and go with /event seasons. The core four are always out there, being patient.' })
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+// ─── JOURNAL ──────────────────────────────────────────────────────────────────
+
+async function handleJournal(interaction) {
+    const userData = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+
+    const journal = userData?.exploration?.journal ?? [];
+    if (!journal.length) {
+        return interaction.reply({
+            content: 'Your journal is empty. Every page is still possible. `/explore go` writes the first one.',
+            ephemeral: true,
+        });
+    }
+
+    const lines = journal.slice(0, 12).map(entry => {
+        const region = REGIONS[entry.regionId];
+        const stamp = `<t:${Math.floor(new Date(entry.at).getTime() / 1000)}:R>`;
+        return `${EVENT_TYPE_EMOJI[entry.eventType] ?? '🥾'} ${region?.emoji ?? ''} **${region?.name ?? entry.regionId}** — ${entry.summary} *(${stamp})*`;
+    });
+
+    const embed = new EmbedBuilder()
+        .setColor('#8d6e63')
+        .setTitle(`📔 Expedition Journal — ${interaction.user.username}`)
+        .setDescription(lines.join('\n'))
+        .setFooter({ text: 'The last 20 entries are kept. The rest live in the retelling.' })
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+// ─── PROFILE ──────────────────────────────────────────────────────────────────
+
+async function handleProfile(interaction) {
+    const target = interaction.options.getUser('user') ?? interaction.user;
+    const isSelf = target.id === interaction.user.id;
+
+    const [userData, guildSettings] = await Promise.all([
+        User.findOne({ userId: target.id, guildId: interaction.guild.id }),
+        Guild.findOne({ guildId: interaction.guild.id }),
+    ]);
+
+    if (!userData?.exploration?.totalExpeditions) {
+        return interaction.reply({
+            content: isSelf
+                ? 'You haven\'t set out yet. The wilds have noticed. `/explore go` settles the matter.'
+                : `${target.username} hasn't set a single boot past the gate yet.`,
+            ephemeral: true,
+        });
+    }
+
+    ensureExploreData(userData);
+    if (isSelf) applyStaminaRegen(userData);
+
+    const e = userData.exploration;
+    const currency = guildSettings?.economy?.currency ?? '💰';
+    const levelData = getLevelData(e.level);
+    const toNext = xpToNextLevel(e.level, e.xp);
+    const activeRegion = REGIONS[e.activeRegion];
+    const nextThreshold = EXPLORER_LEVELS.find(l => l.level === e.level + 1)?.xpRequired;
+
+    const stamBar = '⚡'.repeat(e.stamina) + '▪️'.repeat(Math.max(0, LIMITS.MAX_STAMINA - e.stamina));
+    const regenMs = msUntilNextStamina(userData);
+
+    const embed = new EmbedBuilder()
+        .setColor(activeRegion?.color ?? '#2e7d32')
+        .setTitle(`🧭 ${target.username}'s Explorer Profile`)
+        .setThumbnail(target.displayAvatarURL({ dynamic: true }))
+        .addFields(
+            {
+                name: '🥾 Rank',
+                value: `**${levelData.title}** (Level ${e.level})`,
+                inline: true,
+            },
+            {
+                name: '⭐ Explorer XP',
+                value: toNext !== null
+                    ? `${e.xp.toLocaleString()} / ${nextThreshold.toLocaleString()} XP\n${progressBar(e.xp, nextThreshold, 12)}\n${toNext.toLocaleString()} to Level ${e.level + 1}`
+                    : `${e.xp.toLocaleString()} XP — **MAX LEVEL**`,
+                inline: true,
+            },
+            {
+                name: '🗺️ Active Region',
+                value: activeRegion ? `${activeRegion.emoji} ${activeRegion.name}` : 'Unknown',
+                inline: true,
+            },
+            {
+                name: '⚡ Stamina',
+                value: `${stamBar}\n${e.stamina}/${LIMITS.MAX_STAMINA}${e.stamina < LIMITS.MAX_STAMINA ? `\nNext regen: ${formatMs(regenMs)}` : '\nFull!'}`,
+                inline: true,
+            },
+            {
+                name: '💰 Balance',
+                value: `${currency}${userData.balance.toLocaleString()}`,
+                inline: true,
+            },
+            {
+                name: '📊 Field Record',
+                value: [
+                    `Expeditions:     **${e.totalExpeditions.toLocaleString()}**`,
+                    `Total Earned:    **${currency}${e.totalEarned.toLocaleString()}**`,
+                    `Best Haul:       **${currency}${e.bestHaul.toLocaleString()}**`,
+                    `Secrets Found:   **${e.secretsFound}**`,
+                    `Relics:          **${e.relicsRecovered}**`,
+                    `Traps Sprung:    **${e.trapsSprung}** *(we don't judge here. much.)*`,
+                ].join('\n'),
+                inline: false,
+            }
+        )
+        .setTimestamp();
+
+    if (isSelf) {
+        embed.setFooter({ text: `Daily: ${e.dailyExpeditions} expeditions · ${currency}${e.dailyCoins.toLocaleString()} earned (cap: ${currency}${LIMITS.DAILY_HARD_CAP.toLocaleString()})` });
+    }
+
+    return interaction.reply({ embeds: [embed] });
+}

--- a/src/commands/economy/map.js
+++ b/src/commands/economy/map.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const { SlashCommandBuilder } = require('discord.js');
+const { handleMap } = require('./explore');
+
+// /map — a shortcut to the Explorer's Map. Same render as /explore map;
+// cartographers shouldn't have to type subcommands.
+module.exports = {
+    cooldown: 5,
+
+    data: new SlashCommandBuilder()
+        .setName('map')
+        .setDescription("Unroll your Explorer's Map — every region, landmark, and secret you've charted."),
+
+    async execute(interaction) {
+        return handleMap(interaction);
+    },
+};

--- a/src/commands/utility/help.js
+++ b/src/commands/utility/help.js
@@ -30,6 +30,8 @@ const CATEGORIES = [
             { name: 'crime',          description: 'Attempt a crime for coins (40% success, 2.5h cooldown)' },
             { name: 'rob',            description: 'Try to rob another member\'s wallet' },
             { name: 'mine',           description: 'Dig for ore in the mines (2h cooldown)' },
+            { name: 'explore',        description: 'Set out on narrated expeditions — chart regions, find treasure, lore, and secrets' },
+            { name: 'map',            description: "Unroll your Explorer's Map and see every region you've charted" },
             { name: 'hunt',           description: 'Hunt animals, manage gear, quests, zones, and prestige — all in one place' },
             { name: 'craft',          description: 'Craft items from hunting materials' },
             { name: 'fish',           description: 'Fishing: cast lines, manage gear, shop, craft, quests, locations, and prestige' },

--- a/src/dashboard/routes/api.js
+++ b/src/dashboard/routes/api.js
@@ -320,7 +320,7 @@ const ALLOWED_SETTING_PARENTS = new Set([
     'dailyNews', 'dailyNewsProfiles', 'rssFeeds',
     'autoRoles', 'reactionRoles', 'analytics',
     'giveaways', 'notifications',
-    'newspaper', 'heist'
+    'newspaper', 'heist', 'exploration'
 ]);
 
 function isAllowedSettingKey(key) {
@@ -494,6 +494,34 @@ function validateNewspaperUpdate(updates) {
     return null;
 }
 
+// Field-level validation for exploration settings before they reach Mongoose.
+// Returns an error string, or null if valid.
+function validateExplorationUpdate(updates) {
+    for (const [key, value] of Object.entries(updates)) {
+        if (!key.startsWith('exploration.') && key !== 'exploration') continue;
+        const field = key.split('.')[1];
+        if (field === 'enabled' || field === 'announceSecrets') {
+            if (typeof value !== 'boolean') return `exploration.${field} must be a boolean`;
+        }
+        if (field === 'dropRateMultiplier') {
+            if (typeof value !== 'number' || !Number.isFinite(value) || value < 0.1 || value > 5) {
+                return 'exploration.dropRateMultiplier must be a number between 0.1 and 5';
+            }
+        }
+        if (field === 'rareEventBonus') {
+            if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 0.25) {
+                return 'exploration.rareEventBonus must be a number between 0 and 0.25';
+            }
+        }
+        if (field === 'disabledRegions') {
+            if (!Array.isArray(value) || value.some(v => typeof v !== 'string' || v.length > 64)) {
+                return 'exploration.disabledRegions must be an array of region id strings';
+            }
+        }
+    }
+    return null;
+}
+
 function validateHeistUpdate(updates) {
     for (const [key, value] of Object.entries(updates)) {
         if (!key.startsWith('heist.') && key !== 'heist') continue;
@@ -539,6 +567,9 @@ router.post('/guild/:guildId/settings', checkAuth, checkGuildAccess, checkCsrfOr
 
     const heistError = validateHeistUpdate(updates);
     if (heistError) return res.status(400).json({ error: heistError });
+
+    const explorationError = validateExplorationUpdate(updates);
+    if (explorationError) return res.status(400).json({ error: explorationError });
 
     try {
         const guildSettings = await Guild.findOne({ guildId });

--- a/src/dashboard/routes/api.js
+++ b/src/dashboard/routes/api.js
@@ -484,7 +484,7 @@ function validateNewspaperUpdate(updates) {
             if (err) return err;
         }
         if (field === 'quoteChannelIds') {
-            if (!Array.isArray(value)) return 'newspaper.quoteChannelIds must be an array';
+            if (!Array.isArray(value) || value.length > 100) return 'newspaper.quoteChannelIds must be an array of at most 100 channel ids';
             for (const id of value) {
                 const err = validateSnowflakeOrNull(id, 'newspaper.quoteChannelIds entry');
                 if (err) return err;
@@ -514,8 +514,8 @@ function validateExplorationUpdate(updates) {
             }
         }
         if (field === 'disabledRegions') {
-            if (!Array.isArray(value) || value.some(v => typeof v !== 'string' || v.length > 64)) {
-                return 'exploration.disabledRegions must be an array of region id strings';
+            if (!Array.isArray(value) || value.length > 100 || value.some(v => typeof v !== 'string' || v.length > 64)) {
+                return 'exploration.disabledRegions must be an array of at most 100 region id strings';
             }
         }
     }

--- a/src/dashboard/routes/dashboard.js
+++ b/src/dashboard/routes/dashboard.js
@@ -9,6 +9,8 @@ const { ensureDefaultShopItems } = require('../../data/defaultShopItems');
 const { WEAPON_TIERS, AMMO_PACKS, CONSUMABLES: HUNT_CONSUMABLES, WEAPON_UPGRADES } = require('../../data/huntData');
 const { ROD_TIERS, BAIT_PACKS, CONSUMABLES: FISH_CONSUMABLES, ROD_UPGRADES } = require('../../data/fishData');
 const { PICKAXE_TIERS, BLAST_PACKS, CONSUMABLES: MINE_CONSUMABLES, PICKAXE_UPGRADES } = require('../../data/mineData');
+const { REGION_LIST } = require('../../data/exploreData');
+const { SEASONAL_EVENTS } = require('../../data/seasonalEvents');
 
 function checkAuth(req, res, next) {
     if (req.isAuthenticated()) return next();
@@ -150,6 +152,15 @@ async function renderGuildSettings(req, res) {
             consumables: Object.values(MINE_CONSUMABLES).map(c => toItem('mine', c))
         };
 
+        // Canonical exploration region catalog for the dashboard panel —
+        // derived from exploreData so the template never drifts from the game data.
+        const explorationRegions = REGION_LIST.map(r => ({
+            id: r.id,
+            emoji: r.emoji,
+            name: r.name,
+            seasonal: r.seasonalEventId ? (SEASONAL_EVENTS[r.seasonalEventId]?.name ?? r.seasonalEventId) : false,
+        }));
+
         res.render('guild-settings', {
             user: req.user,
             guild: { id: guild.id, name: guild.name, icon: guild.icon, ownerId: guild.ownerId, owner: req.user.id === guild.ownerId },
@@ -164,7 +175,8 @@ async function renderGuildSettings(req, res) {
             builtinAchievements,
             huntItems,
             fishItems,
-            mineItems
+            mineItems,
+            explorationRegions
         });
     } catch (error) {
         console.error('Dashboard error:', error);

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -75,6 +75,7 @@
         <ul class="dash-nav">
             <li class="nav-item" data-tab="achievements" data-keywords="badge milestone unlock reward"><span class="nav-emoji">🏅</span><span>Achievements</span></li>
             <li class="nav-item" data-tab="quests" data-keywords="task challenge daily weekly mission"><span class="nav-emoji">🗺️</span><span>Quests</span></li>
+            <li class="nav-item" data-tab="exploration" data-keywords="explore expedition region map secret treasure relic wilds"><span class="nav-emoji">🥾</span><span>Exploration</span></li>
             <li class="nav-item" data-tab="season" data-keywords="seasonal pass battle tier"><span class="nav-emoji">🏆</span><span>Season Pass</span></li>
             <li class="nav-item" data-tab="progressiontracks" data-keywords="track creator helper raider bonus xp multiplier"><span class="nav-emoji">🧭</span><span>Progression Tracks</span></li>
         </ul>
@@ -151,6 +152,7 @@
         <%- include('partials/panels/starboard') %>
         <%- include('partials/panels/eventlog') %>
         <%- include('partials/panels/quests') %>
+        <%- include('partials/panels/exploration') %>
         <%- include('partials/panels/newspaper') %>
         <%- include('partials/panels/season') %>
         <%- include('partials/panels/progressiontracks') %>
@@ -1145,6 +1147,21 @@
                     'heist.minPlayers':            safeInt('heist-min-players', 2),
                     'heist.jailDurationMinutes':   safeInt('heist-jail', 30),
                     'heist.maxPayout':             safeInt('heist-max-payout', 10000),
+                };
+            } else if (section === 'exploration') {
+                const safeFloat = (id, fallback, min, max) => {
+                    const v = parseFloat(document.getElementById(id).value);
+                    return Number.isFinite(v) ? Math.min(max, Math.max(min, v)) : fallback;
+                };
+                const disabledRegions = Array.from(document.querySelectorAll('.exploration-region'))
+                    .filter(cb => !cb.checked)
+                    .map(cb => cb.dataset.regionId);
+                data = {
+                    'exploration.enabled':            document.getElementById('exploration-enabled').checked,
+                    'exploration.dropRateMultiplier': safeFloat('exploration-droprate', 1, 0.1, 5),
+                    'exploration.rareEventBonus':     safeFloat('exploration-rarebonus', 0, 0, 0.25),
+                    'exploration.announceSecrets':    document.getElementById('exploration-announce-secrets').checked,
+                    'exploration.disabledRegions':    disabledRegions,
                 };
             }
 

--- a/src/dashboard/views/partials/panels/exploration.ejs
+++ b/src/dashboard/views/partials/panels/exploration.ejs
@@ -1,0 +1,60 @@
+<%
+// Region catalog mirrored from src/data/exploreData.js — keep ids in sync.
+const explorationRegions = [
+    { id: 'whispering_forest', emoji: '🌲', name: 'Whispering Forest', seasonal: false },
+    { id: 'crumbling_ruins',   emoji: '🏛️', name: 'Crumbling Ruins',   seasonal: false },
+    { id: 'crystal_caves',     emoji: '💎', name: 'Crystal Caves',     seasonal: false },
+    { id: 'sunken_docks',      emoji: '⚓', name: 'Sunken Docks',      seasonal: false },
+    { id: 'frostveil_pass',    emoji: '❄️', name: 'Frostveil Pass',    seasonal: 'Winter Wonderland' },
+    { id: 'hollowgrave_lane',  emoji: '🎃', name: 'Hollowgrave Lane',  seasonal: 'Spooky Season' },
+    { id: 'scorchglass_shore', emoji: '☀️', name: 'Scorchglass Shore', seasonal: 'Summer Festival' },
+    { id: 'velvet_arcade',     emoji: '💝', name: 'The Velvet Arcade', seasonal: "Valentine's Day" },
+];
+const explorationDisabled = settings.exploration?.disabledRegions || [];
+%>
+                <section id="exploration" class="panel">
+                    <div class="panel-head">
+                        <h2>Exploration</h2>
+                        <p>World exploration sends members on narrated expeditions with <code>/explore</code>. Loot feeds the economy and inventory, XP feeds leveling, and rare finds unlock achievements. The Explorer's Map is visible via <code>/map</code>.</p>
+                    </div>
+                    <label class="toggle">
+                        <span class="toggle-text"><strong>Enable exploration</strong></span>
+                        <span class="switch"><input type="checkbox" id="exploration-enabled" <%= settings.exploration?.enabled !== false ? 'checked' : '' %>><span class="slider"></span></span>
+                    </label>
+
+                    <div class="panel-head" style="margin-top:1.25rem"><h3>Drop rates</h3></div>
+                    <div class="field" style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;">
+                        <div>
+                            <label class="field-label" for="exploration-droprate">Payout multiplier <small>(0.1–5, default 1)</small></label>
+                            <input type="number" id="exploration-droprate" step="0.1" min="0.1" max="5" value="<%= settings.exploration?.dropRateMultiplier ?? 1 %>">
+                            <small>Scales every expedition's coin payout. Raise for a generous server, lower to slow inflation.</small>
+                        </div>
+                        <div>
+                            <label class="field-label" for="exploration-rarebonus">Rare event bonus <small>(0–0.25, default 0)</small></label>
+                            <input type="number" id="exploration-rarebonus" step="0.01" min="0" max="0.25" value="<%= settings.exploration?.rareEventBonus ?? 0 %>">
+                            <small>Shifts the event table away from quiet runs and traps, toward treasure and secrets.</small>
+                        </div>
+                    </div>
+
+                    <label class="toggle" style="margin-top:.75rem">
+                        <span class="toggle-text"><strong>Announce secret discoveries</strong> <small>— posts to the economy announcement channel</small></span>
+                        <span class="switch"><input type="checkbox" id="exploration-announce-secrets" <%= settings.exploration?.announceSecrets !== false ? 'checked' : '' %>><span class="slider"></span></span>
+                    </label>
+
+                    <div class="panel-head" style="margin-top:1.25rem"><h3>Regions</h3></div>
+                    <div class="field">
+                        <small>Unchecked regions are hidden from <code>/explore</code> and the map. Seasonal regions also require their event to be running.</small>
+                        <div style="display:grid;grid-template-columns:1fr 1fr;gap:.5rem;margin-top:.5rem;">
+                            <% explorationRegions.forEach(region => { %>
+                            <label class="toggle">
+                                <span class="toggle-text"><%= region.emoji %> <%= region.name %><% if (region.seasonal) { %> <small>(seasonal — <%= region.seasonal %>)</small><% } %></span>
+                                <span class="switch"><input type="checkbox" class="exploration-region" data-region-id="<%= region.id %>" <%= explorationDisabled.includes(region.id) ? '' : 'checked' %>><span class="slider"></span></span>
+                            </label>
+                            <% }); %>
+                        </div>
+                    </div>
+
+                    <div class="actions-row">
+                        <button class="btn btn-primary" onclick="saveSettings('exploration')">Save changes</button>
+                    </div>
+                </section>

--- a/src/dashboard/views/partials/panels/exploration.ejs
+++ b/src/dashboard/views/partials/panels/exploration.ejs
@@ -1,15 +1,6 @@
 <%
-// Region catalog mirrored from src/data/exploreData.js — keep ids in sync.
-const explorationRegions = [
-    { id: 'whispering_forest', emoji: '🌲', name: 'Whispering Forest', seasonal: false },
-    { id: 'crumbling_ruins',   emoji: '🏛️', name: 'Crumbling Ruins',   seasonal: false },
-    { id: 'crystal_caves',     emoji: '💎', name: 'Crystal Caves',     seasonal: false },
-    { id: 'sunken_docks',      emoji: '⚓', name: 'Sunken Docks',      seasonal: false },
-    { id: 'frostveil_pass',    emoji: '❄️', name: 'Frostveil Pass',    seasonal: 'Winter Wonderland' },
-    { id: 'hollowgrave_lane',  emoji: '🎃', name: 'Hollowgrave Lane',  seasonal: 'Spooky Season' },
-    { id: 'scorchglass_shore', emoji: '☀️', name: 'Scorchglass Shore', seasonal: 'Summer Festival' },
-    { id: 'velvet_arcade',     emoji: '💝', name: 'The Velvet Arcade', seasonal: "Valentine's Day" },
-];
+// Region catalog is injected by the dashboard route (explorationRegions),
+// derived from src/data/exploreData.js so the panel never drifts from game data.
 const explorationDisabled = settings.exploration?.disabledRegions || [];
 %>
                 <section id="exploration" class="panel">

--- a/src/data/achievements.js
+++ b/src/data/achievements.js
@@ -659,6 +659,140 @@ const ACHIEVEMENTS = [
         check: (user) => (user.lifetimeGambled || 0) >= 250_000,
         progress: (user) => [Math.min(user.lifetimeGambled || 0, 250_000), 250_000]
     },
+
+    // ── Exploration ───────────────────────────────────────────────────────────
+    {
+        id: 'first_footsteps',
+        name: 'First Footsteps',
+        description: 'Set out on your first expedition',
+        emoji: '🥾',
+        category: 'exploration',
+        xpReward: 25,
+        coinReward: 100,
+        check: (user) => (user.exploration?.totalExpeditions || 0) >= 1,
+        progress: (user) => [Math.min(user.exploration?.totalExpeditions || 0, 1), 1]
+    },
+    {
+        id: 'wayfarer',
+        name: 'Wayfarer',
+        description: 'Complete 50 expeditions',
+        emoji: '🧭',
+        category: 'exploration',
+        xpReward: 100,
+        coinReward: 750,
+        check: (user) => (user.exploration?.totalExpeditions || 0) >= 50,
+        progress: (user) => [Math.min(user.exploration?.totalExpeditions || 0, 50), 50]
+    },
+    {
+        id: 'no_blank_spaces',
+        name: 'No Blank Spaces',
+        description: 'Complete 250 expeditions',
+        emoji: '🗺️',
+        category: 'exploration',
+        xpReward: 300,
+        coinReward: 4_000,
+        check: (user) => (user.exploration?.totalExpeditions || 0) >= 250,
+        progress: (user) => [Math.min(user.exploration?.totalExpeditions || 0, 250), 250]
+    },
+    {
+        id: 'four_corners',
+        name: 'The Four Corners',
+        description: 'Set foot in all four core regions',
+        emoji: '🌍',
+        category: 'exploration',
+        xpReward: 200,
+        coinReward: 2_000,
+        check: (user) => {
+            const visited = (user.exploration?.regions || []).map(r => r.regionId);
+            return ['whispering_forest', 'crumbling_ruins', 'crystal_caves', 'sunken_docks']
+                .every(id => visited.includes(id));
+        },
+        progress: (user) => {
+            const visited = (user.exploration?.regions || []).map(r => r.regionId);
+            const count = ['whispering_forest', 'crumbling_ruins', 'crystal_caves', 'sunken_docks']
+                .filter(id => visited.includes(id)).length;
+            return [count, 4];
+        }
+    },
+    {
+        id: 'loremonger',
+        name: 'Loremonger',
+        description: 'Collect 10 lore fragments',
+        emoji: '📜',
+        category: 'exploration',
+        xpReward: 150,
+        coinReward: 1_000,
+        check: (user) => (user.exploration?.loreCollected || 0) >= 10,
+        progress: (user) => [Math.min(user.exploration?.loreCollected || 0, 10), 10]
+    },
+    {
+        id: 'relic_runner',
+        name: 'Relic Runner',
+        description: 'Recover 5 relics from the wilds',
+        emoji: '🏺',
+        category: 'exploration',
+        xpReward: 200,
+        coinReward: 1_500,
+        check: (user) => (user.exploration?.relicsRecovered || 0) >= 5,
+        progress: (user) => [Math.min(user.exploration?.relicsRecovered || 0, 5), 5]
+    },
+    {
+        id: 'trap_connoisseur',
+        name: 'Trap Connoisseur',
+        description: 'Spring 10 traps and live to file the expense reports',
+        emoji: '🪤',
+        category: 'exploration',
+        xpReward: 75,
+        coinReward: 500,
+        check: (user) => (user.exploration?.trapsSprung || 0) >= 10,
+        progress: (user) => [Math.min(user.exploration?.trapsSprung || 0, 10), 10]
+    },
+    {
+        id: 'secret_seeker',
+        name: 'Secret Seeker',
+        description: 'Uncover your first secret',
+        emoji: '✨',
+        category: 'exploration',
+        xpReward: 250,
+        coinReward: 2_000,
+        secret: true,
+        check: (user) => (user.exploration?.secretsFound || 0) >= 1,
+        progress: (user) => [Math.min(user.exploration?.secretsFound || 0, 1), 1]
+    },
+    {
+        id: 'keeper_of_secrets',
+        name: 'Keeper of Secrets',
+        description: 'Uncover 8 secrets across the world',
+        emoji: '🗝️',
+        category: 'exploration',
+        xpReward: 500,
+        coinReward: 6_000,
+        check: (user) => (user.exploration?.secretsFound || 0) >= 8,
+        progress: (user) => [Math.min(user.exploration?.secretsFound || 0, 8), 8]
+    },
+    {
+        id: 'the_atlas_complete',
+        name: 'The Atlas Complete',
+        description: 'Uncover all 16 secrets of the four core regions',
+        emoji: '👑',
+        category: 'exploration',
+        xpReward: 1_000,
+        coinReward: 20_000,
+        check: (user) => {
+            const core = ['whispering_forest', 'crumbling_ruins', 'crystal_caves', 'sunken_docks'];
+            const found = (user.exploration?.regions || [])
+                .filter(r => core.includes(r.regionId))
+                .reduce((sum, r) => sum + (r.secretsFound?.length || 0), 0);
+            return found >= 16;
+        },
+        progress: (user) => {
+            const core = ['whispering_forest', 'crumbling_ruins', 'crystal_caves', 'sunken_docks'];
+            const found = (user.exploration?.regions || [])
+                .filter(r => core.includes(r.regionId))
+                .reduce((sum, r) => sum + (r.secretsFound?.length || 0), 0);
+            return [Math.min(found, 16), 16];
+        }
+    },
 ];
 
 const CATEGORY_LABELS = {
@@ -666,6 +800,7 @@ const CATEGORY_LABELS = {
     leveling: 'Leveling',
     hunt: 'Hunt',
     fishing: 'Fishing',
+    exploration: 'Exploration',
     community: 'Community',
     moderation: 'Moderation',
     custom: 'Custom'
@@ -676,6 +811,7 @@ const CATEGORY_EMOJIS = {
     leveling: '📈',
     hunt: '🏹',
     fishing: '🎣',
+    exploration: '🧭',
     community: '👥',
     moderation: '🛡️',
     custom: '⚙️'

--- a/src/data/exploreData.js
+++ b/src/data/exploreData.js
@@ -1,0 +1,803 @@
+'use strict';
+
+// World Exploration data tables.
+// Regions, weighted event tables, secrets, lore fragments, landmarks, relics,
+// and explorer progression. All user-facing strings are written in Clawdia's
+// voice: dry, ancient, a little amused, always watching.
+
+// ─── LIMITS ──────────────────────────────────────────────────────────────────
+
+const LIMITS = {
+    EXPLORE_COOLDOWN_MS:  60_000,
+    INJURY_PENALTY_MS:    10 * 60_000,
+    STAMINA_REGEN_MS:     5 * 60_000,
+    MAX_STAMINA:          10,
+    DAILY_WINDOW_MS:      24 * 3_600_000,
+    DAILY_HARD_CAP:       100_000,
+    JOURNAL_CAP:          20,
+    // Secret pity: each expedition without a secret adds bonus weight to the
+    // secret slot, so long droughts self-correct.
+    SECRET_PITY_PER_RUN:  0.15,
+    SECRET_PITY_MAX:      6,
+};
+
+// ─── EXPLORER PROGRESSION ────────────────────────────────────────────────────
+// xpRequired is the cumulative explorer XP needed to REACH that level.
+
+const EXPLORER_LEVELS = [
+    { level: 1,  xpRequired: 0,      title: 'Doorstep Wanderer' },
+    { level: 2,  xpRequired: 120,    title: 'Doorstep Wanderer' },
+    { level: 3,  xpRequired: 280,    title: 'Doorstep Wanderer' },
+    { level: 4,  xpRequired: 500,    title: 'Pathfinder' },
+    { level: 5,  xpRequired: 800,    title: 'Pathfinder' },
+    { level: 6,  xpRequired: 1_200,  title: 'Pathfinder' },
+    { level: 7,  xpRequired: 1_700,  title: 'Wayfarer' },
+    { level: 8,  xpRequired: 2_300,  title: 'Wayfarer' },
+    { level: 9,  xpRequired: 3_000,  title: 'Wayfarer' },
+    { level: 10, xpRequired: 3_900,  title: 'Trailblazer' },
+    { level: 11, xpRequired: 5_000,  title: 'Trailblazer' },
+    { level: 12, xpRequired: 6_300,  title: 'Trailblazer' },
+    { level: 13, xpRequired: 7_800,  title: 'Cartographer' },
+    { level: 14, xpRequired: 9_500,  title: 'Cartographer' },
+    { level: 15, xpRequired: 11_500, title: 'Cartographer' },
+    { level: 16, xpRequired: 13_800, title: 'Horizon Chaser' },
+    { level: 17, xpRequired: 16_400, title: 'Horizon Chaser' },
+    { level: 18, xpRequired: 19_300, title: 'Horizon Chaser' },
+    { level: 19, xpRequired: 22_600, title: 'Edge of the Map' },
+    { level: 20, xpRequired: 26_300, title: 'Edge of the Map' },
+    { level: 21, xpRequired: 30_400, title: 'Edge of the Map' },
+    { level: 22, xpRequired: 35_000, title: 'Mythwalker' },
+    { level: 23, xpRequired: 40_100, title: 'Mythwalker' },
+    { level: 24, xpRequired: 45_800, title: 'Mythwalker' },
+    { level: 25, xpRequired: 52_100, title: 'The Map Remembers You' },
+    { level: 26, xpRequired: 59_100, title: 'The Map Remembers You' },
+    { level: 27, xpRequired: 66_800, title: 'The Map Remembers You' },
+    { level: 28, xpRequired: 75_300, title: 'Legend of the Blank Spaces' },
+    { level: 29, xpRequired: 84_700, title: 'Legend of the Blank Spaces' },
+    { level: 30, xpRequired: 95_000, title: 'Legend of the Blank Spaces' },
+];
+
+// Explorer XP awarded per event type
+const EVENT_XP = {
+    discovery:        30,
+    lore:             25,
+    treasure:         20,
+    encounter_win:    35,
+    encounter_safe:   15,
+    encounter_loss:   10,
+    trap:             10,
+    secret:           100,
+    quiet:            8,
+};
+
+// Treasure rarity roll: weight + coin range (before region/guild multipliers)
+const TREASURE_TIERS = [
+    { tier: 'common',    weight: 46, min: 150,   max: 400,    relicChance: 0.00, stars: '⭐' },
+    { tier: 'uncommon',  weight: 30, min: 400,   max: 900,    relicChance: 0.05, stars: '⭐⭐' },
+    { tier: 'rare',      weight: 16, min: 1_200, max: 2_500,  relicChance: 0.35, stars: '⭐⭐⭐' },
+    { tier: 'epic',      weight: 6,  min: 3_000, max: 6_000,  relicChance: 0.70, stars: '⭐⭐⭐⭐' },
+    { tier: 'legendary', weight: 2,  min: 8_000, max: 15_000, relicChance: 1.00, stars: '⭐⭐⭐⭐⭐' },
+];
+
+const TIER_COLORS = {
+    common:    '#9e9e9e',
+    uncommon:  '#4caf50',
+    rare:      '#2196f3',
+    epic:      '#9c27b0',
+    legendary: '#ff9800',
+};
+
+// ─── REGIONS ─────────────────────────────────────────────────────────────────
+// Core regions are always available (level/coin gated). Seasonal regions only
+// open while their seasonal event is running on the guild, and are free to
+// enter — the calendar is the gate.
+
+const REGIONS = {
+    // ── Core: starter region ─────────────────────────────────────────────────
+    whispering_forest: {
+        id: 'whispering_forest',
+        name: 'Whispering Forest',
+        emoji: '🌲',
+        color: '#2e7d32',
+        defaultUnlocked: true,
+        unlockLevel: 1,
+        unlockCost: 0,
+        payoutMultiplier: 1.0,
+        tagline: 'The trees talk. Mostly about you.',
+        description: 'Old pines, older shadows. The forest has opinions about visitors and shares them in a language of creaks and falling needles.',
+        intros: [
+            'You step under the canopy. The light goes green and the noise of the world politely excuses itself.',
+            'The forest notices you immediately. It pretends it didn\'t. You pretend you didn\'t notice it noticing.',
+            'Pine needles. Damp earth. Somewhere ahead, something that is not wind moves through the branches.',
+            'The path in is easy to find. The paths out keep rearranging themselves. Typical.',
+        ],
+        eventWeights: { encounter: 22, discovery: 18, trap: 14, treasure: 22, lore: 14, secret: 3, quiet: 7 },
+        landmarks: [
+            { id: 'wf_hollow_oak',      name: 'The Hollow Oak',         line: 'An oak big enough to live in. Judging by the tea set inside, something already does.' },
+            { id: 'wf_mossy_shrine',    name: 'Moss-Eaten Shrine',      line: 'A shrine to a forgotten god of small comforts. The offerings are acorns. All of them recent.' },
+            { id: 'wf_silver_brook',    name: 'Silverthread Brook',     line: 'The water runs uphill on Tuesdays. Today is Tuesday. You decide not to think about it.' },
+            { id: 'wf_hanging_garden',  name: 'The Hanging Garden',     line: 'Flowers growing upside-down from a stone arch. They turn to face you. Slowly.' },
+            { id: 'wf_owl_court',       name: 'Court of Owls',          line: 'A clearing ringed with owl statues. You count nine. On the way out you count ten.' },
+        ],
+        lore: [
+            { id: 'wf_lore_1', text: '“The forest was planted in a single night. Nobody remembers by whom. The trees remember. They\'re not telling.”' },
+            { id: 'wf_lore_2', text: '“Travelers report whispers naming their childhood pets. The forest insists this is a coincidence.”' },
+            { id: 'wf_lore_3', text: '“A woodcutter once took an axe to the Hollow Oak. The oak is fine. The axe is now part of the shrine. So is the woodcutter\'s hat.”' },
+            { id: 'wf_lore_4', text: '“Silverthread Brook is said to carry wishes downstream. Upstream, it carries refunds.”' },
+            { id: 'wf_lore_5', text: '“The tenth owl statue predates the other nine. The other nine are watching it.”' },
+        ],
+        encounters: [
+            {
+                id: 'wf_enc_stag',
+                name: 'The Pale Stag',
+                emoji: '🦌',
+                intro: 'A stag the color of moonlight stands in the path. Its antlers hold seven lit candles. It is waiting for you to do something interesting.',
+                winChance: 0.55,
+                reward: { min: 900, max: 1_800 },
+                winLine: 'You hold its gaze and bow, just slightly. The stag inclines its head — a candle drips wax that hardens into coins at your feet. Apparently you passed.',
+                loseLine: 'You blink first. The stag huffs, the candles snuff out, and you spend twenty minutes finding the path again in the dark.',
+                safeLine: 'You watch from the ferns and let it pass. It leaves hoofprints full of soft silver light. You scoop up a little. It spends fine.',
+            },
+            {
+                id: 'wf_enc_mushroom',
+                name: 'The Mushroom Circle Bargainer',
+                emoji: '🍄',
+                intro: 'A ring of mushrooms, and in the middle, a very small person in a very large hat offering you a deal in a voice like rustling leaves.',
+                winChance: 0.50,
+                reward: { min: 800, max: 1_600 },
+                winLine: 'You haggle. It haggles back. You haggle harder. It tips the enormous hat, impressed, and pays you for the entertainment.',
+                loseLine: 'You shake on the deal before reading the fine print written on a leaf. The leaf blows away. So does some of your dignity, and a few coins.',
+                safeLine: 'You decline politely from OUTSIDE the circle. The bargainer nods — smart — and tosses you a tip for knowing the rules.',
+            },
+            {
+                id: 'wf_enc_wolfshade',
+                name: 'A Wolf Made of Dusk',
+                emoji: '🐺',
+                intro: 'Between two pines stands a wolf with no edges — just dusk in the shape of one. It does not growl. That is somehow worse.',
+                winChance: 0.45,
+                reward: { min: 1_100, max: 2_200 },
+                winLine: 'You stand very still and let it sniff your shadow. It takes a small bite of it — you won\'t miss it — and leaves payment in old coins. Fair trade.',
+                loseLine: 'You step back. Wrong move. The dusk-wolf swallows your lantern light and your sense of direction, and the forest charges a finder\'s fee.',
+                safeLine: 'You give it the path and take the long way. From behind, you see it\'s carrying something shiny. It drops a piece. Deliberately, you think.',
+            },
+        ],
+        traps: [
+            { id: 'wf_trap_roots',  name: 'Grasping Roots',     line: 'The roots were lying flat until exactly the moment you stepped on them. You leave the forest minus some coins and most of one boot heel.', penalty: { min: 150, max: 500 }, injuryChance: 0.20 },
+            { id: 'wf_trap_pollen', name: 'Dreaming Pollen',    line: 'A flower exhales gold dust in your face. You wake up two hours later with a flower crown you didn\'t make and lighter pockets you didn\'t empty.', penalty: { min: 200, max: 600 }, injuryChance: 0.30 },
+            { id: 'wf_trap_path',   name: 'The Path That Lies', line: 'The trail loops you back to where you started, three times, smugly. The toll for the lesson is whatever fell out of your pockets while you ran.', penalty: { min: 100, max: 400 }, injuryChance: 0.10 },
+        ],
+        treasureLines: [
+            'Half-buried under the moss: a strongbox the forest apparently forgot to digest.',
+            'A hollow stump, and inside it, somebody\'s emergency stash. Their emergency is now your payday.',
+            'You follow a magpie out of spite. The magpie, insulted, leads you straight to its hoard.',
+        ],
+        relics: [
+            { itemId: 'Whisperwood Charm',  rarity: 'rare',      lore: 'A knot of pale wood that murmurs when storms are coming. Usually about the storms. Sometimes about you.' },
+            { itemId: 'Candlewax Antler',   rarity: 'epic',      lore: 'A shed antler tip, still warm, still faintly lit. The Pale Stag does not do refunds.' },
+            { itemId: 'The Tenth Owl',      rarity: 'legendary', lore: 'A small stone owl. It was a statue when you picked it up. It is lighter every morning.' },
+        ],
+        secrets: [
+            { id: 'wf_secret_door',     name: 'The Door in the Oak',       reward: 4_000,  reveal: 'Behind the tea set in the Hollow Oak: a door six inches tall, and behind it, a stairway going down much further than the tree does. You mark it on your map. The map purrs.' },
+            { id: 'wf_secret_song',     name: 'The Forest\'s True Name',   reward: 5_000,  reveal: 'At the exact center of the forest, the whispers overlap into a single word. You write it down without reading it aloud. Wise. The trees bow as you leave.' },
+            { id: 'wf_secret_grove',    name: 'The Grove of Hung Lanterns', reward: 4_500, reveal: 'A hidden grove where hundreds of lanterns hang, one for every traveler the forest liked. A new one is already lit. It has your name on it.' },
+            { id: 'wf_secret_warden',   name: 'The Sleeping Warden',       reward: 6_000,  reveal: 'Under the Court of Owls, something vast and feathered sleeps in a bed of acorns. You tiptoe out with a souvenir and the strong impression you were allowed to.' },
+        ],
+    },
+
+    // ── Core: tier 2 ─────────────────────────────────────────────────────────
+    crumbling_ruins: {
+        id: 'crumbling_ruins',
+        name: 'Crumbling Ruins',
+        emoji: '🏛️',
+        color: '#8d6e63',
+        defaultUnlocked: false,
+        unlockLevel: 5,
+        unlockCost: 7_500,
+        payoutMultiplier: 1.35,
+        tagline: 'An empire fell here. It left the lights on.',
+        description: 'Toppled columns, headless statues, and architecture that remembers being important. Everything is exactly one bad step from becoming more rubble.',
+        intros: [
+            'You climb over a fallen column carved with warnings. The warnings are in six languages. All of them say "really, don\'t."',
+            'Dust, marble, silence. The kind of silence that used to be a city.',
+            'A headless statue points dramatically at nothing. You follow the gesture anyway. It\'s only polite.',
+            'Your footsteps echo twice. You only took one step. The ruins are padding their numbers.',
+        ],
+        eventWeights: { encounter: 20, discovery: 18, trap: 18, treasure: 22, lore: 14, secret: 3, quiet: 5 },
+        landmarks: [
+            { id: 'cr_amphitheater',  name: 'The Empty Amphitheater', line: 'Ten thousand stone seats facing a stage. When you step onto it, somewhere, faintly: applause.' },
+            { id: 'cr_archive',       name: 'The Burned Archive',     line: 'Shelves of ash that still hold the shape of books. One shelf is untouched. Reserved, apparently.' },
+            { id: 'cr_aqueduct',      name: 'The Dry Aqueduct',       line: 'A river of air where water ran for a thousand years. You can hear it remembering.' },
+            { id: 'cr_throne',        name: 'The Backwards Throne',   line: 'A throne facing the wall. Whatever the last ruler didn\'t want to look at, it\'s still out there.' },
+            { id: 'cr_sundial',       name: 'The Midnight Sundial',   line: 'A sundial that casts a shadow at night. It is currently pointing at you. It does this to everyone. Probably.' },
+        ],
+        lore: [
+            { id: 'cr_lore_1', text: '“The empire did not fall to war or plague. The records say only: \'They finished.\' Finished what, the records decline to specify.”' },
+            { id: 'cr_lore_2', text: '“Every statue in the ruins is missing its head. The heads were not removed. They left.”' },
+            { id: 'cr_lore_3', text: '“The Burned Archive burned from the inside out. Librarians call this \'aggressive weeding.\'”' },
+            { id: 'cr_lore_4', text: '“The last emperor\'s final decree is still posted in the forum. It reads, in full: \'Lock up when you leave.\'”' },
+            { id: 'cr_lore_5', text: '“Coins minted here show a different face every time you look. Merchants accept them anyway. Faces aren\'t legal tender; the gold is.”' },
+        ],
+        encounters: [
+            {
+                id: 'cr_enc_curator',
+                name: 'The Last Curator',
+                emoji: '🗿',
+                intro: 'A stone figure dusts a shelf of rubble with infinite patience. It turns. "The museum," it grinds, "is closed. Unless you\'re here to donate. Or withdraw."',
+                winChance: 0.55,
+                reward: { min: 1_300, max: 2_600 },
+                winLine: 'You compliment the collection — specifically, sincerely. The Curator straightens with pride and processes your "early withdrawal" from the gift shop fund.',
+                loseLine: 'You touch an exhibit. THE exhibit. The Curator escorts you out by the collar and bills you for the velvet rope you were definitely not behind.',
+                safeLine: 'You take the guided tour from a respectful distance. At the end, the Curator tips YOU. The economy of ruins runs backwards.',
+            },
+            {
+                id: 'cr_enc_echo',
+                name: 'An Echo With Opinions',
+                emoji: '🌀',
+                intro: 'Your own voice comes back from the amphitheater — three seconds early. "Don\'t take the left stair," it says. You hadn\'t said anything yet.',
+                winChance: 0.50,
+                reward: { min: 1_200, max: 2_400 },
+                winLine: 'You trust the echo. The left stair collapses behind you; the right one leads to somebody\'s abandoned strongroom. The echo says "you\'re welcome" before you can thank it.',
+                loseLine: 'You take the left stair out of principle. The stair, also on principle, stops being a stair. The climb out costs you in coins and pride.',
+                safeLine: 'You converse with the echo without moving an inch. It gets bored, sighs, and tells you where the small change is hidden just to end the conversation.',
+            },
+            {
+                id: 'cr_enc_legion',
+                name: 'The Off-Duty Legion',
+                emoji: '⚔️',
+                intro: 'A ghost legion drills in the forum, eternally. The phantom centurion squints at you. "Recruit?" he asks, hopefully. They\'ve been short-staffed for nine hundred years.',
+                winChance: 0.45,
+                reward: { min: 1_500, max: 3_000 },
+                winLine: 'You drill with the dead for one hour and don\'t complain once. The centurion, moved nearly to tears, pays you a signing bonus from a pay chest that outlived the empire.',
+                loseLine: 'You march left when the legion marches right. Nine hundred years of formation, ruined. The fine for breaking formation is older than your country.',
+                safeLine: 'You salute crisply and keep walking. The legion returns it as one. A private jogs after you with "back pay" for a soldier you apparently resemble.',
+            },
+        ],
+        traps: [
+            { id: 'cr_trap_floor',   name: 'Optimistic Floor',     line: 'The mosaic floor was load-bearing in a strictly historical sense. You drop one story into the cellar and pay for your own rescue, which is also you.', penalty: { min: 250, max: 700 }, injuryChance: 0.30 },
+            { id: 'cr_trap_curse',   name: 'Discount Curse',       line: 'You read the inscription aloud. Rookie move. It\'s a minor curse — everything you buy this week costs slightly more and the vendors can\'t explain why.', penalty: { min: 300, max: 800 }, injuryChance: 0.15 },
+            { id: 'cr_trap_statue',  name: 'A Statue\'s Grudge',   line: 'You lean on a statue. The statue, headless and patient, has been waiting centuries for exactly this. Your coin pouch is lighter and the statue looks satisfied. Somehow. Without a head.', penalty: { min: 200, max: 600 }, injuryChance: 0.20 },
+        ],
+        treasureLines: [
+            'Under the throne: the royal petty cash. The empire fell; its bookkeeping didn\'t.',
+            'A locked strongbox in the archive, untouched by fire. The lock surrenders out of professional respect.',
+            'You pry up the one mosaic tile that doesn\'t match. Beneath it, a tax collector\'s private retirement plan.',
+        ],
+        relics: [
+            { itemId: 'Headless Coin',        rarity: 'rare',      lore: 'A coin from the ruins. The face changes when unobserved. The denomination, mercifully, does not.' },
+            { itemId: 'Curator\'s Brass Key',  rarity: 'epic',      lore: 'Opens the museum gift shop, anywhere, even where there is no museum. Especially there.' },
+            { itemId: 'The Final Decree',     rarity: 'legendary', lore: 'The last emperor\'s actual signet, pressed into wax that never fully cooled. It is still warm. It is still binding.' },
+        ],
+        secrets: [
+            { id: 'cr_secret_vault',   name: 'The Treasury Below the Treasury', reward: 5_500, reveal: 'The imperial vault was a decoy. Beneath its floor: the real one, modest and full, with a note — "told you so." You map it. The map smells faintly of smoke.' },
+            { id: 'cr_secret_heads',   name: 'Where the Heads Went',            reward: 6_500, reveal: 'A sealed garden where every statue\'s head rests on a plinth, facing the sky, smiling. They were not removed. They retired. One nods at you. You nod back and leave quickly.' },
+            { id: 'cr_secret_clock',   name: 'The Hour That Never Struck',      reward: 5_000, reveal: 'Inside the sundial\'s base, a clockwork hour that was never released into the day. It ticks once when you find it. Somewhere, the empire gets one second longer.' },
+            { id: 'cr_secret_door',    name: 'The Curator\'s Private Wing',     reward: 7_000, reveal: 'The Curator unlocks a wing that doesn\'t exist on any floor plan. "The good collection," it grinds. You may look. You may not touch. You are paid for looking. Museums have changed.' },
+        ],
+    },
+
+    // ── Core: tier 3 ─────────────────────────────────────────────────────────
+    crystal_caves: {
+        id: 'crystal_caves',
+        name: 'Crystal Caves',
+        emoji: '💎',
+        color: '#7e57c2',
+        defaultUnlocked: false,
+        unlockLevel: 12,
+        unlockCost: 25_000,
+        payoutMultiplier: 1.75,
+        tagline: 'Everything down here reflects. Not everything reflects you.',
+        description: 'Galleries of living crystal that hum in chords. Light goes in and comes out changed. So, occasionally, do explorers.',
+        intros: [
+            'The cave mouth exhales cold, mineral air. The crystals are already humming your arrival to each other.',
+            'A thousand reflections of you walk in. You\'re fairly sure the same number walks each corridor. Fairly.',
+            'The walls glow without a source. The dark down here had to be negotiated with, and the crystals won.',
+            'You tap a crystal. It tings a perfect C. Three caverns away, something tings back, off-key, on purpose.',
+        ],
+        eventWeights: { encounter: 20, discovery: 16, trap: 18, treasure: 24, lore: 12, secret: 4, quiet: 6 },
+        landmarks: [
+            { id: 'cc_chandelier',   name: 'The Grand Chandelier',  line: 'A crystal formation the size of a cathedral, hanging point-down. It has never fallen. It is, the hum suggests, considering it.' },
+            { id: 'cc_mirror_lake',  name: 'The Still Mirror Lake', line: 'Water so flat it shows the cavern ceiling perfectly — plus one extra stalactite that isn\'t there. You don\'t point. It might notice being noticed.' },
+            { id: 'cc_singing_hall', name: 'The Singing Gallery',   line: 'Walk through and the crystals harmonize with your footsteps. Run, and it\'s opera. You walk. You\'re not ready for opera.' },
+            { id: 'cc_geode_throne', name: 'The Geode Parlor',      line: 'A split geode big enough to sit in, furnished — by someone — with cushions. The cushions are warm.' },
+            { id: 'cc_frozen_storm', name: 'The Frozen Lightning',  line: 'A bolt of lightning, caught mid-strike inside a crystal column a million years ago. It is still very angry about it.' },
+        ],
+        lore: [
+            { id: 'cc_lore_1', text: '“The caves grow a new gallery every century. Surveyors gave up. The maps were always one room ahead of them.”' },
+            { id: 'cc_lore_2', text: '“Crystals here record sound. Press your ear to the old ones and hear conversations a thousand years stale. Press your ear to the new ones and hear yourself, arriving.”' },
+            { id: 'cc_lore_3', text: '“Miners never struck these veins. Every expedition reported the same thing: the tunnels they dug were already there by morning, tidier.”' },
+            { id: 'cc_lore_4', text: '“The Mirror Lake has a depth of four inches and a reflection of four miles.”' },
+            { id: 'cc_lore_5', text: '“Something keeps the Geode Parlor\'s cushions warm. The leading theory is hospitality.”' },
+        ],
+        encounters: [
+            {
+                id: 'cc_enc_reflection',
+                name: 'Your Better Reflection',
+                emoji: '🪞',
+                intro: 'In a wall of polished amethyst, your reflection straightens its collar a half-second before you do. It smiles first, too. It seems to want to talk.',
+                winChance: 0.50,
+                reward: { min: 1_800, max: 3_600 },
+                winLine: 'You play mirror with it and deliberately fumble. It corrects you — smug — and in doing so steps out of sync. The forfeit, by ancient cave rules, is paid in gems.',
+                loseLine: 'You try to out-smug your own reflection. Bold. It mimics your coin pouch perfectly, and now yours is the copy. Lighter. Reflections round down.',
+                safeLine: 'You wave, it waves, everyone behaves. As you leave it taps the glass and points down: a seam of gem dust at your feet. A tip, from you, to you.',
+            },
+            {
+                id: 'cc_enc_chordwyrm',
+                name: 'The Chord-Wyrm',
+                emoji: '🐉',
+                intro: 'A serpent of living crystal uncoils from the ceiling, scales ringing like a glass harp. It is not hungry. It is bored, which for dragons is more expensive.',
+                winChance: 0.45,
+                reward: { min: 2_200, max: 4_200 },
+                winLine: 'You hum the third note of its chord — the one it can\'t reach. It rears, delighted, and sheds a handful of singing scales as applause. They\'re worth a fortune. They know it.',
+                loseLine: 'You hum flat. The wyrm winces down to its tail, and the entire cavern winces with it. The acoustic fine is deducted in gemstones from your pack.',
+                safeLine: 'You sit and just listen. An hour of glass-harp dragon music, free. On the way out you find it left you a scale anyway. Patronage, it turns out, pays.',
+            },
+            {
+                id: 'cc_enc_lantern',
+                name: 'The Lantern That Went Ahead',
+                emoji: '🏮',
+                intro: 'A miner\'s lantern floats down the gallery, lit, carried by absolutely no one. It pauses. It bobs, invitingly, toward a side passage that is not on your map.',
+                winChance: 0.55,
+                reward: { min: 1_600, max: 3_200 },
+                winLine: 'You follow. The lantern leads you to a forgotten dig where the last crew left their wages and a note: "for whoever the light likes next." It likes you.',
+                loseLine: 'You follow — then second-guess at a fork. The lantern, offended, blows itself out. The dark charges by the minute and accepts only coins.',
+                safeLine: 'You decline with a small bow. The lantern dips, understanding, and drifts off — leaving a pinch of glowing oil on a rock for your trouble. It sells well.',
+            },
+        ],
+        traps: [
+            { id: 'cc_trap_resonance', name: 'Resonance Cascade',  line: 'You sneeze. The Singing Gallery answers — fortissimo. The avalanche of sound shakes loose your gear and your composure; you buy both back from the cave floor in scattered coins.', penalty: { min: 400, max: 1_000 }, injuryChance: 0.25 },
+            { id: 'cc_trap_mirror',    name: 'The Wrong Turn Twin', line: 'You follow your reflection around a corner. Your reflection does not follow the same map. By the time you find the real corridor, something has audited your pockets.', penalty: { min: 350, max: 900 },  injuryChance: 0.15 },
+            { id: 'cc_trap_shard',     name: 'Glass Garden',        line: 'A floor of crystal shards disguised as a floor of crystal floor. You make it across, mostly. Your boots and budget absorb the difference.', penalty: { min: 300, max: 800 },  injuryChance: 0.35 },
+        ],
+        treasureLines: [
+            'A vein of gemstones grows around an old strongbox like the cave was gift-wrapping it for you.',
+            'In the Geode Parlor, under the third cushion: somebody\'s rainy-day gems. It never rains down here. Their loss.',
+            'The Mirror Lake\'s reflection shows a chest on the ceiling. The real one, naturally, is under the water. Four inches down. Heavy.',
+        ],
+        relics: [
+            { itemId: 'Singing Scale',        rarity: 'rare',      lore: 'A scale from the Chord-Wyrm. Hums a perfect fifth when its former owner is in a good mood. It is usually humming.' },
+            { itemId: 'Bottled Resonance',    rarity: 'epic',      lore: 'A sealed vial of the Singing Gallery\'s echo. Do not open indoors. Do not open outdoors. Lovely on a shelf.' },
+            { itemId: 'Shard of the Frozen Storm', rarity: 'legendary', lore: 'A splinter of million-year-old lightning. Still bright. Still furious. Keep it away from the weather; it holds grudges.' },
+        ],
+        secrets: [
+            { id: 'cc_secret_heart',   name: 'The Heart Facet',          reward: 8_000, reveal: 'At the caves\' center, one crystal beats — slow, patient, geological. Every other crystal is an echo of it. You sketch it quickly. Your pencil hums for a week.' },
+            { id: 'cc_secret_choir',   name: 'The Recorded Choir',       reward: 7_000, reveal: 'A gallery of ancient crystals that replay, on touch, the voices of every explorer who ever made it this far. The newest crystal is blank. It records you saying "oh."' },
+            { id: 'cc_secret_stair',   name: 'The Stair Below the Lake', reward: 7_500, reveal: 'The Mirror Lake\'s impossible reflection was a map. Under four inches of water: a stairway, dry, descending into a glow the color of which you have no name for. You note the door. You do not open it. Yet.' },
+            { id: 'cc_secret_parlor',  name: 'The Host of the Parlor',   reward: 9_000, reveal: 'You finally meet who keeps the cushions warm: a vast, gentle thing of facets and firelight that has been hosting lost explorers since before the word "lost." It refreshes your tea and your finances. You are invited back.' },
+        ],
+    },
+
+    // ── Core: tier 4 ─────────────────────────────────────────────────────────
+    sunken_docks: {
+        id: 'sunken_docks',
+        name: 'Sunken Docks',
+        emoji: '⚓',
+        color: '#1565c0',
+        defaultUnlocked: false,
+        unlockLevel: 20,
+        unlockCost: 60_000,
+        payoutMultiplier: 2.25,
+        tagline: 'The harbor drowned. Business hours continue.',
+        description: 'A port city half-swallowed by a patient sea. Bells ring under the water at shift change, and the tide does the bookkeeping.',
+        intros: [
+            'Low tide. The drowned harbor surfaces its rooftops like it\'s checking if anyone\'s still waiting for a ship.',
+            'Barnacled bollards, kelp-strung cranes. Beneath your boots, a cobblestone street and, beneath that, lamplight.',
+            'A harbor bell rings under thirty feet of water. Right on schedule. The Docks never missed a shift; they just changed management.',
+            'The gulls here don\'t cry. They mutter. Mostly figures, freight rates, and your name once, which you ignore.',
+        ],
+        eventWeights: { encounter: 22, discovery: 16, trap: 18, treasure: 24, lore: 12, secret: 4, quiet: 4 },
+        landmarks: [
+            { id: 'sd_lighthouse',   name: 'The Inverted Lighthouse', line: 'A lighthouse standing whole beneath the surface, beam sweeping the sea floor. It is looking for something. It has narrowed it down.' },
+            { id: 'sd_customs',      name: 'The Customs House',       line: 'Ledgers still open on the counters, ink still wet. The last entry is dated tomorrow.' },
+            { id: 'sd_figurehead',   name: 'The Figurehead Yard',     line: 'A yard of salvaged figureheads, all facing the water. At high tide, locals say, they trade gossip. The gossip is about ships. Mostly.' },
+            { id: 'sd_drowned_inn',  name: 'The Drowned Anchor Inn',  line: 'The taproom is six feet under at high tide and dry at low. The regulars adjusted. You can tell which ones by the gills.' },
+            { id: 'sd_bell_tower',   name: 'The Tide Bell',           line: 'The great harbor bell, green with age, rings itself for every ship that never came home. It rings often. It never rings twice for the same ship.' },
+        ],
+        lore: [
+            { id: 'sd_lore_1', text: '“The sea took the harbor in a single night, gently, the way you\'d move a sleeping child. Not one cup was broken. They\'re all still on their shelves, underwater, full.”' },
+            { id: 'sd_lore_2', text: '“The Customs House never closed. Duties are still assessed on everything the tide brings in. The tide, to its credit, pays.”' },
+            { id: 'sd_lore_3', text: '“Divers report the Inverted Lighthouse\'s beam follows them home. Harmless, they insist. Their candles do burn brighter now.”' },
+            { id: 'sd_lore_4', text: '“The last harbormaster\'s log ends mid-sentence: \'tide\'s in early, and it\'s brought—\'. The next page is just salt.”' },
+            { id: 'sd_lore_5', text: '“Ships still dock here on fog-thick nights. Cargo manifests list: memory, ballast, and one (1) passenger, return ticket.”' },
+        ],
+        encounters: [
+            {
+                id: 'sd_enc_harbormaster',
+                name: 'The Harbormaster\'s Late Shift',
+                emoji: '🧜',
+                intro: 'At the Customs House counter, something with too many opinions about tariffs and a coat of wet barnacles looks up. "Declarations?" it gurgles, stamp already inked.',
+                winChance: 0.55,
+                reward: { min: 2_400, max: 4_800 },
+                winLine: 'You declare everything, honestly, including the lint. The Harbormaster is so moved by the paperwork that it pays out a "compliance dividend" from the drowned treasury. Bureaucracy, but wet.',
+                loseLine: 'You undeclare one (1) souvenir. The stamp comes down like a depth charge. The fine is itemized, alphabetized, and immediate.',
+                safeLine: 'You fill out the visitor form only and touch nothing. The Harbormaster nods at a jar on the counter: the gratuity box, outbound. Visitors who behave get the interest.',
+            },
+            {
+                id: 'sd_enc_crew',
+                name: 'The Crew Still Unloading',
+                emoji: '👻',
+                intro: 'A ghost crew hauls phantom cargo from a ship that isn\'t there to a warehouse that mostly is. The bosun waves you over. They\'re one pair of hands short. They have been for ninety years.',
+                winChance: 0.50,
+                reward: { min: 2_200, max: 4_400 },
+                winLine: 'You take the end of a rope that isn\'t there and pull like it is. The crate lands — REAL — on the dock. Your share of the freight fee has been waiting in the manifest since before your grandparents.',
+                loseLine: 'You lift with your back, not your legs, and drop a crate of phantom porcelain. Phantom porcelain, it turns out, bills like the real thing.',
+                safeLine: 'You watch the whole operation and tip your hat to the bosun at shift\'s end. Dockworkers respect a good audience. They point you to where the loose cargo washes up.',
+            },
+            {
+                id: 'sd_enc_siren',
+                name: 'A Siren, Off the Clock',
+                emoji: '🎶',
+                intro: 'On the seawall sits a siren, hair dripping, doing the harbor\'s crossword. She glances up. "I\'m not singing," she says. "Lunch break. But I do trade in interesting rumors, if you\'ve got one."',
+                winChance: 0.45,
+                reward: { min: 2_800, max: 5_500 },
+                winLine: 'You trade her the strangest true thing you\'ve seen out here. She laughs — a sound that briefly stops the tide — and pays in salvage coordinates that check out brilliantly.',
+                loseLine: 'You make a rumor up. Her eyes narrow; sirens fact-check. The tide takes a personal interest in your pockets on the walk back.',
+                safeLine: 'You help with the crossword instead. Seven across, "drowned." She finishes the puzzle, hums one bar of thanks — and the harbor leaves a finder\'s fee in your boot.',
+            },
+        ],
+        traps: [
+            { id: 'sd_trap_tide',    name: 'The Early Tide',        line: 'The tide comes in twenty minutes ahead of schedule, which the Customs House later confirms is "within tolerance." Your boots, supplies, and coin pouch disagree.', penalty: { min: 500, max: 1_200 }, injuryChance: 0.25 },
+            { id: 'sd_trap_plank',   name: 'A Gangplank\'s Opinion', line: 'The gangplank holds for exactly as long as it finds you amusing. You stop being amusing halfway across. The harbor charges a docking fee for bodies, apparently.', penalty: { min: 400, max: 1_000 }, injuryChance: 0.35 },
+            { id: 'sd_trap_net',     name: 'The Patient Net',       line: 'A fishing net, abandoned ninety years, finally catches something: you. By the time you cut loose, the gulls have unionized around your snack budget.', penalty: { min: 350, max: 900 },  injuryChance: 0.20 },
+        ],
+        treasureLines: [
+            'A strongbox in the Customs House marked "UNCLAIMED — 90 YEARS." The Harbormaster stamps it over to you without looking up.',
+            'Low tide bares a rooftop with a chimney, and the chimney is stuffed with a smuggler\'s retirement plan. The smuggler, presumably, retired differently.',
+            'The Tide Bell rings once as you pass — and the wave it shrugs ashore is carrying cargo with your timing written all over it.',
+        ],
+        relics: [
+            { itemId: 'Harbormaster\'s Stamp',  rarity: 'rare',      lore: 'Still inked. Anything you stamp becomes, in a small administrative way, yours. Use responsibly. Or don\'t; the paperwork is self-correcting.' },
+            { itemId: 'Bottled Fog',           rarity: 'epic',      lore: 'Fog from the night the harbor drowned, corked. Through the glass, faintly: lamplight, and a bell, and someone whistling.' },
+            { itemId: 'The Return Ticket',     rarity: 'legendary', lore: 'One (1) passage on a ship that docks only on fog-thick nights. Unpunched. The destination line just says "back."' },
+        ],
+        secrets: [
+            { id: 'sd_secret_ship',     name: 'The Ship That Came Home',    reward: 10_000, reveal: 'In a sea cave behind the lighthouse: a ship, intact, sails furled, waiting. The Tide Bell rings twice for the first time in history. You map the berth. The bell approves.' },
+            { id: 'sd_secret_vault',    name: 'The Wet Vault',              reward: 9_000,  reveal: 'Beneath the Customs House, a vault that floods at high tide — by design. The water inside counts itself. You are paid an "auditor\'s fee" for confirming the total. The total is rude.' },
+            { id: 'sd_secret_song',     name: 'The Song That Sank It',      reward: 9_500,  reveal: 'The siren finally tells you, off the record, what was sung the night the harbor went under. It was a lullaby. The city was tired. You write down only the first three notes. Even those are heavy.' },
+            { id: 'sd_secret_passenger',name: 'The Passenger\'s Name',       reward: 11_000, reveal: 'You find the manifest line for that one (1) passenger, return ticket. The name is blank — until you read it, and then, briefly, it isn\'t. The Docks consider you family now. Family rates apply.' },
+        ],
+    },
+
+    // ── Seasonal: Winter Wonderland ──────────────────────────────────────────
+    frostveil_pass: {
+        id: 'frostveil_pass',
+        name: 'Frostveil Pass',
+        emoji: '❄️',
+        color: '#a8d8f0',
+        defaultUnlocked: false,
+        unlockLevel: 1,
+        unlockCost: 0,
+        seasonalEventId: 'winter_wonderland',
+        payoutMultiplier: 1.5,
+        eventCurrency: { min: 3, max: 8 },
+        tagline: 'Open until the thaw. The snow remembers visitors fondly.',
+        description: 'A mountain pass that only exists while the snow does. Lantern-lit, hushed, and generous in the way of things that know they are temporary.',
+        intros: [
+            'You step into snowfall so quiet you can hear the lanterns thinking. The Pass is open. For now.',
+            'Fresh snow, no footprints — and then, ahead of you, one set, walking out. The Pass likes a little drama.',
+            'The cold here doesn\'t bite. It escorts. You are walked politely into the white.',
+            'Every snowflake that lands on your map melts into a tiny, helpful annotation.',
+        ],
+        eventWeights: { encounter: 20, discovery: 18, trap: 12, treasure: 24, lore: 14, secret: 5, quiet: 7 },
+        landmarks: [
+            { id: 'fp_lantern_road',  name: 'The Lantern Road',     line: 'A mile of lanterns nobody lights and nothing extinguishes. They dim, slightly, when you pass — a bow, lantern-style.' },
+            { id: 'fp_frozen_falls',  name: 'The Listening Falls',  line: 'A waterfall frozen mid-roar. Press an ear to the ice and the roar is still in there, saving itself for spring.' },
+            { id: 'fp_snow_garden',   name: 'The Unmelting Garden', line: 'Roses of packed snow that bloom at dusk. Picked, they last exactly one act of kindness before melting.' },
+        ],
+        lore: [
+            { id: 'fp_lore_1', text: '“The Pass appears with the first true snow and leaves with the last. Mapmakers mark it in pencil.”' },
+            { id: 'fp_lore_2', text: '“Travelers caught out at night report being tucked in by the snowdrifts. Awakening warm, rested, and slightly tucked.”' },
+            { id: 'fp_lore_3', text: '“Nothing is ever lost in Frostveil. Mislaid things surface in the spring melt, miles downhill, neatly labeled.”' },
+        ],
+        encounters: [
+            {
+                id: 'fp_enc_yeti',
+                name: 'A Yeti With a Ledger',
+                emoji: '🦣',
+                intro: 'An enormous white shape blocks the trail, holding a tiny notebook. "Toll," it rumbles, then squints at the page. "Or... rebate? The handwriting is bad. It\'s mine, and it\'s bad."',
+                winChance: 0.55,
+                reward: { min: 1_400, max: 2_800 },
+                winLine: 'You help it decipher its own bookkeeping. It\'s a rebate. The yeti pays out happily and initials your map with one enormous, careful Y.',
+                loseLine: 'You guess "toll." It was a rebate. The yeti, flustered, charges you the toll anyway to balance the books. Accounting is merciless at altitude.',
+                safeLine: 'You wait in line behind a snow hare, who handles the negotiation. The hare wins. The yeti pays out everyone in line on principle. You were in line.',
+            },
+            {
+                id: 'fp_enc_skater',
+                name: 'The Skater on the Falls',
+                emoji: '⛸️',
+                intro: 'Someone is figure-skating on the frozen waterfall. Vertically. They pause mid-axel, upside down, and beckon: the ice apparently seats two.',
+                winChance: 0.45,
+                reward: { min: 1_600, max: 3_200 },
+                winLine: 'You manage thirty vertical seconds without dying. The skater is delighted. Prize money materializes from a sponsor you never see and the ice itself applauds.',
+                loseLine: 'You make it four seconds. Gravity, that traditionalist, files an objection. The entry fee is non-refundable and so is your composure.',
+                safeLine: 'You judge from the bank, holding up scores on snowballs. The skater bows. Judges, it turns out, get an appearance fee here.',
+            },
+        ],
+        traps: [
+            { id: 'fp_trap_drift',  name: 'An Affectionate Snowdrift', line: 'The drift hugs you. Wholeheartedly. By the time you\'re excavated, your pockets have been redistributed to the spring melt.', penalty: { min: 200, max: 600 }, injuryChance: 0.20 },
+            { id: 'fp_trap_ice',    name: 'Black Ice With Timing',     line: 'The Pass waits until your most confident stride. The lanterns dim out of respect. The toll for the performance is collected from whatever scattered.', penalty: { min: 250, max: 700 }, injuryChance: 0.30 },
+        ],
+        treasureLines: [
+            'A snowdrift unzips itself to show you a strongbox it\'s been keeping warm. Cold. Keeping cold.',
+            'Under the Lantern Road\'s seventh lantern: last winter\'s lost-and-found, compounding interest in snowflakes and coins.',
+        ],
+        relics: [
+            { itemId: 'Unmelting Rose',     rarity: 'rare',      lore: 'A snow rose from the garden. It will last until you do something kind, so realistically, forever. (It melted. We both knew it would.)' },
+            { itemId: 'The Yeti\'s Pencil',  rarity: 'epic',      lore: 'Tiny in your hand, tinier in his. Anything tallied with it comes out slightly in your favor. The yeti has noticed. He is too polite to say.' },
+        ],
+        secrets: [
+            { id: 'fp_secret_spring', name: 'Where the Pass Goes in Spring', reward: 6_000, reveal: 'Behind the Listening Falls, a corridor of unmelting frost spirals down past the roots of the mountain. The Pass doesn\'t vanish in spring. It commutes. You map the door and promise to knock.' },
+            { id: 'fp_secret_first',  name: 'The First Snowflake',           reward: 7_000, reveal: 'In a shrine of ice at the summit, under glass: the first snowflake of every winter, all of them, going back further than winters should. This year\'s is already there. It looks like your map. Exactly like your map.' },
+        ],
+    },
+
+    // ── Seasonal: Spooky Season ──────────────────────────────────────────────
+    hollowgrave_lane: {
+        id: 'hollowgrave_lane',
+        name: 'Hollowgrave Lane',
+        emoji: '🎃',
+        color: '#ff6b00',
+        defaultUnlocked: false,
+        unlockLevel: 1,
+        unlockCost: 0,
+        seasonalEventId: 'spooky_season',
+        payoutMultiplier: 1.5,
+        eventCurrency: { min: 3, max: 8 },
+        tagline: 'One street long. Longer after dark.',
+        description: 'A crooked lane of leaning houses that only appears in October. Every door is carved with a different grin, and the porch lights are always on for you. Specifically you.',
+        intros: [
+            'The lane unrolls out of the fog like it was waiting for your footsteps to start the show.',
+            'Jack-o\'-lanterns line every porch. As you pass, each one turns. Politely. Like sunflowers, if sunflowers gossiped.',
+            'Somewhere down the lane, a door creaks open. Then another. Then all of them, in welcome or in appetite.',
+            'The fog smells like cider and old paper. The houses lean in. You\'re the most interesting thing to happen all evening, and the evening is very long here.',
+        ],
+        eventWeights: { encounter: 24, discovery: 16, trap: 16, treasure: 20, lore: 14, secret: 5, quiet: 5 },
+        landmarks: [
+            { id: 'hl_pumpkin_field', name: 'The Self-Carving Patch', line: 'A pumpkin field where the carving happens from the inside. Tonight\'s crop is doing portraits. One of them is flattering. One of them is you.' },
+            { id: 'hl_last_house',    name: 'The House at the End',   line: 'The lane ends at a house that is all door. You knock once. From inside, eventually: one knock back. Pleased to meet you too.' },
+            { id: 'hl_candy_well',    name: 'The Candy Well',         line: 'A wishing well that dispenses instead of receiving. The bucket comes up rattling. The well considers this a long-term investment in your goodwill.' },
+        ],
+        lore: [
+            { id: 'hl_lore_1', text: '“Hollowgrave Lane has thirteen houses, twelve of which are occupied. The thirteenth is taking applications.”' },
+            { id: 'hl_lore_2', text: '“The residents do not haunt. They host. The distinction matters enormously to them and is enforced by committee.”' },
+            { id: 'hl_lore_3', text: '“Trick-or-treaters who visit the Lane receive full-size everything. The Lane does not discuss its budget.”' },
+        ],
+        encounters: [
+            {
+                id: 'hl_enc_skeleton',
+                name: 'The Understudy Skeleton',
+                emoji: '💀',
+                intro: 'A skeleton in a half-painted set rattles its script at you. "The lead ghost called in alive," it sighs. "Run lines with me? The haunting\'s at eight and the pay is criminal. In a good way."',
+                winChance: 0.55,
+                reward: { min: 1_400, max: 2_800 },
+                winLine: 'You deliver "BOO" with subtext, layers, motivation. The skeleton weeps from sockets that shouldn\'t allow it. You\'re paid scale plus a cut of the screams.',
+                loseLine: 'You laugh in the dramatic pause. The skeleton goes very still — professionally hurt — and the union fines you for breaking immersion.',
+                safeLine: 'You volunteer as audience instead. The dress rehearsal is genuinely terrifying. You applaud. Ushers tip YOU here, which says everything about the Lane\'s economy.',
+            },
+            {
+                id: 'hl_enc_witch',
+                name: 'A Witch Doing Inventory',
+                emoji: '🧙',
+                intro: 'A witch counts jars on her porch: eyeballs (pickled), screams (assorted), regret (top shelf). "I\'m over-stocked on luck," she says, not looking up. "Care to trade?"',
+                winChance: 0.50,
+                reward: { min: 1_500, max: 3_000 },
+                winLine: 'You trade her a true story she hasn\'t heard. She laughs herself off the rocking chair, recovers with dignity, and pays in luck. It works retroactively. The walk home is suspiciously smooth.',
+                loseLine: 'You try to haggle with a witch on her own porch. The jars all turn to watch. The trade goes through; the exchange rate is a lesson.',
+                safeLine: 'You help her alphabetize. (Regret files under R; the screams insist on S-sharp.) She pays an honest wage and bags you a sample of the house blend.',
+            },
+        ],
+        traps: [
+            { id: 'hl_trap_porch',  name: 'A Porch With Opinions',   line: 'The third step was a mimic. The whole porch was a mimic. The welcome mat — also a mimic — collects the cover charge while you flee.', penalty: { min: 250, max: 700 }, injuryChance: 0.25 },
+            { id: 'hl_trap_candy',  name: 'The Long Con Caramel',    line: 'You take candy from the unattended bowl marked TAKE ONE. You take two. The Lane\'s honor system has teeth, and a payment plan.', penalty: { min: 200, max: 600 }, injuryChance: 0.15 },
+        ],
+        treasureLines: [
+            'A jack-o\'-lantern grins wider as you approach and coughs up its savings. It\'s been holding that in all month.',
+            'The Candy Well\'s bucket comes up heavy tonight: coins among the caramels. The well winks. Wells can wink here.',
+        ],
+        relics: [
+            { itemId: 'Grinning Doorknocker', rarity: 'rare',      lore: 'A brass knocker from the House at the End. Knock once anywhere and something, somewhere, politely knocks back.' },
+            { itemId: 'Jar of Bottled Dusk',  rarity: 'epic',      lore: 'October dusk, preserved at peak atmosphere. Open for ten seconds of perfect Halloween, any month. Refills annually. The witch insists it\'s a sample, not a gift; samples imply she\'ll see you again.' },
+        ],
+        secrets: [
+            { id: 'hl_secret_thirteenth', name: 'The Thirteenth House',  reward: 6_500, reveal: 'The house that was taking applications has reviewed yours — you applied the moment you stepped onto the Lane; everyone does, it\'s in the fog\'s fine print. The door opens. Inside is a furnished map room. Yours. October residency only.' },
+            { id: 'hl_secret_parade',     name: 'The Quiet Parade',      reward: 7_000, reveal: 'At the exact middle of the night, the Lane\'s residents parade — silent, candlelit, splendid — to honor the one night a year the living visit them. You\'re handed a candle. Front row. The map gains a date circled in orange.' },
+        ],
+    },
+
+    // ── Seasonal: Summer Festival ────────────────────────────────────────────
+    scorchglass_shore: {
+        id: 'scorchglass_shore',
+        name: 'Scorchglass Shore',
+        emoji: '☀️',
+        color: '#ffd700',
+        defaultUnlocked: false,
+        unlockLevel: 1,
+        unlockCost: 0,
+        seasonalEventId: 'summer_festival',
+        payoutMultiplier: 1.5,
+        eventCurrency: { min: 3, max: 8 },
+        tagline: 'The beach where summer goes to show off.',
+        description: 'A coastline of sun-fused glass sand that only surfaces in high summer. The waves keep time with festival drums nobody can find, and the tide pools hold last year\'s best afternoons.',
+        intros: [
+            'Glass sand chimes under your boots. The whole beach is one long wind-chime and the wind knows the tune.',
+            'The sun here doesn\'t beat down. It performs. The sea provides percussion.',
+            'A wave rolls in carrying festival streamers from a party that ended a century ago, or starts tomorrow. Tides are flexible about tense.',
+            'Somewhere down the shore, drums. There are always drums. No one has ever found the drummers, and stopping to look means missing the song.',
+        ],
+        eventWeights: { encounter: 22, discovery: 18, trap: 12, treasure: 24, lore: 12, secret: 5, quiet: 7 },
+        landmarks: [
+            { id: 'ss_glass_dunes',  name: 'The Singing Dunes',    line: 'Dunes of pure scorchglass that ring in harmony at noon. At 12:01 they argue about the setlist.' },
+            { id: 'ss_tide_pools',   name: 'The Keepsake Pools',   line: 'Tide pools that hold reflections of perfect summer days. Lean in and one of them is yours, from before you knew to keep it.' },
+            { id: 'ss_bonfire',      name: 'The Bonfire That Stays Lit', line: 'A driftwood bonfire burning steadily above the tide line. It has never been fed. It has never gone out. There are always exactly enough seats.' },
+        ],
+        lore: [
+            { id: 'ss_lore_1', text: '“The Shore surfaces with the first true heat of summer. Cartographers mark it in sunscreen.”' },
+            { id: 'ss_lore_2', text: '“The festival the drums belong to has no recorded start and no scheduled end. Locals say you don\'t attend it; you realize you\'ve been attending it.”' },
+            { id: 'ss_lore_3', text: '“Glass from this beach holds warmth for years. Winter merchants pay absurdly for a pocketful of July.”' },
+        ],
+        encounters: [
+            {
+                id: 'ss_enc_crab',
+                name: 'The Crab With the Conch Concession',
+                emoji: '🦀',
+                intro: 'A crab in a tiny visor runs a stall of conch shells. "Each one plays a different summer," it clicks. "Most are paid for. One\'s a free sample. I forget which. Wanna gamble?"',
+                winChance: 0.55,
+                reward: { min: 1_400, max: 2_800 },
+                winLine: 'You pick the third shell from the left, on instinct. The free sample — AND it plays the summer the crab opened the stall. Sentimental value pays out in actual value.',
+                loseLine: 'You pick the biggest shell. Rookie. It plays a summer of jellyfish stings and sunburn, billed at full price. The crab does not do refunds; the visor says so.',
+                safeLine: 'You buy the cheapest shell honestly. It plays one perfect minute of last July. The crab, touched by a customer who just pays, slips a bonus in the bag.',
+            },
+            {
+                id: 'ss_enc_lifeguard',
+                name: 'The Lifeguard of the Deep End',
+                emoji: '🌊',
+                intro: 'A figure of living seawater sits on a lifeguard chair facing the open ocean. "No one\'s drowned on my watch in four hundred years," it says. "Race you to the buoy. I\'ll give you the head start and the current."',
+                winChance: 0.45,
+                reward: { min: 1_700, max: 3_400 },
+                winLine: 'You lose, obviously — it IS the water — but you finish, which apparently no one does. The prize for finishing has been compounding since the chair was built.',
+                loseLine: 'You cramp at the halfway buoy and get escorted back with overwhelming, humiliating gentleness. The rescue is free. Your dropped valuables join the collection in the deep end.',
+                safeLine: 'You decline the race and hold its towel instead. Four hundred years and no one has ever held its towel. It tips like the sea: largely.',
+            },
+        ],
+        traps: [
+            { id: 'ss_trap_sunglare', name: 'The Glare Off the Dunes',  line: 'Noon hits the scorchglass and the whole beach becomes one lens. You navigate out by sound, lighter in pocket and crispier in general.', penalty: { min: 200, max: 600 }, injuryChance: 0.25 },
+            { id: 'ss_trap_undertow', name: 'A Flirtatious Undertow',   line: 'The undertow only wanted to show you the sandbar. The sandbar is lovely. The walk back through the surf costs you everything not zipped shut.', penalty: { min: 250, max: 700 }, injuryChance: 0.20 },
+        ],
+        treasureLines: [
+            'The tide rolls a sea chest up the glass sand and waits for you to take the hint.',
+            'Under the bonfire\'s third seat: the festival\'s lost-and-found. The festival defines "lost" generously in your favor.',
+        ],
+        relics: [
+            { itemId: 'Pocketful of July',  rarity: 'rare',      lore: 'A handful of scorchglass, still warm. Will be warm in ten winters. Has strong opinions about being kept in drawers.' },
+            { itemId: 'The Free Sample',    rarity: 'epic',      lore: 'A conch from the crab\'s stall. Plays a different perfect summer every time. The crab maintains you stole it. The receipt in the shell says otherwise.' },
+        ],
+        secrets: [
+            { id: 'ss_secret_drummers', name: 'The Drummers, Finally',    reward: 6_500, reveal: 'You follow the drums at dusk, the one hour the glass doesn\'t glare — and find them: the waves themselves, drumming on the hulls of every ship that ever missed this festival. You\'re given a drum. The map gains a rhythm.' },
+            { id: 'ss_secret_tide',     name: 'Where Summer Winters',     reward: 7_000, reveal: 'Beneath the Keepsake Pools, a grotto where the Shore stores the off-season: folded sunlight, stacked afternoons, the smell of hot sand in labeled jars. You\'re allowed one jar. You take June.' },
+        ],
+    },
+
+    // ── Seasonal: Valentine's Day ────────────────────────────────────────────
+    velvet_arcade: {
+        id: 'velvet_arcade',
+        name: 'The Velvet Arcade',
+        emoji: '💝',
+        color: '#ff69b4',
+        defaultUnlocked: false,
+        unlockLevel: 1,
+        unlockCost: 0,
+        seasonalEventId: 'valentines_day',
+        payoutMultiplier: 1.5,
+        eventCurrency: { min: 3, max: 8 },
+        tagline: 'A covered promenade of old flames and older letters.',
+        description: 'A gaslit arcade of shops that appears for one week in February. Every storefront sells something that can\'t usually be bought: apologies, first dances, the right words.',
+        intros: [
+            'The arcade\'s gas lamps light themselves one by one ahead of you, like a slow round of applause.',
+            'Every shop window displays something you almost said once. The mannequins are tactful about it.',
+            'Violin music from nowhere in particular. It changes key when you slow down at a window. The arcade works on commission.',
+            'The air smells of roses and sealing wax. Somewhere a register rings for a purchase made forty years ago, finally.',
+        ],
+        eventWeights: { encounter: 22, discovery: 18, trap: 12, treasure: 22, lore: 16, secret: 5, quiet: 5 },
+        landmarks: [
+            { id: 'va_letter_office', name: 'The Dead Letter Office',  line: 'Every love letter never sent ends up here, filed by ache. The clerk assures you yours are well cared for. You didn\'t mention having any. The clerk smiles.' },
+            { id: 'va_dance_floor',   name: 'The Borrowed Ballroom',   line: 'A ballroom that lends out first dances. The floor remembers every step ever taken on it and will cover for yours.' },
+            { id: 'va_mirror_shop',   name: 'The Flattering Mirror',   line: 'A mirror shop with one mirror. It shows you the way someone, somewhere, once looked at you. People stand there a long time. The shop sells handkerchiefs, too. Brisk business.' },
+        ],
+        lore: [
+            { id: 'va_lore_1', text: '“The Arcade opens the week of the 14th and not one lamp sooner. Couples who met there can find it any day of the year, but only together.”' },
+            { id: 'va_lore_2', text: '“The Dead Letter Office has never lost a letter. Delivery is available. The postage is courage, exact change only.”' },
+            { id: 'va_lore_3', text: '“Nothing in the Arcade is priced in coin, officially. Unofficially, the merchants accept it with a sigh, like everyone else.”' },
+        ],
+        encounters: [
+            {
+                id: 'va_enc_matchmaker',
+                name: 'The Retired Matchmaker',
+                emoji: '🏹',
+                intro: 'At a café table sits a small ancient person with a ledger of every match they ever made. "Four thousand weddings," they say. "One mistake. Help me find it in the books and I\'ll make it worth your while."',
+                winChance: 0.50,
+                reward: { min: 1_500, max: 3_000 },
+                winLine: 'You find it: page 812, two names matched to each other\'s handwriting instead of each other. The matchmaker stares, laughs for a full minute, and pays the finder\'s fee. The couple, for the record, is still happy. Some mistakes hold.',
+                loseLine: 'You point confidently at page 9. Page 9 is the matchmaker\'s own wedding. The coffee you must now buy by way of apology is the most expensive in the Arcade.',
+                safeLine: 'You just keep them company while they search. At closing they find it themselves, and tip you for the conversation — matchmakers know exactly what company is worth.',
+            },
+            {
+                id: 'va_enc_cupid',
+                name: 'A Cupid on Inventory Day',
+                emoji: '💘',
+                intro: 'A cupid counts arrows behind the fletcher\'s stall, frowning. "One missing. Do you know what an unaccounted arrow DOES out there? Help me track it. Hazard pay included."',
+                winChance: 0.50,
+                reward: { min: 1_600, max: 3_200 },
+                winLine: 'You trace it to the Dead Letter Office, lodged in a mailbag — the arrow had a crush on a letter. Naturally. The cupid pays hazard rate and swears you to secrecy. (This embed doesn\'t count.)',
+                loseLine: 'You find the arrow by stepping on it. The paperwork for a self-inflicted administrative crush takes hours and costs you the filing fee. You feel very fondly about the form afterward. That\'s the arrow.',
+                safeLine: 'You hold the quiver and count while the cupid searches. The count comes out right twice in a row, which has never happened. Audit bonus. Cupids pay union rates.',
+            },
+        ],
+        traps: [
+            { id: 'va_trap_perfume',  name: 'The Sample Spritz',     line: 'A perfume called "Remember Me" is enthusiastically administered. You spend an hour remembering everyone. The lost time and the bottle you somehow bought are both billed.', penalty: { min: 200, max: 600 }, injuryChance: 0.15 },
+            { id: 'va_trap_dance',    name: 'The Pity Waltz',        line: 'The Borrowed Ballroom\'s floor decides you need the practice and refuses to release you for three full waltzes. Cover charge, shoe wear, dignity: itemized.', penalty: { min: 250, max: 650 }, injuryChance: 0.20 },
+        ],
+        treasureLines: [
+            'A shopkeeper hands you a velvet box: "Paid for in 1962. He never came back for it. It should be SOMEONE\'S." The box disagrees politely, then relents.',
+            'The Dead Letter Office pays cash bounties for re-shelving misfiled aches. You\'re efficient. The clerk is impressed and the drawer is generous.',
+        ],
+        relics: [
+            { itemId: 'Exact Change (Courage)',  rarity: 'rare',      lore: 'A small brass token, legal postage at the Dead Letter Office. Spend it to send the unsendable. They mint very few. Most people keep them forever, which the mint considers the point.' },
+            { itemId: 'The Unclaimed Velvet Box', rarity: 'epic',     lore: 'Paid for in 1962. Inside: a ring sized, impossibly, for whoever opens it. The Arcade does not explain itself.' },
+        ],
+        secrets: [
+            { id: 'va_secret_post',   name: 'The Midnight Delivery Round', reward: 6_500, reveal: 'At midnight the Dead Letter Office delivers — one letter a year, the one whose courage finally arrived. You\'re invited to walk the round. The recipient\'s face goes on your map of things worth finding.' },
+            { id: 'va_secret_lamp',   name: 'The First Lamp',              reward: 7_000, reveal: 'The Arcade\'s oldest gas lamp burns from no line and no main. Inside the flame, very small, two figures dance. The lamplighter tells you who they were. The Arcade exists because of them. Now your map does, a little, too.' },
+        ],
+    },
+};
+
+const REGION_LIST = Object.values(REGIONS);
+const CORE_REGION_IDS = REGION_LIST.filter(r => !r.seasonalEventId).map(r => r.id);
+const SEASONAL_REGION_IDS = REGION_LIST.filter(r => r.seasonalEventId).map(r => r.id);
+
+// Total secrets across core regions — used by achievements
+const TOTAL_CORE_SECRETS = REGION_LIST
+    .filter(r => !r.seasonalEventId)
+    .reduce((sum, r) => sum + r.secrets.length, 0);
+
+// ─── SHARED VOICE LINES ──────────────────────────────────────────────────────
+
+// Quiet runs — nothing happened, in an atmospheric way
+const QUIET_LINES = [
+    'Nothing finds you today. You walk, the world holds its breath, and you both agree to call it a draw.',
+    'A long, beautiful, profitless wander. The map gains nothing. You gain the kind of quiet money can\'t buy, which is convenient, because there isn\'t any.',
+    'Today the wilderness simply watches you pass. You get the feeling you were the event.',
+    'You find footprints. They\'re yours. You\'ve been walking in one enormous, contemplative circle, and honestly? Good for you.',
+    'The horizon stays exactly where horizons stay. Some expeditions are just stretching your legs with extra steps.',
+];
+
+// Footer flavor rotated on result embeds
+const FOOTER_LINES = [
+    'The map fills in. The blank spaces take notes.',
+    'Somewhere, the unexplored is rearranging itself to stay interesting.',
+    'I watched the whole thing. You did fine. Mostly.',
+    'Every expedition ends. The good ones end at home.',
+    'The world is bigger than your map. For now.',
+];
+
+// Trap injury notice
+const INJURY_LINES = [
+    'You\'ll walk that off. Eventually. Sit down for a bit.',
+    'Nothing broken except momentum. Rest up.',
+    'The wilderness plays rough when it likes you. Take ten.',
+];
+
+module.exports = {
+    LIMITS,
+    EXPLORER_LEVELS,
+    EVENT_XP,
+    TREASURE_TIERS,
+    TIER_COLORS,
+    REGIONS,
+    REGION_LIST,
+    CORE_REGION_IDS,
+    SEASONAL_REGION_IDS,
+    TOTAL_CORE_SECRETS,
+    QUIET_LINES,
+    FOOTER_LINES,
+    INJURY_LINES,
+};

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -735,6 +735,19 @@ const guildSchema = new Schema({
         announceChannelId:     { type: String,  default: null }
     },
 
+    // World Exploration System
+    exploration: {
+        enabled:            { type: Boolean, default: true },
+        // Scales all expedition coin payouts (0.1×–5×)
+        dropRateMultiplier: { type: Number,  default: 1,   min: 0.1, max: 5 },
+        // Shifts event-table weight from quiet/trap rolls toward treasure & secrets (0–0.25)
+        rareEventBonus:     { type: Number,  default: 0,   min: 0,   max: 0.25 },
+        // Region ids switched off by admins (hidden from /explore and the map)
+        disabledRegions:    [{ type: String }],
+        // Broadcast secret discoveries to the economy announcement channel
+        announceSecrets:    { type: Boolean, default: true }
+    },
+
     // Scheduler claim timestamps — prevent duplicate runs across cron restarts
     potwLastRunAt:          { type: Date, default: null },
     bankInterestLastRunAt:  { type: Date, default: null },

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -432,6 +432,63 @@ const userSchema = new Schema({
     },
     // ─────────────────────────────────────────────────────────────────────────
 
+    // ── World Exploration System ─────────────────────────────────────────────
+    exploration: {
+        // Stamina (regenerates over time, gates how often you can explore)
+        stamina:          { type: Number, default: 10 },
+        staminaLastRegen: { type: Date,   default: null },
+
+        // Explorer progression (cumulative XP; separate from Discord leveling XP)
+        xp:    { type: Number, default: 0 },
+        level: { type: Number, default: 1 },
+
+        // Cooldowns
+        lastExplore: { type: Date, default: null },
+        injuryUntil: { type: Date, default: null },
+
+        // Active region & purchased region unlocks (seasonal regions are
+        // calendar-gated instead and never appear here)
+        activeRegion:    { type: String, default: 'whispering_forest' },
+        unlockedRegions: [{ type: String }],
+
+        // The Explorer's Map: per-region chart progress, created on first visit
+        regions: [{
+            regionId:       { type: String, required: true },
+            discoveredAt:   { type: Date,   default: Date.now },
+            expeditions:    { type: Number, default: 0 },
+            landmarksFound: [{ type: String }],
+            loreFound:      [{ type: String }],
+            secretsFound:   [{ type: String }],
+        }],
+
+        // Expedition journal — most recent finds first, capped in the service
+        journal: [{
+            at:        { type: Date,   default: Date.now },
+            regionId:  { type: String },
+            eventType: { type: String },
+            summary:   { type: String },
+        }],
+
+        // Lifetime stats (used by achievement checks)
+        totalExpeditions:    { type: Number, default: 0 },
+        treasuresFound:      { type: Number, default: 0 },
+        trapsSprung:         { type: Number, default: 0 },
+        encountersWon:       { type: Number, default: 0 },
+        secretsFound:        { type: Number, default: 0 },
+        loreCollected:       { type: Number, default: 0 },
+        landmarksDiscovered: { type: Number, default: 0 },
+        relicsRecovered:     { type: Number, default: 0 },
+        totalEarned:         { type: Number, default: 0 },
+        bestHaul:            { type: Number, default: 0 },
+        sinceSecret:         { type: Number, default: 0 },  // expeditions since last secret (pity)
+
+        // Anti-exploit: rolling 24-hour window tracking
+        dailyCoins:       { type: Number, default: 0 },
+        dailyExpeditions: { type: Number, default: 0 },
+        dailyWindowStart: { type: Date,   default: null },
+    },
+    // ─────────────────────────────────────────────────────────────────────────
+
     // Rob trap — set via /trap set; triggers on successful rob against this user
     trap: {
         setAt:     { type: Date, default: null },

--- a/src/services/exploreService.js
+++ b/src/services/exploreService.js
@@ -143,7 +143,11 @@ function applyExplorerXp(user, amount) {
     return { leveled, newLevel: e.level, newTitle: getLevelData(e.level).title };
 }
 
-// ─── RNG ─────────────────────────────────────────────────────────────────────
+// ─── RNG / UTILS ─────────────────────────────────────────────────────────────
+
+function clamp(n, min, max) {
+    return Math.min(max, Math.max(min, n));
+}
 
 function weightedRoll(items) {
     const total = items.reduce((s, i) => s + i.weight, 0);
@@ -439,10 +443,6 @@ function finishAsTreasure(user, region, progress, result, coinMult, { smallOnly 
 }
 
 // ─── REWARD HELPERS ──────────────────────────────────────────────────────────
-
-function clamp(n, min, max) {
-    return Math.min(max, Math.max(min, n));
-}
 
 // Credit coins, respecting the rolling daily hard cap. Returns amount granted.
 function applyPayout(user, amount) {

--- a/src/services/exploreService.js
+++ b/src/services/exploreService.js
@@ -1,0 +1,580 @@
+'use strict';
+
+const {
+    LIMITS,
+    EXPLORER_LEVELS,
+    EVENT_XP,
+    TREASURE_TIERS,
+    REGIONS,
+    REGION_LIST,
+    QUIET_LINES,
+} = require('../data/exploreData');
+
+// ─── INIT ────────────────────────────────────────────────────────────────────
+
+function ensureExploreData(user) {
+    if (!user.exploration) user.exploration = {};
+    const e = user.exploration;
+
+    if (e.stamina          == null) e.stamina          = LIMITS.MAX_STAMINA;
+    if (e.staminaLastRegen == null) e.staminaLastRegen = null;
+    if (e.xp               == null) e.xp               = 0;
+    if (e.level            == null) e.level            = 1;
+    if (e.lastExplore      == null) e.lastExplore      = null;
+    if (e.injuryUntil      == null) e.injuryUntil      = null;
+    if (e.activeRegion     == null) e.activeRegion     = 'whispering_forest';
+    if (!Array.isArray(e.unlockedRegions)) e.unlockedRegions = [];
+    if (!Array.isArray(e.regions))         e.regions         = [];
+    if (!Array.isArray(e.journal))         e.journal         = [];
+
+    if (e.totalExpeditions     == null) e.totalExpeditions     = 0;
+    if (e.treasuresFound       == null) e.treasuresFound       = 0;
+    if (e.trapsSprung          == null) e.trapsSprung          = 0;
+    if (e.encountersWon        == null) e.encountersWon        = 0;
+    if (e.secretsFound         == null) e.secretsFound         = 0;
+    if (e.loreCollected        == null) e.loreCollected        = 0;
+    if (e.landmarksDiscovered  == null) e.landmarksDiscovered  = 0;
+    if (e.relicsRecovered      == null) e.relicsRecovered      = 0;
+    if (e.totalEarned          == null) e.totalEarned          = 0;
+    if (e.bestHaul             == null) e.bestHaul             = 0;
+    if (e.sinceSecret          == null) e.sinceSecret          = 0;
+
+    if (e.dailyCoins        == null) e.dailyCoins        = 0;
+    if (e.dailyExpeditions  == null) e.dailyExpeditions  = 0;
+    if (e.dailyWindowStart  == null) e.dailyWindowStart  = null;
+
+    if (!e.unlockedRegions.includes('whispering_forest')) {
+        e.unlockedRegions.push('whispering_forest');
+    }
+
+    user.markModified('exploration');
+}
+
+// Per-region progress record (creates one on first visit)
+function getRegionProgress(user, regionId, { create = false } = {}) {
+    const e = user.exploration;
+    let rec = e.regions.find(r => r.regionId === regionId);
+    if (!rec && create) {
+        e.regions.push({
+            regionId,
+            discoveredAt: new Date(),
+            expeditions: 0,
+            landmarksFound: [],
+            loreFound: [],
+            secretsFound: [],
+        });
+        rec = e.regions[e.regions.length - 1];
+        user.markModified('exploration');
+    }
+    return rec ?? null;
+}
+
+// ─── STAMINA / DAILY WINDOW ──────────────────────────────────────────────────
+
+function applyStaminaRegen(user) {
+    const e = user.exploration;
+    const max = LIMITS.MAX_STAMINA;
+    if (e.stamina >= max) {
+        e.stamina = max;
+        e.staminaLastRegen = new Date();
+        user.markModified('exploration');
+        return;
+    }
+    if (!e.staminaLastRegen) {
+        e.staminaLastRegen = new Date();
+        user.markModified('exploration');
+        return;
+    }
+    const elapsed = Date.now() - e.staminaLastRegen.getTime();
+    const intervals = Math.floor(elapsed / LIMITS.STAMINA_REGEN_MS);
+    if (intervals <= 0) return;
+
+    e.stamina = Math.min(max, e.stamina + intervals);
+    e.staminaLastRegen = new Date(e.staminaLastRegen.getTime() + intervals * LIMITS.STAMINA_REGEN_MS);
+    user.markModified('exploration');
+}
+
+function msUntilNextStamina(user) {
+    const e = user.exploration;
+    if (e.stamina >= LIMITS.MAX_STAMINA) return 0;
+    if (!e.staminaLastRegen) return LIMITS.STAMINA_REGEN_MS;
+    const elapsed = Date.now() - e.staminaLastRegen.getTime();
+    return Math.max(0, LIMITS.STAMINA_REGEN_MS - (elapsed % LIMITS.STAMINA_REGEN_MS));
+}
+
+function applyDailyReset(user) {
+    const e = user.exploration;
+    const now = Date.now();
+    if (!e.dailyWindowStart || now - e.dailyWindowStart.getTime() >= LIMITS.DAILY_WINDOW_MS) {
+        e.dailyCoins       = 0;
+        e.dailyExpeditions = 0;
+        e.dailyWindowStart = new Date(now);
+        user.markModified('exploration');
+    }
+}
+
+// ─── EXPLORER XP / LEVELS ────────────────────────────────────────────────────
+
+function getLevelData(level) {
+    return EXPLORER_LEVELS[Math.min(level, EXPLORER_LEVELS.length) - 1] ?? EXPLORER_LEVELS[0];
+}
+
+function xpToNextLevel(level, xp) {
+    const next = EXPLORER_LEVELS.find(l => l.level === level + 1);
+    if (!next) return null; // max level
+    return Math.max(0, next.xpRequired - xp);
+}
+
+/**
+ * Add explorer XP (cumulative), handling multi-level crossings.
+ * Returns { leveled, newLevel, newTitle }.
+ */
+function applyExplorerXp(user, amount) {
+    const e = user.exploration;
+    e.xp += amount;
+    let leveled = false;
+    let next = EXPLORER_LEVELS.find(l => l.level === e.level + 1);
+    while (next && e.xp >= next.xpRequired) {
+        e.level += 1;
+        leveled = true;
+        next = EXPLORER_LEVELS.find(l => l.level === e.level + 1);
+    }
+    user.markModified('exploration');
+    return { leveled, newLevel: e.level, newTitle: getLevelData(e.level).title };
+}
+
+// ─── RNG ─────────────────────────────────────────────────────────────────────
+
+function weightedRoll(items) {
+    const total = items.reduce((s, i) => s + i.weight, 0);
+    let r = Math.random() * total;
+    for (const item of items) {
+        r -= item.weight;
+        if (r <= 0) return item;
+    }
+    return items[items.length - 1];
+}
+
+function randInt(min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function randomFrom(arr) {
+    return arr[Math.floor(Math.random() * arr.length)];
+}
+
+// ─── REGION AVAILABILITY ─────────────────────────────────────────────────────
+
+/**
+ * Returns true if a seasonal region's event is currently running on the guild.
+ * Core regions always return true here (gating is unlock-based).
+ */
+function isRegionInSeason(region, guildSettings) {
+    if (!region.seasonalEventId) return true;
+    const ev = guildSettings?.activeEvent;
+    if (!ev?.type || ev.type !== region.seasonalEventId) return false;
+    if (ev.endsAt && new Date(ev.endsAt) <= new Date()) return false;
+    return true;
+}
+
+function isRegionEnabled(region, guildSettings) {
+    const disabled = guildSettings?.exploration?.disabledRegions ?? [];
+    return !disabled.includes(region.id);
+}
+
+/**
+ * Regions a player can currently set out into: unlocked core regions plus
+ * any in-season seasonal regions, minus anything an admin switched off.
+ */
+function getAvailableRegions(user, guildSettings) {
+    const e = user.exploration;
+    return REGION_LIST.filter(r => {
+        if (!isRegionEnabled(r, guildSettings)) return false;
+        if (r.seasonalEventId) return isRegionInSeason(r, guildSettings);
+        return e.unlockedRegions.includes(r.id);
+    });
+}
+
+// ─── EVENT ROLL ──────────────────────────────────────────────────────────────
+
+/**
+ * Roll the event type for an expedition into a region.
+ * Admin rareEventBonus and the secret pity counter shift weight toward
+ * the rarer slots.
+ */
+function rollEventType(user, region, guildSettings) {
+    const w = { ...region.eventWeights };
+
+    // Admin knob: shift weight from the mundane to secrets + treasure
+    const rareBonus = Math.min(0.25, Math.max(0, guildSettings?.exploration?.rareEventBonus ?? 0));
+    if (rareBonus > 0) {
+        const shift = (w.quiet + w.trap) * rareBonus;
+        w.quiet    = Math.max(1, w.quiet - shift * 0.5);
+        w.trap     = Math.max(1, w.trap  - shift * 0.5);
+        w.treasure += shift * 0.6;
+        w.secret   += shift * 0.4;
+    }
+
+    // Secret pity: long droughts self-correct
+    const pity = Math.min(
+        LIMITS.SECRET_PITY_MAX,
+        (user.exploration.sinceSecret ?? 0) * LIMITS.SECRET_PITY_PER_RUN
+    );
+    w.secret += pity;
+
+    const items = Object.entries(w)
+        .map(([type, weight]) => ({ type, weight }))
+        .filter(i => i.weight > 0);
+    return weightedRoll(items).type;
+}
+
+function rollTreasureTier() {
+    return weightedRoll(TREASURE_TIERS.map(t => ({ ...t, weight: t.weight })));
+}
+
+// ─── EXECUTE EXPLORE ─────────────────────────────────────────────────────────
+
+/**
+ * Run one expedition. Mutates the user document in memory (coins, XP, stats,
+ * region progress, inventory relics) but does NOT save it.
+ *
+ * Encounters are NOT resolved here — they return a pending result so the
+ * command layer can offer the approach/observe choice, then call
+ * resolveEncounter() with the player's decision.
+ *
+ * @param {object} user           - Mongoose user doc (ensureExploreData applied)
+ * @param {object} region         - region definition from exploreData
+ * @param {object} guildSettings  - guild doc (for drop-rate multipliers)
+ * @param {object} [opts]         - { coinMultiplier } event coin multiplier
+ * @returns {object} result
+ */
+function executeExplore(user, region, guildSettings, opts = {}) {
+    const e = user.exploration;
+    const progress = getRegionProgress(user, region.id, { create: true });
+    const firstVisit = progress.expeditions === 0;
+
+    e.stamina -= 1;
+    e.lastExplore = new Date();
+    e.totalExpeditions += 1;
+    e.dailyExpeditions += 1;
+    progress.expeditions += 1;
+
+    const dropRate = clamp(guildSettings?.exploration?.dropRateMultiplier ?? 1, 0.1, 5);
+    const coinMult = (opts.coinMultiplier ?? 1) * dropRate * region.payoutMultiplier;
+
+    const result = {
+        regionId: region.id,
+        firstVisit,
+        type: rollEventType(user, region, guildSettings),
+        payout: 0,
+        xp: 0,
+        intro: randomFrom(region.intros),
+        coinMultiplier: opts.coinMultiplier ?? 1,
+    };
+
+    switch (result.type) {
+        case 'discovery': {
+            const unfound = region.landmarks.filter(l => !progress.landmarksFound.includes(l.id));
+            if (unfound.length === 0) {
+                // Region fully charted — fall through to a modest treasure
+                return finishAsTreasure(user, region, progress, result, coinMult, { smallOnly: true });
+            }
+            const landmark = randomFrom(unfound);
+            progress.landmarksFound.push(landmark.id);
+            e.landmarksDiscovered += 1;
+            result.landmark = landmark;
+            result.payout = applyPayout(user, Math.round(randInt(300, 700) * coinMult));
+            result.xp = grantXp(user, EVENT_XP.discovery);
+            break;
+        }
+
+        case 'lore': {
+            const unfound = region.lore.filter(l => !progress.loreFound.includes(l.id));
+            if (unfound.length === 0) {
+                return finishAsTreasure(user, region, progress, result, coinMult, { smallOnly: true });
+            }
+            const fragment = randomFrom(unfound);
+            progress.loreFound.push(fragment.id);
+            e.loreCollected += 1;
+            result.lore = fragment;
+            result.payout = applyPayout(user, Math.round(randInt(150, 400) * coinMult));
+            result.xp = grantXp(user, EVENT_XP.lore);
+            break;
+        }
+
+        case 'secret': {
+            const unfound = region.secrets.filter(s => !progress.secretsFound.includes(s.id));
+            if (unfound.length === 0) {
+                return finishAsTreasure(user, region, progress, result, coinMult);
+            }
+            const secret = randomFrom(unfound);
+            progress.secretsFound.push(secret.id);
+            e.secretsFound += 1;
+            e.sinceSecret = 0;
+            result.secret = secret;
+            result.payout = applyPayout(user, Math.round(secret.reward * coinMult));
+            result.xp = grantXp(user, EVENT_XP.secret);
+            break;
+        }
+
+        case 'treasure': {
+            return finishAsTreasure(user, region, progress, result, coinMult);
+        }
+
+        case 'trap': {
+            const trap = randomFrom(region.traps);
+            const rawPenalty = randInt(trap.penalty.min, trap.penalty.max);
+            const penalty = Math.min(rawPenalty, Math.max(0, user.balance));
+            user.balance -= penalty;
+            e.trapsSprung += 1;
+            result.trap = trap;
+            result.penalty = penalty;
+            result.xp = grantXp(user, EVENT_XP.trap);
+            if (Math.random() < trap.injuryChance) {
+                e.injuryUntil = new Date(Date.now() + LIMITS.INJURY_PENALTY_MS);
+                result.injured = true;
+            }
+            break;
+        }
+
+        case 'encounter': {
+            // Pending: command layer resolves via resolveEncounter()
+            result.encounter = randomFrom(region.encounters);
+            result.pendingChoice = true;
+            break;
+        }
+
+        case 'quiet':
+        default: {
+            result.type = 'quiet';
+            result.quietLine = randomFrom(QUIET_LINES);
+            result.xp = grantXp(user, EVENT_XP.quiet);
+            break;
+        }
+    }
+
+    if (result.type !== 'secret' && !result.pendingChoice) {
+        e.sinceSecret += 1;
+    }
+
+    finalizeStats(user, result);
+    user.markModified('exploration');
+    return result;
+}
+
+/**
+ * Resolve a pending encounter after the player chose.
+ * @param {string} choice - 'approach' | 'observe' | null (timeout = observe)
+ */
+function resolveEncounter(user, region, guildSettings, result, choice) {
+    const e = user.exploration;
+    const enc = result.encounter;
+    const dropRate = clamp(guildSettings?.exploration?.dropRateMultiplier ?? 1, 0.1, 5);
+    const coinMult = (result.coinMultiplier ?? 1) * dropRate * region.payoutMultiplier;
+
+    result.pendingChoice = false;
+    result.choice = choice === 'approach' ? 'approach' : 'observe';
+
+    if (result.choice === 'approach') {
+        if (Math.random() < enc.winChance) {
+            result.outcome = 'win';
+            e.encountersWon += 1;
+            result.payout = applyPayout(user, Math.round(randInt(enc.reward.min, enc.reward.max) * coinMult));
+            result.xp = grantXp(user, EVENT_XP.encounter_win);
+        } else {
+            result.outcome = 'loss';
+            const penalty = Math.min(Math.round(randInt(200, 600) * dropRate), Math.max(0, user.balance));
+            user.balance -= penalty;
+            result.penalty = penalty;
+            result.xp = grantXp(user, EVENT_XP.encounter_loss);
+            if (Math.random() < 0.15) {
+                e.injuryUntil = new Date(Date.now() + LIMITS.INJURY_PENALTY_MS);
+                result.injured = true;
+            }
+        }
+    } else {
+        result.outcome = 'safe';
+        result.payout = applyPayout(user, Math.round(randInt(enc.reward.min, enc.reward.max) * coinMult * 0.35));
+        result.xp = grantXp(user, EVENT_XP.encounter_safe);
+    }
+
+    e.sinceSecret += 1;
+    finalizeStats(user, result);
+    user.markModified('exploration');
+    return result;
+}
+
+// Treasure resolution, also used as the fallback when a region is fully charted
+function finishAsTreasure(user, region, progress, result, coinMult, { smallOnly = false } = {}) {
+    const e = user.exploration;
+    result.type = 'treasure';
+
+    let tier = rollTreasureTier();
+    if (smallOnly && ['epic', 'legendary'].includes(tier.tier)) {
+        tier = TREASURE_TIERS.find(t => t.tier === 'uncommon');
+    }
+    result.treasureTier = tier;
+    result.treasureLine = randomFrom(region.treasureLines);
+    result.payout = applyPayout(user, Math.round(randInt(tier.min, tier.max) * coinMult));
+    result.xp = grantXp(user, EVENT_XP.treasure);
+    e.treasuresFound += 1;
+
+    // Rare+ treasures may carry a relic into the player's inventory
+    if (!smallOnly && Math.random() < tier.relicChance) {
+        const pool = region.relics.filter(r =>
+            tier.tier === 'legendary' ? true : r.rarity !== 'legendary'
+        );
+        if (pool.length) {
+            const relic = randomFrom(pool);
+            addRelicToInventory(user, relic);
+            e.relicsRecovered += 1;
+            result.relic = relic;
+        }
+    }
+
+    e.sinceSecret += 1;
+    finalizeStats(user, result);
+    user.markModified('exploration');
+    return result;
+}
+
+// ─── REWARD HELPERS ──────────────────────────────────────────────────────────
+
+function clamp(n, min, max) {
+    return Math.min(max, Math.max(min, n));
+}
+
+// Credit coins, respecting the rolling daily hard cap. Returns amount granted.
+function applyPayout(user, amount) {
+    const e = user.exploration;
+    const remaining = Math.max(0, LIMITS.DAILY_HARD_CAP - e.dailyCoins);
+    const granted = Math.min(amount, remaining);
+    if (granted > 0) {
+        user.balance       += granted;
+        e.totalEarned      += granted;
+        e.dailyCoins       += granted;
+    }
+    return granted;
+}
+
+// Explorer XP + report the amount so the command layer can mirror it into guild XP
+function grantXp(user, amount) {
+    applyExplorerXp(user, amount);
+    return amount;
+}
+
+function addRelicToInventory(user, relic) {
+    if (!user.inventory) user.inventory = [];
+    const existing = user.inventory.find(i => i.itemId === relic.itemId);
+    if (existing) existing.quantity += 1;
+    else user.inventory.push({ itemId: relic.itemId, quantity: 1 });
+    user.markModified('inventory');
+}
+
+function finalizeStats(user, result) {
+    const e = user.exploration;
+    if (result.payout > e.bestHaul) e.bestHaul = result.payout;
+}
+
+// ─── JOURNAL ─────────────────────────────────────────────────────────────────
+
+function addJournalEntry(user, regionId, eventType, summary) {
+    const e = user.exploration;
+    e.journal.unshift({ at: new Date(), regionId, eventType, summary });
+    if (e.journal.length > LIMITS.JOURNAL_CAP) {
+        e.journal.splice(LIMITS.JOURNAL_CAP);
+    }
+    user.markModified('exploration');
+}
+
+// ─── MAP RENDERING ───────────────────────────────────────────────────────────
+
+function regionCompletion(region, progress) {
+    const total = region.landmarks.length + region.lore.length + region.secrets.length;
+    if (!progress || total === 0) return 0;
+    const found = progress.landmarksFound.length + progress.loreFound.length + progress.secretsFound.length;
+    return Math.round((found / total) * 100);
+}
+
+function chartBar(pct, width = 10) {
+    const filled = Math.round((pct / 100) * width);
+    return '▰'.repeat(filled) + '▱'.repeat(width - filled);
+}
+
+/**
+ * Render the Explorer's Map as embed-ready text sections.
+ * Undiscovered regions appear as redacted entries; seasonal regions only
+ * appear if visited at least once or currently in season.
+ */
+function renderMap(user, guildSettings) {
+    const e = user.exploration;
+    const lines = [];
+
+    for (const region of REGION_LIST) {
+        if (!isRegionEnabled(region, guildSettings)) continue;
+        const progress = e.regions.find(r => r.regionId === region.id) ?? null;
+        const inSeason = isRegionInSeason(region, guildSettings);
+
+        // Seasonal regions the player has never seen and that aren't running: hidden entirely
+        if (region.seasonalEventId && !progress && !inSeason) continue;
+
+        if (!progress) {
+            const gate = region.seasonalEventId
+                ? 'in season now — go look'
+                : e.unlockedRegions.includes(region.id)
+                    ? 'unlocked — never entered'
+                    : `locked · Explorer Lv ${region.unlockLevel}`;
+            lines.push(`🌫️ **??? — uncharted**\n> \`▒▒▒▒▒▒▒▒▒▒\` *${gate}*`);
+            continue;
+        }
+
+        const pct = regionCompletion(region, progress);
+        const seasonalTag = region.seasonalEventId
+            ? (inSeason ? ' · *in season*' : ' · *out of season*')
+            : '';
+        lines.push(
+            `${region.emoji} **${region.name}** — ${pct}% charted${seasonalTag}\n` +
+            `> \`${chartBar(pct)}\` ` +
+            `🗿 ${progress.landmarksFound.length}/${region.landmarks.length} · ` +
+            `📜 ${progress.loreFound.length}/${region.lore.length} · ` +
+            `✨ ${progress.secretsFound.length}/${region.secrets.length}`
+        );
+    }
+
+    return lines;
+}
+
+// ─── MISC ────────────────────────────────────────────────────────────────────
+
+function formatMs(ms) {
+    const totalSec = Math.ceil(ms / 1000);
+    const h = Math.floor(totalSec / 3600);
+    const m = Math.floor((totalSec % 3600) / 60);
+    const s = totalSec % 60;
+    if (h > 0) return `${h}h ${m}m`;
+    if (m > 0) return `${m}m ${s}s`;
+    return `${s}s`;
+}
+
+module.exports = {
+    ensureExploreData,
+    getRegionProgress,
+    applyStaminaRegen,
+    msUntilNextStamina,
+    applyDailyReset,
+    getLevelData,
+    xpToNextLevel,
+    applyExplorerXp,
+    weightedRoll,
+    randomFrom,
+    isRegionInSeason,
+    isRegionEnabled,
+    getAvailableRegions,
+    executeExplore,
+    resolveEncounter,
+    addJournalEntry,
+    regionCompletion,
+    renderMap,
+    formatMs,
+    REGIONS,
+};

--- a/tests/exploreService.test.js
+++ b/tests/exploreService.test.js
@@ -1,0 +1,310 @@
+'use strict';
+
+const {
+    ensureExploreData,
+    applyStaminaRegen,
+    applyDailyReset,
+    applyExplorerXp,
+    xpToNextLevel,
+    getLevelData,
+    isRegionInSeason,
+    isRegionEnabled,
+    getAvailableRegions,
+    executeExplore,
+    resolveEncounter,
+    addJournalEntry,
+    regionCompletion,
+    renderMap,
+} = require('../src/services/exploreService');
+const {
+    LIMITS,
+    REGIONS,
+    REGION_LIST,
+    TOTAL_CORE_SECRETS,
+    EXPLORER_LEVELS,
+} = require('../src/data/exploreData');
+
+function makeUser(overrides = {}) {
+    const user = {
+        balance: 50_000,
+        inventory: [],
+        markModified: jest.fn(),
+        ...overrides,
+    };
+    ensureExploreData(user);
+    return user;
+}
+
+function makeGuildSettings(overrides = {}) {
+    return {
+        exploration: { enabled: true, dropRateMultiplier: 1, rareEventBonus: 0, disabledRegions: [] },
+        ...overrides,
+    };
+}
+
+describe('exploreData integrity', () => {
+    test('has 4 core and 4 seasonal regions', () => {
+        const core = REGION_LIST.filter(r => !r.seasonalEventId);
+        const seasonal = REGION_LIST.filter(r => r.seasonalEventId);
+        expect(core).toHaveLength(4);
+        expect(seasonal).toHaveLength(4);
+    });
+
+    test('core regions hold 16 secrets total (matches achievement target)', () => {
+        expect(TOTAL_CORE_SECRETS).toBe(16);
+    });
+
+    test('every region has a complete event table', () => {
+        for (const region of REGION_LIST) {
+            for (const slot of ['encounter', 'discovery', 'trap', 'treasure', 'lore', 'secret', 'quiet']) {
+                expect(region.eventWeights[slot]).toBeGreaterThan(0);
+            }
+        }
+    });
+
+    test('landmark/lore/secret ids are globally unique', () => {
+        const ids = REGION_LIST.flatMap(r => [
+            ...r.landmarks.map(l => l.id),
+            ...r.lore.map(l => l.id),
+            ...r.secrets.map(s => s.id),
+        ]);
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    test('explorer level table is strictly increasing', () => {
+        for (let i = 1; i < EXPLORER_LEVELS.length; i++) {
+            expect(EXPLORER_LEVELS[i].xpRequired).toBeGreaterThan(EXPLORER_LEVELS[i - 1].xpRequired);
+        }
+    });
+});
+
+describe('ensureExploreData', () => {
+    test('initialises defaults and the starter region', () => {
+        const user = makeUser();
+        expect(user.exploration.stamina).toBe(LIMITS.MAX_STAMINA);
+        expect(user.exploration.level).toBe(1);
+        expect(user.exploration.activeRegion).toBe('whispering_forest');
+        expect(user.exploration.unlockedRegions).toContain('whispering_forest');
+    });
+});
+
+describe('stamina regen', () => {
+    test('regenerates one point per interval', () => {
+        const user = makeUser();
+        user.exploration.stamina = 5;
+        user.exploration.staminaLastRegen = new Date(Date.now() - 2 * LIMITS.STAMINA_REGEN_MS);
+        applyStaminaRegen(user);
+        expect(user.exploration.stamina).toBe(7);
+    });
+
+    test('never exceeds the cap', () => {
+        const user = makeUser();
+        user.exploration.stamina = 9;
+        user.exploration.staminaLastRegen = new Date(Date.now() - 50 * LIMITS.STAMINA_REGEN_MS);
+        applyStaminaRegen(user);
+        expect(user.exploration.stamina).toBe(LIMITS.MAX_STAMINA);
+    });
+});
+
+describe('daily window', () => {
+    test('resets coins and expedition count after 24h', () => {
+        const user = makeUser();
+        user.exploration.dailyCoins = 5_000;
+        user.exploration.dailyExpeditions = 12;
+        user.exploration.dailyWindowStart = new Date(Date.now() - LIMITS.DAILY_WINDOW_MS - 1);
+        applyDailyReset(user);
+        expect(user.exploration.dailyCoins).toBe(0);
+        expect(user.exploration.dailyExpeditions).toBe(0);
+    });
+});
+
+describe('explorer XP', () => {
+    test('crosses multiple levels in one grant', () => {
+        const user = makeUser();
+        applyExplorerXp(user, 1_000);
+        expect(user.exploration.level).toBeGreaterThanOrEqual(5);
+    });
+
+    test('xpToNextLevel returns null at max level', () => {
+        const max = EXPLORER_LEVELS[EXPLORER_LEVELS.length - 1];
+        expect(xpToNextLevel(max.level, max.xpRequired)).toBeNull();
+    });
+
+    test('titles resolve for every level', () => {
+        for (const entry of EXPLORER_LEVELS) {
+            expect(getLevelData(entry.level).title).toBeTruthy();
+        }
+    });
+});
+
+describe('region availability', () => {
+    test('seasonal region requires its matching active event', () => {
+        const region = REGIONS.frostveil_pass;
+        expect(isRegionInSeason(region, makeGuildSettings())).toBe(false);
+        const withEvent = makeGuildSettings({
+            activeEvent: { type: 'winter_wonderland', endsAt: new Date(Date.now() + 3_600_000) },
+        });
+        expect(isRegionInSeason(region, withEvent)).toBe(true);
+    });
+
+    test('expired seasonal event closes the region', () => {
+        const withExpired = makeGuildSettings({
+            activeEvent: { type: 'winter_wonderland', endsAt: new Date(Date.now() - 1) },
+        });
+        expect(isRegionInSeason(REGIONS.frostveil_pass, withExpired)).toBe(false);
+    });
+
+    test('admin-disabled regions are excluded everywhere', () => {
+        const settings = makeGuildSettings();
+        settings.exploration.disabledRegions = ['whispering_forest'];
+        expect(isRegionEnabled(REGIONS.whispering_forest, settings)).toBe(false);
+        const user = makeUser();
+        const available = getAvailableRegions(user, settings);
+        expect(available.find(r => r.id === 'whispering_forest')).toBeUndefined();
+    });
+});
+
+describe('executeExplore', () => {
+    test('consumes stamina and records the expedition', () => {
+        const user = makeUser();
+        const result = executeExplore(user, REGIONS.whispering_forest, makeGuildSettings(), {});
+        if (result.pendingChoice) {
+            resolveEncounter(user, REGIONS.whispering_forest, makeGuildSettings(), result, 'observe');
+        }
+        expect(user.exploration.stamina).toBe(LIMITS.MAX_STAMINA - 1);
+        expect(user.exploration.totalExpeditions).toBe(1);
+        expect(result.firstVisit).toBe(true);
+        expect(user.exploration.regions[0].regionId).toBe('whispering_forest');
+    });
+
+    test('payouts respect the daily hard cap', () => {
+        const user = makeUser();
+        user.exploration.dailyCoins = LIMITS.DAILY_HARD_CAP;
+        user.exploration.dailyWindowStart = new Date();
+        const before = user.balance;
+        for (let i = 0; i < 30; i++) {
+            user.exploration.stamina = LIMITS.MAX_STAMINA;
+            user.exploration.lastExplore = null;
+            const r = executeExplore(user, REGIONS.whispering_forest, makeGuildSettings(), {});
+            if (r.pendingChoice) resolveEncounter(user, REGIONS.whispering_forest, makeGuildSettings(), r, 'observe');
+        }
+        // Capped: balance can only go down (traps/losses), never up
+        expect(user.balance).toBeLessThanOrEqual(before);
+    });
+
+    test('trap penalties never push balance negative', () => {
+        const user = makeUser({ balance: 0 });
+        for (let i = 0; i < 100; i++) {
+            user.exploration.stamina = LIMITS.MAX_STAMINA;
+            const r = executeExplore(user, REGIONS.sunken_docks, makeGuildSettings(), {});
+            if (r.pendingChoice) resolveEncounter(user, REGIONS.sunken_docks, makeGuildSettings(), r, 'approach');
+            expect(user.balance).toBeGreaterThanOrEqual(0);
+            user.exploration.dailyCoins = 0;
+            user.balance = 0;
+        }
+    });
+
+    test('secrets land on the map exactly once and reset pity', () => {
+        const user = makeUser();
+        const region = REGIONS.whispering_forest;
+        // Force the secret slot by exhausting pity weighting: run until all found
+        let guard = 5_000;
+        const progress = () => user.exploration.regions.find(r => r.regionId === region.id);
+        while ((progress()?.secretsFound.length ?? 0) < region.secrets.length && guard-- > 0) {
+            user.exploration.stamina = LIMITS.MAX_STAMINA;
+            user.exploration.dailyCoins = 0;
+            const r = executeExplore(user, region, makeGuildSettings(), {});
+            if (r.pendingChoice) resolveEncounter(user, region, makeGuildSettings(), r, 'observe');
+            if (r.type === 'secret') expect(user.exploration.sinceSecret).toBe(0);
+        }
+        const found = progress().secretsFound;
+        expect(new Set(found).size).toBe(found.length);
+        expect(found.length).toBe(region.secrets.length);
+    });
+
+    test('relics stack in the shared inventory', () => {
+        const user = makeUser();
+        const region = REGIONS.crystal_caves;
+        let guard = 10_000;
+        while (user.exploration.relicsRecovered < 2 && guard-- > 0) {
+            user.exploration.stamina = LIMITS.MAX_STAMINA;
+            user.exploration.dailyCoins = 0;
+            const r = executeExplore(user, region, makeGuildSettings(), {});
+            if (r.pendingChoice) resolveEncounter(user, region, makeGuildSettings(), r, 'observe');
+        }
+        const total = user.inventory.reduce((s, i) => s + i.quantity, 0);
+        expect(total).toBe(user.exploration.relicsRecovered);
+    });
+});
+
+describe('encounters', () => {
+    function forceEncounter(user, region, settings) {
+        let guard = 2_000;
+        while (guard-- > 0) {
+            user.exploration.stamina = LIMITS.MAX_STAMINA;
+            user.exploration.dailyCoins = 0;
+            const r = executeExplore(user, region, settings, {});
+            if (r.pendingChoice) return r;
+        }
+        throw new Error('no encounter rolled');
+    }
+
+    test('observe always pays a smaller, safe reward', () => {
+        const user = makeUser();
+        const settings = makeGuildSettings();
+        const r = forceEncounter(user, REGIONS.whispering_forest, settings);
+        resolveEncounter(user, REGIONS.whispering_forest, settings, r, 'observe');
+        expect(r.outcome).toBe('safe');
+        expect(r.payout).toBeGreaterThan(0);
+    });
+
+    test('timeout (null choice) is treated as observing', () => {
+        const user = makeUser();
+        const settings = makeGuildSettings();
+        const r = forceEncounter(user, REGIONS.whispering_forest, settings);
+        resolveEncounter(user, REGIONS.whispering_forest, settings, r, null);
+        expect(r.choice).toBe('observe');
+    });
+});
+
+describe('journal', () => {
+    test('caps at the configured length, newest first', () => {
+        const user = makeUser();
+        for (let i = 0; i < LIMITS.JOURNAL_CAP + 10; i++) {
+            addJournalEntry(user, 'whispering_forest', 'quiet', `entry ${i}`);
+        }
+        expect(user.exploration.journal).toHaveLength(LIMITS.JOURNAL_CAP);
+        expect(user.exploration.journal[0].summary).toBe(`entry ${LIMITS.JOURNAL_CAP + 9}`);
+    });
+});
+
+describe('map rendering', () => {
+    test('shows uncharted entries before first visit and progress after', () => {
+        const user = makeUser();
+        const settings = makeGuildSettings();
+        let lines = renderMap(user, settings);
+        expect(lines.join('\n')).toContain('uncharted');
+
+        const r = executeExplore(user, REGIONS.whispering_forest, settings, {});
+        if (r.pendingChoice) resolveEncounter(user, REGIONS.whispering_forest, settings, r, 'observe');
+        lines = renderMap(user, settings);
+        expect(lines.join('\n')).toContain('Whispering Forest');
+    });
+
+    test('completion is 100% when everything is found', () => {
+        const region = REGIONS.whispering_forest;
+        const progress = {
+            landmarksFound: region.landmarks.map(l => l.id),
+            loreFound: region.lore.map(l => l.id),
+            secretsFound: region.secrets.map(s => s.id),
+        };
+        expect(regionCompletion(region, progress)).toBe(100);
+        expect(regionCompletion(region, null)).toBe(0);
+    });
+
+    test('hidden seasonal regions stay off the map until visited or in season', () => {
+        const user = makeUser();
+        const lines = renderMap(user, makeGuildSettings());
+        expect(lines.join('\n')).not.toContain('Frostveil');
+    });
+});


### PR DESCRIPTION
A complete exploration gameplay loop narrated in Clawdia's voice:

- /explore go runs staged, atmospheric expeditions into 4 core regions
  (Whispering Forest, Crumbling Ruins, Crystal Caves, Sunken Docks) and
  4 seasonal regions tied to the existing seasonal events (Frostveil
  Pass, Hollowgrave Lane, Scorchglass Shore, The Velvet Arcade)
- Weighted per-region event tables: encounters (with an interactive
  approach/observe choice), discoveries, traps, treasure, lore
  fragments, and rare secrets with a pity system
- Persistent Explorer's Map per player (landmarks/lore/secrets charted
  per region) via /map or /explore map, plus journal and profile views
- Integration: coin payouts feed the economy (transaction-logged,
  daily hard cap), relics land in the shared /inventory, expeditions
  mirror guild leveling XP, 10 new exploration achievements (incl. a
  secret one), seasonal regions drop event-shop currency, big finds hit
  the big-win feed and announcement channel
- User.exploration / Guild.exploration schema blocks following the
  hunt/fish/mine embedded-subdocument convention
- Dashboard panel for admins: enable/disable, per-region toggles,
  payout multiplier, rare-event bonus, secret announcements (whitelisted
  + validated in the settings API)
- 26 unit tests covering data integrity, stamina/daily windows, region
  gating, payout caps, secrets, relics, journal, and map rendering

https://claude.ai/code/session_012ToGvoRgN5RS6QQ8QVp5yU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * World Exploration system: narrated expeditions, stamina/XP/levels, secrets/relics, and Explorer’s Map
  * New slash commands: /explore (go/map/travel/regions/journal/profile) and /map
  * Exploration achievements and in-game progress tracking

* **Dashboard**
  * Guild settings UI for Exploration: enable/disable, payout multipliers, rare-event bonus, secret announcements, disabled regions

* **Documentation**
  * Added detailed Exploration section to FEATURES.md

* **Tests**
  * Comprehensive tests for exploration service and data

* **Chores**
  * Adjusted achievements category ordering to surface exploration items
<!-- end of auto-generated comment: release notes by coderabbit.ai -->