### PR TITLE
Fix Discord embed field limits and add session persistence

### DIFF
--- a/src/commands/economy/craft.js
+++ b/src/commands/economy/craft.js
@@ -125,20 +125,46 @@ module.exports = {
                 });
             }
 
+            // Discord embed field values must be 1..1024 chars. Split a category's
+            // lines across multiple same-named fields rather than overflowing one.
+            const FIELD_LIMIT = 1024;
+            function buildFields(name, lines) {
+                if (!lines.length) return [{ name, value: 'None', inline: false }];
+                const fields = [];
+                let chunk = '';
+                for (const line of lines) {
+                    const candidate = chunk ? `${chunk}\n\n${line}` : line;
+                    if (candidate.length > FIELD_LIMIT) {
+                        if (chunk) fields.push(chunk);
+                        chunk = line.length > FIELD_LIMIT ? line.slice(0, FIELD_LIMIT - 1) + '…' : line;
+                    } else {
+                        chunk = candidate;
+                    }
+                }
+                if (chunk) fields.push(chunk);
+                return fields.map((value, i) => ({
+                    name: i === 0 ? name : `${name} (cont.)`,
+                    value,
+                    inline: false
+                }));
+            }
+
             const huntLines  = recipeLines(HUNT_RECIPES,  { luckyPaw: h.luckyPaw });
             const mineLines  = recipeLines(MINE_RECIPES);
             const fishLines  = recipeLines(FISH_CRAFT_RECIPES, { luckyHook: f.luckyHook });
             const crossLines = recipeLines(CROSS_CRAFT_RECIPES, { precisionScope: h.precisionScope });
 
+            const fields = [
+                ...buildFields('🏹 Hunting Recipes', huntLines),
+                ...buildFields('⛏️ Mining Recipes', mineLines),
+                ...buildFields('🎣 Fishing Recipes', fishLines),
+                ...buildFields('🔗 Cross-System Recipes', crossLines)
+            ].slice(0, 25);
+
             const embed = new EmbedBuilder()
                 .setColor('#1abc9c')
                 .setTitle('🔨 Crafting Recipes')
-                .addFields(
-                    { name: '🏹 Hunting Recipes',        value: huntLines.join('\n\n')  || 'None', inline: false },
-                    { name: '⛏️ Mining Recipes',          value: mineLines.join('\n\n')  || 'None', inline: false },
-                    { name: '🎣 Fishing Recipes',         value: fishLines.join('\n\n')  || 'None', inline: false },
-                    { name: '🔗 Cross-System Recipes',    value: crossLines.join('\n\n') || 'None', inline: false }
-                )
+                .addFields(...fields)
                 .setFooter({ text: '✅ = can craft now  •  /craft make <recipe>' });
 
             return interaction.reply({ embeds: [embed] });

--- a/src/commands/moderation/case.js
+++ b/src/commands/moderation/case.js
@@ -35,7 +35,7 @@ module.exports = {
                 { name: 'Target', value: `<@${modCase.targetUserId}> (${modCase.targetUserId})`, inline: true },
                 { name: 'Moderator', value: `<@${modCase.moderatorId}>`, inline: true },
                 { name: 'Status', value: `${STATUS_EMOJI[modCase.status] || '⚪'} ${modCase.status}`, inline: true },
-                { name: 'Reason', value: modCase.reason }
+                { name: 'Reason', value: (modCase.reason || 'No reason provided').slice(0, 1024) }
             )
             .setTimestamp(modCase.createdAt);
 
@@ -63,13 +63,15 @@ module.exports = {
         if (modCase.notes?.length) {
             const notesText = modCase.notes
                 .slice(-3)
-                .map((n, i) => `**${i + 1}.** <@${n.moderatorId}>: ${n.content}`)
-                .join('\n');
+                .map((n, i) => `**${i + 1}.** <@${n.moderatorId}>: ${n.content.slice(0, 300)}`)
+                .join('\n')
+                .slice(0, 1024);
             embed.addFields({ name: `Notes (last ${Math.min(3, modCase.notes.length)})`, value: notesText });
         }
 
         if (modCase.labels?.length) {
-            embed.addFields({ name: 'Labels', value: modCase.labels.join(', '), inline: true });
+            const labelsText = modCase.labels.join(', ').slice(0, 1024) || 'None';
+            embed.addFields({ name: 'Labels', value: labelsText, inline: true });
         }
 
         await interaction.reply({ embeds: [embed], ephemeral: true });

--- a/src/commands/moderation/note.js
+++ b/src/commands/moderation/note.js
@@ -9,9 +9,9 @@ module.exports = {
         .addIntegerOption(o =>
             o.setName('case_id').setDescription('Case ID').setRequired(true).setMinValue(1))
         .addStringOption(o =>
-            o.setName('text').setDescription('Note text').setRequired(true))
+            o.setName('text').setDescription('Note text').setRequired(true).setMaxLength(1024))
         .addStringOption(o =>
-            o.setName('label').setDescription('Add a label to the case').setRequired(false))
+            o.setName('label').setDescription('Add a label to the case').setRequired(false).setMaxLength(256))
         .addUserOption(o =>
             o.setName('assign').setDescription('Assign this case to a moderator').setRequired(false))
         .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto');
 const express = require('express');
 const session = require('express-session');
+const MongoStore = require('connect-mongo');
 const passport = require('passport');
 const DiscordStrategy = require('passport-discord').Strategy;
 const path = require('path');
@@ -117,6 +118,7 @@ function start(client) {
     });
 
     app.use(session({
+        store: MongoStore.create({ mongoUrl: process.env.MONGODB_URI, collectionName: 'sessions' }),
         secret: process.env.SESSION_SECRET,
         resave: false,
         saveUninitialized: false,


### PR DESCRIPTION
## Summary
This PR addresses Discord API constraints on embed field values and improves session management by adding MongoDB persistence. The changes ensure embeds don't exceed Discord's 1024-character field limit and prevent session data loss.

## Key Changes

- **Craft command embed handling**: Implemented `buildFields()` helper function to split long recipe lists across multiple embed fields with continuation labels, preventing field value overflow
- **Case command field truncation**: Added `.slice(0, 1024)` to reason, notes, and labels fields to ensure they stay within Discord's embed field limits
- **Note command input validation**: Added `setMaxLength()` constraints to text (1024 chars) and label (256 chars) options for better input validation
- **Session persistence**: Integrated MongoDB session store (`connect-mongo`) to persist user sessions across server restarts, improving user experience by maintaining authentication state

## Implementation Details

The `buildFields()` function intelligently chunks content by:
- Respecting the 1024-character Discord limit per field
- Preserving line breaks between recipe entries
- Truncating individual lines that exceed the limit with an ellipsis
- Creating continuation fields with "(cont.)" suffix for readability
- Limiting total fields to Discord's 25-field maximum per embed

Session store configuration uses the `MONGODB_URI` environment variable and stores sessions in a dedicated `sessions` collection.

https://claude.ai/code/session_01JUneV2hptCz35VjfumZKYv