### PR TITLE
fix: allow inline event handlers blocked by CSP script-src-attr

### DIFF
--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -103,6 +103,9 @@ function start(client) {
         res.setHeader('Content-Security-Policy', [
             "default-src 'self'",
             `script-src 'self' 'nonce-${nonce}' https://cdn.jsdelivr.net`,
+            // Inline event handlers (onclick, onchange, etc.) cannot carry nonces,
+            // so allow them the same way inline styles are allowed.
+            "script-src-attr 'unsafe-inline'",
             "style-src 'self' 'unsafe-inline'",
             "img-src 'self' data: https: cdn.discordapp.com",
             "connect-src 'self'",


### PR DESCRIPTION
The CSP script-src directive includes a nonce, which causes browsers to also enforce the nonce requirement on inline event handlers via the script-src-attr fallback. Since onclick/onchange attributes cannot carry nonces, every save button and interactive control in the dashboard was silently blocked — explaining why changing the AI model and clicking Save produced no confirmation.

Adds an explicit script-src-attr 'unsafe-inline' directive (mirroring the existing style-src 'unsafe-inline' for inline style attributes) until all handlers are migrated to addEventListener.

https://claude.ai/code/session_01AFFdA2aptpLn22NZW8u62P