### PR TITLE
Document economy, exploration, and insights features

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -16,6 +16,7 @@
 ### Configuration Options
 
 **Global Configuration** (`.env` file):
+
 ```env
 OPENAI_API_KEY=sk-...
 GEMINI_API_KEY=AIza...
@@ -38,7 +39,8 @@ OLLAMA_BASE_URL=http://localhost:11434
 - Bot shows typing indicator while processing
 
 **Customization:**
-```
+
+```text
 System Prompt Examples:
 - "You are a helpful gaming assistant for our Discord server."
 - "You are a coding tutor. Explain concepts simply."
@@ -56,7 +58,7 @@ lists them and `/ai memories delete <number>` removes one.
 provider. Session state lives in the `DmSession` model, so an adventure survives
 a bot restart.
 
-```
+```text
 /dm start            - Start a new session in this channel
 /dm join <name> <class> - Join with a character
 /dm begin            - Begin the adventure (host only)
@@ -75,7 +77,7 @@ Requires a working AI provider — the same one configured for AI Chat.
 
 Two other features call the AI provider directly:
 
-- **`/questgen`** — spends **200 coins** to generate a personal legendary quest tuned to one mechanic (hunt, fishing, mining, chat, economy, or commands), with targets clamped to sane ranges per mechanic. 23-hour cooldown, and only **one** AI quest can be active at a time.
+- **`/questgen`** — spends **200 coins** to generate a personal legendary quest tuned to one mechanic (`hunt`, `fishing`, `mining`, `social`, `economy`, or `explore`), with targets clamped to sane ranges per mechanic. 23-hour cooldown, and only **one** AI quest can be active at a time.
 - **`/newspaper preview`** — renders the AI-written server newspaper on demand. Requires **Manage Server**, and the Newspaper must be enabled under **Engagement → Newspaper** in the dashboard. The scheduled edition posts on its own; this is just the preview.
 
 ## 📰 Daily News Digest
@@ -107,21 +109,24 @@ Compiles multiple RSS feeds into a single daily post at a scheduled time.
 ### RSS Feed Examples
 
 **Technology:**
-```
+
+```text
 https://techcrunch.com/feed/
 https://www.theverge.com/rss/index.xml
 https://arstechnica.com/feed/
 ```
 
 **Gaming:**
-```
+
+```text
 https://www.ign.com/articles?format=rss
 https://www.polygon.com/rss/index.xml
 https://kotaku.com/rss
 ```
 
 **General News:**
-```
+
+```text
 http://feeds.bbci.co.uk/news/rss.xml
 http://rss.cnn.com/rss/cnn_topstories.rss
 https://www.reddit.com/r/worldnews/.rss
@@ -177,7 +182,8 @@ Set a moderation log channel to track:
 - Level formula: `Level * 100 + 100` XP needed
 
 **Commands:**
-```
+
+```text
 /rank                - View your rank card
 /leaderboard         - Server leaderboard
 ```
@@ -193,7 +199,8 @@ The economy is the largest system in the bot — 43 of 98 commands and roughly a
 third of the code. The sections below cover it in full.
 
 **Core currency:**
-```
+
+```text
 /balance             - Check balance
 /daily               - Daily reward (24h cooldown)
 /work                - Work for coins (1h cooldown)
@@ -218,7 +225,7 @@ third of the code. The sections below cover it in full.
 each with its own stamina pool, material table, and rarity tiers. Materials feed
 crafting, pet food, and the market.
 
-```
+```text
 /fish · /hunt · /mine  - Gathering activities (stamina-gated)
 /craft                 - Craft items from gathered materials
 /forge <rarity>        - Have the AI forge a one-of-a-kind item
@@ -252,7 +259,7 @@ gathering tracks. `/synergies` shows progress toward each:
 **Pets** are passive-bonus companions with their own hunger, mood, level, and
 evolution track.
 
-```
+```text
 /pet adopt <type> [name]  - Adopt a pet from the shop
 /pet status               - View your pets and their mood
 /pet feed <material>      - Feed a pet (favourite foods restore most, grant bonus XP)
@@ -267,7 +274,7 @@ evolution track.
 
 ### Trading & Server Investment
 
-```
+```text
 /gift <user> <coins|item>  - Send coins or an item to another player
 /market list <item> <qty> <price>  - List an item for sale
 /market browse [item]      - Browse active listings
@@ -294,7 +301,7 @@ coin goal and, once funded, activates its benefit for **7 days**:
 
 ### Group Play & PvP
 
-```
+```text
 /duel <user>              - Challenge another user
 /heist start <target>     - Open a heist lobby (60s join window)
 /heist status             - Check the running heist
@@ -337,7 +344,7 @@ target's active protections first — at the cost of a 2-minute cooldown per che
 
 ### Progression
 
-```
+```text
 /prestige info      - Every prestige tier and what it unlocks
 /prestige up        - Prestige your account (resets level)
 /prestige [user]    - Inspect a player's rank, bonuses, and unlocks
@@ -368,7 +375,7 @@ coin and 250 XP bonus, claimable once every 24 hours.
 
 ### Feeds & Rotation
 
-```
+```text
 /featured   - Today's featured rotation (+25% payout, +10% rare chance)
 /winfeed    - Last 20 big wins in this server (50k+ coins or legendary drops)
 ```
@@ -380,7 +387,7 @@ coin and 250 XP bonus, claimable once every 24 hours.
 
 These are only usable while their seasonal event is running:
 
-```
+```text
 /trackhunt   - Track game across the Arctic Tundra (Winter Hunt)
 /sandcastle  - Build a sandcastle on the shore (Summer Festival)
 /lovenote    - Send a love note into the Arcade (Valentine's Day)
@@ -439,7 +446,7 @@ Narrated expeditions in Clawdia's voice. Players set out into distinct regions, 
 
 ### Variables
 
-```
+```text
 {user}         - Mention the user
 {server}       - Server name
 {memberCount}  - Total member count
@@ -449,14 +456,16 @@ Narrated expeditions in Clawdia's voice. Players set out into distinct regions, 
 ### Example Messages
 
 **Welcome:**
-```
+
+```text
 Welcome {user} to {server}! 🎉
 You are member #{memberCount}!
 Check out #rules to get started.
 ```
 
 **Farewell:**
-```
+
+```text
 Goodbye {user}! We'll miss you 😢
 ```
 
@@ -511,7 +520,8 @@ open work items, not wording problems:
 ### Custom Commands
 
 Create simple text response commands in dashboard:
-```
+
+```text
 Trigger: !website
 Response: Visit us at https://example.com
 ```
@@ -526,7 +536,8 @@ Automatically assign roles to new members:
 ### Reminders
 
 Set personal reminders using relative time options, or an absolute time:
-```
+
+```text
 /remind minutes:30 message:Check the oven
 /remind hours:2 message:Meeting at 9am
 /remind days:2 message:Submit report
@@ -534,6 +545,7 @@ Set personal reminders using relative time options, or an absolute time:
 /remind at:"2026-07-20 09:00" message:Submit report
 /remind message:Standup every:daily at:9:00
 ```
+
 Reminders post in the channel where they were set; if that channel is no longer
 reachable, the bot DMs the user instead. Set `/timezone set` so absolute times
 (and the AI's natural-language reminders — e.g. "remind me at 5pm") resolve to

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -45,6 +45,39 @@ System Prompt Examples:
 - "You are a dungeon master for D&D campaigns."
 ```
 
+**Memories:**
+
+Clawdia pins facts she learns about a user across conversations. `/ai memories`
+lists them and `/ai memories delete <number>` removes one.
+
+### AI Dungeon Master
+
+`/dm` runs a collaborative text RPG in a channel, narrated by the configured AI
+provider. Session state lives in the `DmSession` model, so an adventure survives
+a bot restart.
+
+```
+/dm start            - Start a new session in this channel
+/dm join <name> <class> - Join with a character
+/dm begin            - Begin the adventure (host only)
+/dm action <text>    - Describe what your character does
+/dm status           - Show current party status
+/dm stop             - End the session
+```
+
+- Up to **6 players** per session, one session per channel
+- Six classes with distinct starting HP and inventory: Warrior (120), Paladin (110), Cleric (100), Ranger (95), Rogue (90), Mage (70)
+- The last 20 story beats are kept as context for the narrator
+
+Requires a working AI provider — the same one configured for AI Chat.
+
+### AI-Generated Content
+
+Two other features call the AI provider directly:
+
+- **`/questgen`** — spends **200 coins** to generate a personal legendary quest tuned to one mechanic (hunt, fishing, mining, chat, economy, or commands), with targets clamped to sane ranges per mechanic. 23-hour cooldown, and only **one** AI quest can be active at a time.
+- **`/newspaper preview`** — renders the AI-written server newspaper on demand. Requires **Manage Server**, and the Newspaper must be enabled under **Engagement → Newspaper** in the dashboard. The scheduled edition posts on its own; this is just the preview.
+
 ## 📰 Daily News Digest
 
 ### Overview
@@ -156,21 +189,205 @@ Set a moderation log channel to track:
 
 ### Economy
 
-**Commands:**
+The economy is the largest system in the bot — 43 of 98 commands and roughly a
+third of the code. The sections below cover it in full.
+
+**Core currency:**
 ```
 /balance             - Check balance
 /daily               - Daily reward (24h cooldown)
 /work                - Work for coins (1h cooldown)
+/jobs                - View and take jobs
+/crime               - Attempt a crime for coins
 /bank transfer <user> <amount> - Send coins
 /casino <game>       - Casino games: blackjack, crash, cupgame, higherlower, keno, poker, roulette, slots
 /casino roulette     - Bet on Red/Black, Odd/Even, Low/High, dozens, columns, or a straight number
 /casino jackpot      - View the current progressive jackpot pool
+/quiz                - Answer trivia for rewards
+/boost               - Activate economy boosts
 ```
 
 **Dashboard Settings:**
 - Currency symbol (💰, 🪙, $, etc.)
 - Daily reward amount
 - Work reward range (min-max)
+
+### Gathering, Crafting & Pets
+
+**Gathering:** `/fish`, `/hunt`, and `/mine` are three parallel grind tracks,
+each with its own stamina pool, material table, and rarity tiers. Materials feed
+crafting, pet food, and the market.
+
+```
+/fish · /hunt · /mine  - Gathering activities (stamina-gated)
+/craft                 - Craft items from gathered materials
+/forge <rarity>        - Have the AI forge a one-of-a-kind item
+/showcase [user]       - Trophy card: rarest materials and top achievements
+/synergies             - Cross-system bonuses and progress toward them
+```
+
+**`/forge`** spends coins to have the configured AI provider invent a unique
+item, with cost and XP scaling by rarity tier:
+
+| Rarity | Cost | XP |
+|---|---:|---:|
+| Common | 500 | 25 |
+| Uncommon | 1,000 | 50 |
+| Rare | 2,500 | 100 |
+| Epic | 5,000 | 200 |
+| Mythic | 10,000 | 400 |
+| Legendary | 25,000 | 1,000 |
+
+**Synergies** unlock automatically once you hit level thresholds in two or more
+gathering tracks. `/synergies` shows progress toward each:
+
+| Synergy | Requires | Grants |
+|---|---|---|
+| 🌿 Outdoorsman | Hunt 30, Fishing 30 | +1 max stamina in Hunting and Fishing |
+| 🪝 Deep Prospector | Fishing 30, Mining 30 | +1 max stamina in Fishing and Mining |
+| ⚒️ Artificer | Mining 50 | +5% ore yield, +1 max mining stamina |
+| ⚙️ Iron Will | Mining 50, Hunt 50 | Blocks cave-ins below 50% pickaxe durability |
+| 💼 Merchant | Hunt/Fishing/Mining 20 each | +5% coins from `/work` and `/crime` while carrying items |
+
+**Pets** are passive-bonus companions with their own hunger, mood, level, and
+evolution track.
+
+```
+/pet adopt <type> [name]  - Adopt a pet from the shop
+/pet status               - View your pets and their mood
+/pet feed <material>      - Feed a pet (favourite foods restore most, grant bonus XP)
+/pet rename <slot> <name> - Rename a pet
+/pet release <slot>       - Release a pet permanently
+```
+
+- **Six purchasable pets** — Dog and Cat (2,000), Bird and Fish (3,000), Fox (5,000), Wolf (8,000) — each granting a different passive: work earnings, crime success, XP gain, fish yield, rob success, or hunt yield.
+- **Three rare pets** — Eagle, Shark, and Crystal Fox — are not sold anywhere. Each is tied to one grind track and drops at a 4% chance alongside a legendary-tier result there.
+- **Progression:** pets level to 30 across three evolution stages (1–9, 10–19, 20+), with stage multipliers of 1.0×/1.5×/2.0× on the passive plus per-level growth. Stacked bonuses of the same type cap at **40%**.
+- **Upkeep:** hunger decays 10/day (5/day while resting). Below 30 a pet is starving, and a pet left starving for 3 days runs away. Base capacity is 3 slots, expandable 3 times.
+
+### Trading & Server Investment
+
+```
+/gift <user> <coins|item>  - Send coins or an item to another player
+/market list <item> <qty> <price>  - List an item for sale
+/market browse [item]      - Browse active listings
+/market buy <listing_id>   - Buy a listing
+/market cancel <listing_id>- Cancel a listing and reclaim the item
+/invest contribute <district> <amount>  - Fund a server district
+/invest status             - District funding progress and active benefits
+```
+
+**Market:** 5 listings per user, 48-hour listing TTL, 5% sale fee, 10-coin
+minimum unit price, and a confirmation prompt above 500 coins. `lifesaver` and
+`streak_shield` are soulbound and cannot be listed.
+
+**Districts** are server-wide goals funded collectively. Each has a 1,000,000
+coin goal and, once funded, activates its benefit for **7 days**:
+
+| District | Benefit when funded |
+|---|---|
+| 🛒 Marketplace | +10% shop item drop chance from activities |
+| 🏦 Bank | +5% interest on banked coins (weekly, first 100k) |
+| 🕳️ Underground | −15% crime fine severity |
+| 🌲 Wilderness | +10% hunt/fish/mine yield for all members |
+| 🏟️ Arena | +15% duel prize pool |
+
+### Group Play & PvP
+
+```
+/duel <user>              - Challenge another user
+/heist start <target>     - Open a heist lobby (60s join window)
+/heist status             - Check the running heist
+/syndicate create|join|leave|invite|kick|open|info
+/syndicate leaderboard|heist|sabotage|upgrade
+/war challenge|accept|status|cancel  - Server-vs-server war (admin)
+/rob <user>               - Rob another player
+/robstatus <user>         - Spy on a target's active rob protections
+/trap set|status          - Arm a tripwire that fires when someone robs you
+```
+
+**Heists** are role-based group runs. Each participant takes a role — Hacker
+(logic question), Lookout (spot the duplicate), Muscle (higher-lower), or Driver
+(pick the safe route) — and passes or fails a skill check that feeds the crew's
+overall success roll. Targets scale the reward: Server Bank (1.0×), Casino Safe
+(1.25×), Faction Vault (1.5×).
+
+**Syndicates** are persistent crews with a leader, invite-only or open
+membership, a shared heat level, and their own heist targets. Skill checks are
+DM'd to each member and resolve when everyone answers or time runs out. Seven
+roles are available (driver, hacker, lookout, muscle, grifter, courier, scout).
+
+| Syndicate target | Min crew | Base success | Payout | Heat |
+|---|---:|---:|---|---:|
+| 🏦 Bank Job | 3 | 45% | 10k–25k | +8 |
+| 🏛️ Museum Heist | 5 | 30% | 30k–80k | +15 |
+| 🏙️ City Hall Con | 7 | 20% | 100k–200k | +25 |
+| 🔐 Vault Breach | 9 | 15% | 250k–500k | +35 |
+
+Vault Breach requires the syndicate's fourth-target upgrade. Syndicate
+leadership itself is gated behind Prestige III.
+
+**Wars** run 7 days between two servers, matched by exchanging invite codes. An
+admin on each side uses `/war challenge` and `/war accept`; points accrue from
+member activity and `/war status` shows the live scoreboard.
+
+**Rob protections:** `/trap` arms a 12-hour tripwire for 6,000 coins that fires
+on a successful rob against you. `/robstatus` lets a would-be robber scout a
+target's active protections first — at the cost of a 2-minute cooldown per check.
+
+### Progression
+
+```
+/prestige info      - Every prestige tier and what it unlocks
+/prestige up        - Prestige your account (resets level)
+/prestige [user]    - Inspect a player's rank, bonuses, and unlocks
+/dailychallenge     - Claim the Prestige VI+ daily challenge bonus
+/season             - Current season info
+```
+
+**Prestige** resets your level in exchange for a permanent global bonus stack
+and content unlocks, across 10 ranks:
+
+| Rank | Unlocks at this tier |
+|---|---|
+| P1 | 🏴 Black Market shop tab |
+| P2 | 🗺️ Legendary hunt / fish / mine zones |
+| P3 | 🕴️ Crime syndicate leadership |
+| P4 | 🦝 Exclusive pets |
+| P5 | ⭐ Prestige V star + animated badge |
+| P6 | 📋 Daily Challenge board |
+| P7 | 👥 +2 syndicate member slots (12 total) for leaders |
+| P8 | 💠 P8+ Black Market items (Voidsteel Cache, Ghost Ledger, Obsidian Crown) |
+| P10 | ✨ "The Ascended" title + animated profile accent |
+
+Bonuses stack with rank, reaching +10% yield, +10% stamina regen, +10% crime
+success, +10% XP, and a +1.5% rare-tier shift at P10.
+
+**`/dailychallenge`** is the P6+ board: a rotating objective with a flat 5,000
+coin and 250 XP bonus, claimable once every 24 hours.
+
+### Feeds & Rotation
+
+```
+/featured   - Today's featured rotation (+25% payout, +10% rare chance)
+/winfeed    - Last 20 big wins in this server (50k+ coins or legendary drops)
+```
+
+`/featured` rotates daily per guild and highlights specific activities.
+`/winfeed` pulls from hunt, fish, mine, slots, crash, keno, and duel results.
+
+### Seasonal Commands
+
+These are only usable while their seasonal event is running:
+
+```
+/trackhunt   - Track game across the Arctic Tundra (Winter Hunt)
+/sandcastle  - Build a sandcastle on the shore (Summer Festival)
+/lovenote    - Send a love note into the Arcade (Valentine's Day)
+/snowball    - Winter snowball throwing
+/trickortreat- Spooky-season treat run
+/eventshop   - Spend event currency
+```
 
 ### World Exploration
 
@@ -257,22 +474,37 @@ Auto-generated cards include:
 
 ### Decision-Focused Dashboards
 
-Clawdia now provides decision-grade analytics so server owners can move from raw events to clear actions.
+The Insights view turns the data Clawdia already collects — member join/leave
+counts, command usage, and moderation cases — into a small set of decision-
+oriented figures. Everything is computed from those three sources, which bounds
+what the metrics can honestly say. Definitions are spelled out below because
+several of them are proxies rather than the textbook metric of the same name.
 
 ### Included Insights
 
-- **Retention Cohorts**: D1/D7/D30 retention segmented by join week
-- **Active Hours**: Hourly and weekday heatmaps for engagement timing
-- **Toxic Channels**: Channels scored by moderation incidents and warning concentration
-- **Mod SLA Trends**: First-response and resolution-time trends for moderation actions
-- **Newcomer Conversion**: 7-day and 30-day conversion from joiner to active member
+| Insight | What is actually computed | Source |
+|---|---|---|
+| **Net Retention (7/30 d)** | `(joins − leaves) / joins`, clamped at 0, over the last 7 and 30 tracked member-event days. Guild-wide **proxy** — individual members are not followed, so there is no D1 figure and no join-week cohort | `analytics.memberEvents` |
+| **Active Hours** | 24-bucket histogram of command invocations by hour, plus the top 5 hours. **UTC only** — no weekday dimension, no server-timezone rendering | `analytics.commandUsage` |
+| **Toxic Channels** | Up to 8 channels from the most recent 1,000 cases, scored `warns + (2 × severe)` where severe is mute/kick/ban. Channel is parsed from the case's evidence jump URL; cases without one fall into `unknown` | `Case` |
+| **Mod Resolution Time** | Median hours from case creation to case **resolution**, plus a 6-month monthly trend. Time-to-close, **not** time-to-first-response | `Case` |
+| **Newcomer Conversion** | Share of user records at least 7 / 30 days old that have reached 20+ messages or level 2+ | `User` |
+
+### Known gaps
+
+These were previously documented as shipped and are not implemented. They are
+open work items, not wording problems:
+
+- **Retention cohorts** — D1/D7/D30 segmented by join week needs per-member join dates retained over time. Only aggregate daily join/leave counts are stored, so no cohort can be reconstructed from existing data.
+- **Weekday heatmap / server timezone** — `commandUsage` records the UTC hour and nothing else. A weekday dimension needs a schema change; a timezone toggle needs the guild's timezone plumbed through the endpoint.
+- **First-response SLA** — `Case` carries `createdAt` and `resolvedAt` but no first-mod-action timestamp, so response time cannot be distinguished from resolution time.
 
 ### Practical Actions
 
-- Move events and announcements to high-engagement windows
+- Move events and announcements to high-engagement windows (read the histogram as UTC)
 - Rebalance moderator coverage by time block
-- Prioritize intervention in channels with rising toxicity
-- A/B test onboarding and compare conversion gains over time
+- Prioritize intervention in channels with rising incident scores
+- Compare newcomer conversion across onboarding changes over time
 
 ## 🔧 Advanced Features
 
@@ -322,20 +554,22 @@ Access at `http://your-domain:3000`
 4. **Raid Detection / Anti-Nuke** - Server protection settings
 5. **Leveling** - XP system settings
 6. **Economy** - Currency configuration
-7. **Achievements / Quests** - Milestone and quest tracking
-8. **Season Pass / Progression Tracks** - Season and progression rewards
-9. **Starboard** - Highlight popular messages
-10. **Suggestions** - Community suggestion tracking
-11. **Reaction Roles** - Self-assignable roles via reactions
-12. **Temp Voice** - Temporary voice channel management
-13. **Birthdays** - Birthday announcements
-14. **Bible Verses** - Daily scripture posts
-15. **RSS Feeds** - Individual feed management
-16. **Daily News** - Digest configuration
-17. **AI Chat** - Provider and prompt settings
-18. **Analytics** - Insights and engagement metrics
-19. **Event Log** - Audit log for server events
-20. **Command Policies** - Per-command permission overrides
+7. **Exploration** - Region toggles, payout multipliers, secret announcements
+8. **Achievements / Quests** - Milestone and quest tracking
+9. **Season Pass / Progression Tracks** - Season and progression rewards
+10. **Starboard** - Highlight popular messages
+11. **Suggestions** - Community suggestion tracking
+12. **Reaction Roles** - Self-assignable roles via reactions
+13. **Temp Voice** - Temporary voice channel management
+14. **Birthdays** - Birthday announcements
+15. **Bible Verses** - Daily scripture posts
+16. **RSS Feeds** - Individual feed management
+17. **Daily News** - Digest configuration
+18. **Newspaper** - AI-written server recap (Engagement → Newspaper)
+19. **AI Chat** - Provider and prompt settings
+20. **Analytics** - Insights and engagement metrics
+21. **Event Log** - Audit log for server events
+22. **Command Policies** - Per-command permission overrides
 
 ### Multi-Server Support
 
@@ -392,9 +626,13 @@ Prevent spam with built-in cooldowns:
 | Command | Cooldown |
 |---------|----------|
 | `/daily` | 24 hours |
+| `/dailychallenge` | 24 hours |
+| `/questgen` | 23 hours |
 | `/work` | 1 hour |
 | `/casino` (games) | 5–10 seconds |
-| `/play` | 3 seconds |
+| `/newspaper preview` | 30 seconds |
+| `/winfeed` | 10 seconds |
+| `/fish`, `/hunt`, `/mine`, `/explore` | 5 seconds (plus stamina) |
 | Most others | 3 seconds |
 
 ## 🎨 Customization Ideas

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ npm start
 - `/note` - Add a moderator note to a user
 
 ### Economy — currency and items
+
 - `/balance` - Check balance
 - `/bank` - Manage your bank account
 - `/daily` - Claim daily reward
@@ -147,6 +148,7 @@ npm start
 - `/featured` - Today's featured rotation (+25% payout, +10% rare chance)
 
 ### Economy — gathering, crafting, and exploration
+
 - `/fish` / `/hunt` / `/mine` - Gathering activities
 - `/craft` - Craft items from gathered materials
 - `/forge` - Spend coins to have the AI forge a one-of-a-kind item
@@ -156,6 +158,7 @@ npm start
 - `/showcase` - Trophy card of a player's rarest items and top achievements
 
 ### Economy — competition and groups
+
 - `/duel` - Challenge another user
 - `/heist` - Plan and run a group heist
 - `/syndicate` - Crime syndicates: create, join, leave, invite, kick, open, info, leaderboard, heist, sabotage, upgrade
@@ -165,12 +168,14 @@ npm start
 - `/winfeed` - Last 20 big wins in this server (50k+ coins or legendary drops)
 
 ### Economy — progression
+
 - `/prestige` - Reset your level for permanent rewards and unlocks
 - `/dailychallenge` - Prestige VI+ daily challenge board
 - `/synergies` - Cross-system synergy bonuses and your progress toward them
 - `/season` - View current season info
 
 ### Economy — seasonal
+
 - `/eventshop` - Seasonal event shop
 - `/trackhunt` - Track game across the Arctic Tundra (Winter Hunt only)
 - `/sandcastle` - Build a sandcastle (Summer Festival only)
@@ -193,7 +198,7 @@ npm start
 - `/notifications` - Manage your notifications
 - `/track` - Track events or milestones
 - `/questgen` - Spend coins to have the AI generate a personal legendary quest
-- `/newspaper` - Preview the AI-written server newspaper (Manage Server)
+- `/newspaper preview` - Preview the AI-written server newspaper (Manage Server)
 
 ### Fun
 - `/8ball` - Ask the magic 8-ball
@@ -258,7 +263,12 @@ Configuration that previously lived behind slash commands (settings link, level 
    - Get your API key from https://console.anthropic.com/
    - Add to `.env` as `ANTHROPIC_API_KEY` or configure per-server in dashboard
 
-4. **Local (Ollama)**
+4. **OpenRouter**
+   - Get your API key from https://openrouter.ai/keys
+   - Add to `.env` as `OPENROUTER_API_KEY` or configure per-server in dashboard
+   - Reaches many models through one API; defaults to `openai/gpt-4o-mini`
+
+5. **Local (Ollama)**
    - Point `OLLAMA_BASE_URL` to your local instance
    - Configure `OLLAMA_MODEL` in dashboard (e.g., `llama3.2`, `mistral`)
    - Ideal for private, zero-cost inference
@@ -283,7 +293,7 @@ definitions below matter. Read them before acting on a number.
 
 ### Key Metrics
 
-- **Net Retention (7/30 days)**: `(joins − leaves) / joins` over the last 7 and 30 days of tracked member events. A guild-wide **proxy** — it does not follow individual members, so there is no D1 figure and no join-week segmentation.
+- **Net Retention (7/30 days)**: `(joins − leaves) / joins`, clamped at 0, over the last 7 and 30 days of tracked member events. A guild-wide **proxy** — it does not follow individual members, so there is no D1 figure and no join-week segmentation.
 - **Active Hours**: A 24-bucket histogram of command usage by hour, plus the top 5 hours. **Always UTC**; there is no server-timezone option and no weekday dimension.
 - **Toxic Channel Detection**: Ranks up to 8 channels from the most recent 1,000 moderation cases, scored as `warns + (2 × severe)`, where severe is mute/kick/ban. Channels are resolved from case evidence jump URLs; cases without one are bucketed as `unknown`.
 - **Moderator Resolution Time**: Median hours from case creation to case **resolution**, with a 6-month trend. This is time-to-close, **not** time-to-first-response.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,71 @@
 # Clawdia
 
-A chill, self-hosted Discord bot with serious teeth. Clawdia brings moderation, AI chat, leveling, economy, RSS feeds, and a full-featured web dashboard to your community — without any cloud lock-in.
+A chill, self-hosted Discord bot with serious teeth — no cloud lock-in, no per-server pricing.
+
+By volume, Clawdia is an **economy/RPG bot**: 43 of her 98 commands and about a
+third of the code are the coin economy, the gathering and crafting loop, and the
+progression systems stacked on top of them. Around that sits a full
+server-management suite — moderation with a case system, leveling, welcome
+cards, AI chat, RSS digests, and a dashboard that configures all of it.
+
+If you want a lean moderation bot, Clawdia will do the job, but you will be
+running a lot of code you don't need. If you want a server-wide game with
+moderation attached, that is what she is built for.
+
+## Shape of the codebase
+
+| Area | Commands | Lines |
+|---|---:|---:|
+| Economy / RPG | 43 | 22,572 |
+| Utility | 14 | 1,479 |
+| Moderation | 16 | 1,076 |
+| Fun | 8 | 1,354 |
+| Community | 7 | 1,122 |
+| Admin | 2 | 507 |
+| Leveling | 4 | 486 |
+| AI | 4 | 332 |
+
+`/fish` alone is 3,190 lines — more than the moderation, leveling, AI, and admin
+command sets put together.
 
 ## Features
 
-- **Moderation**: Ban, kick, warn, mute, timeout, and message clearing
-- **Welcome/Farewell**: Customizable messages with image cards
-- **Leveling System**: XP and level tracking with leaderboards
-- **Economy**: Balance, daily rewards, work command, and transfers
+### The game layer
+
+- **Core economy**: Balance, bank, daily/work/crime/rob, item shop, inventory, gifting, and a player-to-player market
+- **Gathering & crafting**: `/fish`, `/hunt`, `/mine`, material tiers, crafting, and AI-forged one-off items
+- **Exploration**: Narrated expeditions across gated regions, with relics, landmarks, and secrets
+- **Pets**: Adopt, name, feed, and grow companions that feed back into the gathering loop
+- **Group & PvP**: Syndicates, group heists, duels, server-vs-server wars, and rob protections
+- **Progression**: Prestige tiers, season pass, quests, achievements, cross-system synergies, and daily challenges
+- **Casino**: Blackjack, crash, cup game, higher-lower, keno, poker, roulette, slots, and a progressive jackpot
+- **Seasonal events**: Event shop, event currency, and per-event commands and regions
+
+### Server management
+
+- **Moderation**: Ban, kick, warn, mute, timeout, clear, lockdown, and slowmode, plus a case system with appeals and mod notes
+- **Auto-Moderation**: Spam, invite, link, profanity, caps, emoji, mention, and zalgo filtering
+- **Raid Detection / Anti-Nuke**: Join-rate thresholds with automatic response
+- **Welcome/Farewell**: Customizable messages with generated image cards
+- **Leveling System**: XP and level tracking with rank cards and leaderboards
+- **Web Dashboard**: Full-featured admin dashboard, per server
+
+### Content & extras
+
+- **AI Chat**: OpenAI GPT, Google Gemini, Anthropic Claude, OpenRouter, or optional local Ollama
+- **AI Dungeon Master**: `/dm` runs a collaborative text RPG in a channel
 - **RSS Feeds**: Automatic RSS feed monitoring and posting
 - **Daily News Digest**: Compile multiple RSS feeds into a daily summary
-- **AI Chat**: OpenAI GPT, Google Gemini, or optional local Ollama integration
-- **Reminders**: Set reminders with flexible time options
-- **Web Dashboard**: Full-featured admin dashboard for configuration
-- **Auto-Moderation**: Spam, invite, and link filtering
-- **Server Insights**: Retention cohorts, active hours, toxic channel hotspots, mod SLA trends, and newcomer conversion
+- **Server Newspaper**: AI-written recap of recent server activity
+- **Reminders**: Relative, absolute, and recurring, with per-user timezones
+- **Server Insights**: Net-retention proxy, active-hours histogram, channel hotspots, mod resolution-time trends, and newcomer conversion
 
 ## Prerequisites
 
 - Node.js 22.12+
 - MongoDB (local or cloud)
 - Discord Application with Bot & OAuth2 scopes enabled
-- (Optional) OpenAI API Key, Google Gemini API Key, or local Ollama instance
+- (Optional) An AI provider — OpenAI, Google Gemini, Anthropic, or OpenRouter API key, or a local Ollama instance
 
 ## Quick Start with Docker (Portainer)
 
@@ -61,6 +105,7 @@ npm start
 - `OPENAI_API_KEY` - (Optional) OpenAI API key for AI features
 - `GEMINI_API_KEY` - (Optional) Google Gemini API key for AI features
 - `ANTHROPIC_API_KEY` - (Optional) Anthropic Claude API key for AI features
+- `OPENROUTER_API_KEY` - (Optional) OpenRouter API key for AI features
 - `OLLAMA_BASE_URL` - (Optional) Local Ollama endpoint (e.g., `http://localhost:11434`)
 - `IMGFLIP_USERNAME` / `IMGFLIP_PASSWORD` - (Optional) Imgflip credentials for `/meme` command
 
@@ -74,6 +119,7 @@ npm start
 - `/warn` - Warn a user
 - `/mute` - Timeout a user
 - `/unmute` - Remove timeout
+- `/unban` - Unban a user
 - `/clear` - Delete messages
 - `/slowmode` - Set channel slowmode
 - `/lockdown` - Lock a channel
@@ -81,22 +127,54 @@ npm start
 - `/appeal` - Submit a ban appeal
 - `/note` - Add a moderator note to a user
 
-### Economy
+### Economy — currency and items
 - `/balance` - Check balance
 - `/bank` - Manage your bank account
 - `/daily` - Claim daily reward
 - `/work` - Work for coins
+- `/jobs` - View and take jobs
 - `/crime` - Attempt a crime for coins
 - `/rob` - Rob another user
-- `/duel` - Challenge another user
-- `/shop` / `/buy` / `/inventory` / `/use` - Item economy
-- `/craft` - Craft items
-- `/jobs` - View and take jobs
-- `/casino` - Casino games
-- `/fish` / `/hunt` / `/mine` - Gathering activities
-- `/quiz` - Answer trivia for rewards
+- `/robstatus` - Spy on a target's active rob protections before committing
+- `/trap set` / `/trap status` - Arm a hidden tripwire that fires when someone robs you
+- `/shop` - Browse and buy items (`/shop buy`)
+- `/inventory` - View your items
+- `/use` - Use an item
+- `/gift` - Send coins or an item to another user
+- `/market` - Player-to-player marketplace (list, browse, buy, cancel)
+- `/invest` - Fund server districts to unlock server-wide benefits
 - `/boost` - Activate economy boosts
+- `/featured` - Today's featured rotation (+25% payout, +10% rare chance)
+
+### Economy — gathering, crafting, and exploration
+- `/fish` / `/hunt` / `/mine` - Gathering activities
+- `/craft` - Craft items from gathered materials
+- `/forge` - Spend coins to have the AI forge a one-of-a-kind item
+- `/explore` - Narrated expeditions across regions (go, travel, regions, journal, relics, profile, map)
+- `/map` - Shortcut for `/explore map`
+- `/pet` - Adopt, name, feed, rename, and release pets
+- `/showcase` - Trophy card of a player's rarest items and top achievements
+
+### Economy — competition and groups
+- `/duel` - Challenge another user
+- `/heist` - Plan and run a group heist
+- `/syndicate` - Crime syndicates: create, join, leave, invite, kick, open, info, leaderboard, heist, sabotage, upgrade
+- `/war` - Server-vs-server war events (admin to challenge/accept)
+- `/casino` - Casino games and the progressive jackpot
+- `/quiz` - Answer trivia for rewards
+- `/winfeed` - Last 20 big wins in this server (50k+ coins or legendary drops)
+
+### Economy — progression
+- `/prestige` - Reset your level for permanent rewards and unlocks
+- `/dailychallenge` - Prestige VI+ daily challenge board
+- `/synergies` - Cross-system synergy bonuses and your progress toward them
+- `/season` - View current season info
+
+### Economy — seasonal
 - `/eventshop` - Seasonal event shop
+- `/trackhunt` - Track game across the Arctic Tundra (Winter Hunt only)
+- `/sandcastle` - Build a sandcastle (Summer Festival only)
+- `/lovenote` - Send a love note into the Arcade (Valentine's Day only)
 
 ### Leveling
 - `/rank` - View rank card
@@ -114,6 +192,8 @@ npm start
 - `/season` - View current season info
 - `/notifications` - Manage your notifications
 - `/track` - Track events or milestones
+- `/questgen` - Spend coins to have the AI generate a personal legendary quest
+- `/newspaper` - Preview the AI-written server newspaper (Manage Server)
 
 ### Fun
 - `/8ball` - Ask the magic 8-ball
@@ -142,6 +222,8 @@ npm start
 
 ### AI
 - `@Clawdia` - Mention the bot to start an AI conversation
+- `/ai memories` - View and manage the facts Clawdia has pinned about you
+- `/dm` - AI Dungeon Master: run a collaborative text RPG (start, join, begin, action, status, stop)
 
 ### Admin
 - `/raidmode` - Configure raid detection and case management
@@ -194,15 +276,26 @@ Members can chat with Clawdia in the designated channel or mention her anywhere.
 
 ## Insights Layer
 
-Clawdia includes an **Insights** view in the dashboard focused on decisions instead of raw event logs.
+Clawdia includes an **Insights** view in the dashboard focused on decisions
+instead of raw event logs. It is derived from data the bot already collects —
+member join/leave counts, command usage, and moderation cases — so the metric
+definitions below matter. Read them before acting on a number.
 
 ### Key Metrics
 
-- **Retention Cohorts**: Track D1/D7/D30 member retention by join week
-- **Active Hours Heatmap**: See peak activity hours by day/time (UTC or server timezone)
-- **Toxic Channel Detection**: Rank channels by moderation events, warning density, and repeat offenders
-- **Moderator SLA Trends**: Measure median response time from incident to first mod action
-- **Newcomer Conversion (7/30 days)**: Track how many new members become active contributors
+- **Net Retention (7/30 days)**: `(joins − leaves) / joins` over the last 7 and 30 days of tracked member events. A guild-wide **proxy** — it does not follow individual members, so there is no D1 figure and no join-week segmentation.
+- **Active Hours**: A 24-bucket histogram of command usage by hour, plus the top 5 hours. **Always UTC**; there is no server-timezone option and no weekday dimension.
+- **Toxic Channel Detection**: Ranks up to 8 channels from the most recent 1,000 moderation cases, scored as `warns + (2 × severe)`, where severe is mute/kick/ban. Channels are resolved from case evidence jump URLs; cases without one are bucketed as `unknown`.
+- **Moderator Resolution Time**: Median hours from case creation to case **resolution**, with a 6-month trend. This is time-to-close, **not** time-to-first-response.
+- **Newcomer Conversion (7/30 days)**: Share of members whose record is at least 7 or 30 days old and who have reached 20+ messages or level 2+.
+
+### Not implemented
+
+Previously advertised here, and not built. These are open work, not wording gaps:
+
+- **Retention cohorts** (D1/D7/D30 by join week) — needs per-member join dates retained over time; only aggregate join/leave counts are stored today
+- **Weekday heatmaps and server-local timezones** for active hours — the histogram records the hour only, and renders UTC
+- **First-response SLA** — needs a first-mod-action timestamp on cases, which is not currently recorded
 
 ## Daily News Digest
 


### PR DESCRIPTION
## Summary

Comprehensive documentation update for FEATURES.md and README.md to reflect the full scope of Clawdia's economy/RPG systems, exploration mechanics, and analytics capabilities. This brings the public-facing documentation into alignment with the actual codebase.

## Key changes

**FEATURES.md:**
- Added detailed **Memories** section documenting user fact retention
- Added **AI Dungeon Master** (`/dm`) feature with command reference and session mechanics
- Added **AI-Generated Content** section covering `/questgen` and `/newspaper preview`
- Expanded **Economy** section from basic commands to comprehensive subsystems:
  - Core currency commands
  - Gathering, crafting, and pets with synergy table
  - Trading and server investment (market, districts)
  - Group play and PvP (heists, syndicates, wars, rob protections)
  - Progression system (prestige tiers, daily challenges, season pass)
  - Feeds and rotation (`/featured`, `/winfeed`)
  - Seasonal commands
- Rewrote **Insights** section with honest metric definitions:
  - Clarified what each metric actually computes vs. what it's named
  - Added "Known gaps" subsection documenting three unimplemented features (retention cohorts, weekday heatmaps, first-response SLA)
  - Updated practical actions to match actual capabilities
- Updated dashboard settings list to reflect current configuration options (added Exploration, Newspaper; renumbered subsequent items)
- Updated cooldown table with new commands and accurate timings

**README.md:**
- Rewrote opening to clarify Clawdia is primarily an economy/RPG bot (43 of 98 commands, ~1/3 of codebase)
- Added "Shape of the codebase" table showing command and line-of-code distribution by area
- Reorganized feature list into four sections: game layer, server management, content & extras
- Expanded command reference with full economy subsystem breakdown (currency, gathering, competition, progression, seasonal)
- Added OpenRouter to AI provider list
- Rewrote Insights section with metric definitions and "Not implemented" subsection matching FEATURES.md
- Clarified that insights are derived from existing data sources (member events, command usage, cases)

## Notable details

- Both documents now explicitly document what is **not** implemented (retention cohorts, weekday heatmaps, first-response SLA) rather than implying they exist
- Metric definitions include their actual computation and known limitations (e.g., "guild-wide proxy" for retention, "UTC only" for active hours)
- Economy documentation now includes cost/reward tables for `/forge` rarity tiers and syndicate heist targets
- Pet progression mechanics fully documented (evolution stages, stacked bonus caps, hunger decay)
- District benefits and unlock conditions clearly specified

https://claude.ai/code/session_01UViPEQGZR9vpxG74G6Xrna

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded feature documentation for AI memories, Dungeon Master interactions, quests, newspaper previews, economy systems, analytics, dashboards, cooldowns, and seasonal mechanics.
  * Updated the README with broader moderation, AI, RPG, economy, and seasonal feature coverage.
  * Added documentation for new commands, including `/questgen`, `/newspaper`, `/ai memories`, and `/dm`.
  * Clarified supported analytics metrics and documented known limitations.
  * Added setup guidance for OpenRouter integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->