### PR TITLE
Increase token limits and fix audit log import path

### DIFF
--- a/src/commands/community/questgen.js
+++ b/src/commands/community/questgen.js
@@ -150,7 +150,7 @@ Create a legendary quest that feels fitting for their journey so far.`;
                 history: [],
                 prompt,
                 temperature: 0.9,
-                maxTokens: 200,
+                maxTokens: 500,
             });
 
             // Strip any accidental markdown fences

--- a/src/commands/economy/forge.js
+++ b/src/commands/economy/forge.js
@@ -126,7 +126,7 @@ Respond with ONLY the JSON object. No markdown, no extra text.`;
                 history: [],
                 prompt,
                 temperature: 0.95,
-                maxTokens: 150,
+                maxTokens: 500,
             });
 
             const cleaned = raw.replace(/```json|```/gi, '').trim();

--- a/src/dashboard/lib/apiHelpers.js
+++ b/src/dashboard/lib/apiHelpers.js
@@ -23,7 +23,7 @@ function sanitizeMongoValue(value) {
 // swallowed so audit errors never block the main operation.
 async function logAuditEvent(req, guildId, action, details = null) {
     try {
-        const AuditLog = require('../models/AuditLog');
+        const AuditLog = require('../../models/AuditLog');
         await AuditLog.create({
             guildId,
             userId:    req.user?.id || 'unknown',


### PR DESCRIPTION
## Summary
This PR increases the maximum token limits for AI-generated content in quest and forge commands, and fixes an incorrect import path in the audit logging helper.

## Key Changes
- **questgen.js**: Increased `maxTokens` from 200 to 500 to allow for more detailed legendary quest descriptions
- **forge.js**: Increased `maxTokens` from 150 to 500 to provide more flexibility for item forging responses
- **apiHelpers.js**: Fixed incorrect relative import path for AuditLog model from `../models/AuditLog` to `../../models/AuditLog` to correctly resolve from the dashboard/lib directory

## Implementation Details
The token limit increases enable the AI models to generate more comprehensive and detailed responses for quest generation and item forging operations, improving content quality. The import path correction ensures the audit logging functionality properly locates the AuditLog model without relying on incorrect relative paths.

https://claude.ai/code/session_01AS5SFqPx6KhEyWQ2qCzo5x