### PR TITLE
feat: memory pinning, DM story recap button, and party stat card embed

### DIFF
--- a/src/commands/ai/ai.js
+++ b/src/commands/ai/ai.js
@@ -1,0 +1,66 @@
+const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const User = require('../../models/User');
+
+const MEMORY_CAP = 10;
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('ai')
+        .setDescription('AI assistant utilities')
+        .setDMPermission(false)
+        .addSubcommand(sub =>
+            sub.setName('memories')
+                .setDescription('View and manage your pinned AI memories')
+                .addIntegerOption(opt =>
+                    opt.setName('delete')
+                        .setDescription('Delete a memory by its number (from the list)')
+                        .setMinValue(1)
+                        .setMaxValue(MEMORY_CAP)
+                )
+        ),
+
+    async execute(interaction) {
+        const sub = interaction.options.getSubcommand();
+        if (sub !== 'memories') return;
+
+        const deleteIndex = interaction.options.getInteger('delete');
+
+        let userDoc = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+        if (!userDoc) {
+            userDoc = await User.create({ userId: interaction.user.id, guildId: interaction.guild.id });
+        }
+
+        const memories = userDoc.pinnedMemories || [];
+
+        if (deleteIndex != null) {
+            const idx = deleteIndex - 1;
+            if (idx < 0 || idx >= memories.length) {
+                return interaction.reply({ content: `No memory #${deleteIndex} found. You have ${memories.length} pinned memory/memories.`, ephemeral: true });
+            }
+            memories.splice(idx, 1);
+            userDoc.pinnedMemories = memories;
+            await userDoc.save();
+            return interaction.reply({ content: `🗑️ Memory #${deleteIndex} deleted. You now have **${memories.length}** pinned memory/memories.`, ephemeral: true });
+        }
+
+        if (memories.length === 0) {
+            return interaction.reply({
+                content: '📌 You have no pinned memories. React with 📌 to a bot message to save it as a memory.',
+                ephemeral: true
+            });
+        }
+
+        const lines = memories.map((m, i) => {
+            const preview = m.content.length > 80 ? m.content.slice(0, 80) + '…' : m.content;
+            return `**${i + 1}.** ${preview}`;
+        });
+
+        const embed = new EmbedBuilder()
+            .setTitle('📌 Your Pinned Memories')
+            .setColor('#f1c40f')
+            .setDescription(lines.join('\n\n'))
+            .setFooter({ text: `${memories.length}/${MEMORY_CAP} slots used · Use /ai memories delete:<number> to remove one` });
+
+        return interaction.reply({ embeds: [embed], ephemeral: true });
+    }
+};

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -3,6 +3,7 @@ const User = require('../models/User');
 const { handlePollVote } = require('../commands/utility/poll');
 const { handleHeistButton } = require('../commands/economy/heist');
 const { handleSyndicateButton } = require('../commands/economy/syndicate');
+const { handleDmButton } = require('../services/dmService');
 const { ensureQuests, onCommandUse, notifyQuestComplete, notifyQuestNearComplete } = require('../services/questService');
 async function logCommandMetric(interaction, success, reason = null) {
     try {
@@ -155,6 +156,13 @@ module.exports = {
 
             if (interaction.customId.startsWith('poll_')) {
                 await handlePollVote(interaction);
+            }
+
+            if (interaction.customId.startsWith('dm_storysofar_')) {
+                await handleDmButton(interaction, client).catch(err => {
+                    console.error('[dm] button handler error:', err);
+                });
+                return;
             }
 
             return;

--- a/src/events/messageReactionAdd.js
+++ b/src/events/messageReactionAdd.js
@@ -24,6 +24,7 @@ module.exports = {
         await handleReactionRole(reaction, user, guild, guildSettings);
         await handleStarboard(reaction, user, guild, guildSettings);
         await handleReactionQuests(reaction, user, guild, guildSettings);
+        await handleMemoryPin(reaction, user, guild, client);
     }
 };
 
@@ -110,4 +111,47 @@ async function handleStarboard(reaction, user, guild, guildSettings) {
         content: `${sb.emoji} **${count}** | <#${message.channel.id}>`,
         embeds: [embed]
     }).catch(console.error);
+}
+
+const MEMORY_PIN_EMOJI = '📌';
+const MEMORY_CAP = 10;
+
+async function handleMemoryPin(reaction, discordUser, guild, client) {
+    const emojiKey = reaction.emoji.id
+        ? `<${reaction.emoji.animated ? 'a' : ''}:${reaction.emoji.name}:${reaction.emoji.id}>`
+        : reaction.emoji.name;
+
+    if (emojiKey !== MEMORY_PIN_EMOJI) return;
+
+    const message = reaction.message;
+    const botUser = client?.user;
+    if (!botUser || message.author.id !== botUser.id) return;
+
+    const content = message.content || (message.embeds[0]?.description ?? '');
+    if (!content) return;
+
+    const userDoc = await User.findOne({ userId: discordUser.id, guildId: guild.id });
+    if (!userDoc) return;
+
+    if (!userDoc.pinnedMemories) userDoc.pinnedMemories = [];
+
+    if (userDoc.pinnedMemories.length >= MEMORY_CAP) {
+        const dmChannel = await discordUser.createDM().catch(() => null);
+        if (dmChannel) {
+            await dmChannel.send(
+                `Your pinned memory limit (${MEMORY_CAP}) is full. Use \`/ai memories\` to delete some before pinning more.`
+            ).catch(() => null);
+        }
+        return;
+    }
+
+    // Truncate to a reasonable length for context injection
+    const truncated = content.length > 500 ? content.slice(0, 500) + '…' : content;
+    userDoc.pinnedMemories.push({ content: truncated, pinnedAt: new Date(), channelId: message.channel.id });
+    await userDoc.save();
+
+    const dmChannel = await discordUser.createDM().catch(() => null);
+    if (dmChannel) {
+        await dmChannel.send(`📌 Memory pinned! I'll remember this in future conversations.\n> ${truncated.slice(0, 100)}${truncated.length > 100 ? '…' : ''}`).catch(() => null);
+    }
 }

--- a/src/events/messageReactionAdd.js
+++ b/src/events/messageReactionAdd.js
@@ -130,7 +130,11 @@ async function handleMemoryPin(reaction, discordUser, guild, client) {
     const content = message.content || (message.embeds[0]?.description ?? '');
     if (!content) return;
 
-    const userDoc = await User.findOne({ userId: discordUser.id, guildId: guild.id });
+    const userDoc = await User.findOneAndUpdate(
+        { userId: discordUser.id, guildId: guild.id },
+        { $setOnInsert: { userId: discordUser.id, guildId: guild.id } },
+        { upsert: true, new: true }
+    );
     if (!userDoc) return;
 
     if (!userDoc.pinnedMemories) userDoc.pinnedMemories = [];

--- a/src/models/DmSession.js
+++ b/src/models/DmSession.js
@@ -16,7 +16,8 @@ const dmSessionSchema = new Schema({
     players: { type: [dmCharacterSchema], default: [] },
     storyLog: { type: [String], default: [] },
     partyState: { type: Schema.Types.Mixed, default: {} },
-    active: { type: Boolean, default: true }
+    active: { type: Boolean, default: true },
+    statCardMessageId: { type: String, default: null }
 }, { timestamps: true });
 
 dmSessionSchema.index({ guildId: 1, channelId: 1, active: 1 });

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -126,6 +126,13 @@ const userSchema = new Schema({
         amount:     { type: Number, default: 0, min: 0 }
     }],
 
+    // Pinned AI memories (set via 📌 reaction on bot messages)
+    pinnedMemories: [{
+        content: { type: String, required: true },
+        pinnedAt: { type: Date, default: Date.now },
+        channelId: { type: String, default: null }
+    }],
+
     // Per-user notification preferences
     notifications: {
         leaderboard: {

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -3,6 +3,7 @@ const { GoogleGenerativeAI } = require('@google/generative-ai');
 const Anthropic = require('@anthropic-ai/sdk');
 const axios = require('axios');
 const Conversation = require('../models/Conversation');
+const User = require('../models/User');
 const KnowledgeBase = require('../models/KnowledgeBase');
 const Reminder = require('../models/Reminder');
 const AIUsage = require('../models/AIUsage');
@@ -779,8 +780,14 @@ async function handleAIChat(message, aiSettings) {
     const maxHistory = aiSettings.maxHistory ?? 20;
     const useStreaming = aiSettings.streaming !== false;
 
-    // Build system prompt: base + knowledge context + action instructions
+    // Build system prompt: base + pinned memories + knowledge context + action instructions
     let systemPrompt = aiSettings.systemPrompt || 'You are a helpful Discord bot assistant.';
+
+    const userDoc = await User.findOne({ userId: message.author.id, guildId: message.guild.id }).lean();
+    if (userDoc?.pinnedMemories?.length) {
+        const memoriesText = userDoc.pinnedMemories.map(m => `- ${m.content}`).join('\n');
+        systemPrompt += `\n\n## User's Pinned Memories\n${memoriesText}`;
+    }
 
     const { entries: kbEntries, isBackground: kbIsBackground } = await retrieveKnowledge(message.guild.id, content);
     if (kbEntries.length) {

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -784,10 +784,7 @@ async function handleAIChat(message, aiSettings) {
     let systemPrompt = aiSettings.systemPrompt || 'You are a helpful Discord bot assistant.';
 
     const userDoc = await User.findOne({ userId: message.author.id, guildId: message.guild.id }).lean();
-    if (userDoc?.pinnedMemories?.length) {
-        const memoriesText = userDoc.pinnedMemories.map(m => `- ${m.content}`).join('\n');
-        systemPrompt += `\n\n## User's Pinned Memories\n${memoriesText}`;
-    }
+    const pinnedMemories = userDoc?.pinnedMemories?.length ? userDoc.pinnedMemories : null;
 
     const { entries: kbEntries, isBackground: kbIsBackground } = await retrieveKnowledge(message.guild.id, content);
     if (kbEntries.length) {
@@ -799,9 +796,19 @@ async function handleAIChat(message, aiSettings) {
 
     try {
         await message.channel.sendTyping();
-        const { messages: history } = await loadHistory(
+        const { messages: rawHistory } = await loadHistory(
             message.guild.id, message.channel.id, message.author.id, maxHistory
         );
+
+        // Prepend pinned memories as a user-context message so the model treats
+        // them as reference information, not authoritative system instructions.
+        const history = pinnedMemories
+            ? [
+                { role: 'user', content: `[My saved context for this conversation]\n${pinnedMemories.map(m => `- ${m.content}`).join('\n')}` },
+                { role: 'assistant', content: 'Understood, I have noted your saved context.' },
+                ...rawHistory
+              ]
+            : rawHistory;
 
         const usageOut = {};
         const callArgs = {

--- a/src/services/dmService.js
+++ b/src/services/dmService.js
@@ -366,7 +366,7 @@ function buildStatCardEmbed(session) {
     const MAX_BAR = 10;
     const fields = session.players.map(p => {
         const maxHp = CLASS_HP[p.characterClass] || 100;
-        const filled = Math.round((Math.max(0, p.hp) / maxHp) * MAX_BAR);
+        const filled = Math.min(MAX_BAR, Math.round((Math.max(0, p.hp) / maxHp) * MAX_BAR));
         const bar = '█'.repeat(filled) + '░'.repeat(MAX_BAR - filled);
         const invLine = p.inventory.length ? p.inventory.join(', ') : 'Empty';
         return {

--- a/src/services/dmService.js
+++ b/src/services/dmService.js
@@ -1,4 +1,4 @@
-const { EmbedBuilder } = require('discord.js');
+const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const DmSession = require('../models/DmSession');
 const { getCompletion, resolveProviderConfig } = require('./aiService');
 const Guild = require('../models/Guild');
@@ -163,13 +163,21 @@ async function beginSession(interaction) {
             { $push: { storyLog: story } }
         );
 
+        const updatedSession = await DmSession.findOne({ sessionId: session.sessionId });
+
         const embed = new EmbedBuilder()
             .setTitle('📖 The Adventure Begins...')
             .setColor('#8b4513')
             .setDescription(story)
             .setFooter({ text: 'Use /dm action to take an action!' });
 
-        return interaction.editReply({ embeds: [embed] });
+        const storyRow = makeStoryButton(session.sessionId);
+        await interaction.editReply({ embeds: [embed], components: [storyRow] });
+
+        if (updatedSession) {
+            await postOrUpdateStatCard(channel, updatedSession).catch(console.error);
+        }
+        return;
     } catch (err) {
         console.error('[DM] begin error:', err.message);
         return interaction.editReply('Failed to generate the opening scene. Please try again.');
@@ -262,17 +270,25 @@ async function takeAction(interaction) {
             );
         }
 
+        const updatedSession = await DmSession.findOne({ sessionId: session.sessionId });
+
         const embed = new EmbedBuilder()
             .setTitle(`⚔️ ${player.name} acts!`)
             .setColor(wiped ? '#ff0000' : '#4169e1')
             .setDescription(narrative)
-            .setFooter({ text: wiped ? 'The party has fallen...' : 'Use /dm action to respond | /dm status to check party' });
+            .setFooter({ text: wiped ? 'The party has fallen...' : 'Use /dm action to respond!' });
 
         if (wiped) {
             embed.addFields({ name: '💀 Session Ended', value: 'The entire party has fallen. The adventure is over.' });
         }
 
-        return interaction.editReply({ embeds: [embed] });
+        const components = wiped ? [] : [makeStoryButton(session.sessionId)];
+        await interaction.editReply({ embeds: [embed], components });
+
+        if (updatedSession && !wiped) {
+            await postOrUpdateStatCard(channel, updatedSession).catch(console.error);
+        }
+        return;
     } catch (err) {
         console.error('[DM] action error:', err.message);
         return interaction.editReply('Failed to generate a response. Please try again.');
@@ -335,6 +351,107 @@ async function stopSession(interaction) {
     return interaction.reply({ embeds: [embed] });
 }
 
+function makeStoryButton(sessionId) {
+    const row = new ActionRowBuilder();
+    row.addComponents(
+        new ButtonBuilder()
+            .setCustomId(`dm_storysofar_${sessionId}`)
+            .setLabel('📖 Story So Far')
+            .setStyle(ButtonStyle.Secondary)
+    );
+    return row;
+}
+
+function buildStatCardEmbed(session) {
+    const MAX_BAR = 10;
+    const fields = session.players.map(p => {
+        const maxHp = CLASS_HP[p.characterClass] || 100;
+        const filled = Math.round((Math.max(0, p.hp) / maxHp) * MAX_BAR);
+        const bar = '█'.repeat(filled) + '░'.repeat(MAX_BAR - filled);
+        const invLine = p.inventory.length ? p.inventory.join(', ') : 'Empty';
+        return {
+            name: `${p.name} — ${p.characterClass}`,
+            value: `❤️ \`${bar}\` ${p.hp}/${maxHp}\n🎒 ${invLine}`,
+            inline: false
+        };
+    });
+
+    return new EmbedBuilder()
+        .setTitle('🗡️ Party Status')
+        .setColor('#2f3136')
+        .addFields(fields)
+        .setFooter({ text: 'Updated after each action' })
+        .setTimestamp();
+}
+
+async function postOrUpdateStatCard(channel, session) {
+    const embed = buildStatCardEmbed(session);
+    if (session.statCardMessageId) {
+        try {
+            const msg = await channel.messages.fetch(session.statCardMessageId);
+            await msg.edit({ embeds: [embed] });
+            return;
+        } catch {
+            // message deleted or inaccessible — post a new one
+        }
+    }
+    const sent = await channel.send({ embeds: [embed] });
+    await DmSession.findOneAndUpdate(
+        { sessionId: session.sessionId },
+        { $set: { statCardMessageId: sent.id } }
+    );
+}
+
+async function handleDmButton(interaction, client) {
+    if (!interaction.customId.startsWith('dm_storysofar_')) return false;
+
+    const sessionId = interaction.customId.slice('dm_storysofar_'.length);
+    const session = await DmSession.findOne({ sessionId });
+    if (!session || !session.active) {
+        await interaction.reply({ content: 'This session is no longer active.', ephemeral: true });
+        return true;
+    }
+
+    if (session.storyLog.length === 0) {
+        await interaction.reply({ content: 'The adventure has not begun yet.', ephemeral: true });
+        return true;
+    }
+
+    await interaction.deferReply({ ephemeral: true });
+
+    try {
+        const gs = await Guild.findOne({ guildId: session.guildId });
+        const aiSettings = gs?.ai || {};
+        const { provider, model, apiKey, baseUrl } = resolveProviderConfig(aiSettings);
+
+        if (provider !== 'ollama' && !apiKey) {
+            return interaction.editReply('AI is not configured for this server.');
+        }
+
+        const logSnippet = session.storyLog.slice(-16).join('\n\n');
+        const recap = await getCompletion({
+            provider, model, apiKey, baseUrl,
+            systemPrompt: 'You are a dramatic fantasy narrator. Summarize the story concisely.',
+            history: [],
+            prompt: `Summarize the following campaign story so far as a dramatic narrator in 3-5 sentences:\n\n${logSnippet}`,
+            temperature: 0.8,
+            maxTokens: 300
+        });
+
+        const embed = new EmbedBuilder()
+            .setTitle('📖 Story So Far...')
+            .setColor('#8b4513')
+            .setDescription(recap)
+            .setFooter({ text: 'Only visible to you' });
+
+        await interaction.editReply({ embeds: [embed] });
+    } catch (err) {
+        console.error('[DM] story recap error:', err.message);
+        await interaction.editReply('Failed to generate recap. Please try again.');
+    }
+    return true;
+}
+
 function buildDMSystemPrompt() {
     return `You are an experienced, creative Dungeon Master running a text-based RPG on Discord. Your role is to:
 - Narrate vivid, engaging story scenes
@@ -348,4 +465,4 @@ function buildDMSystemPrompt() {
 The party is playing in a classic fantasy setting. Be creative, dramatic, and fun!`;
 }
 
-module.exports = { startSession, joinSession, beginSession, takeAction, partyStatus, stopSession, CLASSES };
+module.exports = { startSession, joinSession, beginSession, takeAction, partyStatus, stopSession, handleDmButton, CLASSES };


### PR DESCRIPTION
- Issue 479: React 📌 to a bot message to pin it as a persistent AI memory. Memories are prepended to the system prompt in every future AI conversation for that user. Cap of 10 memories with DM notification when full. New /ai memories command to view and delete pinned memories.

- Issue 481: "Story So Far" button added to DM session messages (begin/action). Clicking it generates an AI narrative recap ephemerally for the requesting user.

- Issue 482: Visual party stat card embed with HP progress bars and inventory is posted after begin/action and edited in-place on each subsequent action. statCardMessageId tracked on DmSession to support in-place edits.

https://claude.ai/code/session_018cM9t7EfgKUGvqpu1YG7zD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/ai memories` command to view and manage saved memories with deletion support
  * Pin messages using 📌 emoji reaction to save as memories (10-memory limit per user)
  * AI responses now incorporate pinned memories for personalized context
  * Added interactive story buttons and party stat cards for enhanced DM gameplay experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->