### PR TITLE
feat: add Dynamic Pricing toggle to dashboard Economy panel

### DIFF
--- a/src/dashboard/routes/api/settings.js
+++ b/src/dashboard/routes/api/settings.js
@@ -23,7 +23,8 @@ const ALLOWED_SETTING_PARENTS = new Set([
     'dailyNews', 'dailyNewsProfiles', 'rssFeeds',
     'autoRoles', 'reactionRoles', 'analytics',
     'giveaways', 'notifications',
-    'newspaper', 'heist', 'exploration'
+    'newspaper', 'heist', 'exploration',
+    'dynamicPricing'
 ]);
 
 function isAllowedSettingKey(key) {
@@ -225,6 +226,30 @@ function validateExplorationUpdate(updates) {
     return null;
 }
 
+function validateDynamicPricingUpdate(updates) {
+    for (const [key, value] of Object.entries(updates)) {
+        if (!key.startsWith('dynamicPricing.') && key !== 'dynamicPricing') continue;
+        const field = key.split('.')[1];
+        if (field === 'enabled') {
+            if (typeof value !== 'boolean') return 'dynamicPricing.enabled must be a boolean';
+        }
+        if (field === 'volatility') {
+            if (!['low', 'medium', 'high'].includes(value)) return "dynamicPricing.volatility must be 'low', 'medium', or 'high'";
+        }
+        if (field === 'priceBand') {
+            if (typeof value !== 'number' || !Number.isFinite(value) || value < 0.05 || value > 0.9) {
+                return 'dynamicPricing.priceBand must be a number between 0.05 and 0.9';
+            }
+        }
+        if (field === 'recalcMinutes') {
+            if (typeof value !== 'number' || !Number.isInteger(value) || value < 15 || value > 1440) {
+                return 'dynamicPricing.recalcMinutes must be an integer between 15 and 1440';
+            }
+        }
+    }
+    return null;
+}
+
 function validateHeistUpdate(updates) {
     for (const [key, value] of Object.entries(updates)) {
         if (!key.startsWith('heist.') && key !== 'heist') continue;
@@ -267,6 +292,9 @@ router.post('/guild/:guildId/settings', checkAuth, checkGuildAccess, checkCsrfOr
 
     const newspaperError = validateNewspaperUpdate(updates);
     if (newspaperError) return res.status(400).json({ error: newspaperError });
+
+    const dynamicPricingError = validateDynamicPricingUpdate(updates);
+    if (dynamicPricingError) return res.status(400).json({ error: dynamicPricingError });
 
     const heistError = validateHeistUpdate(updates);
     if (heistError) return res.status(400).json({ error: heistError });

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -1148,6 +1148,15 @@
                     'heist.jailDurationMinutes':   safeInt('heist-jail', 30),
                     'heist.maxPayout':             safeInt('heist-max-payout', 10000),
                 };
+            } else if (section === 'dynamicPricing') {
+                const bandPct = parseFloat(document.getElementById('dynamic-pricing-band').value);
+                const recalc  = parseInt(document.getElementById('dynamic-pricing-recalc').value, 10);
+                data = {
+                    'dynamicPricing.enabled':       document.getElementById('dynamic-pricing-enabled').checked,
+                    'dynamicPricing.volatility':    document.getElementById('dynamic-pricing-volatility').value,
+                    'dynamicPricing.priceBand':     Number.isFinite(bandPct) ? Math.min(0.9, Math.max(0.05, bandPct / 100)) : 0.5,
+                    'dynamicPricing.recalcMinutes': Number.isFinite(recalc)  ? Math.min(1440, Math.max(15, recalc))          : 60
+                };
             } else if (section === 'exploration') {
                 const safeFloat = (id, fallback, min, max) => {
                     const v = parseFloat(document.getElementById(id).value);

--- a/src/dashboard/views/partials/panels/economy.ejs
+++ b/src/dashboard/views/partials/panels/economy.ejs
@@ -12,6 +12,7 @@
                         <button class="ai-inner-tab eco-inner-tab" data-eco-tab="eco-tab-fish">🎣 Fishing</button>
                         <button class="ai-inner-tab eco-inner-tab" data-eco-tab="eco-tab-mine">⛏️ Mining</button>
                         <button class="ai-inner-tab eco-inner-tab" data-eco-tab="eco-tab-heist">🎭 Heist</button>
+                        <button class="ai-inner-tab eco-inner-tab" data-eco-tab="eco-tab-dynamic-pricing">📈 Dynamic Pricing</button>
                         <button class="ai-inner-tab eco-inner-tab" data-eco-tab="eco-tab-health">📊 Economy Health</button>
                     </div>
 
@@ -160,6 +161,50 @@
 
                         <div class="actions-row">
                             <button class="btn btn-primary" onclick="saveSettings('economy')">Save changes</button>
+                        </div>
+                    </div>
+
+                    <!-- Dynamic Pricing -->
+                    <div id="eco-tab-dynamic-pricing" class="ai-inner-panel">
+                        <div class="panel-head">
+                            <h3>📈 Dynamic Pricing</h3>
+                            <p>Let shop item prices fluctuate automatically based on member demand. Prices drift up when items are bought and decay when idle.</p>
+                        </div>
+
+                        <label class="toggle">
+                            <span class="toggle-text"><strong>Enable dynamic pricing</strong><span>Item prices adjust automatically based on purchase demand</span></span>
+                            <span class="switch"><input type="checkbox" id="dynamic-pricing-enabled" <%= settings.dynamicPricing?.enabled ? 'checked' : '' %>><span class="slider"></span></span>
+                        </label>
+
+                        <div class="field" style="margin-top:1rem">
+                            <label class="field-label" for="dynamic-pricing-volatility">Volatility</label>
+                            <select id="dynamic-pricing-volatility">
+                                <option value="low"    <%= (settings.dynamicPricing?.volatility ?? 'medium') === 'low'    ? 'selected' : '' %>>Low — gentle swings (±10%)</option>
+                                <option value="medium" <%= (settings.dynamicPricing?.volatility ?? 'medium') === 'medium' ? 'selected' : '' %>>Medium — moderate swings (±18%)</option>
+                                <option value="high"   <%= (settings.dynamicPricing?.volatility ?? 'medium') === 'high'   ? 'selected' : '' %>>High — aggressive swings (±28%)</option>
+                            </select>
+                            <small>Controls how sharply prices respond to demand changes</small>
+                        </div>
+
+                        <div class="field" style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;margin-top:.5rem">
+                            <div>
+                                <label class="field-label" for="dynamic-pricing-band">Price band <small>(5%–90%)</small></label>
+                                <input type="number" id="dynamic-pricing-band"
+                                    value="<%= Math.round((settings.dynamicPricing?.priceBand ?? 0.5) * 100) %>"
+                                    min="5" max="90" step="1">
+                                <small>Maximum % a price can deviate from its base price</small>
+                            </div>
+                            <div>
+                                <label class="field-label" for="dynamic-pricing-recalc">Recalc interval <small>(minutes, 15–1440)</small></label>
+                                <input type="number" id="dynamic-pricing-recalc"
+                                    value="<%= settings.dynamicPricing?.recalcMinutes ?? 60 %>"
+                                    min="15" max="1440">
+                                <small>How often the scheduler recalculates prices</small>
+                            </div>
+                        </div>
+
+                        <div class="actions-row">
+                            <button class="btn btn-primary" onclick="saveSettings('dynamicPricing')">Save changes</button>
                         </div>
                     </div>
 


### PR DESCRIPTION
- Add 'dynamicPricing' to ALLOWED_SETTING_PARENTS whitelist so the API
  accepts saves (previously any save attempt was rejected with 400)
- Add validateDynamicPricingUpdate() with field-level validation for
  enabled (bool), volatility (enum), priceBand (0.05–0.9), and
  recalcMinutes (15–1440)
- Add 'Dynamic Pricing' inner tab to the Economy panel with toggle,
  volatility selector, price band %, and recalc interval inputs
- Wire saveSettings('dynamicPricing') in guild-settings.ejs to POST
  all four fields to the settings API

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PwU9rBdJppZctmw6yc5qVU