### PR TITLE
Add bulk buy support to /shop buy with quantity parameter

### DIFF
--- a/src/commands/economy/shop.js
+++ b/src/commands/economy/shop.js
@@ -386,11 +386,13 @@ module.exports = {
             const itemName = rawName.toLowerCase();
             const quantity = interaction.options.getInteger('quantity') ?? 1;
 
-            // Exact name match first (what autocomplete sends), then fall back to a
-            // partial match so a hand-typed "pet food" or "padlock" still resolves.
+            // Exact matches win — display name first (what autocomplete sends), then
+            // canonical itemId. Only then fall back to a partial name match, so a
+            // hand-typed itemId can never be shadowed by some other item that merely
+            // contains it in its display name.
             const item = guildSettings.shop.find(i => i.name.toLowerCase() === itemName)
-                ?? guildSettings.shop.find(i => i.name.toLowerCase().includes(itemName))
-                ?? guildSettings.shop.find(i => (i.itemId ?? '').toLowerCase() === itemName);
+                ?? guildSettings.shop.find(i => (i.itemId ?? '').toLowerCase() === itemName)
+                ?? guildSettings.shop.find(i => i.name.toLowerCase().includes(itemName));
 
             if (!item) {
                 return interaction.reply({ content: `Item \`${rawName}\` not found. Use \`/shop view\` to see available items.`, flags: MessageFlags.Ephemeral });
@@ -479,6 +481,23 @@ module.exports = {
                 }
                 const freshPrice = effectivePrice(freshItem, !!freshGuild.dynamicPricing?.enabled);
                 const freshTotal = freshPrice * quantity;
+
+                // A dynamic-pricing recalc can land between the quote and the charge.
+                // Never debit more than the buyer was shown — bail out and make them
+                // re-run so the new total gets quoted (and re-checked against
+                // CONFIRM_THRESHOLD) before any coins move. A price *drop* is safe to
+                // honour: they pay less than they agreed to.
+                if (freshTotal > totalCost) {
+                    return reply({
+                        content:
+                            `The price of **${freshItem.name}** changed while you were deciding — ` +
+                            `${quantity > 1 ? `${quantity}× ` : ''}now costs ${currency}${freshTotal.toLocaleString()}, ` +
+                            `not ${currency}${totalCost.toLocaleString()}. Nothing was charged; ` +
+                            `run \`/shop buy\` again to accept the new price.`,
+                        embeds: [], components: []
+                    });
+                }
+
                 if (!freshUser || freshUser.balance < freshTotal) {
                     const wanted = quantity > 1 ? ` for ${quantity}× **${freshItem.name}**` : '';
                     return reply({

--- a/src/commands/economy/shop.js
+++ b/src/commands/economy/shop.js
@@ -20,6 +20,10 @@ const { hasUnlock } = require('../../utils/prestige');
 const CONFIRM_THRESHOLD = 500;
 const NEW_ITEM_TTL_MS   = 48 * 3_600_000; // 48 hours
 
+// Upper bound on a single /shop buy. Matches the cap the hunt shop uses so the
+// two storefronts behave the same way.
+const MAX_BUY_QUANTITY = 20;
+
 const RARITY_EMOJIS = {
     Common:   '⚪',
     Uncommon: '🟢',
@@ -125,7 +129,7 @@ async function buildShopPages(guildSettings, currency, viewerPrestigeRank = 0) {
             const ep = effectivePrice(item, dynamicEnabled);
             const trendStr = dynamicEnabled ? ` ${trendBucket(item).arrow}` : '';
             return `**${i + 1}. ${item.name}** — ${currency}${ep.toLocaleString()}${trendStr} (Stock: ${stock})`;
-        }).join('\n') + `\n\n*Use /shop buy <item name> to purchase*`;
+        }).join('\n') + `\n\n*Use /shop buy <item name> [quantity] to purchase*`;
 
         pages.push({
             id:       `rarity_${rarity.toLowerCase()}`,
@@ -166,7 +170,7 @@ async function buildShopPages(guildSettings, currency, viewerPrestigeRank = 0) {
                 const ep = effectivePrice(item, dynamicEnabled);
                 return `**${i + 1}. ${item.name}** — ${currency}${ep.toLocaleString()} (Stock: ${stock})`;
             }).join('\n') +
-            `\n\n*Use /shop buy <item name> to purchase*`;
+            `\n\n*Use /shop buy <item name> [quantity] to purchase*`;
 
         pages.push({
             id:       'prestige',
@@ -201,7 +205,7 @@ async function buildShopPages(guildSettings, currency, viewerPrestigeRank = 0) {
                 const ep = effectivePrice(item, dynamicEnabled);
                 return `**${i + 1}. ${item.name}** — ${currency}${ep.toLocaleString()} (Stock: ${stock})`;
             }).join('\n') +
-            `\n\n*Use /shop buy <item name> to purchase*`;
+            `\n\n*Use /shop buy <item name> [quantity] to purchase*`;
 
         pages.push({
             id:       'black_market',
@@ -226,7 +230,13 @@ module.exports = {
         .addSubcommand(sub =>
             sub.setName('buy')
                 .setDescription('Purchase an item from the shop')
-                .addStringOption(o => o.setName('item').setDescription('Item to buy').setRequired(true).setAutocomplete(true)))
+                .addStringOption(o => o.setName('item').setDescription('Item to buy').setRequired(true).setAutocomplete(true))
+                .addIntegerOption(o =>
+                    o.setName('quantity')
+                        .setDescription(`How many to buy (default: 1, max: ${MAX_BUY_QUANTITY})`)
+                        .setRequired(false)
+                        .setMinValue(1)
+                        .setMaxValue(MAX_BUY_QUANTITY)))
         .addSubcommand(sub =>
             sub.setName('trends')
                 .setDescription('Show price movement on shop items (dynamic pricing must be enabled).'))
@@ -235,13 +245,48 @@ module.exports = {
     async autocomplete(interaction) {
         try {
             const focused = interaction.options.getFocused()?.toLowerCase() ?? '';
-            const guildSettings = await Guild.findOne({ guildId: interaction.guild.id }, 'shop').lean();
-            const items = guildSettings?.shop ?? [];
+            const [guildSettings, viewer] = await Promise.all([
+                Guild.findOne({ guildId: interaction.guild.id }, 'shop economy dynamicPricing').lean(),
+                User.findOne(
+                    { userId: interaction.user.id, guildId: interaction.guild.id },
+                    'accountPrestige'
+                ).lean(),
+            ]);
+
+            const rank = viewer?.accountPrestige?.rank ?? 0;
+            const currency = guildSettings?.economy?.currency ?? '';
+            const dynamicEnabled = !!guildSettings?.dynamicPricing?.enabled;
+
+            // Don't advertise items the buyer can't purchase yet.
+            const items = (guildSettings?.shop ?? []).filter(i => {
+                if (isBlackMarketItem(i.itemId)   && !hasUnlock(rank, 'black_market'))    return false;
+                if (isP8BlackMarketItem(i.itemId) && !hasUnlock(rank, 'p8_black_market')) return false;
+                return true;
+            });
+
             const matches = focused
                 ? items.filter(i => i.name.toLowerCase().includes(focused))
                 : items;
+
+            // Prefix matches first, then substring matches, so typing "pet" surfaces
+            // "Pet Food" ahead of "Carpet".
+            const ranked = focused
+                ? [...matches].sort((a, b) => {
+                    const aPre = a.name.toLowerCase().startsWith(focused) ? 0 : 1;
+                    const bPre = b.name.toLowerCase().startsWith(focused) ? 0 : 1;
+                    return aPre - bPre || a.name.localeCompare(b.name);
+                })
+                : matches;
+
             await interaction.respond(
-                matches.slice(0, 25).map(i => ({ name: i.name, value: i.name }))
+                ranked.slice(0, 25).map(i => {
+                    const price = effectivePrice(i, dynamicEnabled);
+                    const stock = i.stock === 0 ? ' · out of stock' : (i.stock > 0 ? ` · ${i.stock} left` : '');
+                    return {
+                        name:  `${i.name} — ${currency}${price.toLocaleString()}${stock}`.slice(0, 100),
+                        value: i.name,
+                    };
+                })
             );
         } catch (err) {
             console.error('[shop] autocomplete error:', err);
@@ -286,7 +331,7 @@ module.exports = {
 
             const userData = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
             const userBalance = userData?.balance ?? 0;
-            const balanceFooter = `Balance: ${currency}${userBalance.toLocaleString()} · Use /shop buy <item name>`;
+            const balanceFooter = `Balance: ${currency}${userBalance.toLocaleString()} · Use /shop buy <item name> [quantity]`;
 
             return runShopBrowse(interaction, {
                 activity: pages[0].id.replace('rarity_', 'shop_'),
@@ -337,12 +382,23 @@ module.exports = {
 
         // ── BUY ───────────────────────────────────────────────────────────────
         if (sub === 'buy') {
-            const itemName = interaction.options.getString('item').toLowerCase();
-            const item = guildSettings.shop.find(i => i.name.toLowerCase() === itemName);
+            const rawName  = interaction.options.getString('item');
+            const itemName = rawName.toLowerCase();
+            const quantity = interaction.options.getInteger('quantity') ?? 1;
+
+            // Exact name match first (what autocomplete sends), then fall back to a
+            // partial match so a hand-typed "pet food" or "padlock" still resolves.
+            const item = guildSettings.shop.find(i => i.name.toLowerCase() === itemName)
+                ?? guildSettings.shop.find(i => i.name.toLowerCase().includes(itemName))
+                ?? guildSettings.shop.find(i => (i.itemId ?? '').toLowerCase() === itemName);
 
             if (!item) {
-                return interaction.reply({ content: `Item \`${itemName}\` not found. Use \`/shop view\` to see available items.`, flags: MessageFlags.Ephemeral });
+                return interaction.reply({ content: `Item \`${rawName}\` not found. Use \`/shop view\` to see available items.`, flags: MessageFlags.Ephemeral });
             }
+
+            // Resolved name is what every later lookup keys off, so a partial match
+            // can't drift onto a different item mid-purchase.
+            const matchedName = item.name.toLowerCase();
 
             // Gate Black Market behind prestige unlock
             if (isBlackMarketItem(item.itemId) && !hasUnlock(viewerPrestigeRank, 'black_market')) {
@@ -364,8 +420,25 @@ module.exports = {
                 return interaction.reply({ content: 'That item is out of stock!', flags: MessageFlags.Ephemeral });
             }
 
+            // A role reward is granted once — buying ten of them would just charge
+            // ten times for the same role.
+            if (item.roleId && quantity > 1) {
+                return interaction.reply({
+                    content: `**${item.name}** grants a role, so it can only be bought one at a time.`,
+                    flags: MessageFlags.Ephemeral,
+                });
+            }
+
+            if (item.stock > 0 && item.stock < quantity) {
+                return interaction.reply({
+                    content: `Only **${item.stock}× ${item.name}** left in stock — you asked for ${quantity}.`,
+                    flags: MessageFlags.Ephemeral,
+                });
+            }
+
             const dynamicEnabled = !!guildSettings.dynamicPricing?.enabled;
             const itemPrice = effectivePrice(item, dynamicEnabled);
+            const totalCost = itemPrice * quantity;
 
             const userData = await User.findOneAndUpdate(
                 { userId: interaction.user.id, guildId: interaction.guild.id },
@@ -373,9 +446,16 @@ module.exports = {
                 { upsert: true, new: true }
             );
 
-            if (userData.balance < itemPrice) {
+            if (userData.balance < totalCost) {
+                // With dynamic pricing the unit price isn't obvious from /shop view,
+                // so spell out how many they could actually afford.
+                const affordable = itemPrice > 0 ? Math.floor(userData.balance / itemPrice) : 0;
+                const hint = quantity > 1 && affordable > 0
+                    ? ` You can afford **${affordable}** at ${currency}${itemPrice.toLocaleString()} each.`
+                    : '';
+                const wanted = quantity > 1 ? ` for ${quantity}× **${item.name}**` : '';
                 return interaction.reply({
-                    content: `You need ${currency}${itemPrice.toLocaleString()} but only have ${currency}${userData.balance.toLocaleString()}.`,
+                    content: `You need ${currency}${totalCost.toLocaleString()}${wanted} but only have ${currency}${userData.balance.toLocaleString()}.${hint}`,
                     flags: MessageFlags.Ephemeral
                 });
             }
@@ -387,22 +467,30 @@ module.exports = {
                     User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id })
                 ]);
 
-                const freshItem = freshGuild?.shop.find(i => i.name.toLowerCase() === itemName);
+                const freshItem = freshGuild?.shop.find(i => i.name.toLowerCase() === matchedName);
                 if (!freshItem || freshItem.stock === 0) {
                     return reply({ content: 'That item is no longer available.', embeds: [], components: [] });
                 }
-                const freshPrice = effectivePrice(freshItem, !!freshGuild.dynamicPricing?.enabled);
-                if (!freshUser || freshUser.balance < freshPrice) {
+                if (freshItem.stock > 0 && freshItem.stock < quantity) {
                     return reply({
-                        content: `You need ${currency}${freshPrice.toLocaleString()} but only have ${currency}${(freshUser?.balance ?? 0).toLocaleString()}.`,
+                        content: `Only **${freshItem.stock}× ${freshItem.name}** left in stock — you asked for ${quantity}. Nothing was charged.`,
+                        embeds: [], components: []
+                    });
+                }
+                const freshPrice = effectivePrice(freshItem, !!freshGuild.dynamicPricing?.enabled);
+                const freshTotal = freshPrice * quantity;
+                if (!freshUser || freshUser.balance < freshTotal) {
+                    const wanted = quantity > 1 ? ` for ${quantity}× **${freshItem.name}**` : '';
+                    return reply({
+                        content: `You need ${currency}${freshTotal.toLocaleString()}${wanted} but only have ${currency}${(freshUser?.balance ?? 0).toLocaleString()}.`,
                         embeds: [], components: []
                     });
                 }
 
                 // Atomically deduct balance — prevents double-spend if balance changed between checks
                 const chargedUser = await User.findOneAndUpdate(
-                    { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: freshPrice } },
-                    { $inc: { balance: -freshPrice } },
+                    { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: freshTotal } },
+                    { $inc: { balance: -freshTotal } },
                     { new: true }
                 );
                 if (!chargedUser) {
@@ -413,21 +501,28 @@ module.exports = {
                 // $elemMatch binds both predicates to the SAME array element so
                 // the positional update can't accidentally decrement a different
                 // item just because some other item happens to have stock > 0.
+                // Guarding on `>= quantity` makes the whole batch all-or-nothing —
+                // a concurrent buyer can't leave this one partially filled.
                 if (freshItem.stock > 0) {
                     const stockResult = await Guild.findOneAndUpdate(
                         {
                             guildId: interaction.guild.id,
-                            shop: { $elemMatch: { _id: freshItem._id, stock: { $gt: 0 } } },
+                            shop: { $elemMatch: { _id: freshItem._id, stock: { $gte: quantity } } },
                         },
-                        { $inc: { 'shop.$.stock': -1 } }
+                        { $inc: { 'shop.$.stock': -quantity } }
                     );
                     if (!stockResult) {
                         try {
                             await User.findOneAndUpdate(
                                 { userId: interaction.user.id, guildId: interaction.guild.id },
-                                { $inc: { balance: freshPrice } }
+                                { $inc: { balance: freshTotal } }
                             );
-                            return reply({ content: 'That item just sold out. Your coins have been refunded.', embeds: [], components: [] });
+                            return reply({
+                                content: quantity > 1
+                                    ? `There aren't ${quantity} left in stock anymore. Your coins have been refunded.`
+                                    : 'That item just sold out. Your coins have been refunded.',
+                                embeds: [], components: []
+                            });
                         } catch (refundErr) {
                             console.error('[shop] refund failed after sell-out:', refundErr);
                             return reply({ content: 'That item just sold out and the automatic refund failed — please contact support.', embeds: [], components: [] });
@@ -436,10 +531,12 @@ module.exports = {
                 }
 
                 // Bump demand score so the next price recalc moves this item's price up.
+                // Scaled by quantity so a bulk buy moves the market like the same
+                // number of single buys would.
                 if (freshGuild.dynamicPricing?.enabled) {
                     await Guild.updateOne(
                         { guildId: interaction.guild.id, 'shop._id': freshItem._id },
-                        { $inc: { 'shop.$.demandScore': 1 } }
+                        { $inc: { 'shop.$.demandScore': quantity } }
                     ).catch(err => console.error('[shop] demand bump failed:', err));
                 }
 
@@ -447,10 +544,11 @@ module.exports = {
                 const inventoryId = freshItem.itemId || freshItem.name;
 
                 // Inventory upsert in a single atomic aggregation-pipeline update:
-                // when the itemId exists, bump its quantity by 1; otherwise append
-                // a new entry. Done in one call so concurrent buys can't race
-                // between an unsuccessful $inc and a guarded $push and lose a unit.
-                await User.updateOne(
+                // when the itemId exists, bump its quantity by the amount bought;
+                // otherwise append a new entry. Done in one call so concurrent buys
+                // can't race between an unsuccessful $inc and a guarded $push and
+                // lose units.
+                const stockedUser = await User.findOneAndUpdate(
                     { userId: interaction.user.id, guildId: interaction.guild.id },
                     [{
                         $set: {
@@ -464,7 +562,7 @@ module.exports = {
                                             in: {
                                                 $cond: [
                                                     { $eq: ['$$slot.itemId', inventoryId] },
-                                                    { itemId: '$$slot.itemId', quantity: { $add: ['$$slot.quantity', 1] } },
+                                                    { itemId: '$$slot.itemId', quantity: { $add: ['$$slot.quantity', quantity] } },
                                                     '$$slot'
                                                 ]
                                             }
@@ -473,14 +571,36 @@ module.exports = {
                                     else: {
                                         $concatArrays: [
                                             { $ifNull: ['$inventory', []] },
-                                            [{ itemId: inventoryId, quantity: 1 }]
+                                            [{ itemId: inventoryId, quantity }]
                                         ]
                                     }
                                 }
                             }
                         }
-                    }]
-                );
+                    }],
+                    { new: true }
+                ).catch(err => {
+                    console.error('[shop] inventory grant failed:', err);
+                    return null;
+                });
+
+                if (!stockedUser) {
+                    // Roll back the charge and the stock we just took so the buyer
+                    // isn't left paying for items they never received.
+                    await User.updateOne(
+                        { userId: interaction.user.id, guildId: interaction.guild.id },
+                        { $inc: { balance: freshTotal } }
+                    ).catch(err => console.error('[shop] refund after failed grant:', err));
+                    if (freshItem.stock > 0) {
+                        await Guild.updateOne(
+                            { guildId: interaction.guild.id, 'shop._id': freshItem._id },
+                            { $inc: { 'shop.$.stock': quantity } }
+                        ).catch(err => console.error('[shop] stock restore after failed grant:', err));
+                    }
+                    return reply({ content: 'Purchase failed — your coins have been refunded. Please try again.', embeds: [], components: [] });
+                }
+
+                const ownedNow = stockedUser.inventory?.find(s => s.itemId === inventoryId)?.quantity ?? quantity;
 
                 if (freshItem.roleId) {
                     await interaction.member.roles.add(freshItem.roleId).catch(console.error);
@@ -490,20 +610,26 @@ module.exports = {
                     userId:  interaction.user.id,
                     guildId: interaction.guild.id,
                     type:    'shop_buy',
-                    amount:  -freshPrice,
+                    amount:  -freshTotal,
                     balance: chargedUser.balance,
                     note:    inventoryId,
                 });
 
+                const boughtLabel = quantity > 1 ? `${quantity}× **${freshItem.name}**` : `**${freshItem.name}**`;
                 const successLore = getItemLore(freshItem.itemId);
                 const successDesc = successLore
-                    ? `You bought **${freshItem.name}** for ${currency}${freshPrice.toLocaleString()}.\n\n*${successLore}*`
-                    : `You bought **${freshItem.name}** for ${currency}${freshPrice.toLocaleString()}.`;
+                    ? `You bought ${boughtLabel} for ${currency}${freshTotal.toLocaleString()}.\n\n*${successLore}*`
+                    : `You bought ${boughtLabel} for ${currency}${freshTotal.toLocaleString()}.`;
                 const successEmbed = new EmbedBuilder()
                     .setColor('#00ff00')
                     .setTitle('Purchase Successful')
                     .setDescription(successDesc)
                     .addFields({ name: 'New Balance', value: `${currency}${chargedUser.balance.toLocaleString()}`, inline: true });
+
+                if (quantity > 1) {
+                    successEmbed.addFields({ name: 'Unit Price', value: `${currency}${freshPrice.toLocaleString()}`, inline: true });
+                }
+                successEmbed.addFields({ name: 'In Inventory', value: `${ownedNow.toLocaleString()}× ${freshItem.name}`, inline: true });
 
                 if (freshItem.roleId) {
                     successEmbed.addFields({ name: 'Role Granted', value: `<@&${freshItem.roleId}>`, inline: true });
@@ -516,23 +642,36 @@ module.exports = {
                 return reply(successPayload);
             };
 
-            if (itemPrice >= CONFIRM_THRESHOLD) {
+            // Threshold is checked against the total, so a bulk buy of cheap items
+            // still asks for confirmation before it drains a wallet.
+            if (totalCost >= CONFIRM_THRESHOLD) {
                 const row = new ActionRowBuilder().addComponents(
                     new ButtonBuilder().setCustomId('shop_confirm').setLabel('Confirm Purchase').setStyle(ButtonStyle.Success),
                     new ButtonBuilder().setCustomId('shop_cancel').setLabel('Cancel').setStyle(ButtonStyle.Secondary)
                 );
 
+                const buyLabel = quantity > 1 ? `${quantity}× **${item.name}**` : `**${item.name}**`;
                 const confirmLore = getItemLore(item.itemId);
                 const confirmDesc = confirmLore
-                    ? `Buy **${item.name}** for **${currency}${itemPrice.toLocaleString()}**?\n\n*${confirmLore}*`
-                    : `Buy **${item.name}** for **${currency}${itemPrice.toLocaleString()}**?`;
+                    ? `Buy ${buyLabel} for **${currency}${totalCost.toLocaleString()}**?\n\n*${confirmLore}*`
+                    : `Buy ${buyLabel} for **${currency}${totalCost.toLocaleString()}**?`;
                 const confirmEmbed = new EmbedBuilder()
                     .setColor('#f39c12')
                     .setTitle('Confirm Purchase')
-                    .setDescription(confirmDesc)
+                    .setDescription(confirmDesc);
+
+                if (quantity > 1) {
+                    confirmEmbed.addFields(
+                        { name: 'Quantity',   value: `${quantity}× ${item.name}`,                  inline: true },
+                        { name: 'Unit Price', value: `${currency}${itemPrice.toLocaleString()}`,   inline: true },
+                        { name: 'Total Cost', value: `${currency}${totalCost.toLocaleString()}`,   inline: true }
+                    );
+                }
+
+                confirmEmbed
                     .addFields(
                         { name: 'Your Balance', value: `${currency}${userData.balance.toLocaleString()}`, inline: true },
-                        { name: 'After Purchase', value: `${currency}${(userData.balance - itemPrice).toLocaleString()}`, inline: true }
+                        { name: 'After Purchase', value: `${currency}${(userData.balance - totalCost).toLocaleString()}`, inline: true }
                     )
                     .setFooter({ text: 'This confirmation expires in 30 seconds' });
 

--- a/tests/shopBuyQuantity.test.js
+++ b/tests/shopBuyQuantity.test.js
@@ -1,0 +1,227 @@
+'use strict';
+
+// Exercises /shop buy's quantity option end to end: the confirm flow, the
+// atomic charge/stock/inventory writes, and the guards that reject a bulk buy
+// before any coins move.
+
+const PET_FOOD_PRICE = 250;
+
+// Mutable per-test mockWorld, reset in beforeEach.
+let mockWorld;
+
+function mockQuery(value) {
+    // Stands in for a mongoose Query: awaitable directly and via .lean().
+    return {
+        lean: async () => value,
+        then: (resolve, reject) => Promise.resolve(value).then(resolve, reject),
+    };
+}
+
+jest.mock('../src/models/Guild', () => ({
+    findOneAndUpdate: jest.fn(async (query, update) => {
+        // Stock decrement path: { shop: { $elemMatch: { _id, stock: { $gte: n } } } }
+        const elem = query.shop?.$elemMatch;
+        if (elem) {
+            const item = mockWorld.guild.shop.find(i => i._id === elem._id);
+            const need = elem.stock?.$gte ?? 1;
+            if (!item || item.stock < need) return null;
+            item.stock += update.$inc['shop.$.stock'];
+            mockWorld.stockWrites.push({ itemId: item.itemId, delta: update.$inc['shop.$.stock'] });
+            return mockWorld.guild;
+        }
+        return mockWorld.guild;
+    }),
+    findOne: jest.fn(() => mockQuery(mockWorld.guild)),
+    updateOne: jest.fn(async (query, update) => {
+        if (update.$inc?.['shop.$.demandScore'] != null) {
+            const item = mockWorld.guild.shop.find(i => i._id === query['shop._id']);
+            if (item) item.demandScore = (item.demandScore ?? 0) + update.$inc['shop.$.demandScore'];
+        }
+        if (update.$inc?.['shop.$.stock'] != null) {
+            const item = mockWorld.guild.shop.find(i => i._id === query['shop._id']);
+            if (item) item.stock += update.$inc['shop.$.stock'];
+        }
+        return {};
+    }),
+}));
+
+jest.mock('../src/models/User', () => ({
+    findOneAndUpdate: jest.fn(async (query, update) => {
+        // Inventory grant is an aggregation-pipeline update.
+        if (Array.isArray(update)) {
+            const appended = update[0].$set.inventory.$cond.else.$concatArrays[1][0];
+            const { itemId, quantity } = appended;
+            const slot = mockWorld.user.inventory.find(s => s.itemId === itemId);
+            if (slot) slot.quantity += quantity;
+            else mockWorld.user.inventory.push({ itemId, quantity });
+            return mockWorld.user;
+        }
+        // Balance charge / refund.
+        if (update.$inc?.balance != null) {
+            const floor = query.balance?.$gte;
+            if (floor != null && mockWorld.user.balance < floor) return null;
+            mockWorld.user.balance += update.$inc.balance;
+            mockWorld.balanceWrites.push(update.$inc.balance);
+            return mockWorld.user;
+        }
+        return mockWorld.user;
+    }),
+    findOne: jest.fn(() => mockQuery(mockWorld.user)),
+    updateOne: jest.fn(async (query, update) => {
+        if (update.$inc?.balance != null) {
+            mockWorld.user.balance += update.$inc.balance;
+            mockWorld.balanceWrites.push(update.$inc.balance);
+        }
+        return {};
+    }),
+}));
+
+jest.mock('../src/models/Transaction', () => ({
+    create: jest.fn(async (doc) => { mockWorld.transactions.push(doc); return doc; }),
+    aggregate: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../src/utils/itemImageHelper', () => ({
+    getItemImageAttachment: jest.fn().mockResolvedValue(null),
+}));
+
+const shopCommand = require('../src/commands/economy/shop.js');
+
+function buildWorld({ petFoodStock = -1, balance = 100_000 } = {}) {
+    return {
+        guild: {
+            guildId: 'g1',
+            name: 'Test Guild',
+            shopDefaultsSeeded: true,
+            economy: { currency: '💰' },
+            dynamicPricing: { enabled: false },
+            shop: [
+                { _id: 'oid_petfood', name: 'Pet Food', itemId: 'pet_food', description: '🍖 Feeds any pet.', price: PET_FOOD_PRICE, stock: petFoodStock, roleId: null, demandScore: 0 },
+                { _id: 'oid_vip',     name: 'VIP Pass', itemId: 'vip_pass',  description: '💎 A role.',       price: 1000,           stock: -1,           roleId: 'role_vip', demandScore: 0 },
+            ],
+            save: jest.fn().mockResolvedValue(true),
+        },
+        user: { userId: 'u1', guildId: 'g1', balance, inventory: [], accountPrestige: { rank: 0 } },
+        stockWrites: [],
+        balanceWrites: [],
+        transactions: [],
+    };
+}
+
+function buildInteraction({ item, quantity }) {
+    const state = { replies: [], editReplies: [], collectHandler: null };
+    const message = {
+        createMessageComponentCollector: () => ({
+            on: (event, cb) => { if (event === 'collect') state.collectHandler = cb; },
+            stop: () => {},
+        }),
+    };
+    const interaction = {
+        guild:   { id: 'g1', name: 'Test Guild' },
+        guildId: 'g1',
+        user:    { id: 'u1', username: 'tester' },
+        member:  { roles: { add: jest.fn().mockResolvedValue(true) } },
+        options: {
+            getSubcommand: () => 'buy',
+            getString:  (name) => (name === 'item' ? item : null),
+            getInteger: (name) => (name === 'quantity' ? quantity ?? null : null),
+        },
+        reply:      jest.fn(async (payload) => { state.replies.push(payload); return message; }),
+        deferReply: jest.fn().mockResolvedValue(),
+        editReply:  jest.fn(async (payload) => { state.editReplies.push(payload); return message; }),
+    };
+    return { interaction, state };
+}
+
+async function confirm(state) {
+    expect(state.collectHandler).toBeTruthy();
+    await state.collectHandler({
+        user: { id: 'u1' },
+        customId: 'shop_confirm',
+        deferUpdate: jest.fn().mockResolvedValue(),
+        update: jest.fn().mockResolvedValue(),
+    });
+}
+
+beforeEach(() => {
+    mockWorld = buildWorld();
+    jest.clearAllMocks();
+});
+
+test('buying 10 Pet Food charges the total once and grants all 10', async () => {
+    const { interaction, state } = buildInteraction({ item: 'Pet Food', quantity: 10 });
+    await shopCommand.execute(interaction);
+
+    // 10 × 250 = 2500, over CONFIRM_THRESHOLD, so it asks first.
+    const confirmEmbed = state.replies[0].embeds[0].data;
+    expect(confirmEmbed.description).toContain('10× **Pet Food**');
+    expect(confirmEmbed.description).toContain('2,500');
+    expect(confirmEmbed.fields.find(f => f.name === 'Total Cost').value).toBe('💰2,500');
+    expect(confirmEmbed.fields.find(f => f.name === 'Unit Price').value).toBe('💰250');
+
+    await confirm(state);
+
+    expect(mockWorld.balanceWrites).toEqual([-2500]);
+    expect(mockWorld.user.balance).toBe(97_500);
+    expect(mockWorld.user.inventory).toEqual([{ itemId: 'pet_food', quantity: 10 }]);
+    expect(mockWorld.transactions).toHaveLength(1);
+    expect(mockWorld.transactions[0]).toMatchObject({ type: 'shop_buy', amount: -2500, note: 'pet_food' });
+
+    const success = state.editReplies.at(-1).embeds[0].data;
+    expect(success.title).toBe('Purchase Successful');
+    expect(success.description).toContain('10× **Pet Food**');
+    expect(success.fields.find(f => f.name === 'In Inventory').value).toBe('10× Pet Food');
+});
+
+test('a bulk buy decrements limited stock by the full quantity', async () => {
+    mockWorld = buildWorld({ petFoodStock: 12 });
+    const { interaction, state } = buildInteraction({ item: 'Pet Food', quantity: 10 });
+    await shopCommand.execute(interaction);
+    await confirm(state);
+
+    expect(mockWorld.stockWrites).toEqual([{ itemId: 'pet_food', delta: -10 }]);
+    expect(mockWorld.guild.shop.find(i => i.itemId === 'pet_food').stock).toBe(2);
+});
+
+test('asking for more than the remaining stock is rejected before any charge', async () => {
+    mockWorld = buildWorld({ petFoodStock: 3 });
+    const { interaction, state } = buildInteraction({ item: 'Pet Food', quantity: 10 });
+    await shopCommand.execute(interaction);
+
+    expect(state.replies[0].content).toContain('Only **3× Pet Food** left in stock');
+    expect(mockWorld.balanceWrites).toEqual([]);
+    expect(mockWorld.user.inventory).toEqual([]);
+});
+
+test('an unaffordable bulk buy reports the total and how many are affordable', async () => {
+    mockWorld = buildWorld({ balance: 900 });
+    const { interaction, state } = buildInteraction({ item: 'Pet Food', quantity: 10 });
+    await shopCommand.execute(interaction);
+
+    expect(state.replies[0].content).toContain('💰2,500 for 10× **Pet Food**');
+    expect(state.replies[0].content).toContain('You can afford **3**');
+    expect(mockWorld.balanceWrites).toEqual([]);
+});
+
+test('role rewards cannot be bought in bulk', async () => {
+    const { interaction, state } = buildInteraction({ item: 'VIP Pass', quantity: 3 });
+    await shopCommand.execute(interaction);
+
+    expect(state.replies[0].content).toContain('grants a role');
+    expect(mockWorld.balanceWrites).toEqual([]);
+});
+
+test('omitting quantity still buys exactly one', async () => {
+    const { interaction, state } = buildInteraction({ item: 'Pet Food' });
+    await shopCommand.execute(interaction);
+
+    // 250 is under CONFIRM_THRESHOLD, so it buys straight away.
+    expect(interaction.deferReply).toHaveBeenCalled();
+    expect(mockWorld.balanceWrites).toEqual([-250]);
+    expect(mockWorld.user.inventory).toEqual([{ itemId: 'pet_food', quantity: 1 }]);
+
+    const success = state.editReplies.at(-1).embeds[0].data;
+    expect(success.description).toContain('**Pet Food**');
+    expect(success.description).not.toContain('1× **Pet Food**');
+    expect(success.fields.find(f => f.name === 'Unit Price')).toBeUndefined();
+});

--- a/tests/shopBuyQuantity.test.js
+++ b/tests/shopBuyQuantity.test.js
@@ -87,17 +87,21 @@ jest.mock('../src/utils/itemImageHelper', () => ({
 
 const shopCommand = require('../src/commands/economy/shop.js');
 
-function buildWorld({ petFoodStock = -1, balance = 100_000 } = {}) {
+function buildWorld({ petFoodStock = -1, balance = 100_000, dynamicPricing = false } = {}) {
     return {
         guild: {
             guildId: 'g1',
             name: 'Test Guild',
             shopDefaultsSeeded: true,
             economy: { currency: '💰' },
-            dynamicPricing: { enabled: false },
+            dynamicPricing: { enabled: dynamicPricing },
             shop: [
                 { _id: 'oid_petfood', name: 'Pet Food', itemId: 'pet_food', description: '🍖 Feeds any pet.', price: PET_FOOD_PRICE, stock: petFoodStock, roleId: null, demandScore: 0 },
                 { _id: 'oid_vip',     name: 'VIP Pass', itemId: 'vip_pass',  description: '💎 A role.',       price: 1000,           stock: -1,           roleId: 'role_vip', demandScore: 0 },
+                // Listed before the item whose itemId is 'padlock' so a
+                // partial-name match would grab the wrong one.
+                { _id: 'oid_kit',     name: 'Padlock Repair Kit',  itemId: 'repair_kit', description: '🔧 Fixes locks.', price: 100, stock: -1, roleId: null, demandScore: 0 },
+                { _id: 'oid_padlock', name: 'Reinforced Padlock',  itemId: 'padlock',    description: '🔒 Locks up.',    price: 100, stock: -1, roleId: null, demandScore: 0 },
             ],
             save: jest.fn().mockResolvedValue(true),
         },
@@ -224,4 +228,49 @@ test('omitting quantity still buys exactly one', async () => {
     expect(success.description).toContain('**Pet Food**');
     expect(success.description).not.toContain('1× **Pet Food**');
     expect(success.fields.find(f => f.name === 'Unit Price')).toBeUndefined();
+});
+
+test('an exact itemId wins over another item whose name contains it', async () => {
+    const { interaction } = buildInteraction({ item: 'padlock' });
+    await shopCommand.execute(interaction);
+
+    // 'Padlock Repair Kit' contains "padlock" and comes first in the shop array,
+    // but the exact itemId match must win.
+    expect(mockWorld.user.inventory).toEqual([{ itemId: 'padlock', quantity: 1 }]);
+});
+
+test('a partial name still resolves when nothing matches exactly', async () => {
+    const { interaction } = buildInteraction({ item: 'repair kit' });
+    await shopCommand.execute(interaction);
+
+    expect(mockWorld.user.inventory).toEqual([{ itemId: 'repair_kit', quantity: 1 }]);
+});
+
+test('a price rise between quote and confirm cancels the purchase', async () => {
+    mockWorld = buildWorld({ dynamicPricing: true });
+    const { interaction, state } = buildInteraction({ item: 'Pet Food', quantity: 10 });
+    await shopCommand.execute(interaction);
+
+    expect(state.replies[0].embeds[0].data.description).toContain('2,500');
+
+    // Dynamic pricing recalculates while the confirmation is still open.
+    mockWorld.guild.shop.find(i => i.itemId === 'pet_food').currentPrice = 400;
+    await confirm(state);
+
+    expect(state.editReplies.at(-1).content).toContain('price of **Pet Food** changed');
+    expect(mockWorld.balanceWrites).toEqual([]);
+    expect(mockWorld.user.inventory).toEqual([]);
+    expect(mockWorld.transactions).toEqual([]);
+});
+
+test('a price drop between quote and confirm is honoured at the lower total', async () => {
+    mockWorld = buildWorld({ dynamicPricing: true });
+    const { interaction, state } = buildInteraction({ item: 'Pet Food', quantity: 10 });
+    await shopCommand.execute(interaction);
+
+    mockWorld.guild.shop.find(i => i.itemId === 'pet_food').currentPrice = 200;
+    await confirm(state);
+
+    expect(mockWorld.balanceWrites).toEqual([-2000]);
+    expect(mockWorld.user.inventory).toEqual([{ itemId: 'pet_food', quantity: 10 }]);
 });


### PR DESCRIPTION
## Summary
Extends the `/shop buy` command to support purchasing multiple items at once via a new optional `quantity` parameter (1-20), with comprehensive validation, atomic database operations, and improved user feedback.

## Key Changes

- **Quantity parameter**: Added optional `quantity` integer option (1-20) to `/shop buy` subcommand, defaulting to 1 if omitted
- **Validation guards**: Implemented pre-purchase checks that reject bulk buys before any coins move:
  - Rejects purchases exceeding available stock
  - Rejects bulk purchases of role-granting items (can only buy one at a time)
  - Reports total cost and affordable quantity when user lacks funds
- **Atomic operations**: Updated all database writes to handle bulk quantities:
  - Balance charge multiplied by quantity
  - Stock decrements by full quantity (guarded with `$gte` to prevent partial fills)
  - Inventory grants quantity units in single aggregation-pipeline update
  - Demand score bumped by quantity for dynamic pricing
- **Confirmation flow**: Threshold check now applies to total cost (not unit price), so bulk buys of cheap items still require confirmation
- **Improved UX**:
  - Confirmation embed shows quantity, unit price, and total cost for bulk purchases
  - Success message displays total owned and unit price for bulk buys
  - Autocomplete now shows item prices and stock levels, with prefix-matching prioritization
  - Better error messages for affordability and stock issues, including how many units are affordable
- **Rollback safety**: Added comprehensive error handling to refund charges and restore stock if inventory grant fails mid-transaction
- **Help text updates**: Updated shop view footers and instructions to mention `[quantity]` parameter

## Implementation Details

- Resolved item name is locked after initial lookup to prevent partial-match drift during the purchase flow
- Stock validation uses `$elemMatch` with `$gte: quantity` to make the entire batch atomic and prevent concurrent buyers from leaving partial fills
- Inventory update uses aggregation pipeline to atomically increment existing slots or append new entries, scaled by quantity
- Demand score scaling ensures bulk buys move dynamic pricing the same way as equivalent single purchases would
- Comprehensive test suite validates confirm flow, atomic writes, and all guard conditions

https://claude.ai/code/session_01V9eiigZbkHoTAcxNaMKbtv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quantity selection to `/shop buy`, supporting purchases of up to 20 items.
  * Displays quantity-aware pricing and stock information.
  * Supports item lookup by exact name, partial name, or item ID.
  * Provides improved validation for stock, balance, and restricted items.
  * Processes bulk purchases atomically and updates inventory, stock, and transactions together.
  * Adds confirmation prompts for higher-cost purchases.

* **Bug Fixes**
  * Improved rollback handling when inventory delivery fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->