### PR TITLE
Fix explore game cooldown race, reward scaling, and silent error handling

### DIFF
--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -210,6 +210,20 @@ async function handleGo(interaction) {
     const result = executeExplore(user, region, guildSettings, { coinMultiplier });
     const firstVisit = result.firstVisit;
 
+    // Commit stamina spend + cooldown timestamp now, before the (up to 20s)
+    // encounter prompt below. Otherwise a second /explore go fired while this
+    // one is still waiting on a button press reads stale DB state and slips
+    // past the cooldown/stamina gate.
+    try {
+        await user.save();
+    } catch (err) {
+        if (err.name === 'VersionError') {
+            return interaction.reply({ content: 'A simultaneous request tangled your expedition log. Try `/explore go` again.', flags: MessageFlags.Ephemeral });
+        }
+        console.error('[explore] pre-encounter save error:', err);
+        return interaction.reply({ content: 'Something went wrong writing your expedition down. Try again.', flags: MessageFlags.Ephemeral });
+    }
+
     // Staged narration: the setting-out beat, then the find
     const delay = ms => new Promise(r => setTimeout(r, ms));
     await interaction.reply({

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -287,7 +287,10 @@ async function handleGo(interaction) {
     addJournalEntry(user, region.id, result.type, summarizeResult(result, currency));
 
     // Achievements (checked against the freshly mutated user doc)
-    const newAchievements = await checkAndAward(user, guildSettings).catch(() => []);
+    const newAchievements = await checkAndAward(user, guildSettings).catch(err => {
+        console.error('[explore] checkAndAward error:', err);
+        return [];
+    });
 
     try {
         await user.save();
@@ -300,10 +303,12 @@ async function handleGo(interaction) {
     }
 
     if (newAchievements.length) {
-        announceAchievements(interaction.client, guildSettings, user, interaction.member, newAchievements).catch(() => null);
+        announceAchievements(interaction.client, guildSettings, user, interaction.member, newAchievements)
+            .catch(err => console.error('[explore] announceAchievements error:', err));
     }
     if (leveledUp) {
-        announceLevelUp(user, guildSettings, interaction.member, interaction.guild, interaction.channel).catch(() => null);
+        announceLevelUp(user, guildSettings, interaction.member, interaction.guild, interaction.channel)
+            .catch(err => console.error('[explore] announceLevelUp error:', err));
     }
 
     // Transaction audit log
@@ -336,7 +341,7 @@ async function handleGo(interaction) {
                     `*The map has fewer blank spaces tonight. The blank spaces are taking it personally.*`
                 )
                 .setTimestamp()],
-        }).catch(() => null);
+        }).catch(err => console.error('[explore] secret announce error:', err));
     }
 }
 

--- a/src/services/exploreService.js
+++ b/src/services/exploreService.js
@@ -387,7 +387,7 @@ function resolveEncounter(user, region, guildSettings, result, choice) {
             result.xp = grantXp(user, EVENT_XP.encounter_win);
         } else {
             result.outcome = 'loss';
-            const penalty = Math.min(Math.round(randInt(200, 600) * dropRate), Math.max(0, user.balance));
+            const penalty = Math.min(Math.round(randInt(200, 600) * coinMult), Math.max(0, user.balance));
             user.balance -= penalty;
             result.penalty = penalty;
             result.xp = grantXp(user, EVENT_XP.encounter_loss);


### PR DESCRIPTION
## Summary
- Save the user doc immediately after `executeExplore` (stamina spend + cooldown timestamp) instead of waiting until after the up-to-20s encounter button prompt, so a second `/explore go` fired during that window can't read stale DB state and bypass the cooldown/stamina gate.
- Make `resolveEncounter`'s loss-outcome penalty scale with region `payoutMultiplier` and the event coin multiplier (`coinMult`) instead of just `dropRateMultiplier`, matching every other payout/penalty in the file.
- Log errors in previously-silent `.catch()` handlers around `checkAndAward`, `announceAchievements`, `announceLevelUp`, and the secret announcement send, so failures there are diagnosable in production instead of disappearing.

## Test plan
- [x] `node -c` syntax check on both modified files
- [x] `npx jest tests/exploreService.test.js` — 26/26 passing
- [x] Rebased onto latest `main`, no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fpb2wEyN48GbyzSmoQ5Ho


---
_Generated by [Claude Code](https://claude.ai/code/session_016fpb2wEyN48GbyzSmoQ5Ho)_