### PR TITLE
Fix fishing escape reversions and improve randomization

### DIFF
--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -540,10 +540,16 @@ async function handleCast(interaction) {
     const marketplaceActive = isDistrictActive(guildSettings, 'marketplace');
 
     // Snapshot pre-cast reward state so we can reverse it if the fish escapes
-    const preCastBalance      = user.balance;
-    const preCastTotalEarned  = user.fishing.totalEarned;
-    const preCastDailyCoins   = user.fishing.dailyCoins;
-    const preCastSuccessful   = user.fishing.successfulCasts;
+    const preCastBalance          = user.balance;
+    const preCastTotalEarned      = user.fishing.totalEarned;
+    const preCastDailyCoins       = user.fishing.dailyCoins;
+    const preCastSuccessful       = user.fishing.successfulCasts;
+    const preCastXp               = user.fishing.xp;
+    const preCastLevel            = user.fishing.level;
+    const preCastLegendaryCatches = user.fishing.legendaryCatches;
+    const preCastEventCatches     = user.fishing.eventCatches;
+    const preCastBestPayout       = user.fishing.bestPayout;
+    const preCastMaterials        = JSON.parse(JSON.stringify(user.fishing.materials ?? {}));
     const preCastPersonalBest = user.fishing.personalBest
         ? JSON.parse(JSON.stringify(user.fishing.personalBest))
         : null;
@@ -593,23 +599,34 @@ async function handleCast(interaction) {
 
         if (!reelPressed) {
             if (cfg.required) {
-                // Reverse all reward mutations — fish escapes, only stamina is spent
-                user.balance                  = preCastBalance;
-                user.fishing.totalEarned      = preCastTotalEarned;
-                user.fishing.dailyCoins       = preCastDailyCoins;
-                user.fishing.successfulCasts  = preCastSuccessful;
+                // Reverse all reward mutations — fish escapes, only stamina and rod durability are spent
+                user.balance                   = preCastBalance;
+                user.fishing.totalEarned       = preCastTotalEarned;
+                user.fishing.dailyCoins        = preCastDailyCoins;
+                user.fishing.successfulCasts   = preCastSuccessful;
+                user.fishing.xp                = preCastXp;
+                user.fishing.level             = preCastLevel;
+                user.fishing.legendaryCatches  = preCastLegendaryCatches;
+                user.fishing.eventCatches      = preCastEventCatches;
+                user.fishing.bestPayout        = preCastBestPayout;
+                user.fishing.materials         = preCastMaterials;
                 if (preCastPersonalBest !== null) user.fishing.personalBest = preCastPersonalBest;
+                user.markModified('fishing');
                 result.success      = false;
                 result.finalPayout  = 0;
                 result.rawPayout    = 0;
+                result.xpEarned     = 0;
+                result.levelUp      = null;
+                result.specialDrop  = null;
                 result.escaped      = true;
                 reelResult = { caught: false, icon: '💨', label: `${result.tier} fish escaped!` };
 
+                const durLine = result.durabilityLost > 0 ? ` Rod took ${result.durabilityLost} durability damage.` : '';
                 await interaction.editReply({
                     embeds: [new EmbedBuilder()
                         .setColor('#888888')
                         .setTitle('💨 It Got Away!')
-                        .setDescription(`*The ${result.fish.name} snapped the line and vanished into the depths.*\n\nStamina spent — nothing to show for it.`)
+                        .setDescription(`*The ${result.fish.name} snapped the line and vanished into the depths.*\n\nStamina spent — nothing to show for it.${durLine}`)
                         .setAuthor(authorOpts)],
                     components: [],
                 });
@@ -883,7 +900,11 @@ async function handleCast(interaction) {
         for (let i = 0; i < phaseCount; i++) {
             state = await runPhase(i, state.results, state.btn);
             if (state.timedOut) {
-                interaction.editReply({ embeds: [embed], components: [] }).catch(() => {});
+                const timeoutEmbed = new EmbedBuilder()
+                    .setColor('#1C0A00')
+                    .setTitle(`${bossType.emoji} ${bossType.name} Slipped Away`)
+                    .setDescription(`⏱️ *You hesitated too long — the ${bossType.name} broke free before you could respond.*\n\nThe base catch above still counts; no bonus boss payout was earned.`);
+                interaction.editReply({ embeds: [embed, timeoutEmbed], components: [] }).catch(() => {});
                 return;
             }
         }

--- a/src/services/fishService.js
+++ b/src/services/fishService.js
@@ -828,7 +828,11 @@ function assignDailyFishQuests(user) {
         (t.type !== 'location_casts' || f.unlockedLocations.includes(t.location))
     );
 
-    const shuffled  = eligible.slice().sort(() => Math.random() - 0.5);
+    const shuffled = eligible.slice();
+    for (let i = shuffled.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
     const toAssign  = shuffled.slice(0, DAILY_QUEST_COUNT);
     const expiresAt = new Date(now + LIMITS.DAILY_WINDOW_MS);
 


### PR DESCRIPTION
## Summary
This PR fixes critical issues with the fishing escape mechanic and improves the randomization algorithm used for daily quest assignment.

## Key Changes

- **Complete escape state reversal**: Extended the pre-cast snapshot to capture all fishing statistics (XP, level, legendary catches, event catches, best payout, and materials) so they are properly reverted when a fish escapes. Previously, only balance and basic stats were being reversed.

- **Improved escape feedback**: Updated the escape message to include rod durability damage information when applicable, giving players clearer feedback on the consequences of a failed catch.

- **Enhanced timeout handling for boss phases**: When a boss fishing phase times out, the response now displays a dedicated timeout embed alongside the base catch embed, providing better context that the player hesitated and lost the bonus payout opportunity.

- **Fixed daily quest randomization**: Replaced the naive `sort(() => Math.random() - 0.5)` shuffle with the Fisher-Yates algorithm, which provides proper uniform randomization. The previous implementation had bias issues that could skew quest distribution.

- **State management improvements**: Added explicit `markModified('fishing')` call when reverting escape state to ensure Mongoose properly tracks the nested object changes.

- **Result object cleanup**: Ensured all relevant result fields (`xpEarned`, `levelUp`, `specialDrop`) are properly reset to null/0 when a fish escapes.

## Notable Implementation Details
- The materials snapshot uses `JSON.parse(JSON.stringify())` to create a deep copy, preventing reference issues with nested objects
- The timeout embed uses the boss type's emoji and name for consistency with the fishing system's visual language

https://claude.ai/code/session_016oxXMnx6w2vkqvmiUhkFYB