### PR TITLE
Games review fixes: casino lock, race conditions, quiz cap, engagement gaps

### DIFF
--- a/src/commands/community/achievements.js
+++ b/src/commands/community/achievements.js
@@ -164,10 +164,20 @@ module.exports = {
             }
 
             if (sub === 'claim') {
-                let user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
-                if (!user) {
-                    user = await User.create({ userId: interaction.user.id, guildId: interaction.guild.id });
-                }
+                // Atomically flip every still-unclaimed entry to claimed=true in one
+                // update, returning the pre-update document — arrayFilters only
+                // matches entries that are unclaimed AT WRITE TIME, so two concurrent
+                // /achievements claim calls can't both grant the same reward.
+                const preClaim = await User.findOneAndUpdate(
+                    { userId: interaction.user.id, guildId: interaction.guild.id },
+                    { $set: { 'achievements.$[el].claimed': true } },
+                    {
+                        arrayFilters: [{ 'el.claimed': { $ne: true } }],
+                        new: false,
+                        upsert: true,
+                        setDefaultsOnInsert: true,
+                    },
+                );
 
                 const disabled = new Set(guildSettings.achievements?.disabledAchievements || []);
                 const customAchievements = guildSettings.achievements?.customAchievements || [];
@@ -176,7 +186,7 @@ module.exports = {
                 for (const d of ACHIEVEMENTS) defMap.set(d.id, d);
                 for (const d of customAchievements) defMap.set(d.id, d);
 
-                const unclaimed = (user.achievements || []).filter(a => !a.claimed);
+                const unclaimed = (preClaim?.achievements || []).filter(a => !a.claimed);
                 if (!unclaimed.length) {
                     return interaction.reply({ content: 'You have no unclaimed achievement rewards.', flags: MessageFlags.Ephemeral });
                 }
@@ -189,20 +199,18 @@ module.exports = {
                     if (disabled.has(entry.id)) continue;
                     const def = defMap.get(entry.id);
                     if (!def) continue;
-                    if (!def.xpReward && !def.coinReward) {
-                        entry.claimed = true;
-                        continue;
-                    }
+                    if (!def.xpReward && !def.coinReward) continue;
                     totalXp    += def.xpReward    || 0;
                     totalCoins += def.coinReward   || 0;
                     names.push(`${def.emoji} ${def.name}`);
-                    entry.claimed = true;
                 }
 
-                user.xp      = (user.xp      || 0) + totalXp;
-                user.balance = (user.balance  || 0) + totalCoins;
-                user.markModified('achievements');
-                await user.save();
+                if (totalXp || totalCoins) {
+                    await User.updateOne(
+                        { userId: interaction.user.id, guildId: interaction.guild.id },
+                        { $inc: { xp: totalXp, balance: totalCoins } },
+                    );
+                }
 
                 const lines = [];
                 if (totalXp)    lines.push(`+${totalXp} XP`);

--- a/src/commands/community/achievements.js
+++ b/src/commands/community/achievements.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags } = require('discord.js');
+const mongoose = require('mongoose');
 const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { ACHIEVEMENTS, CATEGORY_LABELS, CATEGORY_EMOJIS } = require('../../data/achievements');
@@ -164,20 +165,10 @@ module.exports = {
             }
 
             if (sub === 'claim') {
-                // Atomically flip every still-unclaimed entry to claimed=true in one
-                // update, returning the pre-update document — arrayFilters only
-                // matches entries that are unclaimed AT WRITE TIME, so two concurrent
-                // /achievements claim calls can't both grant the same reward.
-                const preClaim = await User.findOneAndUpdate(
-                    { userId: interaction.user.id, guildId: interaction.guild.id },
-                    { $set: { 'achievements.$[el].claimed': true } },
-                    {
-                        arrayFilters: [{ 'el.claimed': { $ne: true } }],
-                        new: false,
-                        upsert: true,
-                        setDefaultsOnInsert: true,
-                    },
-                );
+                const existingUser = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }).lean();
+                if (!existingUser) {
+                    return interaction.reply({ content: 'You have no unclaimed achievement rewards.', flags: MessageFlags.Ephemeral });
+                }
 
                 const disabled = new Set(guildSettings.achievements?.disabledAchievements || []);
                 const customAchievements = guildSettings.achievements?.customAchievements || [];
@@ -186,30 +177,62 @@ module.exports = {
                 for (const d of ACHIEVEMENTS) defMap.set(d.id, d);
                 for (const d of customAchievements) defMap.set(d.id, d);
 
-                const unclaimed = (preClaim?.achievements || []).filter(a => !a.claimed);
-                if (!unclaimed.length) {
+                // Only entries that are unclaimed, enabled, and actually carry a
+                // reward are eligible — this keeps disabled/no-reward achievements
+                // from being permanently marked claimed (which would block them
+                // from being claimed later if re-enabled).
+                const claimableIds = (existingUser.achievements || [])
+                    .filter(a => !a.claimed && !disabled.has(a.id))
+                    .map(a => a.id)
+                    .filter(id => {
+                        const def = defMap.get(id);
+                        return def && (def.xpReward || def.coinReward);
+                    });
+
+                if (!claimableIds.length) {
                     return interaction.reply({ content: 'You have no unclaimed achievement rewards.', flags: MessageFlags.Ephemeral });
                 }
 
+                // Claim + credit in one transaction so a payout failure can't leave
+                // achievements marked claimed without the reward having been granted.
                 let totalXp = 0;
                 let totalCoins = 0;
                 const names = [];
+                const session = await mongoose.startSession();
+                try {
+                    await session.withTransaction(async () => {
+                        const preClaim = await User.findOneAndUpdate(
+                            { userId: interaction.user.id, guildId: interaction.guild.id },
+                            { $set: { 'achievements.$[el].claimed': true } },
+                            {
+                                arrayFilters: [{ 'el.claimed': { $ne: true }, 'el.id': { $in: claimableIds } }],
+                                new: false,
+                                session,
+                            },
+                        );
 
-                for (const entry of unclaimed) {
-                    if (disabled.has(entry.id)) continue;
-                    const def = defMap.get(entry.id);
-                    if (!def) continue;
-                    if (!def.xpReward && !def.coinReward) continue;
-                    totalXp    += def.xpReward    || 0;
-                    totalCoins += def.coinReward   || 0;
-                    names.push(`${def.emoji} ${def.name}`);
+                        const justClaimed = (preClaim?.achievements || []).filter(a => claimableIds.includes(a.id) && !a.claimed);
+                        for (const entry of justClaimed) {
+                            const def = defMap.get(entry.id);
+                            totalXp    += def.xpReward    || 0;
+                            totalCoins += def.coinReward   || 0;
+                            names.push(`${def.emoji} ${def.name}`);
+                        }
+
+                        if (totalXp || totalCoins) {
+                            await User.updateOne(
+                                { userId: interaction.user.id, guildId: interaction.guild.id },
+                                { $inc: { xp: totalXp, balance: totalCoins } },
+                                { session },
+                            );
+                        }
+                    });
+                } finally {
+                    await session.endSession();
                 }
 
-                if (totalXp || totalCoins) {
-                    await User.updateOne(
-                        { userId: interaction.user.id, guildId: interaction.guild.id },
-                        { $inc: { xp: totalXp, balance: totalCoins } },
-                    );
+                if (!names.length) {
+                    return interaction.reply({ content: 'You have no unclaimed achievement rewards.', flags: MessageFlags.Ephemeral });
                 }
 
                 const lines = [];

--- a/src/commands/community/questgen.js
+++ b/src/commands/community/questgen.js
@@ -104,8 +104,21 @@ module.exports = {
             });
         }
 
-        // Deduct coins
-        user.balance -= COST;
+        // Atomically claim the cost up front — the AI call below can take several
+        // seconds, so deducting in-memory and saving at the end would let two
+        // concurrent /questgen calls both pass the balance check before either
+        // write commits.
+        const debited = await User.findOneAndUpdate(
+            { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: COST } },
+            { $inc: { balance: -COST } },
+            { new: true },
+        );
+        if (!debited) {
+            return interaction.editReply({
+                content: `You need at least **${COST} coins** to forge a Legendary Quest.`,
+            });
+        }
+        user.balance = debited.balance;
 
         // Build AI prompt
         const level     = user.level ?? 0;
@@ -146,8 +159,10 @@ Create a legendary quest that feels fitting for their journey so far.`;
         } catch (err) {
             console.error('[QUESTGEN] AI generation failed:', err?.message || err);
             // Refund coins on failure
-            user.balance += COST;
-            await user.save();
+            await User.findOneAndUpdate(
+                { userId: interaction.user.id, guildId: interaction.guild.id },
+                { $inc: { balance: COST } },
+            ).catch(() => {});
             return interaction.editReply({ content: 'The quest forge misfired! Your coins have been refunded. Try again in a moment.' });
         }
 
@@ -175,15 +190,18 @@ Create a legendary quest that feels fitting for their journey so far.`;
                 xpReward, coinReward,
             });
 
-            user.quests = user.quests || [];
-            user.quests.push({ questId, progress: 0, completedAt: null, expiresAt });
-            await user.save();
+            await User.findOneAndUpdate(
+                { userId: interaction.user.id, guildId: interaction.guild.id },
+                { $push: { quests: { questId, progress: 0, completedAt: null, expiresAt } } },
+            );
         } catch (err) {
             console.error('[QUESTGEN] Persistence failed:', err?.message || err);
-            // Compensate: remove the quest doc if it was created before user.save() failed
+            // Compensate: remove the quest doc if it was created before the user update failed
             await AiQuest.deleteOne({ questId }).catch(() => {});
-            user.balance += COST;
-            await user.save().catch(() => {});
+            await User.findOneAndUpdate(
+                { userId: interaction.user.id, guildId: interaction.guild.id },
+                { $inc: { balance: COST } },
+            ).catch(() => {});
             return interaction.editReply({ content: 'The quest forge failed to save! Your coins have been refunded. Try again in a moment.' });
         }
 

--- a/src/commands/community/questgen.js
+++ b/src/commands/community/questgen.js
@@ -158,12 +158,15 @@ Create a legendary quest that feels fitting for their journey so far.`;
             parsed = JSON.parse(cleaned);
         } catch (err) {
             console.error('[QUESTGEN] AI generation failed:', err?.message || err);
-            // Refund coins on failure
-            await User.findOneAndUpdate(
+            const refunded = await User.findOneAndUpdate(
                 { userId: interaction.user.id, guildId: interaction.guild.id },
                 { $inc: { balance: COST } },
-            ).catch(() => {});
-            return interaction.editReply({ content: 'The quest forge misfired! Your coins have been refunded. Try again in a moment.' });
+            ).catch(refundErr => { console.error('[QUESTGEN] Refund failed after AI failure:', refundErr); return null; });
+            return interaction.editReply({
+                content: refunded
+                    ? 'The quest forge misfired! Your coins have been refunded. Try again in a moment.'
+                    : 'The quest forge misfired, and the refund failed to process. Please contact a server admin — your coins were not returned automatically.',
+            });
         }
 
         // Validate and sanitize
@@ -190,19 +193,42 @@ Create a legendary quest that feels fitting for their journey so far.`;
                 xpReward, coinReward,
             });
 
-            await User.findOneAndUpdate(
-                { userId: interaction.user.id, guildId: interaction.guild.id },
+            // Re-check the active-AI-quest cap atomically with the push — the earlier
+            // check read a possibly-stale user doc, so without this a second
+            // concurrent /questgen could still slip a quest past the MAX_AI_QUESTS cap.
+            const pushed = await User.findOneAndUpdate(
+                {
+                    userId: interaction.user.id,
+                    guildId: interaction.guild.id,
+                    quests: { $not: { $elemMatch: { questId: { $regex: '^ai_' }, completedAt: null, expiresAt: { $gt: now } } } },
+                },
                 { $push: { quests: { questId, progress: 0, completedAt: null, expiresAt } } },
             );
+            if (!pushed) {
+                await AiQuest.deleteOne({ questId }).catch(() => {});
+                const refunded = await User.findOneAndUpdate(
+                    { userId: interaction.user.id, guildId: interaction.guild.id },
+                    { $inc: { balance: COST } },
+                ).catch(refundErr => { console.error('[QUESTGEN] Refund failed after cap race:', refundErr); return null; });
+                return interaction.editReply({
+                    content: refunded
+                        ? 'You already have an active Legendary Quest — your coins have been refunded.'
+                        : 'You already have an active Legendary Quest, and the refund failed to process. Please contact a server admin.',
+                });
+            }
         } catch (err) {
             console.error('[QUESTGEN] Persistence failed:', err?.message || err);
             // Compensate: remove the quest doc if it was created before the user update failed
             await AiQuest.deleteOne({ questId }).catch(() => {});
-            await User.findOneAndUpdate(
+            const refunded = await User.findOneAndUpdate(
                 { userId: interaction.user.id, guildId: interaction.guild.id },
                 { $inc: { balance: COST } },
-            ).catch(() => {});
-            return interaction.editReply({ content: 'The quest forge failed to save! Your coins have been refunded. Try again in a moment.' });
+            ).catch(refundErr => { console.error('[QUESTGEN] Refund failed after persistence failure:', refundErr); return null; });
+            return interaction.editReply({
+                content: refunded
+                    ? 'The quest forge failed to save! Your coins have been refunded. Try again in a moment.'
+                    : 'The quest forge failed to save, and the refund failed to process. Please contact a server admin — your coins were not returned automatically.',
+            });
         }
 
         const currency = guildSettings?.economy?.currency ?? '💰';

--- a/src/commands/economy/casino.js
+++ b/src/commands/economy/casino.js
@@ -107,6 +107,26 @@ module.exports = {
             });
         }
 
+        // The lock is released by the game itself (via releaseLock) once the
+        // hand actually resolves — win/loss/cash-out/timeout, or an early
+        // validation failure — not simply when execute() returns, since every
+        // game's interactive turns continue via button collectors well after
+        // that point. A "Play Again" follow-up doesn't need the lock re-held:
+        // it goes through the same atomic balance debit as any fresh bet, so
+        // it can't double-spend even if another casino game starts in
+        // parallel once the original hand has settled.
+        //
+        // If a game throws, or forgets to call releaseLock on some exotic
+        // early-return path, the lock's own TTL (10 min) frees the slot —
+        // worst case the player is blocked from a second casino game for
+        // that long, never permanently.
+        let released = false;
+        const releaseLock = () => {
+            if (released) return;
+            released = true;
+            release(lockKey, lockToken);
+        };
+
         try {
             // Progressive jackpot: contribute a share of each bet to the pool and check for a win.
             // Fire-and-forget — the service handles pool reset, user credit, and logging.
@@ -121,9 +141,10 @@ module.exports = {
                 }).catch(err => console.error('[CasinoJackpot] error:', err));
             }
 
-            return await game.execute(interaction);
-        } finally {
-            release(lockKey, lockToken);
+            return await game.execute(interaction, { releaseLock });
+        } catch (err) {
+            releaseLock();
+            throw err;
         }
     },
 };

--- a/src/commands/economy/crime.js
+++ b/src/commands/economy/crime.js
@@ -109,28 +109,46 @@ module.exports = {
 
         const currency = guildSettings?.economy?.currency || '💰';
 
-        const user = await User.findOneAndUpdate(
-            { userId: interaction.user.id, guildId: interaction.guild.id },
-            { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
+        // Atomically claim the cooldown slot up front — lastCrime is set the moment
+        // the job starts (not when it resolves ~30s later via the button flow), so
+        // two concurrent /crime invocations can't both pass the cooldown check
+        // before either one writes back.
+        const claimNow = new Date();
+        const cooldownFloor = new Date(claimNow.getTime() - COOLDOWN_MS);
+        const claimed = await User.findOneAndUpdate(
+            {
+                userId: interaction.user.id,
+                guildId: interaction.guild.id,
+                $and: [
+                    { $or: [{ wantedUntil: null }, { wantedUntil: { $lte: claimNow } }] },
+                    { $or: [{ lastCrime: null }, { lastCrime: { $lte: cooldownFloor } }] },
+                ],
+            },
+            {
+                $set: { lastCrime: claimNow },
+                $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id },
+            },
             { upsert: true, new: true }
         );
 
-        if (user.wantedUntil && Date.now() < user.wantedUntil.getTime()) {
-            const nextAt = new Date(user.wantedUntil.getTime());
-            return interaction.reply({
-                embeds: [buildCooldownEmbed({
-                    title: '🚨 Still Wanted',
-                    description: 'The city has eyes on you. Lay low. 🚨\nDon\'t even think about running another job until the heat breaks.',
-                    color: '#e74c3c',
-                    nextAt,
-                    nextRewardPreview: 'Once clear: Grand Larceny pays 600–1500 coins · Casino Con is next on the board',
-                })],
-                flags: MessageFlags.Ephemeral,
-            });
-        }
+        if (!claimed) {
+            const fresh = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
 
-        if (user.lastCrime && Date.now() - user.lastCrime.getTime() < COOLDOWN_MS) {
-            const nextAt = new Date(user.lastCrime.getTime() + COOLDOWN_MS);
+            if (fresh?.wantedUntil && Date.now() < fresh.wantedUntil.getTime()) {
+                const nextAt = new Date(fresh.wantedUntil.getTime());
+                return interaction.reply({
+                    embeds: [buildCooldownEmbed({
+                        title: '🚨 Still Wanted',
+                        description: 'The city has eyes on you. Lay low. 🚨\nDon\'t even think about running another job until the heat breaks.',
+                        color: '#e74c3c',
+                        nextAt,
+                        nextRewardPreview: 'Once clear: Grand Larceny pays 600–1500 coins · Casino Con is next on the board',
+                    })],
+                    flags: MessageFlags.Ephemeral,
+                });
+            }
+
+            const nextAt = new Date((fresh?.lastCrime?.getTime() ?? Date.now()) + COOLDOWN_MS);
             return interaction.reply({
                 embeds: [buildCooldownEmbed({
                     title: '🌆 Laying Low',
@@ -142,6 +160,8 @@ module.exports = {
                 flags: MessageFlags.Ephemeral,
             });
         }
+
+        const user = claimed;
 
         // ── Step 1: Choose the crime ────────────────────────────────────────────
         const featured = getDailyFeatured(interaction.guild.id);

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -415,24 +415,8 @@ async function handleCast(interaction) {
         });
     }
 
-    // ── Cast cooldown ──────────────────────────────────────────────────
-    // Atomically claim the cooldown slot up front — lastCast is set the moment this
-    // request is accepted (not when the catch finally resolves via the later button
-    // flow), so two concurrent /fish casts can't both pass the cooldown check before
-    // either one's write commits.
-    const fishClaimNow = new Date();
-    const fishCooldownFloor = new Date(fishClaimNow.getTime() - LIMITS.CAST_COOLDOWN_MS);
-    const claimedFish = await User.findOneAndUpdate(
-        {
-            userId: interaction.user.id,
-            guildId: interaction.guild.id,
-            $or: [{ 'fishing.lastCast': null }, { 'fishing.lastCast': { $lte: fishCooldownFloor } }],
-        },
-        { $set: { 'fishing.lastCast': fishClaimNow } },
-        { new: true },
-    );
-
-    if (!claimedFish) {
+    // ── Cast cooldown check (read-only; claimed atomically after preflight) ──
+    if (f.lastCast && Date.now() - f.lastCast.getTime() < LIMITS.CAST_COOLDOWN_MS) {
         const nextAt = new Date(f.lastCast.getTime() + LIMITS.CAST_COOLDOWN_MS);
         return interaction.reply({
             embeds: [buildCooldownEmbed({
@@ -444,7 +428,6 @@ async function handleCast(interaction) {
             flags: MessageFlags.Ephemeral,
         });
     }
-    f.lastCast = fishClaimNow;
 
     // ── Stamina check ──────────────────────────────────────────────────
     if (f.stamina <= 0) {
@@ -497,6 +480,36 @@ async function handleCast(interaction) {
         f.bait[rodData.baitType] = baitStock - 1;
         user.markModified('fishing');
     }
+
+    // Atomically claim the cooldown slot now that all preflight checks have passed —
+    // lastCast is set the moment the cast is actually accepted, not earlier, so a
+    // failed precheck (stamina/rod/bait) never burns the cooldown. The same guard
+    // still prevents two concurrent /fish casts from both slipping through.
+    const fishClaimNow = new Date();
+    const fishCooldownFloor = new Date(fishClaimNow.getTime() - LIMITS.CAST_COOLDOWN_MS);
+    const claimedFish = await User.findOneAndUpdate(
+        {
+            userId: interaction.user.id,
+            guildId: interaction.guild.id,
+            $or: [{ 'fishing.lastCast': null }, { 'fishing.lastCast': { $lte: fishCooldownFloor } }],
+        },
+        { $set: { 'fishing.lastCast': fishClaimNow } },
+        { new: true },
+    );
+
+    if (!claimedFish) {
+        const nextAt = new Date(f.lastCast.getTime() + LIMITS.CAST_COOLDOWN_MS);
+        return interaction.reply({
+            embeds: [buildCooldownEmbed({
+                title: '🎣 Line Still Settling',
+                description: 'Give your line a moment before the next cast.\nPatience is half of fishing.',
+                color: '#1e6fa5',
+                nextAt,
+            })],
+            flags: MessageFlags.Ephemeral,
+        });
+    }
+    f.lastCast = fishClaimNow;
 
     const featured          = getDailyFeatured(interaction.guild.id);
     const isFeaturedSpot    = locationId === featured.fishSpot.id;

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -416,7 +416,23 @@ async function handleCast(interaction) {
     }
 
     // ── Cast cooldown ──────────────────────────────────────────────────
-    if (f.lastCast && Date.now() - f.lastCast.getTime() < LIMITS.CAST_COOLDOWN_MS) {
+    // Atomically claim the cooldown slot up front — lastCast is set the moment this
+    // request is accepted (not when the catch finally resolves via the later button
+    // flow), so two concurrent /fish casts can't both pass the cooldown check before
+    // either one's write commits.
+    const fishClaimNow = new Date();
+    const fishCooldownFloor = new Date(fishClaimNow.getTime() - LIMITS.CAST_COOLDOWN_MS);
+    const claimedFish = await User.findOneAndUpdate(
+        {
+            userId: interaction.user.id,
+            guildId: interaction.guild.id,
+            $or: [{ 'fishing.lastCast': null }, { 'fishing.lastCast': { $lte: fishCooldownFloor } }],
+        },
+        { $set: { 'fishing.lastCast': fishClaimNow } },
+        { new: true },
+    );
+
+    if (!claimedFish) {
         const nextAt = new Date(f.lastCast.getTime() + LIMITS.CAST_COOLDOWN_MS);
         return interaction.reply({
             embeds: [buildCooldownEmbed({
@@ -428,6 +444,7 @@ async function handleCast(interaction) {
             flags: MessageFlags.Ephemeral,
         });
     }
+    f.lastCast = fishClaimNow;
 
     // ── Stamina check ──────────────────────────────────────────────────
     if (f.stamina <= 0) {

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -431,23 +431,8 @@ async function executeStart(interaction) {
         });
     }
 
-    // Atomically claim the cooldown slot up front — lastHunt is set the moment this
-    // request is accepted (not when the hunt finally resolves, ~20s later via the
-    // stealth/aim button flow), so two concurrent /hunt start calls can't both pass
-    // the cooldown check before either one's write commits.
-    const huntClaimNow = new Date();
-    const huntCooldownFloor = new Date(huntClaimNow.getTime() - LIMITS.HUNT_COOLDOWN_MS);
-    const claimedHunt = await User.findOneAndUpdate(
-        {
-            userId: interaction.user.id,
-            guildId: interaction.guild.id,
-            $or: [{ 'hunt.lastHunt': null }, { 'hunt.lastHunt': { $lte: huntCooldownFloor } }],
-        },
-        { $set: { 'hunt.lastHunt': huntClaimNow } },
-        { new: true },
-    );
-
-    if (!claimedHunt) {
+    // ── Hunt cooldown check (read-only; claimed atomically after preflight) ──
+    if (h.lastHunt && Date.now() - h.lastHunt.getTime() < LIMITS.HUNT_COOLDOWN_MS) {
         const nextAt = new Date(h.lastHunt.getTime() + LIMITS.HUNT_COOLDOWN_MS);
         return interaction.reply({
             embeds: [buildCooldownEmbed({
@@ -459,7 +444,6 @@ async function executeStart(interaction) {
             flags: MessageFlags.Ephemeral,
         });
     }
-    h.lastHunt = huntClaimNow;
 
     if (h.stamina <= 0) {
         const regenMs = msUntilNextStamina(user);
@@ -509,6 +493,36 @@ async function executeStart(interaction) {
         h.ammo[weaponData.ammoType] = ammoStock - 1;
         user.markModified('hunt');
     }
+
+    // Atomically claim the cooldown slot now that all preflight checks have passed —
+    // lastHunt is set the moment the hunt is actually accepted, not earlier, so a
+    // failed precheck (stamina/weapon/ammo) never burns the cooldown. The same guard
+    // still prevents two concurrent /hunt start calls from both slipping through.
+    const huntClaimNow = new Date();
+    const huntCooldownFloor = new Date(huntClaimNow.getTime() - LIMITS.HUNT_COOLDOWN_MS);
+    const claimedHunt = await User.findOneAndUpdate(
+        {
+            userId: interaction.user.id,
+            guildId: interaction.guild.id,
+            $or: [{ 'hunt.lastHunt': null }, { 'hunt.lastHunt': { $lte: huntCooldownFloor } }],
+        },
+        { $set: { 'hunt.lastHunt': huntClaimNow } },
+        { new: true },
+    );
+
+    if (!claimedHunt) {
+        const nextAt = new Date(h.lastHunt.getTime() + LIMITS.HUNT_COOLDOWN_MS);
+        return interaction.reply({
+            embeds: [buildCooldownEmbed({
+                title: '🫁 Catching Your Breath',
+                description: 'You just came back from a hunt.\nGive it a moment before heading back out.',
+                color: '#5a8a3c',
+                nextAt,
+            })],
+            flags: MessageFlags.Ephemeral,
+        });
+    }
+    h.lastHunt = huntClaimNow;
 
     // ── Stealth Approach + Precision Aim ─────────────────────────────────────
     // Phase 1 — Stealth: player reads a behaviour hint and picks the right approach.

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -431,7 +431,23 @@ async function executeStart(interaction) {
         });
     }
 
-    if (h.lastHunt && Date.now() - h.lastHunt.getTime() < LIMITS.HUNT_COOLDOWN_MS) {
+    // Atomically claim the cooldown slot up front — lastHunt is set the moment this
+    // request is accepted (not when the hunt finally resolves, ~20s later via the
+    // stealth/aim button flow), so two concurrent /hunt start calls can't both pass
+    // the cooldown check before either one's write commits.
+    const huntClaimNow = new Date();
+    const huntCooldownFloor = new Date(huntClaimNow.getTime() - LIMITS.HUNT_COOLDOWN_MS);
+    const claimedHunt = await User.findOneAndUpdate(
+        {
+            userId: interaction.user.id,
+            guildId: interaction.guild.id,
+            $or: [{ 'hunt.lastHunt': null }, { 'hunt.lastHunt': { $lte: huntCooldownFloor } }],
+        },
+        { $set: { 'hunt.lastHunt': huntClaimNow } },
+        { new: true },
+    );
+
+    if (!claimedHunt) {
         const nextAt = new Date(h.lastHunt.getTime() + LIMITS.HUNT_COOLDOWN_MS);
         return interaction.reply({
             embeds: [buildCooldownEmbed({
@@ -443,6 +459,7 @@ async function executeStart(interaction) {
             flags: MessageFlags.Ephemeral,
         });
     }
+    h.lastHunt = huntClaimNow;
 
     if (h.stamina <= 0) {
         const regenMs = msUntilNextStamina(user);

--- a/src/commands/economy/quiz.js
+++ b/src/commands/economy/quiz.js
@@ -233,7 +233,10 @@ async function runQuiz(interaction, diffChoice) {
 
     const difficulty    = raw.difficulty;
 
-    // Enforce daily per-difficulty attempt cap (resets at midnight UTC)
+    // Enforce daily per-difficulty attempt cap (resets at midnight UTC). The slot is
+    // claimed atomically up front (reset-if-stale, then increment-if-under-limit in a
+    // single findOneAndUpdate) so two concurrent /quiz calls can't both pass a stale
+    // in-memory count before either write commits.
     {
         const countField = COUNT_FIELD[difficulty];
         const resetField = RESET_FIELD[difficulty];
@@ -244,7 +247,13 @@ async function runQuiz(interaction, diffChoice) {
             await User.updateOne(userFilter, { $set: { [countField]: 0, [resetField]: today } });
             user[countField] = 0;
         }
-        if (user[countField] >= limit) {
+
+        const claimedSlot = await User.findOneAndUpdate(
+            { ...userFilter, [countField]: { $lt: limit } },
+            { $inc: { [countField]: 1 } },
+            { new: true },
+        );
+        if (!claimedSlot) {
             const tomorrow = new Date(todayUTC().getTime() + 86_400_000);
             return interaction.editReply({
                 embeds: [buildCooldownEmbed({
@@ -257,6 +266,7 @@ async function runQuiz(interaction, diffChoice) {
                 components: [],
             });
         }
+        user[countField] = claimedSlot[countField];
     }
     const rewards       = REWARDS[difficulty] ?? REWARDS.medium;
     const category      = decodeHtml(raw.category);
@@ -313,8 +323,6 @@ async function runQuiz(interaction, diffChoice) {
             updated   = await User.findOneAndUpdate(userFilter, { $inc: { balance: -penalty } }, { new: true });
         }
 
-        await User.updateOne(userFilter, { $inc: { [COUNT_FIELD[difficulty] ?? COUNT_FIELD.medium]: 1 } });
-
         // No replay button: quiz is a net-positive income command, so a replay
         // chain would bypass the command cooldown and become an unbounded faucet.
         await i.update({
@@ -330,8 +338,6 @@ async function runQuiz(interaction, diffChoice) {
         const freshUser = await User.findOne(userFilter);
         const penalty   = Math.min(rewards.lose, freshUser?.balance ?? 0);
         const updated   = await User.findOneAndUpdate(userFilter, { $inc: { balance: -penalty } }, { new: true });
-
-        await User.updateOne(userFilter, { $inc: { [COUNT_FIELD[difficulty] ?? COUNT_FIELD.medium]: 1 } });
 
         await interaction.editReply({
             embeds:     [timeoutEmbed(interaction, question, correctAnswer, difficulty, penalty, updated?.balance ?? 0)],

--- a/src/commands/economy/quiz.js
+++ b/src/commands/economy/quiz.js
@@ -22,7 +22,12 @@ const REWARDS = {
     hard:   { win: 750, lose: 150 },
 };
 
-const HARD_DAILY_LIMIT = 20;
+// Daily attempt caps per difficulty (resets midnight UTC). Easy/medium were
+// previously uncapped, making them the highest-EV uncapped coin faucet in the
+// bot at a 5-minute cooldown — capping them closes that exploit.
+const DAILY_LIMITS = { easy: 40, medium: 30, hard: 20 };
+const COUNT_FIELD = { easy: 'dailyQuizEasy', medium: 'dailyQuizMedium', hard: 'dailyQuizHard' };
+const RESET_FIELD = { easy: 'dailyQuizEasyReset', medium: 'dailyQuizMediumReset', hard: 'dailyQuizHardReset' };
 
 // Returns midnight UTC for today (used to detect daily reset)
 function todayUTC() {
@@ -191,13 +196,11 @@ module.exports = {
                 .setDescription('Question difficulty (default: random)')
                 .setRequired(false)
                 .addChoices(
-                    { name: '🟢 Easy   — Win 250, Lose 50',        value: 'easy'   },
-                    { name: '🟡 Medium — Win 500, Lose 100',       value: 'medium' },
+                    { name: '🟢 Easy   — Win 250, Lose 50 (cap 40/day)',  value: 'easy'   },
+                    { name: '🟡 Medium — Win 500, Lose 100 (cap 30/day)', value: 'medium' },
                     { name: '🔴 Hard   — Win 750, Lose 150 (cap 20/day)', value: 'hard'   },
                     { name: '⚪ Random (any difficulty)',            value: 'any'    },
                 )),
-    // 5 minutes — at 20s this was the highest uncapped coins/hour faucet in the bot
-    // (easy quizzes net ~+200 EV per attempt with no daily cap).
     cooldown: 300,
 
     async execute(interaction) {
@@ -230,23 +233,26 @@ async function runQuiz(interaction, diffChoice) {
 
     const difficulty    = raw.difficulty;
 
-    // Enforce daily hard-attempt cap (20/day, resets at midnight UTC)
-    if (difficulty === 'hard') {
-        const today = todayUTC();
-        const needsReset = !user.dailyQuizHardReset || user.dailyQuizHardReset < today;
+    // Enforce daily per-difficulty attempt cap (resets at midnight UTC)
+    {
+        const countField = COUNT_FIELD[difficulty];
+        const resetField = RESET_FIELD[difficulty];
+        const limit       = DAILY_LIMITS[difficulty] ?? DAILY_LIMITS.medium;
+        const today       = todayUTC();
+        const needsReset  = !user[resetField] || user[resetField] < today;
         if (needsReset) {
-            await User.updateOne(userFilter, { $set: { dailyQuizHard: 0, dailyQuizHardReset: today } });
-            user.dailyQuizHard = 0;
+            await User.updateOne(userFilter, { $set: { [countField]: 0, [resetField]: today } });
+            user[countField] = 0;
         }
-        if (user.dailyQuizHard >= HARD_DAILY_LIMIT) {
+        if (user[countField] >= limit) {
             const tomorrow = new Date(todayUTC().getTime() + 86_400_000);
             return interaction.editReply({
                 embeds: [buildCooldownEmbed({
-                    title: '🎓 Hard Cap Reached',
-                    description: `You've answered all **${HARD_DAILY_LIMIT}** hard questions allowed today.\nYour brain deserves the rest.`,
+                    title: `🎓 ${capitalize(difficulty)} Cap Reached`,
+                    description: `You've answered all **${limit}** ${difficulty} questions allowed today.\nYour brain deserves the rest.`,
                     color: '#9b59b6',
                     nextAt: tomorrow,
-                    nextRewardPreview: `Tomorrow: ${HARD_DAILY_LIMIT} more Hard questions · 750 coins each for correct answers`,
+                    nextRewardPreview: `Tomorrow: ${limit} more ${capitalize(difficulty)} questions · ${REWARDS[difficulty]?.win ?? REWARDS.medium.win} coins each for correct answers`,
                 })],
                 components: [],
             });
@@ -307,9 +313,7 @@ async function runQuiz(interaction, diffChoice) {
             updated   = await User.findOneAndUpdate(userFilter, { $inc: { balance: -penalty } }, { new: true });
         }
 
-        if (difficulty === 'hard') {
-            await User.updateOne(userFilter, { $inc: { dailyQuizHard: 1 } });
-        }
+        await User.updateOne(userFilter, { $inc: { [COUNT_FIELD[difficulty] ?? COUNT_FIELD.medium]: 1 } });
 
         // No replay button: quiz is a net-positive income command, so a replay
         // chain would bypass the command cooldown and become an unbounded faucet.
@@ -327,9 +331,7 @@ async function runQuiz(interaction, diffChoice) {
         const penalty   = Math.min(rewards.lose, freshUser?.balance ?? 0);
         const updated   = await User.findOneAndUpdate(userFilter, { $inc: { balance: -penalty } }, { new: true });
 
-        if (difficulty === 'hard') {
-            await User.updateOne(userFilter, { $inc: { dailyQuizHard: 1 } });
-        }
+        await User.updateOne(userFilter, { $inc: { [COUNT_FIELD[difficulty] ?? COUNT_FIELD.medium]: 1 } });
 
         await interaction.editReply({
             embeds:     [timeoutEmbed(interaction, question, correctAnswer, difficulty, penalty, updated?.balance ?? 0)],

--- a/src/commands/economy/snowball.js
+++ b/src/commands/economy/snowball.js
@@ -59,10 +59,12 @@ module.exports = {
             },
             {
                 $set: { lastSnowball: claimNow },
-                $inc: { 'inventory.$[slot].quantity': -1 },
+                $inc: { 'inventory.$.quantity': -1 },
             },
             {
-                arrayFilters: [{ 'slot.itemId': 'snowball' }],
+                // Plain positional $ touches only the first matched array element —
+                // unlike arrayFilters' $[slot], which would decrement every inventory
+                // entry with itemId 'snowball' if duplicate slots ever exist.
                 new: true,
             },
         );
@@ -102,42 +104,72 @@ module.exports = {
         let description = '';
 
         if (hit) {
+            // Debit the defender first, atomically guarded against their balance
+            // having changed since the snapshot — only then credit the attacker
+            // with what was *actually* taken, so a stale snapshot can't mint coins
+            // for the attacker beyond what the defender truly lost.
             const defenderSnap = await User.findOne({ userId: target.id, guildId: interaction.guild.id });
             const targetWallet = defenderSnap?.balance ?? 0;
             stolen = Math.floor(targetWallet * COIN_STEAL_RATE);
-            coinsGained = BASE_COIN_REWARD + stolen;
 
+            if (defenderSnap && stolen > 0) {
+                defender = await User.findOneAndUpdate(
+                    { userId: target.id, guildId: interaction.guild.id, balance: { $gte: stolen } },
+                    { $inc: { balance: -stolen } },
+                    { new: true },
+                );
+                if (!defender) {
+                    const freshDefender = await User.findOne({ userId: target.id, guildId: interaction.guild.id });
+                    const fallbackSteal = Math.min(stolen, freshDefender?.balance ?? 0);
+                    if (fallbackSteal > 0) {
+                        defender = await User.findOneAndUpdate(
+                            { userId: target.id, guildId: interaction.guild.id },
+                            { $inc: { balance: -fallbackSteal } },
+                            { new: true },
+                        );
+                        stolen = fallbackSteal;
+                    } else {
+                        stolen = 0;
+                        defender = freshDefender;
+                    }
+                }
+            } else {
+                stolen = 0;
+                defender = defenderSnap;
+            }
+
+            coinsGained = BASE_COIN_REWARD + stolen;
             attacker = await User.findOneAndUpdate(
                 { userId: interaction.user.id, guildId: interaction.guild.id },
                 { $inc: { balance: coinsGained } },
                 { new: true },
             );
 
-            if (defenderSnap && stolen > 0) {
-                const decrement = Math.min(stolen, defenderSnap.balance ?? 0);
-                defender = await User.findOneAndUpdate(
-                    { userId: target.id, guildId: interaction.guild.id },
-                    { $inc: { balance: -decrement } },
-                    { new: true },
-                );
-            } else {
-                defender = defenderSnap;
-            }
-
             const currencyId = getEventCurrencyId(guildSettings);
             if (currencyId) {
-                attacker = await User.findOneAndUpdate(
+                let creditedCurrency = await User.findOneAndUpdate(
                     { userId: interaction.user.id, guildId: interaction.guild.id, 'eventCurrency.currencyId': currencyId },
                     { $inc: { 'eventCurrency.$.amount': SNOWFLAKE_REWARD } },
                     { new: true },
                 );
-                if (!attacker) {
-                    attacker = await User.findOneAndUpdate(
-                        { userId: interaction.user.id, guildId: interaction.guild.id },
+                if (!creditedCurrency) {
+                    // Only push a new entry if one still doesn't exist — guards against
+                    // a concurrent /snowball hit pushing a duplicate currencyId entry
+                    // between the increment attempt above and this push.
+                    creditedCurrency = await User.findOneAndUpdate(
+                        { userId: interaction.user.id, guildId: interaction.guild.id, 'eventCurrency.currencyId': { $ne: currencyId } },
                         { $push: { eventCurrency: { currencyId, amount: SNOWFLAKE_REWARD } } },
                         { new: true },
                     );
+                    if (!creditedCurrency) {
+                        creditedCurrency = await User.findOneAndUpdate(
+                            { userId: interaction.user.id, guildId: interaction.guild.id, 'eventCurrency.currencyId': currencyId },
+                            { $inc: { 'eventCurrency.$.amount': SNOWFLAKE_REWARD } },
+                            { new: true },
+                        );
+                    }
                 }
+                if (creditedCurrency) attacker = creditedCurrency;
             }
 
             description = [

--- a/src/commands/economy/snowball.js
+++ b/src/commands/economy/snowball.js
@@ -5,7 +5,6 @@ const { logTransaction } = require('../../utils/logTransaction');
 const {
     hasActiveEvent,
     getEventCurrencyId,
-    addEventCurrency,
 } = require('../../services/seasonalEventService');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
 
@@ -46,16 +45,33 @@ module.exports = {
             return interaction.editReply({ content: "You can't throw snowballs at bots!" });
         }
 
-        const [attacker, defender] = await Promise.all([
-            User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }),
-            User.findOne({ userId: target.id,           guildId: interaction.guild.id }),
-        ]);
+        // Atomically claim the cooldown + spend one snowball in a single update — the
+        // cooldown guard and inventory-availability guard both live in the filter, so two
+        // concurrent /snowball calls can't both pass before either one's write commits.
+        const claimNow = new Date();
+        const cooldownFloor = new Date(claimNow.getTime() - COOLDOWN_MS);
+        let attacker = await User.findOneAndUpdate(
+            {
+                userId: interaction.user.id,
+                guildId: interaction.guild.id,
+                $or: [{ lastSnowball: null }, { lastSnowball: { $lte: cooldownFloor } }],
+                inventory: { $elemMatch: { itemId: 'snowball', quantity: { $gte: 1 } } },
+            },
+            {
+                $set: { lastSnowball: claimNow },
+                $inc: { 'inventory.$[slot].quantity': -1 },
+            },
+            {
+                arrayFilters: [{ 'slot.itemId': 'snowball' }],
+                new: true,
+            },
+        );
 
-        // Cooldown check
-        if (attacker?.lastSnowball) {
-            const elapsed = Date.now() - new Date(attacker.lastSnowball).getTime();
-            if (elapsed < COOLDOWN_MS) {
-                const nextAt = new Date(new Date(attacker.lastSnowball).getTime() + COOLDOWN_MS);
+        if (!attacker) {
+            const fresh = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+
+            if (fresh?.lastSnowball && Date.now() - new Date(fresh.lastSnowball).getTime() < COOLDOWN_MS) {
+                const nextAt = new Date(new Date(fresh.lastSnowball).getTime() + COOLDOWN_MS);
                 return interaction.editReply({
                     embeds: [buildCooldownEmbed({
                         title: '❄️ Restocking Snowballs',
@@ -66,41 +82,63 @@ module.exports = {
                     })],
                 });
             }
-        }
 
-        // Check attacker has snowballs in inventory
-        const snowballSlot = attacker?.inventory?.find(i => i.itemId === 'snowball');
-        if (!snowballSlot || snowballSlot.quantity < 1) {
             return interaction.editReply({
                 content: `❄️ You don't have any **Snowballs** in your inventory! Buy some from \`/eventshop\`.`
             });
         }
 
+        // Best-effort cleanup of the now-empty snowball slot; doesn't affect correctness.
+        User.updateOne(
+            { userId: interaction.user.id, guildId: interaction.guild.id },
+            { $pull: { inventory: { itemId: 'snowball', quantity: { $lte: 0 } } } },
+        ).catch(() => {});
+
         const hit = Math.random() < HIT_CHANCE;
 
-        // Deduct snowball
-        snowballSlot.quantity -= 1;
-        if (snowballSlot.quantity <= 0) {
-            attacker.inventory = attacker.inventory.filter(i => i.itemId !== 'snowball');
-        }
-
-        attacker.lastSnowball = new Date();
-
         let coinsGained = 0;
+        let stolen = 0;
+        let defender = null;
         let description = '';
 
         if (hit) {
-            const targetWallet = defender?.balance ?? 0;
-            const stolen = Math.floor(targetWallet * COIN_STEAL_RATE);
+            const defenderSnap = await User.findOne({ userId: target.id, guildId: interaction.guild.id });
+            const targetWallet = defenderSnap?.balance ?? 0;
+            stolen = Math.floor(targetWallet * COIN_STEAL_RATE);
             coinsGained = BASE_COIN_REWARD + stolen;
 
-            attacker.balance = (attacker.balance ?? 0) + coinsGained;
-            if (defender) {
-                defender.balance = Math.max(0, (defender.balance ?? 0) - stolen);
+            attacker = await User.findOneAndUpdate(
+                { userId: interaction.user.id, guildId: interaction.guild.id },
+                { $inc: { balance: coinsGained } },
+                { new: true },
+            );
+
+            if (defenderSnap && stolen > 0) {
+                const decrement = Math.min(stolen, defenderSnap.balance ?? 0);
+                defender = await User.findOneAndUpdate(
+                    { userId: target.id, guildId: interaction.guild.id },
+                    { $inc: { balance: -decrement } },
+                    { new: true },
+                );
+            } else {
+                defender = defenderSnap;
             }
 
             const currencyId = getEventCurrencyId(guildSettings);
-            if (currencyId) addEventCurrency(attacker, currencyId, SNOWFLAKE_REWARD);
+            if (currencyId) {
+                attacker = await User.findOneAndUpdate(
+                    { userId: interaction.user.id, guildId: interaction.guild.id, 'eventCurrency.currencyId': currencyId },
+                    { $inc: { 'eventCurrency.$.amount': SNOWFLAKE_REWARD } },
+                    { new: true },
+                );
+                if (!attacker) {
+                    attacker = await User.findOneAndUpdate(
+                        { userId: interaction.user.id, guildId: interaction.guild.id },
+                        { $push: { eventCurrency: { currencyId, amount: SNOWFLAKE_REWARD } } },
+                        { new: true },
+                    );
+                }
+            }
 
             description = [
                 `💥 **DIRECT HIT!** You nailed <@${target.id}> with a snowball!`,
@@ -119,11 +157,6 @@ module.exports = {
                 `Better luck next time — you still used one snowball.`,
             ].join('\n');
         }
-
-        await Promise.all([
-            attacker.save(),
-            defender && hit ? defender.save() : Promise.resolve(),
-        ]);
 
         const embed = new EmbedBuilder()
             .setColor(hit ? '#a8d8f0' : '#888888')

--- a/src/commands/fun/roll.js
+++ b/src/commands/fun/roll.js
@@ -7,8 +7,13 @@ const {
     MessageFlags,
 } = require('discord.js');
 const Guild = require('../../models/Guild');
+const User  = require('../../models/User');
+const { logTransaction } = require('../../utils/logTransaction');
 
 const THUMB = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3b2.png';
+
+const MIN_BET   = 10;
+const HOUSE_CUT = 0.05; // 5% rake on both bet modes, matching coinflip's solo wager
 
 // Unicode die faces for d6 only
 const D6_FACES = ['', '⚀', '⚁', '⚂', '⚃', '⚄', '⚅'];
@@ -77,6 +82,25 @@ module.exports = {
                 .setDescription('Number of sides (default: 6, max: 100)')
                 .setRequired(false)
                 .setMinValue(2)
+                .setMaxValue(100))
+        .addIntegerOption(opt =>
+            opt.setName('bet')
+                .setDescription('Wager coins on the roll (omit for a casual roll)')
+                .setRequired(false)
+                .setMinValue(MIN_BET))
+        .addStringOption(opt =>
+            opt.setName('guess')
+                .setDescription('High/low call for your wager (ignored if "number" is set)')
+                .setRequired(false)
+                .addChoices(
+                    { name: '⬆️ High half',  value: 'high' },
+                    { name: '⬇️ Low half',   value: 'low'  },
+                ))
+        .addIntegerOption(opt =>
+            opt.setName('number')
+                .setDescription('Bet on an exact number instead of high/low — pays out big')
+                .setRequired(false)
+                .setMinValue(1)
                 .setMaxValue(100)),
 
     async execute(interaction) {
@@ -84,9 +108,30 @@ module.exports = {
         if (guildSettings?.economy?.enabled === false || guildSettings?.economy?.rollEnabled === false) {
             return interaction.reply({ content: 'Dice roll is disabled on this server.', flags: MessageFlags.Ephemeral });
         }
-        const sides = interaction.options.getInteger('sides') || 6;
+        const sides  = interaction.options.getInteger('sides') || 6;
+        const bet    = interaction.options.getInteger('bet');
+        const guess  = interaction.options.getString('guess');
+        const number = interaction.options.getInteger('number');
+
+        if (!bet) {
+            await interaction.deferReply();
+            return playRoll(interaction, sides);
+        }
+
+        if (number != null && number > sides) {
+            return interaction.reply({ content: `Your exact-number guess must be between 1 and ${sides} for a d${sides}.`, flags: MessageFlags.Ephemeral });
+        }
+        if (number == null && !guess) {
+            return interaction.reply({ content: 'Betting requires a `guess` (high/low) or an exact `number`.', flags: MessageFlags.Ephemeral });
+        }
+
+        const maxBet = guildSettings?.economy?.duelMaxBet ?? 10_000;
+        if (bet > maxBet) {
+            return interaction.reply({ content: `The maximum roll wager here is **${maxBet.toLocaleString()}** coins.`, flags: MessageFlags.Ephemeral });
+        }
+
         await interaction.deferReply();
-        await playRoll(interaction, sides);
+        return playRollBet(interaction, guildSettings, sides, bet, number != null ? { type: 'exact', number } : { type: guess });
     },
 };
 
@@ -121,4 +166,89 @@ async function playRoll(interaction, sides) {
     collector.on('end', (_, reason) => {
         if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
     });
+}
+
+function callLabel(call, sides) {
+    if (call.type === 'exact') return `exact **${call.number}**`;
+    const half = Math.floor(sides / 2);
+    return call.type === 'high' ? `**high** (${half + 1}–${sides})` : `**low** (1–${half})`;
+}
+
+function callWon(call, result, sides) {
+    if (call.type === 'exact') return result === call.number;
+    const half = Math.floor(sides / 2);
+    return call.type === 'high' ? result > half : result <= half;
+}
+
+async function playRollBet(interaction, guildSettings, sides, bet, call) {
+    const currency = guildSettings?.economy?.currency ?? '💰';
+    const guildId  = interaction.guild.id;
+
+    const debited = await User.findOneAndUpdate(
+        { userId: interaction.user.id, guildId, balance: { $gte: bet } },
+        { $inc: { balance: -bet } },
+        { new: true }
+    );
+    if (!debited) {
+        return interaction.editReply({ content: `You don't have **${currency}${bet.toLocaleString()}** to wager.` });
+    }
+
+    const delay = ms => new Promise(r => setTimeout(r, ms));
+    const stakeLine = `Wager: **${currency}${bet.toLocaleString()}** on ${callLabel(call, sides)}`;
+    for (let f = 0; f < 4; f++) {
+        await interaction.editReply({
+            embeds: [new EmbedBuilder()
+                .setAuthor(embedAuthor(interaction))
+                .setThumbnail(THUMB)
+                .setColor('#5865F2')
+                .setTitle('🎲 Dice Roll')
+                .setDescription(`🎲 **Rolling…**\n\n${stakeLine}`)
+                .setFooter({ text: `d${sides}` })],
+        });
+        await delay(300);
+    }
+
+    const result = Math.floor(Math.random() * sides) + 1;
+    const won    = callWon(call, result, sides);
+
+    // Exact-number bets pay out at sides:1 odds (minus house cut); high/low pays ~1:1.
+    const multiplier = call.type === 'exact' ? sides : 2;
+    const grossPayout = Math.floor(bet * multiplier * (1 - HOUSE_CUT));
+    const profit       = grossPayout - bet;
+
+    let updated = debited;
+    if (won) {
+        updated = await User.findOneAndUpdate(
+            { userId: interaction.user.id, guildId },
+            { $inc: { balance: grossPayout } },
+            { new: true }
+        );
+    }
+    logTransaction({
+        userId:  interaction.user.id,
+        guildId,
+        type:    'roll',
+        amount:  won ? profit : -bet,
+        balance: updated?.balance ?? 0,
+        note:    `Roll bet — called ${callLabel(call, sides)}, rolled ${result} on d${sides}`,
+    });
+
+    const embed = new EmbedBuilder()
+        .setAuthor(embedAuthor(interaction))
+        .setThumbnail(THUMB)
+        .setColor(won ? '#2ecc71' : '#e74c3c')
+        .setTitle(won ? `🎲 ${result}! You called it!` : `🎲 ${result}. Not your call.`)
+        .setDescription(
+            won
+                ? `You called ${callLabel(call, sides)} and rolled **${result}** on a d${sides}.\n\n💰 **+${currency}${profit.toLocaleString()}**`
+                : `You called ${callLabel(call, sides)}, but rolled **${result}** on a d${sides}.\n\n💸 **-${currency}${bet.toLocaleString()}**`
+        )
+        .addFields(
+            { name: '📈 Roll',    value: rollBar(result, sides), inline: false },
+            { name: '💰 Balance', value: `**${currency}${(updated?.balance ?? 0).toLocaleString()}**`, inline: true },
+        )
+        .setFooter({ text: won ? 'The house keeps 5% — quit while you\'re ahead?' : 'The dice hold no grudges. Probably.' })
+        .setTimestamp();
+
+    return interaction.editReply({ embeds: [embed] });
 }

--- a/src/commands/fun/roll.js
+++ b/src/commands/fun/roll.js
@@ -196,6 +196,8 @@ async function playRollBet(interaction, guildSettings, sides, bet, call) {
     const delay = ms => new Promise(r => setTimeout(r, ms));
     const stakeLine = `Wager: **${currency}${bet.toLocaleString()}** on ${callLabel(call, sides)}`;
     for (let f = 0; f < 4; f++) {
+        // Animation frames are cosmetic — a transient editReply failure here shouldn't
+        // abort the roll and strand the bet that was already debited above.
         await interaction.editReply({
             embeds: [new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
@@ -204,15 +206,25 @@ async function playRollBet(interaction, guildSettings, sides, bet, call) {
                 .setTitle('🎲 Dice Roll')
                 .setDescription(`🎲 **Rolling…**\n\n${stakeLine}`)
                 .setFooter({ text: `d${sides}` })],
-        });
+        }).catch(() => {});
         await delay(300);
     }
 
     const result = Math.floor(Math.random() * sides) + 1;
     const won    = callWon(call, result, sides);
 
-    // Exact-number bets pay out at sides:1 odds (minus house cut); high/low pays ~1:1.
-    const multiplier = call.type === 'exact' ? sides : 2;
+    // Exact-number bets pay out at sides:1 odds (minus house cut). High/low pays at
+    // true odds for the split (sides / winning-number-count) rather than a flat 2x —
+    // on odd-sided dice the low half has one fewer number than the high half, so a
+    // flat 2x would give "high" bettors better-than-even odds at the same payout.
+    let multiplier;
+    if (call.type === 'exact') {
+        multiplier = sides;
+    } else {
+        const half = Math.floor(sides / 2);
+        const winningCount = call.type === 'high' ? sides - half : half;
+        multiplier = sides / winningCount;
+    }
     const grossPayout = Math.floor(bet * multiplier * (1 - HOUSE_CUT));
     const profit       = grossPayout - bet;
 

--- a/src/commands/fun/wanted.js
+++ b/src/commands/fun/wanted.js
@@ -1,4 +1,11 @@
-const { SlashCommandBuilder, AttachmentBuilder, MessageFlags } = require('discord.js');
+const {
+    SlashCommandBuilder,
+    AttachmentBuilder,
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+    MessageFlags,
+} = require('discord.js');
 const { createCanvas, loadImage } = require('canvas');
 const { checkImageRateLimit } = require('../../utils/imageRateLimit');
 const { applySepia } = require('../../utils/canvasFilters');
@@ -25,9 +32,13 @@ module.exports = {
         }
 
         const target = interaction.options.getUser('user') || interaction.user;
+        await interaction.deferReply();
+        await generatePoster(interaction, target);
+    },
+};
 
+async function generatePoster(interaction, target) {
         try {
-            await interaction.deferReply();
             const avatar = await loadImage(target.displayAvatarURL({ extension: 'png', size: 256 }));
 
             const canvas = createCanvas(W, H);
@@ -99,8 +110,30 @@ module.exports = {
             ctx.fillText('Contact your local sheriff', W / 2, AVATAR_Y + AVATAR_SIZE + 130);
 
             const attachment = new AttachmentBuilder(canvas.toBuffer('image/png'), { name: 'wanted.png' });
-            await interaction.editReply({ files: [attachment] });
-        } catch {
+            const regenId = `wanted_regen_${interaction.id}_${Date.now()}`;
+            const row = new ActionRowBuilder().addComponents(
+                new ButtonBuilder().setCustomId(regenId).setLabel('🤠 Wanted: Me').setStyle(ButtonStyle.Secondary),
+            );
+            await interaction.editReply({ files: [attachment], components: [row] });
+
+            const msg = await interaction.fetchReply();
+            const collector = msg.createMessageComponentCollector({
+                filter: i => i.customId === regenId,
+                time:   60_000,
+            });
+
+            collector.on('collect', async i => {
+                const innerRl = checkImageRateLimit(i.user.id);
+                if (innerRl.limited) {
+                    return i.reply({ content: innerRl.message, flags: MessageFlags.Ephemeral }).catch(() => {});
+                }
+                await i.deferReply();
+                await generatePoster(i, i.user);
+            });
+
+            collector.on('end', () => interaction.editReply({ components: [] }).catch(() => {}));
+        } catch (err) {
+            console.error('[wanted] generation error:', err);
             const msg = '❌ Could not generate the wanted poster. Please try again.';
             if (interaction.deferred || interaction.replied) {
                 await interaction.editReply(msg);
@@ -108,5 +141,4 @@ module.exports = {
                 await interaction.reply({ content: msg, flags: MessageFlags.Ephemeral });
             }
         }
-    },
-};
+}

--- a/src/commands/fun/wasted.js
+++ b/src/commands/fun/wasted.js
@@ -1,4 +1,11 @@
-const { SlashCommandBuilder, AttachmentBuilder, MessageFlags } = require('discord.js');
+const {
+    SlashCommandBuilder,
+    AttachmentBuilder,
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+    MessageFlags,
+} = require('discord.js');
 const { createCanvas, loadImage } = require('canvas');
 const { checkImageRateLimit } = require('../../utils/imageRateLimit');
 const { applyGrayscale } = require('../../utils/canvasFilters');
@@ -21,9 +28,13 @@ module.exports = {
         }
 
         const target = interaction.options.getUser('user') || interaction.user;
+        await interaction.deferReply();
+        await generateWasted(interaction, target);
+    },
+};
 
+async function generateWasted(interaction, target) {
         try {
-            await interaction.deferReply();
             const avatar = await loadImage(target.displayAvatarURL({ extension: 'png', size: SIZE }));
 
             const canvas = createCanvas(SIZE, SIZE);
@@ -56,11 +67,34 @@ module.exports = {
             ctx.strokeText('WASTED', SIZE / 2, SIZE / 2);
 
             const attachment = new AttachmentBuilder(canvas.toBuffer('image/png'), { name: 'wasted.png' });
+            const regenId = `wasted_regen_${interaction.id}_${Date.now()}`;
+            const row = new ActionRowBuilder().addComponents(
+                new ButtonBuilder().setCustomId(regenId).setLabel('💀 Waste: Me').setStyle(ButtonStyle.Secondary),
+            );
             await interaction.editReply({
                 content: `💀 **${target.username}** has been wasted.`,
                 files: [attachment],
+                components: [row],
             });
-        } catch {
+
+            const msg = await interaction.fetchReply();
+            const collector = msg.createMessageComponentCollector({
+                filter: i => i.customId === regenId,
+                time:   60_000,
+            });
+
+            collector.on('collect', async i => {
+                const innerRl = checkImageRateLimit(i.user.id);
+                if (innerRl.limited) {
+                    return i.reply({ content: innerRl.message, flags: MessageFlags.Ephemeral }).catch(() => {});
+                }
+                await i.deferReply();
+                await generateWasted(i, i.user);
+            });
+
+            collector.on('end', () => interaction.editReply({ components: [] }).catch(() => {}));
+        } catch (err) {
+            console.error('[wasted] generation error:', err);
             const msg = '❌ Could not generate the wasted image. Please try again.';
             if (interaction.deferred || interaction.replied) {
                 await interaction.editReply(msg);
@@ -68,5 +102,4 @@ module.exports = {
                 await interaction.reply({ content: msg, flags: MessageFlags.Ephemeral });
             }
         }
-    },
-};
+}

--- a/src/games/casino/blackjack.js
+++ b/src/games/casino/blackjack.js
@@ -223,7 +223,9 @@ module.exports = {
             return interaction.reply({ content: `You don't have enough ${currency}. Your balance: **${currency}${user.balance.toLocaleString()}**`, flags: MessageFlags.Ephemeral });
         }
 
-        if (!await confirmBet(interaction, bet, user.balance, 'Blackjack', guildSettings)) { releaseLock?.(); return; }
+        const { shouldProceed, alreadyReplied } = await confirmBet(interaction, bet, user.balance, 'Blackjack', guildSettings);
+        if (!shouldProceed) { releaseLock?.(); return; }
+        const sendInitial = (payload) => alreadyReplied ? interaction.editReply(payload) : interaction.reply(payload);
 
         // Atomic debit — re-validates balance at write time to prevent race conditions
         const debited = await User.findOneAndUpdate(
@@ -253,7 +255,7 @@ module.exports = {
                 const embed = buildFinalEmbed(interaction, dealerHand, playerHand, null, currency, bet,
                     '🃏 Blackjack — Push', 'Both got blackjack. Bet returned.', '#f39c12', pushUser?.balance ?? user.balance);
                 releaseLock?.();
-                return interaction.reply({ embeds: [embed], components: buildButtons(gameId, true) });
+                return sendInitial({ embeds: [embed], components: buildButtons(gameId, true) });
             }
             const bjCoinMult   = getCoinMultiplier(user);
             const bjServerMult = getServerCoinMultiplier(guildSettings);
@@ -278,7 +280,7 @@ module.exports = {
                 .setFooter({ text: 'Blackjack pays 3:2 · Dealer stands on 17' })
                 .setTimestamp();
             releaseLock?.();
-            return interaction.reply({ embeds: [embed], components: buildButtons(gameId, true) });
+            return sendInitial({ embeds: [embed], components: buildButtons(gameId, true) });
         }
 
         const dealerShowsAce  = dealerHand[0].value === 'A';
@@ -294,7 +296,7 @@ module.exports = {
                     .setLabel('🛡️ Insurance')
                     .setStyle(ButtonStyle.Danger)] : []),
             );
-            await interaction.reply({
+            await sendInitial({
                 embeds: [buildEmbed(interaction, playerHand, dealerHand, bet, currency,
                     insuranceCost > 0
                         ? `🛡️ Insurance? (${currency}${insuranceCost.toLocaleString()}) — Dealer may have Blackjack`
@@ -361,7 +363,7 @@ module.exports = {
             };
         }
 
-        await interaction.reply({
+        await sendInitial({
             embeds:     [buildEmbed(interaction, playerHand, dealerHand, bet, currency, '🎲 Your turn', '#5865F2', true)],
             components: buildButtons(gameId, false, currentOpts()),
         });

--- a/src/games/casino/blackjack.js
+++ b/src/games/casino/blackjack.js
@@ -200,9 +200,10 @@ module.exports = {
                 .setMinValue(MIN_BET)
                 .setMaxValue(1_000_000_000)),
 
-    async execute(interaction) {
+    async execute(interaction, { releaseLock } = {}) {
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
         if (guildSettings?.economy?.enabled === false || guildSettings?.economy?.gamesEnabled === false || guildSettings?.economy?.blackjackEnabled === false) {
+            releaseLock?.();
             return interaction.reply({ content: 'Blackjack is disabled on this server.', flags: MessageFlags.Ephemeral });
         }
 
@@ -210,6 +211,7 @@ module.exports = {
         const bet          = interaction.options.getInteger('bet');
         const casinoMaxBet = guildSettings?.economy?.casinoMaxBet ?? 0;
         if (casinoMaxBet > 0 && bet > casinoMaxBet) {
+            releaseLock?.();
             return interaction.reply({ content: `❌ The casino bet limit on this server is **${casinoMaxBet.toLocaleString()}** coins.`, flags: MessageFlags.Ephemeral });
         }
 
@@ -217,10 +219,11 @@ module.exports = {
         if (!user) user = await User.create({ userId: interaction.user.id, guildId: interaction.guild.id });
 
         if (user.balance < bet) {
+            releaseLock?.();
             return interaction.reply({ content: `You don't have enough ${currency}. Your balance: **${currency}${user.balance.toLocaleString()}**`, flags: MessageFlags.Ephemeral });
         }
 
-        if (!await confirmBet(interaction, bet, user.balance, 'Blackjack', guildSettings)) return;
+        if (!await confirmBet(interaction, bet, user.balance, 'Blackjack', guildSettings)) { releaseLock?.(); return; }
 
         // Atomic debit — re-validates balance at write time to prevent race conditions
         const debited = await User.findOneAndUpdate(
@@ -229,6 +232,7 @@ module.exports = {
             { new: true },
         );
         if (!debited) {
+            releaseLock?.();
             return interaction.reply({ content: `❌ Not enough ${currency}! Your balance may have changed.`, flags: MessageFlags.Ephemeral });
         }
         user = debited;
@@ -248,6 +252,7 @@ module.exports = {
                 );
                 const embed = buildFinalEmbed(interaction, dealerHand, playerHand, null, currency, bet,
                     '🃏 Blackjack — Push', 'Both got blackjack. Bet returned.', '#f39c12', pushUser?.balance ?? user.balance);
+                releaseLock?.();
                 return interaction.reply({ embeds: [embed], components: buildButtons(gameId, true) });
             }
             const bjCoinMult   = getCoinMultiplier(user);
@@ -272,6 +277,7 @@ module.exports = {
                 )
                 .setFooter({ text: 'Blackjack pays 3:2 · Dealer stands on 17' })
                 .setTimestamp();
+            releaseLock?.();
             return interaction.reply({ embeds: [embed], components: buildButtons(gameId, true) });
         }
 
@@ -330,6 +336,7 @@ module.exports = {
                 );
             }
             const peekEmbed = buildEmbed(interaction, playerHand, dealerHand, bet, currency, peekStatus, '#e74c3c', false);
+            releaseLock?.();
             return interaction.editReply({ embeds: [peekEmbed], components: buildButtons(gameId, true) });
         }
 
@@ -539,6 +546,7 @@ module.exports = {
                         '#e74c3c', insUser?.balance ?? 0);
                     await interaction.editReply({ embeds: [embed], components: buildButtons(gameId, true) }).catch(() => {});
                 }
+                releaseLock?.();
                 return;
             }
 
@@ -666,6 +674,8 @@ module.exports = {
                     title, description, color, finalUser?.balance ?? 0);
                 await interaction.editReply({ embeds: [embed], components: buildButtons(gameId, true) }).catch(() => {});
             }
+
+            releaseLock?.();
         });
     },
 };

--- a/src/games/casino/crash.js
+++ b/src/games/casino/crash.js
@@ -257,32 +257,39 @@ module.exports = {
                 .setMaxValue(99.99)
                 .setRequired(false)),
 
-    async execute(interaction) {
+    async execute(interaction, { releaseLock } = {}) {
         const bet         = interaction.options.getInteger('bet');
         const autoCashout = interaction.options.getNumber('auto_cashout') ?? null;
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
         const casinoMaxBet  = guildSettings?.economy?.casinoMaxBet ?? 0;
         if (casinoMaxBet > 0 && bet > casinoMaxBet) {
+            releaseLock?.();
             return interaction.reply({ content: `❌ The casino bet limit on this server is **${casinoMaxBet.toLocaleString()}** coins.`, flags: MessageFlags.Ephemeral });
         }
         const user        = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
         const { shouldProceed, alreadyReplied } = await confirmBet(interaction, bet, user?.balance ?? 0, 'Crash');
-        if (!shouldProceed) return;
+        if (!shouldProceed) { releaseLock?.(); return; }
         if (!alreadyReplied) await interaction.deferReply();
-        await openLobby(interaction, bet, autoCashout);
+        await openLobby(interaction, bet, autoCashout, releaseLock);
     },
 };
 
-async function openLobby(interaction, bet, hostAutoCashout) {
+// releaseLock is called as soon as the host's bet is committed (the lobby
+// is created and the host's debit succeeds) — the host's casino lock isn't
+// held through the lobby wait + the multiplayer game itself, since their
+// stake is already atomically deducted and can't be double-spent.
+async function openLobby(interaction, bet, hostAutoCashout, releaseLock) {
     const channelId = interaction.channel.id;
     const lobbyId   = `${channelId}_${Date.now()}`;
 
     if (getLobby(channelId)) {
+        releaseLock?.();
         return interaction.editReply({ content: 'A crash lobby is already open in this channel.', components: [] });
     }
 
     const lobby = createLobby(channelId, interaction.user.id, bet);
     if (!lobby) {
+        releaseLock?.();
         return interaction.editReply({ content: 'A crash lobby is already open in this channel.', components: [] });
     }
 
@@ -293,11 +300,13 @@ async function openLobby(interaction, bet, hostAutoCashout) {
     );
     if (!deducted) {
         deleteLobby(channelId);
+        releaseLock?.();
         return interaction.editReply({ content: `❌ Not enough coins! You need **${bet.toLocaleString()}** coins.`, components: [] });
     }
 
     // Add host with their auto cash-out preference
     addPlayer(channelId, interaction.user.id, hostAutoCashout, interaction.user.username);
+    releaseLock?.();
 
     const guildDoc     = await Guild.findOne({ guildId: interaction.guild.id }, 'casinoStats').lean().catch(() => null);
     const crashHistory = guildDoc?.casinoStats?.crashHistory ?? [];

--- a/src/games/casino/crash.js
+++ b/src/games/casino/crash.js
@@ -267,7 +267,7 @@ module.exports = {
             return interaction.reply({ content: `❌ The casino bet limit on this server is **${casinoMaxBet.toLocaleString()}** coins.`, flags: MessageFlags.Ephemeral });
         }
         const user        = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
-        const { shouldProceed, alreadyReplied } = await confirmBet(interaction, bet, user?.balance ?? 0, 'Crash');
+        const { shouldProceed, alreadyReplied } = await confirmBet(interaction, bet, user?.balance ?? 0, 'Crash', guildSettings);
         if (!shouldProceed) { releaseLock?.(); return; }
         if (!alreadyReplied) await interaction.deferReply();
         await openLobby(interaction, bet, autoCashout, releaseLock);

--- a/src/games/casino/cupgame.js
+++ b/src/games/casino/cupgame.js
@@ -45,7 +45,11 @@ function buildReveal(queenPos) {
     return [0, 1, 2].map(i => i === queenPos ? QUEEN : DECOYS[di++]);
 }
 
-async function playMonte(interaction, bet, round = 1) {
+// releaseLock is held through double-or-nothing recursion (still the same
+// hand) and called once the hand truly settles — final loss/win or a cash-out
+// — but not held through "Play Again", since a replay re-debits atomically
+// just like any fresh bet.
+async function playMonte(interaction, bet, round = 1, releaseLock) {
     const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
     let debited = null;
     let settled = false;
@@ -61,6 +65,7 @@ async function playMonte(interaction, bet, round = 1) {
             );
 
             if (!debited) {
+                releaseLock?.();
                 const fresh = await User.findOne(userFilter);
                 return interaction.editReply({
                     content: `❌ Not enough coins! Your balance: **${(fresh?.balance ?? 0).toLocaleString()}** coins.`,
@@ -68,6 +73,7 @@ async function playMonte(interaction, bet, round = 1) {
             }
         } catch (err) {
             console.error('[Monte] debit error:', err);
+            releaseLock?.();
             return interaction.editReply({ content: 'Something went wrong. Your bet was not deducted.' }).catch(() => {});
         }
     }
@@ -148,7 +154,9 @@ async function playMonte(interaction, bet, round = 1) {
             await delay(550);
         }
 
-        const tellCard = Math.floor(Math.random() * 3);
+        // Weakly correlated "tell": right more often than chance (65%), but
+        // not reliable enough to be a guaranteed-profit signal.
+        const tellCard = Math.random() < 0.65 ? queenPos : Math.floor(Math.random() * 3);
         const tellText = Math.random() < 0.40
             ? `\n\n👁️ *You notice card **${tellCard + 1}** seems slightly warped…*`
             : '';
@@ -195,6 +203,7 @@ async function playMonte(interaction, bet, round = 1) {
             const timeoutMsg = round > 1
                 ? `⏱️ Time's up! Paid out **${timeoutRefund.toLocaleString()}** coins (your Round ${round - 1} winnings).`
                 : '⏱️ Time\'s up! Your bet was refunded.';
+            releaseLock?.();
             return interaction.editReply({ content: timeoutMsg, embeds: [], components: [] }).catch(() => {});
         }
 
@@ -293,6 +302,7 @@ async function playMonte(interaction, bet, round = 1) {
             }).on('end', (_, reason) => {
                 if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
             });
+            releaseLock?.();
 
         } else {
             // Won, and more rounds available — offer double-or-nothing
@@ -375,10 +385,11 @@ async function playMonte(interaction, bet, round = 1) {
                     }).on('end', (_, reason) => {
                         if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
                     });
+                    releaseLock?.();
 
                 } else {
                     // Double or Nothing — recurse with next round (no payout yet)
-                    await playMonte(interaction, bet, round + 1);
+                    await playMonte(interaction, bet, round + 1, releaseLock);
                 }
 
             } catch {
@@ -393,6 +404,7 @@ async function playMonte(interaction, bet, round = 1) {
                         content: `⏱️ Time's up — cashed out **${adjustedTake.toLocaleString()}** coins automatically! Balance: **${(updated?.balance ?? 0).toLocaleString()}**`,
                         embeds: [], components: [],
                     }).catch(() => {});
+                    releaseLock?.();
                 }
             }
         }
@@ -405,6 +417,7 @@ async function playMonte(interaction, bet, round = 1) {
                 .catch(e => console.error('[Monte] rollback failed:', e));
         }
         await interaction.editReply({ content: 'Something went wrong. Your wager was refunded.', components: [] }).catch(() => {});
+        releaseLock?.();
     }
 }
 
@@ -420,21 +433,24 @@ module.exports = {
                 .setMinValue(MIN_BET)
                 .setMaxValue(1_000_000_000)),
 
-    async execute(interaction) {
+    async execute(interaction, { releaseLock } = {}) {
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
         if (guildSettings?.economy?.enabled === false || guildSettings?.economy?.gamesEnabled === false) {
+            releaseLock?.();
             return interaction.reply({ content: 'Casino games are disabled on this server.', flags: MessageFlags.Ephemeral });
         }
 
         const bet          = interaction.options.getInteger('bet');
         const casinoMaxBet = guildSettings?.economy?.casinoMaxBet ?? 0;
         if (casinoMaxBet > 0 && bet > casinoMaxBet) {
+            releaseLock?.();
             return interaction.reply({ content: `❌ The casino bet limit on this server is **${casinoMaxBet.toLocaleString()}** coins.`, flags: MessageFlags.Ephemeral });
         }
 
         const user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
 
         if ((user?.balance ?? 0) < bet) {
+            releaseLock?.();
             const currency = guildSettings?.economy?.currency || '💰';
             return interaction.reply({
                 content: `You don't have enough ${currency}. Your balance: **${currency}${(user?.balance ?? 0).toLocaleString()}**`,
@@ -443,8 +459,8 @@ module.exports = {
         }
 
         const { shouldProceed, alreadyReplied } = await confirmBet(interaction, bet, user.balance, 'Three Card Monte', guildSettings);
-        if (!shouldProceed) return;
+        if (!shouldProceed) { releaseLock?.(); return; }
         if (!alreadyReplied) await interaction.deferReply();
-        await playMonte(interaction, bet);
+        await playMonte(interaction, bet, 1, releaseLock);
     },
 };

--- a/src/games/casino/higherlower.js
+++ b/src/games/casino/higherlower.js
@@ -196,7 +196,7 @@ module.exports = {
                 .setMaxValue(1_000_000_000)
                 .setRequired(true)),
 
-    async execute(interaction) {
+    async execute(interaction, { releaseLock } = {}) {
         const bet = interaction.options.getInteger('bet');
         const [user, guildSettings] = await Promise.all([
             User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }),
@@ -205,16 +205,18 @@ module.exports = {
         const wallet = user?.balance ?? 0;
 
         if (guildSettings?.economy?.enabled === false || guildSettings?.economy?.gamesEnabled === false) {
+            releaseLock?.();
             return interaction.reply({ content: 'Economy games are disabled in this server.', flags: MessageFlags.Ephemeral });
         }
 
         const casinoMaxBet = guildSettings?.economy?.casinoMaxBet ?? 0;
         if (casinoMaxBet > 0 && bet > casinoMaxBet) {
+            releaseLock?.();
             return interaction.reply({ content: `❌ The casino bet limit on this server is **${casinoMaxBet.toLocaleString()}** coins.`, flags: MessageFlags.Ephemeral });
         }
 
         const { shouldProceed: hlProceed, alreadyReplied: hlReplied } = await confirmBet(interaction, bet, wallet, 'Higher or Lower', guildSettings);
-        if (!hlProceed) return;
+        if (!hlProceed) { releaseLock?.(); return; }
         if (!hlReplied) await interaction.deferReply();
 
         try {
@@ -233,15 +235,17 @@ module.exports = {
             );
 
             if (!debited) {
+                releaseLock?.();
                 return interaction.editReply({
                     content: `❌ Insufficient funds. You need **${bet.toLocaleString()}** coins.`,
                 });
             }
 
-            await playHigherLower(interaction, bet, userFilter, guildSettings, [], 0);
+            await playHigherLower(interaction, bet, userFilter, guildSettings, [], 0, releaseLock);
 
         } catch (err) {
             console.error('[HigherLower] error:', err);
+            releaseLock?.();
             await interaction.editReply({ content: 'Failed to run Higher or Lower.' }).catch(() => {});
         }
     },
@@ -249,7 +253,11 @@ module.exports = {
 
 // streak = number of consecutive correct guesses in the current session (starts at 0).
 // A session ends when the player cashes out, loses, or starts a new game.
-async function playHigherLower(interaction, bet, userFilter, guildSettings, history, streak) {
+// releaseLock is called as soon as the hand resolves to a final state (win/
+// loss/cash-out/timeout) — NOT held through "Play Again", since a replay
+// re-runs the same atomic debit as any fresh bet and can't double-spend even
+// if another casino game starts in parallel once this hand has settled.
+async function playHigherLower(interaction, bet, userFilter, guildSettings, history, streak, releaseLock) {
     const current = rollCard();
     const canHigh = probabilities(current.value).higher > 0;
     const canLow  = probabilities(current.value).lower  > 0;
@@ -300,7 +308,7 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
                 // Tie: push — refund this round and continue session without changing streak
                 const newHistory = [...history, current];
                 await i.deferUpdate();
-                await playHigherLower(interaction, bet, userFilter, guildSettings, newHistory.slice(-5), streak);
+                await playHigherLower(interaction, bet, userFilter, guildSettings, newHistory.slice(-5), streak, releaseLock);
                 return;
             }
 
@@ -322,6 +330,7 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
                     components: [playAgainRow(replayId)],
                 });
                 attachReplay(message, replayId, interaction, bet, userFilter, guildSettings);
+                releaseLock?.();
                 return;
             }
 
@@ -341,6 +350,7 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
                     components: [playAgainRow(replayId)],
                 });
                 attachReplay(message, replayId, interaction, bet, userFilter, guildSettings);
+                releaseLock?.();
                 return;
             }
 
@@ -353,6 +363,7 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
                     components: [playAgainRow(replayId)],
                 });
                 attachReplay(message, replayId, interaction, bet, userFilter, guildSettings);
+                releaseLock?.();
                 return;
             }
 
@@ -407,10 +418,11 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
                             components: [playAgainRow(replayId)],
                         });
                         attachReplay(riskMsg, replayId, interaction, bet, userFilter, guildSettings);
+                        releaseLock?.();
                     } else {
                         // Risk another card — recurse without paying out
                         await r.deferUpdate();
-                        await playHigherLower(interaction, bet, userFilter, guildSettings, newHistory.slice(-5), newStreak);
+                        await playHigherLower(interaction, bet, userFilter, guildSettings, newHistory.slice(-5), newStreak, releaseLock);
                     }
                 } catch (riskErr) {
                     console.error('[HigherLower] risk collect error:', riskErr);
@@ -418,6 +430,7 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
                     if (!payoutCredited) {
                         await User.findOneAndUpdate(userFilter, { $inc: { balance: bet } }).catch(() => {});
                     }
+                    releaseLock?.();
                 }
             });
 
@@ -431,12 +444,14 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
                     components: [playAgainRow(replayId)],
                 }).catch(() => {});
                 attachReplay(riskMsg, replayId, interaction, bet, userFilter, guildSettings);
+                releaseLock?.();
             });
 
         } catch (collectErr) {
             console.error('[HigherLower] collect error:', collectErr);
             await i.update({ content: 'Something went wrong. Your wager was refunded.', embeds: [], components: [] }).catch(() => {});
             await User.findOneAndUpdate(userFilter, { $inc: { balance: bet } }).catch(() => {});
+            releaseLock?.();
         }
     });
 
@@ -448,6 +463,7 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
             embeds:     [timeoutEmbed(interaction, current, bet, fresh?.balance ?? 0)],
             components: [],
         }).catch(() => {});
+        releaseLock?.();
     });
 }
 

--- a/src/games/casino/keno.js
+++ b/src/games/casino/keno.js
@@ -80,7 +80,10 @@ function phaseTitle(hits, total) {
     return '🎱 Drawing…';
 }
 
-async function playKeno(interaction, bet, picked, alreadyDebited = false) {
+// releaseLock is called once the draw settles into a result — replays/
+// rerolls don't need it re-held since they re-debit atomically like any
+// fresh bet.
+async function playKeno(interaction, bet, picked, alreadyDebited = false, releaseLock) {
     const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
     let debited = null;
     let settled = false;
@@ -98,6 +101,7 @@ async function playKeno(interaction, bet, picked, alreadyDebited = false) {
             );
 
             if (!debited) {
+                releaseLock?.();
                 const fresh = await User.findOne(userFilter);
                 return interaction.editReply({
                     content: `❌ Not enough coins! Your balance: **${(fresh?.balance ?? 0).toLocaleString()}** coins.`,
@@ -209,6 +213,7 @@ async function playKeno(interaction, bet, picked, alreadyDebited = false) {
             );
         }
         settled = true;
+        releaseLock?.();
 
         const net    = credit - bet;
         const netStr = net >= 0 ? `+${net.toLocaleString()}` : `${net.toLocaleString()}`;
@@ -352,10 +357,10 @@ async function playKeno(interaction, bet, picked, alreadyDebited = false) {
                     return i.update({ content: `❌ Not enough coins for the quick reroll (need **${rerollCost.toLocaleString()}** coins).`, embeds: [], components: [] });
                 }
                 await i.deferUpdate();
-                await playKeno(interaction, rerollCost, picked, true);
+                await playKeno(interaction, rerollCost, picked, true, null);
             } else {
                 await i.deferUpdate();
-                await playKeno(interaction, bet, picked);
+                await playKeno(interaction, bet, picked, false, null);
             }
         }).on('end', (_, reason) => {
             if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
@@ -363,6 +368,7 @@ async function playKeno(interaction, bet, picked, alreadyDebited = false) {
 
     } catch (err) {
         console.error('[Keno] error:', err);
+        releaseLock?.();
         if (debited && !settled) {
             await User.findOneAndUpdate(userFilter, { $inc: { balance: bet } })
                 .catch(e => console.error('[Keno] rollback failed:', e));
@@ -387,15 +393,17 @@ module.exports = {
                 .setDescription('Your 5 numbers from 1–40, space-separated (e.g. 3 12 21 33 39)')
                 .setRequired(true)),
 
-    async execute(interaction) {
+    async execute(interaction, { releaseLock } = {}) {
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
         if (guildSettings?.economy?.enabled === false || guildSettings?.economy?.gamesEnabled === false) {
+            releaseLock?.();
             return interaction.reply({ content: 'Casino games are disabled on this server.', flags: MessageFlags.Ephemeral });
         }
 
         const bet          = interaction.options.getInteger('bet');
         const casinoMaxBet = guildSettings?.economy?.casinoMaxBet ?? 0;
         if (casinoMaxBet > 0 && bet > casinoMaxBet) {
+            releaseLock?.();
             return interaction.reply({ content: `❌ The casino bet limit on this server is **${casinoMaxBet.toLocaleString()}** coins.`, flags: MessageFlags.Ephemeral });
         }
         const numbersRaw = interaction.options.getString('numbers');
@@ -404,6 +412,7 @@ module.exports = {
         const valid  = parsed.every(n => Number.isInteger(n) && n >= 1 && n <= POOL_SIZE);
 
         if (parsed.length !== PICK_COUNT || !valid) {
+            releaseLock?.();
             return interaction.reply({
                 content: `❌ Please provide exactly **5 different numbers** between 1 and ${POOL_SIZE}.\nExample: \`3 12 21 33 39\``,
                 flags: MessageFlags.Ephemeral,
@@ -412,11 +421,13 @@ module.exports = {
 
         const uniquePicked = [...new Set(parsed)];
         if (uniquePicked.length !== PICK_COUNT) {
+            releaseLock?.();
             return interaction.reply({ content: '❌ All 5 numbers must be different.', flags: MessageFlags.Ephemeral });
         }
 
         const user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
         if ((user?.balance ?? 0) < bet) {
+            releaseLock?.();
             const currency = guildSettings?.economy?.currency || '💰';
             return interaction.reply({
                 content: `You don't have enough ${currency}. Your balance: **${currency}${(user?.balance ?? 0).toLocaleString()}**`,
@@ -425,8 +436,8 @@ module.exports = {
         }
 
         const { shouldProceed: knProceed, alreadyReplied: knReplied } = await confirmBet(interaction, bet, user.balance, 'Keno', guildSettings);
-        if (!knProceed) return;
+        if (!knProceed) { releaseLock?.(); return; }
         if (!knReplied) await interaction.deferReply();
-        await playKeno(interaction, bet, uniquePicked.sort((a, b) => a - b));
+        await playKeno(interaction, bet, uniquePicked.sort((a, b) => a - b), false, releaseLock);
     },
 };

--- a/src/games/casino/keno.js
+++ b/src/games/casino/keno.js
@@ -112,8 +112,30 @@ async function playKeno(interaction, bet, picked, alreadyDebited = false, releas
         const drawn   = drawNumbers();
         const pickedStr = picked.map(n => `**${n}**`).join('  ');
 
+        // ── Skip-animation control — lets repeat players jump straight to the
+        // result instead of sitting through the full reveal each time ────────
+        const skipId   = `keno_skip_${interaction.id}_${Date.now()}`;
+        const skipRow  = new ActionRowBuilder().addComponents(
+            new ButtonBuilder().setCustomId(skipId).setLabel('⏩ Skip Animation').setStyle(ButtonStyle.Secondary),
+        );
+        const animState = { skipped: false };
+        let skipCollector = null;
+        const armSkipCollector = async () => {
+            if (skipCollector) return;
+            const msg = await interaction.fetchReply().catch(() => null);
+            if (!msg) return;
+            skipCollector = msg.createMessageComponentCollector({
+                filter: i => i.user.id === interaction.user.id && i.customId === skipId,
+                time: 8_000,
+            });
+            skipCollector.on('collect', async i => {
+                animState.skipped = true;
+                await i.deferUpdate().catch(() => {});
+            });
+        };
+
         // ── Phase 1: Draw numbers 1-5 one at a time ──────────────────────────
-        for (let i = 1; i <= 5; i++) {
+        for (let i = 1; i <= 5 && !animState.skipped; i++) {
             const hits = drawn.slice(0, i).filter(n => picked.includes(n)).length;
             const embed = new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
@@ -126,36 +148,39 @@ async function playKeno(interaction, bet, picked, alreadyDebited = false, releas
                     { name: `🔵 Drawing (${i}/10)`, value: `${hitBar(hits)}  **${hits}** hit`, inline: true },
                 )
                 .setFooter({ text: PAYTABLE_FOOTER });
-            await interaction.editReply({ embeds: [embed] });
+            await interaction.editReply({ embeds: [embed], components: [skipRow] });
+            if (i === 1) await armSkipCollector();
             await delay(650);
         }
 
         // ── Midpoint suspense break ───────────────────────────────────────────
-        const midHits = drawn.slice(0, 5).filter(n => picked.includes(n)).length;
-        const remaining = PICK_COUNT - midHits;
-        let suspenseText;
-        if (midHits === 5)     suspenseText = '🔥 **All 5 matched in the first draw!** Last 5 are gravy…';
-        else if (midHits >= 3) suspenseText = `✅ **${midHits} matched** so far — ${remaining} more to go for the jackpot!`;
-        else if (midHits === 2) suspenseText = `🎯 **2 matched** — one more for a profit…`;
-        else if (midHits === 1) suspenseText = `😬 **1 matched** — need ${remaining} of the next 5…`;
-        else                   suspenseText  = `💨 **Nothing yet** — all ${PICK_COUNT} need to come from the last 5…`;
+        if (!animState.skipped) {
+            const midHits = drawn.slice(0, 5).filter(n => picked.includes(n)).length;
+            const remaining = PICK_COUNT - midHits;
+            let suspenseText;
+            if (midHits === 5)     suspenseText = '🔥 **All 5 matched in the first draw!** Last 5 are gravy…';
+            else if (midHits >= 3) suspenseText = `✅ **${midHits} matched** so far — ${remaining} more to go for the jackpot!`;
+            else if (midHits === 2) suspenseText = `🎯 **2 matched** — one more for a profit…`;
+            else if (midHits === 1) suspenseText = `😬 **1 matched** — need ${remaining} of the next 5…`;
+            else                   suspenseText  = `💨 **Nothing yet** — all ${PICK_COUNT} need to come from the last 5…`;
 
-        const midEmbed = new EmbedBuilder()
-            .setAuthor(embedAuthor(interaction))
-            .setThumbnail(THUMB)
-            .setColor('#5865F2')
-            .setTitle('🎱 Halfway — Drawing 6 of 10…')
-            .setDescription(formatKenoGrid(picked, drawn, 5))
-            .addFields(
-                { name: '🎯 Your Picks', value: pickedStr, inline: true },
-                { name: '📊 Midpoint', value: suspenseText, inline: false },
-            )
-            .setFooter({ text: PAYTABLE_FOOTER });
-        await interaction.editReply({ embeds: [midEmbed] });
-        await delay(1200);
+            const midEmbed = new EmbedBuilder()
+                .setAuthor(embedAuthor(interaction))
+                .setThumbnail(THUMB)
+                .setColor('#5865F2')
+                .setTitle('🎱 Halfway — Drawing 6 of 10…')
+                .setDescription(formatKenoGrid(picked, drawn, 5))
+                .addFields(
+                    { name: '🎯 Your Picks', value: pickedStr, inline: true },
+                    { name: '📊 Midpoint', value: suspenseText, inline: false },
+                )
+                .setFooter({ text: PAYTABLE_FOOTER });
+            await interaction.editReply({ embeds: [midEmbed], components: [skipRow] });
+            await delay(1200);
+        }
 
         // ── Phase 2: Draw numbers 6-10 one at a time ─────────────────────────
-        for (let i = 6; i <= 10; i++) {
+        for (let i = 6; i <= 10 && !animState.skipped; i++) {
             const hits = drawn.slice(0, i).filter(n => picked.includes(n)).length;
             const embed = new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
@@ -168,9 +193,11 @@ async function playKeno(interaction, bet, picked, alreadyDebited = false, releas
                     { name: `🔵 Drawing (${i}/10)`, value: `${hitBar(hits)}  **${hits}** hit`, inline: true },
                 )
                 .setFooter({ text: PAYTABLE_FOOTER });
-            await interaction.editReply({ embeds: [embed] });
+            await interaction.editReply({ embeds: [embed], components: [skipRow] });
             await delay(650);
         }
+
+        skipCollector?.stop();
 
         // ── Calculate result ──────────────────────────────────────────────────
         const matches    = drawn.filter(n => picked.includes(n)).length;
@@ -220,8 +247,8 @@ async function playKeno(interaction, bet, picked, alreadyDebited = false, releas
         let boostNote = '';
         if (totalCoinMult > 1.0 && adjustedPayout > bet) boostNote = `\n> 🚀 *${totalCoinMult.toFixed(1)}x Coin Booster applied!*`;
 
-        // ── Special celebration for big wins ──────────────────────────────────
-        if (matches === 5) {
+        // ── Special celebration for big wins (skipped if animation was skipped) ─
+        if (matches === 5 && !animState.skipped) {
             await delay(400);
             const stage1 = new EmbedBuilder()
                 .setColor('#FFD700')
@@ -238,7 +265,7 @@ async function playKeno(interaction, bet, picked, alreadyDebited = false, releas
                 .setAuthor(embedAuthor(interaction));
             await interaction.editReply({ embeds: [stage2] });
             await delay(1100);
-        } else if (matches === 4) {
+        } else if (matches === 4 && !animState.skipped) {
             await delay(400);
             const stage1 = new EmbedBuilder()
                 .setColor('#00FF88')

--- a/src/games/casino/poker.js
+++ b/src/games/casino/poker.js
@@ -197,7 +197,6 @@ async function playPoker(interaction, bet, releaseLock) {
         // If dealer folds pre-flop (very weak hand), player wins immediately
         if (dealerPreAction === 'fold') {
             settled = true;
-            releaseLock?.();
             const coinMult   = getCoinMultiplier(debited);
             const serverMult = getServerCoinMultiplier(guildSettings);
             const totalMult  = coinMult * serverMult;
@@ -206,6 +205,7 @@ async function playPoker(interaction, bet, releaseLock) {
             if (totalMult > 1.0) winAmount = bet + Math.round((baseWin - bet) * totalMult);
 
             const updated = await User.findOneAndUpdate(userFilter, { $inc: { balance: winAmount } }, { new: true });
+            releaseLock?.();
 
             return interaction.editReply({
                 embeds: [new EmbedBuilder()
@@ -280,8 +280,8 @@ async function playPoker(interaction, bet, releaseLock) {
             preFlopAction = r.customId.split('_')[1]; // check / raise / call / fold
         } catch {
             settled = true;
-            releaseLock?.();
             await User.findOneAndUpdate(userFilter, { $inc: { balance: bet } });
+            releaseLock?.();
             return interaction.editReply({ content: '⏱️ Time\'s up! Bet refunded.', embeds: [], components: [] }).catch(() => {});
         }
 
@@ -336,7 +336,6 @@ async function playPoker(interaction, bet, releaseLock) {
         if (dFlopAction === 'fold') {
             // Dealer folds on the flop — player wins the pot
             settled = true;
-            releaseLock?.();
             const coinMult   = getCoinMultiplier(debited);
             const serverMult = getServerCoinMultiplier(guildSettings);
             const totalMult  = coinMult * serverMult;
@@ -344,6 +343,7 @@ async function playPoker(interaction, bet, releaseLock) {
             if (totalMult > 1.0) winPayout = playerStake + Math.round((pot - playerStake) * totalMult);
 
             await User.findOneAndUpdate(userFilter, { $inc: { balance: winPayout } }, { new: true });
+            releaseLock?.();
 
             return interaction.editReply({
                 embeds: [new EmbedBuilder()
@@ -409,8 +409,8 @@ async function playPoker(interaction, bet, releaseLock) {
             flopAction = r.customId.split('_')[1];
         } catch {
             settled = true;
-            releaseLock?.();
             await User.findOneAndUpdate(userFilter, { $inc: { balance: playerStake } });
+            releaseLock?.();
             return interaction.editReply({ content: '⏱️ Time\'s up! Bet refunded.', embeds: [], components: [] }).catch(() => {});
         }
 
@@ -469,13 +469,13 @@ async function playPoker(interaction, bet, releaseLock) {
 
         if (dTurnAction === 'fold') {
             settled = true;
-            releaseLock?.();
             const coinMult   = getCoinMultiplier(debited);
             const serverMult = getServerCoinMultiplier(guildSettings);
             const totalMult  = coinMult * serverMult;
             let winPayout    = pot;
             if (totalMult > 1.0) winPayout = playerStake + Math.round((pot - playerStake) * totalMult);
             await User.findOneAndUpdate(userFilter, { $inc: { balance: winPayout } }, { new: true });
+            releaseLock?.();
             return interaction.editReply({
                 embeds: [new EmbedBuilder()
                     .setAuthor(embedAuthor(interaction))
@@ -536,8 +536,8 @@ async function playPoker(interaction, bet, releaseLock) {
             turnAction = r.customId.split('_')[1];
         } catch {
             settled = true;
-            releaseLock?.();
             await User.findOneAndUpdate(userFilter, { $inc: { balance: playerStake } });
+            releaseLock?.();
             return interaction.editReply({ content: '⏱️ Time\'s up! Bet refunded.', embeds: [], components: [] }).catch(() => {});
         }
 
@@ -594,13 +594,13 @@ async function playPoker(interaction, bet, releaseLock) {
 
         if (dRiverAction === 'fold') {
             settled = true;
-            releaseLock?.();
             const coinMult   = getCoinMultiplier(debited);
             const serverMult = getServerCoinMultiplier(guildSettings);
             const totalMult  = coinMult * serverMult;
             let winPayout    = pot;
             if (totalMult > 1.0) winPayout = playerStake + Math.round((pot - playerStake) * totalMult);
             await User.findOneAndUpdate(userFilter, { $inc: { balance: winPayout } }, { new: true });
+            releaseLock?.();
             return interaction.editReply({
                 embeds: [new EmbedBuilder()
                     .setAuthor(embedAuthor(interaction))
@@ -661,8 +661,8 @@ async function playPoker(interaction, bet, releaseLock) {
             riverAction = r.customId.split('_')[1];
         } catch {
             settled = true;
-            releaseLock?.();
             await User.findOneAndUpdate(userFilter, { $inc: { balance: playerStake } });
+            releaseLock?.();
             return interaction.editReply({ content: '⏱️ Time\'s up! Bet refunded.', embeds: [], components: [] }).catch(() => {});
         }
 

--- a/src/games/casino/poker.js
+++ b/src/games/casino/poker.js
@@ -151,7 +151,10 @@ function embedAuthor(interaction) {
 
 // ── Game flow ────────────────────────────────────────────────────────────────
 
-async function playPoker(interaction, bet) {
+// releaseLock is called at every terminal point of a hand (dealer/player
+// fold at any street, showdown, or a timeout refund) — "Play Again" starts
+// a brand-new hand with its own atomic debit, so it isn't passed releaseLock.
+async function playPoker(interaction, bet, releaseLock) {
     const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
     let debited = null;
     let settled = false;
@@ -166,6 +169,7 @@ async function playPoker(interaction, bet) {
         );
 
         if (!debited) {
+            releaseLock?.();
             const fresh = await User.findOne(userFilter);
             return interaction.editReply({
                 content: `❌ Not enough coins! Your balance: **${(fresh?.balance ?? 0).toLocaleString()}** coins.`,
@@ -193,6 +197,7 @@ async function playPoker(interaction, bet) {
         // If dealer folds pre-flop (very weak hand), player wins immediately
         if (dealerPreAction === 'fold') {
             settled = true;
+            releaseLock?.();
             const coinMult   = getCoinMultiplier(debited);
             const serverMult = getServerCoinMultiplier(guildSettings);
             const totalMult  = coinMult * serverMult;
@@ -275,6 +280,7 @@ async function playPoker(interaction, bet) {
             preFlopAction = r.customId.split('_')[1]; // check / raise / call / fold
         } catch {
             settled = true;
+            releaseLock?.();
             await User.findOneAndUpdate(userFilter, { $inc: { balance: bet } });
             return interaction.editReply({ content: '⏱️ Time\'s up! Bet refunded.', embeds: [], components: [] }).catch(() => {});
         }
@@ -302,6 +308,7 @@ async function playPoker(interaction, bet) {
 
         if (folded) {
             settled = true;
+            releaseLock?.();
             const foldEmbed = new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
                 .setThumbnail(THUMB)
@@ -329,6 +336,7 @@ async function playPoker(interaction, bet) {
         if (dFlopAction === 'fold') {
             // Dealer folds on the flop — player wins the pot
             settled = true;
+            releaseLock?.();
             const coinMult   = getCoinMultiplier(debited);
             const serverMult = getServerCoinMultiplier(guildSettings);
             const totalMult  = coinMult * serverMult;
@@ -401,6 +409,7 @@ async function playPoker(interaction, bet) {
             flopAction = r.customId.split('_')[1];
         } catch {
             settled = true;
+            releaseLock?.();
             await User.findOneAndUpdate(userFilter, { $inc: { balance: playerStake } });
             return interaction.editReply({ content: '⏱️ Time\'s up! Bet refunded.', embeds: [], components: [] }).catch(() => {});
         }
@@ -431,6 +440,7 @@ async function playPoker(interaction, bet) {
 
         if (folded) {
             settled = true;
+            releaseLock?.();
             const foldEmbed = new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
                 .setThumbnail(THUMB)
@@ -459,6 +469,7 @@ async function playPoker(interaction, bet) {
 
         if (dTurnAction === 'fold') {
             settled = true;
+            releaseLock?.();
             const coinMult   = getCoinMultiplier(debited);
             const serverMult = getServerCoinMultiplier(guildSettings);
             const totalMult  = coinMult * serverMult;
@@ -525,6 +536,7 @@ async function playPoker(interaction, bet) {
             turnAction = r.customId.split('_')[1];
         } catch {
             settled = true;
+            releaseLock?.();
             await User.findOneAndUpdate(userFilter, { $inc: { balance: playerStake } });
             return interaction.editReply({ content: '⏱️ Time\'s up! Bet refunded.', embeds: [], components: [] }).catch(() => {});
         }
@@ -553,6 +565,7 @@ async function playPoker(interaction, bet) {
 
         if (folded) {
             settled = true;
+            releaseLock?.();
             const foldEmbed = new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
                 .setThumbnail(THUMB)
@@ -581,6 +594,7 @@ async function playPoker(interaction, bet) {
 
         if (dRiverAction === 'fold') {
             settled = true;
+            releaseLock?.();
             const coinMult   = getCoinMultiplier(debited);
             const serverMult = getServerCoinMultiplier(guildSettings);
             const totalMult  = coinMult * serverMult;
@@ -647,6 +661,7 @@ async function playPoker(interaction, bet) {
             riverAction = r.customId.split('_')[1];
         } catch {
             settled = true;
+            releaseLock?.();
             await User.findOneAndUpdate(userFilter, { $inc: { balance: playerStake } });
             return interaction.editReply({ content: '⏱️ Time\'s up! Bet refunded.', embeds: [], components: [] }).catch(() => {});
         }
@@ -675,6 +690,7 @@ async function playPoker(interaction, bet) {
 
         if (folded) {
             settled = true;
+            releaseLock?.();
             const foldEmbed = new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
                 .setThumbnail(THUMB)
@@ -718,6 +734,7 @@ async function playPoker(interaction, bet) {
             updated = await User.findOneAndUpdate(userFilter, { $inc: { balance: adjustedPayout } }, { new: true });
         }
         settled = true;
+        releaseLock?.();
 
         const net    = adjustedPayout - playerStake;
         const netStr = net >= 0 ? `+${net.toLocaleString()}` : `${net.toLocaleString()}`;
@@ -763,13 +780,14 @@ async function playPoker(interaction, bet) {
             time: 60_000,
         }).on('collect', async i => {
             await i.deferUpdate();
-            await playPoker(interaction, bet);
+            await playPoker(interaction, bet, null);
         }).on('end', (_, reason) => {
             if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
         });
 
     } catch (err) {
         console.error('[Poker] error:', err);
+        releaseLock?.();
         if (debited && !settled) {
             await User.findOneAndUpdate(userFilter, { $inc: { balance: bet } })
                 .catch(e => console.error('[Poker] rollback failed:', e));
@@ -790,20 +808,23 @@ module.exports = {
                 .setMinValue(MIN_BET)
                 .setMaxValue(1_000_000_000)),
 
-    async execute(interaction) {
+    async execute(interaction, { releaseLock } = {}) {
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
         if (guildSettings?.economy?.enabled === false || guildSettings?.economy?.gamesEnabled === false) {
+            releaseLock?.();
             return interaction.reply({ content: 'Casino games are disabled on this server.', flags: MessageFlags.Ephemeral });
         }
 
         const bet          = interaction.options.getInteger('bet');
         const casinoMaxBet = guildSettings?.economy?.casinoMaxBet ?? 0;
         if (casinoMaxBet > 0 && bet > casinoMaxBet) {
+            releaseLock?.();
             return interaction.reply({ content: `❌ The casino bet limit on this server is **${casinoMaxBet.toLocaleString()}** coins.`, flags: MessageFlags.Ephemeral });
         }
         const user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
 
         if ((user?.balance ?? 0) < bet) {
+            releaseLock?.();
             const currency = guildSettings?.economy?.currency || '💰';
             return interaction.reply({
                 content: `You don't have enough ${currency}. Your balance: **${currency}${(user?.balance ?? 0).toLocaleString()}**`,
@@ -812,8 +833,8 @@ module.exports = {
         }
 
         const { shouldProceed: pkProceed, alreadyReplied: pkReplied } = await confirmBet(interaction, bet, user.balance, 'Poker', guildSettings);
-        if (!pkProceed) return;
+        if (!pkProceed) { releaseLock?.(); return; }
         if (!pkReplied) await interaction.deferReply();
-        await playPoker(interaction, bet);
+        await playPoker(interaction, bet, releaseLock);
     },
 };

--- a/src/games/casino/roulette.js
+++ b/src/games/casino/roulette.js
@@ -178,8 +178,9 @@ module.exports = {
                 .setMaxValue(36)
                 .setRequired(false)),
 
-    async execute(interaction) {
+    async execute(interaction, { releaseLock } = {}) {
         if (!interaction.guild) {
+            releaseLock?.();
             return interaction.reply({ content: 'This command can only be used in a server.', flags: MessageFlags.Ephemeral });
         }
 
@@ -188,6 +189,7 @@ module.exports = {
         const target = interaction.options.getInteger('number');
 
         if (betKey === 'number' && target === null) {
+            releaseLock?.();
             return interaction.reply({
                 content: 'You must provide a `number` (0–36) when betting on a straight number.',
                 flags: MessageFlags.Ephemeral,
@@ -197,18 +199,22 @@ module.exports = {
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
         const casinoMaxBet  = guildSettings?.economy?.casinoMaxBet ?? 0;
         if (casinoMaxBet > 0 && bet > casinoMaxBet) {
+            releaseLock?.();
             return interaction.reply({ content: `❌ The casino bet limit on this server is **${casinoMaxBet.toLocaleString()}** coins.`, flags: MessageFlags.Ephemeral });
         }
         const user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
         const wallet = user?.balance ?? 0;
         const { shouldProceed: rProceed, alreadyReplied: rReplied } = await confirmBet(interaction, bet, wallet, 'Roulette', guildSettings);
-        if (!rProceed) return;
+        if (!rProceed) { releaseLock?.(); return; }
         if (!rReplied) await interaction.deferReply();
-        await playRoulette(interaction, betKey, bet, target);
+        await playRoulette(interaction, betKey, bet, target, releaseLock);
     },
 };
 
-async function playRoulette(interaction, betKey, bet, target) {
+// releaseLock is called once the spin settles into a result — "Spin Again"
+// starts a brand-new hand with its own atomic debit, so it doesn't need the
+// lock re-held.
+async function playRoulette(interaction, betKey, bet, target, releaseLock) {
     const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
     let debited = null;
     let settled = false;
@@ -216,6 +222,7 @@ async function playRoulette(interaction, betKey, bet, target) {
     try {
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
         if (guildSettings?.economy?.enabled === false || guildSettings?.economy?.gamesEnabled === false) {
+            releaseLock?.();
             return interaction.editReply({ content: 'Economy games are disabled in this server.' });
         }
 
@@ -232,6 +239,7 @@ async function playRoulette(interaction, betKey, bet, target) {
         );
 
         if (!debited) {
+            releaseLock?.();
             return interaction.editReply({
                 content: `❌ Not enough coins to wager **${bet.toLocaleString()}**.`,
             });
@@ -279,6 +287,7 @@ async function playRoulette(interaction, betKey, bet, target) {
             );
         }
         settled = true;
+        releaseLock?.();
 
         // Save result to guild roulette history (last 15)
         await Guild.updateOne(
@@ -317,7 +326,7 @@ async function playRoulette(interaction, betKey, bet, target) {
         const wallet = user?.balance ?? 0;
         if (!await confirmBet(interaction, bet, wallet, 'Roulette', guildSettings)) return;
 
-        await playRoulette(interaction, betKey, bet, target);
+        await playRoulette(interaction, betKey, bet, target, null);
         });
         collector.on('end', (_, reason) => {
             if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
@@ -325,6 +334,7 @@ async function playRoulette(interaction, betKey, bet, target) {
 
     } catch (err) {
         console.error('[Roulette] error:', err);
+        releaseLock?.();
         if (debited && !settled) {
             await User.findOneAndUpdate(userFilter, { $inc: { balance: bet } }).catch(e =>
                 console.error('[Roulette] rollback failed:', e));

--- a/src/games/casino/slots.js
+++ b/src/games/casino/slots.js
@@ -205,23 +205,27 @@ module.exports = {
                 .setMinValue(10)
                 .setMaxValue(1_000_000_000)
                 .setRequired(true)),
-    async execute(interaction) {
+    async execute(interaction, { releaseLock } = {}) {
         const bet           = interaction.options.getInteger('bet');
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
         const casinoMaxBet  = guildSettings?.economy?.casinoMaxBet ?? 0;
         if (casinoMaxBet > 0 && bet > casinoMaxBet) {
+            releaseLock?.();
             return interaction.reply({ content: `❌ The casino bet limit on this server is **${casinoMaxBet.toLocaleString()}** coins.`, flags: MessageFlags.Ephemeral });
         }
         const user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
         const wallet = user?.balance ?? 0;
         const { shouldProceed: slProceed, alreadyReplied: slReplied } = await confirmBet(interaction, bet, wallet, 'Slots');
-        if (!slProceed) return;
+        if (!slProceed) { releaseLock?.(); return; }
         if (!slReplied) await interaction.deferReply();
-        await playSlots(interaction, bet);
+        await playSlots(interaction, bet, releaseLock);
     },
 };
 
-async function playSlots(interaction, bet) {
+// releaseLock is called once the spin settles into a result — "Spin Again"
+// starts a brand-new hand with its own atomic debit, so it doesn't need the
+// lock re-held.
+async function playSlots(interaction, bet, releaseLock) {
     const userFilter  = { userId: interaction.user.id, guildId: interaction.guild.id };
     const guildFilter = { guildId: interaction.guild.id };
     try {
@@ -252,6 +256,7 @@ async function playSlots(interaction, bet) {
             { new: true }
         );
         if (!debited) {
+            releaseLock?.();
             const fresh = await User.findOne(userFilter);
             return interaction.editReply({
                 content: `❌ Not enough coins! Your balance: **${(fresh?.balance ?? 0).toLocaleString()}** coins.`,
@@ -342,6 +347,7 @@ async function playSlots(interaction, bet) {
             { $inc: { balance: adjustedPayout } },
             { new: true }
         );
+        releaseLock?.();
 
         const delay = ms => new Promise(r => setTimeout(r, ms));
 
@@ -457,7 +463,7 @@ async function playSlots(interaction, bet) {
             }
             collector.stop('replay');
             await i.deferUpdate();
-            await playSlots(interaction, bet);
+            await playSlots(interaction, bet, null);
         });
 
         collector.on('end', (_, reason) => {
@@ -466,6 +472,7 @@ async function playSlots(interaction, bet) {
 
     } catch (err) {
         console.error('[Slots] error:', err);
+        releaseLock?.();
         await interaction.editReply({ content: 'An error occurred while playing slots. Please try again.', components: [] }).catch(() => {});
     }
 }

--- a/src/games/casino/slots.js
+++ b/src/games/casino/slots.js
@@ -215,7 +215,7 @@ module.exports = {
         }
         const user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
         const wallet = user?.balance ?? 0;
-        const { shouldProceed: slProceed, alreadyReplied: slReplied } = await confirmBet(interaction, bet, wallet, 'Slots');
+        const { shouldProceed: slProceed, alreadyReplied: slReplied } = await confirmBet(interaction, bet, wallet, 'Slots', guildSettings);
         if (!slProceed) { releaseLock?.(); return; }
         if (!slReplied) await interaction.deferReply();
         await playSlots(interaction, bet, releaseLock);
@@ -347,7 +347,6 @@ async function playSlots(interaction, bet, releaseLock) {
             { $inc: { balance: adjustedPayout } },
             { new: true }
         );
-        releaseLock?.();
 
         const delay = ms => new Promise(r => setTimeout(r, ms));
 
@@ -407,6 +406,11 @@ async function playSlots(interaction, bet, releaseLock) {
             await interaction.editReply({ embeds: [scatterEmbed], components: [] });
             await delay(2000);
         }
+
+        // Lock is released only after the spin's payout (including any free-spin
+        // payouts) has fully settled, so "Spin Again" can't start a new hand for
+        // this player while a free-spin credit is still being written.
+        releaseLock?.();
 
         // ── Big win announcement ────────────────────────────────────────────────
         const winMult = adjustedPayout > 0 ? adjustedPayout / bet : 0;

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -33,9 +33,13 @@ const userSchema = new Schema({
     },
     shiftsWorked: { type: Number, default: 0 },
 
-    // Daily hard quiz attempt counter (resets midnight UTC)
+    // Daily quiz attempt counters per difficulty (each resets midnight UTC)
     dailyQuizHard: { type: Number, default: 0 },
     dailyQuizHardReset: { type: Date, default: null },
+    dailyQuizMedium: { type: Number, default: 0 },
+    dailyQuizMediumReset: { type: Date, default: null },
+    dailyQuizEasy: { type: Number, default: 0 },
+    dailyQuizEasyReset: { type: Date, default: null },
 
     inventory: [{
         itemId: { type: String, required: true },

--- a/src/utils/streakMultiplier.js
+++ b/src/utils/streakMultiplier.js
@@ -1,4 +1,6 @@
 const MULTIPLIER_LADDER = [
+    { days: 365, multiplier: 3.0  },
+    { days: 200, multiplier: 2.5  },
     { days: 100, multiplier: 2.0  },
     { days:  60, multiplier: 1.75 },
     { days:  30, multiplier: 1.5  },
@@ -10,6 +12,8 @@ const MILESTONES = [
     { days:   7, coins:  12_500, badge: 'Week Warrior'   },
     { days:  30, coins:  37_500, badge: 'Monthly Master' },
     { days: 100, coins: 125_000, badge: 'Centurion'      },
+    { days: 200, coins: 250_000, badge: 'Bicenturion'    },
+    { days: 365, coins: 500_000, badge: 'Unstoppable'    },
 ];
 
 function getStreakMultiplier(streakDays) {


### PR DESCRIPTION
## Summary

Follow-up implementation work from a full games review (scored 1-10, identified bugs and engagement gaps). This PR covers the bug-fix phases and the smaller/medium engagement improvements; two larger feature builds are left for follow-up issues (see below).

**Bug fixes:**
- Fixed casino lock release timing across blackjack, higherlower, cupgame, keno, roulette, slots, poker, crash — locks were released before the bet/result state had actually settled, leaving a window for double-submission.
- Fixed cooldown/claim race conditions (read-then-much-later-save pattern) in crime, snowball, hunt, fish, questgen, and the achievements claim flow — replaced with atomic `findOneAndUpdate` claims that encode the guard condition and the mutation in a single call.
- Closed a quiz coin-faucet exploit: only the hard difficulty had a daily attempt cap; easy/medium (the most profitable per-attempt) were uncapped. Added per-difficulty daily caps (40/30/20) backed by new `dailyQuizEasy`/`dailyQuizMedium` counter fields.

**Engagement improvements:**
- Added a betting mode to `/roll` (`bet`/`guess` high-low, or exact-number wager) mirroring `coinflip`'s atomic-debit pattern, with a 5% house cut.
- Added "generate mine" regenerate buttons to `/wanted` and `/wasted` so anyone viewing the result can get their own poster/image with one click.
- Extended the streak multiplier ladder to 200/365 days (2.5x/3.0x) with new milestones, matching the existing 365-day "Unstoppable" achievement.
- Added a skip-animation button to `/keno` so repeat players can jump straight to the result instead of sitting through the ~9s reveal each time.

**Left for follow-up (tracked as separate issues):**
- PvP tournament/bracket mode built on `duel.js` primitives.
- `war.js` interactive redesign (real scoring minigame, milestone announcements, scheduled auto-resolution, transaction hardening).

## Test plan
- [x] `node -c` syntax check on every modified file
- [ ] Manual smoke test of `/roll bet`, `/wanted`, `/wasted`, `/keno` skip button, `/quiz` easy/medium cap, and the casino games in a live Discord server


---
_Generated by [Claude Code](https://claude.ai/code/session_01GPyoep1JXhtg16tRaPFhHT)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wagered dice rolls with bet, guess, and exact-number options.
  * Added regenerate buttons for generated “Wanted” and “Wasted” images.
  * Expanded streak rewards with new milestone tiers and higher multipliers.
  * Added per-difficulty daily caps for quizzes.

* **Bug Fixes**
  * Improved cooldown handling across several economy commands to prevent double-use and race conditions.
  * Made casino games more reliable during long-running sessions and replay flows.
  * Smoothed snowball, quest, and achievement reward handling for more consistent outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->