### PR TITLE
Add autocomplete to shop buy command and improve inventory display

### DIFF
--- a/src/commands/economy/inventory.js
+++ b/src/commands/economy/inventory.js
@@ -94,10 +94,11 @@ function buildItemsEmbed(inventory, shopItems, activeEffects, currency, color, f
             } else {
                 const shopItem = shopItems.find(s => s.name.toLowerCase() === entry.itemId.toLowerCase()
                                                   || (s.itemId && s.itemId.toLowerCase() === entry.itemId.toLowerCase()));
+                const displayName = shopItem ? shopItem.name : entry.itemId;
                 const worth    = shopItem ? ` (worth ${currency}${shopItem.price} each)` : '';
                 const lore     = getItemLore(entry.itemId);
                 const loreLine = lore ? `\n*${lore}*` : '';
-                shopLines.push(`**${entry.itemId}** ×${entry.quantity}${worth}${loreLine}`);
+                shopLines.push(`**${displayName}** ×${entry.quantity}${worth}${loreLine}`);
             }
         }
         if (shopLines.length) {

--- a/src/commands/economy/shop.js
+++ b/src/commands/economy/shop.js
@@ -229,15 +229,20 @@ module.exports = {
         .setDefaultMemberPermissions(null),
 
     async autocomplete(interaction) {
-        const focused = interaction.options.getFocused()?.toLowerCase() ?? '';
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id }, 'shop').lean();
-        const items = guildSettings?.shop ?? [];
-        const matches = focused
-            ? items.filter(i => i.name.toLowerCase().includes(focused))
-            : items;
-        await interaction.respond(
-            matches.slice(0, 25).map(i => ({ name: i.name, value: i.name }))
-        );
+        try {
+            const focused = interaction.options.getFocused()?.toLowerCase() ?? '';
+            const guildSettings = await Guild.findOne({ guildId: interaction.guild.id }, 'shop').lean();
+            const items = guildSettings?.shop ?? [];
+            const matches = focused
+                ? items.filter(i => i.name.toLowerCase().includes(focused))
+                : items;
+            await interaction.respond(
+                matches.slice(0, 25).map(i => ({ name: i.name, value: i.name }))
+            );
+        } catch (err) {
+            console.error('[shop] autocomplete error:', err);
+            await interaction.respond([]).catch(() => {});
+        }
     },
 
     async execute(interaction) {

--- a/src/commands/economy/shop.js
+++ b/src/commands/economy/shop.js
@@ -222,11 +222,23 @@ module.exports = {
         .addSubcommand(sub =>
             sub.setName('buy')
                 .setDescription('Purchase an item from the shop')
-                .addStringOption(o => o.setName('item').setDescription('Exact name of the item to buy (see /shop view for the full list)').setRequired(true)))
+                .addStringOption(o => o.setName('item').setDescription('Item to buy').setRequired(true).setAutocomplete(true)))
         .addSubcommand(sub =>
             sub.setName('trends')
                 .setDescription('Show price movement on shop items (dynamic pricing must be enabled).'))
         .setDefaultMemberPermissions(null),
+
+    async autocomplete(interaction) {
+        const focused = interaction.options.getFocused()?.toLowerCase() ?? '';
+        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id }, 'shop').lean();
+        const items = guildSettings?.shop ?? [];
+        const matches = focused
+            ? items.filter(i => i.name.toLowerCase().includes(focused))
+            : items;
+        await interaction.respond(
+            matches.slice(0, 25).map(i => ({ name: i.name, value: i.name }))
+        );
+    },
 
     async execute(interaction) {
         const sub = interaction.options.getSubcommand();


### PR DESCRIPTION
## Summary
This PR enhances the shop system with autocomplete functionality for the buy command and improves inventory item display by showing proper item names instead of internal IDs.

## Key Changes
- **Shop Buy Command Autocomplete**: Added autocomplete support to the `/shop buy` item parameter, allowing users to see matching items as they type. The autocomplete filters shop items based on user input and returns up to 25 matches.
- **Inventory Display**: Fixed inventory display to show the proper shop item name instead of the internal item ID, improving user experience when viewing their inventory.
- **Description Update**: Simplified the `/shop buy` command description from "Exact name of the item to buy (see /shop view for the full list)" to "Item to buy" since autocomplete now guides users.

## Implementation Details
- The autocomplete handler queries the guild's shop settings and filters items by name (case-insensitive substring matching)
- Inventory display now looks up the corresponding shop item to get the proper display name while maintaining fallback to the item ID if no match is found
- Autocomplete is limited to 25 results per Discord's API constraints

https://claude.ai/code/session_01CmwYxUBWibysJuRm8kxdJc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shop inventory items now display with their proper names instead of technical item IDs.

* **New Features**
  * Added autocomplete support to the `/shop buy` command. When selecting items, suggestions are filtered based on item names as you type, making selection faster and more convenient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->