### PR TITLE
Stop advertising features that don't exist, and finish the Clawdia rebrand

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@ CLIENT_SECRET=your_client_secret_here
 DISCORD_TOKEN=your_bot_token_here
 
 # Database (use service name "mongodb" when running via Docker Compose)
+#
+# The database is still named "ultrabot" after the pre-rebrand name. It is left
+# that way on purpose: renaming it does not move any data, it just points the bot
+# at a new, empty database, so every existing deployment would come up looking
+# wiped. Change it only alongside a deliberate dump-and-restore into the new name.
 MONGODB_URI=mongodb://mongodb:27017/ultrabot
 
 # Dashboard

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1,6 +1,6 @@
-# UltraBot API Reference
+# Clawdia API Reference
 
-## Developer Guide for Extending UltraBot
+## Developer Guide for Extending Clawdia
 
 This guide is for developers who want to add custom features or modify existing functionality.
 
@@ -667,7 +667,7 @@ if (interaction.isButton()) {
 ### Building Docker Image
 
 ```bash
-docker build -t ultrabot:latest .
+docker build -t clawdia:latest .
 ```
 
 ### Running Locally

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -162,21 +162,15 @@ Set a moderation log channel to track:
 /daily               - Daily reward (24h cooldown)
 /work                - Work for coins (1h cooldown)
 /bank transfer <user> <amount> - Send coins
-/casino wheel        - Spin the Wheel of Fortune (free spin per cooldown, or buy extra spins)
+/casino <game>       - Casino games: blackjack, crash, cupgame, higherlower, keno, poker, roulette, slots
 /casino roulette     - Bet on Red/Black, Odd/Even, Low/High, dozens, columns, or a straight number
+/casino jackpot      - View the current progressive jackpot pool
 ```
-
-**Wheel of Fortune:**
-- One free spin per cooldown window (default: 24 hours, configurable per server)
-- Optional paid spins at any time using server currency
-- Weighted prize segments — coins, jackpot, free re-spin, or bust
-- Animated reveal in the embed before the result is shown
 
 **Dashboard Settings:**
 - Currency symbol (💰, 🪙, $, etc.)
 - Daily reward amount
 - Work reward range (min-max)
-- Wheel of Fortune: enable/disable, cooldown hours, extra spin cost
 
 ### World Exploration
 
@@ -263,7 +257,7 @@ Auto-generated cards include:
 
 ### Decision-Focused Dashboards
 
-UltraBot now provides decision-grade analytics so server owners can move from raw events to clear actions.
+Clawdia now provides decision-grade analytics so server owners can move from raw events to clear actions.
 
 ### Included Insights
 
@@ -399,8 +393,7 @@ Prevent spam with built-in cooldowns:
 |---------|----------|
 | `/daily` | 24 hours |
 | `/work` | 1 hour |
-| `/casino wheel` | 24 hours (configurable; bypass with paid spin) |
-| `/casino` (other games) | 5–10 seconds |
+| `/casino` (games) | 5–10 seconds |
 | `/play` | 3 seconds |
 | Most others | 3 seconds |
 

--- a/PRODUCTIONREADY.md
+++ b/PRODUCTIONREADY.md
@@ -1,12 +1,22 @@
-# Production Readiness Checklist
+# Feature Audit Log
 
-This file tracks the production readiness status of each feature/function in Clawdia.
+A record of the subsystems that have been through a line-by-line audit, and what
+was found and fixed in each. **It is not a survey of the whole bot.** Nine
+subsystems have been audited — all of them long-stable, low-churn ones. The
+majority of the codebase, including every economy subsystem, has never been
+audited; see [Not yet reviewed](#not-yet-reviewed) for the full list.
+
+A subsystem appearing here means it was audited on the date at the bottom of
+this file and the findings were resolved. A subsystem *not* appearing here means
+nothing — neither that it is broken nor that it is sound. Do not read the
+absence of a section as a clean bill of health, and do not treat this file as a
+release gate.
 
 ---
 
 ## Welcome Function
 
-**Status: PRODUCTION READY** ✓
+**Status: Audited — all findings resolved** ✓
 
 **Files reviewed/fixed:**
 - `src/utils/cardGenerator.js`
@@ -51,7 +61,7 @@ This file tracks the production readiness status of each feature/function in Cla
 
 ## Farewell Function
 
-**Status: PRODUCTION READY** ✓
+**Status: Audited — all findings resolved** ✓
 
 **Files reviewed/fixed:**
 - `src/events/guildMemberRemove.js`
@@ -89,7 +99,7 @@ This file tracks the production readiness status of each feature/function in Cla
 
 ## Birthday Function
 
-**Status: PRODUCTION READY** ✓
+**Status: Audited — all findings resolved** ✓
 
 **Files reviewed/fixed:**
 - `src/services/birthdayService.js`
@@ -121,7 +131,7 @@ This file tracks the production readiness status of each feature/function in Cla
 
 ## Moderation Function
 
-**Status: PRODUCTION READY** ✓
+**Status: Audited — all findings resolved** ✓
 
 **Files reviewed/fixed:**
 - `src/commands/moderation/appeal.js`
@@ -137,7 +147,6 @@ This file tracks the production readiness status of each feature/function in Cla
 - `src/commands/moderation/note.js`
 - `src/commands/moderation/slowmode.js`
 - `src/commands/moderation/softban.js`
-- `src/commands/moderation/ticket.js`
 - `src/commands/moderation/unban.js`
 - `src/commands/moderation/unmute.js`
 - `src/commands/moderation/warn.js`
@@ -159,23 +168,27 @@ This file tracks the production readiness status of each feature/function in Cla
 |---|-------|-----|-------|
 | 1 | `warn add` subcommand had 5+ sequential DB/API operations before `interaction.reply` — routinely exceeded Discord's 3-second response deadline, causing "This interaction failed" errors | Added `interaction.deferReply()` immediately after the bot-check guard; changed reply to `editReply`; fixed the catch path to use `editReply` when already deferred | `warn.js` |
 | 2 | `appeal.js` had 2 DB operations before any reply — at-risk of 3-second timeout | Added `interaction.deferReply({ ephemeral: true })` before first DB call; changed all subsequent `reply` calls to `editReply` | `appeal.js` |
-| 3 | `ticket open` subcommand had a DB save + channel creation (2+ slow operations) before reply | Added `interaction.deferReply({ ephemeral: true })` before the slow section; changed final `reply` to `editReply` | `ticket.js` |
 
 #### Warnings (all resolved)
 
 | # | Issue | Fix | Files |
 |---|-------|-----|-------|
-| 4 | `user.tag` deprecated throughout — in the new Discord username system `.tag` always returns `username#0000` for non-legacy accounts | Replaced all `user.tag` / `interaction.user.tag` / `ban.user.tag` / `msg.author.tag` / `targetUser.tag` / `botUser.tag` with `globalName ?? username` | `appeal.js`, `ban.js`, `cases.js`, `closecase.js`, `escalationService.js`, `kick.js`, `logger.js`, `massban.js`, `mute.js`, `note.js`, `slowmode.js`, `softban.js`, `ticket.js`, `unban.js`, `unmute.js`, `warn.js` |
-| 5 | `displayAvatarURL({ dynamic: true })` deprecated in discord.js v14 | Removed the `{ dynamic: true }` option; the method returns animated URLs by default | `cases.js` |
-| 6 | `c.createdAt / 1000` in the case list embed (`cases.js`) — implicit Date→number coercion instead of explicit `.getTime()` | Changed to `c.createdAt.getTime() / 1000` | `cases.js` |
-| 7 | `massban.js` fallback user object used `{ id, tag }` — mismatched logger's `globalName ?? username` lookup after fix #4 | Changed to `{ id, globalName: null, username: userId }` | `massban.js` |
-| 8 | `warn.js` used flat `if` chains for subcommand dispatch — all three branches evaluated on every call | Changed to `if / else if / else if` | `warn.js` |
+| 3 | `user.tag` deprecated throughout — in the new Discord username system `.tag` always returns `username#0000` for non-legacy accounts | Replaced all `user.tag` / `interaction.user.tag` / `ban.user.tag` / `msg.author.tag` / `targetUser.tag` / `botUser.tag` with `globalName ?? username` | `appeal.js`, `ban.js`, `cases.js`, `closecase.js`, `escalationService.js`, `kick.js`, `logger.js`, `massban.js`, `mute.js`, `note.js`, `slowmode.js`, `softban.js`, `unban.js`, `unmute.js`, `warn.js` |
+| 4 | `displayAvatarURL({ dynamic: true })` deprecated in discord.js v14 | Removed the `{ dynamic: true }` option; the method returns animated URLs by default | `cases.js` |
+| 5 | `c.createdAt / 1000` in the case list embed (`cases.js`) — implicit Date→number coercion instead of explicit `.getTime()` | Changed to `c.createdAt.getTime() / 1000` | `cases.js` |
+| 6 | `massban.js` fallback user object used `{ id, tag }` — mismatched logger's `globalName ?? username` lookup after fix #3 | Changed to `{ id, globalName: null, username: userId }` | `massban.js` |
+| 7 | `warn.js` used flat `if` chains for subcommand dispatch — all three branches evaluated on every call | Changed to `if / else if / else if` | `warn.js` |
+
+> **No ticket system exists.** Earlier revisions of this file listed
+> `src/commands/moderation/ticket.js` as reviewed and fixed. That file has never
+> existed in any commit, and no ticket command is registered. The claims have
+> been struck; a ticket system remains an unimplemented feature, not a reviewed one.
 
 ---
 
 ## Temp Voice Function
 
-**Status: PRODUCTION READY** ✓
+**Status: Audited — all findings resolved** ✓
 
 **Files reviewed/fixed:**
 - `src/services/tempVoiceService.js`
@@ -213,7 +226,7 @@ This file tracks the production readiness status of each feature/function in Cla
 
 ## Raid Detection Function
 
-**Status: PRODUCTION READY** ✓
+**Status: Audited — all findings resolved** ✓
 
 **Files reviewed/fixed:**
 - `src/services/raidService.js`
@@ -251,7 +264,7 @@ This file tracks the production readiness status of each feature/function in Cla
 
 ## Bible Verses Function
 
-**Status: PRODUCTION READY** ✓
+**Status: Audited — all findings resolved** ✓
 
 **Files reviewed/fixed:**
 - `src/services/bibleService.js`
@@ -283,7 +296,7 @@ This file tracks the production readiness status of each feature/function in Cla
 
 ## Analytics Function
 
-**Status: PRODUCTION READY** ✓
+**Status: Audited — all findings resolved** ✓
 
 **Files reviewed/fixed:**
 - `src/events/guildMemberAdd.js`
@@ -320,7 +333,7 @@ This file tracks the production readiness status of each feature/function in Cla
 
 ## Event Log Function
 
-**Status: PRODUCTION READY** ✓
+**Status: Audited — all findings resolved** ✓
 
 **Files reviewed/fixed:**
 - `src/events/messageDelete.js`
@@ -352,4 +365,39 @@ This file tracks the production readiness status of each feature/function in Cla
 
 ---
 
-*Last reviewed: 2026-05-28*
+## Not yet reviewed
+
+Nothing below has been audited. Several of these are the highest-churn areas of
+the codebase — the economy alone is roughly a third of `src/` and takes the bulk
+of ongoing rework — so the gap between what this file covers and what ships is
+wide, and it is widest exactly where the risk is.
+
+**Economy** — the largest uncovered area:
+
+- `hunt` (`huntService.js`, `hunt.js`, `trackhunt.js`, `craft.js`, `forge.js`)
+- `mine` (`mineService.js`, `mine.js`)
+- `fish` (`fishService.js`, `fish.js`)
+- `pet` (`petService.js`, `pet.js`)
+- `use` / items / effects (`use.js`, `effectsService.js`, `inventory.js`, `shop.js`)
+- exploration (`exploreService.js`, `explore.js`, `map.js`)
+- casino (`src/games/casino/*`, `casino.js`, `casinoJackpotService.js`)
+- core currency (`balance.js`, `bank.js`, `daily.js`, `work.js`, `jobs.js`, `crime.js`, `rob.js`, `invest.js`, `market.js`, `gift.js`)
+- group and PvP systems (`heistService.js`, `syndicateService.js`, `war.js`, `duel.js`, `rivalryService.js`, `tournamentService.js`)
+- progression (`prestige.js`, `season.js`, `synergyService.js`, `dailychallenge.js`)
+- seasonal events (`seasonalEventService.js`, `eventshop.js`, and the seasonal commands)
+
+**Everything else uncovered:**
+
+- AI chat, personas, and summaries (`aiService.js`, `summaryService.js`, `ai.js`, `dm.js`)
+- RSS feeds and the daily newspaper (`rssService.js`, `newspaperService.js`, `newspaper.js`, `feed.js`)
+- quests and achievements (`questService.js`, `achievementService.js`, `quests.js`, `questgen.js`, `achievements.js`)
+- giveaways (`giveawayService.js`, `giveaway.js`)
+- starboard, suggestions, and reaction roles
+- command policies and the permission layer
+- reminders (`reminderService.js`), polls, profiles, and the remaining utility commands
+- anti-nuke (`antiNukeService.js`) and the scheduler (`schedulerService.js`)
+- the dashboard beyond the settings validators named above
+
+---
+
+*Sections above last reviewed: 2026-05-28*

--- a/PRODUCTIONREADY.md
+++ b/PRODUCTIONREADY.md
@@ -400,4 +400,5 @@ wide, and it is widest exactly where the risk is.
 
 ---
 
-*Sections above last reviewed: 2026-05-28*
+*The audited subsystems — and only those — were last reviewed on 2026-05-28.
+"Not yet reviewed" carries no review date, because nothing in it has been reviewed.*

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -1,4 +1,4 @@
-# UltraBot Setup Guide
+# Clawdia Setup Guide
 
 ## Table of Contents
 1. [Discord Bot Setup](#discord-bot-setup)
@@ -146,7 +146,8 @@ DISCORD_TOKEN=your_bot_token_here
 CLIENT_ID=your_client_id_here
 CLIENT_SECRET=your_client_secret_here
 
-# Database
+# Database — the name is still "ultrabot" from before the rebrand, deliberately.
+# Renaming it points the bot at a new, empty database rather than moving data.
 MONGODB_URI=mongodb://mongodb:27017/ultrabot
 
 # Dashboard
@@ -182,14 +183,14 @@ node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 1. Open Portainer
 2. Go to "Stacks"
 3. Click "Add stack"
-4. Name it "ultrabot"
+4. Name it "clawdia"
 5. Paste the `docker-compose.yml` content
 6. Add environment variables in the env section or upload `.env` file
 7. Click "Deploy the stack"
 
 ### Method 2: Manual Container Creation
 
-1. Create a custom bridge network: `ultrabot-network`
+1. Create a custom bridge network: `clawdia-network`
 2. Deploy MongoDB container first
 3. Deploy bot container with environment variables
 4. Link containers to the network
@@ -197,7 +198,7 @@ node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ### Updating the Bot
 
 **With Portainer:**
-1. Go to Stacks > ultrabot
+1. Go to Stacks > clawdia
 2. Click "Pull and redeploy"
 
 **Manual:**
@@ -208,11 +209,11 @@ docker-compose up -d
 
 ### Viewing Logs
 
-**Portainer:** Stacks > ultrabot > bot > Logs
+**Portainer:** Stacks > clawdia > bot > Logs
 
 **Command line:**
 ```bash
-docker logs ultrabot -f
+docker logs clawdia -f
 ```
 
 ## Database Management
@@ -224,15 +225,15 @@ The bot automatically creates the database and collections. No manual setup need
 ### Backup Database
 
 ```bash
-docker exec ultrabot-mongodb mongodump --out /data/backup
-docker cp ultrabot-mongodb:/data/backup ./backup
+docker exec clawdia-mongodb mongodump --out /data/backup
+docker cp clawdia-mongodb:/data/backup ./backup
 ```
 
 ### Restore Database
 
 ```bash
-docker cp ./backup ultrabot-mongodb:/data/backup
-docker exec ultrabot-mongodb mongorestore /data/backup
+docker cp ./backup clawdia-mongodb:/data/backup
+docker exec clawdia-mongodb mongorestore /data/backup
 ```
 
 ## Troubleshooting
@@ -242,7 +243,7 @@ docker exec ultrabot-mongodb mongorestore /data/backup
 1. Check bot is online in Discord
 2. Verify `DISCORD_TOKEN` is correct
 3. Check intents are enabled in Discord Developer Portal
-4. View logs: `docker logs ultrabot`
+4. View logs: `docker logs clawdia`
 
 ### Dashboard Not Loading
 
@@ -297,7 +298,7 @@ docker exec ultrabot-mongodb mongorestore /data/backup
 
 ## Getting Help
 
-- Check logs first: `docker logs ultrabot -f`
+- Check logs first: `docker logs clawdia -f`
 - Review this guide thoroughly
 - Check Discord.js documentation for bot issues
 - Review API provider documentation for AI issues

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -50,6 +50,7 @@
 ### 3. Invite Bot to Server
 
 Use this URL (replace CLIENT_ID with yours):
+
 ```
 https://discord.com/api/oauth2/authorize?client_id=CLIENT_ID&permissions=8&scope=bot%20applications.commands
 ```
@@ -174,6 +175,7 @@ NODE_ENV=production
 ### Generating Session Secret
 
 Use this command to generate a secure session secret:
+
 ```bash
 node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ```
@@ -246,6 +248,7 @@ before deleting anything.
 2. Click "Pull and redeploy"
 
 **Manual:**
+
 ```bash
 docker-compose pull
 docker-compose up -d
@@ -256,6 +259,7 @@ docker-compose up -d
 **Portainer:** Stacks > clawdia > bot > Logs
 
 **Command line:**
+
 ```bash
 docker logs clawdia -f
 ```

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -148,6 +148,8 @@ CLIENT_SECRET=your_client_secret_here
 
 # Database — the name is still "ultrabot" from before the rebrand, deliberately.
 # Renaming it points the bot at a new, empty database rather than moving data.
+# Upgrading an existing deployment? See "Migrating an existing UltraBot stack"
+# below: the volume holding this database is namespaced by your stack name.
 MONGODB_URI=mongodb://mongodb:27017/ultrabot
 
 # Dashboard
@@ -178,12 +180,54 @@ node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 
 ## Portainer Deployment
 
+### Migrating an existing UltraBot stack
+
+Skip this section on a fresh install. If you already run the stack under the old
+name, read it before deploying — the container and network renames are not
+drop-in.
+
+**The data lives in the volume, and the volume is namespaced by the stack name.**
+`mongodb_data` is a normal (non-external) named volume, so Compose stores it as
+`<stack-name>_mongodb_data`. A stack deployed as `ultrabot` holds its data in
+`ultrabot_mongodb_data`. Deploy the same file under the name `clawdia` and
+Compose creates a *new, empty* `clawdia_mongodb_data` — the bot starts up clean
+and the old data is still on disk, just orphaned. Confirm what you have first:
+
+```bash
+docker volume ls | grep mongodb_data
+```
+
+Then pick one:
+
+- **Keep the stack name (simplest).** Leave the Portainer stack called
+  `ultrabot` and redeploy the updated file into it. The containers and network
+  get their new names; the volume path never changes, so nothing moves.
+- **Rename the stack and reuse the volume.** Stop and remove the old stack
+  first — `container_name` is fixed, so `clawdia-mongodb` and `clawdia` collide
+  with the still-running old containers, as does the published port. Then, in
+  the new stack, point at the existing volume explicitly:
+
+  ```yaml
+  volumes:
+    mongodb_data:
+      external: true
+      name: ultrabot_mongodb_data
+  ```
+
+- **Rename the stack and move the data.** Run `./scripts/backup.sh` against the
+  old stack, deploy the new one, then `./scripts/restore.sh <archive>`. Use this
+  if you want the volume named after the new stack too.
+
+Removing a stack in Portainer does not delete its volumes, so the old data
+survives a mistake here — but verify the bot came up with your servers intact
+before deleting anything.
+
 ### Method 1: Docker Compose in Portainer
 
 1. Open Portainer
 2. Go to "Stacks"
 3. Click "Add stack"
-4. Name it "clawdia"
+4. Name it "clawdia" (or keep your existing stack name — see the migration note above)
 5. Paste the `docker-compose.yml` content
 6. Add environment variables in the env section or upload `.env` file
 7. Click "Deploy the stack"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   mongodb:
     image: mongo:7
-    container_name: ultrabot-mongodb
+    container_name: clawdia-mongodb
     restart: unless-stopped
     volumes:
       - mongodb_data:/data/db
@@ -16,7 +16,7 @@ services:
 
   bot:
     build: .
-    container_name: ultrabot
+    container_name: clawdia
     restart: unless-stopped
     env_file:
       - .env
@@ -34,7 +34,7 @@ services:
       - ./backups:/app/backups
     networks:
       - db-network      # reaches MongoDB
-      - ultrabot-network # reaches the internet (Discord API, AI APIs, etc.)
+      - clawdia-network # reaches the internet (Discord API, AI APIs, etc.)
     logging:
       driver: "json-file"
       options:
@@ -59,7 +59,7 @@ services:
   # Optional scheduled backup (runs mongodump once a day at 03:00 UTC)
   backup:
     image: mongo:7
-    container_name: ultrabot-backup
+    container_name: clawdia-backup
     profiles:
       - backup
     restart: unless-stopped
@@ -84,10 +84,12 @@ services:
         while true; do
           TIMESTAMP=$$(date -u +"%Y%m%dT%H%M%SZ");
           echo "[backup] Starting backup at $$TIMESTAMP";
-          mongodump --uri="$$MONGODB_URI" --gzip --archive="/backups/ultrabot-$$TIMESTAMP.gz" &&
-            echo "[backup] Done: /backups/ultrabot-$$TIMESTAMP.gz" ||
+          mongodump --uri="$$MONGODB_URI" --gzip --archive="/backups/clawdia-$$TIMESTAMP.gz" &&
+            echo "[backup] Done: /backups/clawdia-$$TIMESTAMP.gz" ||
             echo "[backup] FAILED";
-          find /backups -name "ultrabot-*.gz" -mtime +30 -delete;
+          # Prunes the old ultrabot-* prefix too, so archives written before the
+          # rename are still aged out instead of accumulating forever.
+          find /backups \( -name "clawdia-*.gz" -o -name "ultrabot-*.gz" \) -mtime +30 -delete;
           sleep 86400;
         done'
 
@@ -95,7 +97,7 @@ volumes:
   mongodb_data:
 
 networks:
-  ultrabot-network:
+  clawdia-network:
     driver: bridge
   db-network:
     driver: bridge

--- a/portainer-stack.yml
+++ b/portainer-stack.yml
@@ -24,7 +24,7 @@
 services:
   mongodb:
     image: mongo:7
-    container_name: ultrabot-mongodb
+    container_name: clawdia-mongodb
     restart: unless-stopped
     volumes:
       - mongodb_data:/data/db
@@ -39,7 +39,7 @@ services:
 
   bot:
     image: ghcr.io/theshield2594/clawdia:latest
-    container_name: ultrabot
+    container_name: clawdia
     restart: unless-stopped
     environment:
       # --- Required ---
@@ -58,6 +58,9 @@ services:
       - IMGFLIP_USERNAME=${IMGFLIP_USERNAME}
       - IMGFLIP_PASSWORD=${IMGFLIP_PASSWORD}
       # --- Defaults (override if needed) ---
+      # The database name is still "ultrabot" after the rebrand, on purpose:
+      # renaming it does not move data, it just points the bot at an empty
+      # database. Change it only alongside a dump-and-restore into the new name.
       - MONGODB_URI=${MONGODB_URI:-mongodb://mongodb:27017/ultrabot}
       - DASHBOARD_PORT=7001
       - AUDIT_LOG_RETENTION_DAYS=${AUDIT_LOG_RETENTION_DAYS:-90}
@@ -71,7 +74,7 @@ services:
         condition: service_healthy
     networks:
       - db-network       # reaches MongoDB
-      - ultrabot-network # reaches the internet (Discord API, AI APIs, etc.)
+      - clawdia-network # reaches the internet (Discord API, AI APIs, etc.)
     logging:
       driver: "json-file"
       options:
@@ -98,7 +101,7 @@ volumes:
   mongodb_data:
 
 networks:
-  ultrabot-network:
+  clawdia-network:
     driver: bridge
   db-network:
     driver: bridge

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -30,10 +30,22 @@ else
     # own loopback interface (the service hostname is not reachable from within).
     echo "[backup] mongodump not found locally; attempting via Docker container 'clawdia-mongodb'"
     CONTAINER_URI="${MONGO_URI/localhost/127.0.0.1}"
+    # Dump into a private directory (mktemp -d is 0700) rather than a fixed,
+    # guessable path in the container's world-readable /tmp. Cleanup runs from an
+    # EXIT trap: a trailing rm would be skipped by `set -e` if mongodump or
+    # docker cp failed, stranding a full copy of the database in the container.
+    REMOTE_DIR=$(docker exec clawdia-mongodb mktemp -d)
+    # An empty result would send the dump to the container root and make the
+    # cleanup a no-op, so refuse rather than guess a path. `set -u` does not
+    # catch this: the variable is set, just empty.
+    if [ -z "${REMOTE_DIR}" ]; then
+        echo "[backup] ERROR: could not create a temp directory in clawdia-mongodb" >&2
+        exit 1
+    fi
+    trap 'docker exec clawdia-mongodb rm -rf "${REMOTE_DIR}" >/dev/null 2>&1 || true' EXIT
     docker exec clawdia-mongodb \
-        mongodump --uri="${CONTAINER_URI}" --gzip --archive=/tmp/clawdia-backup.gz
-    docker cp clawdia-mongodb:/tmp/clawdia-backup.gz "${ARCHIVE}"
-    docker exec clawdia-mongodb rm /tmp/clawdia-backup.gz
+        mongodump --uri="${CONTAINER_URI}" --gzip --archive="${REMOTE_DIR}/backup.gz"
+    docker cp "clawdia-mongodb:${REMOTE_DIR}/backup.gz" "${ARCHIVE}"
 fi
 
 SIZE=$(du -sh "${ARCHIVE}" | cut -f1)

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Backup UltraBot MongoDB data to a timestamped archive.
+# Backup Clawdia MongoDB data to a timestamped archive.
 # Usage: ./scripts/backup.sh [output-dir]
-# Requires: mongodump on PATH, or runs inside the ultrabot-mongodb container.
+# Requires: mongodump on PATH, or runs inside the clawdia-mongodb container.
 set -euo pipefail
 
 BACKUP_DIR="${1:-./backups}"
 TIMESTAMP=$(date -u +"%Y%m%dT%H%M%SZ")
-ARCHIVE="${BACKUP_DIR}/ultrabot-${TIMESTAMP}.gz"
+ARCHIVE="${BACKUP_DIR}/clawdia-${TIMESTAMP}.gz"
 
 # Load .env if present and MONGODB_URI is not already set
 if [ -z "${MONGODB_URI:-}" ] && [ -f "$(dirname "$0")/../.env" ]; then
@@ -28,17 +28,18 @@ else
     # Fall back to running mongodump inside the Docker container.
     # Replace 'localhost' with '127.0.0.1' so the URI points to the container's
     # own loopback interface (the service hostname is not reachable from within).
-    echo "[backup] mongodump not found locally; attempting via Docker container 'ultrabot-mongodb'"
+    echo "[backup] mongodump not found locally; attempting via Docker container 'clawdia-mongodb'"
     CONTAINER_URI="${MONGO_URI/localhost/127.0.0.1}"
-    docker exec ultrabot-mongodb \
-        mongodump --uri="${CONTAINER_URI}" --gzip --archive=/tmp/ultrabot-backup.gz
-    docker cp ultrabot-mongodb:/tmp/ultrabot-backup.gz "${ARCHIVE}"
-    docker exec ultrabot-mongodb rm /tmp/ultrabot-backup.gz
+    docker exec clawdia-mongodb \
+        mongodump --uri="${CONTAINER_URI}" --gzip --archive=/tmp/clawdia-backup.gz
+    docker cp clawdia-mongodb:/tmp/clawdia-backup.gz "${ARCHIVE}"
+    docker exec clawdia-mongodb rm /tmp/clawdia-backup.gz
 fi
 
 SIZE=$(du -sh "${ARCHIVE}" | cut -f1)
 echo "[backup] Done. Archive size: ${SIZE} → ${ARCHIVE}"
 
-# Prune archives older than 30 days
-find "${BACKUP_DIR}" -name 'ultrabot-*.gz' -mtime +30 -print -delete \
+# Prune archives older than 30 days. Matches the old ultrabot-* prefix too, so
+# archives written before the rename are still aged out.
+find "${BACKUP_DIR}" \( -name 'clawdia-*.gz' -o -name 'ultrabot-*.gz' \) -mtime +30 -print -delete \
     && echo "[backup] Pruned backups older than 30 days"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Restore UltraBot MongoDB data from a backup archive.
+# Restore Clawdia MongoDB data from a backup archive.
 # Usage: ./scripts/restore.sh <path-to-archive.gz> [--drop]
 #   --drop  Drop existing collections before restoring (clean restore)
 set -euo pipefail
@@ -44,14 +44,14 @@ if command -v mongorestore &>/dev/null; then
     # shellcheck disable=SC2086
     mongorestore --uri="${MONGO_URI}" --gzip --archive="${ARCHIVE}" ${DROP_FLAG}
 else
-    echo "[restore] mongorestore not found locally; attempting via Docker container 'ultrabot-mongodb'"
-    docker cp "${ARCHIVE}" ultrabot-mongodb:/tmp/ultrabot-restore.gz
+    echo "[restore] mongorestore not found locally; attempting via Docker container 'clawdia-mongodb'"
+    docker cp "${ARCHIVE}" clawdia-mongodb:/tmp/clawdia-restore.gz
     # Replace 'localhost' with '127.0.0.1' so the URI resolves inside the container.
     SAFE_URI="${MONGO_URI/localhost/127.0.0.1}"
     # shellcheck disable=SC2086
-    docker exec ultrabot-mongodb \
-        mongorestore --uri="${SAFE_URI}" --gzip --archive=/tmp/ultrabot-restore.gz ${DROP_FLAG}
-    docker exec ultrabot-mongodb rm /tmp/ultrabot-restore.gz
+    docker exec clawdia-mongodb \
+        mongorestore --uri="${SAFE_URI}" --gzip --archive=/tmp/clawdia-restore.gz ${DROP_FLAG}
+    docker exec clawdia-mongodb rm /tmp/clawdia-restore.gz
 fi
 
 echo "[restore] Restore complete."

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -45,13 +45,25 @@ if command -v mongorestore &>/dev/null; then
     mongorestore --uri="${MONGO_URI}" --gzip --archive="${ARCHIVE}" ${DROP_FLAG}
 else
     echo "[restore] mongorestore not found locally; attempting via Docker container 'clawdia-mongodb'"
-    docker cp "${ARCHIVE}" clawdia-mongodb:/tmp/clawdia-restore.gz
+    # Stage the archive in a private directory (mktemp -d is 0700) rather than a
+    # fixed, guessable path in the container's world-readable /tmp. Cleanup runs
+    # from an EXIT trap: a trailing rm would be skipped by `set -e` if
+    # mongorestore failed, stranding a full copy of the data in the container.
+    REMOTE_DIR=$(docker exec clawdia-mongodb mktemp -d)
+    # An empty result would stage the archive at the container root and make the
+    # cleanup a no-op, so refuse rather than guess a path. `set -u` does not
+    # catch this: the variable is set, just empty.
+    if [ -z "${REMOTE_DIR}" ]; then
+        echo "[restore] ERROR: could not create a temp directory in clawdia-mongodb" >&2
+        exit 1
+    fi
+    trap 'docker exec clawdia-mongodb rm -rf "${REMOTE_DIR}" >/dev/null 2>&1 || true' EXIT
+    docker cp "${ARCHIVE}" "clawdia-mongodb:${REMOTE_DIR}/restore.gz"
     # Replace 'localhost' with '127.0.0.1' so the URI resolves inside the container.
     SAFE_URI="${MONGO_URI/localhost/127.0.0.1}"
     # shellcheck disable=SC2086
     docker exec clawdia-mongodb \
-        mongorestore --uri="${SAFE_URI}" --gzip --archive=/tmp/clawdia-restore.gz ${DROP_FLAG}
-    docker exec clawdia-mongodb rm /tmp/clawdia-restore.gz
+        mongorestore --uri="${SAFE_URI}" --gzip --archive="${REMOTE_DIR}/restore.gz" ${DROP_FLAG}
 fi
 
 echo "[restore] Restore complete."

--- a/src/commands/utility/help.js
+++ b/src/commands/utility/help.js
@@ -35,7 +35,7 @@ const CATEGORIES = [
             { name: 'hunt',           description: 'Hunt animals, manage gear, quests, zones, and prestige — all in one place' },
             { name: 'craft',          description: 'Craft items from hunting materials' },
             { name: 'fish',           description: 'Fishing: cast lines, manage gear, shop, craft, quests, locations, and prestige' },
-            { name: 'casino',         description: 'Casino games: baccarat, blackjack, crash, doubleornothing, higherlower, plinko, roulette, slots, wheel' },
+            { name: 'casino',         description: 'Casino games: blackjack, crash, cupgame, higherlower, keno, poker, roulette, slots' },
             { name: 'duel',           description: 'Challenge another user to a coin duel' },
             { name: 'quiz',           description: 'Answer trivia questions to win coins' },
         ],

--- a/src/dashboard/views/index.ejs
+++ b/src/dashboard/views/index.ejs
@@ -32,7 +32,7 @@
                 <a href="#features">Modules</a>
                 <a href="#insights">Insights</a>
                 <a href="#self-host">Self-host</a>
-                <a href="https://github.com/theshield2594/ultrabot" target="_blank" rel="noopener">Docs</a>
+                <a href="https://github.com/TheShield2594/clawdia" target="_blank" rel="noopener">Docs</a>
             </div>
             <div class="cw-nav-cta">
                 <% if (user) { %>
@@ -65,7 +65,7 @@
             <% } else { %>
                 <a href="/auth/login" class="cw-btn cw-btn-claw">Add to Discord <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
             <% } %>
-            <a href="https://github.com/theshield2594/ultrabot" target="_blank" rel="noopener" class="cw-btn cw-btn-ghost">
+            <a href="https://github.com/TheShield2594/clawdia" target="_blank" rel="noopener" class="cw-btn cw-btn-ghost">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
                 View on GitHub
             </a>
@@ -167,7 +167,7 @@
                     <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8"/><path d="M10 9h3a2 2 0 0 1 0 4h-3v-4zM10 13v3"/></svg>
                 </div>
                 <h3>Economy</h3>
-                <p>Currency, daily rewards, work, transfers, jobs, wheel of fortune, blackjack and crash.</p>
+                <p>Currency, daily rewards, work, transfers, jobs, blackjack, roulette and crash.</p>
                 <span class="cw-feature-tag">fun</span>
             </div>
             <!-- RSS -->
@@ -313,8 +313,8 @@
                     </div>
                 </div>
                 <div class="cw-host-cta">
-                    <a href="https://github.com/theshield2594/ultrabot" target="_blank" rel="noopener" class="cw-btn cw-btn-dark">Read setup guide <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
-                    <a href="https://github.com/theshield2594/ultrabot" target="_blank" rel="noopener" class="cw-btn cw-btn-ghost">⌥ View on GitHub</a>
+                    <a href="https://github.com/TheShield2594/clawdia" target="_blank" rel="noopener" class="cw-btn cw-btn-dark">Read setup guide <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+                    <a href="https://github.com/TheShield2594/clawdia" target="_blank" rel="noopener" class="cw-btn cw-btn-ghost">⌥ View on GitHub</a>
                 </div>
             </div>
             <div class="cw-terminal">
@@ -324,8 +324,8 @@
                     <span class="cw-terminal-dot" style="background:#28c840;"></span>
                     <span>~/clawdia · zsh</span>
                 </div>
-                <pre><span class="pr">$</span> git clone git@github.com:theshield2594/ultrabot.git
-<span class="pr">$</span> cd ultrabot &amp;&amp; cp .env.example .env
+                <pre><span class="pr">$</span> git clone git@github.com:TheShield2594/clawdia.git
+<span class="pr">$</span> cd clawdia &amp;&amp; cp .env.example .env
 <span class="cm"># add DISCORD_TOKEN, MONGODB_URI, etc.</span>
 <span class="pr">$</span> docker compose up -d
 
@@ -349,7 +349,7 @@
             <% } else { %>
                 <a href="/auth/login" class="cw-btn cw-btn-dark">Add to Discord <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
             <% } %>
-            <a href="https://github.com/theshield2594/ultrabot" target="_blank" rel="noopener" class="cw-btn cw-btn-cream">⌥ Self-host on Docker</a>
+            <a href="https://github.com/TheShield2594/clawdia" target="_blank" rel="noopener" class="cw-btn cw-btn-cream">⌥ Self-host on Docker</a>
         </div>
     </section>
 
@@ -382,7 +382,7 @@
             <div>
                 <h4>Resources</h4>
                 <ul>
-                    <li><a href="https://github.com/theshield2594/ultrabot" target="_blank" rel="noopener">Setup guide</a></li>
+                    <li><a href="https://github.com/TheShield2594/clawdia" target="_blank" rel="noopener">Setup guide</a></li>
                     <li><a>API reference</a></li>
                     <li><a>Commands</a></li>
                     <li><a>Discord</a></li>
@@ -391,7 +391,7 @@
             <div>
                 <h4>Community</h4>
                 <ul>
-                    <li><a href="https://github.com/theshield2594/ultrabot" target="_blank" rel="noopener">GitHub</a></li>
+                    <li><a href="https://github.com/TheShield2594/clawdia" target="_blank" rel="noopener">GitHub</a></li>
                     <li><a>Contributing</a></li>
                     <li><a>Roadmap</a></li>
                     <li><a>Sponsor</a></li>

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -525,7 +525,7 @@ function openRouterArgs(base) {
         ...base,
         baseURL: 'https://openrouter.ai/api/v1',
         defaultHeaders: {
-            'HTTP-Referer': process.env.OPENROUTER_REFERER || 'https://github.com/theshield2594/ultrabot',
+            'HTTP-Referer': process.env.OPENROUTER_REFERER || 'https://github.com/TheShield2594/clawdia',
             'X-Title': 'Clawdia'
         }
     };


### PR DESCRIPTION
## Summary

Four documentation and product-accuracy issues. Every change is to docs, marketing copy, config, or a help string — **no behavioral code changes**, beyond one default URL and the Docker fallback in the backup/restore scripts.

Closes #694, #695, #696, #702

## Wheel of Fortune, deleted by migration 006 but still advertised (#694)

`006_drop_wheel_fields.js` `$unset`s the wheel fields and no wheel game exists in `src/games/casino/`. Removed the six stale references:

- `FEATURES.md` — the `/casino wheel` command line, the "Wheel of Fortune" feature block, the dashboard-settings bullet (those settings don't exist either), and the cooldown-table row
- `src/dashboard/views/index.ejs:170` — the economy card on the public landing page
- `src/commands/utility/help.js:38` — the casino description

The help string listed `baccarat, blackjack, crash, doubleornothing, higherlower, plinko, roulette, slots, wheel`. Four of those don't exist and three that do (`cupgame`, `keno`, `poker`) were missing, so it now matches the registry in `casino.js`: `blackjack, crash, cupgame, higherlower, keno, poker, roulette, slots`.

## PRODUCTIONREADY.md certified a file that never existed (#695)

Confirmed the issue's finding — no `ticket.js` in any commit, no ticket command registered. Struck it from the files-reviewed list, deleted the critical row describing a fix to it, and removed it from the `user.tag` warning row. Remaining rows renumbered (moderation now has 2 criticals, not 3).

Added a short note recording that the claims were struck and that a ticket system is unimplemented — so the removal doesn't read as the feature having quietly existed.

**The other claims in the file were left alone.** The issue spot-checked them as accurate and I did not re-audit them; this PR only removes the false ones.

## PRODUCTIONREADY.md scope (#696)

Retitled to **Feature Audit Log** and rewrote the opening to say what it actually is: nine audited subsystems, all low-churn, and not a survey of the bot. It now states outright that absence from the file means nothing either way, and that it isn't a release gate.

Added a **Not yet reviewed** section listing what's uncovered — every economy subsystem, AI chat, RSS/newspaper, quests, achievements, giveaways, starboard, suggestions, reaction roles, command policies, anti-nuke, scheduler, and the dashboard. The date footer now names the audited subsystems specifically, so it can't be read as covering the uncovered list beneath it.

## Rebrand sweep (#702)

- **Landing page** — the 9 `github.com/theshield2594/ultrabot` links (nav, hero, setup CTA, footer) and the `git clone` snippet users are told to copy, which pointed at a repo that doesn't exist
- **`src/services/aiService.js:528`** — default OpenRouter referer
- **Docs** — `API_REFERENCE.md` and `SETUP_GUIDE.md` titles, the `docker build -t ultrabot:latest` example, the `FEATURES.md` analytics line
- **Containers and networks** — `ultrabot`/`ultrabot-mongodb`/`ultrabot-backup` → `clawdia*`, `ultrabot-network` → `clawdia-network`, across both compose files, both scripts, and the setup guide

### Two things deliberately not renamed

**The database name stays `ultrabot`.** Renaming it doesn't move data — it points the bot at a new, empty database, so every existing deployment would come up looking wiped. Left as-is with a comment at each default explaining why, so it doesn't get "fixed" later.

**Backup archives** are now written as `clawdia-*.gz`, but the 30-day prune matches `ultrabot-*.gz` too. Otherwise archives written before the rename would age out of the retention policy and accumulate forever.

### Migration guidance

Renaming the Portainer stack to match the rebrand orphans the data: `mongodb_data` is a non-external volume, so Compose namespaces it by stack name and a stack deployed as `clawdia` comes up on an empty `clawdia_mongodb_data`. Added a migration section covering the three ways through it, defaulting to keeping the existing stack name.

## Review round

- Scoped the audit-date footer so it can't be read as covering the "Not yet reviewed" list
- The Docker fallbacks in `backup.sh`/`restore.sh` wrote to a fixed path in the container's world-readable `/tmp` and cleaned up on the last line — which `set -e` skips on failure, stranding a full copy of the database in the container. Both now use a private `mktemp -d` with cleanup in an `EXIT` trap, and refuse if `mktemp` returns an empty path (which would write to the container root and make the cleanup a silent no-op)
- Blank lines around four fenced code blocks in `SETUP_GUIDE.md` (markdownlint MD031)

## Validation

- 611 tests across 43 suites pass
- `docker compose config` valid for both compose files
- `index.ejs` compiles; `help.js` loads and builds its command data
- `bash -n` clean on both scripts. shellcheck couldn't install in this environment, so the Docker fallbacks were exercised against a stubbed `docker`: dump-fails, restore-fails, both success paths, `--drop` preserved, and the empty-`mktemp` guard. Cleanup runs on every path

https://claude.ai/code/session_019cWMgEKA9eLqJmLS842bog