### PR TITLE
Fix typing indicator cleanup in AI chat streaming

### DIFF
--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -833,30 +833,33 @@ async function handleAIChat(message, aiSettings) {
             // Keep the typing indicator alive for long generations
             const typingInterval = setInterval(() => message.channel.sendTyping().catch(() => {}), TYPING_REFRESH_INTERVAL_MS);
 
-            await withRetry(async () => {
-                fullResponse = '';
-                currentBuf = '';
-                for await (const piece of streamCompletion(callArgs)) {
-                    fullResponse += piece;
-                    currentBuf += piece;
-                    if (currentBuf.length >= DISCORD_MAX_LEN - 50) {
-                        await currentMsg.edit(currentBuf.slice(0, DISCORD_MAX_LEN));
-                        const overflow = currentBuf.slice(DISCORD_MAX_LEN);
-                        currentMsg = await message.channel.send(overflow || '…');
-                        sentMessages.push(currentMsg);
-                        currentBuf = overflow;
-                        lastEdit = Date.now();
-                        continue;
+            try {
+                await withRetry(async () => {
+                    fullResponse = '';
+                    currentBuf = '';
+                    for await (const piece of streamCompletion(callArgs)) {
+                        fullResponse += piece;
+                        currentBuf += piece;
+                        if (currentBuf.length >= DISCORD_MAX_LEN - 50) {
+                            await currentMsg.edit(currentBuf.slice(0, DISCORD_MAX_LEN));
+                            const overflow = currentBuf.slice(DISCORD_MAX_LEN);
+                            currentMsg = await message.channel.send(overflow || '…');
+                            sentMessages.push(currentMsg);
+                            currentBuf = overflow;
+                            lastEdit = Date.now();
+                            continue;
+                        }
+                        const now = Date.now();
+                        if (now - lastEdit >= STREAM_EDIT_INTERVAL_MS) {
+                            await currentMsg.edit(currentBuf || '…').catch(() => {});
+                            lastEdit = now;
+                        }
                     }
-                    const now = Date.now();
-                    if (now - lastEdit >= STREAM_EDIT_INTERVAL_MS) {
-                        await currentMsg.edit(currentBuf || '…').catch(() => {});
-                        lastEdit = now;
-                    }
-                }
-                if (currentBuf) await currentMsg.edit(currentBuf).catch(() => {});
-            });
-            clearInterval(typingInterval);
+                    if (currentBuf) await currentMsg.edit(currentBuf).catch(() => {});
+                });
+            } finally {
+                clearInterval(typingInterval);
+            }
 
             // Post-process: reconcile sentMessages against the canonical cleanText chunks
             if (aiSettings.actionsEnabled) {


### PR DESCRIPTION
## Summary
Wrapped the AI chat streaming logic in a try-finally block to ensure the typing indicator interval is properly cleared even if an error occurs during message streaming.

## Key Changes
- Added try-finally block around the `withRetry` call in `handleAIChat`
- Moved `clearInterval(typingInterval)` into a finally block to guarantee cleanup
- This ensures the typing indicator is stopped regardless of whether the streaming completes successfully or throws an error

## Implementation Details
Previously, if an error occurred during the streaming operation, the typing indicator interval would continue running indefinitely. By using a finally block, we guarantee that `clearInterval(typingInterval)` executes in all code paths, preventing resource leaks and ensuring the typing indicator doesn't persist after the operation completes or fails.

https://claude.ai/code/session_01UMtwiQ5MiEH4YcRhg52ZGq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the Discord typing indicator would remain active if an error occurred during AI chat streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->