### PR TITLE
Remove explicit null default from sourceKey field in KnowledgeBase

### DIFF
--- a/src/models/KnowledgeBase.js
+++ b/src/models/KnowledgeBase.js
@@ -12,7 +12,7 @@ const knowledgeBaseSchema = new Schema({
 });
 
 knowledgeBaseSchema.index({ guildId: 1, createdAt: -1 });
-// Sparse unique index on sourceKey so reruns of sync-pins upsert in place and manual entries (sourceKey=null) are unaffected
+// Sparse unique index on sourceKey so reruns of sync-pins upsert in place and manual entries (sourceKey absent/undefined, not present) are unaffected
 knowledgeBaseSchema.index({ guildId: 1, sourceKey: 1 }, { unique: true, sparse: true });
 // Compound text index with guildId as equality-prefix so MongoDB can scope $text searches per guild
 knowledgeBaseSchema.index({ guildId: 1, title: 'text', content: 'text', tags: 'text' });

--- a/src/models/KnowledgeBase.js
+++ b/src/models/KnowledgeBase.js
@@ -6,8 +6,8 @@ const knowledgeBaseSchema = new Schema({
     content:   { type: String, required: true },
     tags:      [{ type: String }],
     addedBy:   { type: String, required: true },
-    // Stable key for pin-synced entries (`${guildId}:${messageId}`); null for manual entries
-    sourceKey: { type: String, default: null },
+    // Stable key for pin-synced entries (`${guildId}:${messageId}`); absent for manual entries
+    sourceKey: { type: String },
     createdAt: { type: Date, default: Date.now }
 });
 


### PR DESCRIPTION
## Summary
Updated the KnowledgeBase schema to remove the explicit `default: null` assignment from the `sourceKey` field, allowing MongoDB to handle the absence of the field naturally.

## Key Changes
- Removed `default: null` from the `sourceKey` field definition
- Updated the comment to reflect that manual entries have an "absent" sourceKey rather than an explicit null value
- This aligns with MongoDB best practices where optional fields are simply omitted rather than explicitly set to null

## Implementation Details
The `sourceKey` field is used to store a stable identifier (`${guildId}:${messageId}`) for entries synced from pinned messages. Manual entries do not have this key. By removing the explicit default, the field will only be present in documents when explicitly set, which is more idiomatic for MongoDB schemas and can provide minor storage and query performance benefits.

https://claude.ai/code/session_018Lapu4C4Fwsac5XMgp34Ek

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how manually-created knowledge base entries are stored by properly handling missing source identifiers instead of storing null values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->