### PR TITLE
Prevent duplicate RSS feed articles across digests

### DIFF
--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -233,7 +233,11 @@ const guildSchema = new Schema({
         feeds: [{ type: String }],
         title: { type: String, default: '📰 Daily News Digest' },
         maxItemsPerFeed: { type: Number, default: 3 },
-        timezone: { type: String, default: 'UTC' }
+        timezone: { type: String, default: 'UTC' },
+        sentLinks: [{
+            link: { type: String, required: true },
+            sentAt: { type: Date, required: true }
+        }]
     },
 
     dailyNewsProfiles: {
@@ -246,7 +250,11 @@ const guildSchema = new Schema({
             timezone: { type: String, default: null },
             feeds: [{ type: String }],
             title: { type: String, default: '📰 Daily News Digest' },
-            maxItemsPerFeed: { type: Number, default: 3 }
+            maxItemsPerFeed: { type: Number, default: 3 },
+            sentLinks: [{
+                link: { type: String, required: true },
+                sentAt: { type: Date, required: true }
+            }]
         }],
         validate: {
             validator: distinctProfileIds,

--- a/src/services/rssService.js
+++ b/src/services/rssService.js
@@ -14,6 +14,8 @@ const feedLastFailTime = new Map();
 const DEAD_FEED_THRESHOLD = 3;
 const DEAD_FEED_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
 
+const SENT_LINKS_RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
 function createLegacyProfile(guild) {
     const legacy = guild.dailyNews || {};
     return {
@@ -24,8 +26,32 @@ function createLegacyProfile(guild) {
         timezone: runtimeTimezone || undefined,
         feeds: Array.isArray(legacy.feeds) ? legacy.feeds : [],
         title: legacy.title || '📰 Daily News Digest',
-        maxItemsPerFeed: legacy.maxItemsPerFeed || 3
+        maxItemsPerFeed: legacy.maxItemsPerFeed || 3,
+        sentLinks: Array.isArray(legacy.sentLinks) ? legacy.sentLinks : []
     };
+}
+
+function getProfileSentLinksContainer(guild, profileId) {
+    if (Array.isArray(guild.dailyNewsProfiles) && guild.dailyNewsProfiles.length > 0) {
+        return guild.dailyNewsProfiles.find(p => p.profileId === profileId) || null;
+    }
+    return profileId === 'default' ? guild.dailyNews : null;
+}
+
+async function persistSentLinks(guild, profile, newlySentLinks) {
+    const container = getProfileSentLinksContainer(guild, profile.profileId);
+    if (!container) return;
+
+    const cutoff = Date.now() - SENT_LINKS_RETENTION_MS;
+    const existing = Array.isArray(container.sentLinks) ? container.sentLinks : [];
+    const now = new Date();
+
+    const merged = existing
+        .filter(entry => entry.sentAt && entry.sentAt.getTime() > cutoff)
+        .concat(newlySentLinks.map(link => ({ link, sentAt: now })));
+
+    container.sentLinks = merged;
+    await guild.save();
 }
 
 function getDailyNewsProfiles(guild) {
@@ -144,7 +170,7 @@ async function sendDailyNewsForProfile(client, guild, profile) {
                     source: parsedFeed.title || 'Unknown Source',
                     date: new Date(item.pubDate || item.isoDate)
                 }))
-                .filter(item => !Number.isNaN(item.date.getTime()) && item.date.getTime() >= cutoffMs)
+                .filter(item => Number.isNaN(item.date.getTime()) || item.date.getTime() >= cutoffMs)
                 .sort((a, b) => b.date.getTime() - a.date.getTime())
                 .slice(0, profile.maxItemsPerFeed || 3);
 
@@ -161,10 +187,14 @@ async function sendDailyNewsForProfile(client, guild, profile) {
         }
     }
 
+    const previouslySent = new Set(
+        (Array.isArray(profile.sentLinks) ? profile.sentLinks : []).map(entry => entry.link)
+    );
+
     const uniqueItems = [];
     const seenLinks = new Set();
     for (const item of allItems) {
-        if (item.normalizedLink && seenLinks.has(item.normalizedLink)) continue;
+        if (item.normalizedLink && (seenLinks.has(item.normalizedLink) || previouslySent.has(item.normalizedLink))) continue;
         seenLinks.add(item.normalizedLink);
         uniqueItems.push(item);
     }
@@ -194,6 +224,9 @@ async function sendDailyNewsForProfile(client, guild, profile) {
     embed.setFooter({ text: `${uniqueItems.length} articles from ${profile.feeds.length} sources • last 24h` });
 
     await channel.send({ embeds: [embed] });
+
+    const sentLinks = uniqueItems.slice(0, 10).map(item => item.normalizedLink).filter(Boolean);
+    await persistSentLinks(guild, profile, sentLinks);
 }
 
 async function sendDailyNews(client, guildId, profileId = null) {

--- a/src/services/rssService.js
+++ b/src/services/rssService.js
@@ -16,6 +16,17 @@ const DEAD_FEED_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
 
 const SENT_LINKS_RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
+function compareByDateDesc(a, b) {
+    const aTime = a.date.getTime();
+    const bTime = b.date.getTime();
+    const aValid = !Number.isNaN(aTime);
+    const bValid = !Number.isNaN(bTime);
+    if (aValid && bValid) return bTime - aTime;
+    if (aValid) return -1;
+    if (bValid) return 1;
+    return 0;
+}
+
 function createLegacyProfile(guild) {
     const legacy = guild.dailyNews || {};
     return {
@@ -171,7 +182,7 @@ async function sendDailyNewsForProfile(client, guild, profile) {
                     date: new Date(item.pubDate || item.isoDate)
                 }))
                 .filter(item => Number.isNaN(item.date.getTime()) || item.date.getTime() >= cutoffMs)
-                .sort((a, b) => b.date.getTime() - a.date.getTime())
+                .sort(compareByDateDesc)
                 .slice(0, profile.maxItemsPerFeed || 3);
 
             allItems.push(...feedItems);
@@ -201,7 +212,7 @@ async function sendDailyNewsForProfile(client, guild, profile) {
 
     if (uniqueItems.length === 0) return;
 
-    uniqueItems.sort((a, b) => b.date - a.date);
+    uniqueItems.sort(compareByDateDesc);
 
     const embed = new EmbedBuilder()
         .setColor('#0099ff')


### PR DESCRIPTION
## Summary
This PR implements link deduplication for RSS feed digests to prevent the same articles from being sent multiple times across different digest cycles. Previously sent links are now tracked and filtered out from future digests.

## Key Changes
- **Link tracking**: Added `sentLinks` field to both default and custom daily news profiles in the Guild schema to store previously sent article links with timestamps
- **Retention policy**: Implemented 7-day retention window for sent links to balance deduplication with allowing articles to be resent after a reasonable period
- **Deduplication logic**: Modified article filtering to exclude links that have been sent within the retention period, preventing duplicate content in digests
- **Persistence**: Added `persistSentLinks()` function to save newly sent links to the database after each digest is sent, with automatic cleanup of expired entries
- **Bug fix**: Corrected date filtering logic to properly handle items with invalid dates (changed from `&&` to `||` in filter condition)

## Implementation Details
- The `sentLinks` array stores objects with `link` (string) and `sentAt` (Date) properties for each sent article
- Sent links are automatically pruned when persisted, removing entries older than 7 days
- Only the top 10 articles from each digest are tracked to limit database growth
- The deduplication check uses normalized links to catch variations of the same URL
- Works seamlessly with both legacy default profiles and new multi-profile setups

https://claude.ai/code/session_01BeBnzixPqpjTrSzsHLnvmg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Daily news articles are now tracked to prevent the same articles from being sent repeatedly within a 7-day period.
  * Feed filtering now prioritizes articles published within the last 24 hours.
  * Deduplication logic now checks against previously sent article links for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->