### PR TITLE
Exploration: charting, relics, and secret pity visibility

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -189,16 +189,25 @@ Narrated expeditions in Clawdia's voice. Players set out into distinct regions, 
 /explore travel        - Unlock and move between regions
 /explore regions       - Browse every region, requirements, and progress
 /explore journal       - Reread your most recent finds
+/explore relics        - Open your relic case and see what it earns you
 /explore profile       - Explorer level, stamina, and field record
 /explore map  or  /map - Unroll your persistent Explorer's Map
 ```
 
 **Regions:**
-- Core: Whispering Forest → Crumbling Ruins → Crystal Caves → Sunken Docks (level + coin gated, rising payouts)
-- Seasonal: Frostveil Pass (winter), Hollowgrave Lane (spooky), Scorchglass Shore (summer), The Velvet Arcade (Valentine's) — open only while their seasonal event runs and they drop event currency for the event shop
+- Core: Whispering Forest → Crumbling Ruins → Crystal Caves → Sunken Docks → Starfall Wastes (level + coin gated, rising payouts)
+- Seasonal: Frostveil Pass (winter), Hollowgrave Lane (spooky), Scorchglass Shore (summer), The Velvet Arcade (Valentine's), Arctic Tundra (winter hunt) — open only while their seasonal event runs, and they drop event currency for the event shop
+- A bare `/explore go` follows your active region, and reroutes itself if that region has gone out of season or been switched off
+
+**Progression:**
+- **Secret pity** — every expedition into a region that still hides a secret lifts the odds of finding one, shown as a live chance on the result embed. Regions you have fully uncovered stop building pity instead of promising a secret they can't deliver
+- **Fully surveyed** — chart every landmark, lore fragment and secret in a region and everything it pays you afterwards carries a standing +15%
+- **Relic case** — each distinct relic is worth +1% on exploration coins, up to +10%. Treasure prefers relics you don't own yet, so the case fills instead of stacking duplicates
+- **Quiet expeditions** cost the cooldown but refund the stamina point — a blank walk isn't charged for
+- Losses scale with how deep the region is, and deliberately *not* with the seasonal coin bonus or the admin drop-rate knob
 
 **Integration:**
-- Treasure coins feed the economy (transaction-logged, daily-capped); relics land in `/inventory`
+- Treasure coins feed the economy (transaction-logged, daily-capped — and the embed says so when the cap trims a haul); relics land in `/inventory` under their own section
 - Expeditions grant Explorer XP and mirror guild leveling XP
 - Rare finds unlock exploration achievements (including secret ones)
 - The Explorer's Map persists per player: landmarks, lore, and secrets charted per region

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -6,10 +6,11 @@ const { attachGrind, persistGrindIfNew } = require('../../utils/grindProfile');
 const GrindProfile = require('../../models/GrindProfile');
 const Guild = require('../../models/Guild');
 const {
-    LIMITS, EXPLORER_LEVELS, TIER_COLORS, REGIONS, REGION_LIST,
+    LIMITS, EXPLORER_LEVELS, TIER_COLORS, REGIONS, REGION_LIST, CORE_REGION_IDS,
     RELIC_LIST, RELIC_RARITY_ORDER, TOTAL_CORE_RELICS,
     FOOTER_LINES, INJURY_LINES,
 } = require('../../data/exploreData');
+const { fitDescription, EMBED_LIMITS } = require('../../utils/embedFields');
 const {
     ensureExploreData,
     applyStaminaRegen,
@@ -231,7 +232,7 @@ async function handleGo(interaction) {
                 description: 'You just got back. Shake the dust off, check your boots for stowaways, then go again.',
                 color: '#2e7d32',
                 nextAt: new Date(e.lastExplore.getTime() + LIMITS.EXPLORE_COOLDOWN_MS),
-                nextRewardPreview: secretTeaser(user, region),
+                nextRewardPreview: secretTeaser(user, region, guildSettings),
             })],
             flags: MessageFlags.Ephemeral,
         });
@@ -287,7 +288,7 @@ async function handleGo(interaction) {
                 description: 'You just got back. Shake the dust off, check your boots for stowaways, then go again.',
                 color: '#2e7d32',
                 nextAt: new Date(new Date(lastAt).getTime() + LIMITS.EXPLORE_COOLDOWN_MS),
-                nextRewardPreview: secretTeaser(user, region),
+                nextRewardPreview: secretTeaser(user, region, guildSettings),
             })],
             flags: MessageFlags.Ephemeral,
         });
@@ -446,7 +447,7 @@ async function handleGo(interaction) {
         }
 
         // ── Result embed ──────────────────────────────────────────────────────────
-        const embed = buildResultEmbed(result, region, user, currency, eventDrop, mainXp, firstVisit);
+        const embed = buildResultEmbed(result, region, user, currency, eventDrop, mainXp, firstVisit, guildSettings);
         await interaction.editReply({ embeds: [embed], components: [] });
 
         // Server-wide whisper for secrets
@@ -498,9 +499,9 @@ function summarizeResult(result, currency) {
  * region still HAS a secret to give. Once it's fully uncovered, saying it is
  * a promise nothing can keep, so say something honest instead.
  */
-function secretTeaser(user, region) {
+function secretTeaser(user, region, guildSettings) {
     if (!region) return 'The map never fills itself in.';
-    const odds = getSecretOdds(user, region, getRegionProgress(user, region.id));
+    const odds = getSecretOdds(user, region, getRegionProgress(user, region.id), guildSettings);
     if (odds.exhausted) {
         return `${region.name} has nothing left to hide from you. Other maps still do.`;
     }
@@ -515,8 +516,8 @@ function secretTeaser(user, region) {
  * invisible and a dry run just looks like bad luck with no reason to believe
  * it lets up — the same reason hunt, fishing and mining grew a streak field.
  */
-function buildSecretPityField(user, region) {
-    const odds = getSecretOdds(user, region, getRegionProgress(user, region.id));
+function buildSecretPityField(user, region, guildSettings) {
+    const odds = getSecretOdds(user, region, getRegionProgress(user, region.id), guildSettings);
     if (odds.exhausted) return null;
 
     const barLen = 16;
@@ -540,7 +541,7 @@ function buildSecretPityField(user, region) {
     };
 }
 
-function buildResultEmbed(result, region, user, currency, eventDrop, mainXp, firstVisit) {
+function buildResultEmbed(result, region, user, currency, eventDrop, mainXp, firstVisit, guildSettings) {
     const e = user.exploration;
     const embed = new EmbedBuilder().setTimestamp();
     const lines = [];
@@ -653,7 +654,7 @@ function buildResultEmbed(result, region, user, currency, eventDrop, mainXp, fir
 
     // Pity curve — only on runs that didn't turn up the secret
     if (result.type !== 'secret') {
-        const pityField = buildSecretPityField(user, region);
+        const pityField = buildSecretPityField(user, region, guildSettings);
         if (pityField) embed.addFields(pityField);
     }
 
@@ -801,7 +802,7 @@ async function handleRegions(interaction) {
         .setColor('#2e7d32')
         .setTitle('🧭 Known Regions')
         .setDescription(sections.join('\n\n'))
-        .setFooter({ text: 'Seasonal regions come and go with /event seasons. The core four are always out there, being patient.' })
+        .setFooter({ text: `Seasonal regions come and go with /event seasons. The core ${CORE_REGION_IDS.length} are always out there, being patient.` })
         .setTimestamp();
 
     return interaction.reply({ embeds: [embed] });
@@ -858,15 +859,37 @@ async function handleRelics(interaction) {
         });
     }
 
-    // Grouped by rarity, rarest first — the case should read like a case.
-    const byRarity = [...RELIC_RARITY_ORDER].reverse().map(rarity => {
+    // Grouped by rarity, rarest first — the case should read like a case. Any
+    // rarity not in the ladder still gets a group rather than silently vanishing
+    // from a case whose totals already count it.
+    const knownRarities = [...RELIC_RARITY_ORDER].reverse();
+    const extraRarities = [...new Set(collection.map(r => r.rarity))].filter(r => !knownRarities.includes(r));
+
+    const renderGroups = withLore => [...knownRarities, ...extraRarities].map(rarity => {
         const held = collection.filter(r => r.rarity === rarity);
         if (!held.length) return null;
-        const rows = held.map(r =>
-            `${r.emoji} **${r.itemId}**${r.quantity > 1 ? ` ×${r.quantity}` : ''} — *${r.regionName}* · ${currency}${r.value.toLocaleString()}\n> *${r.lore}*`
-        );
+        const rows = held.map(r => {
+            const head = `${r.emoji} **${r.itemId}**${r.quantity > 1 ? ` ×${r.quantity}` : ''} — *${r.regionName}* · ${currency}${r.value.toLocaleString()}`;
+            return withLore ? `${head}\n> *${r.lore}*` : head;
+        });
         return `**${rarity.charAt(0).toUpperCase() + rarity.slice(1)}**\n${rows.join('\n')}`;
     }).filter(Boolean);
+
+    // A full 25-relic case with lore runs past the 4096-char description limit,
+    // and discord.js throws rather than truncating. Drop the lore before dropping
+    // relics — the case is a list first and a story second.
+    const budget = EMBED_LIMITS.DESCRIPTION - 120; // headroom for the omission note
+    let groups = renderGroups(true);
+    let loreDropped = false;
+    if (groups.join('\n\n').length > budget) {
+        groups = renderGroups(false);
+        loreDropped = true;
+    }
+    const { text: caseText, omitted } = fitDescription(groups, { limit: budget, separator: '\n\n' });
+    const caseNote = [
+        loreDropped ? '*The case has outgrown its little plaques — names only from here.*' : '',
+        omitted > 0 ? `*…and ${omitted} more group${omitted === 1 ? '' : 's'} that wouldn't fit.*` : '',
+    ].filter(Boolean).join('\n');
 
     const distinct = collection.length;
     const bonus = getRelicBonus(userData);
@@ -877,7 +900,7 @@ async function handleRelics(interaction) {
         .setColor('#c9a227')
         .setTitle(`🏺 The Relic Case — ${target.username}`)
         .setThumbnail(target.displayAvatarURL({ dynamic: true }))
-        .setDescription(byRarity.join('\n\n'))
+        .setDescription(caseNote ? `${caseText}\n\n${caseNote}` : caseText)
         .addFields(
             {
                 name: '📚 The Collection',

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -2,10 +2,11 @@
 
 const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags } = require('discord.js');
 const User  = require('../../models/User');
-const { attachGrind } = require('../../utils/grindProfile');
+const { attachGrind, saveGrind } = require('../../utils/grindProfile');
 const Guild = require('../../models/Guild');
 const {
     LIMITS, EXPLORER_LEVELS, TIER_COLORS, REGIONS, REGION_LIST,
+    RELIC_LIST, RELIC_RARITY_ORDER, TOTAL_CORE_RELICS,
     FOOTER_LINES, INJURY_LINES,
 } = require('../../data/exploreData');
 const {
@@ -18,7 +19,11 @@ const {
     getRegionProgress,
     isRegionInSeason,
     isRegionEnabled,
-    getAvailableRegions,
+    isRegionFullyCharted,
+    resolveActiveRegion,
+    getRelicCollection,
+    getRelicBonus,
+    getSecretOdds,
     executeExplore,
     resolveEncounter,
     addJournalEntry,
@@ -82,6 +87,13 @@ module.exports = {
             sub.setName('journal')
                 .setDescription('Reread your expedition journal — your most recent finds, in order.'))
         .addSubcommand(sub =>
+            sub.setName('relics')
+                .setDescription('Open your relic case — everything the wilds let you keep, and what it earns you.')
+                .addUserOption(o =>
+                    o.setName('user')
+                        .setDescription('Collector to inspect')
+                        .setRequired(false)))
+        .addSubcommand(sub =>
             sub.setName('profile')
                 .setDescription("View your or another wanderer's explorer profile")
                 .addUserOption(o =>
@@ -96,6 +108,7 @@ module.exports = {
         if (sub === 'travel')  return handleTravel(interaction);
         if (sub === 'regions') return handleRegions(interaction);
         if (sub === 'journal') return handleJournal(interaction);
+        if (sub === 'relics')  return handleRelics(interaction);
         if (sub === 'profile') return handleProfile(interaction);
     },
 
@@ -105,7 +118,8 @@ module.exports = {
 
 // ─── Shared guards ────────────────────────────────────────────────────────────
 
-async function loadContext(interaction) {
+// Returns the guild doc, or null after replying if exploration is switched off.
+async function loadGuildOrReply(interaction) {
     const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
     if (guildSettings?.economy?.enabled === false) {
         await interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
@@ -115,13 +129,31 @@ async function loadContext(interaction) {
         await interaction.reply({ content: 'Exploration is switched off on this server. The wilds will wait — they\'re good at it.', flags: MessageFlags.Ephemeral });
         return null;
     }
+    return guildSettings ?? {};
+}
+
+async function loadContext(interaction) {
+    const guildSettings = await loadGuildOrReply(interaction);
+    if (!guildSettings) return null;
     const user = await User.findOneAndUpdate(
         { userId: interaction.user.id, guildId: interaction.guild.id },
         { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
         { upsert: true, new: true }
     );
     await attachGrind(user);
-    ensureExploreData(user);
+    const seeded = ensureExploreData(user);
+    return { guildSettings, user, seeded, currency: guildSettings?.economy?.currency ?? '💰' };
+}
+
+/**
+ * Read-only loader for map/journal/relics/profile: honours the same enable
+ * switches as the write paths, and loads whichever user is being inspected.
+ */
+async function loadReadContext(interaction, target = interaction.user) {
+    const guildSettings = await loadGuildOrReply(interaction);
+    if (!guildSettings) return null;
+    const user = await User.findOne({ userId: target.id, guildId: interaction.guild.id });
+    await attachGrind(user);
     return { guildSettings, user, currency: guildSettings?.economy?.currency ?? '💰' };
 }
 
@@ -153,15 +185,31 @@ async function handleGo(interaction) {
     if (!ctx) return;
     const { guildSettings, user, currency } = ctx;
 
-    applyStaminaRegen(user);
-    applyDailyReset(user);
-    if (user.isModified()) {
-        await user.save().catch(e => console.error('[explore] pre-check save error:', e));
+    const e = user.exploration;
+    let dirty = ctx.seeded;
+    dirty = applyStaminaRegen(user) || dirty;
+    dirty = applyDailyReset(user)   || dirty;
+
+    // A bare /explore go follows your active region — unless that region has
+    // gone out of season or been switched off underneath you, in which case
+    // resolveActiveRegion moves you somewhere you can actually walk.
+    const explicitRegionId = interaction.options.getString('region');
+    let region, rerouted = null;
+    if (explicitRegionId) {
+        region = REGIONS[explicitRegionId];
+    } else {
+        const resolved = resolveActiveRegion(user, guildSettings);
+        region = resolved.region;
+        if (resolved.switched) {
+            rerouted = resolved.from;
+            dirty = true;
+        }
     }
 
-    const e = user.exploration;
-    const regionId = interaction.options.getString('region') ?? e.activeRegion;
-    const region = REGIONS[regionId];
+    if (dirty) {
+        // exploration lives in GrindProfile, so user.isModified() never sees it
+        await saveGrind(user, ['exploration']).catch(err => console.error('[explore] pre-check save error:', err));
+    }
 
     const gateError = regionGateError(user, region, guildSettings);
     if (gateError) return interaction.reply({ content: gateError, flags: MessageFlags.Ephemeral });
@@ -185,9 +233,7 @@ async function handleGo(interaction) {
                 description: 'You just got back. Shake the dust off, check your boots for stowaways, then go again.',
                 color: '#2e7d32',
                 nextAt: new Date(e.lastExplore.getTime() + LIMITS.EXPLORE_COOLDOWN_MS),
-                nextRewardPreview: e.sinceSecret >= 10
-                    ? `It's been ${e.sinceSecret} expeditions since your last secret. Something is overdue to find you.`
-                    : 'The map never fills itself in.',
+                nextRewardPreview: secretTeaser(user, region),
             })],
             flags: MessageFlags.Ephemeral,
         });
@@ -227,11 +273,14 @@ async function handleGo(interaction) {
 
     // Staged narration: the setting-out beat, then the find
     const delay = ms => new Promise(r => setTimeout(r, ms));
+    const reroutedLine = rerouted
+        ? `\n\n🧭 **${rerouted.emoji} ${rerouted.name}** is closed to you right now, so your compass reset to **${region.emoji} ${region.name}**. It'll wait.`
+        : '';
     await interaction.reply({
         embeds: [new EmbedBuilder()
             .setColor(region.color)
             .setTitle(`${region.emoji} Setting out — ${region.name}`)
-            .setDescription(`*${result.intro}*`)
+            .setDescription(`*${result.intro}*${reroutedLine}`)
             .setFooter({ text: region.tagline })],
     });
     await delay(2000);
@@ -361,11 +410,17 @@ async function handleGo(interaction) {
 }
 
 function summarizeResult(result, currency) {
+    // Once the daily cap bites, payouts land at zero — say so rather than
+    // logging a triumphant haul of nothing.
+    const haul = result.payout > 0
+        ? `${currency}${result.payout.toLocaleString()}`
+        : result.cappedByDailyCap ? 'nothing the daily cap would let you keep' : `${currency}0`;
+
     switch (result.type) {
         case 'discovery': return `Charted ${result.landmark.name}`;
         case 'lore':      return `Recovered a lore fragment`;
         case 'secret':    return `Uncovered the secret: ${result.secret.name}`;
-        case 'treasure':  return `${result.relic ? `Recovered ${result.relic.itemId} and ` : ''}hauled ${currency}${result.payout.toLocaleString()} in treasure`;
+        case 'treasure':  return `${result.relic ? `Recovered ${result.relic.itemId} and ` : ''}hauled ${haul} in treasure`;
         case 'trap':      return `Sprang ${result.trap.name} (−${currency}${(result.penalty ?? 0).toLocaleString()})`;
         case 'encounter': return result.outcome === 'win'
             ? `Faced ${result.encounter.name} and came out ahead`
@@ -374,6 +429,53 @@ function summarizeResult(result, currency) {
                 : `Faced ${result.encounter.name} and paid the tuition`;
         default:          return 'A long, quiet walk';
     }
+}
+
+/**
+ * "It's been N expeditions since your last secret" is only true while the
+ * region still HAS a secret to give. Once it's fully uncovered, saying it is
+ * a promise nothing can keep, so say something honest instead.
+ */
+function secretTeaser(user, region) {
+    if (!region) return 'The map never fills itself in.';
+    const odds = getSecretOdds(user, region, getRegionProgress(user, region.id));
+    if (odds.exhausted) {
+        return `${region.name} has nothing left to hide from you. Other maps still do.`;
+    }
+    if (odds.sinceSecret >= 10) {
+        return `It's been ${odds.sinceSecret} expeditions since your last secret — the odds are up to ${(odds.chance * 100).toFixed(1)}% and still climbing.`;
+    }
+    return 'The map never fills itself in.';
+}
+
+/**
+ * Where the player sits on the secret curve. Without it the pity system is
+ * invisible and a dry run just looks like bad luck with no reason to believe
+ * it lets up — the same reason hunt, fishing and mining grew a streak field.
+ */
+function buildSecretPityField(user, region) {
+    const odds = getSecretOdds(user, region, getRegionProgress(user, region.id));
+    if (odds.exhausted) return null;
+
+    const barLen = 16;
+    const ratio  = Math.min(1, odds.pity / LIMITS.SECRET_PITY_MAX);
+    const bar    = '█'.repeat(Math.round(ratio * barLen)) + '░'.repeat(barLen - Math.round(ratio * barLen));
+    const maxed  = odds.pity >= LIMITS.SECRET_PITY_MAX;
+    const lift   = odds.chance / odds.baseChance;
+
+    if (odds.pity <= 0) {
+        return {
+            name: `✨ Secret Odds — ${(odds.chance * 100).toFixed(1)}%`,
+            value: `\`${bar}\`\nEvery expedition here without a secret nudges these odds up.`,
+            inline: false,
+        };
+    }
+    return {
+        name: `✨ Something's Overdue — ${odds.sinceSecret} expeditions dry`,
+        value: `\`${bar}\`\n**${(odds.chance * 100).toFixed(1)}% secret chance** next time out `
+             + `— ×${lift.toFixed(2)} the base rate${maxed ? ' *(max)*' : ', climbing with every dry run'}.`,
+        inline: false,
+    };
 }
 
 function buildResultEmbed(result, region, user, currency, eventDrop, mainXp, firstVisit) {
@@ -400,7 +502,12 @@ function buildResultEmbed(result, region, user, currency, eventDrop, mainXp, fir
                 .setTitle(`🪙 Treasure — ${tier.tier.charAt(0).toUpperCase() + tier.tier.slice(1)} ${tier.stars}`);
             lines.push(`*${result.treasureLine}*`);
             if (result.relic) {
-                lines.push('', `🏺 **Relic recovered: ${result.relic.itemId}**`, `> *${result.relic.lore}*`, `> It's in your \`/inventory\` now. It was always going to end up there.`);
+                lines.push(
+                    '',
+                    `🏺 **Relic recovered: ${result.relic.itemId}**${result.relicIsNew ? ' — *new to your case*' : ''}`,
+                    `> *${result.relic.lore}*`,
+                    `> It's in your \`/inventory\` now, and in \`/explore relics\`, where it earns its keep.`,
+                );
             }
             break;
         }
@@ -434,10 +541,27 @@ function buildResultEmbed(result, region, user, currency, eventDrop, mainXp, fir
         lines.push('', `🗺️ **New region charted: ${region.emoji} ${region.name}** — it has a place on your map now. So do its blank spaces.`);
     }
 
+    if (result.regionCompleted) {
+        lines.push(
+            '',
+            `🏅 **${region.emoji} ${region.name} — fully surveyed.**`,
+            `Every landmark, every fragment, every secret. There is nothing left in this region that you haven't stood in front of.`,
+            `Everything it pays you from here carries a standing **+${Math.round(result.surveyBonus * 100)}%**. The map keeps its debts.`,
+        );
+    }
+
     embed.setDescription(lines.join('\n'));
 
     const gains = [];
-    if (result.payout > 0)  gains.push(`+${currency}${result.payout.toLocaleString()}`);
+    if (result.payout > 0) {
+        gains.push(`+${currency}${result.payout.toLocaleString()}`);
+    } else if (result.cappedByDailyCap && result.grossPayout > 0) {
+        // Don't render a legendary haul with a blank coin line and no reason.
+        gains.push(`~~+${currency}${result.grossPayout.toLocaleString()}~~ *(daily cap)*`);
+    }
+    if (result.payout > 0 && result.cappedByDailyCap) {
+        gains.push(`*(trimmed from ${currency}${result.grossPayout.toLocaleString()} — daily cap)*`);
+    }
     if (result.penalty > 0) gains.push(`−${currency}${result.penalty.toLocaleString()}`);
     if (result.xp > 0)      gains.push(`+${result.xp} Explorer XP`);
     if (mainXp > 0)         gains.push(`+${mainXp} XP`);
@@ -447,18 +571,41 @@ function buildResultEmbed(result, region, user, currency, eventDrop, mainXp, fir
     }
     if (gains.length) embed.addFields({ name: '🎒 The Haul', value: gains.join('  ·  '), inline: false });
 
-    embed.setFooter({ text: `⚡ ${e.stamina}/${LIMITS.MAX_STAMINA} stamina · ${randomFrom(FOOTER_LINES)}` });
+    if (result.cappedByDailyCap) {
+        embed.addFields({
+            name: '🧾 Daily Cap Reached',
+            value: `You've banked ${currency}${LIMITS.DAILY_HARD_CAP.toLocaleString()} from exploring in the last 24 hours, which is where the coins stop. `
+                 + `Expeditions still chart the map and still pay Explorer XP — the wilds just stop paying cash until the window rolls over.`,
+            inline: false,
+        });
+    }
+
+    // Standing bonuses, shown once they're actually doing something
+    const boosts = [];
+    if (result.surveyed) boosts.push(`🏅 Fully surveyed +${Math.round(LIMITS.SURVEY_BONUS * 100)}%`);
+    const relicBonus = getRelicBonus(user);
+    if (relicBonus > 0) boosts.push(`🏺 Relic case +${Math.round(relicBonus * 100)}%`);
+    if (boosts.length) {
+        embed.addFields({ name: '📈 Standing Bonuses', value: boosts.join('  ·  '), inline: false });
+    }
+
+    // Pity curve — only on runs that didn't turn up the secret
+    if (result.type !== 'secret') {
+        const pityField = buildSecretPityField(user, region);
+        if (pityField) embed.addFields(pityField);
+    }
+
+    const staminaNote = result.staminaSpared ? ' *(a blank walk costs no stamina)*' : '';
+    embed.setFooter({ text: `⚡ ${e.stamina}/${LIMITS.MAX_STAMINA} stamina${staminaNote} · ${randomFrom(FOOTER_LINES)}` });
     return embed;
 }
 
 // ─── MAP ──────────────────────────────────────────────────────────────────────
 
 async function handleMap(interaction) {
-    const [userData, guildSettings] = await Promise.all([
-        User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }),
-        Guild.findOne({ guildId: interaction.guild.id }),
-    ]);
-    await attachGrind(userData);
+    const ctx = await loadReadContext(interaction);
+    if (!ctx) return;
+    const { user: userData, guildSettings } = ctx;
 
     if (!userData?.exploration?.totalExpeditions) {
         return interaction.reply({
@@ -484,7 +631,7 @@ async function handleMap(interaction) {
             value: [
                 `**${levelData.title}** — Explorer Lv ${e.level}`,
                 `🗿 ${e.landmarksDiscovered} landmarks · 📜 ${e.loreCollected} lore · ✨ ${e.secretsFound} secrets · 🏺 ${e.relicsRecovered} relics`,
-                `${e.totalExpeditions.toLocaleString()} expeditions logged`,
+                `${e.totalExpeditions.toLocaleString()} expeditions logged · 🏅 ${surveyedCount(userData, guildSettings)} regions fully surveyed`,
             ].join('\n'),
             inline: false,
         })
@@ -492,6 +639,15 @@ async function handleMap(interaction) {
         .setTimestamp();
 
     return interaction.reply({ embeds: [embed] });
+}
+
+// How many regions the player has charted end to end.
+function surveyedCount(user, guildSettings) {
+    return REGION_LIST.filter(region => {
+        if (!isRegionEnabled(region, guildSettings)) return false;
+        const progress = user.exploration.regions.find(r => r.regionId === region.id);
+        return isRegionFullyCharted(region, progress);
+    }).length;
 }
 
 // ─── TRAVEL ───────────────────────────────────────────────────────────────────
@@ -592,8 +748,9 @@ async function handleRegions(interaction) {
 // ─── JOURNAL ──────────────────────────────────────────────────────────────────
 
 async function handleJournal(interaction) {
-    const userData = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
-    await attachGrind(userData);
+    const ctx = await loadReadContext(interaction);
+    if (!ctx) return;
+    const { user: userData } = ctx;
 
     const journal = userData?.exploration?.journal ?? [];
     if (!journal.length) {
@@ -603,7 +760,7 @@ async function handleJournal(interaction) {
         });
     }
 
-    const lines = journal.slice(0, 12).map(entry => {
+    const lines = journal.slice(0, LIMITS.JOURNAL_CAP).map(entry => {
         const region = REGIONS[entry.regionId];
         const stamp = `<t:${Math.floor(new Date(entry.at).getTime() / 1000)}:R>`;
         return `${EVENT_TYPE_EMOJI[entry.eventType] ?? '🥾'} ${region?.emoji ?? ''} **${region?.name ?? entry.regionId}** — ${entry.summary} *(${stamp})*`;
@@ -613,7 +770,69 @@ async function handleJournal(interaction) {
         .setColor('#8d6e63')
         .setTitle(`📔 Expedition Journal — ${interaction.user.username}`)
         .setDescription(lines.join('\n'))
-        .setFooter({ text: 'The last 20 entries are kept. The rest live in the retelling.' })
+        .setFooter({ text: `The last ${LIMITS.JOURNAL_CAP} entries are kept. The rest live in the retelling.` })
+        .setTimestamp();
+
+    return interaction.reply({ embeds: [embed] });
+}
+
+// ─── RELICS ───────────────────────────────────────────────────────────────────
+
+async function handleRelics(interaction) {
+    const target = interaction.options.getUser('user') ?? interaction.user;
+    const isSelf = target.id === interaction.user.id;
+
+    const ctx = await loadReadContext(interaction, target);
+    if (!ctx) return;
+    const { user: userData, currency } = ctx;
+
+    const collection = userData ? getRelicCollection(userData) : [];
+    if (!collection.length) {
+        return interaction.reply({
+            content: isSelf
+                ? 'Your relic case is a shelf and a hopeful expression. Rare treasure carries relics out of the wilds — `/explore go` is the only supplier.'
+                : `${target.username} hasn't brought anything home worth a shelf yet.`,
+            flags: MessageFlags.Ephemeral,
+        });
+    }
+
+    // Grouped by rarity, rarest first — the case should read like a case.
+    const byRarity = [...RELIC_RARITY_ORDER].reverse().map(rarity => {
+        const held = collection.filter(r => r.rarity === rarity);
+        if (!held.length) return null;
+        const rows = held.map(r =>
+            `${r.emoji} **${r.itemId}**${r.quantity > 1 ? ` ×${r.quantity}` : ''} — *${r.regionName}* · ${currency}${r.value.toLocaleString()}\n> *${r.lore}*`
+        );
+        return `**${rarity.charAt(0).toUpperCase() + rarity.slice(1)}**\n${rows.join('\n')}`;
+    }).filter(Boolean);
+
+    const distinct = collection.length;
+    const bonus = getRelicBonus(userData);
+    const atCap = bonus >= LIMITS.RELIC_BONUS_MAX;
+    const caseValue = collection.reduce((sum, r) => sum + r.value * r.quantity, 0);
+
+    const embed = new EmbedBuilder()
+        .setColor('#c9a227')
+        .setTitle(`🏺 The Relic Case — ${target.username}`)
+        .setThumbnail(target.displayAvatarURL({ dynamic: true }))
+        .setDescription(byRarity.join('\n\n'))
+        .addFields(
+            {
+                name: '📚 The Collection',
+                value: `**${distinct}** distinct of **${RELIC_LIST.length}** known *(${TOTAL_CORE_RELICS} from the core regions, the rest only turn up in season)*\n`
+                     + `Case value: **${currency}${caseValue.toLocaleString()}**`,
+                inline: false,
+            },
+            {
+                name: '📈 What It Earns You',
+                value: `**+${Math.round(bonus * 100)}%** on every coin exploration pays you`
+                     + (atCap
+                         ? ' — *the case is as persuasive as it gets.*'
+                         : `\n*+${Math.round(LIMITS.RELIC_BONUS_PER * 100)}% per distinct relic, up to +${Math.round(LIMITS.RELIC_BONUS_MAX * 100)}%. Duplicates are for trading, not for stacking.*`),
+                inline: false,
+            },
+        )
+        .setFooter({ text: 'Relics have no buyer — nothing out there is qualified. Trade them on the /market if someone disagrees.' })
         .setTimestamp();
 
     return interaction.reply({ embeds: [embed] });
@@ -625,11 +844,9 @@ async function handleProfile(interaction) {
     const target = interaction.options.getUser('user') ?? interaction.user;
     const isSelf = target.id === interaction.user.id;
 
-    const [userData, guildSettings] = await Promise.all([
-        User.findOne({ userId: target.id, guildId: interaction.guild.id }),
-        Guild.findOne({ guildId: interaction.guild.id }),
-    ]);
-    await attachGrind(userData);
+    const ctx = await loadReadContext(interaction, target);
+    if (!ctx) return;
+    const { user: userData, guildSettings, currency } = ctx;
 
     if (!userData?.exploration?.totalExpeditions) {
         return interaction.reply({
@@ -642,9 +859,11 @@ async function handleProfile(interaction) {
 
     ensureExploreData(userData);
     if (isSelf) applyStaminaRegen(userData);
+    // Read-only, but the daily footer should reflect a window that has already
+    // rolled over rather than yesterday's numbers.
+    applyDailyReset(userData);
 
     const e = userData.exploration;
-    const currency = guildSettings?.economy?.currency ?? '💰';
     const levelData = getLevelData(e.level);
     const toNext = xpToNextLevel(e.level, e.xp);
     const activeRegion = REGIONS[e.activeRegion];
@@ -693,12 +912,22 @@ async function handleProfile(interaction) {
                     `Best Haul:       **${currency}${e.bestHaul.toLocaleString()}**`,
                     `Secrets Found:   **${e.secretsFound}**`,
                     `Relics:          **${e.relicsRecovered}**`,
+                    `Regions Surveyed:**${surveyedCount(userData, guildSettings)}**`,
                     `Traps Sprung:    **${e.trapsSprung}** *(we don't judge here. much.)*`,
                 ].join('\n'),
                 inline: false,
             }
         )
         .setTimestamp();
+
+    const relicBonus = getRelicBonus(userData);
+    const surveyed = surveyedCount(userData, guildSettings);
+    if (relicBonus > 0 || surveyed > 0) {
+        const boosts = [];
+        if (surveyed > 0)   boosts.push(`🏅 **+${Math.round(LIMITS.SURVEY_BONUS * 100)}%** in ${surveyed} fully surveyed region${surveyed === 1 ? '' : 's'}`);
+        if (relicBonus > 0) boosts.push(`🏺 **+${Math.round(relicBonus * 100)}%** everywhere, from the relic case`);
+        embed.addFields({ name: '📈 Standing Bonuses', value: boosts.join('\n'), inline: false });
+    }
 
     if (isSelf) {
         embed.setFooter({ text: `Daily: ${e.dailyExpeditions} expeditions · ${currency}${e.dailyCoins.toLocaleString()} earned (cap: ${currency}${LIMITS.DAILY_HARD_CAP.toLocaleString()})` });

--- a/src/commands/economy/inventory.js
+++ b/src/commands/economy/inventory.js
@@ -7,6 +7,7 @@ const { pruneEffects, EFFECT_CONFIGS, timeRemaining } = require('../../services/
 const { MATERIAL_RARITY, TIER_LABELS, TIER_STARS, TIER_COLORS } = require('../../data/materialRarity');
 const { getItemLore } = require('../../data/defaultShopItems');
 const { getRelicMeta } = require('../../data/exploreData');
+const { packFields } = require('../../utils/embedFields');
 
 const TOTAL_MATERIALS = Object.keys(MATERIAL_RARITY).length;
 
@@ -90,9 +91,11 @@ function buildItemsEmbed(inventory, shopItems, activeEffects, currency, color, f
             if (relic) {
                 // Relics come out of /explore, not the shop — without their own
                 // section they render as a bare name with no worth and no story.
+                // The lore stays in `/explore relics`: 25 relics' worth of it
+                // would blow the 1024-char field limit and take the embed down.
                 relicLines.push(
                     `${relic.emoji} **${relic.itemId}**${entry.quantity > 1 ? ` ×${entry.quantity}` : ''} `
-                    + `*(${relic.rarity} · ${relic.regionName} · worth ${currency}${relic.value.toLocaleString()})*\n*${relic.lore}*`
+                    + `*(${relic.rarity} · ${relic.regionName} · ${currency}${relic.value.toLocaleString()})*`
                 );
             } else if (entry.itemId.startsWith('ai_') && aiItemMap[entry.itemId]) {
                 const ai = aiItemMap[entry.itemId];
@@ -120,9 +123,11 @@ function buildItemsEmbed(inventory, shopItems, activeEffects, currency, color, f
             hasContent = true;
         }
         if (relicLines.length) {
+            // A full collection is 25 relics — well past one field's budget.
+            embed.addFields(...packFields('🏺 Relics', relicLines));
             embed.addFields({
-                name: '🏺 Relics',
-                value: `${relicLines.join('\n')}\n\n*Every distinct relic pays a standing bonus on exploration coins — see \`/explore relics\`.*`,
+                name: '​',
+                value: '*Every distinct relic pays a standing bonus on exploration coins — see `/explore relics`.*',
                 inline: false,
             });
             hasContent = true;

--- a/src/commands/economy/inventory.js
+++ b/src/commands/economy/inventory.js
@@ -6,6 +6,7 @@ const Guild = require('../../models/Guild');
 const { pruneEffects, EFFECT_CONFIGS, timeRemaining } = require('../../services/effectsService');
 const { MATERIAL_RARITY, TIER_LABELS, TIER_STARS, TIER_COLORS } = require('../../data/materialRarity');
 const { getItemLore } = require('../../data/defaultShopItems');
+const { getRelicMeta } = require('../../data/exploreData');
 
 const TOTAL_MATERIALS = Object.keys(MATERIAL_RARITY).length;
 
@@ -81,10 +82,19 @@ function buildItemsEmbed(inventory, shopItems, activeEffects, currency, color, f
     let hasContent = false;
 
     if (inventory.length) {
-        const shopLines = [];
-        const aiLines   = [];
+        const shopLines  = [];
+        const aiLines    = [];
+        const relicLines = [];
         for (const entry of inventory) {
-            if (entry.itemId.startsWith('ai_') && aiItemMap[entry.itemId]) {
+            const relic = getRelicMeta(entry.itemId);
+            if (relic) {
+                // Relics come out of /explore, not the shop — without their own
+                // section they render as a bare name with no worth and no story.
+                relicLines.push(
+                    `${relic.emoji} **${relic.itemId}**${entry.quantity > 1 ? ` ×${entry.quantity}` : ''} `
+                    + `*(${relic.rarity} · ${relic.regionName} · worth ${currency}${relic.value.toLocaleString()})*\n*${relic.lore}*`
+                );
+            } else if (entry.itemId.startsWith('ai_') && aiItemMap[entry.itemId]) {
                 const ai = aiItemMap[entry.itemId];
                 const rarityLine = ai.rarity ? ` *(${ai.rarity})*` : '';
                 const loreLine   = ai.lore    ? `\n*${ai.lore}*`   : '';
@@ -107,6 +117,14 @@ function buildItemsEmbed(inventory, shopItems, activeEffects, currency, color, f
         }
         if (aiLines.length) {
             embed.addFields({ name: '⚒️ Forged Items', value: aiLines.join('\n'), inline: false });
+            hasContent = true;
+        }
+        if (relicLines.length) {
+            embed.addFields({
+                name: '🏺 Relics',
+                value: `${relicLines.join('\n')}\n\n*Every distinct relic pays a standing bonus on exploration coins — see \`/explore relics\`.*`,
+                inline: false,
+            });
             hasContent = true;
         }
     }

--- a/src/data/exploreData.js
+++ b/src/data/exploreData.js
@@ -16,9 +16,17 @@ const LIMITS = {
     DAILY_HARD_CAP:       100_000,
     JOURNAL_CAP:          20,
     // Secret pity: each expedition without a secret adds bonus weight to the
-    // secret slot, so long droughts self-correct.
+    // secret slot, so long droughts self-correct. Only expeditions into a
+    // region that still HAS an unfound secret count toward it.
     SECRET_PITY_PER_RUN:  0.15,
     SECRET_PITY_MAX:      6,
+    // Charting a region to 100% pays a standing bonus on everything it drops,
+    // so finishing a map is a reward rather than a retirement.
+    SURVEY_BONUS:         0.15,
+    // Each DISTINCT relic in your collection is worth a small standing payout
+    // bonus, capped so a full set is a nice edge and not a second economy.
+    RELIC_BONUS_PER:      0.01,
+    RELIC_BONUS_MAX:      0.10,
 };
 
 // ─── EXPLORER PROGRESSION ────────────────────────────────────────────────────
@@ -68,6 +76,8 @@ const EVENT_XP = {
     trap:             10,
     secret:           100,
     quiet:            8,
+    // One-off, the first time a region has nothing left to hide from you
+    survey:           250,
 };
 
 // Treasure rarity roll: weight + coin range (before region/guild multipliers)
@@ -922,6 +932,48 @@ const TOTAL_CORE_SECRETS = REGION_LIST
     .filter(r => !r.seasonalEventId)
     .reduce((sum, r) => sum + r.secrets.length, 0);
 
+// ─── RELICS ──────────────────────────────────────────────────────────────────
+// Relics live in the shared /inventory as bare itemIds. This index is what
+// lets everything else — the display case, /inventory, the collection bonus —
+// know what a relic is worth and where it came from.
+
+const RELIC_RARITY_ORDER = ['rare', 'epic', 'legendary'];
+
+// Indicative worth, used for display and for pricing a market listing. Relics
+// are not sold to the bot: exploration already has a daily coin cap, and a
+// bot-side buyback would be an uncapped faucet straight around it.
+const RELIC_VALUES = {
+    rare:      3_000,
+    epic:      7_500,
+    legendary: 20_000,
+};
+
+const RELIC_EMOJI = {
+    rare:      '🏺',
+    epic:      '⚱️',
+    legendary: '👑',
+};
+
+// itemId → { itemId, rarity, lore, regionId, regionName, emoji, value }
+const RELIC_INDEX = Object.fromEntries(
+    REGION_LIST.flatMap(region =>
+        (region.relics ?? []).map(relic => [relic.itemId, {
+            ...relic,
+            regionId:   region.id,
+            regionName: region.name,
+            emoji:      RELIC_EMOJI[relic.rarity] ?? '🏺',
+            value:      RELIC_VALUES[relic.rarity] ?? 0,
+        }])
+    )
+);
+
+const RELIC_LIST = Object.values(RELIC_INDEX);
+const TOTAL_CORE_RELICS = RELIC_LIST.filter(r => !REGIONS[r.regionId].seasonalEventId).length;
+
+function getRelicMeta(itemId) {
+    return RELIC_INDEX[itemId] ?? null;
+}
+
 // ─── SHARED VOICE LINES ──────────────────────────────────────────────────────
 
 // Quiet runs — nothing happened, in an atmospheric way
@@ -960,6 +1012,13 @@ module.exports = {
     CORE_REGION_IDS,
     SEASONAL_REGION_IDS,
     TOTAL_CORE_SECRETS,
+    RELIC_INDEX,
+    RELIC_LIST,
+    RELIC_VALUES,
+    RELIC_EMOJI,
+    RELIC_RARITY_ORDER,
+    TOTAL_CORE_RELICS,
+    getRelicMeta,
     QUIET_LINES,
     FOOTER_LINES,
     INJURY_LINES,

--- a/src/services/exploreService.js
+++ b/src/services/exploreService.js
@@ -301,9 +301,15 @@ function getRelicBonus(user) {
  * Admin rareEventBonus and the secret pity counter shift weight toward
  * the rarer slots.
  */
-function rollEventType(user, region, guildSettings, progress) {
+/**
+ * The region's event table with the admin rareEventBonus knob applied.
+ *
+ * Shared by the roll and by the odds display: computing it in only one of the
+ * two is how a server with rareEventBonus set ends up being quoted a secret
+ * chance lower than the one it actually rolls against.
+ */
+function buildEventWeights(region, guildSettings) {
     const w = { ...region.eventWeights };
-    const secretsLeft = hasUnfoundSecrets(region, progress);
 
     // Admin knob: shift weight from the mundane to secrets + treasure
     const rareBonus = Math.min(0.25, Math.max(0, guildSettings?.exploration?.rareEventBonus ?? 0));
@@ -314,6 +320,12 @@ function rollEventType(user, region, guildSettings, progress) {
         w.treasure += shift * 0.6;
         w.secret   += shift * 0.4;
     }
+    return w;
+}
+
+function rollEventType(user, region, guildSettings, progress) {
+    const w = buildEventWeights(region, guildSettings);
+    const secretsLeft = hasUnfoundSecrets(region, progress);
 
     if (secretsLeft) {
         // Secret pity: long droughts self-correct
@@ -344,11 +356,13 @@ function getSecretPity(user) {
  * chance, the pity-boosted chance, and whether the region has anything left
  * to find at all. Display-only — the roll itself lives in rollEventType.
  */
-function getSecretOdds(user, region, progress) {
+function getSecretOdds(user, region, progress, guildSettings = null) {
     if (!hasUnfoundSecrets(region, progress)) {
         return { exhausted: true, sinceSecret: 0, baseChance: 0, chance: 0, pity: 0 };
     }
-    const w = region.eventWeights;
+    // Same table the roll uses, so a server running rareEventBonus is quoted
+    // the odds it actually plays against.
+    const w = buildEventWeights(region, guildSettings);
     const total = Object.values(w).reduce((s, n) => s + n, 0);
     const pity = getSecretPity(user);
     return {
@@ -573,7 +587,10 @@ function finishAsTreasure(user, region, progress, result, coinMult, { fallback =
 
     // Rare+ treasures may carry a relic into the player's inventory
     if (Math.random() < tier.relicChance) {
-        const pool = region.relics.filter(r =>
+        // Every region in the table defines relics today; the fallback is here so
+        // a future one added without them degrades to a plain treasure instead of
+        // throwing mid-expedition.
+        const pool = (region.relics ?? []).filter(r =>
             tier.tier === 'legendary' ? true : r.rarity !== 'legendary'
         );
         if (pool.length) {
@@ -780,6 +797,7 @@ module.exports = {
     isRegionFullyCharted,
     getRelicCollection,
     getRelicBonus,
+    buildEventWeights,
     getSecretOdds,
     getPayoutMultiplier,
     getPenaltyMultiplier,

--- a/src/services/exploreService.js
+++ b/src/services/exploreService.js
@@ -7,47 +7,59 @@ const {
     TREASURE_TIERS,
     REGIONS,
     REGION_LIST,
+    RELIC_INDEX,
     QUIET_LINES,
 } = require('../data/exploreData');
 
 // ─── INIT ────────────────────────────────────────────────────────────────────
 
+const EXPLORE_COUNTERS = [
+    'xp', 'totalExpeditions', 'treasuresFound', 'trapsSprung', 'encountersWon',
+    'secretsFound', 'loreCollected', 'landmarksDiscovered', 'relicsRecovered',
+    'totalEarned', 'bestHaul', 'sinceSecret', 'regionsSurveyed',
+    'dailyCoins', 'dailyExpeditions',
+];
+
+// Timestamps that legitimately sit at null until something happens
+const EXPLORE_TIMESTAMPS = ['staminaLastRegen', 'lastExplore', 'injuryUntil', 'dailyWindowStart'];
+
+/**
+ * Backfill the exploration profile. Reports whether it actually wrote anything,
+ * so callers can skip a pointless round trip on the overwhelmingly common path
+ * where the profile is already complete.
+ *
+ * @returns {boolean} true if any field was seeded
+ */
 function ensureExploreData(user) {
-    if (!user.exploration) user.exploration = {};
+    let dirty = false;
+    if (!user.exploration) { user.exploration = {}; dirty = true; }
     const e = user.exploration;
 
-    if (e.stamina          == null) e.stamina          = LIMITS.MAX_STAMINA;
-    if (e.staminaLastRegen == null) e.staminaLastRegen = null;
-    if (e.xp               == null) e.xp               = 0;
-    if (e.level            == null) e.level            = 1;
-    if (e.lastExplore      == null) e.lastExplore      = null;
-    if (e.injuryUntil      == null) e.injuryUntil      = null;
-    if (e.activeRegion     == null) e.activeRegion     = 'whispering_forest';
-    if (!Array.isArray(e.unlockedRegions)) e.unlockedRegions = [];
-    if (!Array.isArray(e.regions))         e.regions         = [];
-    if (!Array.isArray(e.journal))         e.journal         = [];
+    const seed = (key, value) => {
+        if (e[key] == null) { e[key] = value; dirty = true; }
+    };
+    const seedArray = key => {
+        if (!Array.isArray(e[key])) { e[key] = []; dirty = true; }
+    };
 
-    if (e.totalExpeditions     == null) e.totalExpeditions     = 0;
-    if (e.treasuresFound       == null) e.treasuresFound       = 0;
-    if (e.trapsSprung          == null) e.trapsSprung          = 0;
-    if (e.encountersWon        == null) e.encountersWon        = 0;
-    if (e.secretsFound         == null) e.secretsFound         = 0;
-    if (e.loreCollected        == null) e.loreCollected        = 0;
-    if (e.landmarksDiscovered  == null) e.landmarksDiscovered  = 0;
-    if (e.relicsRecovered      == null) e.relicsRecovered      = 0;
-    if (e.totalEarned          == null) e.totalEarned          = 0;
-    if (e.bestHaul             == null) e.bestHaul             = 0;
-    if (e.sinceSecret          == null) e.sinceSecret          = 0;
-
-    if (e.dailyCoins        == null) e.dailyCoins        = 0;
-    if (e.dailyExpeditions  == null) e.dailyExpeditions  = 0;
-    if (e.dailyWindowStart  == null) e.dailyWindowStart  = null;
+    seed('stamina', LIMITS.MAX_STAMINA);
+    seed('level', 1);
+    seed('activeRegion', 'whispering_forest');
+    for (const key of EXPLORE_COUNTERS) seed(key, 0);
+    for (const key of EXPLORE_TIMESTAMPS) {
+        if (!(key in e)) { e[key] = null; dirty = true; }
+    }
+    seedArray('unlockedRegions');
+    seedArray('regions');
+    seedArray('journal');
 
     if (!e.unlockedRegions.includes('whispering_forest')) {
         e.unlockedRegions.push('whispering_forest');
+        dirty = true;
     }
 
-    user.markModified('exploration');
+    if (dirty) user.markModified('exploration');
+    return dirty;
 }
 
 // Per-region progress record (creates one on first visit)
@@ -71,27 +83,37 @@ function getRegionProgress(user, regionId, { create = false } = {}) {
 
 // ─── STAMINA / DAILY WINDOW ──────────────────────────────────────────────────
 
+/** @returns {boolean} true if anything was written */
 function applyStaminaRegen(user) {
     const e = user.exploration;
     const max = LIMITS.MAX_STAMINA;
+
     if (e.stamina >= max) {
+        // Sitting at full: keep the regen anchor fresh so the clock starts from
+        // roughly the moment stamina is next spent — but only rewrite it once
+        // it has actually gone stale, or every read would be a write.
+        const stale = !e.staminaLastRegen
+            || Date.now() - e.staminaLastRegen.getTime() >= LIMITS.STAMINA_REGEN_MS;
+        const overfull = e.stamina > max;
         e.stamina = max;
+        if (!stale && !overfull) return false;
         e.staminaLastRegen = new Date();
         user.markModified('exploration');
-        return;
+        return true;
     }
     if (!e.staminaLastRegen) {
         e.staminaLastRegen = new Date();
         user.markModified('exploration');
-        return;
+        return true;
     }
     const elapsed = Date.now() - e.staminaLastRegen.getTime();
     const intervals = Math.floor(elapsed / LIMITS.STAMINA_REGEN_MS);
-    if (intervals <= 0) return;
+    if (intervals <= 0) return false;
 
     e.stamina = Math.min(max, e.stamina + intervals);
     e.staminaLastRegen = new Date(e.staminaLastRegen.getTime() + intervals * LIMITS.STAMINA_REGEN_MS);
     user.markModified('exploration');
+    return true;
 }
 
 function msUntilNextStamina(user) {
@@ -102,6 +124,7 @@ function msUntilNextStamina(user) {
     return Math.max(0, LIMITS.STAMINA_REGEN_MS - (elapsed % LIMITS.STAMINA_REGEN_MS));
 }
 
+/** @returns {boolean} true if the window rolled over */
 function applyDailyReset(user) {
     const e = user.exploration;
     const now = Date.now();
@@ -110,7 +133,9 @@ function applyDailyReset(user) {
         e.dailyExpeditions = 0;
         e.dailyWindowStart = new Date(now);
         user.markModified('exploration');
+        return true;
     }
+    return false;
 }
 
 // ─── EXPLORER XP / LEVELS ────────────────────────────────────────────────────
@@ -195,8 +220,78 @@ function getAvailableRegions(user, guildSettings) {
     return REGION_LIST.filter(r => {
         if (!isRegionEnabled(r, guildSettings)) return false;
         if (r.seasonalEventId) return isRegionInSeason(r, guildSettings);
-        return e.unlockedRegions.includes(r.id);
+        return e.unlockedRegions.includes(r.id) && e.level >= r.unlockLevel;
     });
+}
+
+/**
+ * The region a bare `/explore go` should actually set out into.
+ *
+ * activeRegion is sticky, which strands players: travel into a seasonal region,
+ * let the event end, and every unqualified `/explore go` bounces off the
+ * out-of-season gate until you notice and travel back by hand. Same for a
+ * region an admin switches off. When the stored region is no longer usable we
+ * fall back to the richest one that is, and report the switch so the command
+ * layer can say so out loud.
+ *
+ * @returns {{ region: object|null, switched: boolean, from: object|null }}
+ */
+function resolveActiveRegion(user, guildSettings) {
+    const e = user.exploration;
+    const current = REGIONS[e.activeRegion] ?? null;
+    const available = getAvailableRegions(user, guildSettings);
+
+    if (current && available.some(r => r.id === current.id)) {
+        return { region: current, switched: false, from: null };
+    }
+
+    // Prefer the best-paying core region still open to the player; the starter
+    // region is the floor and is only ever gone if an admin disabled it.
+    const fallback = available
+        .filter(r => !r.seasonalEventId)
+        .sort((a, b) => b.payoutMultiplier - a.payoutMultiplier)[0]
+        ?? available[0]
+        ?? null;
+
+    if (!fallback) return { region: null, switched: false, from: current };
+
+    e.activeRegion = fallback.id;
+    user.markModified('exploration');
+    return { region: fallback, switched: Boolean(current), from: current };
+}
+
+// ─── CHARTING PROGRESS ───────────────────────────────────────────────────────
+
+function hasUnfoundSecrets(region, progress) {
+    if (!progress) return region.secrets.length > 0;
+    return region.secrets.some(s => !progress.secretsFound.includes(s.id));
+}
+
+/** Every landmark, lore fragment and secret in the region accounted for. */
+function isRegionFullyCharted(region, progress) {
+    if (!progress) return false;
+    return progress.landmarksFound.length >= region.landmarks.length
+        && progress.loreFound.length     >= region.lore.length
+        && progress.secretsFound.length  >= region.secrets.length;
+}
+
+// ─── RELIC COLLECTION ────────────────────────────────────────────────────────
+
+/** Distinct relics the player owns, newest data first. */
+function getRelicCollection(user) {
+    return (user.inventory ?? [])
+        .filter(entry => RELIC_INDEX[entry.itemId] && entry.quantity > 0)
+        .map(entry => ({ ...RELIC_INDEX[entry.itemId], quantity: entry.quantity }));
+}
+
+/**
+ * Standing payout bonus from the relic display case: every DISTINCT relic is
+ * worth `RELIC_BONUS_PER`, capped at `RELIC_BONUS_MAX`. Duplicates are for
+ * trading, not for stacking.
+ */
+function getRelicBonus(user) {
+    const distinct = getRelicCollection(user).length;
+    return Math.min(LIMITS.RELIC_BONUS_MAX, distinct * LIMITS.RELIC_BONUS_PER);
 }
 
 // ─── EVENT ROLL ──────────────────────────────────────────────────────────────
@@ -206,8 +301,9 @@ function getAvailableRegions(user, guildSettings) {
  * Admin rareEventBonus and the secret pity counter shift weight toward
  * the rarer slots.
  */
-function rollEventType(user, region, guildSettings) {
+function rollEventType(user, region, guildSettings, progress) {
     const w = { ...region.eventWeights };
+    const secretsLeft = hasUnfoundSecrets(region, progress);
 
     // Admin knob: shift weight from the mundane to secrets + treasure
     const rareBonus = Math.min(0.25, Math.max(0, guildSettings?.exploration?.rareEventBonus ?? 0));
@@ -219,17 +315,49 @@ function rollEventType(user, region, guildSettings) {
         w.secret   += shift * 0.4;
     }
 
-    // Secret pity: long droughts self-correct
-    const pity = Math.min(
-        LIMITS.SECRET_PITY_MAX,
-        (user.exploration.sinceSecret ?? 0) * LIMITS.SECRET_PITY_PER_RUN
-    );
-    w.secret += pity;
+    if (secretsLeft) {
+        // Secret pity: long droughts self-correct
+        w.secret += getSecretPity(user);
+    } else {
+        // Nothing left to uncover here. Drop the slot rather than rolling a
+        // "secret" that silently degrades into a treasure — the weight spreads
+        // across the rest of the table instead of vanishing into a fake.
+        delete w.secret;
+    }
 
     const items = Object.entries(w)
         .map(([type, weight]) => ({ type, weight }))
         .filter(i => i.weight > 0);
     return weightedRoll(items).type;
+}
+
+/** Bonus weight the current secret drought has earned. */
+function getSecretPity(user) {
+    return Math.min(
+        LIMITS.SECRET_PITY_MAX,
+        (user.exploration.sinceSecret ?? 0) * LIMITS.SECRET_PITY_PER_RUN
+    );
+}
+
+/**
+ * Where the player sits on the secret curve for a given region: the base
+ * chance, the pity-boosted chance, and whether the region has anything left
+ * to find at all. Display-only — the roll itself lives in rollEventType.
+ */
+function getSecretOdds(user, region, progress) {
+    if (!hasUnfoundSecrets(region, progress)) {
+        return { exhausted: true, sinceSecret: 0, baseChance: 0, chance: 0, pity: 0 };
+    }
+    const w = region.eventWeights;
+    const total = Object.values(w).reduce((s, n) => s + n, 0);
+    const pity = getSecretPity(user);
+    return {
+        exhausted:   false,
+        sinceSecret: user.exploration.sinceSecret ?? 0,
+        baseChance:  w.secret / total,
+        chance:      (w.secret + pity) / (total + pity),
+        pity,
+    };
 }
 
 function rollTreasureTier() {
@@ -256,6 +384,8 @@ function executeExplore(user, region, guildSettings, opts = {}) {
     const e = user.exploration;
     const progress = getRegionProgress(user, region.id, { create: true });
     const firstVisit = progress.expeditions === 0;
+    const wasFullyCharted = isRegionFullyCharted(region, progress);
+    const secretsLeft = hasUnfoundSecrets(region, progress);
 
     e.stamina -= 1;
     e.lastExplore = new Date();
@@ -263,14 +393,17 @@ function executeExplore(user, region, guildSettings, opts = {}) {
     e.dailyExpeditions += 1;
     progress.expeditions += 1;
 
-    const dropRate = clamp(guildSettings?.exploration?.dropRateMultiplier ?? 1, 0.1, 5);
-    const coinMult = (opts.coinMultiplier ?? 1) * dropRate * region.payoutMultiplier;
+    const coinMult    = getPayoutMultiplier(user, region, guildSettings, opts.coinMultiplier ?? 1, progress);
+    const penaltyMult = getPenaltyMultiplier(region);
 
     const result = {
         regionId: region.id,
         firstVisit,
-        type: rollEventType(user, region, guildSettings),
+        secretsLeft,
+        surveyed: wasFullyCharted,
+        type: rollEventType(user, region, guildSettings, progress),
         payout: 0,
+        grossPayout: 0,
         xp: 0,
         intro: randomFrom(region.intros),
         coinMultiplier: opts.coinMultiplier ?? 1,
@@ -280,14 +413,14 @@ function executeExplore(user, region, guildSettings, opts = {}) {
         case 'discovery': {
             const unfound = region.landmarks.filter(l => !progress.landmarksFound.includes(l.id));
             if (unfound.length === 0) {
-                // Region fully charted — fall through to a modest treasure
-                return finishAsTreasure(user, region, progress, result, coinMult, { smallOnly: true });
+                // Nothing left to chart here — the slot pays out as treasure.
+                return finishAsTreasure(user, region, progress, result, coinMult, { fallback: true });
             }
             const landmark = randomFrom(unfound);
             progress.landmarksFound.push(landmark.id);
             e.landmarksDiscovered += 1;
             result.landmark = landmark;
-            result.payout = applyPayout(user, Math.round(randInt(300, 700) * coinMult));
+            result.payout = applyPayout(user, result, Math.round(randInt(300, 700) * coinMult));
             result.xp = grantXp(user, EVENT_XP.discovery);
             break;
         }
@@ -295,28 +428,25 @@ function executeExplore(user, region, guildSettings, opts = {}) {
         case 'lore': {
             const unfound = region.lore.filter(l => !progress.loreFound.includes(l.id));
             if (unfound.length === 0) {
-                return finishAsTreasure(user, region, progress, result, coinMult, { smallOnly: true });
+                return finishAsTreasure(user, region, progress, result, coinMult, { fallback: true });
             }
             const fragment = randomFrom(unfound);
             progress.loreFound.push(fragment.id);
             e.loreCollected += 1;
             result.lore = fragment;
-            result.payout = applyPayout(user, Math.round(randInt(150, 400) * coinMult));
+            result.payout = applyPayout(user, result, Math.round(randInt(150, 400) * coinMult));
             result.xp = grantXp(user, EVENT_XP.lore);
             break;
         }
 
         case 'secret': {
-            const unfound = region.secrets.filter(s => !progress.secretsFound.includes(s.id));
-            if (unfound.length === 0) {
-                return finishAsTreasure(user, region, progress, result, coinMult);
-            }
-            const secret = randomFrom(unfound);
+            // rollEventType only offers this slot while a secret is unfound.
+            const secret = randomFrom(region.secrets.filter(s => !progress.secretsFound.includes(s.id)));
             progress.secretsFound.push(secret.id);
             e.secretsFound += 1;
             e.sinceSecret = 0;
             result.secret = secret;
-            result.payout = applyPayout(user, Math.round(secret.reward * coinMult));
+            result.payout = applyPayout(user, result, Math.round(secret.reward * coinMult));
             result.xp = grantXp(user, EVENT_XP.secret);
             break;
         }
@@ -327,6 +457,8 @@ function executeExplore(user, region, guildSettings, opts = {}) {
 
         case 'trap': {
             const trap = randomFrom(region.traps);
+            // Trap penalties are hand-tuned per region already, so they take
+            // no region multiplier on top — only the balance floor applies.
             const rawPenalty = randInt(trap.penalty.min, trap.penalty.max);
             const penalty = Math.min(rawPenalty, Math.max(0, user.balance));
             user.balance -= penalty;
@@ -344,24 +476,29 @@ function executeExplore(user, region, guildSettings, opts = {}) {
         case 'encounter': {
             // Pending: command layer resolves via resolveEncounter()
             result.encounter = randomFrom(region.encounters);
+            result.penaltyMultiplier = penaltyMult;
             result.pendingChoice = true;
             break;
         }
 
         case 'quiet':
         default: {
+            // Nothing found, nothing spent. A blank walk costs the cooldown and
+            // the boot leather; it does not also cost a stamina point.
             result.type = 'quiet';
             result.quietLine = randomFrom(QUIET_LINES);
             result.xp = grantXp(user, EVENT_XP.quiet);
+            e.stamina = Math.min(LIMITS.MAX_STAMINA, e.stamina + 1);
+            result.staminaSpared = true;
             break;
         }
     }
 
     if (result.type !== 'secret' && !result.pendingChoice) {
-        e.sinceSecret += 1;
+        countTowardPity(user, result);
     }
 
-    finalizeStats(user, result);
+    finalizeStats(user, region, progress, result, wasFullyCharted);
     user.markModified('exploration');
     return result;
 }
@@ -373,8 +510,9 @@ function executeExplore(user, region, guildSettings, opts = {}) {
 function resolveEncounter(user, region, guildSettings, result, choice) {
     const e = user.exploration;
     const enc = result.encounter;
-    const dropRate = clamp(guildSettings?.exploration?.dropRateMultiplier ?? 1, 0.1, 5);
-    const coinMult = (result.coinMultiplier ?? 1) * dropRate * region.payoutMultiplier;
+    const progress = getRegionProgress(user, region.id);
+    const coinMult    = getPayoutMultiplier(user, region, guildSettings, result.coinMultiplier ?? 1, progress);
+    const penaltyMult = getPenaltyMultiplier(region);
 
     result.pendingChoice = false;
     result.choice = choice === 'approach' ? 'approach' : 'observe';
@@ -383,11 +521,15 @@ function resolveEncounter(user, region, guildSettings, result, choice) {
         if (Math.random() < enc.winChance) {
             result.outcome = 'win';
             e.encountersWon += 1;
-            result.payout = applyPayout(user, Math.round(randInt(enc.reward.min, enc.reward.max) * coinMult));
+            result.payout = applyPayout(user, result, Math.round(randInt(enc.reward.min, enc.reward.max) * coinMult));
             result.xp = grantXp(user, EVENT_XP.encounter_win);
         } else {
             result.outcome = 'loss';
-            const penalty = Math.min(Math.round(randInt(200, 600) * coinMult), Math.max(0, user.balance));
+            // Losses scale with the region only. Folding the event coin bonus
+            // or the admin drop-rate knob in here would mean a "double coins"
+            // weekend also doubled the beating, and a generous admin made
+            // failure five times more expensive.
+            const penalty = Math.min(Math.round(randInt(200, 600) * penaltyMult), Math.max(0, user.balance));
             user.balance -= penalty;
             result.penalty = penalty;
             result.xp = grantXp(user, EVENT_XP.encounter_loss);
@@ -398,54 +540,91 @@ function resolveEncounter(user, region, guildSettings, result, choice) {
         }
     } else {
         result.outcome = 'safe';
-        result.payout = applyPayout(user, Math.round(randInt(enc.reward.min, enc.reward.max) * coinMult * 0.35));
+        result.payout = applyPayout(user, result, Math.round(randInt(enc.reward.min, enc.reward.max) * coinMult * 0.35));
         result.xp = grantXp(user, EVENT_XP.encounter_safe);
     }
 
-    e.sinceSecret += 1;
-    finalizeStats(user, result);
+    countTowardPity(user, result);
+    finalizeStats(user, region, progress, result, isRegionFullyCharted(region, progress));
     user.markModified('exploration');
     return result;
 }
 
-// Treasure resolution, also used as the fallback when a region is fully charted
-function finishAsTreasure(user, region, progress, result, coinMult, { smallOnly = false } = {}) {
+/**
+ * Treasure resolution, also used when a discovery/lore slot has nothing left to
+ * give. A fallback roll is capped at `rare` so an exhausted slot can't become
+ * the best jackpot in the game — but it keeps its relic chance, because
+ * charting a region shouldn't quietly delete its relic drops.
+ */
+function finishAsTreasure(user, region, progress, result, coinMult, { fallback = false } = {}) {
     const e = user.exploration;
     result.type = 'treasure';
+    result.fallbackTreasure = fallback;
 
     let tier = rollTreasureTier();
-    if (smallOnly && ['epic', 'legendary'].includes(tier.tier)) {
-        tier = TREASURE_TIERS.find(t => t.tier === 'uncommon');
+    if (fallback && ['epic', 'legendary'].includes(tier.tier)) {
+        tier = TREASURE_TIERS.find(t => t.tier === 'rare');
     }
     result.treasureTier = tier;
     result.treasureLine = randomFrom(region.treasureLines);
-    result.payout = applyPayout(user, Math.round(randInt(tier.min, tier.max) * coinMult));
+    result.payout = applyPayout(user, result, Math.round(randInt(tier.min, tier.max) * coinMult));
     result.xp = grantXp(user, EVENT_XP.treasure);
     e.treasuresFound += 1;
 
     // Rare+ treasures may carry a relic into the player's inventory
-    if (!smallOnly && Math.random() < tier.relicChance) {
+    if (Math.random() < tier.relicChance) {
         const pool = region.relics.filter(r =>
             tier.tier === 'legendary' ? true : r.rarity !== 'legendary'
         );
         if (pool.length) {
-            const relic = randomFrom(pool);
+            // Prefer relics the player is missing, so a display case actually
+            // fills instead of stacking the same charm forever.
+            const owned = new Set(getRelicCollection(user).map(r => r.itemId));
+            const missing = pool.filter(r => !owned.has(r.itemId));
+            const relic = randomFrom(missing.length ? missing : pool);
             addRelicToInventory(user, relic);
             e.relicsRecovered += 1;
             result.relic = relic;
+            result.relicIsNew = !owned.has(relic.itemId);
         }
     }
 
-    e.sinceSecret += 1;
-    finalizeStats(user, result);
+    countTowardPity(user, result);
+    finalizeStats(user, region, progress, result, isRegionFullyCharted(region, progress));
     user.markModified('exploration');
     return result;
 }
 
 // ─── REWARD HELPERS ──────────────────────────────────────────────────────────
 
-// Credit coins, respecting the rolling daily hard cap. Returns amount granted.
-function applyPayout(user, amount) {
+/**
+ * Everything that multiplies a payout: the seasonal event bonus, the admin
+ * drop-rate knob, how deep the region is, the standing bonus for a fully
+ * surveyed map, and the relic display case.
+ */
+function getPayoutMultiplier(user, region, guildSettings, eventCoinMultiplier = 1, progress = null) {
+    const dropRate = clamp(guildSettings?.exploration?.dropRateMultiplier ?? 1, 0.1, 5);
+    const survey   = isRegionFullyCharted(region, progress) ? 1 + LIMITS.SURVEY_BONUS : 1;
+    const relics   = 1 + getRelicBonus(user);
+    return eventCoinMultiplier * dropRate * region.payoutMultiplier * survey * relics;
+}
+
+/**
+ * What a loss is multiplied by. Deliberately NOT the payout multiplier: a
+ * region's depth is a fair reason for a costlier mistake, a coin-bonus weekend
+ * and an admin generosity setting are not.
+ */
+function getPenaltyMultiplier(region) {
+    return region.payoutMultiplier;
+}
+
+/**
+ * Credit coins, respecting the rolling daily hard cap. Records the gross amount
+ * and a `cappedByDailyCap` flag on the result so the embed can say what the cap
+ * ate — otherwise a legendary haul renders with no coin line and no explanation.
+ * Returns the amount actually granted.
+ */
+function applyPayout(user, result, amount) {
     const e = user.exploration;
     const remaining = Math.max(0, LIMITS.DAILY_HARD_CAP - e.dailyCoins);
     const granted = Math.min(amount, remaining);
@@ -453,6 +632,10 @@ function applyPayout(user, amount) {
         user.balance       += granted;
         e.totalEarned      += granted;
         e.dailyCoins       += granted;
+    }
+    if (result) {
+        result.grossPayout = (result.grossPayout ?? 0) + amount;
+        if (granted < amount) result.cappedByDailyCap = true;
     }
     return granted;
 }
@@ -471,9 +654,28 @@ function addRelicToInventory(user, relic) {
     user.markModified('inventory');
 }
 
-function finalizeStats(user, result) {
+/**
+ * Advance the secret drought counter — but only for expeditions that could
+ * actually have turned up a secret. Counting runs into a fully-uncovered region
+ * inflates the number behind a promise the region can no longer keep.
+ */
+function countTowardPity(user, result) {
+    if (!result.secretsLeft) return;
+    user.exploration.sinceSecret += 1;
+}
+
+function finalizeStats(user, region, progress, result, wasFullyCharted) {
     const e = user.exploration;
     if (result.payout > e.bestHaul) e.bestHaul = result.payout;
+
+    // First time this region has nothing left to hide.
+    if (!wasFullyCharted && isRegionFullyCharted(region, progress)) {
+        progress.completedAt = new Date();
+        result.regionCompleted = true;
+        result.surveyBonus = LIMITS.SURVEY_BONUS;
+        e.regionsSurveyed = (e.regionsSurveyed ?? 0) + 1;
+        result.xp = (result.xp ?? 0) + grantXp(user, EVENT_XP.survey);
+    }
 }
 
 // ─── JOURNAL ─────────────────────────────────────────────────────────────────
@@ -532,8 +734,11 @@ function renderMap(user, guildSettings) {
         const seasonalTag = region.seasonalEventId
             ? (inSeason ? ' · *in season*' : ' · *out of season*')
             : '';
+        const surveyTag = isRegionFullyCharted(region, progress)
+            ? ` · 🏅 *fully surveyed (+${Math.round(LIMITS.SURVEY_BONUS * 100)}% haul)*`
+            : '';
         lines.push(
-            `${region.emoji} **${region.name}** — ${pct}% charted${seasonalTag}\n` +
+            `${region.emoji} **${region.name}** — ${pct}% charted${seasonalTag}${surveyTag}\n` +
             `> \`${chartBar(pct)}\` ` +
             `🗿 ${progress.landmarksFound.length}/${region.landmarks.length} · ` +
             `📜 ${progress.loreFound.length}/${region.lore.length} · ` +
@@ -570,6 +775,14 @@ module.exports = {
     isRegionInSeason,
     isRegionEnabled,
     getAvailableRegions,
+    resolveActiveRegion,
+    hasUnfoundSecrets,
+    isRegionFullyCharted,
+    getRelicCollection,
+    getRelicBonus,
+    getSecretOdds,
+    getPayoutMultiplier,
+    getPenaltyMultiplier,
     executeExplore,
     resolveEncounter,
     addJournalEntry,

--- a/src/utils/embedFields.js
+++ b/src/utils/embedFields.js
@@ -1,0 +1,89 @@
+'use strict';
+
+/**
+ * Discord embed length budgets. discord.js throws rather than truncating, so a
+ * list that grows with player progress has to be packed before it is sent —
+ * otherwise the whole command fails the moment a collection gets large enough.
+ */
+const EMBED_LIMITS = {
+    FIELD_VALUE: 1024,
+    DESCRIPTION: 4096,
+};
+
+/**
+ * Pack pre-rendered lines into embed field values, none exceeding `limit`.
+ *
+ * The first field carries `name`; continuations are titled "<name> (cont.)" so
+ * the list reads as one section. A single line longer than the limit is
+ * truncated rather than dropped — losing the tail of one entry beats losing the
+ * whole embed.
+ *
+ * @param {string} name    field name for the first chunk
+ * @param {string[]} lines rendered lines, joined with `separator`
+ * @param {object} [opts]  { limit, separator, inline, maxFields }
+ * @returns {Array<{name: string, value: string, inline: boolean}>}
+ */
+function packFields(name, lines, {
+    limit = EMBED_LIMITS.FIELD_VALUE,
+    separator = '\n',
+    inline = false,
+    maxFields = Infinity,
+} = {}) {
+    const fields = [];
+    let current = '';
+
+    const flush = () => {
+        if (!current) return;
+        fields.push({
+            name: fields.length === 0 ? name : `${name} (cont.)`,
+            value: current,
+            inline,
+        });
+        current = '';
+    };
+
+    for (const line of lines) {
+        const piece = truncate(line, limit);
+        if (!current) {
+            current = piece;
+        } else if (current.length + separator.length + piece.length <= limit) {
+            current += separator + piece;
+        } else {
+            flush();
+            if (fields.length >= maxFields) return fields;
+            current = piece;
+        }
+    }
+    flush();
+
+    return fields.length > maxFields ? fields.slice(0, maxFields) : fields;
+}
+
+/**
+ * Join lines into an embed description that fits the budget, dropping whole
+ * lines off the end rather than emitting a half-rendered one. Returns the text
+ * plus how many lines did not make it, so callers can say so.
+ *
+ * @returns {{ text: string, omitted: number }}
+ */
+function fitDescription(lines, { limit = EMBED_LIMITS.DESCRIPTION, separator = '\n' } = {}) {
+    const kept = [];
+    let length = 0;
+
+    for (const line of lines) {
+        const cost = kept.length ? separator.length + line.length : line.length;
+        if (length + cost > limit) break;
+        kept.push(line);
+        length += cost;
+    }
+
+    return { text: kept.join(separator), omitted: lines.length - kept.length };
+}
+
+/** Hard-truncate a single string to `limit`, marking the cut with an ellipsis. */
+function truncate(text, limit) {
+    if (text.length <= limit) return text;
+    return `${text.slice(0, Math.max(0, limit - 1)).trimEnd()}…`;
+}
+
+module.exports = { EMBED_LIMITS, packFields, fitDescription, truncate };

--- a/tests/embedFields.test.js
+++ b/tests/embedFields.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const { EMBED_LIMITS, packFields, fitDescription, truncate } = require('../src/utils/embedFields');
+const { RELIC_LIST } = require('../src/data/exploreData');
+
+describe('truncate', () => {
+    test('leaves short strings alone', () => {
+        expect(truncate('short', 10)).toBe('short');
+    });
+
+    test('marks the cut and never exceeds the limit', () => {
+        const out = truncate('x'.repeat(50), 10);
+        expect(out).toHaveLength(10);
+        expect(out.endsWith('…')).toBe(true);
+    });
+});
+
+describe('packFields', () => {
+    test('keeps a small list in a single field', () => {
+        const fields = packFields('Items', ['one', 'two', 'three']);
+        expect(fields).toHaveLength(1);
+        expect(fields[0].name).toBe('Items');
+        expect(fields[0].value).toBe('one\ntwo\nthree');
+    });
+
+    test('splits past the limit and marks continuations', () => {
+        const lines = Array.from({ length: 40 }, (_, i) => `${'x'.repeat(60)}${i}`);
+        const fields = packFields('Items', lines);
+        expect(fields.length).toBeGreaterThan(1);
+        expect(fields[0].name).toBe('Items');
+        expect(fields[1].name).toBe('Items (cont.)');
+        for (const field of fields) {
+            expect(field.value.length).toBeLessThanOrEqual(EMBED_LIMITS.FIELD_VALUE);
+        }
+    });
+
+    test('loses no lines while splitting', () => {
+        const lines = Array.from({ length: 40 }, (_, i) => `${'x'.repeat(60)}${i}`);
+        const rejoined = packFields('Items', lines).map(f => f.value).join('\n').split('\n');
+        expect(rejoined).toEqual(lines);
+    });
+
+    test('truncates an oversized single line rather than dropping it', () => {
+        const fields = packFields('Items', ['y'.repeat(5_000)]);
+        expect(fields).toHaveLength(1);
+        expect(fields[0].value.length).toBe(EMBED_LIMITS.FIELD_VALUE);
+    });
+
+    test('returns nothing for an empty list', () => {
+        expect(packFields('Items', [])).toEqual([]);
+    });
+});
+
+describe('fitDescription', () => {
+    test('keeps everything when it fits', () => {
+        const { text, omitted } = fitDescription(['a', 'b', 'c']);
+        expect(text).toBe('a\nb\nc');
+        expect(omitted).toBe(0);
+    });
+
+    test('drops whole trailing lines and counts them', () => {
+        const lines = Array.from({ length: 10 }, () => 'z'.repeat(1_000));
+        const { text, omitted } = fitDescription(lines);
+        expect(text.length).toBeLessThanOrEqual(EMBED_LIMITS.DESCRIPTION);
+        expect(omitted).toBeGreaterThan(0);
+        // Never a half-rendered line: the kept text is a clean join
+        expect(text.split('\n').every(l => l.length === 1_000)).toBe(true);
+    });
+});
+
+describe('relic views stay inside Discord budgets', () => {
+    const currency = '💰';
+
+    test('a full relic collection fits the inventory field limit', () => {
+        const lines = RELIC_LIST.map(r =>
+            `${r.emoji} **${r.itemId}** *(${r.rarity} · ${r.regionName} · ${currency}${r.value.toLocaleString()})*`
+        );
+        const fields = packFields('🏺 Relics', lines);
+        for (const field of fields) {
+            expect(field.value.length).toBeLessThanOrEqual(EMBED_LIMITS.FIELD_VALUE);
+        }
+        // Nothing silently dropped — a collector sees every relic they own
+        expect(fields.map(f => f.value).join('\n').split('\n')).toHaveLength(RELIC_LIST.length);
+    });
+
+    test('a full relic case fits the description limit once lore is dropped', () => {
+        const render = withLore => RELIC_LIST.map(r => {
+            const head = `${r.emoji} **${r.itemId}** — *${r.regionName}* · ${currency}${r.value.toLocaleString()}`;
+            return withLore ? `${head}\n> *${r.lore}*` : head;
+        });
+
+        // With lore the full set genuinely overflows — that's why the fallback exists
+        expect(render(true).join('\n').length).toBeGreaterThan(EMBED_LIMITS.DESCRIPTION);
+
+        const { text, omitted } = fitDescription(render(false));
+        expect(text.length).toBeLessThanOrEqual(EMBED_LIMITS.DESCRIPTION);
+        expect(omitted).toBe(0);
+    });
+});

--- a/tests/exploreService.test.js
+++ b/tests/exploreService.test.js
@@ -9,7 +9,14 @@ const {
     getLevelData,
     isRegionInSeason,
     isRegionEnabled,
+    isRegionFullyCharted,
     getAvailableRegions,
+    resolveActiveRegion,
+    getRelicCollection,
+    getRelicBonus,
+    getSecretOdds,
+    getPayoutMultiplier,
+    getPenaltyMultiplier,
     executeExplore,
     resolveEncounter,
     addJournalEntry,
@@ -20,8 +27,11 @@ const {
     LIMITS,
     REGIONS,
     REGION_LIST,
+    RELIC_LIST,
+    RELIC_INDEX,
     TOTAL_CORE_SECRETS,
     EXPLORER_LEVELS,
+    getRelicMeta,
 } = require('../src/data/exploreData');
 
 function makeUser(overrides = {}) {
@@ -40,6 +50,32 @@ function makeGuildSettings(overrides = {}) {
         exploration: { enabled: true, dropRateMultiplier: 1, rareEventBonus: 0, disabledRegions: [] },
         ...overrides,
     };
+}
+
+// Marks a region as fully explored on the user's progress record.
+function chartRegion(user, region, { landmarks = true, lore = true, secrets = true } = {}) {
+    const rec = {
+        regionId: region.id,
+        discoveredAt: new Date(),
+        expeditions: 1,
+        landmarksFound: landmarks ? region.landmarks.map(l => l.id) : [],
+        loreFound:      lore     ? region.lore.map(l => l.id)       : [],
+        secretsFound:   secrets  ? region.secrets.map(s => s.id)    : [],
+    };
+    user.exploration.regions.push(rec);
+    return rec;
+}
+
+// Math.random replacement that plays a fixed script, then holds the last value.
+function scriptRandom(values) {
+    let i = 0;
+    return () => values[Math.min(i++, values.length - 1)];
+}
+
+function withRandom(fn, impl) {
+    const original = Math.random;
+    Math.random = impl;
+    try { return fn(); } finally { Math.random = original; }
 }
 
 describe('exploreData integrity', () => {
@@ -171,10 +207,13 @@ describe('region availability', () => {
 describe('executeExplore', () => {
     test('consumes stamina and records the expedition', () => {
         const user = makeUser();
-        const result = executeExplore(user, REGIONS.whispering_forest, makeGuildSettings(), {});
-        if (result.pendingChoice) {
-            resolveEncounter(user, REGIONS.whispering_forest, makeGuildSettings(), result, 'observe');
-        }
+        // 0.6 pins the roll to the treasure slot — a quiet roll refunds the
+        // stamina point and would make this assertion a coin flip.
+        const result = withRandom(
+            () => executeExplore(user, REGIONS.whispering_forest, makeGuildSettings(), {}),
+            () => 0.6,
+        );
+        expect(result.type).toBe('treasure');
         expect(user.exploration.stamina).toBe(LIMITS.MAX_STAMINA - 1);
         expect(user.exploration.totalExpeditions).toBe(1);
         expect(result.firstVisit).toBe(true);
@@ -310,5 +349,387 @@ describe('map rendering', () => {
         const user = makeUser();
         const lines = renderMap(user, makeGuildSettings());
         expect(lines.join('\n')).not.toContain('Frostveil');
+    });
+
+    test('a fully surveyed region is flagged on the map', () => {
+        const user = makeUser();
+        chartRegion(user, REGIONS.whispering_forest);
+        expect(renderMap(user, makeGuildSettings()).join('\n')).toContain('fully surveyed');
+    });
+});
+
+describe('ensureExploreData idempotence', () => {
+    test('reports a write on first seed and nothing on the second pass', () => {
+        const user = { balance: 0, inventory: [], markModified: jest.fn() };
+        expect(ensureExploreData(user)).toBe(true);
+        expect(ensureExploreData(user)).toBe(false);
+    });
+
+    test('leaves null-by-default timestamps alone instead of rewriting them', () => {
+        const user = makeUser();
+        user.exploration.lastExplore = null;
+        expect(ensureExploreData(user)).toBe(false);
+    });
+});
+
+describe('stamina and daily reset report their writes', () => {
+    test('a full, freshly anchored stamina bar is not rewritten', () => {
+        const user = makeUser();
+        user.exploration.staminaLastRegen = new Date();
+        expect(applyStaminaRegen(user)).toBe(false);
+    });
+
+    test('a stale anchor at full stamina is refreshed once', () => {
+        const user = makeUser();
+        user.exploration.staminaLastRegen = new Date(Date.now() - 10 * LIMITS.STAMINA_REGEN_MS);
+        expect(applyStaminaRegen(user)).toBe(true);
+        expect(applyStaminaRegen(user)).toBe(false);
+    });
+
+    test('daily reset only reports the rollover', () => {
+        const user = makeUser();
+        user.exploration.dailyWindowStart = new Date(Date.now() - LIMITS.DAILY_WINDOW_MS - 1);
+        expect(applyDailyReset(user)).toBe(true);
+        expect(applyDailyReset(user)).toBe(false);
+    });
+});
+
+describe('active region fallback', () => {
+    test('keeps a region that is still open', () => {
+        const user = makeUser();
+        const resolved = resolveActiveRegion(user, makeGuildSettings());
+        expect(resolved.region.id).toBe('whispering_forest');
+        expect(resolved.switched).toBe(false);
+    });
+
+    test('reroutes off a seasonal region once its event ends', () => {
+        const user = makeUser();
+        user.exploration.activeRegion = 'frostveil_pass';
+        const resolved = resolveActiveRegion(user, makeGuildSettings());
+        expect(resolved.switched).toBe(true);
+        expect(resolved.from.id).toBe('frostveil_pass');
+        expect(resolved.region.id).toBe('whispering_forest');
+        expect(user.exploration.activeRegion).toBe('whispering_forest');
+    });
+
+    test('reroutes off a region an admin switched off', () => {
+        const user = makeUser();
+        user.exploration.unlockedRegions.push('crumbling_ruins');
+        user.exploration.level = 10;
+        user.exploration.activeRegion = 'crumbling_ruins';
+        const settings = makeGuildSettings();
+        settings.exploration.disabledRegions = ['crumbling_ruins'];
+        expect(resolveActiveRegion(user, settings).region.id).toBe('whispering_forest');
+    });
+
+    test('prefers the richest core region the player has actually earned', () => {
+        const user = makeUser();
+        user.exploration.level = 12;
+        user.exploration.unlockedRegions.push('crumbling_ruins', 'crystal_caves');
+        user.exploration.activeRegion = 'frostveil_pass';
+        expect(resolveActiveRegion(user, makeGuildSettings()).region.id).toBe('crystal_caves');
+    });
+
+    test('an unlocked region below its level requirement is not a fallback', () => {
+        const user = makeUser();
+        user.exploration.level = 4;
+        user.exploration.unlockedRegions.push('crumbling_ruins');
+        user.exploration.activeRegion = 'frostveil_pass';
+        expect(resolveActiveRegion(user, makeGuildSettings()).region.id).toBe('whispering_forest');
+    });
+});
+
+describe('losses do not scale with generosity', () => {
+    function forceLoss(user, region, settings) {
+        let guard = 2_000;
+        while (guard-- > 0) {
+            user.exploration.stamina = LIMITS.MAX_STAMINA;
+            user.exploration.dailyCoins = 0;
+            const r = executeExplore(user, region, settings, { coinMultiplier: settings.__coinMult ?? 1 });
+            if (!r.pendingChoice) continue;
+            // rand = 1 loses the encounter, maxes the penalty roll, dodges injury
+            return withRandom(() => resolveEncounter(user, region, settings, r, 'approach'), () => 0.999999);
+        }
+        throw new Error('no encounter rolled');
+    }
+
+    test('an encounter loss ignores the event coin bonus and the drop-rate knob', () => {
+        const region = REGIONS.whispering_forest;
+
+        const plain = makeUser();
+        const plainSettings = makeGuildSettings();
+        const plainLoss = forceLoss(plain, region, plainSettings);
+
+        const boosted = makeUser();
+        const boostedSettings = makeGuildSettings();
+        boostedSettings.exploration.dropRateMultiplier = 5;
+        boostedSettings.__coinMult = 3;
+        const boostedLoss = forceLoss(boosted, region, boostedSettings);
+
+        expect(plainLoss.outcome).toBe('loss');
+        expect(boostedLoss.outcome).toBe('loss');
+        expect(boostedLoss.penalty).toBe(plainLoss.penalty);
+        expect(plainLoss.penalty).toBe(600); // max roll × 1.0 region multiplier
+    });
+
+    test('a deeper region still costs more to fail in', () => {
+        expect(getPenaltyMultiplier(REGIONS.starfall_wastes))
+            .toBeGreaterThan(getPenaltyMultiplier(REGIONS.whispering_forest));
+        expect(getPenaltyMultiplier(REGIONS.whispering_forest)).toBe(1.0);
+    });
+
+    test('trap penalties stay inside their hand-tuned range', () => {
+        const user = makeUser({ balance: 10_000_000 });
+        const region = REGIONS.starfall_wastes;
+        const settings = makeGuildSettings();
+        settings.exploration.dropRateMultiplier = 5;
+        const worst = Math.max(...region.traps.map(t => t.penalty.max));
+        for (let i = 0; i < 400; i++) {
+            user.exploration.stamina = LIMITS.MAX_STAMINA;
+            user.exploration.dailyCoins = 0;
+            const r = executeExplore(user, region, settings, { coinMultiplier: 3 });
+            if (r.type === 'trap') expect(r.penalty).toBeLessThanOrEqual(worst);
+        }
+    });
+});
+
+describe('daily cap visibility', () => {
+    test('a capped payout reports the gross amount it was trimmed from', () => {
+        const user = makeUser();
+        user.exploration.dailyWindowStart = new Date();
+        user.exploration.dailyCoins = LIMITS.DAILY_HARD_CAP;
+
+        let capped = null;
+        for (let i = 0; i < 400 && !capped; i++) {
+            user.exploration.stamina = LIMITS.MAX_STAMINA;
+            const r = executeExplore(user, REGIONS.whispering_forest, makeGuildSettings(), {});
+            if (r.pendingChoice) resolveEncounter(user, REGIONS.whispering_forest, makeGuildSettings(), r, 'observe');
+            if (r.cappedByDailyCap) capped = r;
+        }
+
+        expect(capped).not.toBeNull();
+        expect(capped.payout).toBe(0);
+        expect(capped.grossPayout).toBeGreaterThan(0);
+    });
+
+    test('a partially capped payout still records what it would have been', () => {
+        const user = makeUser();
+        user.exploration.dailyWindowStart = new Date();
+        user.exploration.dailyCoins = LIMITS.DAILY_HARD_CAP - 50;
+
+        let capped = null;
+        for (let i = 0; i < 400 && !capped; i++) {
+            user.exploration.stamina = LIMITS.MAX_STAMINA;
+            const r = executeExplore(user, REGIONS.whispering_forest, makeGuildSettings(), {});
+            if (r.pendingChoice) resolveEncounter(user, REGIONS.whispering_forest, makeGuildSettings(), r, 'observe');
+            if (r.cappedByDailyCap && r.payout > 0) capped = r;
+        }
+
+        expect(capped).not.toBeNull();
+        expect(capped.grossPayout).toBeGreaterThan(capped.payout);
+        expect(user.exploration.dailyCoins).toBe(LIMITS.DAILY_HARD_CAP);
+    });
+});
+
+describe('secret pity tells the truth', () => {
+    test('an uncovered region never rolls a secret and never builds pity', () => {
+        const user = makeUser();
+        const region = REGIONS.whispering_forest;
+        chartRegion(user, region);
+        const settings = makeGuildSettings();
+
+        for (let i = 0; i < 400; i++) {
+            user.exploration.stamina = LIMITS.MAX_STAMINA;
+            user.exploration.dailyCoins = 0;
+            const r = executeExplore(user, region, settings, {});
+            if (r.pendingChoice) resolveEncounter(user, region, settings, r, 'observe');
+            expect(r.type).not.toBe('secret');
+        }
+        expect(user.exploration.sinceSecret).toBe(0);
+    });
+
+    test('getSecretOdds reports exhaustion instead of a chance', () => {
+        const user = makeUser();
+        const region = REGIONS.whispering_forest;
+        const progress = chartRegion(user, region);
+        expect(getSecretOdds(user, region, progress).exhausted).toBe(true);
+    });
+
+    test('pity lifts the secret chance above its base rate', () => {
+        const user = makeUser();
+        const region = REGIONS.whispering_forest;
+        const progress = chartRegion(user, region, { secrets: false });
+
+        const cold = getSecretOdds(user, region, progress);
+        user.exploration.sinceSecret = 60;
+        const hot = getSecretOdds(user, region, progress);
+
+        expect(cold.chance).toBeCloseTo(cold.baseChance, 10);
+        expect(hot.chance).toBeGreaterThan(hot.baseChance);
+        expect(hot.pity).toBe(LIMITS.SECRET_PITY_MAX);
+    });
+
+    test('expeditions into a region with secrets left do build pity', () => {
+        const user = makeUser();
+        const region = REGIONS.whispering_forest;
+        const settings = makeGuildSettings();
+        for (let i = 0; i < 20; i++) {
+            user.exploration.stamina = LIMITS.MAX_STAMINA;
+            user.exploration.dailyCoins = 0;
+            const r = executeExplore(user, region, settings, {});
+            if (r.pendingChoice) resolveEncounter(user, region, settings, r, 'observe');
+        }
+        expect(user.exploration.sinceSecret).toBeGreaterThan(0);
+    });
+});
+
+describe('surveying a region', () => {
+    test('a fully charted region pays a standing bonus', () => {
+        const user = makeUser();
+        const region = REGIONS.whispering_forest;
+        const settings = makeGuildSettings();
+        const bare = getPayoutMultiplier(user, region, settings, 1, null);
+        const progress = chartRegion(user, region);
+        const surveyed = getPayoutMultiplier(user, region, settings, 1, progress);
+        expect(surveyed / bare).toBeCloseTo(1 + LIMITS.SURVEY_BONUS, 10);
+    });
+
+    test('completing the last landmark fires the survey once', () => {
+        const user = makeUser();
+        const region = REGIONS.whispering_forest;
+        const progress = chartRegion(user, region);
+        progress.landmarksFound = region.landmarks.slice(1).map(l => l.id);
+        expect(isRegionFullyCharted(region, progress)).toBe(false);
+
+        // 0.3 lands the event roll on the discovery slot
+        const result = withRandom(
+            () => executeExplore(user, region, makeGuildSettings(), {}),
+            () => 0.3,
+        );
+
+        expect(result.type).toBe('discovery');
+        expect(result.regionCompleted).toBe(true);
+        expect(progress.completedAt).toBeInstanceOf(Date);
+        expect(user.exploration.regionsSurveyed).toBe(1);
+
+        // A later expedition into the same region doesn't re-announce it
+        user.exploration.stamina = LIMITS.MAX_STAMINA;
+        const next = executeExplore(user, region, makeGuildSettings(), {});
+        if (next.pendingChoice) resolveEncounter(user, region, makeGuildSettings(), next, 'observe');
+        expect(next.regionCompleted).toBeUndefined();
+        expect(user.exploration.regionsSurveyed).toBe(1);
+    });
+});
+
+describe('exhausted slots still pay properly', () => {
+    test('a fallback treasure caps at rare but keeps its relic roll', () => {
+        const user = makeUser();
+        const region = REGIONS.whispering_forest;
+        const progress = chartRegion(user, region, { secrets: false });
+        progress.landmarksFound = region.landmarks.map(l => l.id);
+
+        // event roll → discovery · intro · tier roll (legendary) · line · amount
+        // · relic check · relic pick
+        const result = withRandom(
+            () => executeExplore(user, region, makeGuildSettings(), {}),
+            scriptRandom([0.3, 0.5, 0.99, 0.5, 0.5, 0, 0]),
+        );
+
+        expect(result.type).toBe('treasure');
+        expect(result.fallbackTreasure).toBe(true);
+        expect(result.treasureTier.tier).toBe('rare');
+        expect(result.relic).toBeDefined();
+        expect(user.exploration.relicsRecovered).toBe(1);
+    });
+
+    test('a normal treasure is still allowed to be legendary', () => {
+        const user = makeUser();
+        const region = REGIONS.whispering_forest;
+        // 0.6 lands the event roll on the treasure slot
+        const result = withRandom(
+            () => executeExplore(user, region, makeGuildSettings(), {}),
+            scriptRandom([0.6, 0.5, 0.995, 0.5, 0.5, 0, 0]),
+        );
+        expect(result.type).toBe('treasure');
+        expect(result.fallbackTreasure).toBe(false);
+        expect(result.treasureTier.tier).toBe('legendary');
+    });
+});
+
+describe('quiet expeditions', () => {
+    test('cost the cooldown but not a stamina point', () => {
+        const user = makeUser();
+        const result = withRandom(
+            () => executeExplore(user, REGIONS.whispering_forest, makeGuildSettings(), {}),
+            () => 0.999999,
+        );
+        expect(result.type).toBe('quiet');
+        expect(result.staminaSpared).toBe(true);
+        expect(user.exploration.stamina).toBe(LIMITS.MAX_STAMINA);
+        expect(user.exploration.totalExpeditions).toBe(1);
+        expect(user.exploration.lastExplore).toBeInstanceOf(Date);
+    });
+
+    test('a refund never pushes stamina over the cap', () => {
+        const user = makeUser();
+        user.exploration.stamina = LIMITS.MAX_STAMINA;
+        withRandom(() => executeExplore(user, REGIONS.whispering_forest, makeGuildSettings(), {}), () => 0.999999);
+        expect(user.exploration.stamina).toBe(LIMITS.MAX_STAMINA);
+    });
+});
+
+describe('relic collection', () => {
+    test('every relic in the data tables is indexed with a value', () => {
+        expect(RELIC_LIST.length).toBeGreaterThan(0);
+        for (const relic of RELIC_LIST) {
+            expect(getRelicMeta(relic.itemId)).toBe(RELIC_INDEX[relic.itemId]);
+            expect(relic.value).toBeGreaterThan(0);
+            expect(relic.regionName).toBeTruthy();
+        }
+    });
+
+    test('relic itemIds are unique across every region', () => {
+        const ids = REGION_LIST.flatMap(r => (r.relics ?? []).map(x => x.itemId));
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    test('the bonus counts distinct relics, not duplicates', () => {
+        const first = RELIC_LIST[0].itemId;
+        const user = makeUser({ inventory: [{ itemId: first, quantity: 40 }] });
+        expect(getRelicCollection(user)).toHaveLength(1);
+        expect(getRelicBonus(user)).toBeCloseTo(LIMITS.RELIC_BONUS_PER, 10);
+    });
+
+    test('the bonus is capped and ignores non-relic inventory', () => {
+        const user = makeUser({
+            inventory: [
+                ...RELIC_LIST.map(r => ({ itemId: r.itemId, quantity: 1 })),
+                { itemId: 'lockpick', quantity: 9 },
+            ],
+        });
+        expect(getRelicCollection(user)).toHaveLength(RELIC_LIST.length);
+        expect(getRelicBonus(user)).toBe(LIMITS.RELIC_BONUS_MAX);
+    });
+
+    test('the collection bonus lifts payouts', () => {
+        const region = REGIONS.whispering_forest;
+        const settings = makeGuildSettings();
+        const empty = makeUser();
+        const collector = makeUser({ inventory: RELIC_LIST.slice(0, 5).map(r => ({ itemId: r.itemId, quantity: 1 })) });
+        expect(getPayoutMultiplier(collector, region, settings, 1, null))
+            .toBeGreaterThan(getPayoutMultiplier(empty, region, settings, 1, null));
+    });
+
+    test('treasure prefers relics the collector is missing', () => {
+        const region = REGIONS.whispering_forest;
+        const owned = region.relics[0];
+        const user = makeUser({ inventory: [{ itemId: owned.itemId, quantity: 1 }] });
+        // Legendary treasure: relicChance 1.0, whole regional pool eligible
+        const result = withRandom(
+            () => executeExplore(user, region, makeGuildSettings(), {}),
+            scriptRandom([0.6, 0.5, 0.995, 0.5, 0.5, 0, 0]),
+        );
+        expect(result.relic.itemId).not.toBe(owned.itemId);
+        expect(result.relicIsNew).toBe(true);
     });
 });

--- a/tests/exploreService.test.js
+++ b/tests/exploreService.test.js
@@ -14,6 +14,7 @@ const {
     resolveActiveRegion,
     getRelicCollection,
     getRelicBonus,
+    buildEventWeights,
     getSecretOdds,
     getPayoutMultiplier,
     getPenaltyMultiplier,
@@ -29,6 +30,9 @@ const {
     REGION_LIST,
     RELIC_LIST,
     RELIC_INDEX,
+    RELIC_VALUES,
+    RELIC_EMOJI,
+    RELIC_RARITY_ORDER,
     TOTAL_CORE_SECRETS,
     EXPLORER_LEVELS,
     getRelicMeta,
@@ -555,6 +559,23 @@ describe('secret pity tells the truth', () => {
         expect(getSecretOdds(user, region, progress).exhausted).toBe(true);
     });
 
+    test('the quoted odds use the same table the roll does', () => {
+        const user = makeUser();
+        const region = REGIONS.whispering_forest;
+        const progress = chartRegion(user, region, { secrets: false });
+
+        const plain = makeGuildSettings();
+        const boosted = makeGuildSettings();
+        boosted.exploration.rareEventBonus = 0.25;
+
+        // rareEventBonus shifts weight into the secret slot; the display must
+        // move with it or it quotes a chance the roll never uses.
+        expect(buildEventWeights(region, boosted).secret)
+            .toBeGreaterThan(buildEventWeights(region, plain).secret);
+        expect(getSecretOdds(user, region, progress, boosted).baseChance)
+            .toBeGreaterThan(getSecretOdds(user, region, progress, plain).baseChance);
+    });
+
     test('pity lifts the secret chance above its base rate', () => {
         const user = makeUser();
         const region = REGIONS.whispering_forest;
@@ -686,6 +707,33 @@ describe('relic collection', () => {
             expect(relic.value).toBeGreaterThan(0);
             expect(relic.regionName).toBeTruthy();
         }
+    });
+
+    test('every relic rarity is on the ladder, priced and iconned', () => {
+        // An off-ladder rarity would fall through to value 0 and still raise the
+        // collection bonus — a relic that pays a bonus and shows a price of zero.
+        for (const relic of RELIC_LIST) {
+            expect(RELIC_RARITY_ORDER).toContain(relic.rarity);
+            expect(RELIC_VALUES[relic.rarity]).toBeGreaterThan(0);
+            expect(RELIC_EMOJI[relic.rarity]).toBeTruthy();
+        }
+    });
+
+    test('every region defines a relic pool, and a region without one still pays out', () => {
+        for (const region of REGION_LIST) {
+            expect(Array.isArray(region.relics)).toBe(true);
+        }
+        // Guard the future case: a hand-added region with no relics must degrade
+        // to a plain treasure rather than throwing mid-expedition.
+        const user = makeUser();
+        const barren = { ...REGIONS.whispering_forest, id: 'barren_test', relics: undefined };
+        const result = withRandom(
+            () => executeExplore(user, barren, makeGuildSettings(), {}),
+            scriptRandom([0.6, 0.5, 0.995, 0.5, 0.5, 0, 0]),
+        );
+        expect(result.type).toBe('treasure');
+        expect(result.relic).toBeUndefined();
+        expect(result.payout).toBeGreaterThan(0);
     });
 
     test('relic itemIds are unique across every region', () => {


### PR DESCRIPTION
## Summary

Adds region surveying mechanics, relic collection system, and improved visibility into the secret pity system. Players can now fully chart regions for standing bonuses, collect relics that provide passive income, and see exactly where they stand on the secret drought curve.

## Key Changes

- **Region Charting**: Added `isRegionFullyCharted()` to detect when a region is 100% explored (all landmarks, lore, secrets found). Fully charted regions grant a standing +15% payout bonus on all future expeditions there, with a one-time survey completion bonus.

- **Relic Collection System**: 
  - New `getRelicCollection()` and `getRelicBonus()` functions to track distinct relics owned and calculate passive income bonuses (1% per distinct relic, capped at 10%)
  - Added `RELIC_INDEX`, `RELIC_LIST`, and relic metadata to `exploreData.js`
  - Relics are now tracked in inventory and displayed in a new `/explore relics` command
  - Relic drops now flag whether they're new to the player's collection

- **Secret Pity Visibility**:
  - Extracted `getSecretPity()` and new `getSecretOdds()` function to expose the secret drought curve (base chance, pity-boosted chance, exhaustion state)
  - Secret pity only accumulates when a region still has unfound secrets; fully charted regions don't build pity
  - Added visual pity bar and odds display in region info and cooldown messages
  - `rollEventType()` now drops the secret slot entirely (rather than degrading to treasure) when a region is fully charted

- **Active Region Fallback**: New `resolveActiveRegion()` function handles rerouting players when their active region goes out of season or is disabled by admins, preferring the richest available core region and reporting the switch to the user.

- **Stamina & Daily Reset Reporting**: `applyStaminaRegen()` and `applyDailyReset()` now return booleans indicating whether they wrote changes, reducing unnecessary database saves on the common path.

- **Idempotent Data Seeding**: `ensureExploreData()` now returns a boolean and only marks the user modified if it actually seeded fields, preventing spurious writes.

- **Penalty Scaling**: Added `getPenaltyMultiplier()` to ensure trap penalties scale with region difficulty but ignore admin generosity settings (drop rate, event coin bonuses).

- **Daily Cap Transparency**: Results now include `grossPayout` (what was earned before the daily cap) and `cappedByDailyCap` flag so players see what they would have earned.

## Implementation Details

- Relic data is embedded in region definitions and indexed for O(1) lookup
- Secret pity is only active for regions with unfound secrets, making the mechanic honest about what it can deliver
- The active region fallback is sticky but self-correcting, so seasonal events and admin changes don't strand players
- Fully charted regions are flagged on the map with "fully surveyed" text
- Test coverage expanded significantly with new helper functions (`chartRegion()`, `scriptRandom()`, `withRandom()`) and comprehensive test suites for all new mechanics

https://claude.ai/code/session_01PDPnK66syFXr4iaSM8tDQD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/explore relics` to view collected relics, rarity, value, lore, and exploration bonuses.
  * Added relic rewards, survey progression, completion bonuses, secret pity, and region-based bonuses.
  * Added Arctic Tundra as a seasonal region and improved active-region fallback behavior.
  * Exploration maps, profiles, journals, and inventories now show expanded progression details.

* **Bug Fixes**
  * Quiet expeditions now refund stamina.
  * Loss penalties and treasure rewards are applied more consistently.
  * Daily limits, cooldowns, and inventory handling now provide clearer results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->