### PR TITLE
Reduce mine command cooldown from 30s to 5s

### DIFF
--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -79,7 +79,7 @@ const INTENSITY_LEVELS = [
 ];
 
 module.exports = {
-    cooldown: 30,
+    cooldown: 5,
 
     data: new SlashCommandBuilder()
         .setName('mine')


### PR DESCRIPTION
## Summary
Reduced the cooldown timer for the `/mine` economy command to make it more accessible and allow for faster repeated usage.

## Changes
- Decreased the `cooldown` value from 30 seconds to 5 seconds in the mine command configuration

## Details
This change allows users to execute the mine command more frequently, improving the gameplay experience by reducing wait times between mining attempts. The cooldown is now set to 5 seconds instead of the previous 30-second restriction.

https://claude.ai/code/session_01FStAxuc1ra5dQGjBeYxPj4