### PR TITLE
fix: add 404 handling and model name validation for OpenRouter

### DIFF
--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -763,6 +763,10 @@ async function handleAIChat(message, aiSettings) {
         return message.reply(`${providerLabel} is not configured. Add an API key in the dashboard.`);
     }
 
+    if (provider === 'openrouter' && model && !model.includes('/')) {
+        return message.reply(`OpenRouter model names must include a provider prefix (e.g. \`openai/gpt-4o-mini\`). Your current model \`${model}\` is missing the prefix — update it in the AI settings dashboard.`);
+    }
+
     const content = message.content.trim();
     if (content.toLowerCase() === '!reset') {
         await clearHistory(message.guild.id, message.channel.id, message.author.id);
@@ -922,6 +926,7 @@ async function handleAIChat(message, aiSettings) {
         const status = error?.status || error?.response?.status;
         let detail = status ? ` (HTTP ${status})` : '';
         if (status === 401) detail += ' — check your API key';
+        else if (status === 404) detail += ' — model not found; check your model name in the AI settings';
         else if (status === 429) detail += ' — rate limit exceeded';
         else if (status === 503) detail += ' — provider unavailable';
         await message.reply(`Sorry, I hit an error talking to ${providerLabel}${detail}.`).catch(() => {});


### PR DESCRIPTION
- Validate that OpenRouter model names include a provider prefix
  (e.g. `openai/gpt-4o-mini`) before making the API call, with a
  clear error message guiding users to fix it in the dashboard
- Add specific HTTP 404 error detail so users know a 404 means
  "model not found" rather than seeing an unexplained error

https://claude.ai/code/session_01AFFdA2aptpLn22NZW8u62P

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling provides clearer guidance when AI models cannot be found, directing users to verify their model configuration in the AI settings dashboard.
  * Improved validation for OpenRouter model configuration ensures models include the proper provider prefix format for seamless functionality and reduces configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->