### PR TITLE
Replace inline onclick handlers with event listeners for CSP compliance

### DIFF
--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -2293,8 +2293,8 @@
                     tagsHtml +
                 '</div>' +
                 '<div style="display:flex;gap:.5rem;flex-shrink:0;">' +
-                    '<button class="btn btn-sm" onclick="editKbEntry(\'' + entry._id + '\',\'' + encodeURIComponent(entry.title) + '\',\'' + encodeURIComponent(entry.content) + '\',\'' + encodeURIComponent((entry.tags||[]).join(',')) + '\')">Edit</button>' +
-                    '<button class="btn btn-danger btn-sm" onclick="deleteKbEntry(\'' + entry._id + '\')">Remove</button>' +
+                    '<button class="btn btn-sm kb-edit-btn" data-id="' + entry._id + '" data-title="' + encodeURIComponent(entry.title) + '" data-content="' + encodeURIComponent(entry.content) + '" data-tags="' + encodeURIComponent((entry.tags||[]).join(',')) + '">Edit</button>' +
+                    '<button class="btn btn-danger btn-sm kb-delete-btn" data-id="' + entry._id + '">Remove</button>' +
                 '</div>';
             return div;
         }
@@ -2311,8 +2311,8 @@
                     '<textarea id="kb-edit-content-' + id + '" rows="4" style="width:100%;resize:vertical;" placeholder="Content">' + escHtml(content) + '</textarea>' +
                     '<input id="kb-edit-tags-' + id + '" class="field-input" value="' + escHtml(tags) + '" placeholder="Tags (comma-separated)" style="width:100%;">' +
                     '<div style="display:flex;gap:.5rem;">' +
-                        '<button class="btn btn-primary btn-sm" onclick="saveKbEntry(\'' + id + '\')">Save</button>' +
-                        '<button class="btn btn-sm" onclick="cancelKbEdit()">Cancel</button>' +
+                        '<button class="btn btn-primary btn-sm kb-save-btn" data-id="' + id + '">Save</button>' +
+                        '<button class="btn btn-sm kb-cancel-btn">Cancel</button>' +
                     '</div>' +
                 '</div>';
         }
@@ -2397,6 +2397,29 @@
                 toast('An error occurred', 'error');
             }
         }
+
+        // KB static button listeners (inline onclick blocked by CSP)
+        document.addEventListener('DOMContentLoaded', function() {
+            var addBtn = document.getElementById('kb-add-btn');
+            if (addBtn) addBtn.addEventListener('click', addKbEntry);
+            var retryBtn = document.getElementById('kb-retry-btn');
+            if (retryBtn) retryBtn.addEventListener('click', retryLoadKnowledgeBase);
+            var kbList = document.getElementById('kb-list');
+            if (kbList) {
+                kbList.addEventListener('click', function(e) {
+                    var t = e.target;
+                    if (t.classList.contains('kb-edit-btn')) {
+                        editKbEntry(t.dataset.id, t.dataset.title, t.dataset.content, t.dataset.tags);
+                    } else if (t.classList.contains('kb-delete-btn')) {
+                        deleteKbEntry(t.dataset.id);
+                    } else if (t.classList.contains('kb-save-btn')) {
+                        saveKbEntry(t.dataset.id);
+                    } else if (t.classList.contains('kb-cancel-btn')) {
+                        cancelKbEdit();
+                    }
+                });
+            }
+        });
 
         // ── AI Summaries ──────────────────────────────────────────────────────────
         var summaryJobsLoaded = false;

--- a/src/dashboard/views/partials/panels/ai.ejs
+++ b/src/dashboard/views/partials/panels/ai.ejs
@@ -149,7 +149,7 @@
                             </div>
                             <div id="kb-error" style="display:none" class="analytics-error-card">
                                 <span>⚠ Couldn't load entries</span>
-                                <button class="btn btn-sm" onclick="retryLoadKnowledgeBase()">Retry</button>
+                                <button class="btn btn-sm" id="kb-retry-btn">Retry</button>
                             </div>
                         </div>
                         <div class="panel-head" style="margin-top:1rem"><h3>Add entry</h3></div>
@@ -166,7 +166,7 @@
                             <input type="text" id="kb-tags" placeholder="rules, faq, moderation">
                         </div>
                         <div class="actions-row">
-                            <button class="btn btn-primary" onclick="addKbEntry()">Add entry</button>
+                            <button class="btn btn-primary" id="kb-add-btn">Add entry</button>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
Refactored the Knowledge Base (KB) UI event handling to comply with Content Security Policy (CSP) restrictions by replacing inline `onclick` attributes with data-driven event listeners.

## Key Changes
- **Removed inline onclick handlers** from KB buttons (Edit, Remove, Save, Cancel, Add entry, Retry) in `guild-settings.ejs` and `ai.ejs`
- **Added data attributes** to buttons to store necessary parameters (id, title, content, tags) instead of embedding them in onclick calls
- **Implemented centralized event delegation** using a single `DOMContentLoaded` listener that:
  - Attaches click handlers to the KB list container and static buttons
  - Routes clicks to appropriate handler functions based on button class names
  - Extracts parameters from `dataset` properties instead of inline function arguments
- **Added button IDs** (`kb-add-btn`, `kb-retry-btn`) to enable direct element selection for static button listeners

## Implementation Details
- Event delegation pattern reduces the number of individual event listeners needed
- Data attributes (`data-id`, `data-title`, `data-content`, `data-tags`) replace inline parameter encoding
- All existing functionality is preserved; this is purely a refactoring for CSP compliance
- The solution maintains backward compatibility with the existing KB entry management functions

https://claude.ai/code/session_01S5MwLrd6HToLT2FQaFmkU7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced Knowledge Base UI interaction handling in guild settings and AI panel for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->