### PR TITLE
fix: wire up dead economy and streak quest hooks

### DIFF
--- a/src/commands/economy/daily.js
+++ b/src/commands/economy/daily.js
@@ -353,14 +353,14 @@ module.exports = {
             });
 
             // Quest progress for coins earned from today's claim
-            await ensureQuests(updated, guildSettings);
-            let questsDone = [], questsNear = [];
-            if (actualAmount > 0) {
-                const earn = await onEconomyEarn(updated, guildSettings, actualAmount);
-                questsDone = earn.completed;
-                questsNear = earn.nearComplete;
-            }
             try {
+                await ensureQuests(updated, guildSettings);
+                let questsDone = [], questsNear = [];
+                if (actualAmount > 0) {
+                    const earn = await onEconomyEarn(updated, guildSettings, actualAmount);
+                    questsDone = earn.completed;
+                    questsNear = earn.nearComplete;
+                }
                 await updated.save();
                 if (questsDone.length || questsNear.length) {
                     notifyQuestComplete(guildSettings, interaction.member, questsDone, interaction.channel, updated).catch(() => null);

--- a/src/commands/economy/daily.js
+++ b/src/commands/economy/daily.js
@@ -11,6 +11,7 @@ const { stackBar } = require('../../utils/rewardReveal');
 const { buildCooldownEmbed, getNextStreakMilestone } = require('../../utils/cooldownEmbed');
 const { getTimeBand } = require('../../utils/timeBand');
 const { claimStarterKit } = require('../../utils/starterKit');
+const { ensureQuests, onEconomyEarn, notifyQuestComplete, notifyQuestNearComplete } = require('../../services/questService');
 
 function getStreakColor(streak) {
     if (streak >= 100) return '#9b59b6';
@@ -351,6 +352,24 @@ module.exports = {
                 note: `streak ${user.streak?.current ?? 0}, mult ${combined.toFixed(2)}${capActive ? ' (capped)' : ''}`
             });
 
+            // Quest progress for coins earned from today's claim
+            await ensureQuests(updated, guildSettings);
+            let questsDone = [], questsNear = [];
+            if (actualAmount > 0) {
+                const earn = await onEconomyEarn(updated, guildSettings, actualAmount);
+                questsDone = earn.completed;
+                questsNear = earn.nearComplete;
+            }
+            try {
+                await updated.save();
+                if (questsDone.length || questsNear.length) {
+                    notifyQuestComplete(guildSettings, interaction.member, questsDone, interaction.channel, updated).catch(() => null);
+                    notifyQuestNearComplete(guildSettings, interaction.member, questsNear, interaction.channel).catch(() => null);
+                }
+            } catch (err) {
+                console.error('[daily] quest save error:', err);
+            }
+
             // ── Item Drop Check ───────────────────────────────────────────────────
             const streakCurrent = user.streak?.current ?? 0;
             const claimedDropMilestones = new Set(user.streak?.claimedDropMilestones ?? []);
@@ -531,6 +550,20 @@ module.exports = {
                         balance: bonusUpdated?.balance ?? updated.balance + bonusAmount,
                         note: `daily challenge bonus (${challenge.type})`,
                     });
+
+                    if (bonusUpdated && bonusAmount > 0) {
+                        await ensureQuests(bonusUpdated, guildSettings);
+                        const bonusEarn = await onEconomyEarn(bonusUpdated, guildSettings, bonusAmount);
+                        try {
+                            await bonusUpdated.save();
+                            if (bonusEarn.completed.length || bonusEarn.nearComplete.length) {
+                                notifyQuestComplete(guildSettings, interaction.member, bonusEarn.completed, interaction.channel, bonusUpdated).catch(() => null);
+                                notifyQuestNearComplete(guildSettings, interaction.member, bonusEarn.nearComplete, interaction.channel).catch(() => null);
+                            }
+                        } catch (err) {
+                            console.error('[daily] challenge bonus quest save error:', err);
+                        }
+                    }
 
                     const finalBalance = bonusUpdated?.balance ?? updated.balance + bonusAmount;
                     rewardEmbed.setDescription(

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -28,6 +28,7 @@ const {
     formatMs,
 } = require('../../services/exploreService');
 const { checkAndAward, announceAchievements } = require('../../services/achievementService');
+const { ensureQuests, onEconomyEarn, notifyQuestComplete, notifyQuestNearComplete } = require('../../services/questService');
 const { applyXpGain, announceLevelUp } = require('../../utils/applyXpGain');
 const {
     getEventXpMultiplier, getEventCoinMultiplier,
@@ -292,6 +293,14 @@ async function handleGo(interaction) {
         return [];
     });
 
+    await ensureQuests(user, guildSettings);
+    let questsDone = [], questsNear = [];
+    if (result.payout > 0) {
+        const earn = await onEconomyEarn(user, guildSettings, result.payout);
+        questsDone = earn.completed;
+        questsNear = earn.nearComplete;
+    }
+
     try {
         await user.save();
     } catch (err) {
@@ -305,6 +314,10 @@ async function handleGo(interaction) {
     if (newAchievements.length) {
         announceAchievements(interaction.client, guildSettings, user, interaction.member, newAchievements)
             .catch(err => console.error('[explore] announceAchievements error:', err));
+    }
+    if (questsDone.length || questsNear.length) {
+        notifyQuestComplete(guildSettings, interaction.member, questsDone, interaction.channel, user).catch(() => null);
+        notifyQuestNearComplete(guildSettings, interaction.member, questsNear, interaction.channel).catch(() => null);
     }
     if (leveledUp) {
         announceLevelUp(user, guildSettings, interaction.member, interaction.guild, interaction.channel)

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -58,7 +58,7 @@ const { getTimeBand } = require('../../utils/timeBand');
 const { logBigWin } = require('../../utils/bigWinLogger');
 const { tryUpdateHourlyWinner, getCurrentHourlyLeader } = require('../../utils/hourlyWinner');
 const { isDistrictActive } = require('../../services/districtService');
-const { ensureQuests, onFish, notifyQuestComplete, notifyQuestNearComplete } = require('../../services/questService');
+const { ensureQuests, onFish, onEconomyEarn, notifyQuestComplete, notifyQuestNearComplete } = require('../../services/questService');
 const { getActiveSynergies } = require('../../services/synergyService');
 const { hasActiveEvent, getEventCrossSystemType } = require('../../services/seasonalEventService');
 
@@ -729,6 +729,11 @@ async function handleCast(interaction) {
     updateFishQuestProgress(user, result, locationId);
     await ensureQuests(user, guildSettings);
     const { completed: questsDone, nearComplete: questsNear } = await onFish(user, guildSettings);
+    if (result.success && result.finalPayout > 0) {
+        const earn = await onEconomyEarn(user, guildSettings, result.finalPayout);
+        questsDone.push(...earn.completed);
+        questsNear.push(...earn.nearComplete);
+    }
 
     const fishAchievements = await checkAndAward(user, guildSettings).catch(() => []);
 

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -920,6 +920,7 @@ async function handleCast(interaction) {
         ensureFishingData(freshUser);
         const bossResult = resolveBossEncounter(freshUser, result.bossEncounter.fish, result.bossEncounter.tier, choicesMade, bossType);
 
+        let bossQuestsDone = [], bossQuestsNear = [];
         if (bossResult.bonusPayout > 0) {
             const bossLocation = LOCATIONS[freshUser.fishing.activeLocation] ?? location;
             const { adjustedPayout } = applyPayoutModifiers(freshUser, bossResult.bonusPayout, bossLocation);
@@ -928,10 +929,19 @@ async function handleCast(interaction) {
             freshUser.fishing.totalEarned     += adjustedPayout;
             freshUser.fishing.dailyCoins      += adjustedPayout;
             if (adjustedPayout > freshUser.fishing.bestPayout) freshUser.fishing.bestPayout = adjustedPayout;
+
+            await ensureQuests(freshUser, guildSettings);
+            const earn = await onEconomyEarn(freshUser, guildSettings, adjustedPayout);
+            bossQuestsDone = earn.completed;
+            bossQuestsNear = earn.nearComplete;
         }
         freshUser.markModified('fishing');
         try {
             await freshUser.save();
+            if (bossQuestsDone.length || bossQuestsNear.length) {
+                notifyQuestComplete(guildSettings, interaction.member, bossQuestsDone, interaction.channel, freshUser).catch(() => null);
+                notifyQuestNearComplete(guildSettings, interaction.member, bossQuestsNear, interaction.channel).catch(() => null);
+            }
         } catch (saveErr) {
             console.error('[fish boss] save error:', saveErr);
             return state.btn.update({ content: 'Something went wrong saving your boss result. Please try again.', embeds: [], components: [] });

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -935,6 +935,7 @@ async function executeStart(interaction) {
         ensureHuntData(freshUser);
         const apexResult = resolveApexEncounter(freshUser, result.apexEncounter.animal, result.apexEncounter.tier, choicesMade, apexType, apexWeaponIndex);
 
+        let apexQuestsDone = [], apexQuestsNear = [];
         if (apexResult.bonusPayout > 0) {
             const apexZone = ZONES[freshUser.hunt.activeZone] ?? zone;
             const { adjustedPayout } = applyPayoutModifiers(freshUser, apexResult.bonusPayout, apexZone);
@@ -943,10 +944,19 @@ async function executeStart(interaction) {
             freshUser.hunt.totalEarned += adjustedPayout;
             freshUser.hunt.dailyCoins  += adjustedPayout;
             if (adjustedPayout > freshUser.hunt.bestPayout) freshUser.hunt.bestPayout = adjustedPayout;
+
+            await ensureQuests(freshUser, guildSettings);
+            const earn = await onEconomyEarn(freshUser, guildSettings, adjustedPayout);
+            apexQuestsDone = earn.completed;
+            apexQuestsNear = earn.nearComplete;
         }
         freshUser.markModified('hunt');
         try {
             await freshUser.save();
+            if (apexQuestsDone.length || apexQuestsNear.length) {
+                notifyQuestComplete(guildSettings, interaction.member, apexQuestsDone, interaction.channel, freshUser).catch(() => null);
+                notifyQuestNearComplete(guildSettings, interaction.member, apexQuestsNear, interaction.channel).catch(() => null);
+            }
         } catch (saveErr) {
             console.error('[hunt apex] save error:', saveErr);
             return state.btn.update({ content: 'Something went wrong saving your apex result — the encounter is lost and cannot be retried. Your original hunt rewards were already saved.', embeds: [], components: [] }).catch(() => {});

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -52,7 +52,7 @@ const { getTimeBand } = require('../../utils/timeBand');
 const { logBigWin } = require('../../utils/bigWinLogger');
 const { tryUpdateHourlyWinner, getCurrentHourlyLeader } = require('../../utils/hourlyWinner');
 const { isDistrictActive } = require('../../services/districtService');
-const { ensureQuests, onHunt, notifyQuestComplete, notifyQuestNearComplete } = require('../../services/questService');
+const { ensureQuests, onHunt, onEconomyEarn, notifyQuestComplete, notifyQuestNearComplete } = require('../../services/questService');
 const { getActiveSynergies } = require('../../services/synergyService');
 
 const WILDERNESS_YIELD_BONUS = 0.10;
@@ -730,6 +730,11 @@ async function executeStart(interaction) {
     updateHuntQuestProgress(user, result, zoneId);
     await ensureQuests(user, guildSettings);
     const { completed: questsDone, nearComplete: questsNear } = await onHunt(user, guildSettings);
+    if (result.success && result.finalPayout > 0) {
+        const earn = await onEconomyEarn(user, guildSettings, result.finalPayout);
+        questsDone.push(...earn.completed);
+        questsNear.push(...earn.nearComplete);
+    }
 
     const huntAchievements = await checkAndAward(user, guildSettings).catch(() => []);
 

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -48,7 +48,7 @@ const { getTimeBand } = require('../../utils/timeBand');
 const { logBigWin } = require('../../utils/bigWinLogger');
 const { tryUpdateHourlyWinner, getCurrentHourlyLeader } = require('../../utils/hourlyWinner');
 const { isDistrictActive } = require('../../services/districtService');
-const { ensureQuests, onMine, notifyQuestComplete, notifyQuestNearComplete } = require('../../services/questService');
+const { ensureQuests, onMine, onEconomyEarn, notifyQuestComplete, notifyQuestNearComplete } = require('../../services/questService');
 const { getActiveSynergies } = require('../../services/synergyService');
 const { CROSS_CONSUMABLES } = require('../../data/crossSystemData');
 
@@ -650,6 +650,11 @@ async function handleDig(interaction) {
 
     await ensureQuests(user, guildSettings);
     const { completed: questsDone, nearComplete: questsNear } = await onMine(user, guildSettings);
+    if (result.success && result.finalPayout > 0) {
+        const earn = await onEconomyEarn(user, guildSettings, result.finalPayout);
+        questsDone.push(...earn.completed);
+        questsNear.push(...earn.nearComplete);
+    }
 
     const mineAchievements = await checkAndAward(user, guildSettings).catch(() => []);
 

--- a/src/commands/economy/work.js
+++ b/src/commands/economy/work.js
@@ -335,9 +335,10 @@ module.exports = {
                         exceptionalChallenge = elapsed <= 5000;
                         const bonusRate = exceptionalChallenge ? 0.55 : 0.40;
                         bonusEarned = Math.round(earned * bonusRate);
-                        await User.findOneAndUpdate(
+                        const bonusUpdated = await User.findOneAndUpdate(
                             { userId: interaction.user.id, guildId: interaction.guild.id },
-                            { $inc: { balance: bonusEarned } }
+                            { $inc: { balance: bonusEarned } },
+                            { new: true }
                         );
                         logTransaction({
                             userId: interaction.user.id,
@@ -347,6 +348,20 @@ module.exports = {
                             balance: updated.balance + bonusEarned,
                             note: `work challenge bonus (${challenge.type}${exceptionalChallenge ? ', fast' : ''}) for ${job.name}`,
                         });
+
+                        if (bonusUpdated && bonusEarned > 0) {
+                            try {
+                                await ensureQuests(bonusUpdated, guildSettings);
+                                const earn = await onEconomyEarn(bonusUpdated, guildSettings, bonusEarned);
+                                await bonusUpdated.save();
+                                if (earn.completed.length || earn.nearComplete.length) {
+                                    notifyQuestComplete(guildSettings, interaction.member, earn.completed, interaction.channel, bonusUpdated).catch(() => null);
+                                    notifyQuestNearComplete(guildSettings, interaction.member, earn.nearComplete, interaction.channel).catch(() => null);
+                                }
+                            } catch (err) {
+                                console.error('[work] challenge bonus quest save error:', err);
+                            }
+                        }
                     }
                 } catch {
                     // timed out — base payout already secured

--- a/src/commands/economy/work.js
+++ b/src/commands/economy/work.js
@@ -12,6 +12,7 @@ const { getTotalBonus } = require('../../services/petService');
 const { randomFrom, WORK_ROUGH_LINES, WORK_EXCEPTIONAL_LINES } = require('../../utils/copyLines');
 const { stackBar } = require('../../utils/rewardReveal');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
+const { ensureQuests, onEconomyEarn, notifyQuestComplete, notifyQuestNearComplete } = require('../../services/questService');
 
 function resolveTiers(guildSettings) {
     const saved = guildSettings?.jobTiers;
@@ -253,6 +254,24 @@ module.exports = {
                 balance: updated.balance,
                 note: `${job.name} (${performance.label})${capActive ? ', mult capped' : ''}${challengeFires ? ', challenge' : ''}`
             });
+
+            // Quest progress for coins earned this shift
+            let questsDone = [], questsNear = [];
+            await ensureQuests(updated, guildSettings);
+            if (finalEarned > 0) {
+                const earn = await onEconomyEarn(updated, guildSettings, finalEarned);
+                questsDone = earn.completed;
+                questsNear = earn.nearComplete;
+            }
+            try {
+                await updated.save();
+                if (questsDone.length || questsNear.length) {
+                    notifyQuestComplete(guildSettings, interaction.member, questsDone, interaction.channel, updated).catch(() => null);
+                    notifyQuestNearComplete(guildSettings, interaction.member, questsNear, interaction.channel).catch(() => null);
+                }
+            } catch (err) {
+                console.error('[work] quest save error:', err);
+            }
 
             const nextTier = tierInfo.find(t => t.minShifts > updated.shiftsWorked);
             const promotedTo = tierInfo.find(t => t.minShifts === updated.shiftsWorked);

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -4,7 +4,7 @@ const Case = require('../models/Case');
 const Reminder = require('../models/Reminder');
 const { handleAIChat } = require('../services/aiService');
 const { logModeration } = require('../utils/logger');
-const { ensureQuests, onMessage, notifyQuestComplete, notifyQuestNearComplete, notifyDailyQuestReset } = require('../services/questService');
+const { ensureQuests, onMessage, onStreakUpdate, notifyQuestComplete, notifyQuestNearComplete, notifyDailyQuestReset } = require('../services/questService');
 const { getStreakMultiplier, checkNewMilestones } = require('../utils/streakMultiplier');
 const { hasEffect, consumeEffect, getXpMultiplier, getServerXpMultiplier } = require('../services/effectsService');
 const { checkRivalry } = require('../services/rivalryService');
@@ -188,6 +188,9 @@ async function handleStreakAndQuests(message, guildSettings, existingUser = null
         // Quest progress
         const { assignedNewDaily } = await ensureQuests(user, guildSettings);
         const { completed: completedQuests, nearComplete: nearCompleteQuests } = await onMessage(user, guildSettings);
+        const streakQuests = await onStreakUpdate(user, guildSettings);
+        completedQuests.push(...streakQuests.completed);
+        nearCompleteQuests.push(...streakQuests.nearComplete);
 
         const newlyEarned = await checkAndAward(user, guildSettings).catch(() => []);
 

--- a/src/services/questService.js
+++ b/src/services/questService.js
@@ -421,8 +421,10 @@ async function onStreakUpdate(user, guildSettings) {
             continue;
         }
 
-        // Fire near-complete exactly once: when crossing the 80% threshold
-        const threshold = Math.ceil(def.target * 0.8);
+        // Fire near-complete exactly once: when crossing the 80% threshold.
+        // Clamped below target so small targets (e.g. 3) can't make the
+        // threshold equal the target, which would make this branch unreachable.
+        const threshold = Math.min(Math.ceil(def.target * 0.8), def.target - 1);
         if (entry.progress >= threshold && prevProgress < threshold) {
             nearComplete.push(def);
         }

--- a/src/services/questService.js
+++ b/src/services/questService.js
@@ -411,17 +411,20 @@ async function onStreakUpdate(user, guildSettings) {
         if (!def) continue;
         const entry = user.quests?.find(q => q.questId === questId && !q.completedAt && q.expiresAt > new Date());
         if (!entry) continue;
-        if (streak >= def.target) {
-            if (entry.progress < def.target) {
-                entry.progress    = def.target;
-                entry.completedAt = new Date();
-                completed.push(await awardQuest(user, def, guildSettings));
-            }
-        } else {
-            const threshold = Math.ceil(def.target * 0.8);
-            if (streak >= threshold && entry.progress < def.target) {
-                nearComplete.push(def);
-            }
+
+        const prevProgress = entry.progress || 0;
+        entry.progress = Math.min(streak, def.target);
+
+        if (entry.progress >= def.target) {
+            entry.completedAt = new Date();
+            completed.push(await awardQuest(user, def, guildSettings));
+            continue;
+        }
+
+        // Fire near-complete exactly once: when crossing the 80% threshold
+        const threshold = Math.ceil(def.target * 0.8);
+        if (entry.progress >= threshold && prevProgress < threshold) {
+            nearComplete.push(def);
         }
     }
     return { completed, nearComplete };


### PR DESCRIPTION
Hustler (weekly_economy_500) and every other economy-category quest
(Coin Collector, Money Grubber, High Roller) could never progress —
questService.onEconomyEarn existed but was never called from any
command, so coin income never counted toward them. Likewise
onStreakUpdate (weekly_streak_3/5) was defined but never invoked.

Wire onEconomyEarn into the commands that grant coins through
legitimate play (work, daily + its challenge bonus, hunt, fish, mine,
explore), and call onStreakUpdate from the message-activity streak
handler. Also fix onStreakUpdate to track real progress and fire its
near-complete notice only once per crossing, instead of re-firing on
every message once the streak passes the 80% threshold.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily, work, explore, fish, hunt, mine, and message streak activities now contribute to quest progress.
  * Quest completion and near-completion alerts are now shown more consistently when you earn coins or build streaks.

* **Bug Fixes**
  * Improved quest progress tracking so notifications trigger at the right time and once per milestone.
  * Quest updates are now handled more reliably after rewards are granted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->