### PR TITLE
Fix pickaxe condemnation and repair charge safety

### DIFF
--- a/src/commands/economy/craft.js
+++ b/src/commands/economy/craft.js
@@ -261,9 +261,9 @@ module.exports = {
                 }
 
             } else if (out.type === 'mine_consumable') {
-                if (out.id === 'mine_lock' && m.mineLockActive) {
-                    return interaction.reply({ content: 'Your mine already has an active **Mine Lock**.', flags: MessageFlags.Ephemeral });
-                }
+                // A Mine Lock is stock you arm later with `/mine shop use`, so holding
+                // spares while one is armed is fine — the stack guard above is the only
+                // limit that applies.
                 m.consumables[out.id] = (m.consumables[out.id] ?? 0) + out.qty;
                 const def = MINE_CONSUMABLES[out.id];
                 outputDesc = `${def?.emoji ?? '📦'} **${out.qty}× ${def?.name ?? out.id}**`;

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -2,7 +2,7 @@
 
 const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags } = require('discord.js');
 const User  = require('../../models/User');
-const { attachGrind, persistGrindIfNew } = require('../../utils/grindProfile');
+const { attachGrind, persistGrindIfNew, saveGrind } = require('../../utils/grindProfile');
 const GrindProfile = require('../../models/GrindProfile');
 const Guild = require('../../models/Guild');
 const { getItemImageAttachment } = require('../../utils/itemImageHelper');
@@ -33,14 +33,15 @@ const {
     getLevelData,
     xpToNextLevel,
     activateConsumable,
+    isCondemned,
+    quoteRepair,
     applyRepair,
     updatePickaxeStatus,
     applyXp,
     updateMineMap,
     renderMineMap,
     getOreStashSummary,
-    isOreStashEmpty,
-    activateMineLock
+    isOreStashEmpty
 } = require('../../services/mineService');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
 const { stackBar } = require('../../utils/rewardReveal');
@@ -51,6 +52,7 @@ const { tryUpdateHourlyWinner, getCurrentHourlyLeader } = require('../../utils/h
 const { isDistrictActive } = require('../../services/districtService');
 const { ensureQuests, onMine, onEconomyEarn, notifyQuestComplete, notifyQuestNearComplete } = require('../../services/questService');
 const { getActiveSynergies } = require('../../services/synergyService');
+const { refundEffectCharge } = require('../../services/effectsService');
 const { CROSS_CONSUMABLES } = require('../../data/crossSystemData');
 
 const WILDERNESS_YIELD_BONUS = 0.10;
@@ -60,11 +62,31 @@ function resolveConsumableDef(id) {
     return CONSUMABLES[id] ?? CROSS_CONSUMABLES[id] ?? null;
 }
 
+// Take `cost` coins with a conditional update rather than `user.balance -= cost`
+// followed by a save: the loaded document's balance goes stale the moment any
+// other command pays the player, and saving it back would erase that payout.
+// Returns the updated document, or null when the player can't afford it any more.
+function chargeBalance(interaction, cost) {
+    return User.findOneAndUpdate(
+        { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: cost } },
+        { $inc: { balance: -cost } },
+        { new: true },
+    );
+}
+
+// Undo a chargeBalance when the purchase it paid for could not be persisted.
+function refundBalance(interaction, cost) {
+    return User.updateOne(
+        { userId: interaction.user.id, guildId: interaction.guild.id },
+        { $inc: { balance: cost } },
+    ).catch(err => console.error('[mineshop] refund error:', err));
+}
+
 const DEPTH_CHOICES    = DEPTH_LIST.map(d => ({ name: d.name, value: d.id }));
 const PICKAXE_CHOICES  = PICKAXE_TIERS.map(p => ({ name: `${p.emoji} ${p.name} — ${p.cost.toLocaleString()} coins`, value: p.slug }));
 const ALL_ITEMS        = [...Object.values(CONSUMABLES), ...BLAST_PACKS];
 const ITEM_CHOICES     = ALL_ITEMS.map(i => ({ name: `${i.emoji ?? ''} ${i.name} — ${i.cost} coins`.trim(), value: i.id }));
-const ACTIVATABLE      = ['ore_magnet', 'premium_magnet', 'miners_lamp', 'miners_instinct', 'xp_scroll', 'energy_tonic', 'reinforced_trap'];
+const ACTIVATABLE      = ['ore_magnet', 'premium_magnet', 'miners_lamp', 'miners_instinct', 'xp_scroll', 'energy_tonic', 'reinforced_trap', 'mine_lock'];
 const UPGRADE_CHOICES  = Object.values(PICKAXE_UPGRADES).map(u => ({ name: `${u.emoji} ${u.name} — ${u.description}`, value: u.id }));
 const UNLOCK_CHOICES   = DEPTH_LIST.filter(d => !d.defaultUnlocked).map(d => ({ name: `${d.emoji} ${d.name}`, value: d.id }));
 
@@ -326,17 +348,15 @@ async function handleDig(interaction) {
 
     if (m.lastMine && Date.now() - m.lastMine.getTime() < LIMITS.MINE_COOLDOWN_MS) {
         const nextAt = new Date(m.lastMine.getTime() + LIMITS.MINE_COOLDOWN_MS);
-        const sinceRare = m.sinceRare ?? 0;
-        const depthHint = m.stamina >= 5
-            ? 'Tip: Deep intensity (💎) doubles your yield — try it when stamina is full'
-            : null;
+        // Intensity is earned in the vein-reading rounds, not picked from a menu —
+        // so the preview promises what a good read pays, not a setting to choose.
         return interaction.reply({
             embeds: [buildCooldownEmbed({
                 title: '⛏️ Catching Your Breath',
                 description: 'You just came up from a dig.\nTake a short break before heading back down.',
                 color: '#b5651d',
                 nextAt,
-                nextRewardPreview: depthHint ?? 'Next dig: Abyss tier multiplies your payout by 3×',
+                nextRewardPreview: 'Read the vein 3/3 on your next dig and the haul pays 2× — 3× if it opens into the Abyss',
             })],
             flags: MessageFlags.Ephemeral,
         });
@@ -364,7 +384,9 @@ async function handleDig(interaction) {
                 color: '#b5651d',
                 nextAt,
                 pityStat,
-                nextRewardPreview: 'Full stamina + Deep intensity = best rare material odds',
+                // Stamina buys swings, not luck: tier odds come from the depth you
+                // dig, your pickaxe and an active magnet. Don't imply otherwise.
+                nextRewardPreview: 'Deeper depths, a better pickaxe and an Ore Magnet are what move your rare odds',
             })],
             flags: MessageFlags.Ephemeral,
         });
@@ -458,6 +480,14 @@ async function handleDig(interaction) {
         // never costs the player a charge.
         if (pickaxeData.requiresCharge) {
             m.charges[pickaxeData.chargeType] = (m.charges[pickaxeData.chargeType] ?? 0) - 1;
+            user.markModified('mining');
+        }
+
+        // Digging an explicit depth makes it your active depth. Without this it only
+        // ever moved when you unlocked something, so /mine profile and /mine map kept
+        // reporting a depth you had long since stopped digging.
+        if (requestedDepth && m.activeDepth !== depthId) {
+            m.activeDepth = depthId;
             user.markModified('mining');
         }
 
@@ -656,6 +686,12 @@ async function handleDig(interaction) {
                     m.totalEarned      -= result.caveInPayout;
                     m.dailyCoins       -= result.caveInPayout;
                     result.finalPayout  = 0;
+                }
+                // The doubling charge bought ore that is now buried — hand it back
+                // rather than billing a Black Market item for coins never kept.
+                if (result.gatheringYield) {
+                    refundEffectCharge(user, result.gatheringYield.effect);
+                    result.gatheringYield = null;
                 }
                 if (result.tier === 'legendary') m.legendaryFinds = Math.max(0, m.legendaryFinds - 1);
                 if (result.tier === 'event')     m.eventFinds     = Math.max(0, m.eventFinds - 1);
@@ -1529,10 +1565,23 @@ async function handleShop(interaction, sub) {
             return interaction.reply({ content: `This upgrade costs ${currency}${cost.toLocaleString()} but you only have ${currency}${user.balance.toLocaleString()}.`, flags: MessageFlags.Ephemeral });
         }
 
-        user.balance -= cost;
+        await persistGrindIfNew(user, 'mining');
+        const charged = await chargeBalance(interaction, cost);
+        if (!charged) {
+            return interaction.reply({ content: `This upgrade costs ${currency}${cost.toLocaleString()} — you no longer have enough. Check \`/balance\` and try again.`, flags: MessageFlags.Ephemeral });
+        }
+        user.balance = charged.balance;
+
         pickaxe.upgrade = moduleId;
         user.markModified('mining');
-        await user.save();
+        try {
+            await saveGrind(user, ['mining']);
+        } catch (err) {
+            console.error('[mineshop upgrade] save error:', err);
+            pickaxe.upgrade = null;
+            await refundBalance(interaction, cost);
+            return interaction.reply({ content: 'Installing the upgrade failed — your coins were refunded. Please try again.', flags: MessageFlags.Ephemeral });
+        }
 
         const embed = new EmbedBuilder()
             .setColor('#b5651d')
@@ -1717,16 +1766,32 @@ async function handleShop(interaction, sub) {
         const pickaxe = m.pickaxes[m.equippedPickaxeIndex];
 
         if (method === 'shop') {
-            const repairResult = applyRepair(pickaxe, null);
-            if (repairResult.error) return interaction.reply({ content: repairResult.error, flags: MessageFlags.Ephemeral });
+            // Price it before touching the pickaxe: applyRepair permanently degrades
+            // max durability, so quoting first keeps a player who can't pay from
+            // wearing their pickaxe down for nothing.
+            const quote = quoteRepair(pickaxe, null);
+            if (quote.error) return interaction.reply({ content: quote.error, flags: MessageFlags.Ephemeral });
 
-            if (user.balance < repairResult.cost) {
-                return interaction.reply({ content: `Repair costs ${currency}${repairResult.cost.toLocaleString()} but you only have ${currency}${user.balance.toLocaleString()}.`, flags: MessageFlags.Ephemeral });
+            if (user.balance < quote.cost) {
+                return interaction.reply({ content: `Repair costs ${currency}${quote.cost.toLocaleString()} but you only have ${currency}${user.balance.toLocaleString()}.`, flags: MessageFlags.Ephemeral });
             }
 
-            user.balance -= repairResult.cost;
+            await persistGrindIfNew(user, 'mining');
+            const charged = await chargeBalance(interaction, quote.cost);
+            if (!charged) {
+                return interaction.reply({ content: `Repair costs ${currency}${quote.cost.toLocaleString()} — you no longer have enough. Check \`/balance\` and try again.`, flags: MessageFlags.Ephemeral });
+            }
+            user.balance = charged.balance;
+
+            const repairResult = applyRepair(pickaxe, null);
             user.markModified('mining');
-            await user.save();
+            try {
+                await saveGrind(user, ['mining']);
+            } catch (err) {
+                console.error('[mineshop repair] save error:', err);
+                await refundBalance(interaction, quote.cost);
+                return interaction.reply({ content: 'The repair failed — your coins were refunded. Please try again.', flags: MessageFlags.Ephemeral });
+            }
 
             const embed = new EmbedBuilder()
                 .setColor('#b5651d')
@@ -1755,8 +1820,8 @@ async function handleShop(interaction, sub) {
                 return interaction.reply({ content: `You don't have any **${kit.name}**. Buy one with \`/mine shop buy\`.`, flags: MessageFlags.Ephemeral });
             }
 
-            if (pickaxe.status === 'condemned') {
-                return interaction.reply({ content: 'This pickaxe is condemned and cannot be repaired.', flags: MessageFlags.Ephemeral });
+            if (isCondemned(pickaxe)) {
+                return interaction.reply({ content: 'This pickaxe is condemned and cannot be repaired. Replace it with `/mine shop pickaxe`.', flags: MessageFlags.Ephemeral });
             }
             if (pickaxe.currentDurability >= pickaxe.maxDurability) {
                 return interaction.reply({ content: 'Pickaxe is already at full durability.', flags: MessageFlags.Ephemeral });
@@ -1800,11 +1865,26 @@ async function handleShop(interaction, sub) {
             return interaction.reply({ content: `Unlocking **${depthDef.name}** costs ${currency}${depthDef.unlockCost.toLocaleString()} but you only have ${currency}${user.balance.toLocaleString()}.`, flags: MessageFlags.Ephemeral });
         }
 
-        user.balance -= depthDef.unlockCost;
+        await persistGrindIfNew(user, 'mining');
+        const charged = await chargeBalance(interaction, depthDef.unlockCost);
+        if (!charged) {
+            return interaction.reply({ content: `Unlocking **${depthDef.name}** costs ${currency}${depthDef.unlockCost.toLocaleString()} — you no longer have enough. Check \`/balance\` and try again.`, flags: MessageFlags.Ephemeral });
+        }
+        user.balance = charged.balance;
+
+        const priorDepth = m.activeDepth;
         m.unlockedDepths.push(depthId);
         m.activeDepth = depthId;
         user.markModified('mining');
-        await user.save();
+        try {
+            await saveGrind(user, ['mining']);
+        } catch (err) {
+            console.error('[mineshop unlock] save error:', err);
+            m.unlockedDepths = m.unlockedDepths.filter(id => id !== depthId);
+            m.activeDepth = priorDepth;
+            await refundBalance(interaction, depthDef.unlockCost);
+            return interaction.reply({ content: 'The unlock failed — your coins were refunded. Please try again.', flags: MessageFlags.Ephemeral });
+        }
 
         const embed = new EmbedBuilder()
             .setColor('#b5651d')
@@ -1857,6 +1937,15 @@ function buildMineEmbed(result, user, depth, pickaxe, currency, discordUser) {
         if (mineMultEntries.length > 0) {
             const mineCombined = (result.streakMult ?? 1) * critMultiplier;
             embed.addFields({ name: '📈 Multipliers', value: stackBar(mineMultEntries, mineCombined, finalPayout, currency), inline: false });
+        }
+
+        if (result.gatheringYield) {
+            const { label, emoji, chargesLeft } = result.gatheringYield;
+            embed.addFields({
+                name: `${emoji} ${label}`,
+                value: `Payout doubled · ${chargesLeft > 0 ? `${chargesLeft} charge${chargesLeft === 1 ? '' : 's'} left` : '**last charge**'}`,
+                inline: false,
+            });
         }
 
         if (specialDrop) {
@@ -2013,8 +2102,9 @@ async function handleMap(interaction) {
     const explored = (m.mineMap ?? []).filter(c => c !== 0).length;
     const total    = mapSize * mapSize;
 
-    // Compute depth level proxy from miner level for the yield multiplier hint
-    const intensityHint = m.level >= 40 ? '2.0×–3.0×' : m.level >= 20 ? '1.4×–2.0×' : '1.0×–1.4×';
+    // Yield multiplier comes from the vein-reading rounds, not from miner level:
+    // 0/3 correct pays 0.7× and 3/3 pays 2× (3× on a lucky break into the Abyss).
+    const intensityHint = '0.7×–3.0×, set by your vein read';
 
     const stashLines = getOreStashSummary(user).map(([id, qty]) => `${MATERIAL_NAMES[id] ?? id}: **${qty}**`);
 
@@ -2045,8 +2135,11 @@ async function handleMap(interaction) {
         .setFooter({ text: 'Mine more to expand your map • Use /mine raid to steal from others' })
         .setTimestamp();
 
+    const spareLocks = m.consumables?.mine_lock ?? 0;
     if (m.mineLockActive) {
-        embed.addFields({ name: '🔒 Mine Lock', value: 'Active — your mine is protected from raiders.', inline: true });
+        embed.addFields({ name: '🔒 Mine Lock', value: `Armed — the next raid on your mine bounces off it.${spareLocks > 0 ? `\n${spareLocks} spare in your bag.` : ''}`, inline: true });
+    } else if (spareLocks > 0) {
+        embed.addFields({ name: '🔓 Mine Lock', value: `${spareLocks} in your bag, none armed — use \`/mine shop use item:mine_lock\`.`, inline: true });
     }
 
     return interaction.reply({ embeds: [embed] });
@@ -2230,7 +2323,8 @@ async function handleRaid(interaction) {
             `**${interaction.user.username}** broke into your mine on **${interaction.guild.name}** ` +
             `and stole **${pct}%** of your ore stash!\n\n` +
             `**Lost:**\n${stolenLines}\n\n` +
-            `Craft a **Mine Lock** (\`/craft make mine_lock_from_obsidian\`) to protect yourself next time.`
+            `Get a **Mine Lock** (\`/mine shop buy item:mine_lock\` or \`/craft make mine_lock_from_obsidian\`) ` +
+            `and arm it with \`/mine shop use item:mine_lock\` to block the next raid.`
         )
         .setTimestamp();
     targetUser.send({ embeds: [dmEmbed] }).catch(() => null);

--- a/src/data/mineData.js
+++ b/src/data/mineData.js
@@ -150,7 +150,7 @@ const CONSUMABLES = {
     mine_lock: {
         id: 'mine_lock', name: 'Mine Lock', emoji: '🔒',
         cost: 400, type: 'defense',
-        description: 'Blocks the next raid attempt on your mine; consumed on first use',
+        description: 'Arm it with `/mine shop use` — blocks the next raid on your mine, then breaks',
         maxStack: 3
     }
 };

--- a/src/services/mineService.js
+++ b/src/services/mineService.js
@@ -16,7 +16,7 @@ const { getStreakMultiplier } = require('../utils/streakMultiplier');
 const { getPityBonus } = require('../utils/pityBonus');
 const { hasIronWill } = require('./synergyService');
 const { getBonusMultipliers } = require('../utils/prestige');
-const { getGatheringYieldEffect, consumeEffect } = require('./effectsService');
+const { getGatheringYieldEffect, consumeEffect, getEffect, EFFECT_CONFIGS } = require('./effectsService');
 
 const DANGEROUS_DEPTH_IDS = new Set(['crystal_caves', 'the_abyss']);
 const MINE_DEATH_RATE = 0.08;
@@ -294,6 +294,10 @@ function rollFailureSeverity() {
 
 // ─── PAYOUT CALCULATION ───────────────────────────────────────────────────────
 
+/**
+ * Returns { adjustedPayout, cappedByHard, gatheringYield }, where gatheringYield
+ * is { effect, label, emoji, chargesLeft } when a charge was spent here.
+ */
 function applyPayoutModifiers(user, rawPayout, depth) {
     const m = user.mining;
     let payout = rawPayout;
@@ -316,21 +320,38 @@ function applyPayoutModifiers(user, rawPayout, depth) {
 
     // Hard cap: zero coins — check before consuming item charges
     if (m.dailyCoins >= LIMITS.DAILY_HARD_CAP) {
-        return { adjustedPayout: 0, cappedByHard: true };
+        return { adjustedPayout: 0, cappedByHard: true, gatheringYield: null };
     }
 
-    // Silvered Talisman / Voidsteel Cache: 2x yield, consume 1 charge from whichever is active
+    // Applies the daily soft cap and clamps to the headroom left under the hard cap.
+    const softCapped = m.dailyCoins >= LIMITS.DAILY_SOFT_CAP;
+    const remaining  = LIMITS.DAILY_HARD_CAP - m.dailyCoins;
+    const settle = raw => Math.max(0, Math.min(softCapped ? Math.round(raw * 0.50) : raw, remaining));
+
+    const basePayout    = settle(payout);
+    const doubledPayout = settle(payout * 2);
+
+    // Silvered Talisman / Voidsteel Cache: 2x yield, consume 1 charge from whichever
+    // is active. Only burn the charge when doubling actually pays more — within a
+    // hair of the daily hard cap the headroom clamp swallows the bonus entirely, and
+    // a charge that buys nothing shouldn't be spent.
     const gatherEffect = getGatheringYieldEffect(user);
-    if (gatherEffect) { consumeEffect(user, gatherEffect); payout *= 2; }
-
-    if (m.dailyCoins >= LIMITS.DAILY_SOFT_CAP) {
-        payout = Math.round(payout * 0.50);
+    if (gatherEffect && doubledPayout > basePayout) {
+        consumeEffect(user, gatherEffect);
+        const cfg = EFFECT_CONFIGS[gatherEffect];
+        return {
+            adjustedPayout: doubledPayout,
+            cappedByHard:   false,
+            gatheringYield: {
+                effect:      gatherEffect,
+                label:       cfg?.label ?? gatherEffect.replace(/_/g, ' '),
+                emoji:       cfg?.emoji ?? '✨',
+                chargesLeft: getEffect(user, gatherEffect)?.charges ?? 0,
+            },
+        };
     }
 
-    const remaining = LIMITS.DAILY_HARD_CAP - m.dailyCoins;
-    payout = Math.min(payout, remaining);
-
-    return { adjustedPayout: Math.max(0, payout), cappedByHard: false };
+    return { adjustedPayout: basePayout, cappedByHard: false, gatheringYield: null };
 }
 
 // ─── DURABILITY ───────────────────────────────────────────────────────────────
@@ -344,22 +365,41 @@ function applyDurabilityLoss(pickaxe, baseLoss) {
     updatePickaxeStatus(pickaxe);
 }
 
+/**
+ * True once shop repairs have ground a pickaxe's durability ceiling below 20% of
+ * its original. Derived from the durability ratio rather than `pickaxe.status`:
+ * updatePickaxeStatus reports 'broken' whenever current durability hits 0, which
+ * would otherwise mask condemnation and let a condemned pickaxe be repaired again
+ * every time it breaks — an endless loop that costs a repair instead of a
+ * replacement pickaxe.
+ */
+function isCondemned(pickaxe) {
+    if (!pickaxe?.baseDurability) return false;
+    return pickaxe.maxDurability / pickaxe.baseDurability < 0.20;
+}
+
 function updatePickaxeStatus(pickaxe) {
     if (pickaxe.currentDurability <= 0) {
         pickaxe.status = 'broken';
         return;
     }
     const ratio = pickaxe.maxDurability / pickaxe.baseDurability;
-    if (ratio < 0.20)      pickaxe.status = 'condemned';
-    else if (ratio < 0.50) pickaxe.status = 'degraded';
-    else                   pickaxe.status = 'good';
+    if (isCondemned(pickaxe)) pickaxe.status = 'condemned';
+    else if (ratio < 0.50)    pickaxe.status = 'degraded';
+    else                      pickaxe.status = 'good';
 }
 
-function applyRepair(pickaxe, requestedAmount) {
+/**
+ * Prices one repair cycle without touching the pickaxe, so callers can check
+ * affordability before anything is mutated.
+ *
+ * Returns { cost, amount } or { error }.
+ */
+function quoteRepair(pickaxe, requestedAmount) {
     const pickaxeData = PICKAXE_BY_TIER[pickaxe.tier];
     if (!pickaxeData) throw new Error('Unknown pickaxe tier');
 
-    if (pickaxe.status === 'condemned') {
+    if (isCondemned(pickaxe)) {
         return { error: 'This pickaxe is condemned and cannot be repaired. Replace it.' };
     }
     if (pickaxe.status !== 'broken' && pickaxe.currentDurability >= pickaxe.maxDurability) {
@@ -369,7 +409,14 @@ function applyRepair(pickaxe, requestedAmount) {
     const needed = pickaxe.maxDurability - pickaxe.currentDurability;
     const amount = Math.min(requestedAmount ?? needed, needed);
     const units  = Math.ceil(amount / 20);
-    const cost   = units * pickaxeData.repairCostPer20;
+
+    return { cost: units * pickaxeData.repairCostPer20, amount };
+}
+
+function applyRepair(pickaxe, requestedAmount) {
+    const quote = quoteRepair(pickaxe, requestedAmount);
+    if (quote.error) return quote;
+    const { cost, amount } = quote;
 
     pickaxe.currentDurability = Math.min(pickaxe.maxDurability, pickaxe.currentDurability + amount);
 
@@ -380,7 +427,7 @@ function applyRepair(pickaxe, requestedAmount) {
 
     updatePickaxeStatus(pickaxe);
 
-    return { cost, restoredAmount: amount, newStatus: pickaxe.status, condemned: pickaxe.status === 'condemned' };
+    return { cost, restoredAmount: amount, newStatus: pickaxe.status, condemned: isCondemned(pickaxe) };
 }
 
 // ─── LEVEL / XP ──────────────────────────────────────────────────────────────
@@ -468,6 +515,12 @@ function activateConsumable(user, consumableId) {
         }
         m.consumables[consumableId] -= 1;
         m.activeReinforcedTrapMinesLeft = def.minesLeft;
+    } else if (def.type === 'defense' && consumableId === 'mine_lock') {
+        if (m.mineLockActive) {
+            return { success: false, error: 'Your mine already has an active **Mine Lock**. It stays armed until a raider trips it.' };
+        }
+        m.consumables[consumableId] -= 1;
+        m.mineLockActive = true;
     } else if (def.type === 'repair') {
         return { success: false, error: `Use repair kits with \`/mine shop repair\`.` };
     } else {
@@ -535,7 +588,7 @@ function executeMine(user, depthId, options = {}) {
 
         const streakMult = getStreakMultiplier(user.streak?.current ?? 0);
         const payoutBeforeMods = Math.round(rawPayout * critMultiplier * streakMult);
-        const { adjustedPayout, cappedByHard } = applyPayoutModifiers(user, payoutBeforeMods, depth);
+        const { adjustedPayout, cappedByHard, gatheringYield } = applyPayoutModifiers(user, payoutBeforeMods, depth);
 
         let specialDrop = null;
         const mineDropChance = (isCrit ? ore.specialDrop?.chance * 2 : ore.specialDrop?.chance ?? 0) * (options.marketplaceActive ? 1.10 : 1.0);
@@ -560,7 +613,9 @@ function executeMine(user, depthId, options = {}) {
         user.balance     += adjustedPayout;
         m.totalEarned    += adjustedPayout;
         m.dailyCoins     += adjustedPayout;
-        if (adjustedPayout > m.bestPayout) m.bestPayout = adjustedPayout;
+        // bestPayout is deliberately NOT booked here: the intensity multiplier,
+        // the yield bonuses and the cave-in resolution all still run in mine.js,
+        // so only the caller knows what the player actually walked away with.
 
         m.successfulMines  += 1;
         m.consecutiveFails  = 0;
@@ -575,6 +630,7 @@ function executeMine(user, depthId, options = {}) {
             specialDrop, xpEarned: xpGain,
             levelUp: lvResult.leveledUp ? lvResult : null,
             cappedByHard,
+            gatheringYield,
             streakMult
         });
 
@@ -854,13 +910,6 @@ function isOreStashEmpty(user) {
     return getOreStashSummary(user).length === 0;
 }
 
-// ─── MINE LOCK ────────────────────────────────────────────────────────────────
-
-function activateMineLock(user) {
-    user.mining.mineLockActive = true;
-    user.markModified('mining');
-}
-
 module.exports = {
     ensureMineData,
     getMaxStamina,
@@ -875,6 +924,8 @@ module.exports = {
     applyPayoutModifiers,
     applyDurabilityLoss,
     updatePickaxeStatus,
+    isCondemned,
+    quoteRepair,
     applyRepair,
     levelFromXp,
     getLevelData,
@@ -891,6 +942,5 @@ module.exports = {
     updateMineMap,
     renderMineMap,
     getOreStashSummary,
-    isOreStashEmpty,
-    activateMineLock
+    isOreStashEmpty
 };

--- a/tests/mineRepair.test.js
+++ b/tests/mineRepair.test.js
@@ -1,0 +1,191 @@
+'use strict';
+
+const {
+    isCondemned,
+    quoteRepair,
+    applyRepair,
+    updatePickaxeStatus,
+    applyPayoutModifiers,
+    activateConsumable,
+    ensureMineData,
+} = require('../src/services/mineService');
+const { DEPTHS, LIMITS, PICKAXE_BY_TIER } = require('../src/data/mineData');
+
+function makePickaxe(overrides = {}) {
+    return {
+        name: 'Wooden Pickaxe',
+        tier: 1,
+        currentDurability: 80,
+        maxDurability: 80,
+        baseDurability: 80,
+        repairCount: 0,
+        upgrade: null,
+        status: 'good',
+        ...overrides,
+    };
+}
+
+/** Repairs until the pickaxe is condemned, returning it. */
+function repairUntilCondemned(pickaxe) {
+    for (let i = 0; i < 50 && !isCondemned(pickaxe); i++) {
+        pickaxe.currentDurability = 0;
+        updatePickaxeStatus(pickaxe);
+        const res = applyRepair(pickaxe, pickaxe.maxDurability);
+        if (res.error) break;
+    }
+    return pickaxe;
+}
+
+describe('pickaxe condemnation', () => {
+    test('shop repairs eventually condemn a pickaxe', () => {
+        const pickaxe = repairUntilCondemned(makePickaxe());
+        expect(isCondemned(pickaxe)).toBe(true);
+        expect(pickaxe.maxDurability / pickaxe.baseDurability).toBeLessThan(0.20);
+    });
+
+    test('a condemned pickaxe cannot be repaired even after it breaks', () => {
+        const pickaxe = repairUntilCondemned(makePickaxe());
+
+        // Break it: updatePickaxeStatus labels it 'broken', which used to mask
+        // 'condemned' and reopen the repair path for another cycle — a loop that
+        // let one pickaxe be nursed forever instead of replaced.
+        pickaxe.currentDurability = 0;
+        updatePickaxeStatus(pickaxe);
+        expect(pickaxe.status).toBe('broken');
+
+        expect(isCondemned(pickaxe)).toBe(true);
+        expect(quoteRepair(pickaxe, 20).error).toMatch(/condemned/i);
+        expect(applyRepair(pickaxe, 20).error).toMatch(/condemned/i);
+    });
+
+    test('breaking a condemned pickaxe does not restore any durability', () => {
+        const pickaxe = repairUntilCondemned(makePickaxe());
+        pickaxe.currentDurability = 0;
+        updatePickaxeStatus(pickaxe);
+        const repairsBefore = pickaxe.repairCount;
+
+        applyRepair(pickaxe, pickaxe.maxDurability);
+
+        expect(pickaxe.currentDurability).toBe(0);
+        expect(pickaxe.repairCount).toBe(repairsBefore);
+    });
+
+    test('a healthy pickaxe is not condemned', () => {
+        const pickaxe = makePickaxe({ currentDurability: 10 });
+        expect(isCondemned(pickaxe)).toBe(false);
+        expect(quoteRepair(pickaxe, 20).error).toBeUndefined();
+    });
+});
+
+describe('quoteRepair', () => {
+    test('prices a repair without mutating the pickaxe', () => {
+        const pickaxe = makePickaxe({ currentDurability: 20 });
+        const snapshot = { ...pickaxe };
+
+        const quote = quoteRepair(pickaxe, 60);
+
+        expect(quote.cost).toBe(3 * PICKAXE_BY_TIER[1].repairCostPer20);
+        expect(quote.amount).toBe(60);
+        expect(pickaxe).toEqual(snapshot);
+    });
+
+    test('agrees with the cost applyRepair actually charges', () => {
+        const pickaxe = makePickaxe({ currentDurability: 20 });
+        const quote   = quoteRepair(pickaxe, 60);
+        const result  = applyRepair(pickaxe, 60);
+
+        expect(result.cost).toBe(quote.cost);
+        expect(result.restoredAmount).toBe(quote.amount);
+    });
+
+    test('refuses a pickaxe already at full durability', () => {
+        expect(quoteRepair(makePickaxe(), 20).error).toMatch(/full durability/i);
+    });
+});
+
+describe('gathering-yield charges', () => {
+    function makeUser(dailyCoins) {
+        return {
+            mining: { dailyCoins, dailyMines: 0, prestige: 0 },
+            activeEffects: [
+                { type: 'silvered_talisman', charges: 5, expiresAt: new Date(Date.now() + 3600_000) },
+            ],
+            markModified: () => {},
+        };
+    }
+
+    test('doubles the payout and spends a charge with headroom to spare', () => {
+        const user = makeUser(0);
+
+        const { adjustedPayout } = applyPayoutModifiers(user, 5000, DEPTHS.surface_quarry);
+
+        expect(adjustedPayout).toBe(10_000);
+        expect(user.activeEffects[0].charges).toBe(4);
+    });
+
+    test('still pays past the soft cap, where x2 beats the halving', () => {
+        const user = makeUser(LIMITS.DAILY_SOFT_CAP);
+
+        const { adjustedPayout } = applyPayoutModifiers(user, 5000, DEPTHS.surface_quarry);
+
+        expect(adjustedPayout).toBe(5000);
+        expect(user.activeEffects[0].charges).toBe(4);
+    });
+
+    test('is not consumed when the hard-cap headroom makes doubling worthless', () => {
+        const user = makeUser(LIMITS.DAILY_HARD_CAP - 1);
+
+        const { adjustedPayout } = applyPayoutModifiers(user, 5000, DEPTHS.surface_quarry);
+
+        expect(adjustedPayout).toBe(1);
+        expect(user.activeEffects[0].charges).toBe(5);
+    });
+
+    test('reports the effect and remaining charges so the embed can show them', () => {
+        const user = makeUser(0);
+
+        const { gatheringYield } = applyPayoutModifiers(user, 5000, DEPTHS.surface_quarry);
+
+        expect(gatheringYield).toMatchObject({ effect: 'silvered_talisman', chargesLeft: 4 });
+        expect(gatheringYield.label).toBe('Silvered Talisman');
+    });
+});
+
+describe('mine lock', () => {
+    function makeMiner(lockStock) {
+        const user = { markModified: () => {} };
+        ensureMineData(user);
+        user.mining.consumables.mine_lock = lockStock;
+        return user;
+    }
+
+    test('arming a lock spends one from the bag', () => {
+        const user = makeMiner(2);
+
+        const result = activateConsumable(user, 'mine_lock');
+
+        expect(result.success).toBe(true);
+        expect(user.mining.mineLockActive).toBe(true);
+        expect(user.mining.consumables.mine_lock).toBe(1);
+    });
+
+    test('refuses to stack a second lock on an already armed mine', () => {
+        const user = makeMiner(2);
+        activateConsumable(user, 'mine_lock');
+
+        const second = activateConsumable(user, 'mine_lock');
+
+        expect(second.success).toBe(false);
+        expect(second.error).toMatch(/already has an active/i);
+        expect(user.mining.consumables.mine_lock).toBe(1);
+    });
+
+    test('refuses to arm a lock nobody owns', () => {
+        const user = makeMiner(0);
+
+        const result = activateConsumable(user, 'mine_lock');
+
+        expect(result.success).toBe(false);
+        expect(user.mining.mineLockActive).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

This PR fixes critical issues with pickaxe condemnation logic and adds safety mechanisms to prevent charge loss during failed transactions. It also improves the gathering yield effect system to only consume charges when the bonus actually increases payout.

## Key Changes

- **Pickaxe Condemnation**: Refactored condemnation detection to use a dedicated `isCondemned()` function based on durability ratio rather than status string. This prevents condemned pickaxes from being repaired again after breaking, which previously created an infinite repair loop.

- **Repair Safety**: Split repair logic into `quoteRepair()` (pricing without mutation) and `applyRepair()` (applying the repair). This allows checking affordability before degrading the pickaxe, preventing wasted durability on failed transactions.

- **Charge Consumption Logic**: Modified `applyPayoutModifiers()` to only consume gathering yield charges (Silvered Talisman, Voidsteel Cache) when the doubling bonus actually increases the final payout. Near the hard cap, the headroom clamp can eliminate the bonus entirely—charges are no longer wasted in these cases.

- **Transaction Safety**: Added `chargeBalance()` and `refundBalance()` helpers using conditional updates to prevent race conditions where concurrent commands could cause balance inconsistencies. Shop operations (pickaxe purchase, repair, depth unlock) now charge first, persist, and refund on failure.

- **Mine Lock Improvements**: 
  - Added `mine_lock` to the `ACTIVATABLE` consumables list
  - Integrated mine lock activation into `activateConsumable()` with proper validation
  - Updated `/mine map` display to show lock status and spare inventory
  - Removed the separate `activateMineLock()` function in favor of unified handling

- **Gathering Yield Display**: Enhanced the mine result embed to show which effect doubled the payout and how many charges remain, with special emphasis on the last charge.

- **Active Depth Tracking**: Fixed `/mine dig` to update `activeDepth` when an explicit depth is chosen, ensuring `/mine profile` and `/mine map` reflect the player's current digging location.

- **Payout Calculation**: Clarified that `bestPayout` is not updated in `executeMine()` since intensity multipliers and cave-in resolution happen in the command handler—only the final result should count.

- **Test Coverage**: Added comprehensive test suite (`mineRepair.test.js`) covering condemnation logic, repair quoting, charge consumption edge cases, and mine lock activation.

## Notable Implementation Details

- Condemnation is now determined by `maxDurability / baseDurability < 0.20` rather than a status flag, making it immune to status updates that would otherwise mask it.
- The soft cap and hard cap logic in `applyPayoutModifiers()` now calculates both base and doubled payouts before deciding whether to consume a charge, ensuring charges are only spent when beneficial.
- Database operations use `findOneAndUpdate()` with balance guards to prevent concurrent payment races from corrupting account state.

https://claude.ai/code/session_01Bg9ET6mMgGtJCXkvtjKUyv