### PR TITLE
Phase 4 live-service: pet evolution & battles + season pass overhaul

### DIFF
--- a/src/commands/economy/pet.js
+++ b/src/commands/economy/pet.js
@@ -568,6 +568,19 @@ function petUsable(pet) {
     return { ok: true };
 }
 
+function onBattleCooldown(pet) {
+    return pet?.lastBattle && Date.now() - new Date(pet.lastBattle).getTime() < BATTLE_COOLDOWN_MS;
+}
+
+// Snapshot the combat-relevant fields so result rendering reflects PRE-battle
+// state even after applyPetXp mutates the live pet (level/stage/xp).
+function petSnapshot(pet) {
+    return { petId: pet.petId, name: pet.name, personality: pet.personality, level: pet.level ?? 1, evolutionStage: pet.evolutionStage ?? 1 };
+}
+
+// petA/petB must be PRE-battle snapshots: result.finalHpA/B and the HP-bar
+// denominators (max HP) are computed from pre-battle stats, so rendering from
+// post-XP pets would mismatch the bars and show the wrong level.
 function battleResultEmbed({ color, title, petA, petB, result, currency, payoutLine, xpLineA, xpLineB }) {
     const da = getPetDisplay(petA), db = getPetDisplay(petB);
     const sa = getPetStats(petA),   sb = getPetStats(petB);
@@ -619,7 +632,12 @@ async function executeBattle(interaction) {
         return interaction.reply({ content: `${getPetDisplay(myPet).emoji} **${getPetDisplay(myPet).titledName}** is recovering — ready to battle again in **${mins}m**.`, ephemeral: true });
     }
 
-    if (!opponent) return wildBattle(interaction, user, slot, currency, guildSettings);
+    if (!opponent) {
+        if (bet > 0) {
+            return interaction.reply({ content: "You can't wager against a wild pet — challenge a member instead.", ephemeral: true });
+        }
+        return wildBattle(interaction, user, slot, currency, guildSettings);
+    }
 
     // ── PvP setup ──
     if (bet > 0) {
@@ -648,10 +666,11 @@ async function wildBattle(interaction, user, slot, currency, guildSettings) {
     await interaction.deferReply();
     const myPet  = user.pets[slot];
     const wild   = makeWildPet(myPet.level ?? 1);
+    const mySnap = petSnapshot(myPet); // pre-XP snapshot for consistent result rendering
     const result = simulateBattle(myPet, wild);
     const won    = result.winner === 'a';
 
-    const da = getPetDisplay(myPet), db = getPetDisplay(wild);
+    const da = getPetDisplay(mySnap), db = getPetDisplay(wild);
     const intro = new EmbedBuilder()
         .setColor('#9b59b6')
         .setTitle('⚔️ A wild challenger appears!')
@@ -675,7 +694,7 @@ async function wildBattle(interaction, user, slot, currency, guildSettings) {
         embeds: [battleResultEmbed({
             color: won ? '#2ecc71' : '#e74c3c',
             title: won ? `🏆 ${da.titledName} won the wild battle!` : `💀 ${da.titledName} was beaten back…`,
-            petA: myPet, petB: wild, result, currency,
+            petA: mySnap, petB: wild, result, currency,
             payoutLine: null,
             xpLineA: petXpLine(da.titledName, xpRes),
         })],
@@ -738,15 +757,21 @@ async function pvpBattle(interaction, ctx) {
         const aPet = chUser?.pets?.[slot];
         const bPet = opUser?.pets?.find(p => p.hunger >= STARVING_THRESHOLD);
 
-        // If a fighter vanished (released mid-challenge), refund and abort
-        if (!aPet || !bPet) {
+        // If a fighter is gone, no longer battle-ready, or went on cooldown
+        // between the challenge and acceptance, refund and abort.
+        const refundAndCancel = (reason) => {
             if (bet > 0) {
-                await User.updateOne({ userId: interaction.user.id, guildId }, { $inc: { balance: bet } }).catch(() => {});
-                await User.updateOne({ userId: opponent.id, guildId }, { $inc: { balance: bet } }).catch(() => {});
+                User.updateOne({ userId: interaction.user.id, guildId }, { $inc: { balance: bet } }).catch(() => {});
+                User.updateOne({ userId: opponent.id, guildId }, { $inc: { balance: bet } }).catch(() => {});
             }
-            return interaction.editReply({ content: null, embeds: [EmbedBuilder.from(challengeEmbed).setColor('#e74c3c').setDescription('A pet is no longer available — the battle was cancelled and any wagers refunded.')], components: [] }).catch(() => {});
-        }
+            return interaction.editReply({ content: null, embeds: [EmbedBuilder.from(challengeEmbed).setColor('#e74c3c').setDescription(`${reason} — the battle was cancelled${bet > 0 ? ' and any wagers refunded' : ''}.`)], components: [] }).catch(() => {});
+        };
+        if (!aPet || !bPet) return refundAndCancel('A pet is no longer available');
+        if (!petUsable(aPet).ok || !petUsable(bPet).ok) return refundAndCancel('A pet is no longer battle-ready');
+        if (onBattleCooldown(aPet) || onBattleCooldown(bPet)) return refundAndCancel('A pet is now recovering from a recent battle');
 
+        // Pre-battle snapshots for consistent result rendering (applyPetXp below mutates levels)
+        const aSnap = petSnapshot(aPet), bSnap = petSnapshot(bPet);
         const result = simulateBattle(aPet, bPet);
         const aWon   = result.winner === 'a';
 
@@ -789,14 +814,14 @@ async function pvpBattle(interaction, ctx) {
             console.error('[pet battle] save error:', err);
         }
 
-        const da2 = getPetDisplay(aPet), db2 = getPetDisplay(bPet);
+        const da2 = getPetDisplay(aSnap), db2 = getPetDisplay(bSnap);
         const winnerDisp = aWon ? da2 : db2;
         return interaction.editReply({
             content: null,
             embeds: [battleResultEmbed({
                 color: '#f1c40f',
                 title: `🏆 ${winnerDisp.titledName} wins the battle!`,
-                petA: aPet, petB: bPet, result, currency,
+                petA: aSnap, petB: bSnap, result, currency,
                 payoutLine,
                 xpLineA: petXpLine(da2.titledName, aXp),
                 xpLineB: petXpLine(db2.titledName, bXp),

--- a/src/commands/economy/pet.js
+++ b/src/commands/economy/pet.js
@@ -18,12 +18,46 @@ const {
     getMoodLine,
     getMoodColor,
     heartBar,
+    PET_MAX_LEVEL,
+    XP_FEED_FAVORITE,
+    XP_FEED_OTHER,
+    XP_BATTLE_WIN,
+    XP_BATTLE_LOSS,
+    XP_WILD_WIN,
+    XP_WILD_LOSS,
+    xpForLevel,
+    getPetDisplay,
+    getEffectiveBonusPct,
+    applyPetXp,
+    getPetStats,
+    simulateBattle,
+    makeWildPet,
     assignPersonality,
 } = require('../../services/petService');
 const { generatePetSprite } = require('../../utils/cardGenerator');
 const { applyXpGain, announceLevelUp } = require('../../utils/applyXpGain');
+const { logTransaction } = require('../../utils/logTransaction');
 
 const HUNGER_BAR_LENGTH = 10;
+const BATTLE_COOLDOWN_MS  = 10 * 60 * 1000;    // per-pet battle cooldown
+const BATTLE_MIN_ACCOUNT_AGE_MS = 7 * 24 * 3_600_000; // wagered battles only
+const BATTLE_RAKE = 0.05;
+const _delay = ms => new Promise(r => setTimeout(r, ms));
+
+function hpBar(current, max, length = 10) {
+    const filled = Math.max(0, Math.round((current / Math.max(1, max)) * length));
+    return '🟩'.repeat(Math.min(filled, length)) + '⬛'.repeat(Math.max(0, length - filled));
+}
+
+// Compact battle log: highlight up to the last few exchanges of the fight.
+function battleLogLines(rounds, nameA, nameB) {
+    return rounds.slice(-6).map(rd => {
+        const who = rd.attacker === 'a' ? nameA : nameB;
+        const tgt = rd.attacker === 'a' ? nameB : nameA;
+        const crit = rd.crit ? ' 💥' : '';
+        return `• **${who}** hits **${tgt}** for **${rd.damage}**${crit}`;
+    });
+}
 
 function hungerBar(hunger) {
     const filled = Math.round((hunger / 100) * HUNGER_BAR_LENGTH);
@@ -97,7 +131,8 @@ function buildPetEmbed(pet, index, total, ownerAvatarURL) {
     const moodColor   = getMoodColor(pet.hunger);
     const bonusActive = pet.hunger >= STARVING_THRESHOLD;
     const bonusEmoji  = bonusActive ? '✅' : '❌';
-    const bonusLabel  = `+${def?.bonusPct ?? 0}% ${(def?.bonusType ?? '').replace(/_/g, ' ')}${bonusActive ? '' : ' *(inactive)*'}`;
+    const effPct      = getEffectiveBonusPct(pet);
+    const bonusLabel  = `+${effPct}% ${(def?.bonusType ?? '').replace(/_/g, ' ')}${bonusActive ? '' : ' *(inactive)*'}`;
 
     const lastFedMs  = pet.lastFed ? Date.now() - new Date(pet.lastFed).getTime() : 0;
     const lastFedH   = Math.floor(lastFedMs / 3600000);
@@ -114,15 +149,27 @@ function buildPetEmbed(pet, index, total, ownerAvatarURL) {
     const personalityDef = pet.personality ? PERSONALITY_TRAITS[pet.personality] : null;
     const personalityLine = personalityDef ? `\n${personalityDef.emoji} *${personalityDef.label}* — ${personalityDef.desc}` : '';
 
+    const { emoji: dispEmoji } = getPetDisplay(pet);
+    const level   = pet.level ?? 1;
+    const stage   = pet.evolutionStage ?? 1;
+    const stageStars = '⭐'.repeat(stage);
+    const xpInLevel  = (pet.xp ?? 0) - xpForLevel(level);
+    const xpToNext   = level >= PET_MAX_LEVEL ? 0 : xpForLevel(level + 1) - xpForLevel(level);
+    const levelLine  = level >= PET_MAX_LEVEL
+        ? `Lv. **${level}** (MAX) ${stageStars}`
+        : `Lv. **${level}** ${stageStars} — ${xpInLevel}/${xpToNext} XP`;
+    const record = `${pet.battleWins ?? 0}W / ${pet.battleLosses ?? 0}L`;
+
     return new EmbedBuilder()
         .setColor(moodColor)
-        .setAuthor({ name: `${displayName} • ${def?.name ?? pet.petId}`, iconURL: ownerAvatarURL })
-        .setDescription(`*${moodLine}*${personalityLine}${potwLine}${restLine}`)
+        .setAuthor({ name: `${getPetDisplay(pet).titledName} • ${def?.name ?? pet.petId}`, iconURL: ownerAvatarURL })
+        .setDescription(`${dispEmoji} *${moodLine}*${personalityLine}${potwLine}${restLine}`)
         .addFields(
+            { name: '📈 Level',             value: levelLine,                            inline: false },
             { name: '❤️ Bond',              value: `${heartBar(bondDays)} ${bondDays}d`, inline: false },
             { name: '🍖 Hunger',            value: hungerBar(pet.hunger),                inline: false },
             { name: `${bonusEmoji} Bonus`,  value: bonusLabel,                           inline: true  },
-            { name: '🐾 Species',           value: `${def?.emoji ?? ''} ${def?.name ?? pet.petId}`, inline: true },
+            { name: '⚔️ Battle Record',     value: record,                               inline: true  },
         )
         .setFooter({ text: `Pet ${index + 1} of ${total} • Last fed ${lastFedStr}` })
         .setTimestamp();
@@ -286,6 +333,7 @@ async function executeStatus(interaction) {
 
             const xpGain = 15 + Math.floor(Math.random() * 11); // 15–25 XP
             const { leveled } = applyXpGain(freshUser, xpGain);
+            const petXpResult = applyPetXp(freshUser.pets[idx], 10);
             freshUser.pets[idx].lastPlay           = new Date();
             freshUser.pets[idx].weeklyInteractions = (freshUser.pets[idx].weeklyInteractions || 0) + 1;
             freshUser.markModified('pets');
@@ -305,7 +353,12 @@ async function executeStatus(interaction) {
             }
 
             const levelNote = leveled ? `\n🎉 **Level up! You're now level ${freshUser.level}!**` : '';
-            await btn.reply({ content: `🎾 You played with **${name}**! They loved it.\n✨ **+${xpGain} XP** earned!${levelNote}`, ephemeral: true });
+            const petNote = petXpResult.evolved
+                ? `\n🌟 **${name} evolved to ${getPetDisplay(freshUser.pets[idx]).titledName}!**`
+                : petXpResult.leveledUp
+                ? `\n📈 **${name} reached pet Level ${petXpResult.toLevel}!**`
+                : '';
+            await btn.reply({ content: `🎾 You played with **${name}**! They loved it.\n✨ **+${xpGain} XP** for you, **+${petXpResult.gained} XP** for ${name}!${levelNote}${petNote}`, ephemeral: true });
             await interaction.editReply({
                 embeds:     [buildPetEmbed(freshUser.pets[idx], idx, freshUser.pets.length, ownerAvatarURL)],
                 components: buildNavComponents(interaction.user.id, idx, freshUser.pets.length),
@@ -427,6 +480,7 @@ async function executeFeed(interaction) {
     user.pets[petIndex].starving        = result.hunger < STARVING_THRESHOLD;
     user.pets[petIndex].weeklyInteractions = (user.pets[petIndex].weeklyInteractions || 0) + 1;
     if (result.hunger >= STARVING_THRESHOLD) user.pets[petIndex].starvingStartAt = null;
+    const feedXp = applyPetXp(user.pets[petIndex], result.isFavorite ? XP_FEED_FAVORITE : XP_FEED_OTHER);
     user.markModified('pets');
 
     try {
@@ -438,10 +492,16 @@ async function executeFeed(interaction) {
 
     const displayName  = pet.name || def?.name || pet.petId;
     const favoriteNote = result.isFavorite ? ' *(favorite food — +25 hunger!)*' : ' *(not favorite — +10 hunger)*';
+    const progressNote = feedXp.evolved
+        ? `\n🌟 **${displayName} evolved!** Now an **${getPetDisplay(user.pets[petIndex]).titledName}** (Stage ${feedXp.toStage})!`
+        : feedXp.leveledUp
+        ? `\n🎉 **${displayName} reached Level ${feedXp.toLevel}!**`
+        : '';
 
     const embed = new EmbedBuilder()
         .setColor(result.hunger >= STARVING_THRESHOLD ? '#4caf50' : '#ff5722')
-        .setTitle(`${def?.emoji ?? '🐾'} ${displayName} fed!`)
+        .setTitle(`${getPetDisplay(user.pets[petIndex]).emoji} ${displayName} fed!`)
+        .setDescription(`✨ **+${feedXp.gained} pet XP**${progressNote}`)
         .addFields(
             { name: 'Food',   value: `\`${materialId}\`${favoriteNote}`,   inline: true  },
             { name: 'Hunger', value: hungerBar(result.hunger),              inline: false },
@@ -498,6 +558,258 @@ async function executeRename(interaction) {
 
     const def = PET_DEFINITIONS[user.pets[petIndex].petId];
     return interaction.reply({ content: `${def?.emoji ?? '🐾'} Pet renamed to **${newName}**!`, ephemeral: true });
+}
+
+// ── Battle ──────────────────────────────────────────────────────────────────
+
+function petUsable(pet) {
+    if (!pet) return { ok: false, reason: 'no pet in that slot' };
+    if (pet.hunger < STARVING_THRESHOLD) return { ok: false, reason: 'too hungry to fight (feed it first)' };
+    return { ok: true };
+}
+
+function battleResultEmbed({ color, title, petA, petB, result, currency, payoutLine, xpLineA, xpLineB }) {
+    const da = getPetDisplay(petA), db = getPetDisplay(petB);
+    const sa = getPetStats(petA),   sb = getPetStats(petB);
+    return new EmbedBuilder()
+        .setColor(color)
+        .setTitle(title)
+        .setDescription(
+            `${da.emoji} **${da.titledName}** (Lv.${petA.level ?? 1})  🆚  ${db.emoji} **${db.titledName}** (Lv.${petB.level ?? 1})\n\n` +
+            `${da.emoji} ${hpBar(result.finalHpA, sa.hp)} ${Math.max(0, result.finalHpA)}/${sa.hp}\n` +
+            `${db.emoji} ${hpBar(result.finalHpB, sb.hp)} ${Math.max(0, result.finalHpB)}/${sb.hp}\n\n` +
+            battleLogLines(result.rounds, da.titledName, db.titledName).join('\n') +
+            (payoutLine ? `\n\n${payoutLine}` : '') +
+            (xpLineA ? `\n${xpLineA}` : '') +
+            (xpLineB ? `\n${xpLineB}` : '')
+        )
+        .setTimestamp();
+}
+
+function petXpLine(name, res) {
+    if (res.evolved)   return `🌟 **${name}** evolved to Stage ${res.toStage}! (+${res.gained} XP)`;
+    if (res.leveledUp) return `📈 **${name}** reached Level ${res.toLevel}! (+${res.gained} XP)`;
+    return `✨ **${name}** +${res.gained} XP`;
+}
+
+async function executeBattle(interaction) {
+    const opponent = interaction.options.getUser('opponent');
+    const slot     = interaction.options.getInteger('slot') ?? 0;
+    const bet      = interaction.options.getInteger('bet') ?? 0;
+
+    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    if (guildSettings?.economy?.enabled === false) {
+        return interaction.reply({ content: 'The economy is disabled in this server.', ephemeral: true });
+    }
+    const currency = guildSettings?.economy?.currency ?? '💰';
+
+    const user = await resolveUser(interaction);
+    await syncHungerAndRunaway(user, interaction);
+    await user.save().catch(() => {});
+
+    const myPet = user.pets?.[slot];
+    const usable = petUsable(myPet);
+    if (!usable.ok) {
+        return interaction.reply({ content: `Your pet in slot ${slot} is ${usable.reason}.`, ephemeral: true });
+    }
+
+    // Per-pet cooldown
+    if (myPet.lastBattle && Date.now() - new Date(myPet.lastBattle).getTime() < BATTLE_COOLDOWN_MS) {
+        const mins = Math.ceil((BATTLE_COOLDOWN_MS - (Date.now() - new Date(myPet.lastBattle).getTime())) / 60000);
+        return interaction.reply({ content: `${getPetDisplay(myPet).emoji} **${getPetDisplay(myPet).titledName}** is recovering — ready to battle again in **${mins}m**.`, ephemeral: true });
+    }
+
+    if (!opponent) return wildBattle(interaction, user, slot, currency, guildSettings);
+
+    // ── PvP setup ──
+    if (bet > 0) {
+        if (opponent.id === interaction.user.id) return interaction.reply({ content: "You can't wager against yourself.", ephemeral: true });
+        if (opponent.bot) return interaction.reply({ content: "Bots don't keep pets.", ephemeral: true });
+        const maxBet = guildSettings?.economy?.duelMaxBet ?? 10_000;
+        if (bet > maxBet) return interaction.reply({ content: `The maximum battle wager here is **${maxBet.toLocaleString()}** coins.`, ephemeral: true });
+        if (Date.now() - interaction.user.createdTimestamp < BATTLE_MIN_ACCOUNT_AGE_MS
+            || Date.now() - opponent.createdTimestamp < BATTLE_MIN_ACCOUNT_AGE_MS) {
+            return interaction.reply({ content: 'Both accounts must be at least 7 days old for wagered battles.', ephemeral: true });
+        }
+    } else if (opponent.id === interaction.user.id || opponent.bot) {
+        return interaction.reply({ content: 'Pick another member to battle.', ephemeral: true });
+    }
+
+    const oppUser = await User.findOne({ userId: opponent.id, guildId: interaction.guild.id });
+    const oppPet  = oppUser?.pets?.find(p => p.hunger >= STARVING_THRESHOLD);
+    if (!oppPet) {
+        return interaction.reply({ content: `${opponent.username} has no battle-ready pet (they need a fed pet).`, ephemeral: true });
+    }
+
+    return pvpBattle(interaction, { user, myPet, slot, opponent, oppUser, oppPet, bet, currency, guildSettings });
+}
+
+async function wildBattle(interaction, user, slot, currency, guildSettings) {
+    await interaction.deferReply();
+    const myPet  = user.pets[slot];
+    const wild   = makeWildPet(myPet.level ?? 1);
+    const result = simulateBattle(myPet, wild);
+    const won    = result.winner === 'a';
+
+    const da = getPetDisplay(myPet), db = getPetDisplay(wild);
+    const intro = new EmbedBuilder()
+        .setColor('#9b59b6')
+        .setTitle('⚔️ A wild challenger appears!')
+        .setDescription(`${da.emoji} **${da.titledName}** squares off against ${db.emoji} **${db.name}** (Lv.${wild.level})…`);
+    await interaction.editReply({ embeds: [intro] });
+    await _delay(1500);
+
+    const xpRes = applyPetXp(myPet, won ? XP_WILD_WIN : XP_WILD_LOSS);
+    myPet.lastBattle  = new Date();
+    if (won) myPet.battleWins   = (myPet.battleWins ?? 0) + 1;
+    else     myPet.battleLosses = (myPet.battleLosses ?? 0) + 1;
+    user.markModified('pets');
+    try {
+        await user.save();
+    } catch (err) {
+        if (err.name === 'VersionError') return interaction.editReply({ content: 'Edit conflict — please try again.', embeds: [] });
+        throw err;
+    }
+
+    return interaction.editReply({
+        embeds: [battleResultEmbed({
+            color: won ? '#2ecc71' : '#e74c3c',
+            title: won ? `🏆 ${da.titledName} won the wild battle!` : `💀 ${da.titledName} was beaten back…`,
+            petA: myPet, petB: wild, result, currency,
+            payoutLine: null,
+            xpLineA: petXpLine(da.titledName, xpRes),
+        })],
+    });
+}
+
+async function pvpBattle(interaction, ctx) {
+    const { myPet, slot, opponent, bet, currency, guildSettings } = ctx;
+    const guildId = interaction.guild.id;
+    const da = getPetDisplay(myPet);
+
+    const acceptId  = `petb_accept_${interaction.id}`;
+    const declineId = `petb_decline_${interaction.id}`;
+    const challengeEmbed = new EmbedBuilder()
+        .setColor('#9b59b6')
+        .setTitle('⚔️ Pet Battle Challenge!')
+        .setDescription(
+            `${da.emoji} **${interaction.member?.displayName ?? interaction.user.username}'s ${da.titledName}** (Lv.${myPet.level ?? 1}) ` +
+            `challenges ${opponent} to a battle!` +
+            (bet > 0 ? `\n\n💰 Wager: **${currency}${bet.toLocaleString()}** each — winner takes the pot.` : '\n\n*Friendly match — pet XP only.*')
+        )
+        .setFooter({ text: 'Accept within 60 seconds' });
+
+    const row = new ActionRowBuilder().addComponents(
+        new ButtonBuilder().setCustomId(acceptId).setLabel('⚔️ Accept').setStyle(ButtonStyle.Success),
+        new ButtonBuilder().setCustomId(declineId).setLabel('🏳️ Decline').setStyle(ButtonStyle.Danger),
+    );
+
+    await interaction.reply({ content: `${opponent}`, embeds: [challengeEmbed], components: [row] });
+    const msg = await interaction.fetchReply();
+
+    const collector = msg.createMessageComponentCollector({
+        filter: i => i.user.id === opponent.id && [acceptId, declineId].includes(i.customId),
+        max: 1, time: 60_000,
+    });
+
+    collector.on('collect', async i => {
+        if (i.customId === declineId) {
+            return i.update({ content: null, embeds: [EmbedBuilder.from(challengeEmbed).setColor('#95a5a6').setDescription(`${opponent.username} declined the battle.`)], components: [] }).catch(() => {});
+        }
+
+        // Escrow wagers atomically (challenger then opponent), refund on shortfall
+        if (bet > 0) {
+            const ch = await User.findOneAndUpdate({ userId: interaction.user.id, guildId, balance: { $gte: bet } }, { $inc: { balance: -bet } });
+            if (!ch) return i.update({ content: null, embeds: [EmbedBuilder.from(challengeEmbed).setColor('#e74c3c').setDescription(`${interaction.user.username} can no longer cover the wager.`)], components: [] }).catch(() => {});
+            const op = await User.findOneAndUpdate({ userId: opponent.id, guildId, balance: { $gte: bet } }, { $inc: { balance: -bet } });
+            if (!op) {
+                await User.updateOne({ userId: interaction.user.id, guildId }, { $inc: { balance: bet } });
+                return i.update({ content: null, embeds: [EmbedBuilder.from(challengeEmbed).setColor('#e74c3c').setDescription(`${opponent.username} can't cover the wager.`)], components: [] }).catch(() => {});
+            }
+        }
+
+        await i.deferUpdate().catch(() => {});
+
+        // Re-fetch both fighters fresh so concurrent feeds/battles are reflected
+        const [chUser, opUser] = await Promise.all([
+            User.findOne({ userId: interaction.user.id, guildId }),
+            User.findOne({ userId: opponent.id, guildId }),
+        ]);
+        const aPet = chUser?.pets?.[slot];
+        const bPet = opUser?.pets?.find(p => p.hunger >= STARVING_THRESHOLD);
+
+        // If a fighter vanished (released mid-challenge), refund and abort
+        if (!aPet || !bPet) {
+            if (bet > 0) {
+                await User.updateOne({ userId: interaction.user.id, guildId }, { $inc: { balance: bet } }).catch(() => {});
+                await User.updateOne({ userId: opponent.id, guildId }, { $inc: { balance: bet } }).catch(() => {});
+            }
+            return interaction.editReply({ content: null, embeds: [EmbedBuilder.from(challengeEmbed).setColor('#e74c3c').setDescription('A pet is no longer available — the battle was cancelled and any wagers refunded.')], components: [] }).catch(() => {});
+        }
+
+        const result = simulateBattle(aPet, bPet);
+        const aWon   = result.winner === 'a';
+
+        const intro = new EmbedBuilder()
+            .setColor('#9b59b6').setTitle('⚔️ Battle commencing…')
+            .setDescription(`${getPetDisplay(aPet).emoji} **${getPetDisplay(aPet).titledName}**  🆚  ${getPetDisplay(bPet).emoji} **${getPetDisplay(bPet).titledName}**`);
+        await interaction.editReply({ content: null, embeds: [intro], components: [] }).catch(() => {});
+        await _delay(1800);
+
+        // XP + records
+        const aXp = applyPetXp(aPet, aWon ? XP_BATTLE_WIN : XP_BATTLE_LOSS);
+        const bXp = applyPetXp(bPet, aWon ? XP_BATTLE_LOSS : XP_BATTLE_WIN);
+        if (aWon) { aPet.battleWins = (aPet.battleWins ?? 0) + 1; bPet.battleLosses = (bPet.battleLosses ?? 0) + 1; }
+        else      { bPet.battleWins = (bPet.battleWins ?? 0) + 1; aPet.battleLosses = (aPet.battleLosses ?? 0) + 1; }
+        aPet.lastBattle = new Date(); bPet.lastBattle = new Date();
+        chUser.markModified('pets'); opUser.markModified('pets');
+
+        // Payout
+        let payoutLine = null;
+        if (bet > 0) {
+            const pot      = bet * 2;
+            const houseCut = guildSettings?.economy?.duelHouseCut ?? BATTLE_RAKE;
+            const payout   = pot - Math.floor(pot * houseCut);
+            const winnerId = aWon ? interaction.user.id : opponent.id;
+            const loserId  = aWon ? opponent.id : interaction.user.id;
+            // chUser/opUser balances are post-escrow; loser keeps theirs, winner gains the pot.
+            const loserBalance  = (aWon ? opUser : chUser).balance ?? 0;
+            const winnerBalance = ((aWon ? chUser : opUser).balance ?? 0) + payout;
+            await User.updateOne({ userId: winnerId, guildId }, { $inc: { balance: payout } });
+            logTransaction({ userId: winnerId, guildId, type: 'pet_battle', amount: payout - bet, balance: winnerBalance, relatedUserId: loserId, note: 'Pet battle win' });
+            logTransaction({ userId: loserId,  guildId, type: 'pet_battle', amount: -bet, balance: loserBalance, relatedUserId: winnerId, note: 'Pet battle loss' });
+            const winnerName = aWon ? interaction.user.username : opponent.username;
+            payoutLine = `🏆 **${winnerName}** takes the pot: **+${currency}${(payout - bet).toLocaleString()}**` +
+                (houseCut > 0 ? `  *(house kept ${Math.round(houseCut * 100)}%)*` : '');
+        }
+
+        try {
+            await Promise.all([chUser.save(), opUser.save()]);
+        } catch (err) {
+            console.error('[pet battle] save error:', err);
+        }
+
+        const da2 = getPetDisplay(aPet), db2 = getPetDisplay(bPet);
+        const winnerDisp = aWon ? da2 : db2;
+        return interaction.editReply({
+            content: null,
+            embeds: [battleResultEmbed({
+                color: '#f1c40f',
+                title: `🏆 ${winnerDisp.titledName} wins the battle!`,
+                petA: aPet, petB: bPet, result, currency,
+                payoutLine,
+                xpLineA: petXpLine(da2.titledName, aXp),
+                xpLineB: petXpLine(db2.titledName, bXp),
+            })],
+            components: [],
+        }).catch(() => {});
+    });
+
+    collector.on('end', (collected, reason) => {
+        if (reason === 'time' && collected.size === 0) {
+            interaction.editReply({ content: null, embeds: [EmbedBuilder.from(challengeEmbed).setColor('#95a5a6').setDescription(`${opponent.username} didn't respond in time.`)], components: [] }).catch(() => {});
+        }
+    });
 }
 
 async function executeList(interaction) {
@@ -603,7 +915,16 @@ module.exports = {
                 )
         )
         .addSubcommand(sub => sub.setName('list').setDescription('View all available pets in the shop.'))
-        .addSubcommand(sub => sub.setName('leaderboard').setDescription('View the top bonded pets in this server.')),
+        .addSubcommand(sub => sub.setName('leaderboard').setDescription('View the top bonded pets in this server.'))
+        .addSubcommand(sub =>
+            sub.setName('battle')
+                .setDescription('Battle a wild pet for XP, or challenge another member (optionally for coins).')
+                .addUserOption(opt =>
+                    opt.setName('opponent').setDescription('Member to challenge (leave empty to fight a wild pet)').setRequired(false))
+                .addIntegerOption(opt =>
+                    opt.setName('slot').setDescription('Which of your pets fights (0 = first, default 0)').setRequired(false).setMinValue(0).setMaxValue(9))
+                .addIntegerOption(opt =>
+                    opt.setName('bet').setDescription('Coins to wager (requires an opponent)').setRequired(false).setMinValue(1))),
 
     async execute(interaction) {
         const sub = interaction.options.getSubcommand();
@@ -615,6 +936,7 @@ module.exports = {
             if (sub === 'rename')      return await executeRename(interaction);
             if (sub === 'list')        return await executeList(interaction);
             if (sub === 'leaderboard') return await executeLeaderboard(interaction);
+            if (sub === 'battle')      return await executeBattle(interaction);
         } catch (err) {
             console.error('[pet] error:', err);
             const msg = { content: 'Something went wrong with the pet command.', ephemeral: true };

--- a/src/commands/economy/pet.js
+++ b/src/commands/economy/pet.js
@@ -759,10 +759,14 @@ async function pvpBattle(interaction, ctx) {
 
         // If a fighter is gone, no longer battle-ready, or went on cooldown
         // between the challenge and acceptance, refund and abort.
-        const refundAndCancel = (reason) => {
+        const refundAndCancel = async (reason) => {
             if (bet > 0) {
-                User.updateOne({ userId: interaction.user.id, guildId }, { $inc: { balance: bet } }).catch(() => {});
-                User.updateOne({ userId: opponent.id, guildId }, { $inc: { balance: bet } }).catch(() => {});
+                const [rA, rB] = await Promise.allSettled([
+                    User.updateOne({ userId: interaction.user.id, guildId }, { $inc: { balance: bet } }),
+                    User.updateOne({ userId: opponent.id, guildId }, { $inc: { balance: bet } }),
+                ]);
+                if (rA.status === 'rejected') console.error('[pet battle] refund failed for challenger:', rA.reason);
+                if (rB.status === 'rejected') console.error('[pet battle] refund failed for opponent:', rB.reason);
             }
             return interaction.editReply({ content: null, embeds: [EmbedBuilder.from(challengeEmbed).setColor('#e74c3c').setDescription(`${reason} — the battle was cancelled${bet > 0 ? ' and any wagers refunded' : ''}.`)], components: [] }).catch(() => {});
         };

--- a/src/commands/economy/season.js
+++ b/src/commands/economy/season.js
@@ -8,6 +8,18 @@ const { getEventCurrencyBalance } = require('../../services/seasonalEventService
 const { progressBar } = require('../../utils/progressBar');
 const { rewardReveal } = require('../../utils/rewardReveal');
 const { logTransaction } = require('../../utils/logTransaction');
+const { awardSeasonXp } = require('../../services/questService');
+
+// Reset a user's season sub-document to the fresh shape when their stored
+// seasonId is stale (a new season started). Prevents carrying old xp / claimed
+// tiers / premium across seasons. Returns true if a reset happened.
+function normalizeSeason(user, seasonId) {
+    if (!seasonId) return false;
+    if (user.season?.seasonId === seasonId) return false;
+    user.season = { seasonId, xp: 0, tier: 0, claimedTiers: [], premium: false, claimedPremiumTiers: [], weekXp: 0, weekStart: null };
+    user.markModified('season');
+    return true;
+}
 
 // ── Battle pass tier definitions ─────────────────────────────────────────────
 // 50 tiers across a free track and a premium track (see src/data/seasonPass.js).
@@ -67,6 +79,7 @@ async function executeView(interaction) {
     }
 
     await ensureMissions(user);
+    normalizeSeason(user, season.seasonId); // drop stale cross-season progress
 
     const userXp = user.season?.xp ?? 0;
     const currentTier = getTierFromXp(userXp);
@@ -145,6 +158,7 @@ async function executeClaim(interaction) {
 
     const wantsPremium = interaction.options.getBoolean('premium') ?? false;
     const currency = guildSettings?.economy?.currency ?? '💰';
+    normalizeSeason(user, season.seasonId); // drop stale cross-season progress
     const userXp = user.season?.xp ?? 0;
     const unlockedTier = getTierFromXp(userXp);
 
@@ -372,9 +386,10 @@ async function executeClaimMission(interaction) {
     if (mission.claimed) return interaction.reply({ content: 'Already claimed!', ephemeral: true });
 
     user.seasonMissions[missionIndex].claimed = true;
-    if (!user.season) user.season = {};
-    user.season.xp = (user.season.xp ?? 0) + mission.seasonXp;
-    user.season.tier = getTierFromXp(user.season.xp);
+    normalizeSeason(user, season.seasonId);
+    // Route through the shared grant so the weekly XP cap and rollover apply.
+    await awardSeasonXp(user, mission.seasonXp, guildSettings);
+    user.season.tier = getTierFromXp(user.season.xp ?? 0);
     user.balance += mission.coinReward;
     user.markModified('seasonMissions');
     user.markModified('season');

--- a/src/commands/economy/season.js
+++ b/src/commands/economy/season.js
@@ -388,8 +388,8 @@ async function executeClaimMission(interaction) {
     user.seasonMissions[missionIndex].claimed = true;
     normalizeSeason(user, season.seasonId);
     // Route through the shared grant so the weekly XP cap and rollover apply.
-    await awardSeasonXp(user, mission.seasonXp, guildSettings);
-    user.season.tier = getTierFromXp(user.season.xp ?? 0);
+    // awardSeasonXp returns the actual granted amount (may be < mission.seasonXp if capped).
+    const grantedXp = await awardSeasonXp(user, mission.seasonXp, guildSettings);
     user.balance += mission.coinReward;
     user.markModified('seasonMissions');
     user.markModified('season');
@@ -402,7 +402,7 @@ async function executeClaimMission(interaction) {
     }
 
     return interaction.reply({
-        content: `✅ Mission claimed! +**${mission.seasonXp} Season XP** and +**${mission.coinReward.toLocaleString()} ${currency}**`,
+        content: `✅ Mission claimed! +**${grantedXp} Season XP** and +**${mission.coinReward.toLocaleString()} ${currency}**`,
         ephemeral: true
     });
 }

--- a/src/commands/economy/season.js
+++ b/src/commands/economy/season.js
@@ -7,59 +7,22 @@ const { SEASONAL_EVENTS } = require('../../data/seasonalEvents');
 const { getEventCurrencyBalance } = require('../../services/seasonalEventService');
 const { progressBar } = require('../../utils/progressBar');
 const { rewardReveal } = require('../../utils/rewardReveal');
+const { logTransaction } = require('../../utils/logTransaction');
 
-// ── Battle pass tier reward definitions ──────────────────────────────────────
-// 20 tiers; alternating between coin bonuses, cosmetic badges, material bundles, rare items
-// itemId present → add 1× to user.inventory on claim; cosmetic badges have no itemId
-const TIER_REWARDS = [
-    { tier: 1,  coins: 500,   label: '💰 500 coins' },
-    { tier: 2,  coins: 0,     label: '🎖️ Apprentice Badge' },
-    { tier: 3,  coins: 1000,  label: '💰 1,000 coins' },
-    { tier: 4,  coins: 0,     label: '🗡️ Hunter\'s Crest Badge' },
-    { tier: 5,  coins: 2000,  label: '💰 2,000 coins' },
-    { tier: 6,  coins: 0,     label: '⚗️ Material Bundle (×5 random)' },
-    { tier: 7,  coins: 3000,  label: '💰 3,000 coins' },
-    { tier: 8,  coins: 0,     label: '🎭 Prestige Frame Badge' },
-    { tier: 9,  coins: 4000,  label: '💰 4,000 coins' },
-    { tier: 10, coins: 0,     label: '🛡️ Lifesaver (rare item)',      itemId: 'lifesaver'     },
-    { tier: 11, coins: 5000,  label: '💰 5,000 coins' },
-    { tier: 12, coins: 0,     label: '🌟 Elite Badge' },
-    { tier: 13, coins: 6000,  label: '💰 6,000 coins' },
-    { tier: 14, coins: 0,     label: '⚗️ Premium Material Bundle (×10)' },
-    { tier: 15, coins: 8000,  label: '💰 8,000 coins' },
-    { tier: 16, coins: 0,     label: '💫 Radiant Badge' },
-    { tier: 17, coins: 10000, label: '💰 10,000 coins' },
-    { tier: 18, coins: 0,     label: '🔥 Legend Badge' },
-    { tier: 19, coins: 15000, label: '💰 15,000 coins' },
-    { tier: 20, coins: 0,     label: '❄️ Streak Shield (rare item)',   itemId: 'streak_shield' }
-];
+// ── Battle pass tier definitions ─────────────────────────────────────────────
+// 50 tiers across a free track and a premium track (see src/data/seasonPass.js).
+// Premium is unlocked with a large coin payment (/season unlock) — the economy's
+// primary deliberate money sink.
+const { TIER_COUNT, XP_PER_TIER, TIER_TABLE, loreForTier } = require('../../data/seasonPass');
 
-const XP_PER_TIER = 100;
-const MAX_TIERS = 20;
+const MAX_TIERS = TIER_COUNT;
+const DEFAULT_PREMIUM_COST = 100_000;
 
-// Flavor lore shown on claim embeds
-const TIER_LORE = [
-    'Every journey starts with a single step.',
-    'The spark of ambition ignites here.',
-    'Diligence rewarded — this is just the beginning.',
-    'Forged in discipline, tempered by purpose.',
-    'Halfway to legendary. The path sharpens.',
-    'Matter responds to mastery.',
-    'A warrior refined — not born.',
-    'Prestige is earned, never given.',
-    'Nine tiers climbed. Eleven more await.',
-    'The rarest items demand the rarest resolve.',
-    'Champions do not rest at the summit.',
-    'A radiant mark for those who endure.',
-    'Six thousand reasons to keep going.',
-    'Only the tireless reach this depth.',
-    'Wealth and will in equal measure.',
-    'Radiance touches those who refuse to quit.',
-    'Ten thousand coins — a testament to grind.',
-    'Legends write their names in fire.',
-    'Fifteen thousand. The last stretch burns bright.',
-    'You have reached the pinnacle. The season bows to you.',
-];
+function tierDef(tier)     { return TIER_TABLE[tier - 1] ?? null; }
+function rewardFor(tier, premium) {
+    const def = tierDef(tier);
+    return def ? (premium ? def.premium : def.free) : null;
+}
 
 function getTierFromXp(xp) {
     return Math.min(MAX_TIERS, Math.floor(xp / XP_PER_TIER));
@@ -107,27 +70,49 @@ async function executeView(interaction) {
 
     const userXp = user.season?.xp ?? 0;
     const currentTier = getTierFromXp(userXp);
-    const claimedTiers = new Set(user.season?.claimedTiers ?? []);
+    const premium = user.season?.premium === true;
+    const claimedFree    = new Set(user.season?.claimedTiers ?? []);
+    const claimedPremium = new Set(user.season?.claimedPremiumTiers ?? []);
     const currency = guildSettings?.economy?.currency ?? '💰';
 
-    const nextRewards = TIER_REWARDS
-        .filter(r => r.tier > currentTier)
-        .slice(0, 5)
-        .map(r => `Tier ${r.tier}: ${r.label}`)
+    // Upcoming rewards across both tracks
+    const upcoming = TIER_TABLE
+        .filter(t => t.tier > currentTier)
+        .slice(0, 4)
+        .map(t => `**Tier ${t.tier}** — 🆓 ${t.free.label}  ·  ✨ ${t.premium.label}`)
         .join('\n') || 'All tiers unlocked! 🎉';
+
+    // Unclaimed rewards already available
+    const claimableFree = TIER_TABLE.filter(t => t.tier <= currentTier && !claimedFree.has(t.tier)).length;
+    const claimablePrem = premium
+        ? TIER_TABLE.filter(t => t.tier <= currentTier && !claimedPremium.has(t.tier)).length
+        : 0;
 
     const endsIn = season.endDate
         ? `<t:${Math.floor(new Date(season.endDate).getTime() / 1000)}:R>`
         : '*No end date set*';
 
+    const premiumCost = season.premiumCost ?? DEFAULT_PREMIUM_COST;
+    const premiumLine = premium
+        ? '✨ **Premium unlocked** — claim premium rewards on every tier you reach.'
+        : `🔒 Premium locked — unlock both tracks for **${currency}${premiumCost.toLocaleString()}** with \`/season unlock\`.`;
+
+    const weeklyCap = season.weeklyXpCap ?? 0;
+    const weekXp    = user.season?.weekXp ?? 0;
+    const weeklyLine = weeklyCap > 0
+        ? `\n🗓️ Weekly XP: **${Math.min(weekXp, weeklyCap)}/${weeklyCap}**`
+        : '';
+
     const embed = new EmbedBuilder()
-        .setColor('#5865f2')
+        .setColor(premium ? '#ffd700' : '#5865f2')
         .setTitle(`🎫 ${season.name ?? 'Season Pass'}`)
+        .setDescription(`${premiumLine}${weeklyLine}`)
         .addFields(
             { name: '📊 Your Progress', value: xpProgressBar(userXp) },
             { name: '🏆 Current Tier', value: `**Tier ${currentTier} / ${MAX_TIERS}**`, inline: true },
             { name: '⏰ Season Ends', value: endsIn, inline: true },
-            { name: '🎁 Upcoming Rewards', value: nextRewards },
+            { name: '🎁 Unclaimed', value: `🆓 ${claimableFree} free${premium ? `  ·  ✨ ${claimablePrem} premium` : ''}`, inline: true },
+            { name: '🪜 Upcoming Rewards', value: upcoming },
             {
                 name: '📋 Today\'s Missions',
                 value: (user.seasonMissions ?? []).map(m =>
@@ -135,7 +120,7 @@ async function executeView(interaction) {
                 ).join('\n') || '*No missions generated*'
             }
         )
-        .setFooter({ text: `Season XP: ${userXp} total | Use /season claim to collect tier rewards` })
+        .setFooter({ text: `Season XP: ${userXp} total | /season claim tier:<n> [premium:true]` })
         .setTimestamp();
 
     await user.save().catch(() => {});
@@ -158,13 +143,24 @@ async function executeClaim(interaction) {
         return interaction.reply({ content: 'No active season pass is running.', ephemeral: true });
     }
 
+    const wantsPremium = interaction.options.getBoolean('premium') ?? false;
     const currency = guildSettings?.economy?.currency ?? '💰';
     const userXp = user.season?.xp ?? 0;
     const unlockedTier = getTierFromXp(userXp);
-    const claimedTiers = new Set(user.season?.claimedTiers ?? []);
+
+    // Guard against missing sub-document arrays on old docs
+    if (!user.season) user.season = {};
+    if (!Array.isArray(user.season.claimedTiers))        user.season.claimedTiers = [];
+    if (!Array.isArray(user.season.claimedPremiumTiers)) user.season.claimedPremiumTiers = [];
+
+    const claimedTiers = new Set(wantsPremium ? user.season.claimedPremiumTiers : user.season.claimedTiers);
 
     if (tier > MAX_TIERS || tier < 1) {
         return interaction.reply({ content: `Tier must be between 1 and ${MAX_TIERS}.`, ephemeral: true });
+    }
+    if (wantsPremium && user.season.premium !== true) {
+        const premiumCost = season.premiumCost ?? DEFAULT_PREMIUM_COST;
+        return interaction.reply({ content: `You haven't unlocked the premium track. Unlock it for **${currency}${premiumCost.toLocaleString()}** with \`/season unlock\`.`, ephemeral: true });
     }
     if (tier > unlockedTier) {
         return interaction.reply({
@@ -173,22 +169,17 @@ async function executeClaim(interaction) {
         });
     }
     if (claimedTiers.has(tier)) {
-        return interaction.reply({ content: `You've already claimed Tier ${tier}'s reward!`, ephemeral: true });
+        return interaction.reply({ content: `You've already claimed Tier ${tier}'s ${wantsPremium ? 'premium' : 'free'} reward!`, ephemeral: true });
     }
 
-    const reward = TIER_REWARDS.find(r => r.tier === tier);
+    const reward = rewardFor(tier, wantsPremium);
     if (!reward) return interaction.reply({ content: 'Invalid tier.', ephemeral: true });
-
-    // Guard against missing sub-document array on old docs
-    if (!Array.isArray(user.season?.claimedTiers)) {
-        if (!user.season) user.season = {};
-        user.season.claimedTiers = [];
-    }
 
     if (reward.coins > 0) user.balance += reward.coins;
     if (reward.itemId) user.inventory.push({ itemId: reward.itemId, quantity: 1 });
-    user.season.claimedTiers.push(tier);
+    (wantsPremium ? user.season.claimedPremiumTiers : user.season.claimedTiers).push(tier);
     user.markModified('season');
+    if (reward.itemId) user.markModified('inventory');
 
     try {
         await user.save();
@@ -197,31 +188,33 @@ async function executeClaim(interaction) {
         throw err;
     }
 
-    // Social proof: how many users in this guild have claimed this tier
+    // Social proof: how many users in this guild have claimed this tier (this track)
     const claimedCount = await User.countDocuments({
         guildId: interaction.guild.id,
-        'season.claimedTiers': tier
+        [wantsPremium ? 'season.claimedPremiumTiers' : 'season.claimedTiers']: tier
     }).catch(() => null);
 
-    // Next tier teaser
-    const nextTier = TIER_REWARDS.find(r => r.tier === tier + 1);
+    // Next tier teaser (same track)
+    const nextTier = tier + 1 <= MAX_TIERS ? tierDef(tier + 1) : null;
+    const nextReward = nextTier ? rewardFor(tier + 1, wantsPremium) : null;
     const xpToNext = nextTier ? Math.max(0, (tier + 1) * XP_PER_TIER - (user.season?.xp ?? 0)) : 0;
 
-    const lore = TIER_LORE[tier - 1] ?? 'Your dedication speaks louder than words.';
+    const lore = loreForTier(tier);
 
+    const trackLabel = wantsPremium ? '✨ Premium' : '🆓 Free';
     const embed = new EmbedBuilder()
-        .setColor('#ffd700')
-        .setTitle(reward.label)
+        .setColor(wantsPremium ? '#ffd700' : '#5865f2')
+        .setTitle(`${trackLabel} — Tier ${tier}`)
         .setDescription(
             `> *${lore}*\n\n` +
             `You received: **${reward.label}**` +
             (reward.coins > 0 ? `\n+**${reward.coins.toLocaleString()} ${currency}** added to your wallet` : '')
         );
 
-    if (nextTier) {
+    if (nextTier && nextReward) {
         embed.addFields({
-            name: `⏭️ Next: Tier ${nextTier.tier}`,
-            value: `${nextTier.label}${xpToNext > 0 ? ` — ${xpToNext} XP away` : ' — **Ready to claim!**'}`
+            name: `⏭️ Next: Tier ${nextTier.tier} (${wantsPremium ? 'premium' : 'free'})`,
+            value: `${nextReward.label}${xpToNext > 0 ? ` — ${xpToNext} XP away` : ' — **Ready to claim!**'}`
         });
     }
 
@@ -231,8 +224,9 @@ async function executeClaim(interaction) {
 
     embed.setTimestamp();
 
-    // Broadcast to announcement channel for mythic-tier (≥ 10) rewards
-    if (tier >= 10) {
+    // Broadcast milestone tiers (every 10th) to the announcement channel —
+    // with 50 tiers, broadcasting everything past 10 would be spam.
+    if (tier % 10 === 0) {
         const announceChannelId = guildSettings?.economy?.announcementChannelId;
         if (announceChannelId) {
             const announceChannel = interaction.guild.channels.cache.get(announceChannelId);
@@ -258,6 +252,61 @@ async function executeClaim(interaction) {
         resultEmbed: embed,
         delayMs: 900,
     });
+}
+
+async function executeUnlock(interaction) {
+    const [user, guildSettings] = await Promise.all([
+        User.findOneAndUpdate(
+            { userId: interaction.user.id, guildId: interaction.guild.id },
+            { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
+            { upsert: true, new: true }
+        ),
+        Guild.findOne({ guildId: interaction.guild.id })
+    ]);
+
+    const season = guildSettings?.season;
+    if (!season?.enabled || !season?.seasonId) {
+        return interaction.reply({ content: 'No active season pass is running.', ephemeral: true });
+    }
+
+    const currency = guildSettings?.economy?.currency ?? '💰';
+    const cost = season.premiumCost ?? DEFAULT_PREMIUM_COST;
+
+    // If the user's season state is stale, reset it to the current season first.
+    if (user.season?.seasonId !== season.seasonId) {
+        await User.updateOne(
+            { userId: interaction.user.id, guildId: interaction.guild.id },
+            { $set: { 'season.seasonId': season.seasonId, 'season.premium': false, 'season.claimedPremiumTiers': [] } }
+        );
+    } else if (user.season?.premium === true) {
+        return interaction.reply({ content: '✨ You already have the premium track unlocked this season.', ephemeral: true });
+    }
+
+    // Atomic: debit the cost and flip premium on in one guarded update (coin sink).
+    const unlocked = await User.findOneAndUpdate(
+        { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: cost }, 'season.premium': { $ne: true } },
+        { $inc: { balance: -cost }, $set: { 'season.premium': true } },
+        { new: true }
+    );
+    if (!unlocked) {
+        const bal = (await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }, 'balance'))?.balance ?? 0;
+        return interaction.reply({ content: `You need **${currency}${cost.toLocaleString()}** to unlock the premium track — you have **${currency}${bal.toLocaleString()}**.`, ephemeral: true });
+    }
+    logTransaction({ userId: interaction.user.id, guildId: interaction.guild.id, type: 'season_premium', amount: -cost, balance: unlocked.balance, note: 'Season pass premium unlock' });
+
+    const unlockedTier = getTierFromXp(unlocked.season?.xp ?? 0);
+    const embed = new EmbedBuilder()
+        .setColor('#ffd700')
+        .setTitle('✨ Premium Season Pass Unlocked!')
+        .setDescription(
+            `You paid **${currency}${cost.toLocaleString()}** to unlock the **premium track** for **${season.name ?? 'this season'}**.\n\n` +
+            `Premium rewards are now claimable on every tier you've reached` +
+            (unlockedTier > 0 ? ` — that's **${unlockedTier}** tier${unlockedTier === 1 ? '' : 's'} ready right now!` : '.') +
+            `\n\nClaim them with \`/season claim tier:<n> premium:true\`.`
+        )
+        .setFooter({ text: 'Premium rewards include exclusive items and richer coin payouts.' })
+        .setTimestamp();
+    return interaction.reply({ embeds: [embed] });
 }
 
 async function executeMissions(interaction) {
@@ -643,11 +692,20 @@ module.exports = {
                 .setDescription('Claim a tier reward from the season pass.')
                 .addIntegerOption(opt =>
                     opt.setName('tier')
-                        .setDescription('Tier number to claim (1–20)')
+                        .setDescription('Tier number to claim (1–50)')
                         .setRequired(true)
                         .setMinValue(1)
-                        .setMaxValue(20)
+                        .setMaxValue(50)
                 )
+                .addBooleanOption(opt =>
+                    opt.setName('premium')
+                        .setDescription('Claim the premium-track reward for this tier (requires /season unlock)')
+                        .setRequired(false)
+                )
+        )
+        .addSubcommand(sub =>
+            sub.setName('unlock')
+                .setDescription('Unlock the premium season-pass track for a one-time coin payment.')
         )
         .addSubcommand(sub =>
             sub.setName('missions')
@@ -706,6 +764,7 @@ module.exports = {
         try {
             if (sub === 'view')          return await executeView(interaction);
             if (sub === 'claim')         return await executeClaim(interaction);
+            if (sub === 'unlock')        return await executeUnlock(interaction);
             if (sub === 'missions')      return await executeMissions(interaction);
             if (sub === 'claim-mission') return await executeClaimMission(interaction);
             if (sub === 'leaderboard')   return await executeLeaderboard(interaction);

--- a/src/data/seasonPass.js
+++ b/src/data/seasonPass.js
@@ -80,12 +80,15 @@ function buildTierTable() {
         const pItem  = PREMIUM_ITEMS[tier];
         const pBadge = PREMIUM_BADGES[tier];
         const pCoins = premiumCoins(tier);
+        const pParts = [];
+        if (pItem)      pParts.push(pItem.label);
+        if (pBadge)     pParts.push(pBadge);                              // titles stack with items
+        if (pCoins > 0) pParts.push(`💰 ${pCoins.toLocaleString()}`);
         const premium = {
             coins:  pCoins,
             itemId: pItem?.itemId ?? null,
-            label:  pItem
-                ? (pCoins > 0 ? `${pItem.label} + 💰 ${pCoins.toLocaleString()}` : pItem.label)
-                : pBadge ?? `💰 ${pCoins.toLocaleString()} coins`,
+            title:  pBadge ?? null,
+            label:  pParts.length ? pParts.join(' + ') : `💰 ${pCoins.toLocaleString()} coins`,
         };
 
         table.push({ tier, free, premium });

--- a/src/data/seasonPass.js
+++ b/src/data/seasonPass.js
@@ -1,0 +1,122 @@
+// Season pass tier table — 50 tiers across a free track and a premium track.
+//
+// The premium track is unlocked with a large coin payment (see season.unlock),
+// making it the economy's primary deliberate money sink: it drains a big chunk
+// of a player's balance in exchange for cosmetic/consumable rewards rather than
+// minting new currency.
+//
+// Each tier: { tier, free: {coins,itemId,label}, premium: {coins,itemId,label} }.
+// itemId (when present) grants 1× of that shop item on claim; label is display.
+
+const TIER_COUNT  = 50;
+const XP_PER_TIER = 100; // 5,000 season XP to reach tier 50
+
+// Milestone item rewards keyed by tier. Free track gets the occasional
+// consumable; premium gets something at every milestone plus exclusive items.
+const FREE_ITEMS = {
+    5:  { itemId: 'lucky_charm',     label: '🍀 Lucky Charm' },
+    10: { itemId: 'lifesaver',       label: '🛟 Lifesaver' },
+    15: { itemId: 'xp_booster_2x',   label: '⭐ 2x XP Booster' },
+    20: { itemId: 'streak_shield',   label: '❄️ Streak Shield' },
+    25: { itemId: 'coin_booster_2x', label: '💰 2x Coin Booster' },
+    30: { itemId: 'lucky_charm',     label: '🍀 Lucky Charm' },
+    35: { itemId: 'lifesaver',       label: '🛟 Lifesaver' },
+    40: { itemId: 'xp_booster_2x',   label: '⭐ 2x XP Booster' },
+    45: { itemId: 'streak_shield',   label: '❄️ Streak Shield' },
+    50: { itemId: 'lifesaver',       label: '🛟 Lifesaver' },
+};
+
+const PREMIUM_ITEMS = {
+    1:  { itemId: 'lucky_charm',       label: '🍀 Lucky Charm' },
+    5:  { itemId: 'coin_booster_2x',   label: '💰 2x Coin Booster' },
+    10: { itemId: 'salary_raise',      label: '📈 Salary Raise' },
+    15: { itemId: 'knife',             label: '🔪 Knife' },
+    20: { itemId: 'padlock',           label: '🔒 Padlock' },
+    25: { itemId: 'invisibility_cloak',label: '🧥 Invisibility Cloak' },
+    30: { itemId: 'robbery_bag',       label: '💼 Robbery Bag' },
+    35: { itemId: 'shield',            label: '🛡️ Shield' },
+    40: { itemId: 'lucky_streak',      label: '🎯 Lucky Streak' },
+    45: { itemId: 'coin_booster_2x',   label: '💰 2x Coin Booster' },
+    50: { itemId: 'lifesaver',         label: '🛟 Lifesaver' },
+};
+
+// Cosmetic badge labels on free-track tiers that have no item.
+const FREE_BADGES = {
+    8:  '🎖️ Apprentice Badge',
+    18: '🎭 Prestige Frame',
+    28: '🌟 Elite Badge',
+    38: '💫 Radiant Badge',
+    48: '🔥 Legend Badge',
+};
+
+const PREMIUM_BADGES = {
+    50: '👑 Season Sovereign Title',
+};
+
+// Free coins scale gently; premium coins are richer. Coins are a faucet, so
+// they're modest relative to the premium unlock cost (premium is a net sink).
+function freeCoins(tier) {
+    if (FREE_ITEMS[tier] || FREE_BADGES[tier]) return 0;
+    return 300 + tier * 60; // tier 1 → 360, tier 49 → ~3,240
+}
+
+function premiumCoins(tier) {
+    if (PREMIUM_ITEMS[tier] || PREMIUM_BADGES[tier]) return Math.round((400 + tier * 80) / 2);
+    return 400 + tier * 80; // tier 1 → 480, tier 49 → ~4,320
+}
+
+function buildTierTable() {
+    const table = [];
+    for (let tier = 1; tier <= TIER_COUNT; tier++) {
+        const fItem  = FREE_ITEMS[tier];
+        const fBadge = FREE_BADGES[tier];
+        const fCoins = freeCoins(tier);
+        const free = {
+            coins:  fCoins,
+            itemId: fItem?.itemId ?? null,
+            label:  fItem?.label ?? fBadge ?? `💰 ${fCoins.toLocaleString()} coins`,
+        };
+
+        const pItem  = PREMIUM_ITEMS[tier];
+        const pBadge = PREMIUM_BADGES[tier];
+        const pCoins = premiumCoins(tier);
+        const premium = {
+            coins:  pCoins,
+            itemId: pItem?.itemId ?? null,
+            label:  pItem
+                ? (pCoins > 0 ? `${pItem.label} + 💰 ${pCoins.toLocaleString()}` : pItem.label)
+                : pBadge ?? `💰 ${pCoins.toLocaleString()} coins`,
+        };
+
+        table.push({ tier, free, premium });
+    }
+    return table;
+}
+
+const TIER_TABLE = buildTierTable();
+
+// Flavor lore shown on claim embeds (one per tier, cycled if short).
+const TIER_LORE = [
+    'Every journey starts with a single step.',
+    'The spark of ambition ignites here.',
+    'Diligence rewarded — this is just the beginning.',
+    'Forged in discipline, tempered by purpose.',
+    'The climb steepens, and so does your resolve.',
+    'Momentum is a force of its own now.',
+    'Few make it this far. Fewer keep going.',
+    'Your name is starting to echo in the halls.',
+    'Mastery is not given. It is taken, tier by tier.',
+    'The summit is no longer a rumor — it is a destination.',
+];
+
+function loreForTier(tier) {
+    return TIER_LORE[(tier - 1) % TIER_LORE.length];
+}
+
+module.exports = {
+    TIER_COUNT,
+    XP_PER_TIER,
+    TIER_TABLE,
+    buildTierTable,
+    loreForTier,
+};

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -545,6 +545,9 @@ const guildSchema = new Schema({
         endDate: { type: Date, default: null },
         xpPerTier: { type: Number, default: 100 },
         maxTiers: { type: Number, default: 50 },
+        // Premium track unlock price (coin sink) and weekly season-XP cap (pacing)
+        premiumCost: { type: Number, default: 100000 },
+        weeklyXpCap: { type: Number, default: 1500 },
         tierRewards: [{
             tier: { type: Number, required: true },
             coins: { type: Number, default: 0 },

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -546,8 +546,8 @@ const guildSchema = new Schema({
         xpPerTier: { type: Number, default: 100 },
         maxTiers: { type: Number, default: 50 },
         // Premium track unlock price (coin sink) and weekly season-XP cap (pacing)
-        premiumCost: { type: Number, default: 100000 },
-        weeklyXpCap: { type: Number, default: 1500 },
+        premiumCost: { type: Number, default: 100000, min: 0 },
+        weeklyXpCap: { type: Number, default: 1500, min: 0 },
         tierRewards: [{
             tier: { type: Number, required: true },
             coins: { type: Number, default: 0 },

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -75,7 +75,13 @@ const userSchema = new Schema({
         seasonId: { type: String, default: null },
         xp: { type: Number, default: 0 },
         tier: { type: Number, default: 0 },
-        claimedTiers: [{ type: Number }]
+        claimedTiers: [{ type: Number }],
+        // Premium track (unlocked via a large coin sink — see /season unlock)
+        premium: { type: Boolean, default: false },
+        claimedPremiumTiers: [{ type: Number }],
+        // Weekly XP pacing
+        weekXp: { type: Number, default: 0 },
+        weekStart: { type: Date, default: null },
     },
 
     // Progression archetype track

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -150,6 +150,14 @@ const userSchema = new Schema({
         potw:               { type: Boolean, default: false },
         weeklyInteractions: { type: Number,  default: 0    },
         personality:        { type: String,  default: null },
+        // Progression (Phase 4): pets gain XP from feeding and battles, level up,
+        // and evolve through stages that scale their passive bonus.
+        level:              { type: Number,  default: 1, min: 1 },
+        xp:                 { type: Number,  default: 0, min: 0 },
+        evolutionStage:     { type: Number,  default: 1, min: 1, max: 3 },
+        battleWins:         { type: Number,  default: 0 },
+        battleLosses:       { type: Number,  default: 0 },
+        lastBattle:         { type: Date,    default: null },
     }],
 
     // Pet of the Week tracking

--- a/src/services/petService.js
+++ b/src/services/petService.js
@@ -215,16 +215,200 @@ function getPetBonus(pet) {
 
 /**
  * Get total bonus of a given type from all active pets.
+ * Uses each pet's *effective* bonus (scaled by evolution + level), so investing
+ * in a pet meaningfully improves its passive.
  */
 function getTotalBonus(pets, bonusType) {
     let total = 0;
     for (const pet of pets) {
         const bonus = getPetBonus(pet);
         if (bonus && bonus.bonusType === bonusType) {
-            total += bonus.bonusPct;
+            total += getEffectiveBonusPct(pet);
         }
     }
     return total;
+}
+
+// ── Progression: leveling & evolution ───────────────────────────────────────
+
+const PET_MAX_LEVEL = 30;
+// Evolution stage boundaries by level. Stage 1: 1–9, Stage 2: 10–19, Stage 3: 20+.
+const EVOLUTION_LEVELS = [10, 20];
+// Effective passive bonus multiplier per evolution stage.
+const STAGE_BONUS_MULT = { 1: 1.0, 2: 1.5, 3: 2.0 };
+// Per-level passive growth on top of the stage multiplier (caps the total at a
+// sane ceiling so the 10x combined-multiplier economy isn't blown open).
+const PER_LEVEL_BONUS_GROWTH = 0.03;
+const MAX_EFFECTIVE_BONUS_MULT = 2.5;
+
+// XP sources
+const XP_FEED_FAVORITE = 8;
+const XP_FEED_OTHER    = 4;
+const XP_BATTLE_WIN    = 30;
+const XP_BATTLE_LOSS   = 10;
+const XP_WILD_WIN      = 22;
+const XP_WILD_LOSS     = 8;
+
+// Evolution display: stage title prefixes + an optional evolved emoji per pet.
+const EVOLUTION_TITLES = { 1: '', 2: 'Seasoned ', 3: 'Apex ' };
+const EVOLVED_EMOJI = {
+    dog:         { 2: '🐕',  3: '🐺' },
+    cat:         { 2: '🐈',  3: '🐅' },
+    bird:        { 2: '🦜',  3: '🦅' },
+    fish:        { 2: '🐟',  3: '🦈' },
+    fox:         { 2: '🦊',  3: '🌟' },
+    wolf:        { 2: '🐺',  3: '🌑' },
+    eagle:       { 2: '🦅',  3: '⚡' },
+    shark:       { 2: '🦈',  3: '🌊' },
+    crystal_fox: { 2: '💎',  3: '🔮' },
+};
+
+// Total XP required to *reach* a given level (cumulative). Gentle quadratic curve.
+function xpForLevel(level) {
+    if (level <= 1) return 0;
+    let total = 0;
+    for (let l = 2; l <= level; l++) total += 40 + (l - 1) * 20;
+    return total;
+}
+
+function stageForLevel(level) {
+    let stage = 1;
+    for (const boundary of EVOLUTION_LEVELS) if (level >= boundary) stage += 1;
+    return stage;
+}
+
+/**
+ * Display emoji + name for a pet, accounting for its evolution stage.
+ */
+function getPetDisplay(pet) {
+    const def   = PET_DEFINITIONS[pet.petId] ?? { emoji: '🐾', name: pet.petId };
+    const stage = pet.evolutionStage ?? 1;
+    const emoji = EVOLVED_EMOJI[pet.petId]?.[stage] ?? def.emoji;
+    const title = EVOLUTION_TITLES[stage] ?? '';
+    const baseName = pet.name || def.name;
+    return { emoji, name: baseName, titledName: `${title}${baseName}`.trim() };
+}
+
+/**
+ * Effective passive bonus % for a pet (base × stage × per-level growth), capped.
+ */
+function getEffectiveBonusPct(pet) {
+    const def = PET_DEFINITIONS[pet.petId];
+    if (!def) return 0;
+    const stage = pet.evolutionStage ?? 1;
+    const level = pet.level ?? 1;
+    const mult  = Math.min(
+        MAX_EFFECTIVE_BONUS_MULT,
+        (STAGE_BONUS_MULT[stage] ?? 1.0) + (level - 1) * PER_LEVEL_BONUS_GROWTH
+    );
+    return Math.round(def.bonusPct * mult * 10) / 10;
+}
+
+/**
+ * Award XP to a pet, applying level-ups and evolution.
+ * Mutates `pet` in place. Returns { gained, leveledUp, fromLevel, toLevel, evolved, fromStage, toStage }.
+ */
+function applyPetXp(pet, amount) {
+    const fromLevel = pet.level ?? 1;
+    const fromStage = pet.evolutionStage ?? 1;
+    pet.level = fromLevel;
+    pet.xp = (pet.xp ?? 0) + Math.max(0, amount);
+
+    while (pet.level < PET_MAX_LEVEL && pet.xp >= xpForLevel(pet.level + 1)) {
+        pet.level += 1;
+    }
+    pet.evolutionStage = stageForLevel(pet.level);
+
+    return {
+        gained:    Math.max(0, amount),
+        leveledUp: pet.level > fromLevel,
+        fromLevel, toLevel: pet.level,
+        evolved:   pet.evolutionStage > fromStage,
+        fromStage, toStage: pet.evolutionStage,
+    };
+}
+
+// ── Battle engine ───────────────────────────────────────────────────────────
+
+// Personalities tilt combat stats: each leans into attack/defense/speed.
+const PERSONALITY_COMBAT = {
+    energetic:   { atk: 2, def: 0, spd: 2 },
+    mischievous: { atk: 2, def: 1, spd: 1 },
+    loyal:       { atk: 1, def: 3, spd: 0 },
+    lazy:        { atk: 0, def: 2, spd: 1 },
+};
+
+/**
+ * Derive battle stats from a pet's level, evolution, and personality.
+ */
+function getPetStats(pet) {
+    const level = pet.level ?? 1;
+    const stage = pet.evolutionStage ?? 1;
+    const p     = PERSONALITY_COMBAT[pet.personality] ?? { atk: 1, def: 1, spd: 1 };
+    return {
+        hp:  40 + level * 6 + stage * 10,
+        atk: 8  + level * 2 + stage * 3 + p.atk,
+        def: 4  + level * 1 + stage * 2 + p.def,
+        spd: 5  + level + p.spd,
+    };
+}
+
+/**
+ * Simulate a battle between two pets. `rng` is injectable for testing.
+ * Returns { winner: 'a'|'b', rounds, finalHpA, finalHpB }.
+ */
+function simulateBattle(petA, petB, rng = Math.random) {
+    const a = getPetStats(petA);
+    const b = getPetStats(petB);
+    let hpA = a.hp, hpB = b.hp;
+    const rounds = [];
+
+    // Faster pet strikes first each round.
+    let turnA = a.spd >= b.spd;
+    const MAX_ROUNDS = 30;
+
+    for (let r = 0; r < MAX_ROUNDS && hpA > 0 && hpB > 0; r++) {
+        const atk = turnA ? a : b;
+        const def = turnA ? b : a;
+        // Damage = atk - def/2, ±25% variance, min 1; ~10% crit for 1.5x.
+        const base     = Math.max(1, atk.atk - def.def / 2);
+        const variance = 0.75 + rng() * 0.5;
+        const crit     = rng() < 0.10 ? 1.5 : 1.0;
+        const damage   = Math.max(1, Math.round(base * variance * crit));
+
+        if (turnA) hpB = Math.max(0, hpB - damage);
+        else       hpA = Math.max(0, hpA - damage);
+
+        rounds.push({ attacker: turnA ? 'a' : 'b', damage, crit: crit > 1, hpA, hpB });
+        turnA = !turnA;
+    }
+
+    // On HP tie / round cap, higher remaining HP fraction wins; final tiebreak: A.
+    let winner;
+    if (hpA <= 0 && hpB <= 0) winner = hpA >= hpB ? 'a' : 'b';
+    else if (hpB <= 0) winner = 'a';
+    else if (hpA <= 0) winner = 'b';
+    else winner = (hpA / a.hp) >= (hpB / b.hp) ? 'a' : 'b';
+
+    return { winner, rounds, finalHpA: hpA, finalHpB: hpB };
+}
+
+/**
+ * Build a scaled "wild" opponent pet near the given level for PvE battles.
+ */
+function makeWildPet(level, rng = Math.random) {
+    const WILD = [
+        { petId: 'wild_boar',   name: 'Wild Boar',   personality: 'energetic' },
+        { petId: 'feral_cat',   name: 'Feral Cat',   personality: 'mischievous' },
+        { petId: 'stray_hound', name: 'Stray Hound', personality: 'loyal' },
+        { petId: 'cave_bat',    name: 'Cave Bat',    personality: 'energetic' },
+    ];
+    const pick = WILD[Math.floor(rng() * WILD.length)];
+    const lvl  = Math.max(1, level + Math.floor(rng() * 3) - 1); // ±1 around the player
+    return {
+        petId: pick.petId, name: pick.name, personality: pick.personality,
+        level: lvl, evolutionStage: stageForLevel(lvl), hunger: 100, wild: true,
+    };
 }
 
 module.exports = {
@@ -246,4 +430,20 @@ module.exports = {
     getMoodColor,
     heartBar,
     assignPersonality,
+    // Progression & battles
+    PET_MAX_LEVEL,
+    XP_FEED_FAVORITE,
+    XP_FEED_OTHER,
+    XP_BATTLE_WIN,
+    XP_BATTLE_LOSS,
+    XP_WILD_WIN,
+    XP_WILD_LOSS,
+    xpForLevel,
+    stageForLevel,
+    getPetDisplay,
+    getEffectiveBonusPct,
+    applyPetXp,
+    getPetStats,
+    simulateBattle,
+    makeWildPet,
 };

--- a/src/services/questService.js
+++ b/src/services/questService.js
@@ -238,8 +238,25 @@ async function awardSeasonXp(user, xp, guildSettings) {
     const season = guildSettings?.season;
     if (!season?.enabled || !season.seasonId) return;
     if (user.season?.seasonId !== season.seasonId) {
-        user.season = { seasonId: season.seasonId, xp: 0, tier: 0, claimedTiers: [] };
+        user.season = { seasonId: season.seasonId, xp: 0, tier: 0, claimedTiers: [], premium: false, claimedPremiumTiers: [], weekXp: 0, weekStart: null };
     }
+
+    // Weekly XP cap (pacing): roll the window over after 7 days and clamp the
+    // grant so the pass can't be finished in a few days of grinding.
+    const weeklyCap = season.weeklyXpCap || 0;
+    if (weeklyCap > 0) {
+        const now = Date.now();
+        const weekStart = user.season.weekStart ? new Date(user.season.weekStart).getTime() : 0;
+        if (!weekStart || now - weekStart >= 7 * 24 * 60 * 60 * 1000) {
+            user.season.weekStart = new Date();
+            user.season.weekXp = 0;
+        }
+        const remaining = Math.max(0, weeklyCap - (user.season.weekXp || 0));
+        xp = Math.min(xp, remaining);
+        if (xp <= 0) return;
+        user.season.weekXp = (user.season.weekXp || 0) + xp;
+    }
+
     user.season.xp = (user.season.xp || 0) + xp;
     const xpPerTier = season.xpPerTier || 100;
     const maxTiers  = season.maxTiers  || 50;

--- a/src/services/questService.js
+++ b/src/services/questService.js
@@ -236,7 +236,7 @@ async function awardQuest(user, questDef, guildSettings) {
 
 async function awardSeasonXp(user, xp, guildSettings) {
     const season = guildSettings?.season;
-    if (!season?.enabled || !season.seasonId) return;
+    if (!season?.enabled || !season.seasonId) return 0;
     if (user.season?.seasonId !== season.seasonId) {
         user.season = { seasonId: season.seasonId, xp: 0, tier: 0, claimedTiers: [], premium: false, claimedPremiumTiers: [], weekXp: 0, weekStart: null };
     }
@@ -253,7 +253,7 @@ async function awardSeasonXp(user, xp, guildSettings) {
         }
         const remaining = Math.max(0, weeklyCap - (user.season.weekXp || 0));
         xp = Math.min(xp, remaining);
-        if (xp <= 0) return;
+        if (xp <= 0) return 0;
         user.season.weekXp = (user.season.weekXp || 0) + xp;
     }
 
@@ -261,6 +261,7 @@ async function awardSeasonXp(user, xp, guildSettings) {
     const xpPerTier = season.xpPerTier || 100;
     const maxTiers  = season.maxTiers  || 50;
     user.season.tier = Math.min(Math.floor(user.season.xp / xpPerTier), maxTiers);
+    return xp;
 }
 
 // ── Event hooks ──────────────────────────────────────────────────────────────

--- a/tests/petBattle.test.js
+++ b/tests/petBattle.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const {
+    xpForLevel,
+    stageForLevel,
+    applyPetXp,
+    getEffectiveBonusPct,
+    getPetStats,
+    simulateBattle,
+    makeWildPet,
+    getPetDisplay,
+    PET_MAX_LEVEL,
+} = require('../src/services/petService');
+
+describe('pet XP curve', () => {
+    test('level 1 needs no XP; curve is strictly increasing', () => {
+        expect(xpForLevel(1)).toBe(0);
+        for (let l = 2; l <= PET_MAX_LEVEL; l++) {
+            expect(xpForLevel(l)).toBeGreaterThan(xpForLevel(l - 1));
+        }
+    });
+
+    test('stage boundaries land at 10 and 20', () => {
+        expect(stageForLevel(1)).toBe(1);
+        expect(stageForLevel(9)).toBe(1);
+        expect(stageForLevel(10)).toBe(2);
+        expect(stageForLevel(19)).toBe(2);
+        expect(stageForLevel(20)).toBe(3);
+        expect(stageForLevel(30)).toBe(3);
+    });
+});
+
+describe('applyPetXp', () => {
+    test('levels up and evolves when crossing a stage boundary', () => {
+        const pet = { petId: 'wolf', level: 1, xp: 0, evolutionStage: 1 };
+        const res = applyPetXp(pet, xpForLevel(10));
+        expect(pet.level).toBe(10);
+        expect(pet.evolutionStage).toBe(2);
+        expect(res.leveledUp).toBe(true);
+        expect(res.evolved).toBe(true);
+        expect(res.toStage).toBe(2);
+    });
+
+    test('does not exceed max level', () => {
+        const pet = { petId: 'wolf', level: 1, xp: 0, evolutionStage: 1 };
+        applyPetXp(pet, 10_000_000);
+        expect(pet.level).toBe(PET_MAX_LEVEL);
+        expect(pet.evolutionStage).toBe(3);
+    });
+
+    test('partial XP does not level when below threshold', () => {
+        const pet = { petId: 'cat', level: 1, xp: 0, evolutionStage: 1 };
+        const res = applyPetXp(pet, xpForLevel(2) - 1);
+        expect(pet.level).toBe(1);
+        expect(res.leveledUp).toBe(false);
+    });
+});
+
+describe('getEffectiveBonusPct', () => {
+    test('scales with level/stage but stays capped at 2.5x base', () => {
+        const base = { petId: 'wolf', level: 1, evolutionStage: 1 }; // wolf base 10%
+        expect(getEffectiveBonusPct(base)).toBe(10);
+
+        const mid = { petId: 'wolf', level: 10, evolutionStage: 2 };
+        const midPct = getEffectiveBonusPct(mid);
+        expect(midPct).toBeGreaterThan(10);
+        expect(midPct).toBeLessThanOrEqual(25);
+
+        const maxed = { petId: 'wolf', level: 30, evolutionStage: 3 };
+        expect(getEffectiveBonusPct(maxed)).toBe(25); // 10 * 2.5 cap
+    });
+
+    test('unknown pet contributes nothing', () => {
+        expect(getEffectiveBonusPct({ petId: 'nope' })).toBe(0);
+    });
+});
+
+describe('getPetStats', () => {
+    test('a higher-level evolved pet is strictly stronger', () => {
+        const weak   = getPetStats({ petId: 'cat', level: 1, evolutionStage: 1, personality: 'lazy' });
+        const strong = getPetStats({ petId: 'cat', level: 20, evolutionStage: 3, personality: 'energetic' });
+        expect(strong.hp).toBeGreaterThan(weak.hp);
+        expect(strong.atk).toBeGreaterThan(weak.atk);
+    });
+});
+
+describe('simulateBattle', () => {
+    const fixedRng = () => 0.5; // no crits, neutral variance
+
+    test('a vastly stronger pet reliably wins', () => {
+        const strong = { petId: 'wolf', level: 25, evolutionStage: 3, personality: 'energetic' };
+        const weak   = { petId: 'cat',  level: 1,  evolutionStage: 1, personality: 'lazy' };
+        const res = simulateBattle(strong, weak, fixedRng);
+        expect(res.winner).toBe('a');
+        expect(res.rounds.length).toBeGreaterThan(0);
+    });
+
+    test('is deterministic for a fixed rng', () => {
+        const a = { petId: 'fox', level: 8, evolutionStage: 1, personality: 'mischievous' };
+        const b = { petId: 'dog', level: 7, evolutionStage: 1, personality: 'loyal' };
+        const r1 = simulateBattle(a, b, fixedRng);
+        const r2 = simulateBattle(a, b, fixedRng);
+        expect(r1.winner).toBe(r2.winner);
+        expect(r1.rounds.length).toBe(r2.rounds.length);
+    });
+
+    test('always produces a single winner', () => {
+        for (let i = 0; i < 50; i++) {
+            const lvlA = 1 + Math.floor(Math.random() * 30);
+            const lvlB = 1 + Math.floor(Math.random() * 30);
+            const a = { petId: 'wolf', level: lvlA, evolutionStage: 1, personality: 'energetic' };
+            const b = { petId: 'cat',  level: lvlB, evolutionStage: 1, personality: 'loyal' };
+            const res = simulateBattle(a, b);
+            expect(['a', 'b']).toContain(res.winner);
+        }
+    });
+});
+
+describe('makeWildPet', () => {
+    test('scales near the given level and is battle-ready', () => {
+        const wild = makeWildPet(10, () => 0.5);
+        expect(wild.level).toBeGreaterThanOrEqual(9);
+        expect(wild.level).toBeLessThanOrEqual(12);
+        expect(wild.hunger).toBe(100);
+        expect(wild.wild).toBe(true);
+    });
+});
+
+describe('getPetDisplay', () => {
+    test('applies an evolution title at higher stages', () => {
+        expect(getPetDisplay({ petId: 'wolf', name: 'Rex', evolutionStage: 1 }).titledName).toBe('Rex');
+        expect(getPetDisplay({ petId: 'wolf', name: 'Rex', evolutionStage: 2 }).titledName).toBe('Seasoned Rex');
+        expect(getPetDisplay({ petId: 'wolf', name: 'Rex', evolutionStage: 3 }).titledName).toBe('Apex Rex');
+    });
+});

--- a/tests/seasonPass.test.js
+++ b/tests/seasonPass.test.js
@@ -34,6 +34,14 @@ describe('season pass tier table', () => {
         expect(TIER_TABLE[0].premium.itemId).toBe('lucky_charm'); // tier 1 premium hook
     });
 
+    test('tier 50 grants both the item and the Season Sovereign title', () => {
+        const t50 = TIER_TABLE[49].premium;
+        expect(t50.itemId).toBe('lifesaver');
+        expect(t50.title).toMatch(/Sovereign/);
+        expect(t50.label).toMatch(/Lifesaver/);
+        expect(t50.label).toMatch(/Sovereign/); // title not dropped when an item is also present
+    });
+
     test('lore exists for every tier', () => {
         for (let t = 1; t <= TIER_COUNT; t++) expect(loreForTier(t)).toBeTruthy();
     });

--- a/tests/seasonPass.test.js
+++ b/tests/seasonPass.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const { TIER_COUNT, XP_PER_TIER, TIER_TABLE, loreForTier } = require('../src/data/seasonPass');
+const { awardSeasonXp } = require('../src/services/questService');
+
+describe('season pass tier table', () => {
+    test('has 50 sequential tiers with both tracks labeled', () => {
+        expect(TIER_TABLE.length).toBe(TIER_COUNT);
+        expect(TIER_COUNT).toBe(50);
+        TIER_TABLE.forEach((t, i) => {
+            expect(t.tier).toBe(i + 1);
+            expect(t.free.label).toBeTruthy();
+            expect(t.premium.label).toBeTruthy();
+        });
+    });
+
+    test('premium coin total stays close to the default unlock cost (net sink)', () => {
+        const premiumCoins = TIER_TABLE.reduce((s, t) => s + t.premium.coins, 0);
+        // Full completion should roughly break even on coins (items/badges are the
+        // value-add); anything wildly above the 100k default cost would make the
+        // "sink" a faucet.
+        expect(premiumCoins).toBeLessThan(120_000);
+        expect(premiumCoins).toBeGreaterThan(60_000);
+    });
+
+    test('free coin faucet is bounded', () => {
+        const freeCoins = TIER_TABLE.reduce((s, t) => s + t.free.coins, 0);
+        expect(freeCoins).toBeLessThan(80_000);
+    });
+
+    test('milestone tiers carry items', () => {
+        expect(TIER_TABLE[9].free.itemId).toBe('lifesaver');    // tier 10
+        expect(TIER_TABLE[49].free.itemId).toBe('lifesaver');   // tier 50
+        expect(TIER_TABLE[0].premium.itemId).toBe('lucky_charm'); // tier 1 premium hook
+    });
+
+    test('lore exists for every tier', () => {
+        for (let t = 1; t <= TIER_COUNT; t++) expect(loreForTier(t)).toBeTruthy();
+    });
+});
+
+describe('awardSeasonXp weekly cap', () => {
+    const guildSettings = (overrides = {}) => ({
+        season: { enabled: true, seasonId: 's1', xpPerTier: 100, maxTiers: 50, weeklyXpCap: 1500, ...overrides },
+    });
+
+    const freshUser = () => ({ season: { seasonId: 's1', xp: 0, tier: 0, claimedTiers: [], weekXp: 0, weekStart: new Date() } });
+
+    test('grants XP under the cap', async () => {
+        const user = freshUser();
+        await awardSeasonXp(user, 100, guildSettings());
+        expect(user.season.xp).toBe(100);
+        expect(user.season.weekXp).toBe(100);
+    });
+
+    test('clamps a grant that crosses the cap', async () => {
+        const user = freshUser();
+        user.season.weekXp = 1450;
+        await awardSeasonXp(user, 100, guildSettings());
+        expect(user.season.xp).toBe(50);       // only the remaining 50 granted
+        expect(user.season.weekXp).toBe(1500);
+    });
+
+    test('grants nothing once the cap is reached', async () => {
+        const user = freshUser();
+        user.season.weekXp = 1500;
+        await awardSeasonXp(user, 100, guildSettings());
+        expect(user.season.xp).toBe(0);
+    });
+
+    test('rolls the window over after 7 days', async () => {
+        const user = freshUser();
+        user.season.weekXp = 1500;
+        user.season.weekStart = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
+        await awardSeasonXp(user, 100, guildSettings());
+        expect(user.season.xp).toBe(100);
+        expect(user.season.weekXp).toBe(100);
+    });
+
+    test('no cap when weeklyXpCap is 0', async () => {
+        const user = freshUser();
+        await awardSeasonXp(user, 5000, guildSettings({ weeklyXpCap: 0 }));
+        expect(user.season.xp).toBe(5000);
+    });
+
+    test('season rollover resets progress and premium', async () => {
+        const user = { season: { seasonId: 'old', xp: 900, tier: 9, claimedTiers: [1], premium: true, claimedPremiumTiers: [1] } };
+        await awardSeasonXp(user, 50, guildSettings());
+        expect(user.season.seasonId).toBe('s1');
+        expect(user.season.xp).toBe(50);
+        expect(user.season.premium).toBe(false);
+        expect(user.season.claimedPremiumTiers).toEqual([]);
+    });
+
+    test('tier derives from xp and respects maxTiers', async () => {
+        const user = freshUser();
+        await awardSeasonXp(user, 1500, guildSettings({ weeklyXpCap: 0 }));
+        expect(user.season.tier).toBe(15);
+    });
+});


### PR DESCRIPTION
Two of the four Phase 4 "live-service" features from the audit roadmap. Rebased clean onto `main`. The remaining two (syndicate territory/leaderboards, spectator duel betting) are tracked as separate issues.

## 1. Pet evolution & battles
Turns the pet collection into a real progression/retention loop.

**Progression** (`petService.js`, `User.pets` schema)
- Pets earn XP from feeding (8 favorite / 4 other), the existing `/pet play` button (+10), and battles.
- 30-level curve (~9,860 XP to max) with three evolution stages at levels 1 / 10 / 20 — evolved emoji + "Seasoned"/"Apex" titles per species.
- Effective passive bonus scales with stage × level (e.g. a wolf's hunt yield grows 10% → 25%), **capped at 2.5× base** so the 10× combined-multiplier economy stays bounded. `getTotalBonus` reads the effective value at the single chokepoint, so all six consumers benefit with no other edits. Existing pets read as level 1 / stage 1 via null-coalescing — no economic disruption, no migration.

**Battles** (`/pet battle`)
- **Wild (PvE):** fight a level-scaled wild pet for XP on a 10-min per-pet cooldown — the solo progression faucet.
- **PvP:** accept/decline challenge, then a simulated fight revealed with HP bars + round log. Wagers are escrowed atomically (challenger→opponent, refund on shortfall, and refunded if a pet is released mid-challenge); winner takes the pot minus the guild house cut. Wagered battles require both accounts 7+ days old (same gate as rob/gift) and log as `pet_battle` transactions.
- Engine derives HP/ATK/DEF/SPD from level, stage, and personality; RNG is injectable for deterministic tests. Pets must be fed (hunger ≥ 30%) to fight.
- Level / evolution / battle record surfaced on the `/pet status` card and in feed/play/battle messages.

## 2. Season pass overhaul
The 20-tier / 2,000-XP pass was exhaustible in <3 weeks of a 90-day season. Rebuilt as a paced dual-track battle pass that doubles as the economy's primary deliberate coin sink.

- **50-tier table** (new `src/data/seasonPass.js`) generated from milestone item maps + scaling coin formulas. Free track ~62k coins + consumables/badges; premium track has rewards every tier (exclusive items, ~109k coins across a full clear, a tier-50 "Season Sovereign" title).
- **Premium unlock** (`/season unlock`): one-time atomic coin payment (guild-configurable `season.premiumCost`, default 100,000), logged as `season_premium`. Full completion ≈ breaks even on coins, so for the median player who never finishes it's a real net sink — the inflation valve the audit asked for. Resets each season.
- **Weekly XP pacing** (`awardSeasonXp`): new `season.weeklyXpCap` (default 1,500) clamps season XP per rolling 7-day window, stretching the pass to ~10–12 weeks. `cap=0` disables.
- `/season view` shows both tracks, per-track unclaimed counts, premium status, weekly XP; `/season claim` gains a `premium:true` option with separate claim tracking; milestone broadcasts fire only every 10th tier.
- Schema additions are all default-safe (no migration).

## Testing
- New `tests/petBattle.test.js` (13 cases): XP curve, stage boundaries, level-up/evolution, capped effective bonus, stat scaling, deterministic + always-decisive battles, wild-pet generation.
- New `tests/seasonPass.test.js` (12 cases): table shape, sink-economics bounds (so a future reward edit that breaks the sink fails CI), weekly-cap clamp/rollover, season rollover resetting premium, tier derivation.
- Full suite **203/204**. The lone failure (`welcome.test.js` / `analytics.test.js`) pre-exists on `main` — the `canvas` native module can't build in CI and an unrelated dashboard route — neither touched here.

## Deploy notes
- No migration required — all new pet and season fields are default-safe and read as their defaults on existing documents.
- New guild knobs: `season.premiumCost`, `season.weeklyXpCap`, plus the existing `economy.chatEventsEnabled` from the prior phase.

https://claude.ai/code/session_011QsmeXMgQ6tbyepteeAXDi

---
_Generated by [Claude Code](https://claude.ai/code/session_011QsmeXMgQ6tbyepteeAXDi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pet battles: wild PvE and optional wagered PvP with challenge/accept flow, round-by-round logs, results/XP/evolution handling
  * Pet progression: XP gain from feeding/playing, level-ups, evolution stages, battle records, and improved pet status display
  * Season pass: 50-tier free+premium tracks, premium unlock flow, tier-specific rewards and milestone broadcasts every 10 tiers
  * Weekly XP caps and premium cost configuration

* **Tests**
  * Added coverage for pet battles, progression, season pass tiers, and weekly XP behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->