### PR TITLE
Fix cooldown race conditions and pity reporting in grind systems

### DIFF
--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -2,7 +2,8 @@
 
 const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags } = require('discord.js');
 const User  = require('../../models/User');
-const { attachGrind } = require('../../utils/grindProfile');
+const { attachGrind, persistGrindIfNew } = require('../../utils/grindProfile');
+const GrindProfile = require('../../models/GrindProfile');
 const Guild = require('../../models/Guild');
 const {
     LIMITS, EXPLORER_LEVELS, TIER_COLORS, REGIONS, REGION_LIST,
@@ -206,157 +207,220 @@ async function handleGo(interaction) {
         });
     }
 
-    // ── Run the expedition ────────────────────────────────────────────────────
-    const coinMultiplier = getEventCoinMultiplier(guildSettings);
-    const result = executeExplore(user, region, guildSettings, { coinMultiplier });
-    const firstVisit = result.firstVisit;
+    // Atomically claim the cooldown slot now that all preflight checks have passed —
+    // lastExplore is set the moment the expedition is actually accepted, not earlier,
+    // so a failed precheck (region/injury/stamina) never burns the cooldown. The same
+    // guard stops two concurrent /explore go calls from both slipping through.
+    //
+    // The claim targets GrindProfile, not User: exploration state lives in its own
+    // collection (see src/models/User.js), so a User-level guard would match every
+    // document on the missing `exploration` field and never reject anything.
+    const exploreClaimNow = new Date();
+    const exploreCooldownFloor = new Date(exploreClaimNow.getTime() - LIMITS.EXPLORE_COOLDOWN_MS);
+    const priorLastExplore = e.lastExplore ?? null;
+    await persistGrindIfNew(user, 'exploration');
+    const exploreClaimQuery = { userId: interaction.user.id, guildId: interaction.guild.id, system: 'exploration' };
+    const claimedExplore = await GrindProfile.findOneAndUpdate(
+        {
+            ...exploreClaimQuery,
+            $or: [{ 'data.lastExplore': null }, { 'data.lastExplore': { $lte: exploreCooldownFloor } }],
+        },
+        { $set: { 'data.lastExplore': exploreClaimNow } },
+        { new: true },
+    );
 
-    // Commit stamina spend + cooldown timestamp now, before the (up to 20s)
-    // encounter prompt below. Otherwise a second /explore go fired while this
-    // one is still waiting on a button press reads stale DB state and slips
-    // past the cooldown/stamina gate.
-    try {
-        await user.save();
-    } catch (err) {
-        if (err.name === 'VersionError') {
-            return interaction.reply({ content: 'A simultaneous request tangled your expedition log. Try `/explore go` again.', flags: MessageFlags.Ephemeral });
-        }
-        console.error('[explore] pre-encounter save error:', err);
-        return interaction.reply({ content: 'Something went wrong writing your expedition down. Try again.', flags: MessageFlags.Ephemeral });
+    if (!claimedExplore) {
+        // Losing the claim means another expedition already took the slot, so the
+        // in-memory snapshot is stale — read the winning timestamp back so the
+        // countdown reflects the expedition that actually happened. If that read
+        // fails, fall back to now rather than the snapshot: reaching the claim at all
+        // means the snapshot was already past the cooldown floor, so it would render
+        // a countdown in the past and say they can set out again.
+        const current = await GrindProfile.findOne(exploreClaimQuery).catch(() => null);
+        const lastAt  = current?.data?.lastExplore ?? exploreClaimNow;
+        return interaction.reply({
+            embeds: [buildCooldownEmbed({
+                title: '🥾 Catching Your Breath',
+                description: 'You just got back. Shake the dust off, check your boots for stowaways, then go again.',
+                color: '#2e7d32',
+                nextAt: new Date(new Date(lastAt).getTime() + LIMITS.EXPLORE_COOLDOWN_MS),
+            })],
+            flags: MessageFlags.Ephemeral,
+        });
     }
+    e.lastExplore = exploreClaimNow;
 
-    // Staged narration: the setting-out beat, then the find
-    const delay = ms => new Promise(r => setTimeout(r, ms));
-    await interaction.reply({
-        embeds: [new EmbedBuilder()
-            .setColor(region.color)
-            .setTitle(`${region.emoji} Setting out — ${region.name}`)
-            .setDescription(`*${result.intro}*`)
-            .setFooter({ text: region.tagline })],
-    });
-    await delay(2000);
+    // The claim is a real write now, so an expedition that dies before its result
+    // is saved would otherwise cost the player a full cooldown for nothing. Hand
+    // the slot back — but only while it is still ours, so a newer claim isn't undone.
+    const releaseExploreClaim = () => GrindProfile.updateOne(
+        { ...exploreClaimQuery, 'data.lastExplore': exploreClaimNow },
+        { $set: { 'data.lastExplore': priorLastExplore } },
+    ).catch(() => null);
 
-    // ── Encounter choice ──────────────────────────────────────────────────────
-    if (result.pendingChoice) {
-        const enc = result.encounter;
-        const encId = `explore_${interaction.id}`;
-        const row = new ActionRowBuilder().addComponents(
-            new ButtonBuilder().setCustomId(`${encId}_approach`).setLabel('🤝 Approach').setStyle(ButtonStyle.Primary),
-            new ButtonBuilder().setCustomId(`${encId}_observe`).setLabel('🌿 Keep Your Distance').setStyle(ButtonStyle.Secondary),
-        );
-        await interaction.editReply({
+    // Everything between here and the pre-encounter save can still fail, and until
+    // that save lands the player has nothing to show for the cooldown they just
+    // paid for. Hand the slot back on the way out unless the expedition committed.
+    let exploreCommitted = false;
+    try {
+
+        // ── Run the expedition ────────────────────────────────────────────────────
+        const coinMultiplier = getEventCoinMultiplier(guildSettings);
+        const result = executeExplore(user, region, guildSettings, { coinMultiplier });
+        const firstVisit = result.firstVisit;
+
+        // Commit stamina spend + cooldown timestamp now, before the (up to 20s)
+        // encounter prompt below. Once this lands the expedition is real, so the
+        // cooldown slot is earned and must not be handed back on a later failure.
+        try {
+            await user.save();
+            exploreCommitted = true;
+        } catch (err) {
+            // Nothing was saved, so give the cooldown slot back before telling them to retry.
+            await releaseExploreClaim();
+            if (err.name === 'VersionError') {
+                return interaction.reply({ content: 'A simultaneous request tangled your expedition log. Try `/explore go` again.', flags: MessageFlags.Ephemeral });
+            }
+            console.error('[explore] pre-encounter save error:', err);
+            return interaction.reply({ content: 'Something went wrong writing your expedition down. Try again.', flags: MessageFlags.Ephemeral });
+        }
+
+        // Staged narration: the setting-out beat, then the find
+        const delay = ms => new Promise(r => setTimeout(r, ms));
+        await interaction.reply({
             embeds: [new EmbedBuilder()
                 .setColor(region.color)
-                .setTitle(`${enc.emoji} ${enc.name}`)
-                .setDescription(`*${enc.intro}*\n\nApproach it, or watch from a safe distance? Bold pays better. Careful always pays.`)
-                .setFooter({ text: '20 seconds to decide. Hesitation counts as keeping your distance, which is honest of it.' })],
-            components: [row],
+                .setTitle(`${region.emoji} Setting out — ${region.name}`)
+                .setDescription(`*${result.intro}*`)
+                .setFooter({ text: region.tagline })],
         });
-        const msg = await interaction.fetchReply();
-        const choice = await new Promise(resolve => {
-            const col = msg.createMessageComponentCollector({
-                filter: i => i.user.id === interaction.user.id && i.customId.startsWith(encId),
-                time: 20_000,
-                max: 1,
+        await delay(2000);
+
+        // ── Encounter choice ──────────────────────────────────────────────────────
+        if (result.pendingChoice) {
+            const enc = result.encounter;
+            const encId = `explore_${interaction.id}`;
+            const row = new ActionRowBuilder().addComponents(
+                new ButtonBuilder().setCustomId(`${encId}_approach`).setLabel('🤝 Approach').setStyle(ButtonStyle.Primary),
+                new ButtonBuilder().setCustomId(`${encId}_observe`).setLabel('🌿 Keep Your Distance').setStyle(ButtonStyle.Secondary),
+            );
+            await interaction.editReply({
+                embeds: [new EmbedBuilder()
+                    .setColor(region.color)
+                    .setTitle(`${enc.emoji} ${enc.name}`)
+                    .setDescription(`*${enc.intro}*\n\nApproach it, or watch from a safe distance? Bold pays better. Careful always pays.`)
+                    .setFooter({ text: '20 seconds to decide. Hesitation counts as keeping your distance, which is honest of it.' })],
+                components: [row],
             });
-            col.on('collect', async i => { await i.deferUpdate(); resolve(i.customId.endsWith('_approach') ? 'approach' : 'observe'); });
-            col.on('end', (_, reason) => { if (reason !== 'limit') resolve(null); });
-        });
-        resolveEncounter(user, region, guildSettings, result, choice);
-    }
-
-    // ── Cross-system rewards ──────────────────────────────────────────────────
-    // Seasonal event currency: a real handful in the seasonal region, loose
-    // change anywhere else while an event runs.
-    let eventDrop = null;
-    const currencyId = getEventCurrencyId(guildSettings);
-    if (currencyId && hasActiveEvent(guildSettings)) {
-        const range = region.eventCurrency ?? { min: 1, max: 2 };
-        const amount = Math.floor(Math.random() * (range.max - range.min + 1)) + range.min;
-        addEventCurrency(user, currencyId, amount);
-        eventDrop = { currencyId, amount };
-    }
-
-    // Guild leveling XP mirrors half the explorer XP
-    let mainXp = Math.floor((result.xp ?? 0) * 0.5 * getEventXpMultiplier(guildSettings));
-    let leveledUp = false;
-    if (mainXp > 0) {
-        // Reassign from `gained` so the embed reports the XP actually credited
-        // (applyXpGain folds in the Bird pet's xp_gain passive).
-        ({ leveled: leveledUp, gained: mainXp } = applyXpGain(user, mainXp));
-    }
-
-    // Journal
-    addJournalEntry(user, region.id, result.type, summarizeResult(result, currency));
-
-    // Achievements (checked against the freshly mutated user doc)
-    const newAchievements = await checkAndAward(user, guildSettings).catch(err => {
-        console.error('[explore] checkAndAward error:', err);
-        return [];
-    });
-
-    await ensureQuests(user, guildSettings);
-    let questsDone = [], questsNear = [];
-    if (result.payout > 0) {
-        const earn = await onEconomyEarn(user, guildSettings, result.payout);
-        questsDone = earn.completed;
-        questsNear = earn.nearComplete;
-    }
-
-    try {
-        await user.save();
-    } catch (err) {
-        if (err.name === 'VersionError') {
-            return interaction.editReply({ content: 'A simultaneous request tangled your expedition log. Try `/explore go` again.', embeds: [], components: [] });
+            const msg = await interaction.fetchReply();
+            const choice = await new Promise(resolve => {
+                const col = msg.createMessageComponentCollector({
+                    filter: i => i.user.id === interaction.user.id && i.customId.startsWith(encId),
+                    time: 20_000,
+                    max: 1,
+                });
+                col.on('collect', async i => { await i.deferUpdate(); resolve(i.customId.endsWith('_approach') ? 'approach' : 'observe'); });
+                col.on('end', (_, reason) => { if (reason !== 'limit') resolve(null); });
+            });
+            resolveEncounter(user, region, guildSettings, result, choice);
         }
-        console.error('[explore] save error:', err);
-        return interaction.editReply({ content: 'Something went wrong writing your expedition down. Try again.', embeds: [], components: [] });
-    }
 
-    if (newAchievements.length) {
-        announceAchievements(interaction.client, guildSettings, user, interaction.member, newAchievements)
-            .catch(err => console.error('[explore] announceAchievements error:', err));
-    }
-    if (questsDone.length || questsNear.length) {
-        notifyQuestComplete(guildSettings, interaction.member, questsDone, interaction.channel, user).catch(() => null);
-        notifyQuestNearComplete(guildSettings, interaction.member, questsNear, interaction.channel).catch(() => null);
-    }
-    if (leveledUp) {
-        announceLevelUp(user, guildSettings, interaction.member, interaction.guild, interaction.channel)
-            .catch(err => console.error('[explore] announceLevelUp error:', err));
-    }
+        // ── Cross-system rewards ──────────────────────────────────────────────────
+        // Seasonal event currency: a real handful in the seasonal region, loose
+        // change anywhere else while an event runs.
+        let eventDrop = null;
+        const currencyId = getEventCurrencyId(guildSettings);
+        if (currencyId && hasActiveEvent(guildSettings)) {
+            const range = region.eventCurrency ?? { min: 1, max: 2 };
+            const amount = Math.floor(Math.random() * (range.max - range.min + 1)) + range.min;
+            addEventCurrency(user, currencyId, amount);
+            eventDrop = { currencyId, amount };
+        }
 
-    // Transaction audit log
-    if (result.payout > 0) {
-        logTransaction({ userId: user.userId, guildId: user.guildId, type: 'explore', amount: result.payout, balance: user.balance, note: `${region.name} · ${result.type}` });
-    } else if (result.penalty > 0) {
-        logTransaction({ userId: user.userId, guildId: user.guildId, type: 'explore', amount: -result.penalty, balance: user.balance, note: `${region.name} · ${result.type}` });
-    }
+        // Guild leveling XP mirrors half the explorer XP
+        let mainXp = Math.floor((result.xp ?? 0) * 0.5 * getEventXpMultiplier(guildSettings));
+        let leveledUp = false;
+        if (mainXp > 0) {
+            // Reassign from `gained` so the embed reports the XP actually credited
+            // (applyXpGain folds in the Bird pet's xp_gain passive).
+            ({ leveled: leveledUp, gained: mainXp } = applyXpGain(user, mainXp));
+        }
 
-    // Big-win feed for legendary treasure and secrets
-    if (result.payout > 0 && (result.treasureTier?.tier === 'legendary' || result.type === 'secret')) {
-        logBigWin({ guildId: interaction.guild.id, userId: interaction.user.id, username: interaction.user.username, amount: result.payout, source: 'explore', details: result.secret?.name ?? `${region.name} legendary treasure` });
-    }
+        // Journal
+        addJournalEntry(user, region.id, result.type, summarizeResult(result, currency));
 
-    // ── Result embed ──────────────────────────────────────────────────────────
-    const embed = buildResultEmbed(result, region, user, currency, eventDrop, mainXp, firstVisit);
-    await interaction.editReply({ embeds: [embed], components: [] });
+        // Achievements (checked against the freshly mutated user doc)
+        const newAchievements = await checkAndAward(user, guildSettings).catch(err => {
+            console.error('[explore] checkAndAward error:', err);
+            return [];
+        });
 
-    // Server-wide whisper for secrets
-    if (result.type === 'secret' && guildSettings?.exploration?.announceSecrets !== false) {
-        const channelId = guildSettings?.economy?.announcementChannelId;
-        const resolved = channelId ? interaction.guild.channels.cache.get(channelId) : null;
-        const announceChannel = resolved?.isTextBased() ? resolved : interaction.channel;
-        announceChannel.send({
-            embeds: [new EmbedBuilder()
-                .setColor('#FFD700')
-                .setTitle('✨ A Secret Has Been Found')
-                .setDescription(
-                    `<@${interaction.user.id}> just uncovered **${result.secret.name}** in ${region.emoji} **${region.name}**.\n\n` +
-                    `*The map has fewer blank spaces tonight. The blank spaces are taking it personally.*`
-                )
-                .setTimestamp()],
-        }).catch(err => console.error('[explore] secret announce error:', err));
+        await ensureQuests(user, guildSettings);
+        let questsDone = [], questsNear = [];
+        if (result.payout > 0) {
+            const earn = await onEconomyEarn(user, guildSettings, result.payout);
+            questsDone = earn.completed;
+            questsNear = earn.nearComplete;
+        }
+
+        try {
+            await user.save();
+        } catch (err) {
+            if (err.name === 'VersionError') {
+                return interaction.editReply({ content: 'A simultaneous request tangled your expedition log. Try `/explore go` again.', embeds: [], components: [] });
+            }
+            console.error('[explore] save error:', err);
+            return interaction.editReply({ content: 'Something went wrong writing your expedition down. Try again.', embeds: [], components: [] });
+        }
+
+        if (newAchievements.length) {
+            announceAchievements(interaction.client, guildSettings, user, interaction.member, newAchievements)
+                .catch(err => console.error('[explore] announceAchievements error:', err));
+        }
+        if (questsDone.length || questsNear.length) {
+            notifyQuestComplete(guildSettings, interaction.member, questsDone, interaction.channel, user).catch(() => null);
+            notifyQuestNearComplete(guildSettings, interaction.member, questsNear, interaction.channel).catch(() => null);
+        }
+        if (leveledUp) {
+            announceLevelUp(user, guildSettings, interaction.member, interaction.guild, interaction.channel)
+                .catch(err => console.error('[explore] announceLevelUp error:', err));
+        }
+
+        // Transaction audit log
+        if (result.payout > 0) {
+            logTransaction({ userId: user.userId, guildId: user.guildId, type: 'explore', amount: result.payout, balance: user.balance, note: `${region.name} · ${result.type}` });
+        } else if (result.penalty > 0) {
+            logTransaction({ userId: user.userId, guildId: user.guildId, type: 'explore', amount: -result.penalty, balance: user.balance, note: `${region.name} · ${result.type}` });
+        }
+
+        // Big-win feed for legendary treasure and secrets
+        if (result.payout > 0 && (result.treasureTier?.tier === 'legendary' || result.type === 'secret')) {
+            logBigWin({ guildId: interaction.guild.id, userId: interaction.user.id, username: interaction.user.username, amount: result.payout, source: 'explore', details: result.secret?.name ?? `${region.name} legendary treasure` });
+        }
+
+        // ── Result embed ──────────────────────────────────────────────────────────
+        const embed = buildResultEmbed(result, region, user, currency, eventDrop, mainXp, firstVisit);
+        await interaction.editReply({ embeds: [embed], components: [] });
+
+        // Server-wide whisper for secrets
+        if (result.type === 'secret' && guildSettings?.exploration?.announceSecrets !== false) {
+            const channelId = guildSettings?.economy?.announcementChannelId;
+            const resolved = channelId ? interaction.guild.channels.cache.get(channelId) : null;
+            const announceChannel = resolved?.isTextBased() ? resolved : interaction.channel;
+            announceChannel.send({
+                embeds: [new EmbedBuilder()
+                    .setColor('#FFD700')
+                    .setTitle('✨ A Secret Has Been Found')
+                    .setDescription(
+                        `<@${interaction.user.id}> just uncovered **${result.secret.name}** in ${region.emoji} **${region.name}**.\n\n` +
+                        `*The map has fewer blank spaces tonight. The blank spaces are taking it personally.*`
+                    )
+                    .setTimestamp()],
+            }).catch(err => console.error('[explore] secret announce error:', err));
+        }
+    } catch (err) {
+        if (!exploreCommitted) await releaseExploreClaim();
+        throw err;
     }
 }
 
@@ -706,3 +770,25 @@ async function handleProfile(interaction) {
 
     return interaction.reply({ embeds: [embed] });
 }
+
+// ── Per-user action lock ──────────────────────────────────────────────────────
+// Exploration mutates the user document with read-modify-write saves, and an
+// expedition can sit for 20s waiting on the encounter prompt. Serialize them:
+// one exploration action at a time per user, matching /fish, /hunt and /mine.
+const { tryAcquire: _lockAcquire, release: _lockRelease } = require('../../utils/activeGameLock');
+const _exploreExecute = module.exports.execute;
+module.exports.execute = async function (interaction) {
+    const lockKey   = `grind:explore:${interaction.guild?.id}:${interaction.user.id}`;
+    const lockToken = _lockAcquire(lockKey, 120_000);
+    if (!lockToken) {
+        return interaction.reply({
+            content: '🥾 You already have an exploration action in progress — finish it first.',
+            flags: MessageFlags.Ephemeral,
+        }).catch(() => {});
+    }
+    try {
+        return await _exploreExecute(interaction);
+    } finally {
+        _lockRelease(lockKey, lockToken);
+    }
+};

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -22,7 +22,7 @@ const {
     BOSS_TYPES
 } = require('../../data/fishData');
 const { MATERIAL_NAMES: HUNT_MATERIAL_NAMES } = require('../../data/huntData');
-const { buildPityStreakField, PITY_COPY } = require('../../utils/pityBonus');
+const { getPityBonus, buildPityStreakField, PITY_COPY } = require('../../utils/pityBonus');
 const { checkAndAward, announceAchievements } = require('../../services/achievementService');
 const {
     ensureFishingData,
@@ -42,7 +42,9 @@ const {
     getLevelData,
     xpToNextLevel,
     activateConsumable,
+    quoteRepair,
     applyRepair,
+    applyPayoutModifiers,
     updateRodStatus,
     applyXp
 } = require('../../services/fishService');
@@ -53,7 +55,7 @@ const { TIER_NUM, TIER_RIBBON } = require('../../data/materialRarity');
 const { randomFrom, FISH_MISS_POOL } = require('../../utils/copyLines');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
 const { stackBar } = require('../../utils/rewardReveal');
-const { submitCatch: submitTournamentCatch, getActiveTournament, buildLeaderboardEmbed, endTournament, buildWinnersEmbed, announceTournamentEnd } = require('../../services/tournamentService');
+const { submitCatch: submitTournamentCatch, startTournament, getActiveTournament, buildLeaderboardEmbed, endTournament, buildWinnersEmbed, announceTournamentEnd } = require('../../services/tournamentService');
 const { getDailyFeatured, FEATURED_PAYOUT_BONUS, FEATURED_RARE_BONUS } = require('../../data/featuredRotation');
 const { getTimeBand } = require('../../utils/timeBand');
 const { logBigWin } = require('../../utils/bigWinLogger');
@@ -62,6 +64,7 @@ const { isDistrictActive } = require('../../services/districtService');
 const { ensureQuests, onFish, onEconomyEarn, notifyQuestComplete, notifyQuestNearComplete } = require('../../services/questService');
 const { getActiveSynergies } = require('../../services/synergyService');
 const { hasActiveEvent, getEventCrossSystemType } = require('../../services/seasonalEventService');
+const { refundEffectCharge } = require('../../services/effectsService');
 
 // Rarity score for hourly fish competition (rarest catch wins)
 const WILDERNESS_YIELD_BONUS = 0.10;
@@ -434,10 +437,18 @@ async function handleCast(interaction) {
     if (f.stamina <= 0) {
         const regenMs   = msUntilNextStamina(user);
         const nextAt    = new Date(Date.now() + regenMs);
-        const sinceRare = f.sinceRare ?? 0;
-        const pityStat  = sinceRare >= 5
-            ? `🎯 ${sinceRare} casts since last Rare+ catch • next rare guaranteed around cast ~50`
-            : null;
+        // Surfaces the fail-streak pity that actually exists, using the shared
+        // curve so this never drifts from what calculateSuccessChance applies.
+        // There is no rare-catch pity — sinceRare is a stat, not a guarantee,
+        // so it is reported as one.
+        const sinceRare  = f.sinceRare ?? 0;
+        const pityBonus  = getPityBonus(f.consecutiveFails ?? 0, LIMITS);
+        const pityBits   = [];
+        if (pityBonus > 0) {
+            pityBits.push(`🎯 ${f.consecutiveFails} ${PITY_COPY.fishing.streakNoun} • +${Math.round(pityBonus * 100)}% success on your next cast`);
+        }
+        if (sinceRare >= 5) pityBits.push(`🐟 ${sinceRare} casts since your last Rare+ catch`);
+        const pityStat = pityBits.length ? pityBits.join('\n') : null;
         return interaction.reply({
             embeds: [buildCooldownEmbed({
                 title: '😮‍💨 Too Tired to Cast',
@@ -445,7 +456,7 @@ async function handleCast(interaction) {
                 color: '#1e6fa5',
                 nextAt,
                 pityStat,
-                nextRewardPreview: 'Full stamina = 10 casts · Boss encounters unlock at Prestige 1+',
+                nextRewardPreview: `Full stamina = ${getMaxStamina(user)} casts · Boss fights can start on any Rare or better catch`,
             })],
             flags: MessageFlags.Ephemeral,
         });
@@ -468,7 +479,7 @@ async function handleCast(interaction) {
         });
     }
 
-    // ── Bait check ────────────────────────────────────────────────────
+    // ── Bait check (read-only; the stock is spent after the claim below) ──
     const rodData = ROD_BY_TIER[rod.tier];
     if (rodData.requiresBait && (f.bait[rodData.baitType] ?? 0) <= 0) {
         return interaction.reply({
@@ -581,14 +592,18 @@ async function handleCast(interaction) {
         const preCastLegendaryCatches = user.fishing.legendaryCatches;
         const preCastEventCatches     = user.fishing.eventCatches;
         const preCastBestPayout       = user.fishing.bestPayout;
+        const preCastConsecutiveFails = user.fishing.consecutiveFails ?? 0;
         const preCastMaterials        = JSON.parse(JSON.stringify(user.fishing.materials ?? {}));
         const preCastPersonalBest = user.fishing.personalBest
             ? JSON.parse(JSON.stringify(user.fishing.personalBest))
             : null;
+        const preCastWeeklyRecord = user.fishing.weeklyRecord
+            ? JSON.parse(JSON.stringify(user.fishing.weeklyRecord))
+            : null;
 
         let reelResult = null; // { caught: bool, label: string, icon: string }
 
-        const result = executeCast(user, locationId, { reactionFactor: 1.0, marketplaceActive });
+        const result = executeCast(user, locationId, { reactionFactor: 1.0, marketplaceActive, username: interaction.user.username });
 
         // ── Rarity-Gated Reel-In ──────────────────────────────────────────────────
         if (result.success && result.catchType === 'fish' && ['rare', 'epic', 'legendary'].includes(result.tier)) {
@@ -643,6 +658,13 @@ async function handleCast(interaction) {
                     user.fishing.bestPayout        = preCastBestPayout;
                     user.fishing.materials         = preCastMaterials;
                     if (preCastPersonalBest !== null) user.fishing.personalBest = preCastPersonalBest;
+                    if (preCastWeeklyRecord !== null) user.fishing.weeklyRecord = preCastWeeklyRecord;
+                    // executeCast zeroed the fail streak on the successful roll; the
+                    // fish was never landed, so restore it and count this as the miss
+                    // it was — otherwise a required reel-in miss hands back pity progress.
+                    user.fishing.consecutiveFails = preCastConsecutiveFails + 1;
+                    // The doubled-yield charge paid for a payout that is being reversed.
+                    if (result.gatherEffectConsumed) refundEffectCharge(user, result.gatherEffectConsumed);
                     user.markModified('fishing');
                     result.success      = false;
                     result.finalPayout  = 0;
@@ -1768,7 +1790,11 @@ async function showBait(interaction, user, currency) {
         });
 
     const activeLines = [];
-    if (f.activeBait)    activeLines.push(`🐟 Chum Bait active (${f.activeBaitCastsLeft} casts left)`);
+    if (f.activeBait) {
+        const activeDef = CONSUMABLES[f.activeBait];
+        const activeName = activeDef?.name ?? f.activeBait.replace(/_/g, ' ');
+        activeLines.push(`${activeDef?.emoji ?? '🐟'} ${activeName} active (${f.activeBaitCastsLeft} casts left)`);
+    }
     if (f.activeLuck)    activeLines.push(`🍀 Angler's Luck queued`);
     if (f.activeXpScroll) activeLines.push(`📜 XP Scroll queued`);
 
@@ -2007,7 +2033,7 @@ async function showShopList(interaction, user, currency) {
         subline: `~${Math.round(u.costMultiplier * 100)}% of rod`
     }));
     const upgradeList = Object.values(ROD_UPGRADES).map(u =>
-        `${u.emoji} **${u.name}** — *${u.description}* · \`/fish shop upgrade module:${u.id}\``
+        `${u.emoji} **${u.name}** — *${u.description}* · \`/fish shop upgrade type:${u.id}\``
     ).join('\n');
 
     const baitItems = BAIT_PACKS.map(p => ({
@@ -2557,18 +2583,21 @@ async function handleRepair(interaction, user, currency) {
     }
 
     const requestedAmount = interaction.options.getInteger('amount') ?? null;
-    const result = applyRepair(rod, requestedAmount);
 
-    if (result.error) {
-        return interaction.reply({ content: result.error, flags: MessageFlags.Ephemeral });
+    // Price the repair before committing — applying it permanently degrades the
+    // rod's max durability, which must not happen on a quote the player can't buy.
+    const quote = quoteRepair(rod, requestedAmount);
+    if (quote.error) {
+        return interaction.reply({ content: quote.error, flags: MessageFlags.Ephemeral });
     }
-    if (user.balance < result.cost) {
+    if (user.balance < quote.cost) {
         return interaction.reply({
-            content: `Repairing **${result.restoredAmount}** durability costs **${currency}${result.cost.toLocaleString()}**. You only have **${currency}${user.balance.toLocaleString()}**.`,
+            content: `Repairing **${quote.restoredAmount}** durability costs **${currency}${quote.cost.toLocaleString()}**. You only have **${currency}${user.balance.toLocaleString()}**.`,
             flags: MessageFlags.Ephemeral
         });
     }
 
+    const result = applyRepair(rod, requestedAmount);
     user.balance -= result.cost;
     user.markModified('fishing');
 

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -17,7 +17,7 @@ const {
 const { checkAndAward, announceAchievements } = require('../../services/achievementService');
 const { TIER_NUM, TIER_RIBBON } = require('../../data/materialRarity');
 const { randomFrom, MINE_CAVE_LINES } = require('../../utils/copyLines');
-const { buildPityStreakField, PITY_COPY } = require('../../utils/pityBonus');
+const { getPityBonus, buildPityStreakField, PITY_COPY } = require('../../utils/pityBonus');
 const {
     ensureMineData,
     applyStaminaRegen,
@@ -345,10 +345,18 @@ async function handleDig(interaction) {
     if (m.stamina <= 0) {
         const regenMs   = msUntilNextStamina(user);
         const nextAt    = new Date(Date.now() + regenMs);
+        // Report the fail-streak pity that actually exists, through the shared curve
+        // so this cannot drift from what calculateSuccessChance applies. Mining has
+        // no rare-material guarantee — only hunting implements one
+        // (LIMITS.RARE_PITY_GUARANTEE) — so sinceRare is reported as the stat it is.
         const sinceRare = m.sinceRare ?? 0;
-        const pityStat  = sinceRare >= 5
-            ? `🎯 ${sinceRare} mines since last Rare+ material • rare guaranteed around mine ~40`
-            : null;
+        const pityBonus = getPityBonus(m.consecutiveFails ?? 0, LIMITS);
+        const pityBits  = [];
+        if (pityBonus > 0) {
+            pityBits.push(`🎯 ${m.consecutiveFails} ${PITY_COPY.mining.streakNoun} • +${Math.round(pityBonus * 100)}% success on your next dig`);
+        }
+        if (sinceRare >= 5) pityBits.push(`⛏️ ${sinceRare} digs since your last Rare+ material`);
+        const pityStat = pityBits.length ? pityBits.join('\n') : null;
         return interaction.reply({
             embeds: [buildCooldownEmbed({
                 title: '😮‍💨 Out of Stamina',

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -378,407 +378,476 @@ async function handleDig(interaction) {
         });
     }
 
+    // ── Charge check (read-only; the stock is spent after the claim below) ──
     const pickaxeData = PICKAXE_BY_TIER[pickaxe.tier];
-    if (pickaxeData.requiresCharge) {
-        const chargeStock = m.charges[pickaxeData.chargeType] ?? 0;
-        if (chargeStock <= 0) {
-            return interaction.reply({
-                content: `You're out of **${pickaxeData.chargeType.replace(/_/g, ' ')}**! Buy more with \`/mine shop buy\`.`,
-                flags: MessageFlags.Ephemeral
-            });
-        }
-        m.charges[pickaxeData.chargeType] = chargeStock - 1;
-        user.markModified('mining');
-    }
-
-    // ── Vein-Following Puzzle ──────────────────────────────────────────────────
-    // 3 rounds of directional navigation through a mine tunnel.
-    // Each round: a 3×3 emoji grid shows the current position (⛏️) and a mineral
-    // trace in one of the 4 adjacent cells. Player picks the matching direction.
-    // Correct directions accumulate depth; final depth maps to intensity level.
-    //   0/3 correct → Surface  (0.7×, 0% cave-in)
-    //   1/3 correct → Shallow  (1.0×, 5% cave-in)
-    //   2/3 correct → Mid      (1.4×, 12% cave-in)
-    //   3/3 correct → Deep     (2.0×, 20% cave-in)
-    //   3/3 + lucky → Abyss    (3.0×, 30% cave-in)  10% chance on a perfect run
-
-    const featured         = getDailyFeatured(interaction.guild.id);
-    const isFeaturedDepth  = depthId === featured.mineDepth.id;
-    const timeBand         = getTimeBand();
-    const delay = ms => new Promise(r => setTimeout(r, ms));
-
-    const DIRS = [
-        { id: 'N', label: '⬆️ North', row: 0, col: 1 },
-        { id: 'S', label: '⬇️ South', row: 2, col: 1 },
-        { id: 'W', label: '⬅️ West',  row: 1, col: 0 },
-        { id: 'E', label: '➡️ East',  row: 1, col: 2 },
-    ];
-
-    // Build a 3×3 grid string highlighting the ore direction
-    function buildGrid(oreDir) {
-        const grid = [
-            ['🪨', '🪨', '🪨'],
-            ['🪨', '⛏️', '🪨'],
-            ['🪨', '🪨', '🪨'],
-        ];
-        const d = DIRS.find(d => d.id === oreDir);
-        grid[d.row][d.col] = '✨';
-        return grid.map(row => row.join(' ')).join('\n');
-    }
-
-    const featuredDepthNote = isFeaturedDepth
-        ? `\n🌟 **Featured Depth!** +${Math.round(FEATURED_PAYOUT_BONUS * 100)}% payout active.`
-        : '';
-
-    await interaction.reply({
-        embeds: [new EmbedBuilder()
-            .setColor(isFeaturedDepth ? '#FFD700' : '#8B4513')
-            .setTitle(`⛏️ Entering ${depth.emoji} ${depth.name}…`)
-            .setDescription(
-                `*You lower yourself into the shaft. Dust settles. Your lamp catches a glint…*\n\n` +
-                `**Follow the vein** — 3 rounds of directional choices. The deeper you follow it, the richer the haul.${featuredDepthNote}`
-            )
-            .setFooter({ text: `${timeBand.emoji} ${timeBand.label} · 15 seconds per choice — miss a round and you stop there.` })],
-        components: [],
-    });
-    const mineMsg = await interaction.fetchReply();
-    await delay(1500);
-
-    let veinDepth = 0;
-    const roundLog = [];
-
-    for (let round = 0; round < 3; round++) {
-        const oreDir  = DIRS[Math.floor(Math.random() * DIRS.length)];
-        const grid    = buildGrid(oreDir.id);
-        const prevLog = roundLog.map((r, i) => r ? `✅` : `❌`).join(' ');
-
-        const veinEmbed = new EmbedBuilder()
-            .setColor('#B8860B')
-            .setTitle(`⛏️ Vein Read — Round ${round + 1}/3`)
-            .setDescription(
-                `${prevLog ? prevLog + '\n\n' : ''}` +
-                `*Mineral trace spotted — which way does the vein run?*\n\n` +
-                `\`\`\`\n${grid}\n\`\`\``
-            )
-            .setFooter({ text: '15 seconds to choose a direction.' });
-
-        const dirRow = new ActionRowBuilder().addComponents(
-            ...DIRS.map(d => new ButtonBuilder()
-                .setCustomId(`vein_${d.id}`)
-                .setLabel(d.label)
-                .setStyle(ButtonStyle.Primary)
-            )
-        );
-
-        await interaction.editReply({ embeds: [veinEmbed], components: [dirRow] });
-
-        const picked = await new Promise(resolve => {
-            const col = mineMsg.createMessageComponentCollector({
-                filter: i => i.user.id === interaction.user.id && i.customId.startsWith('vein_'),
-                time: 15_000,
-                max: 1,
-            });
-            col.on('collect', async i => { await i.deferUpdate(); resolve(i.customId.replace('vein_', '')); });
-            col.on('end',     (_, reason) => { if (reason !== 'limit') resolve(null); });
+    if (pickaxeData.requiresCharge && (m.charges[pickaxeData.chargeType] ?? 0) <= 0) {
+        return interaction.reply({
+            content: `You're out of **${pickaxeData.chargeType.replace(/_/g, ' ')}**! Buy more with \`/mine shop buy\`.`,
+            flags: MessageFlags.Ephemeral
         });
-
-        const correct = picked === oreDir.id;
-        roundLog.push(correct);
-        if (correct) veinDepth++;
-
-        const roundResult = new EmbedBuilder()
-            .setColor(correct ? '#00CC55' : picked ? '#CC4400' : '#888888')
-            .setTitle(correct ? '✅ Vein found!' : picked ? '❌ Dead end — rubble.' : '⏰ Hesitated…')
-            .setDescription(
-                correct
-                    ? `You followed the vein **${oreDir.label}**. It runs deeper here.`
-                    : picked
-                    ? `The vein ran **${oreDir.label}** — you hit rubble instead.`
-                    : `The vein ran **${oreDir.label}** — you didn't move in time.`
-            );
-        await interaction.editReply({ embeds: [roundResult], components: [] });
-        if (round < 2) await delay(900);
     }
 
-    // Map vein depth to intensity level
-    let intensityIndex = veinDepth; // 0→L1, 1→L2, 2→L3, 3→L4
-    if (veinDepth === 3 && Math.random() < 0.10) intensityIndex = 4; // lucky Abyss
-    const chosenIntensity = INTENSITY_LEVELS[intensityIndex];
+    // Atomically claim the cooldown slot now that all preflight checks have passed —
+    // lastMine is set the moment the dig is actually accepted, not earlier, so a
+    // failed precheck (stamina/pickaxe/charge) never burns the cooldown. The same
+    // guard stops two concurrent /mine dig calls from both slipping through.
+    //
+    // The claim targets GrindProfile, not User: mining state lives in its own
+    // collection (see src/models/User.js), so a User-level guard would match every
+    // document on the missing `mining` field and never reject anything.
+    const mineClaimNow = new Date();
+    const mineCooldownFloor = new Date(mineClaimNow.getTime() - LIMITS.MINE_COOLDOWN_MS);
+    const priorLastMine = m.lastMine ?? null;
+    await persistGrindIfNew(user, 'mining');
+    const mineClaimQuery = { userId: interaction.user.id, guildId: interaction.guild.id, system: 'mining' };
+    const claimedMine = await GrindProfile.findOneAndUpdate(
+        {
+            ...mineClaimQuery,
+            $or: [{ 'data.lastMine': null }, { 'data.lastMine': { $lte: mineCooldownFloor } }],
+        },
+        { $set: { 'data.lastMine': mineClaimNow } },
+        { new: true },
+    );
 
-    const finalIcons = roundLog.map(r => r ? '✅' : '❌').join(' ');
-    const confirmEmbed = new EmbedBuilder()
-        .setColor(chosenIntensity.level >= 4 ? '#FF4444' : chosenIntensity.level >= 3 ? '#FFA500' : '#00AA55')
-        .setTitle(`${chosenIntensity.emoji} Digging ${chosenIntensity.name}…`)
-        .setDescription(
-            `${finalIcons}\n\n` +
-            `Vein depth reached: **${veinDepth}/3 correct**\n` +
-            `**${chosenIntensity.multiplier}×** payout  |  **${(chosenIntensity.caveInRisk * 100).toFixed(0)}%** cave-in risk`
-        );
-    await interaction.editReply({ embeds: [confirmEmbed], components: [] });
-
-    // Crystal Fox pet: +15% mine yield (only if hunger >= 30)
-    const { getTotalBonus, PET_DEFINITIONS: PET_DEFS, isPetActive, TRAIT_FLAVOR, tryGrantRarePet } = require('../../services/petService');
-    const petMineYieldPct = getTotalBonus(user.pets || [], 'mine_yield');
-
-    const marketplaceActive = isDistrictActive(guildSettings, 'marketplace');
-    const result = executeMine(user, depthId, { intensity: chosenIntensity, marketplaceActive });
-
-    // ── Cave-in Interactive Event ─────────────────────────────────────────────
-    // Resolved FIRST: pity, find counters, and yield bonuses below must only
-    // apply to rewards the player actually keeps, not ore abandoned in a collapse.
-    if (result.caveIn) {
-        const m = user.mining;
-        const equippedPickaxe = m.pickaxes?.[m.equippedPickaxeIndex];
-        const pickaxeStaticData = equippedPickaxe ? PICKAXE_BY_TIER[equippedPickaxe.tier] : null;
-        const chargeType = pickaxeStaticData?.chargeType;
-        const chargesAvailable = chargeType ? (m.charges?.[chargeType] ?? 0) : 0;
-
-        const caveInEmbed = new EmbedBuilder()
-            .setColor('#8B0000')
-            .setTitle('🌑 CAVE-IN!')
-            .setDescription(
-                `━━━━━━━━━━━━━━━━━━━━━━━\n` +
-                `The tunnel is collapsing around you. Dust fills the air.\n` +
-                `You have seconds to decide.\n\n` +
-                `⚡ **Ore at stake:** ${(result.caveInPayout ?? 0).toLocaleString()} coins\n\n` +
-                (chargesAvailable > 0
-                    ? `💥 You have **${chargesAvailable}** blast charge${chargesAvailable !== 1 ? 's' : ''} — enough to blow an escape route.`
-                    : `⚠️ You have no blast charges — you'll have to run.`)
-            )
-            .setFooter({ text: 'You have 20 seconds to decide.' });
-
-        const caveInId = `cavein_${interaction.id}`;
-        const blastBtn = new ButtonBuilder()
-            .setCustomId(`${caveInId}_blast`)
-            .setLabel('💥 Use a Blast Charge — save your ore')
-            .setStyle(ButtonStyle.Success)
-            .setDisabled(chargesAvailable <= 0);
-        const abandonBtn = new ButtonBuilder()
-            .setCustomId(`${caveInId}_abandon`)
-            .setLabel('🏃 Abandon the Dig — flee empty-handed')
-            .setStyle(ButtonStyle.Danger);
-        const caveInRow = new ActionRowBuilder().addComponents(blastBtn, abandonBtn);
-
-        await interaction.editReply({ embeds: [caveInEmbed], components: [caveInRow] });
-        const caveInMsg = await interaction.fetchReply();
-
-        const caveInChoice = await new Promise(resolve => {
-            const col = caveInMsg.createMessageComponentCollector({
-                filter: i => i.user.id === interaction.user.id && i.customId.startsWith(caveInId),
-                time: 20_000,
-                max: 1,
-            });
-            col.on('collect', async i => { await i.deferUpdate(); resolve(i.customId.endsWith('_blast') ? 'blast' : 'abandon'); });
-            col.on('end', (_, reason) => { if (reason !== 'limit') resolve('abandon'); });
+    if (!claimedMine) {
+        // Losing the claim means another dig already took the slot, so the
+        // in-memory snapshot is stale — read the winning timestamp back so the
+        // countdown reflects the dig that actually happened. If that read fails,
+        // fall back to now rather than the snapshot: reaching the claim at all
+        // means the snapshot was already past the cooldown floor, so it would
+        // render a countdown in the past and tell the player they can dig again.
+        const current = await GrindProfile.findOne(mineClaimQuery).catch(() => null);
+        const lastAt  = current?.data?.lastMine ?? mineClaimNow;
+        const nextAt  = new Date(new Date(lastAt).getTime() + LIMITS.MINE_COOLDOWN_MS);
+        return interaction.reply({
+            embeds: [buildCooldownEmbed({
+                title: '⛏️ Catching Your Breath',
+                description: 'You just came up from a dig.\nTake a short break before heading back down.',
+                color: '#b5651d',
+                nextAt,
+            })],
+            flags: MessageFlags.Ephemeral,
         });
-
-        if (caveInChoice === 'blast' && chargesAvailable > 0) {
-            // Deduct one blast charge and keep the payout
-            if (chargeType) {
-                m.charges[chargeType] = chargesAvailable - 1;
-                user.markModified('mining');
-            }
-            result.caveInEscaped = true;
-        } else {
-            // Abandon: reverse the payout and any tier-find counters executeMine already booked
-            if (result.caveInPayout) {
-                user.balance       -= result.caveInPayout;
-                m.totalEarned      -= result.caveInPayout;
-                m.dailyCoins       -= result.caveInPayout;
-                result.finalPayout  = 0;
-            }
-            if (result.tier === 'legendary') m.legendaryFinds = Math.max(0, m.legendaryFinds - 1);
-            if (result.tier === 'event')     m.eventFinds     = Math.max(0, m.eventFinds - 1);
-            result.caveInAbandoned = true;
-        }
     }
+    m.lastMine = mineClaimNow;
 
-    // Pity counter: reset only when a rare+ find was actually kept (not abandoned in a cave-in)
-    const keptRareFind = result.success && !result.caveInAbandoned && ['rare', 'epic', 'legendary', 'event'].includes(result.tier);
-    if (keptRareFind) {
-        user.mining.sinceRare = 0;
-    } else {
-        user.mining.sinceRare = (user.mining.sinceRare ?? 0) + 1;
-    }
+    // The claim is a real write now, so a dig that dies before its result is
+    // saved would otherwise cost the player a full cooldown for nothing. Hand the
+    // slot back — but only while it is still ours, so a newer claim isn't undone.
+    const releaseMineClaim = () => GrindProfile.updateOne(
+        { ...mineClaimQuery, 'data.lastMine': mineClaimNow },
+        { $set: { 'data.lastMine': priorLastMine } },
+    ).catch(() => null);
 
-    // Yield bonuses below are gated on result.finalPayout > 0, which an abandoned
-    // cave-in resets to 0 above — so abandoning correctly forfeits these too.
-    if (result.success && result.finalPayout > 0 && isFeaturedDepth) {
-        const featBonus = Math.round(result.finalPayout * FEATURED_PAYOUT_BONUS);
-        if (featBonus > 0) {
-            user.balance               += featBonus;
-            user.mining.totalEarned    += featBonus;
-            user.mining.dailyCoins     += featBonus;
-            result.finalPayout         += featBonus;
-            result.featuredDepthBonus   = featBonus;
-        }
-    }
-
-    if (result.success && result.finalPayout > 0 && petMineYieldPct > 0) {
-        const bonus = Math.round(result.finalPayout * petMineYieldPct / 100);
-        if (bonus > 0) {
-            user.balance              += bonus;
-            user.mining.totalEarned   += bonus;
-            user.mining.dailyCoins    += bonus;
-            result.finalPayout        += bonus;
-            result.petYieldBonus       = bonus;
-        }
-    }
-
-    // Wilderness district: +10% mine yield (clamped to daily hard cap)
-    const wildernessActive = isDistrictActive(guildSettings, 'wilderness');
-    if (result.success && result.finalPayout > 0 && wildernessActive) {
-        const remaining = LIMITS.DAILY_HARD_CAP - user.mining.dailyCoins;
-        const rawBonus  = Math.round(result.finalPayout * WILDERNESS_YIELD_BONUS);
-        const bonus     = Math.max(0, Math.min(rawBonus, remaining));
-        if (bonus > 0) {
-            user.balance               += bonus;
-            user.mining.totalEarned    += bonus;
-            user.mining.dailyCoins     += bonus;
-            result.finalPayout         += bonus;
-            result.wildernessBonus      = bonus;
-        }
-    }
-
-    // bestPayout must reflect what the player actually walked away with, so this
-    // runs after the cave-in resolution and all yield bonuses above.
-    if (result.success && result.finalPayout > user.mining.bestPayout) user.mining.bestPayout = result.finalPayout;
-
-    updateMineQuestProgress(user, result, depthId);
-
-    // Update the persistent mine map with this dig's result
-    updateMineMap(user, result);
-
-    await ensureQuests(user, guildSettings);
-    const { completed: questsDone, nearComplete: questsNear } = await onMine(user, guildSettings);
-    if (result.success && result.finalPayout > 0) {
-        const earn = await onEconomyEarn(user, guildSettings, result.finalPayout);
-        questsDone.push(...earn.completed);
-        questsNear.push(...earn.nearComplete);
-    }
-
-    // Rare companions are found, not bought: a legendary result is the only
-    // thing that can turn one up. Rolled before the save below persists it.
-    // Mirrors the keptRareFind predicate above: a cave-in the player fled leaves
-    // result.success true while revoking the find, and an abandoned haul must not
-    // hand out a companion either.
-    const rarePetDrop = result.success && !result.caveInAbandoned
-        ? tryGrantRarePet(user, 'mine', result.tier)
-        : null;
-    if (rarePetDrop) user.markModified('pets');
-
-    const mineAchievements = await checkAndAward(user, guildSettings).catch(() => []);
-
+    // Everything between here and the save can still fail — a Discord API error
+    // while collecting the vein prompts, a service throwing — and until the result
+    // is persisted the player has nothing to show for the cooldown they just paid
+    // for. Hand the slot back on the way out unless the dig committed.
+    let mineCommitted = false;
     try {
-        await user.save();
-        if (mineAchievements.length) {
-            announceAchievements(interaction.client, guildSettings, user, interaction.member, mineAchievements).catch(() => null);
+
+        // The charge comes out only once the cooldown slot is ours, so a lost race
+        // never costs the player a charge.
+        if (pickaxeData.requiresCharge) {
+            m.charges[pickaxeData.chargeType] = (m.charges[pickaxeData.chargeType] ?? 0) - 1;
+            user.markModified('mining');
         }
-        notifyQuestComplete(guildSettings, interaction.member, questsDone, interaction.channel, user).catch(() => null);
-        notifyQuestNearComplete(guildSettings, interaction.member, questsNear, interaction.channel).catch(() => null);
-    } catch (err) {
-        if (err.name === 'VersionError') {
-            return interaction.editReply({ content: 'A simultaneous request conflicted with your mine. Please try `/mine dig` again.' });
+
+        // ── Vein-Following Puzzle ──────────────────────────────────────────────────
+        // 3 rounds of directional navigation through a mine tunnel.
+        // Each round: a 3×3 emoji grid shows the current position (⛏️) and a mineral
+        // trace in one of the 4 adjacent cells. Player picks the matching direction.
+        // Correct directions accumulate depth; final depth maps to intensity level.
+        //   0/3 correct → Surface  (0.7×, 0% cave-in)
+        //   1/3 correct → Shallow  (1.0×, 5% cave-in)
+        //   2/3 correct → Mid      (1.4×, 12% cave-in)
+        //   3/3 correct → Deep     (2.0×, 20% cave-in)
+        //   3/3 + lucky → Abyss    (3.0×, 30% cave-in)  10% chance on a perfect run
+
+        const featured         = getDailyFeatured(interaction.guild.id);
+        const isFeaturedDepth  = depthId === featured.mineDepth.id;
+        const timeBand         = getTimeBand();
+        const delay = ms => new Promise(r => setTimeout(r, ms));
+
+        const DIRS = [
+            { id: 'N', label: '⬆️ North', row: 0, col: 1 },
+            { id: 'S', label: '⬇️ South', row: 2, col: 1 },
+            { id: 'W', label: '⬅️ West',  row: 1, col: 0 },
+            { id: 'E', label: '➡️ East',  row: 1, col: 2 },
+        ];
+
+        // Build a 3×3 grid string highlighting the ore direction
+        function buildGrid(oreDir) {
+            const grid = [
+                ['🪨', '🪨', '🪨'],
+                ['🪨', '⛏️', '🪨'],
+                ['🪨', '🪨', '🪨'],
+            ];
+            const d = DIRS.find(d => d.id === oreDir);
+            grid[d.row][d.col] = '✨';
+            return grid.map(row => row.join(' ')).join('\n');
         }
-        console.error('[mine] save error:', err);
-        return interaction.editReply({ content: 'Something went wrong saving your mine. Please try again.' });
-    }
 
-    // Log big win, then await hourly leader update and re-fetch for accurate footer
-    if (result.success && result.finalPayout > 0) {
-        const bigWinThreshold = guildSettings?.economy?.bigWinThreshold ?? 50000;
-        if (result.finalPayout >= bigWinThreshold || result.tier === 'legendary') {
-            logBigWin({ guildId: interaction.guild.id, userId: interaction.user.id, username: interaction.user.username, amount: result.finalPayout, source: 'mine', details: { itemName: result.ore?.name, rarity: result.tier }, client: interaction.client });
-        }
-        await tryUpdateHourlyWinner({ guildId: interaction.guild.id, category: 'mine', userId: interaction.user.id, username: interaction.user.username, value: result.finalPayout, details: result.ore ? `${result.ore.emoji ?? ''} ${result.ore.name} (${currency}${result.finalPayout.toLocaleString()})`.trim() : `${currency}${result.finalPayout.toLocaleString()}` }).catch(() => null);
-    }
-    const hourlyLeader = await getCurrentHourlyLeader(interaction.guild.id, 'mine').catch(() => null);
+        const featuredDepthNote = isFeaturedDepth
+            ? `\n🌟 **Featured Depth!** +${Math.round(FEATURED_PAYOUT_BONUS * 100)}% payout active.`
+            : '';
 
-    const embed = buildMineEmbed(result, user, depth, pickaxe, currency, interaction.user);
-    {
-        const desc = embed.data.description ?? '';
-        const lines = [`> ⛏️ *${finalIcons} — Vein depth ${veinDepth}/3 → ${chosenIntensity.emoji} ${chosenIntensity.name} (${chosenIntensity.multiplier}×)*`];
-        if (result.caveIn && result.caveInEscaped) lines.push(`> 💥 *Cave-in! You used a blast charge — ore saved.*`);
-        else if (result.caveIn) lines.push(`> 💥 *${randomFrom(MINE_CAVE_LINES)}*`);
-        embed.setDescription(desc + '\n' + lines.join('\n'));
-    }
-    if (result.featuredDepthBonus > 0) {
-        embed.addFields({ name: '🌟 Featured Depth Bonus', value: `+${result.featuredDepthBonus.toLocaleString()} coins (+${Math.round(FEATURED_PAYOUT_BONUS * 100)}%)`, inline: true });
-    }
-    if (result.petYieldBonus > 0) {
-        embed.addFields({ name: '💎 Pet Bonus', value: `+${result.petYieldBonus.toLocaleString()} coins (${petMineYieldPct}% yield)`, inline: true });
-    }
-    if (result.wildernessBonus > 0) {
-        embed.addFields({ name: '🌲 Wilderness District', value: `+${result.wildernessBonus.toLocaleString()} coins (+10% yield)`, inline: true });
-    }
-
-    // Hourly leader footer
-    const leaderNote = hourlyLeader
-        ? `🏆 Biggest dig this hour: ${hourlyLeader.username} — ${hourlyLeader.details ?? hourlyLeader.value.toLocaleString() + ' coins'}`
-        : '🏆 No hourly leader yet — be the first!';
-    const existingFooter = embed.data.footer?.text ?? '';
-    embed.setFooter({ text: existingFooter ? `${existingFooter} · ${timeBand.emoji} ${timeBand.label} · ${leaderNote}` : `${timeBand.emoji} ${timeBand.label} · ${leaderNote}` });
-
-    // Rare companion drop — announced prominently; this is the only way to get one.
-    if (rarePetDrop) {
-        embed.addFields({
-            name: `${rarePetDrop.emoji} A Rare Companion Appears!`,
-            value: `A wild **${rarePetDrop.name}** followed you home! It joined your pets at full hunger.\n`
-                 + `Passive: **+${rarePetDrop.bonusPct}% ${rarePetDrop.bonusType.replace(/_/g, ' ')}** · Favourite food: \`${rarePetDrop.favoriteMaterial}\`\n`
-                 + `*Name it with \`/pet rename\` and keep it fed with \`/pet feed\`.*`,
-            inline: false,
+        await interaction.reply({
+            embeds: [new EmbedBuilder()
+                .setColor(isFeaturedDepth ? '#FFD700' : '#8B4513')
+                .setTitle(`⛏️ Entering ${depth.emoji} ${depth.name}…`)
+                .setDescription(
+                    `*You lower yourself into the shaft. Dust settles. Your lamp catches a glint…*\n\n` +
+                    `**Follow the vein** — 3 rounds of directional choices. The deeper you follow it, the richer the haul.${featuredDepthNote}`
+                )
+                .setFooter({ text: `${timeBand.emoji} ${timeBand.label} · 15 seconds per choice — miss a round and you stop there.` })],
+            components: [],
         });
-    }
+        const mineMsg = await interaction.fetchReply();
+        await delay(1500);
 
-    // Pet narrative: show active pet's personality flavor in description
-    if (result.success) {
-        const activePet = (user.pets || []).find(p => isPetActive(p));
-        if (activePet) {
-            const petDef = PET_DEFS[activePet.petId];
-            const petName = activePet.name || petDef?.name || activePet.petId;
-            const flavorFn = TRAIT_FLAVOR[activePet.personality]?.mine;
-            if (flavorFn && petDef) {
-                const desc = embed.data.description ?? '';
-                embed.setDescription(desc + `\n> ${flavorFn(petName, petDef.emoji)}`);
+        let veinDepth = 0;
+        const roundLog = [];
+
+        for (let round = 0; round < 3; round++) {
+            const oreDir  = DIRS[Math.floor(Math.random() * DIRS.length)];
+            const grid    = buildGrid(oreDir.id);
+            const prevLog = roundLog.map((r, i) => r ? `✅` : `❌`).join(' ');
+
+            const veinEmbed = new EmbedBuilder()
+                .setColor('#B8860B')
+                .setTitle(`⛏️ Vein Read — Round ${round + 1}/3`)
+                .setDescription(
+                    `${prevLog ? prevLog + '\n\n' : ''}` +
+                    `*Mineral trace spotted — which way does the vein run?*\n\n` +
+                    `\`\`\`\n${grid}\n\`\`\``
+                )
+                .setFooter({ text: '15 seconds to choose a direction.' });
+
+            const dirRow = new ActionRowBuilder().addComponents(
+                ...DIRS.map(d => new ButtonBuilder()
+                    .setCustomId(`vein_${d.id}`)
+                    .setLabel(d.label)
+                    .setStyle(ButtonStyle.Primary)
+                )
+            );
+
+            await interaction.editReply({ embeds: [veinEmbed], components: [dirRow] });
+
+            const picked = await new Promise(resolve => {
+                const col = mineMsg.createMessageComponentCollector({
+                    filter: i => i.user.id === interaction.user.id && i.customId.startsWith('vein_'),
+                    time: 15_000,
+                    max: 1,
+                });
+                col.on('collect', async i => { await i.deferUpdate(); resolve(i.customId.replace('vein_', '')); });
+                col.on('end',     (_, reason) => { if (reason !== 'limit') resolve(null); });
+            });
+
+            const correct = picked === oreDir.id;
+            roundLog.push(correct);
+            if (correct) veinDepth++;
+
+            const roundResult = new EmbedBuilder()
+                .setColor(correct ? '#00CC55' : picked ? '#CC4400' : '#888888')
+                .setTitle(correct ? '✅ Vein found!' : picked ? '❌ Dead end — rubble.' : '⏰ Hesitated…')
+                .setDescription(
+                    correct
+                        ? `You followed the vein **${oreDir.label}**. It runs deeper here.`
+                        : picked
+                        ? `The vein ran **${oreDir.label}** — you hit rubble instead.`
+                        : `The vein ran **${oreDir.label}** — you didn't move in time.`
+                );
+            await interaction.editReply({ embeds: [roundResult], components: [] });
+            if (round < 2) await delay(900);
+        }
+
+        // Map vein depth to intensity level
+        let intensityIndex = veinDepth; // 0→L1, 1→L2, 2→L3, 3→L4
+        if (veinDepth === 3 && Math.random() < 0.10) intensityIndex = 4; // lucky Abyss
+        const chosenIntensity = INTENSITY_LEVELS[intensityIndex];
+
+        const finalIcons = roundLog.map(r => r ? '✅' : '❌').join(' ');
+        const confirmEmbed = new EmbedBuilder()
+            .setColor(chosenIntensity.level >= 4 ? '#FF4444' : chosenIntensity.level >= 3 ? '#FFA500' : '#00AA55')
+            .setTitle(`${chosenIntensity.emoji} Digging ${chosenIntensity.name}…`)
+            .setDescription(
+                `${finalIcons}\n\n` +
+                `Vein depth reached: **${veinDepth}/3 correct**\n` +
+                `**${chosenIntensity.multiplier}×** payout  |  **${(chosenIntensity.caveInRisk * 100).toFixed(0)}%** cave-in risk`
+            );
+        await interaction.editReply({ embeds: [confirmEmbed], components: [] });
+
+        // Crystal Fox pet: +15% mine yield (only if hunger >= 30)
+        const { getTotalBonus, PET_DEFINITIONS: PET_DEFS, isPetActive, TRAIT_FLAVOR, tryGrantRarePet } = require('../../services/petService');
+        const petMineYieldPct = getTotalBonus(user.pets || [], 'mine_yield');
+
+        const marketplaceActive = isDistrictActive(guildSettings, 'marketplace');
+        const result = executeMine(user, depthId, { intensity: chosenIntensity, marketplaceActive });
+
+        // ── Cave-in Interactive Event ─────────────────────────────────────────────
+        // Resolved FIRST: pity, find counters, and yield bonuses below must only
+        // apply to rewards the player actually keeps, not ore abandoned in a collapse.
+        if (result.caveIn) {
+            const m = user.mining;
+            const equippedPickaxe = m.pickaxes?.[m.equippedPickaxeIndex];
+            const pickaxeStaticData = equippedPickaxe ? PICKAXE_BY_TIER[equippedPickaxe.tier] : null;
+            const chargeType = pickaxeStaticData?.chargeType;
+            const chargesAvailable = chargeType ? (m.charges?.[chargeType] ?? 0) : 0;
+
+            const caveInEmbed = new EmbedBuilder()
+                .setColor('#8B0000')
+                .setTitle('🌑 CAVE-IN!')
+                .setDescription(
+                    `━━━━━━━━━━━━━━━━━━━━━━━\n` +
+                    `The tunnel is collapsing around you. Dust fills the air.\n` +
+                    `You have seconds to decide.\n\n` +
+                    `⚡ **Ore at stake:** ${(result.caveInPayout ?? 0).toLocaleString()} coins\n\n` +
+                    (chargesAvailable > 0
+                        ? `💥 You have **${chargesAvailable}** blast charge${chargesAvailable !== 1 ? 's' : ''} — enough to blow an escape route.`
+                        : `⚠️ You have no blast charges — you'll have to run.`)
+                )
+                .setFooter({ text: 'You have 20 seconds to decide.' });
+
+            const caveInId = `cavein_${interaction.id}`;
+            const blastBtn = new ButtonBuilder()
+                .setCustomId(`${caveInId}_blast`)
+                .setLabel('💥 Use a Blast Charge — save your ore')
+                .setStyle(ButtonStyle.Success)
+                .setDisabled(chargesAvailable <= 0);
+            const abandonBtn = new ButtonBuilder()
+                .setCustomId(`${caveInId}_abandon`)
+                .setLabel('🏃 Abandon the Dig — flee empty-handed')
+                .setStyle(ButtonStyle.Danger);
+            const caveInRow = new ActionRowBuilder().addComponents(blastBtn, abandonBtn);
+
+            await interaction.editReply({ embeds: [caveInEmbed], components: [caveInRow] });
+            const caveInMsg = await interaction.fetchReply();
+
+            const caveInChoice = await new Promise(resolve => {
+                const col = caveInMsg.createMessageComponentCollector({
+                    filter: i => i.user.id === interaction.user.id && i.customId.startsWith(caveInId),
+                    time: 20_000,
+                    max: 1,
+                });
+                col.on('collect', async i => { await i.deferUpdate(); resolve(i.customId.endsWith('_blast') ? 'blast' : 'abandon'); });
+                col.on('end', (_, reason) => { if (reason !== 'limit') resolve('abandon'); });
+            });
+
+            if (caveInChoice === 'blast' && chargesAvailable > 0) {
+                // Deduct one blast charge and keep the payout
+                if (chargeType) {
+                    m.charges[chargeType] = chargesAvailable - 1;
+                    user.markModified('mining');
+                }
+                result.caveInEscaped = true;
+            } else {
+                // Abandon: reverse the payout and any tier-find counters executeMine already booked
+                if (result.caveInPayout) {
+                    user.balance       -= result.caveInPayout;
+                    m.totalEarned      -= result.caveInPayout;
+                    m.dailyCoins       -= result.caveInPayout;
+                    result.finalPayout  = 0;
+                }
+                if (result.tier === 'legendary') m.legendaryFinds = Math.max(0, m.legendaryFinds - 1);
+                if (result.tier === 'event')     m.eventFinds     = Math.max(0, m.eventFinds - 1);
+                result.caveInAbandoned = true;
             }
         }
-    }
 
-    // Staged loot reveal for rare+ drops
-    await stagedLootReveal(interaction, result.success ? result.tier : null, embed);
+        // Pity counter: reset only when a rare+ find was actually kept (not abandoned in a cave-in)
+        const keptRareFind = result.success && !result.caveInAbandoned && ['rare', 'epic', 'legendary', 'event'].includes(result.tier);
+        if (keptRareFind) {
+            user.mining.sinceRare = 0;
+        } else {
+            user.mining.sinceRare = (user.mining.sinceRare ?? 0) + 1;
+        }
 
-    if (result.success && ['epic', 'legendary'].includes(result.tier) && guildSettings?.economy?.announceRareDrops !== false) {
-        const announceChannelId = guildSettings?.economy?.announcementChannelId;
-        const resolved = announceChannelId ? interaction.guild.channels.cache.get(announceChannelId) : null;
-        const announceChannel = resolved?.isTextBased() ? resolved : interaction.channel;
-        const isLeg = result.tier === 'legendary';
-        const announcementEmbed = new EmbedBuilder()
-            .setColor(isLeg ? '#ff9800' : '#9c27b0')
-            .setTitle(isLeg ? '✨ Legendary Strike! ✨' : '🔮 Epic Ore Unearthed!')
-            .setDescription(
-                `<@${interaction.user.id}> just unearthed ${result.ore.emoji} **${result.ore.name}** [${isLeg ? '⭐⭐⭐⭐⭐' : '⭐⭐⭐⭐'}]\n` +
-                `at the **${depth.name}** depth.\n\n` +
-                (isLeg ? `That vein runs deep — and dangerous.` : `A rare find in these tunnels.`)
-            )
-            .setTimestamp();
-        announceChannel.send({ embeds: [announcementEmbed] }).catch(() => null);
-    }
+        // Yield bonuses below are gated on result.finalPayout > 0, which an abandoned
+        // cave-in resets to 0 above — so abandoning correctly forfeits these too.
+        if (result.success && result.finalPayout > 0 && isFeaturedDepth) {
+            const featBonus = Math.round(result.finalPayout * FEATURED_PAYOUT_BONUS);
+            if (featBonus > 0) {
+                user.balance               += featBonus;
+                user.mining.totalEarned    += featBonus;
+                user.mining.dailyCoins     += featBonus;
+                result.finalPayout         += featBonus;
+                result.featuredDepthBonus   = featBonus;
+            }
+        }
 
-    // Catastrophic cave-in server announcement (Deep or Abyss intensity, pickaxe destroyed)
-    if (result.caveIn && result.pickaxeBroke && chosenIntensity.level >= 4 && guildSettings?.economy?.announceRareDrops !== false) {
-        const announceChannelId = guildSettings?.economy?.announcementChannelId;
-        const resolved = announceChannelId ? interaction.guild.channels.cache.get(announceChannelId) : null;
-        const announceChannel = resolved?.isTextBased() ? resolved : interaction.channel;
-        const caveEmbed = new EmbedBuilder()
-            .setColor('#b5651d')
-            .setTitle('💥 Catastrophic Cave-in!')
-            .setDescription(
-                `<@${interaction.user.id}> just suffered a **catastrophic cave-in** at Depth **${chosenIntensity.name}** (${depth.name})!\n` +
-                `Their **${pickaxe.name}** has been destroyed.\n\n` +
-                `*Others are warned: the tunnel grows less stable the deeper you go.*`
-            )
-            .setTimestamp();
-        announceChannel.send({ embeds: [caveEmbed] }).catch(() => null);
+        if (result.success && result.finalPayout > 0 && petMineYieldPct > 0) {
+            const bonus = Math.round(result.finalPayout * petMineYieldPct / 100);
+            if (bonus > 0) {
+                user.balance              += bonus;
+                user.mining.totalEarned   += bonus;
+                user.mining.dailyCoins    += bonus;
+                result.finalPayout        += bonus;
+                result.petYieldBonus       = bonus;
+            }
+        }
+
+        // Wilderness district: +10% mine yield (clamped to daily hard cap)
+        const wildernessActive = isDistrictActive(guildSettings, 'wilderness');
+        if (result.success && result.finalPayout > 0 && wildernessActive) {
+            const remaining = LIMITS.DAILY_HARD_CAP - user.mining.dailyCoins;
+            const rawBonus  = Math.round(result.finalPayout * WILDERNESS_YIELD_BONUS);
+            const bonus     = Math.max(0, Math.min(rawBonus, remaining));
+            if (bonus > 0) {
+                user.balance               += bonus;
+                user.mining.totalEarned    += bonus;
+                user.mining.dailyCoins     += bonus;
+                result.finalPayout         += bonus;
+                result.wildernessBonus      = bonus;
+            }
+        }
+
+        // bestPayout must reflect what the player actually walked away with, so this
+        // runs after the cave-in resolution and all yield bonuses above.
+        if (result.success && result.finalPayout > user.mining.bestPayout) user.mining.bestPayout = result.finalPayout;
+
+        updateMineQuestProgress(user, result, depthId);
+
+        // Update the persistent mine map with this dig's result
+        updateMineMap(user, result);
+
+        await ensureQuests(user, guildSettings);
+        const { completed: questsDone, nearComplete: questsNear } = await onMine(user, guildSettings);
+        if (result.success && result.finalPayout > 0) {
+            const earn = await onEconomyEarn(user, guildSettings, result.finalPayout);
+            questsDone.push(...earn.completed);
+            questsNear.push(...earn.nearComplete);
+        }
+
+        // Rare companions are found, not bought: a legendary result is the only
+        // thing that can turn one up. Rolled before the save below persists it.
+        // Mirrors the keptRareFind predicate above: a cave-in the player fled leaves
+        // result.success true while revoking the find, and an abandoned haul must not
+        // hand out a companion either.
+        const rarePetDrop = result.success && !result.caveInAbandoned
+            ? tryGrantRarePet(user, 'mine', result.tier)
+            : null;
+        if (rarePetDrop) user.markModified('pets');
+
+        const mineAchievements = await checkAndAward(user, guildSettings).catch(() => []);
+
+        try {
+            await user.save();
+            mineCommitted = true;
+            if (mineAchievements.length) {
+                announceAchievements(interaction.client, guildSettings, user, interaction.member, mineAchievements).catch(() => null);
+            }
+            notifyQuestComplete(guildSettings, interaction.member, questsDone, interaction.channel, user).catch(() => null);
+            notifyQuestNearComplete(guildSettings, interaction.member, questsNear, interaction.channel).catch(() => null);
+        } catch (err) {
+            // Nothing was saved, so give the cooldown slot back before telling them to retry.
+            await releaseMineClaim();
+            if (err.name === 'VersionError') {
+                return interaction.editReply({ content: 'A simultaneous request conflicted with your mine. Please try `/mine dig` again.' });
+            }
+            console.error('[mine] save error:', err);
+            return interaction.editReply({ content: 'Something went wrong saving your mine. Please try again.' });
+        }
+
+        // Log big win, then await hourly leader update and re-fetch for accurate footer
+        if (result.success && result.finalPayout > 0) {
+            const bigWinThreshold = guildSettings?.economy?.bigWinThreshold ?? 50000;
+            if (result.finalPayout >= bigWinThreshold || result.tier === 'legendary') {
+                logBigWin({ guildId: interaction.guild.id, userId: interaction.user.id, username: interaction.user.username, amount: result.finalPayout, source: 'mine', details: { itemName: result.ore?.name, rarity: result.tier }, client: interaction.client });
+            }
+            await tryUpdateHourlyWinner({ guildId: interaction.guild.id, category: 'mine', userId: interaction.user.id, username: interaction.user.username, value: result.finalPayout, details: result.ore ? `${result.ore.emoji ?? ''} ${result.ore.name} (${currency}${result.finalPayout.toLocaleString()})`.trim() : `${currency}${result.finalPayout.toLocaleString()}` }).catch(() => null);
+        }
+        const hourlyLeader = await getCurrentHourlyLeader(interaction.guild.id, 'mine').catch(() => null);
+
+        const embed = buildMineEmbed(result, user, depth, pickaxe, currency, interaction.user);
+        {
+            const desc = embed.data.description ?? '';
+            const lines = [`> ⛏️ *${finalIcons} — Vein depth ${veinDepth}/3 → ${chosenIntensity.emoji} ${chosenIntensity.name} (${chosenIntensity.multiplier}×)*`];
+            if (result.caveIn && result.caveInEscaped) lines.push(`> 💥 *Cave-in! You used a blast charge — ore saved.*`);
+            else if (result.caveIn) lines.push(`> 💥 *${randomFrom(MINE_CAVE_LINES)}*`);
+            embed.setDescription(desc + '\n' + lines.join('\n'));
+        }
+        if (result.featuredDepthBonus > 0) {
+            embed.addFields({ name: '🌟 Featured Depth Bonus', value: `+${result.featuredDepthBonus.toLocaleString()} coins (+${Math.round(FEATURED_PAYOUT_BONUS * 100)}%)`, inline: true });
+        }
+        if (result.petYieldBonus > 0) {
+            embed.addFields({ name: '💎 Pet Bonus', value: `+${result.petYieldBonus.toLocaleString()} coins (${petMineYieldPct}% yield)`, inline: true });
+        }
+        if (result.wildernessBonus > 0) {
+            embed.addFields({ name: '🌲 Wilderness District', value: `+${result.wildernessBonus.toLocaleString()} coins (+10% yield)`, inline: true });
+        }
+
+        // Hourly leader footer
+        const leaderNote = hourlyLeader
+            ? `🏆 Biggest dig this hour: ${hourlyLeader.username} — ${hourlyLeader.details ?? hourlyLeader.value.toLocaleString() + ' coins'}`
+            : '🏆 No hourly leader yet — be the first!';
+        const existingFooter = embed.data.footer?.text ?? '';
+        embed.setFooter({ text: existingFooter ? `${existingFooter} · ${timeBand.emoji} ${timeBand.label} · ${leaderNote}` : `${timeBand.emoji} ${timeBand.label} · ${leaderNote}` });
+
+        // Rare companion drop — announced prominently; this is the only way to get one.
+        if (rarePetDrop) {
+            embed.addFields({
+                name: `${rarePetDrop.emoji} A Rare Companion Appears!`,
+                value: `A wild **${rarePetDrop.name}** followed you home! It joined your pets at full hunger.\n`
+                     + `Passive: **+${rarePetDrop.bonusPct}% ${rarePetDrop.bonusType.replace(/_/g, ' ')}** · Favourite food: \`${rarePetDrop.favoriteMaterial}\`\n`
+                     + `*Name it with \`/pet rename\` and keep it fed with \`/pet feed\`.*`,
+                inline: false,
+            });
+        }
+
+        // Pet narrative: show active pet's personality flavor in description
+        if (result.success) {
+            const activePet = (user.pets || []).find(p => isPetActive(p));
+            if (activePet) {
+                const petDef = PET_DEFS[activePet.petId];
+                const petName = activePet.name || petDef?.name || activePet.petId;
+                const flavorFn = TRAIT_FLAVOR[activePet.personality]?.mine;
+                if (flavorFn && petDef) {
+                    const desc = embed.data.description ?? '';
+                    embed.setDescription(desc + `\n> ${flavorFn(petName, petDef.emoji)}`);
+                }
+            }
+        }
+
+        // Staged loot reveal for rare+ drops
+        await stagedLootReveal(interaction, result.success ? result.tier : null, embed);
+
+        if (result.success && ['epic', 'legendary'].includes(result.tier) && guildSettings?.economy?.announceRareDrops !== false) {
+            const announceChannelId = guildSettings?.economy?.announcementChannelId;
+            const resolved = announceChannelId ? interaction.guild.channels.cache.get(announceChannelId) : null;
+            const announceChannel = resolved?.isTextBased() ? resolved : interaction.channel;
+            const isLeg = result.tier === 'legendary';
+            const announcementEmbed = new EmbedBuilder()
+                .setColor(isLeg ? '#ff9800' : '#9c27b0')
+                .setTitle(isLeg ? '✨ Legendary Strike! ✨' : '🔮 Epic Ore Unearthed!')
+                .setDescription(
+                    `<@${interaction.user.id}> just unearthed ${result.ore.emoji} **${result.ore.name}** [${isLeg ? '⭐⭐⭐⭐⭐' : '⭐⭐⭐⭐'}]\n` +
+                    `at the **${depth.name}** depth.\n\n` +
+                    (isLeg ? `That vein runs deep — and dangerous.` : `A rare find in these tunnels.`)
+                )
+                .setTimestamp();
+            announceChannel.send({ embeds: [announcementEmbed] }).catch(() => null);
+        }
+
+        // Catastrophic cave-in server announcement (Deep or Abyss intensity, pickaxe destroyed)
+        if (result.caveIn && result.pickaxeBroke && chosenIntensity.level >= 4 && guildSettings?.economy?.announceRareDrops !== false) {
+            const announceChannelId = guildSettings?.economy?.announcementChannelId;
+            const resolved = announceChannelId ? interaction.guild.channels.cache.get(announceChannelId) : null;
+            const announceChannel = resolved?.isTextBased() ? resolved : interaction.channel;
+            const caveEmbed = new EmbedBuilder()
+                .setColor('#b5651d')
+                .setTitle('💥 Catastrophic Cave-in!')
+                .setDescription(
+                    `<@${interaction.user.id}> just suffered a **catastrophic cave-in** at Depth **${chosenIntensity.name}** (${depth.name})!\n` +
+                    `Their **${pickaxe.name}** has been destroyed.\n\n` +
+                    `*Others are warned: the tunnel grows less stable the deeper you go.*`
+                )
+                .setTimestamp();
+            announceChannel.send({ embeds: [caveEmbed] }).catch(() => null);
+        }
+    } catch (err) {
+        if (!mineCommitted) await releaseMineClaim();
+        throw err;
     }
 }
 

--- a/src/migrations/009_drop_stale_grind_indexes.js
+++ b/src/migrations/009_drop_stale_grind_indexes.js
@@ -1,0 +1,49 @@
+const mongoose = require('mongoose');
+
+/**
+ * Drops the hunt and fishing indexes that migrations 002 and 003 built on the
+ * users collection.
+ *
+ * Both were written while hunt and fishing state still lived on the User
+ * document. Migration 005 moved all four grind systems into their own
+ * GrindProfile collection and $unset the User fields, so every one of these
+ * indexes now covers a path no document has — they cost write throughput and
+ * disk while serving no query.
+ *
+ * Nothing is created in their place. The surviving queries on that data are
+ * keyed on { guildId, userId, system } (cooldown claims) or sort by data.xp /
+ * data.totalEarned (leaderboards), and GrindProfile already declares indexes
+ * for both — see src/models/GrindProfile.js.
+ *
+ * 002 and 003 are left as they are rather than emptied: they are already
+ * recorded as applied on every existing deployment, and rewriting an applied
+ * migration makes the record lie about what ran. A fresh database creates the
+ * seven indexes and drops them again moments later, which costs one pass over
+ * an empty collection.
+ */
+const STALE_INDEXES = [
+    // 002_hunt_indexes
+    'idx_hunt_stamina_regen',
+    'idx_hunt_leaderboard_earned',
+    'idx_hunt_leaderboard_legendary',
+    // 003_fishing_indexes
+    'idx_fishing_stamina_regen',
+    'idx_fishing_leaderboard_earned',
+    'idx_fishing_leaderboard_legendary',
+    'idx_fishing_last_cast',
+];
+
+module.exports = {
+    name: '009_drop_stale_grind_indexes',
+
+    async up() {
+        const users = mongoose.connection.db.collection('users');
+
+        for (const name of STALE_INDEXES) {
+            await users.dropIndex(name).catch(err => {
+                // A deployment that never ran 002/003 simply has nothing to drop.
+                if (err?.codeName !== 'IndexNotFound') throw err;
+            });
+        }
+    },
+};

--- a/src/services/effectsService.js
+++ b/src/services/effectsService.js
@@ -115,6 +115,27 @@ function consumeEffect(user, type) {
     return true;
 }
 
+// Restore one charge consumed by consumeEffect, re-adding the effect if spending
+// the last charge removed it. Used when an action that already charged the player
+// is reversed (e.g. a fish escaping after the payout was rolled).
+// No-op for unlimited-charge effects (charges === -1), which are never spent.
+function refundEffectCharge(user, type) {
+    const cfg = EFFECT_CONFIGS[type];
+    if (!cfg || cfg.charges === -1) return false;
+    pruneEffects(user);
+    const effect = user.activeEffects.find(e => e.type === type);
+    if (effect) {
+        effect.charges = Math.min(cfg.charges, effect.charges + 1);
+    } else {
+        user.activeEffects.push({
+            type,
+            expiresAt: cfg.durationMs ? new Date(Date.now() + cfg.durationMs) : null,
+            charges:   1,
+        });
+    }
+    return true;
+}
+
 // Returns a human-readable time-remaining string (e.g. "1h 23m")
 function timeRemaining(expiresAt) {
     if (!expiresAt) return 'permanent';
@@ -204,6 +225,7 @@ module.exports = {
     getEffect,
     addEffect,
     consumeEffect,
+    refundEffectCharge,
     timeRemaining,
     getCoinMultiplier,
     getSalaryMultiplier,

--- a/src/services/fishService.js
+++ b/src/services/fishService.js
@@ -30,6 +30,7 @@ const { getBonusMultipliers } = require('../utils/prestige');
 const { getGatheringYieldEffect, consumeEffect } = require('./effectsService');
 
 const DAILY_QUEST_COUNT = 3;
+const WEEK_MS = 7 * 24 * 3_600_000;
 
 // ─── INIT ────────────────────────────────────────────────────────────────────
 
@@ -74,6 +75,7 @@ function ensureFishingData(user) {
     if (f.personalBest         == null) f.personalBest         = { fish: null, weight: 0, payout: 0 };
     if (f.weeklyRecord         == null) f.weeklyRecord         = { fish: null, weight: 0, userId: null, username: null, weekStart: null };
     if (f.lastBossEncounter    == null) f.lastBossEncounter    = null;
+    if (!Array.isArray(f.trophies)) f.trophies = [];
 
     if (!f.unlockedLocations.includes('pond')) f.unlockedLocations.push('pond');
 
@@ -348,8 +350,10 @@ function applyPayoutModifiers(user, rawPayout, location) {
         return { adjustedPayout: 0, cappedByHard: true };
     }
 
-    // Silvered Talisman / Voidsteel Cache: 2x yield, consume 1 charge from whichever is active
-    const gatherEffect = getGatheringYieldEffect(user);
+    // Silvered Talisman / Voidsteel Cache: 2x yield, consume 1 charge from whichever
+    // is active. Only spend a charge when there is something to double — a worthless
+    // junk pull must not burn a charge for 2 × 0.
+    const gatherEffect = payout > 0 ? getGatheringYieldEffect(user) : null;
     if (gatherEffect) { consumeEffect(user, gatherEffect); payout *= 2; }
     if (f.dailyCoins >= LIMITS.DAILY_SOFT_CAP) {
         payout = Math.round(payout * 0.50);
@@ -358,7 +362,7 @@ function applyPayoutModifiers(user, rawPayout, location) {
     const remaining = LIMITS.DAILY_HARD_CAP - f.dailyCoins;
     payout = Math.min(payout, remaining);
 
-    return { adjustedPayout: Math.max(0, payout), cappedByHard: false };
+    return { adjustedPayout: Math.max(0, payout), cappedByHard: false, gatherEffectConsumed: gatherEffect };
 }
 
 // ─── DURABILITY ───────────────────────────────────────────────────────────────
@@ -380,7 +384,13 @@ function updateRodStatus(rod) {
     else                   rod.status = 'good';
 }
 
-function applyRepair(rod, requestedAmount) {
+/**
+ * Prices a shop repair without touching the rod, so a caller can check the
+ * player's balance before committing. A repair permanently degrades max
+ * durability, so quoting and applying must be separable — an unaffordable
+ * quote must leave the rod exactly as it was.
+ */
+function quoteRepair(rod, requestedAmount) {
     const rodData = ROD_BY_TIER[rod.tier];
     if (!rodData) throw new Error('Unknown rod tier');
 
@@ -398,15 +408,22 @@ function applyRepair(rod, requestedAmount) {
     const needed = Math.max(0, newMax - rod.currentDurability);
     const amount = Math.min(requestedAmount ?? needed, needed);
     const units  = Math.ceil(amount / 20);
-    const cost   = units * rodData.repairCostPer20;
 
-    rod.maxDurability     = newMax;
-    rod.currentDurability = Math.min(newMax, rod.currentDurability + amount);
+    return { newMax, restoredAmount: amount, cost: units * rodData.repairCostPer20 };
+}
+
+/** Commits the repair priced by quoteRepair. Mutates the rod. */
+function applyRepair(rod, requestedAmount) {
+    const quote = quoteRepair(rod, requestedAmount);
+    if (quote.error) return quote;
+
+    rod.maxDurability     = quote.newMax;
+    rod.currentDurability = Math.min(quote.newMax, rod.currentDurability + quote.restoredAmount);
     rod.repairCount      += 1;
 
     updateRodStatus(rod);
 
-    return { cost, restoredAmount: amount, newStatus: rod.status, condemned: rod.status === 'condemned' };
+    return { cost: quote.cost, restoredAmount: quote.restoredAmount, newStatus: rod.status, condemned: rod.status === 'condemned' };
 }
 
 // ─── LEVEL / XP ──────────────────────────────────────────────────────────────
@@ -706,7 +723,8 @@ function executeCast(user, locationId, options = {}) {
             const critMultiplier = isCrit ? (1.5 + Math.random() * 1.0) : 1.0;
             const preModPayout   = Math.round(sizedPayout * critMultiplier * traitPayoutMult * streakMult * reactionFactor);
 
-            const { adjustedPayout, cappedByHard } = applyPayoutModifiers(user, preModPayout, location);
+            const { adjustedPayout, cappedByHard, gatherEffectConsumed } = applyPayoutModifiers(user, preModPayout, location);
+            result.gatherEffectConsumed = gatherEffectConsumed;
 
             // ── Special material drop ──────────────────────────────────────
             let specialDrop = null;
@@ -751,10 +769,24 @@ function executeCast(user, locationId, options = {}) {
                     f.personalBest = { fish: fish.name, weight: weightLbs, payout: adjustedPayout, caughtAt: new Date() };
                     isPersonalBest = true;
                 }
-                // Weekly server record stored on user (simplification; a real server record needs a guild-level store)
-                if (!f.weeklyRecord || weightLbs > f.weeklyRecord.weight) {
-                    f.weeklyRecord = { fish: fish.name, weight: weightLbs, weekStart: new Date() };
-                    newRecord = { type: 'personal', fish: fish.name, weight: weightLbs };
+                // Per-player heaviest catch of the current week. The server-wide
+                // records live on the guild document (see checkAndUpdateWorldRecord).
+                // Roll the window over first, otherwise the "weekly" best is just an
+                // all-time best that can never be beaten by a lighter fish.
+                const weekStart = f.weeklyRecord?.weekStart;
+                const weekExpired = !weekStart || (Date.now() - new Date(weekStart).getTime()) >= WEEK_MS;
+                if (weekExpired) {
+                    f.weeklyRecord = { fish: null, weight: 0, userId: null, username: null, weekStart: new Date() };
+                }
+                if (weightLbs > (f.weeklyRecord.weight ?? 0)) {
+                    f.weeklyRecord = {
+                        fish:      fish.name,
+                        weight:    weightLbs,
+                        userId:    user.userId ?? null,
+                        username:  options.username ?? f.weeklyRecord.username ?? null,
+                        weekStart: f.weeklyRecord.weekStart ?? new Date(),
+                    };
+                    newRecord = { type: 'weekly', fish: fish.name, weight: weightLbs };
                 }
             }
 
@@ -1039,6 +1071,7 @@ module.exports = {
     applyPayoutModifiers,
     applyDurabilityLoss,
     updateRodStatus,
+    quoteRepair,
     applyRepair,
     levelFromXp,
     getLevelData,

--- a/tests/fishService.test.js
+++ b/tests/fishService.test.js
@@ -1,0 +1,358 @@
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+// Ships with jest (jest → babel-jest → @babel/core → @babel/parser), so it is
+// always present when this suite runs and is not declared separately.
+const { parse } = require('@babel/parser');
+
+const {
+    applyPayoutModifiers,
+    ensureFishingData,
+    executeCast,
+    quoteRepair,
+    applyRepair,
+} = require('../src/services/fishService');
+const { addEffect, consumeEffect, refundEffectCharge, getEffect, EFFECT_CONFIGS } = require('../src/services/effectsService');
+const { LOCATIONS, LIMITS, ROD_TIERS } = require('../src/data/fishData');
+
+const pond = LOCATIONS.pond;
+
+function makeUser(fishingOverrides = {}) {
+    const bamboo = ROD_TIERS[0];
+    const user = {
+        userId:  'u1',
+        guildId: 'g1',
+        balance: 0,
+        activeEffects: [],
+        quests: [],
+        fishing: {
+            level: 1,
+            prestige: 0,
+            xp: 0,
+            stamina: 10,
+            dailyCoins: 0,
+            dailyCasts: 0,
+            totalCasts: 0,
+            successfulCasts: 0,
+            totalEarned: 0,
+            consecutiveFails: 0,
+            bestPayout: 0,
+            legendaryCatches: 0,
+            eventCatches: 0,
+            activeLocation: 'pond',
+            unlockedLocations: ['pond'],
+            equippedRodIndex: 0,
+            rods: [{
+                name:              bamboo.name,
+                tier:              bamboo.tier,
+                slug:              bamboo.slug,
+                currentDurability: bamboo.baseDurability,
+                maxDurability:     bamboo.baseDurability,
+                baseDurability:    bamboo.baseDurability,
+                repairCount:       0,
+                upgrade:           null,
+                status:            'good',
+            }],
+            bait: {},
+            consumables: {},
+            materials: {},
+            activeBait: null,
+            activeBaitCastsLeft: 0,
+            activeLuck: false,
+            activeXpScroll: false,
+            luckyHook: false,
+            personalBest: { fish: null, weight: 0, payout: 0 },
+            weeklyRecord: { fish: null, weight: 0, userId: null, username: null, weekStart: null },
+            trophies: [],
+            ...fishingOverrides,
+        },
+        markModified: () => {},
+    };
+    return user;
+}
+
+// Casts until the predicate is satisfied, topping up the resources a cast spends.
+// Lets RNG-driven tests assert on outcomes without depending on the internal
+// order of Math.random() calls.
+function castUntil(user, predicate, { maxCasts = 4000, username = 'angler' } = {}) {
+    for (let i = 0; i < maxCasts; i++) {
+        user.fishing.stamina = 10;
+        user.fishing.rods[0].currentDurability = user.fishing.rods[0].maxDurability;
+        user.fishing.rods[0].status = 'good';
+        const result = executeCast(user, 'pond', { reactionFactor: 1.0, username });
+        if (predicate(result)) return result;
+    }
+    return null;
+}
+
+const isWeighedFish = r => r.success && r.catchType === 'fish' && r.weightLbs > 0;
+
+// ─── Reference guard ─────────────────────────────────────────────────────────
+// Two shipped features were dead because a function was called but never added
+// to its require() destructure: applyPayoutModifiers (boss payouts) and
+// startTournament (/fish tournament start). Both are single-line omissions that
+// only surface at runtime, so guard the whole fishing surface against the class.
+
+const JS_GLOBALS = new Set([
+    'require', 'module', 'exports', 'process', 'console', 'Buffer', 'globalThis',
+    'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setImmediate',
+    'queueMicrotask', 'structuredClone', 'fetch', 'URL', 'URLSearchParams',
+    'Object', 'Array', 'String', 'Number', 'Boolean', 'Symbol', 'BigInt',
+    'Math', 'JSON', 'Date', 'RegExp', 'Error', 'TypeError', 'RangeError',
+    'SyntaxError', 'ReferenceError', 'EvalError', 'URIError', 'AggregateError',
+    'Promise', 'Map', 'Set', 'WeakMap', 'WeakSet', 'Proxy', 'Reflect',
+    'Intl', 'parseInt', 'parseFloat', 'isNaN', 'isFinite', 'encodeURIComponent',
+    'decodeURIComponent', 'encodeURI', 'decodeURI', 'ArrayBuffer', 'DataView',
+    'Int8Array', 'Uint8Array', 'Uint8ClampedArray', 'Int16Array', 'Uint16Array',
+    'Int32Array', 'Uint32Array', 'Float32Array', 'Float64Array', 'BigInt64Array',
+    'BigUint64Array', 'AbortController', 'AbortSignal', 'TextEncoder', 'TextDecoder',
+]);
+
+// Collects every identifier the file binds anywhere (declarations, params,
+// catch clauses, destructuring). Deliberately flat rather than scope-aware:
+// a flat set can only produce false negatives, never false positives.
+function collectBindingsAndCalls(ast) {
+    const bound  = new Set();
+    const called = new Set();
+
+    const bindPattern = node => {
+        if (!node) return;
+        switch (node.type) {
+            case 'Identifier':          bound.add(node.name); break;
+            case 'ObjectPattern':       node.properties.forEach(p => bindPattern(p.type === 'RestElement' ? p.argument : p.value)); break;
+            case 'ArrayPattern':        node.elements.forEach(bindPattern); break;
+            case 'AssignmentPattern':   bindPattern(node.left); break;
+            case 'RestElement':         bindPattern(node.argument); break;
+            default: break;
+        }
+    };
+
+    const visit = node => {
+        if (!node || typeof node.type !== 'string') return;
+
+        if (node.type === 'VariableDeclarator') bindPattern(node.id);
+        if (node.type === 'FunctionDeclaration' || node.type === 'ClassDeclaration') bindPattern(node.id);
+        if (node.type === 'CatchClause') bindPattern(node.param);
+        if (/Function(Declaration|Expression)$/.test(node.type) || node.type === 'ArrowFunctionExpression') {
+            bindPattern(node.id);
+            node.params.forEach(bindPattern);
+        }
+        if ((node.type === 'CallExpression' || node.type === 'NewExpression') && node.callee?.type === 'Identifier') {
+            called.add(node.callee.name);
+        }
+
+        for (const key of Object.keys(node)) {
+            if (key === 'loc' || key === 'leadingComments' || key === 'trailingComments') continue;
+            const child = node[key];
+            if (Array.isArray(child)) child.forEach(visit);
+            else if (child && typeof child.type === 'string') visit(child);
+        }
+    };
+
+    visit(ast.program);
+    return { bound, called };
+}
+
+describe('fishing modules reference only names they define or import', () => {
+    const files = ['src/commands/economy/fish.js', 'src/services/fishService.js'];
+
+    test.each(files)('%s calls no undefined function', relPath => {
+        const source = fs.readFileSync(path.join(__dirname, '..', relPath), 'utf8');
+        const ast    = parse(source, { sourceType: 'script', allowReturnOutsideFunction: true });
+        const { bound, called } = collectBindingsAndCalls(ast);
+
+        const undefinedCalls = [...called].filter(name => !bound.has(name) && !JS_GLOBALS.has(name));
+        expect(undefinedCalls).toEqual([]);
+    });
+});
+
+// ─── Gathering-yield charges ─────────────────────────────────────────────────
+
+describe('applyPayoutModifiers gathering-yield charges', () => {
+    test('a worthless pull does not burn a Silvered Talisman charge', () => {
+        const user = makeUser();
+        addEffect(user, 'silvered_talisman');
+        const before = getEffect(user, 'silvered_talisman').charges;
+
+        const { adjustedPayout, gatherEffectConsumed } = applyPayoutModifiers(user, 0, pond);
+
+        expect(adjustedPayout).toBe(0);
+        expect(gatherEffectConsumed).toBeFalsy();
+        expect(getEffect(user, 'silvered_talisman').charges).toBe(before);
+    });
+
+    test('a paying catch spends exactly one charge and doubles the payout', () => {
+        const user = makeUser();
+        addEffect(user, 'silvered_talisman');
+        const before = getEffect(user, 'silvered_talisman').charges;
+
+        const { adjustedPayout, gatherEffectConsumed } = applyPayoutModifiers(user, 100, pond);
+
+        expect(adjustedPayout).toBe(200);
+        expect(gatherEffectConsumed).toBe('silvered_talisman');
+        expect(getEffect(user, 'silvered_talisman').charges).toBe(before - 1);
+    });
+
+    test('no charge is spent once the daily hard cap is reached', () => {
+        const user = makeUser({ dailyCoins: LIMITS.DAILY_HARD_CAP });
+        addEffect(user, 'voidsteel_cache');
+        const before = getEffect(user, 'voidsteel_cache').charges;
+
+        const { adjustedPayout, cappedByHard } = applyPayoutModifiers(user, 5000, pond);
+
+        expect(adjustedPayout).toBe(0);
+        expect(cappedByHard).toBe(true);
+        expect(getEffect(user, 'voidsteel_cache').charges).toBe(before);
+    });
+
+    test('never pushes dailyCoins past the hard cap', () => {
+        const user = makeUser({ dailyCoins: LIMITS.DAILY_HARD_CAP - 1 });
+        const { adjustedPayout } = applyPayoutModifiers(user, 50_000, pond);
+        expect(adjustedPayout).toBeLessThanOrEqual(1);
+    });
+});
+
+describe('refundEffectCharge', () => {
+    test('restores a charge consumed on a reversed action', () => {
+        const user = makeUser();
+        addEffect(user, 'silvered_talisman');
+        const full = getEffect(user, 'silvered_talisman').charges;
+
+        consumeEffect(user, 'silvered_talisman');
+        expect(getEffect(user, 'silvered_talisman').charges).toBe(full - 1);
+
+        refundEffectCharge(user, 'silvered_talisman');
+        expect(getEffect(user, 'silvered_talisman').charges).toBe(full);
+    });
+
+    test('re-adds the effect when the refunded charge was its last', () => {
+        const user = makeUser();
+        addEffect(user, 'silvered_talisman');
+        const full = getEffect(user, 'silvered_talisman').charges;
+        for (let i = 0; i < full; i++) consumeEffect(user, 'silvered_talisman');
+        expect(getEffect(user, 'silvered_talisman')).toBeNull();
+
+        refundEffectCharge(user, 'silvered_talisman');
+        expect(getEffect(user, 'silvered_talisman').charges).toBe(1);
+    });
+
+    test('cannot refund past the configured charge count', () => {
+        const user = makeUser();
+        addEffect(user, 'voidsteel_cache');
+        refundEffectCharge(user, 'voidsteel_cache');
+        expect(getEffect(user, 'voidsteel_cache').charges).toBe(EFFECT_CONFIGS.voidsteel_cache.charges);
+    });
+
+    test('is a no-op for unlimited-charge effects', () => {
+        const user = makeUser();
+        addEffect(user, 'lucky_charm'); // charges: -1
+        expect(refundEffectCharge(user, 'lucky_charm')).toBe(false);
+        expect(getEffect(user, 'lucky_charm').charges).toBe(-1);
+    });
+});
+
+// ─── Weekly record ───────────────────────────────────────────────────────────
+
+describe('weeklyRecord', () => {
+    const DAY = 24 * 3_600_000;
+
+    test('a stale week is cleared so a lighter fish can take the record', () => {
+        const user = makeUser({
+            weeklyRecord: {
+                fish: 'Ancient Leviathan', weight: 9999,
+                userId: 'u1', username: 'angler',
+                weekStart: new Date(Date.now() - 8 * DAY),
+            },
+        });
+
+        const caught = castUntil(user, isWeighedFish);
+        expect(caught).not.toBeNull();
+
+        expect(user.fishing.weeklyRecord.weight).toBe(caught.weightLbs);
+        expect(user.fishing.weeklyRecord.weight).toBeLessThan(9999);
+        expect(Date.now() - new Date(user.fishing.weeklyRecord.weekStart).getTime()).toBeLessThan(DAY);
+    });
+
+    test('within the same week a lighter fish does not take the record', () => {
+        const user = makeUser({
+            weeklyRecord: {
+                fish: 'Ancient Leviathan', weight: 9999,
+                userId: 'u1', username: 'angler',
+                weekStart: new Date(Date.now() - 2 * DAY),
+            },
+        });
+
+        castUntil(user, isWeighedFish);
+
+        expect(user.fishing.weeklyRecord.fish).toBe('Ancient Leviathan');
+        expect(user.fishing.weeklyRecord.weight).toBe(9999);
+    });
+
+    test('a new record records who set it', () => {
+        const user = makeUser();
+        const caught = castUntil(user, isWeighedFish, { username: 'reelbigfish' });
+        expect(caught).not.toBeNull();
+
+        expect(user.fishing.weeklyRecord.userId).toBe('u1');
+        expect(user.fishing.weeklyRecord.username).toBe('reelbigfish');
+        expect(user.fishing.weeklyRecord.weekStart).toBeTruthy();
+    });
+});
+
+// ─── Repair ──────────────────────────────────────────────────────────────────
+
+describe('quoteRepair', () => {
+    const worn = () => ({
+        name: 'Bamboo Rod', tier: 1,
+        currentDurability: 10, maxDurability: 80, baseDurability: 80,
+        repairCount: 0, upgrade: null, status: 'degraded',
+    });
+
+    test('pricing a repair leaves the rod untouched', () => {
+        const rod = worn();
+        const before = JSON.stringify(rod);
+
+        const quote = quoteRepair(rod, null);
+
+        expect(quote.cost).toBeGreaterThan(0);
+        expect(JSON.stringify(rod)).toBe(before);
+    });
+
+    test('applying charges exactly what was quoted and degrades max durability once', () => {
+        const rod   = worn();
+        const quote = quoteRepair(rod, null);
+        const result = applyRepair(rod, null);
+
+        expect(result.cost).toBe(quote.cost);
+        expect(result.restoredAmount).toBe(quote.restoredAmount);
+        expect(rod.maxDurability).toBe(quote.newMax);
+        expect(rod.maxDurability).toBeLessThan(80);
+        expect(rod.repairCount).toBe(1);
+    });
+
+    test('a condemned rod is refused without being mutated', () => {
+        const rod = { ...worn(), status: 'condemned' };
+        const before = JSON.stringify(rod);
+
+        expect(quoteRepair(rod, null).error).toBeTruthy();
+        expect(applyRepair(rod, null).error).toBeTruthy();
+        expect(JSON.stringify(rod)).toBe(before);
+    });
+});
+
+// ─── Initialisation ──────────────────────────────────────────────────────────
+
+describe('ensureFishingData', () => {
+    test('initialises trophies, which profile and prestige both read', () => {
+        const user = { markModified: () => {} };
+        ensureFishingData(user);
+        expect(Array.isArray(user.fishing.trophies)).toBe(true);
+    });
+
+    test('leaves existing trophies untouched', () => {
+        const user = { fishing: { trophies: ['🥉 Bronze Angler'] }, markModified: () => {} };
+        ensureFishingData(user);
+        expect(user.fishing.trophies).toEqual(['🥉 Bronze Angler']);
+    });
+});

--- a/tests/fishService.test.js
+++ b/tests/fishService.test.js
@@ -154,16 +154,55 @@ function collectBindingsAndCalls(ast) {
     return { bound, called };
 }
 
-describe('fishing modules reference only names they define or import', () => {
-    const files = ['src/commands/economy/fish.js', 'src/services/fishService.js'];
+const GRIND_FILES = [
+    'src/commands/economy/fish.js',
+    'src/commands/economy/hunt.js',
+    'src/commands/economy/mine.js',
+    'src/commands/economy/explore.js',
+    'src/services/fishService.js',
+];
 
-    test.each(files)('%s calls no undefined function', relPath => {
-        const source = fs.readFileSync(path.join(__dirname, '..', relPath), 'utf8');
-        const ast    = parse(source, { sourceType: 'script', allowReturnOutsideFunction: true });
-        const { bound, called } = collectBindingsAndCalls(ast);
+const readAst = relPath => parse(
+    fs.readFileSync(path.join(__dirname, '..', relPath), 'utf8'),
+    { sourceType: 'script', allowReturnOutsideFunction: true },
+);
+
+describe('grind modules reference only names they define or import', () => {
+    test.each(GRIND_FILES)('%s calls no undefined function', relPath => {
+        const { bound, called } = collectBindingsAndCalls(readAst(relPath));
 
         const undefinedCalls = [...called].filter(name => !bound.has(name) && !JS_GLOBALS.has(name));
         expect(undefinedCalls).toEqual([]);
+    });
+});
+
+// The four grind systems moved off the User document into GrindProfile
+// (migration 005). A guard written against User silently matches every document
+// on the now-missing path and rejects nothing, which is how the fishing and
+// hunting cooldown claims both shipped doing nothing. Any dotted grind path in
+// a command is a query built against the wrong collection.
+describe('grind commands query no User-level grind paths', () => {
+    const GRIND_PATH = /^(fishing|hunt|mining|exploration)\./;
+
+    test.each(GRIND_FILES)('%s uses no "<system>.<field>" query path', relPath => {
+        const ast = readAst(relPath);
+        const offenders = [];
+
+        const visit = node => {
+            if (!node || typeof node.type !== 'string') return;
+            if (node.type === 'StringLiteral' && GRIND_PATH.test(node.value)) {
+                offenders.push(`${node.value} (line ${node.loc?.start.line})`);
+            }
+            for (const key of Object.keys(node)) {
+                if (key === 'loc') continue;
+                const child = node[key];
+                if (Array.isArray(child)) child.forEach(visit);
+                else if (child && typeof child.type === 'string') visit(child);
+            }
+        };
+        visit(ast.program);
+
+        expect(offenders).toEqual([]);
     });
 });
 

--- a/tests/migrationIndexes.test.js
+++ b/tests/migrationIndexes.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+
+const migrationsDir = path.join(__dirname, '..', 'src', 'migrations');
+const read = file => fs.readFileSync(path.join(migrationsDir, file), 'utf8');
+const indexNamesIn = source => new Set((source.match(/'idx_[a-z0-9_]+'/g) ?? []).map(s => s.slice(1, -1)));
+
+// 009 drops the hunt/fishing indexes that 002 and 003 built on the users
+// collection, which migration 005 left covering paths no document has. A drop
+// naming an index that is never created is a silent no-op, so the two lists
+// have to stay in step.
+describe('009_drop_stale_grind_indexes', () => {
+    const dropped = indexNamesIn(read('009_drop_stale_grind_indexes.js'));
+    const created = new Set([
+        ...indexNamesIn(read('002_hunt_indexes.js')),
+        ...indexNamesIn(read('003_fishing_indexes.js')),
+    ]);
+
+    test('drops every index 002 and 003 create on users', () => {
+        expect([...created].sort()).toEqual([...dropped].sort());
+    });
+
+    test('names only indexes that are actually created', () => {
+        const orphans = [...dropped].filter(name => !created.has(name));
+        expect(orphans).toEqual([]);
+    });
+
+    test('swallows IndexNotFound so a fresh database is not a failure', () => {
+        expect(read('009_drop_stale_grind_indexes.js')).toContain("codeName !== 'IndexNotFound'");
+    });
+
+    test('runs after the migration that moved grind state off User', () => {
+        const files = fs.readdirSync(migrationsDir).filter(f => f.endsWith('.js') && f !== 'runner.js').sort();
+        expect(files.indexOf('009_drop_stale_grind_indexes.js'))
+            .toBeGreaterThan(files.indexOf('005_grind_profiles.js'));
+    });
+});


### PR DESCRIPTION
## Summary

This PR fixes critical race conditions in the mining, fishing, hunting, and exploration cooldown systems, and improves pity streak reporting. The changes ensure that concurrent grind requests cannot both slip past cooldown checks, and that failed preflight checks never burn cooldown slots.

## Key Changes

- **Atomic cooldown claims**: Moved cooldown slot reservation from User-level writes to atomic `GrindProfile.findOneAndUpdate()` operations that happen immediately after preflight checks pass. This prevents two concurrent requests from both reading stale state and bypassing the cooldown.

- **Cooldown slot recovery**: Added try/catch blocks that release claimed cooldown slots if the grind action fails before committing results to the database. A player who loses connection mid-dig no longer wastes a full cooldown.

- **Pity streak reporting**: Updated mining to report actual fail-streak pity bonuses (via `getPityBonus()`) instead of only showing rare-material counters. The pity bonus now displays on stamina-out messages alongside the rare-material counter.

- **Charge spending safety**: Moved pickaxe charge deduction to occur only after the cooldown slot is successfully claimed, so a lost race never costs the player a charge.

- **Gathering-yield effect fix**: Fixed `applyPayoutModifiers()` to not consume a Silvered Talisman or Voidsteel Cache charge when the payout is zero (worthless junk pulls).

- **Reference guard tests**: Added `fishService.test.js` with two test suites that catch missing function exports and User-level grind path queries (both bugs that shipped in production).

- **Stale index cleanup**: Added migration 009 to drop hunt/fishing indexes on the users collection that migration 005 left covering paths no document has, freeing write throughput and disk space.

## Implementation Details

The cooldown claim pattern is now:
1. Preflight checks (stamina, pickaxe, charges) — no writes
2. Atomic claim: `findOneAndUpdate()` with `$or` guard on cooldown floor
3. If claim fails, read back the winning timestamp and show countdown
4. If claim succeeds, proceed with the grind action
5. On any error before result save, release the slot via `updateOne()` with timestamp guard
6. Once result is saved, the slot is earned and must not be released

This ensures the cooldown is only paid when the player gets something to show for it.

https://claude.ai/code/session_015KPmY2toUSFF6YMk78hfbz