### PR TITLE
Fix daily cap enforcement and apex weapon durability tracking

### DIFF
--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -18,7 +18,7 @@ const {
     CONSUMABLES, AMMO_PACKS,
     WEAPON_TIERS, WEAPON_BY_SLUG, WEAPON_UPGRADES,
     HUNTER_LEVELS, PRESTIGE_BONUSES, HUNT_QUEST_TEMPLATES,
-    ANIMAL_TRAITS
+    ANIMAL_TRAITS, MATERIAL_NAMES
 } = require('../../data/huntData');
 const { checkAndAward, announceAchievements } = require('../../services/achievementService');
 const { TIER_NUM, TIER_RIBBON } = require('../../data/materialRarity');
@@ -130,22 +130,6 @@ const PRESTIGE_LABELS = [
     '🏆 Champion Prestige',
     '💎 Diamond Prestige'
 ];
-
-const MATERIAL_NAMES = {
-    rabbits_foot:      "Rabbit's Foot",     acorn_cache:     'Acorn Cache',
-    feather:           'Feather',            down_feather:    'Down Feather',
-    antler_fragment:   'Antler Fragment',    tusk_shard:      'Tusk Shard',
-    badger_pelt:       'Badger Pelt',        beaver_pelt:     'Beaver Pelt',
-    coyote_fang:       'Coyote Fang',        wolf_pelt:       'Wolf Pelt',
-    elk_antler:        'Grand Antler',       lynx_fang:       'Lynx Fang',
-    eagle_talon:       'Eagle Talon',        mountain_horn:   'Mountain Horn',
-    bear_claw:         'Bear Claw',          moose_rack:      'Moose Rack',
-    lion_tooth:        "Lion's Tooth",       wolverine_fur:   'Wolverine Fur',
-    spirit_pelt:       'Spirit Pelt',        megaloceros_crown:'Megaloceros Crown',
-    golden_fur:        'Golden Fur',         spirit_essence:  'Spirit Essence',
-    ancient_claw:      'Ancient Claw',       thunderfeather:  'Thunderfeather',
-    spectral_bone:     'Spectral Bone',      bandit_mask:     'Bandit Mask'
-};
 
 // ─── COMMAND DEFINITION ───────────────────────────────────────────────────────
 
@@ -697,7 +681,8 @@ async function executeStart(interaction) {
     }
 
     if (result.success && result.finalPayout > 0 && petYieldPct > 0) {
-        const bonus = Math.round(result.finalPayout * petYieldPct / 100);
+        const remaining = Math.max(0, LIMITS.DAILY_HARD_CAP - user.hunt.dailyCoins);
+        const bonus = Math.min(Math.round(result.finalPayout * petYieldPct / 100), remaining);
         if (bonus > 0) {
             user.balance           += bonus;
             user.hunt.totalEarned  += bonus;
@@ -716,7 +701,8 @@ async function executeStart(interaction) {
 
     // Featured zone bonus: +25% payout
     if (result.success && result.finalPayout > 0 && isFeaturedZone) {
-        const featBonus = Math.round(result.finalPayout * FEATURED_PAYOUT_BONUS);
+        const remaining = Math.max(0, LIMITS.DAILY_HARD_CAP - user.hunt.dailyCoins);
+        const featBonus = Math.min(Math.round(result.finalPayout * FEATURED_PAYOUT_BONUS), remaining);
         if (featBonus > 0) {
             user.balance              += featBonus;
             user.hunt.totalEarned     += featBonus;
@@ -846,6 +832,9 @@ async function executeStart(interaction) {
 
     // ── Apex encounter — multi-phase showdown (mirrors the fishing boss UI) ──
     if (result.apexEncounter) {
+        // Pin the weapon that was actually equipped for this encounter so durability
+        // loss can't land on a different weapon if the player re-equips mid-flow.
+        const apexWeaponIndex = user.hunt.equippedWeaponIndex;
         const apexType    = rollApexType();
         const choicesMade = [];
         const phaseCount  = apexType.phases.length;
@@ -939,7 +928,7 @@ async function executeStart(interaction) {
         }
         await attachGrind(freshUser);
         ensureHuntData(freshUser);
-        const apexResult = resolveApexEncounter(freshUser, result.apexEncounter.animal, result.apexEncounter.tier, choicesMade, apexType);
+        const apexResult = resolveApexEncounter(freshUser, result.apexEncounter.animal, result.apexEncounter.tier, choicesMade, apexType, apexWeaponIndex);
 
         if (apexResult.bonusPayout > 0) {
             const apexZone = ZONES[freshUser.hunt.activeZone] ?? zone;

--- a/src/migrations/002_hunt_indexes.js
+++ b/src/migrations/002_hunt_indexes.js
@@ -7,28 +7,34 @@ module.exports = {
         const db    = mongoose.connection.db;
         const users = db.collection('users');
 
-        // Stamina regen background-service lookup — sparse is correct for a single optional field
-        await users.createIndex(
-            { 'hunt.staminaLastRegen': 1 },
-            { name: 'idx_hunt_stamina_regen', sparse: true }
-        );
-
-        // Leaderboard: only index documents that actually have hunt data
-        await users.createIndex(
-            { guildId: 1, 'hunt.totalEarned': -1 },
-            {
+        const specs = [
+            // Stamina regen background-service lookup — sparse is correct for a single optional field
+            [{ 'hunt.staminaLastRegen': 1 }, { name: 'idx_hunt_stamina_regen', sparse: true }],
+            // Leaderboard: only index documents that actually have hunt data
+            [{ guildId: 1, 'hunt.totalEarned': -1 }, {
                 name: 'idx_hunt_leaderboard_earned',
                 partialFilterExpression: { 'hunt.totalEarned': { $exists: true } }
-            }
-        );
-
-        await users.createIndex(
-            { guildId: 1, 'hunt.legendaryKills': -1 },
-            {
+            }],
+            [{ guildId: 1, 'hunt.legendaryKills': -1 }, {
                 name: 'idx_hunt_leaderboard_legendary',
                 partialFilterExpression: { 'hunt.legendaryKills': { $exists: true } }
+            }]
+        ];
+
+        const created = [];
+        try {
+            for (const [keys, opts] of specs) {
+                await users.createIndex(keys, opts);
+                created.push(opts.name);
             }
-        );
+        } catch (err) {
+            // Index creation isn't transactional — roll back whatever this run
+            // already created so a failed migration doesn't leave partial state.
+            for (const name of created) {
+                await users.dropIndex(name).catch(() => {});
+            }
+            throw err;
+        }
     },
 
     async down() {

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -598,12 +598,11 @@ function activateConsumable(user, consumableId) {
         h.consumables[consumableId] -= 1;
         h.activeXpScroll = true;
     } else if (def.type === 'stamina') {
-        // Reset tonic day if needed
-        const now = Date.now();
-        const tonicWindowOk = h.lastTonicDayReset && (now - h.lastTonicDayReset.getTime() < LIMITS.DAILY_WINDOW_MS);
-        if (!tonicWindowOk) {
+        // Tonic count tracks the same rolling window as the rest of the daily
+        // counters (h.dailyWindowStart), so it can't desync from applyDailyReset.
+        if (!h.lastTonicDayReset || (h.dailyWindowStart && h.lastTonicDayReset.getTime() < h.dailyWindowStart.getTime())) {
             h.staminaTonicsToday = 0;
-            h.lastTonicDayReset  = new Date(now);
+            h.lastTonicDayReset  = h.dailyWindowStart ? new Date(h.dailyWindowStart.getTime()) : new Date();
         }
         if (h.staminaTonicsToday >= LIMITS.STAMINA_TONICS_PER_DAY) {
             return { success: false, error: `You've already used ${LIMITS.STAMINA_TONICS_PER_DAY} Stamina Tonics today.` };
@@ -1046,8 +1045,9 @@ function resolveApexPhases(apexType, choicesMade) {
  * Resolve the final apex outcome after all phases.
  * Returns { outcome, bonusPayout, durabilityLost, correctCount, phaseResults, apexType, message }
  */
-function resolveApexEncounter(user, animal, tier, choicesMade, apexType) {
-    const weapon = user.hunt?.weapons[user.hunt.equippedWeaponIndex];
+function resolveApexEncounter(user, animal, tier, choicesMade, apexType, weaponIndex) {
+    const idx    = weaponIndex ?? user.hunt.equippedWeaponIndex;
+    const weapon = user.hunt?.weapons[idx];
     const at     = apexType ?? rollApexType();
     const { phaseResults, nerve } = resolveApexPhases(at, choicesMade);
 

--- a/tests/huntService.test.js
+++ b/tests/huntService.test.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const {
+    applyPayoutModifiers,
+    applyDailyReset,
+    activateConsumable,
+    resolveApexEncounter,
+    calculateSuccessChance,
+} = require('../src/services/huntService');
+const { ZONES, LIMITS } = require('../src/data/huntData');
+
+function makeUser(huntOverrides = {}) {
+    return {
+        hunt: {
+            level: 1,
+            prestige: 0,
+            dailyCoins: 0,
+            dailyHunts: 0,
+            consecutiveFails: 0,
+            activeBait: null,
+            activeCharm: null,
+            activeFocus: false,
+            staminaTonicsToday: 0,
+            lastTonicDayReset: null,
+            dailyWindowStart: null,
+            consumables: { stamina_tonic: 5 },
+            weapons: [{ tier: 1, currentDurability: 80, maxDurability: 80, baseDurability: 80, upgrade: null }],
+            equippedWeaponIndex: 0,
+            stamina: 5,
+            ...huntOverrides,
+        },
+        markModified: () => {},
+    };
+}
+
+const zone = ZONES.beginner_forest;
+
+describe('applyPayoutModifiers', () => {
+    test('never pushes dailyCoins past the hard cap', () => {
+        const user = makeUser({ dailyCoins: LIMITS.DAILY_HARD_CAP - 1 });
+        const { adjustedPayout } = applyPayoutModifiers(user, 50_000, zone);
+        expect(adjustedPayout).toBeLessThanOrEqual(1);
+    });
+
+    test('returns zero once dailyCoins is at or above the hard cap', () => {
+        const user = makeUser({ dailyCoins: LIMITS.DAILY_HARD_CAP });
+        const { adjustedPayout, cappedByHard } = applyPayoutModifiers(user, 1000, zone);
+        expect(adjustedPayout).toBe(0);
+        expect(cappedByHard).toBe(true);
+    });
+});
+
+describe('calculateSuccessChance', () => {
+    test('is clamped within [0.10, 0.95] even under extreme inputs', () => {
+        const user = makeUser({ level: 1, consecutiveFails: 0 });
+        const brokenWeapon = { tier: 1, currentDurability: 0, maxDurability: 80, baseDurability: 80, upgrade: null };
+        const chance = calculateSuccessChance(user, brokenWeapon, zone);
+        expect(chance).toBeGreaterThanOrEqual(0.10);
+        expect(chance).toBeLessThanOrEqual(0.95);
+    });
+});
+
+describe('daily reset / stamina tonic window sync', () => {
+    test('activateConsumable does not grant extra tonic uses once the daily window rolls over', () => {
+        const now = Date.now();
+        const user = makeUser({
+            dailyWindowStart: new Date(now - LIMITS.DAILY_WINDOW_MS - 1000),
+            lastTonicDayReset: new Date(now - LIMITS.DAILY_WINDOW_MS - 1000),
+            staminaTonicsToday: LIMITS.STAMINA_TONICS_PER_DAY,
+            stamina: 0,
+        });
+
+        // Daily window has expired; applyDailyReset resets both clocks together.
+        applyDailyReset(user);
+        expect(user.hunt.staminaTonicsToday).toBe(0);
+
+        const result = activateConsumable(user, 'stamina_tonic');
+        expect(result.success).toBe(true);
+        expect(user.hunt.staminaTonicsToday).toBe(1);
+    });
+
+    test('activateConsumable does not silently reset the tonic count mid-window', () => {
+        const user = makeUser({
+            dailyWindowStart: new Date(),
+            lastTonicDayReset: new Date(),
+            staminaTonicsToday: LIMITS.STAMINA_TONICS_PER_DAY,
+            stamina: 0,
+        });
+
+        const result = activateConsumable(user, 'stamina_tonic');
+        expect(result.success).toBe(false);
+        expect(user.hunt.staminaTonicsToday).toBe(LIMITS.STAMINA_TONICS_PER_DAY);
+    });
+});
+
+describe('resolveApexEncounter', () => {
+    test('applies durability loss to the pinned weaponIndex, not whatever is currently equipped', () => {
+        const user = makeUser({
+            weapons: [
+                { tier: 1, currentDurability: 80, maxDurability: 80, baseDurability: 80, upgrade: null },
+                { tier: 2, currentDurability: 80, maxDurability: 80, baseDurability: 80, upgrade: null },
+            ],
+            equippedWeaponIndex: 1, // player re-equipped after the encounter started
+        });
+        const animal = { payoutMin: 100, payoutMax: 200, emoji: '🦌', name: 'Deer' };
+        const apexType = { name: 'Apex', emoji: '⚔️', phases: [{ correct: 'match' }, { correct: 'hold' }] };
+
+        resolveApexEncounter(user, animal, 'rare', ['match', 'hold'], apexType, 0);
+
+        expect(user.hunt.weapons[0].currentDurability).toBeLessThan(80);
+        expect(user.hunt.weapons[1].currentDurability).toBe(80);
+    });
+});


### PR DESCRIPTION
## Summary
This PR fixes several issues with the hunt system's daily coin cap enforcement and apex encounter weapon durability tracking, while also improving code organization and test coverage.

## Key Changes

- **Daily cap enforcement for bonuses**: Pet yield and featured zone bonuses now respect the daily hard cap by clamping their contribution to remaining available coins, preventing players from exceeding `LIMITS.DAILY_HARD_CAP`

- **Apex weapon durability fix**: Apex encounters now pin the weapon index at encounter start, ensuring durability loss applies to the correct weapon even if the player re-equips during the multi-phase encounter

- **Stamina tonic window sync**: Fixed `activateConsumable` to synchronize the tonic daily reset with `applyDailyReset` using `dailyWindowStart`, preventing desync where tonics could be used outside their intended daily window

- **Code organization**: Moved `MATERIAL_NAMES` constant from `hunt.js` to `huntData.js` for better data/logic separation

- **Migration robustness**: Enhanced `002_hunt_indexes.js` to roll back partially-created indexes on failure, preventing inconsistent database state

- **Test coverage**: Added comprehensive test suite (`huntService.test.js`) covering:
  - Daily hard cap enforcement in `applyPayoutModifiers`
  - Success chance clamping in `calculateSuccessChance`
  - Stamina tonic window synchronization across daily resets
  - Apex encounter weapon durability application to correct weapon index

## Implementation Details

The stamina tonic fix ensures that `lastTonicDayReset` is always set to the same `dailyWindowStart` value used by other daily counters, eliminating the possibility of the tonic count resetting independently and allowing extra uses mid-window.

The apex weapon index is now captured before the multi-phase encounter begins and passed through to `resolveApexEncounter`, ensuring durability loss cannot be applied to a different weapon if the player changes their equipped weapon during the encounter flow.

https://claude.ai/code/session_01Hrffu4awVe3SRvR5f5DtSq