### PR TITLE
Fix concurrency bugs in gift, rob, and pet commands

### DIFF
--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -3,6 +3,7 @@
 const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags } = require('discord.js');
 const User  = require('../../models/User');
 const { attachGrind, persistGrindIfNew } = require('../../utils/grindProfile');
+const { isVersionError } = require('../../utils/versionRetry');
 const GrindProfile = require('../../models/GrindProfile');
 const Guild = require('../../models/Guild');
 const {
@@ -323,7 +324,7 @@ async function handleGo(interaction) {
         } catch (err) {
             // Nothing was saved, so give the cooldown slot back before telling them to retry.
             await releaseExploreClaim();
-            if (err.name === 'VersionError') {
+            if (isVersionError(err)) {
                 return interaction.reply({ content: 'A simultaneous request tangled your expedition log. Try `/explore go` again.', flags: MessageFlags.Ephemeral });
             }
             console.error('[explore] pre-encounter save error:', err);
@@ -414,7 +415,7 @@ async function handleGo(interaction) {
         try {
             await user.save();
         } catch (err) {
-            if (err.name === 'VersionError') {
+            if (isVersionError(err)) {
                 return interaction.editReply({ content: 'A simultaneous request tangled your expedition log. Try `/explore go` again.', embeds: [], components: [] });
             }
             console.error('[explore] save error:', err);

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -9,6 +9,7 @@ const {
 } = require('discord.js');
 const User  = require('../../models/User');
 const { attachGrind, persistGrindIfNew } = require('../../utils/grindProfile');
+const { isVersionError } = require('../../utils/versionRetry');
 const GrindProfile = require('../../models/GrindProfile');
 const Guild = require('../../models/Guild');
 const { getItemImageAttachment } = require('../../utils/itemImageHelper');
@@ -807,7 +808,7 @@ async function handleCast(interaction) {
         } catch (err) {
             // Nothing was saved, so give the cooldown slot back before telling them to retry.
             await releaseFishClaim();
-            if (err.name === 'VersionError') {
+            if (isVersionError(err)) {
                 return interaction.editReply({ content: 'A simultaneous request conflicted. Please try `/fish cast` again.' });
             }
             console.error('[fish] save error:', err);

--- a/src/commands/economy/gift.js
+++ b/src/commands/economy/gift.js
@@ -245,8 +245,10 @@ module.exports = {
                 User.updateOne({ userId: target.id, guildId: interaction.guild.id }, {}, { upsert: true }),
             ]);
 
-            const slot = sender.inventory.find(i => i.itemId === itemId);
-            if (!slot || slot.quantity < qty) {
+            // Same predicate as the atomic debit below — `find` on itemId alone
+            // would reject on a small duplicate slot while a later one can cover it.
+            const slot = sender.inventory.find(i => i.itemId === itemId && i.quantity >= qty);
+            if (!slot) {
                 return interaction.reply({
                     content: `You don't have ${qty}x \`${itemId}\` in your inventory.`,
                     flags: MessageFlags.Ephemeral,
@@ -273,8 +275,11 @@ module.exports = {
                     guildId: interaction.guild.id,
                     inventory: { $elemMatch: { itemId, quantity: { $gte: qty } } },
                 },
-                { $inc: { 'inventory.$[slot].quantity': -qty } },
-                { arrayFilters: [{ 'slot.itemId': itemId }], new: true }
+                // Positional `$`, not an arrayFilter: `$[slot]` would decrement
+                // every slot carrying this itemId, and duplicate slots are
+                // reachable — several writers $push without checking for one.
+                { $inc: { 'inventory.$.quantity': -qty } },
+                { new: true }
             );
             if (!debited) {
                 return interaction.reply({

--- a/src/commands/economy/gift.js
+++ b/src/commands/economy/gift.js
@@ -14,6 +14,33 @@ const MIN_ACCOUNT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 // Items that cannot be gifted (soulbound — matches market.js)
 const SOULBOUND_ITEMS = new Set(['lifesaver', 'streak_shield']);
 
+// Add `qty` of `itemId` to a user's inventory without reading it first: bump the
+// existing slot if there is one, otherwise push a new slot, guarding the push so
+// two concurrent credits can never create duplicate slots for the same item.
+// Returns the updated document, or null if the user document does not exist.
+async function addInventoryItem(userId, guildId, itemId, qty) {
+    const bumped = await User.findOneAndUpdate(
+        { userId, guildId, 'inventory.itemId': itemId },
+        { $inc: { 'inventory.$.quantity': qty } },
+        { new: true }
+    );
+    if (bumped) return bumped;
+
+    const pushed = await User.findOneAndUpdate(
+        { userId, guildId, 'inventory.itemId': { $ne: itemId } },
+        { $push: { inventory: { itemId, quantity: qty } } },
+        { new: true }
+    );
+    if (pushed) return pushed;
+
+    // A concurrent write created the slot between the two calls — bump it now.
+    return User.findOneAndUpdate(
+        { userId, guildId, 'inventory.itemId': itemId },
+        { $inc: { 'inventory.$.quantity': qty } },
+        { new: true }
+    );
+}
+
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('gift')
@@ -211,9 +238,11 @@ module.exports = {
                 return interaction.reply({ content: `\`${itemId}\` is soulbound and cannot be gifted.`, flags: MessageFlags.Ephemeral });
             }
 
-            const [sender, recipient] = await Promise.all([
+            // Both documents must exist before the transfer; the sender doc is also
+            // read here for the pre-flight checks below.
+            const [sender] = await Promise.all([
                 User.findOneAndUpdate({ userId: interaction.user.id, guildId: interaction.guild.id }, {}, { upsert: true, new: true }),
-                User.findOneAndUpdate({ userId: target.id,           guildId: interaction.guild.id }, {}, { upsert: true, new: true }),
+                User.updateOne({ userId: target.id, guildId: interaction.guild.id }, {}, { upsert: true }),
             ]);
 
             const slot = sender.inventory.find(i => i.itemId === itemId);
@@ -234,24 +263,56 @@ module.exports = {
                 });
             }
 
-            slot.quantity -= qty;
-            if (slot.quantity <= 0) {
-                sender.inventory = sender.inventory.filter(i => i.itemId !== itemId);
+            // Debit the sender atomically first, then credit the recipient and roll
+            // the debit back if the credit fails — the same shape as the coin path
+            // above. Saving both documents in parallel would duplicate the item
+            // whenever the sender's write lost and the recipient's won.
+            const debited = await User.findOneAndUpdate(
+                {
+                    userId: interaction.user.id,
+                    guildId: interaction.guild.id,
+                    inventory: { $elemMatch: { itemId, quantity: { $gte: qty } } },
+                },
+                { $inc: { 'inventory.$[slot].quantity': -qty } },
+                { arrayFilters: [{ 'slot.itemId': itemId }], new: true }
+            );
+            if (!debited) {
+                return interaction.reply({
+                    content: `You don't have ${qty}x \`${itemId}\` in your inventory.`,
+                    flags: MessageFlags.Ephemeral,
+                });
             }
-            sender.markModified('inventory');
+            // Drop the slot once it is empty so inventory listings stay clean. A
+            // failure here leaves a zero-quantity slot, which is cosmetic only.
+            await User.updateOne(
+                { userId: interaction.user.id, guildId: interaction.guild.id },
+                { $pull: { inventory: { itemId, quantity: { $lte: 0 } } } }
+            ).catch(() => null);
 
-            const recipientSlot = recipient.inventory.find(i => i.itemId === itemId);
-            if (recipientSlot) {
-                recipientSlot.quantity += qty;
-            } else {
-                recipient.inventory.push({ itemId, quantity: qty });
+            let credited = null;
+            try {
+                credited = await addInventoryItem(target.id, interaction.guild.id, itemId, qty);
+            } catch (creditErr) {
+                console.error(`[gift] item credit failed — recipient=${target.id} guild=${interaction.guild.id} item=${itemId} qty=${qty}:`, creditErr);
             }
-            recipient.markModified('inventory');
+            if (!credited) {
+                try {
+                    await addInventoryItem(interaction.user.id, interaction.guild.id, itemId, qty);
+                } catch (rollbackErr) {
+                    console.error(`[gift] CRITICAL: item rollback failed — sender=${interaction.user.id} guild=${interaction.guild.id} item=${itemId} qty=${qty}:`, rollbackErr);
+                    return interaction.reply({
+                        content: 'Something went wrong returning your item — please contact a server admin.',
+                        flags: MessageFlags.Ephemeral,
+                    });
+                }
+                return interaction.reply({
+                    content: 'Could not complete the transfer — your item was returned.',
+                    flags: MessageFlags.Ephemeral,
+                });
+            }
 
-            await Promise.all([sender.save(), recipient.save()]);
-
-            logTransaction({ userId: interaction.user.id, guildId: interaction.guild.id, type: 'gift_item_send',    amount: 0, balance: sender.balance,    relatedUserId: target.id,           note: `Gifted ${qty}x ${itemId}` });
-            logTransaction({ userId: target.id,           guildId: interaction.guild.id, type: 'gift_item_receive', amount: 0, balance: recipient.balance, relatedUserId: interaction.user.id, note: `Received ${qty}x ${itemId}` });
+            logTransaction({ userId: interaction.user.id, guildId: interaction.guild.id, type: 'gift_item_send',    amount: 0, balance: debited.balance,  relatedUserId: target.id,           note: `Gifted ${qty}x ${itemId}` });
+            logTransaction({ userId: target.id,           guildId: interaction.guild.id, type: 'gift_item_receive', amount: 0, balance: credited.balance, relatedUserId: interaction.user.id, note: `Received ${qty}x ${itemId}` });
 
             const embed = new EmbedBuilder()
                 .setColor('#f1c40f')

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -9,6 +9,7 @@ const {
 } = require('discord.js');
 const User  = require('../../models/User');
 const { attachGrind, persistGrindIfNew } = require('../../utils/grindProfile');
+const { isVersionError } = require('../../utils/versionRetry');
 const GrindProfile = require('../../models/GrindProfile');
 const Guild = require('../../models/Guild');
 const { getItemImageAttachment } = require('../../utils/itemImageHelper');
@@ -800,7 +801,7 @@ async function executeStart(interaction) {
         } catch (err) {
             // Nothing was saved, so give the cooldown slot back before telling them to retry.
             await releaseHuntClaim();
-            if (err.name === 'VersionError') {
+            if (isVersionError(err)) {
                 return interaction.editReply({ content: 'A simultaneous request conflicted with your hunt. Please try `/hunt start` again.' });
             }
             console.error('[hunt] save error:', err);

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -3,6 +3,7 @@
 const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags } = require('discord.js');
 const User  = require('../../models/User');
 const { attachGrind, persistGrindIfNew, saveGrind } = require('../../utils/grindProfile');
+const { isVersionError } = require('../../utils/versionRetry');
 const GrindProfile = require('../../models/GrindProfile');
 const Guild = require('../../models/Guild');
 const { getItemImageAttachment } = require('../../utils/itemImageHelper');
@@ -786,7 +787,7 @@ async function handleDig(interaction) {
         } catch (err) {
             // Nothing was saved, so give the cooldown slot back before telling them to retry.
             await releaseMineClaim();
-            if (err.name === 'VersionError') {
+            if (isVersionError(err)) {
                 return interaction.editReply({ content: 'A simultaneous request conflicted with your mine. Please try `/mine dig` again.' });
             }
             console.error('[mine] save error:', err);

--- a/src/commands/economy/pet.js
+++ b/src/commands/economy/pet.js
@@ -7,6 +7,7 @@ const {
 const User  = require('../../models/User');
 const { DECEASED_PET_LIMIT } = User;
 const { attachGrind } = require('../../utils/grindProfile');
+const { isVersionError, withVersionRetry } = require('../../utils/versionRetry');
 const Guild = require('../../models/Guild');
 const {
     PET_DEFINITIONS,
@@ -436,7 +437,7 @@ async function executeAdopt(interaction) {
     try {
         await user.save();
     } catch (err) {
-        if (err.name === 'VersionError') return interaction.reply({ content: 'Edit conflict — please try again.', flags: MessageFlags.Ephemeral });
+        if (isVersionError(err)) return interaction.reply({ content: 'Edit conflict — please try again.', flags: MessageFlags.Ephemeral });
         throw err;
     }
     announcePetAchievements(interaction, user, guildSettings, earned);
@@ -544,7 +545,7 @@ async function executeStatus(interaction) {
             try {
                 await freshUser.save();
             } catch (err) {
-                if (err.name === 'VersionError') {
+                if (isVersionError(err)) {
                     return btn.reply({ content: '⚠️ Action conflict — please try again.', flags: MessageFlags.Ephemeral });
                 }
                 console.error('[pet] play save error:', err);
@@ -585,7 +586,7 @@ async function executeStatus(interaction) {
             try {
                 await freshUser.save();
             } catch (err) {
-                if (err.name === 'VersionError') {
+                if (isVersionError(err)) {
                     return btn.reply({ content: '⚠️ Action conflict — please try again.', flags: MessageFlags.Ephemeral });
                 }
                 console.error('[pet] rest save error:', err);
@@ -611,7 +612,7 @@ async function executeStatus(interaction) {
             try {
                 await freshUser.save();
             } catch (err) {
-                if (err.name === 'VersionError') {
+                if (isVersionError(err)) {
                     return btn.reply({ content: '⚠️ Action conflict — please try again.', flags: MessageFlags.Ephemeral });
                 }
                 console.error('[pet] showcase save error:', err);
@@ -714,7 +715,7 @@ async function executeFeed(interaction) {
     try {
         await user.save();
     } catch (err) {
-        if (err.name === 'VersionError') return interaction.editReply('Edit conflict — please try again.');
+        if (isVersionError(err)) return interaction.editReply('Edit conflict — please try again.');
         throw err;
     }
     announcePetAchievements(interaction, user, guildSettings, earned);
@@ -793,22 +794,31 @@ async function executeRelease(interaction) {
     }
 
     // Re-resolve by id: the roster may have changed while the prompt was open.
-    const fresh = await resolveUser(interaction);
-    const still = resolvePetRef(fresh?.pets, petId);
-    if (!still) {
-        return choice.update({ content: `**${name}** is no longer in your roster.`, embeds: [], components: [] }).catch(() => {});
+    // Dropping a pet by id is a pure function of the freshly read roster, so a
+    // lost version race can simply replay instead of bouncing back to the user.
+    let saved = null;
+    let conflict = false;
+    try {
+        saved = await withVersionRetry(
+            () => resolveUser(interaction),
+            (fresh) => {
+                const still = resolvePetRef(fresh?.pets, petId);
+                if (!still) return false;
+                fresh.pets.splice(still.index, 1);
+                fresh.markModified('pets');
+            },
+            { label: 'pet release' }
+        );
+    } catch (err) {
+        if (!isVersionError(err)) throw err;
+        conflict = true;
     }
 
-    fresh.pets.splice(still.index, 1);
-    fresh.markModified('pets');
-
-    try {
-        await fresh.save();
-    } catch (err) {
-        if (err.name === 'VersionError') {
-            return choice.update({ content: 'Edit conflict — try again.', embeds: [], components: [] }).catch(() => {});
-        }
-        throw err;
+    if (conflict) {
+        return choice.update({ content: 'Edit conflict — try again.', embeds: [], components: [] }).catch(() => {});
+    }
+    if (!saved) {
+        return choice.update({ content: `**${name}** is no longer in your roster.`, embeds: [], components: [] }).catch(() => {});
     }
 
     return choice.update({
@@ -819,23 +829,33 @@ async function executeRelease(interaction) {
 
 async function executeRename(interaction) {
     const newName = interaction.options.getString('name').trim().slice(0, 32);
-    const user    = await resolveUser(interaction);
+    const slotRef = readSlotOption(interaction);
 
-    const target = resolvePetRef(user?.pets, readSlotOption(interaction));
-    if (!target) return interaction.reply({ content: NO_SUCH_PET, flags: MessageFlags.Ephemeral });
-    const petIndex = target.index;
-
-    user.pets[petIndex].name = newName;
-    user.markModified('pets');
-
+    // Setting a name is a pure function of the freshly read roster, so a lost
+    // version race replays rather than asking the user to retype the command.
+    let saved    = null;
+    let conflict = false;
+    let def      = null;
     try {
-        await user.save();
+        saved = await withVersionRetry(
+            () => resolveUser(interaction),
+            (user) => {
+                const target = resolvePetRef(user?.pets, slotRef);
+                if (!target) return false;
+                user.pets[target.index].name = newName;
+                user.markModified('pets');
+                def = PET_DEFINITIONS[user.pets[target.index].petId];
+            },
+            { label: 'pet rename' }
+        );
     } catch (err) {
-        if (err.name === 'VersionError') return interaction.reply({ content: 'Edit conflict — try again.', flags: MessageFlags.Ephemeral });
-        throw err;
+        if (!isVersionError(err)) throw err;
+        conflict = true;
     }
 
-    const def = PET_DEFINITIONS[user.pets[petIndex].petId];
+    if (conflict) return interaction.reply({ content: 'Edit conflict — try again.', flags: MessageFlags.Ephemeral });
+    if (!saved)   return interaction.reply({ content: NO_SUCH_PET, flags: MessageFlags.Ephemeral });
+
     return interaction.reply({ content: `${def?.emoji ?? '🐾'} Pet renamed to **${newName}**!`, flags: MessageFlags.Ephemeral });
 }
 
@@ -985,7 +1005,7 @@ async function wildBattle(interaction, user, myPetId, currency, guildSettings) {
     try {
         await user.save();
     } catch (err) {
-        if (err.name === 'VersionError') return interaction.editReply({ content: 'Edit conflict — please try again.', embeds: [] });
+        if (isVersionError(err)) return interaction.editReply({ content: 'Edit conflict — please try again.', embeds: [] });
         throw err;
     }
     announcePetAchievements(interaction, user, guildSettings, earned);

--- a/src/commands/economy/pet.js
+++ b/src/commands/economy/pet.js
@@ -833,15 +833,20 @@ async function executeRename(interaction) {
 
     // Setting a name is a pure function of the freshly read roster, so a lost
     // version race replays rather than asking the user to retype the command.
+    // The first attempt resolves the slot the user asked for; every retry then
+    // looks the pet up by its stable _id, since a numeric slot ref would land on
+    // a different pet if a concurrent write reordered the roster in between.
     let saved    = null;
     let conflict = false;
     let def      = null;
+    let pinnedId = null;
     try {
         saved = await withVersionRetry(
             () => resolveUser(interaction),
             (user) => {
-                const target = resolvePetRef(user?.pets, slotRef);
+                const target = resolvePetRef(user?.pets, pinnedId ?? slotRef);
                 if (!target) return false;
+                if (target.pet?._id) pinnedId = String(target.pet._id);
                 user.pets[target.index].name = newName;
                 user.markModified('pets');
                 def = PET_DEFINITIONS[user.pets[target.index].petId];

--- a/src/commands/economy/rob.js
+++ b/src/commands/economy/rob.js
@@ -27,19 +27,40 @@ async function saveRobState(robber, victim, robberSnapshot, trapSnapshot, victim
     } else {
         robberCond.$or = [{ lastRob: null }, { lastRob: { $exists: false } }];
     }
-    const robberRes = await User.findOneAndUpdate(robberCond, {
-        $set: {
-            balance:        robber.balance,
-            lastRob:        robber.lastRob,
-            successfulRobs: robber.successfulRobs ?? 0,
-            failedRobs:     robber.failedRobs     ?? 0,
-        },
-    });
+    // The robber's balance and rob counters are written as deltas, not absolute
+    // values: an absolute $set would clobber any concurrent credit (a payout, a
+    // gift received) landing between the read at the top of the command and this
+    // write. The lastRob CAS says nothing about balance, so guard the debit too.
+    const robberBalDelta = robber.balance - robberSnapshot.balance;
+    const successDelta   = (robber.successfulRobs ?? 0) - (robberSnapshot.successfulRobs ?? 0);
+    const failedDelta    = (robber.failedRobs     ?? 0) - (robberSnapshot.failedRobs     ?? 0);
+    if (robberBalDelta < 0) robberCond.balance = { $gte: -robberBalDelta };
+
+    const robberUpdate = { $set: { lastRob: robber.lastRob } };
+    const robberInc = {};
+    if (robberBalDelta !== 0) robberInc.balance        = robberBalDelta;
+    if (successDelta   !== 0) robberInc.successfulRobs = successDelta;
+    if (failedDelta    !== 0) robberInc.failedRobs     = failedDelta;
+    if (Object.keys(robberInc).length) robberUpdate.$inc = robberInc;
+
+    const robberRes = await User.findOneAndUpdate(robberCond, robberUpdate);
     if (!robberRes) {
-        throw Object.assign(
-            new Error('[rob] duplicate rob attempt — cooldown already applied'),
-            { robberCooldownConflict: true }
-        );
+        // Either the lastRob CAS lost to a parallel rob or the balance guard
+        // rejected the debit — read back to tell the user which one happened.
+        const current = await User.findOne(
+            { userId: robber.userId, guildId: robber.guildId },
+            { lastRob: 1 }
+        ).lean();
+        const casLost = String(current?.lastRob ?? '') !== String(robberSnapshot.lastRob ?? '');
+        throw casLost
+            ? Object.assign(
+                new Error('[rob] duplicate rob attempt — cooldown already applied'),
+                { robberCooldownConflict: true }
+            )
+            : Object.assign(
+                new Error('[rob] robber balance changed between read and write'),
+                { robberBalanceChanged: true }
+            );
     }
     try {
         const balDelta  = victim.balance - victimOrigBalance;
@@ -75,16 +96,15 @@ async function saveRobState(robber, victim, robberSnapshot, trapSnapshot, victim
         }
     } catch (victimErr) {
         try {
-            await User.updateOne(
-                { userId: robber.userId, guildId: robber.guildId },
-                { $set: {
-                    balance:         robberSnapshot.balance,
-                    bank:            robberSnapshot.bank,
-                    lastRob:         robberSnapshot.lastRob,
-                    successfulRobs:  robberSnapshot.successfulRobs,
-                    failedRobs:      robberSnapshot.failedRobs,
-                } }
-            );
+            // Reverse the deltas rather than restoring the snapshot values, so a
+            // concurrent credit that landed after the robber write survives.
+            const rollbackInc = {};
+            if (robberBalDelta !== 0) rollbackInc.balance        = -robberBalDelta;
+            if (successDelta   !== 0) rollbackInc.successfulRobs = -successDelta;
+            if (failedDelta    !== 0) rollbackInc.failedRobs     = -failedDelta;
+            const rollback = { $set: { lastRob: robberSnapshot.lastRob } };
+            if (Object.keys(rollbackInc).length) rollback.$inc = rollbackInc;
+            await User.updateOne({ userId: robber.userId, guildId: robber.guildId }, rollback);
         } catch (rollbackErr) {
             console.error('[rob] rollback failed; balances may be inconsistent:', rollbackErr);
         }
@@ -178,7 +198,6 @@ module.exports = {
 
             const robberSnapshot = {
                 balance:        robber.balance,
-                bank:           robber.bank,
                 lastRob:        robber.lastRob ?? null,
                 successfulRobs: robber.successfulRobs ?? 0,
                 failedRobs:     robber.failedRobs     ?? 0,
@@ -427,6 +446,9 @@ module.exports = {
         } catch (error) {
             if (error.robberCooldownConflict) {
                 return interaction.editReply({ content: '⚡ Duplicate rob attempt detected — please try again.' }).catch(() => {});
+            }
+            if (error.robberBalanceChanged) {
+                return interaction.editReply({ content: '⚡ Your balance shifted mid-heist — the rob was called off.' }).catch(() => {});
             }
             if (error.victimBalanceChanged) {
                 return interaction.editReply({ content: "⚡ The target's balance shifted mid-heist — you couldn't complete the rob." }).catch(() => {});

--- a/src/commands/economy/rob.js
+++ b/src/commands/economy/rob.js
@@ -96,15 +96,32 @@ async function saveRobState(robber, victim, robberSnapshot, trapSnapshot, victim
         }
     } catch (victimErr) {
         try {
+            // Give the cooldown slot back only if it is still ours: another rob
+            // may have won the CAS since our write, and restoring the old
+            // lastRob over its value would hand that rob a free cooldown reset.
+            await User.updateOne(
+                { userId: robber.userId, guildId: robber.guildId, lastRob: robber.lastRob },
+                { $set: { lastRob: robberSnapshot.lastRob } }
+            );
+
             // Reverse the deltas rather than restoring the snapshot values, so a
             // concurrent credit that landed after the robber write survives.
-            const rollbackInc = {};
-            if (robberBalDelta !== 0) rollbackInc.balance        = -robberBalDelta;
-            if (successDelta   !== 0) rollbackInc.successfulRobs = -successDelta;
-            if (failedDelta    !== 0) rollbackInc.failedRobs     = -failedDelta;
-            const rollback = { $set: { lastRob: robberSnapshot.lastRob } };
-            if (Object.keys(rollbackInc).length) rollback.$inc = rollbackInc;
-            await User.updateOne({ userId: robber.userId, guildId: robber.guildId }, rollback);
+            // Clamped at zero: spending between the write and here can leave less
+            // on the account than this rob added.
+            const reversals = {};
+            if (robberBalDelta !== 0) reversals.balance        = -robberBalDelta;
+            if (successDelta   !== 0) reversals.successfulRobs = -successDelta;
+            if (failedDelta    !== 0) reversals.failedRobs     = -failedDelta;
+            if (Object.keys(reversals).length) {
+                const clamped = {};
+                for (const [field, delta] of Object.entries(reversals)) {
+                    clamped[field] = { $max: [0, { $add: [{ $ifNull: [`$${field}`, 0] }, delta] }] };
+                }
+                await User.updateOne(
+                    { userId: robber.userId, guildId: robber.guildId },
+                    [{ $set: clamped }]
+                );
+            }
         } catch (rollbackErr) {
             console.error('[rob] rollback failed; balances may be inconsistent:', rollbackErr);
         }

--- a/src/commands/economy/season.js
+++ b/src/commands/economy/season.js
@@ -6,6 +6,7 @@ const { generateDailyMissions } = require('../../data/seasonMissions');
 const { SEASONAL_EVENTS } = require('../../data/seasonalEvents');
 const { getEventCurrencyBalance } = require('../../services/seasonalEventService');
 const { progressBar } = require('../../utils/progressBar');
+const { isVersionError } = require('../../utils/versionRetry');
 const { rewardReveal } = require('../../utils/rewardReveal');
 const { logTransaction } = require('../../utils/logTransaction');
 const { awardSeasonXp } = require('../../services/questService');
@@ -198,7 +199,7 @@ async function executeClaim(interaction) {
     try {
         await user.save();
     } catch (err) {
-        if (err.name === 'VersionError') return interaction.reply({ content: 'Edit conflict — try again.', flags: MessageFlags.Ephemeral });
+        if (isVersionError(err)) return interaction.reply({ content: 'Edit conflict — try again.', flags: MessageFlags.Ephemeral });
         throw err;
     }
 
@@ -397,7 +398,7 @@ async function executeClaimMission(interaction) {
     try {
         await user.save();
     } catch (err) {
-        if (err.name === 'VersionError') return interaction.reply({ content: 'Edit conflict — try again.', flags: MessageFlags.Ephemeral });
+        if (isVersionError(err)) return interaction.reply({ content: 'Edit conflict — try again.', flags: MessageFlags.Ephemeral });
         throw err;
     }
 
@@ -485,7 +486,7 @@ async function executeClaimAll(interaction) {
     try {
         await user.save();
     } catch (err) {
-        if (err.name === 'VersionError') return interaction.reply({ content: 'Edit conflict — try again.', flags: MessageFlags.Ephemeral });
+        if (isVersionError(err)) return interaction.reply({ content: 'Edit conflict — try again.', flags: MessageFlags.Ephemeral });
         throw err;
     }
 

--- a/src/dashboard/public/esc-html.js
+++ b/src/dashboard/public/esc-html.js
@@ -1,0 +1,22 @@
+// Single shared HTML-escaper for the dashboard views.
+//
+// Single quotes and backticks are escaped as well as the usual four, so the
+// result is safe inside single-quoted attributes, not just double-quoted ones.
+//
+// It is NOT safe for building JavaScript source — an inline event handler's
+// attribute value is HTML-decoded *before* it is parsed as JS, so `&#39;` turns
+// back into a quote and closes the string it was meant to sit inside. Untrusted
+// values belong in `data-*` attributes read back through `dataset`, wired up
+// with addEventListener; never concatenate them into an `onclick="..."`.
+function escHtml(value) {
+    if (value === null || value === undefined) return '';
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/`/g, '&#96;');
+}
+
+if (typeof module !== 'undefined' && module.exports) module.exports = { escHtml };

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="/styles.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js" defer></script>
+    <script src="/esc-html.js"></script>
 </head>
 <body style="background:var(--ink-950);margin:0;">
 <div class="dash">
@@ -722,10 +723,6 @@
             });
         }
 
-        function escHtml(str) {
-            return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
-        }
-
         function addDailyNewsProfile() {
             const container = document.getElementById('dailynews-profiles-list');
             const profiles = JSON.parse(container.dataset.profiles || '[]');
@@ -1382,10 +1379,6 @@
         var _cpRuleIdx = -1;
         var _cpCdIdx   = -1;
 
-        function escHtml(s) {
-            return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
-        }
-
         // ── Styled confirmation modal ────────────────────────────────────────
         var _confirmResolve = null;
         var _confirmPrevFocus = null;
@@ -1574,11 +1567,6 @@
         <% roles.forEach(r => { %>_roleMap['<%= r.id %>'] = '<%= r.name.replace(/'/g, "\\'") %>';<% }); %>
         var editingItemIdx = -1;
         var editingJobIdx = -1;
-
-        function escHtml(s) {
-            if (!s) return '';
-            return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
-        }
 
         var _shopItemPendingImages = {}; // itemId -> { file, dataUrl }
         var _shopItemClearedImages = new Set(); // itemIds whose images were explicitly removed
@@ -1879,6 +1867,37 @@
             if (e.target.id === 'ach-modal') closeAchModal();
         });
 
+        // ── Delegated handlers for rendered lists ────────────────────────────
+        // Attacker-influenced values (member nicknames, achievement names, MCP
+        // server names) ride in data-* attributes and come back out through
+        // dataset. They must never be concatenated into an inline handler:
+        // an on*="" attribute is HTML-decoded before it is parsed as JS, so a
+        // `&#39;` from escHtml turns back into a quote and closes the string it
+        // was meant to sit inside.
+        document.addEventListener('click', function(e) {
+            var el = e.target.closest && e.target.closest('[data-action]');
+            if (!el) return;
+            var d = el.dataset;
+            if (d.action === 'ach-grant')      openAchGrantModal(d.achId, d.achName);
+            else if (d.action === 'summary-delete') deleteSummaryJob(d.jobId);
+            else if (d.action === 'persona-remove') removePersona(d.channelId);
+            else if (d.action === 'mcp-test')       testMcpServer(d.serverName, el.closest('.list-item') && el.closest('.list-item').querySelector('.mcp-test-result'));
+            else if (d.action === 'mcp-edit')       editMcpServer(d.serverName);
+            else if (d.action === 'mcp-remove')     removeMcpServer(d.serverName);
+        });
+
+        // mousedown, not click: the dropdown is hidden by the input's blur, which
+        // fires first on a click.
+        document.addEventListener('mousedown', function(e) {
+            var el = e.target.closest && e.target.closest('[data-action="member-select"]');
+            if (el) selectGrantMember(el.dataset.memberId, el.dataset.memberName);
+        });
+
+        document.addEventListener('change', function(e) {
+            var el = e.target.closest && e.target.closest('[data-builtin-ach-id]');
+            if (el) toggleBuiltinAch(el.dataset.builtinAchId, el.checked);
+        });
+
         // ── Achievements ───────────────────────────────────────────────────────────
         var _BUILTIN_ACHS = <%- jsonForScript(builtinAchievements || []) %>;
         var _disabledAchievements = <%- jsonForScript(settings.achievements?.disabledAchievements || []) %>;
@@ -1901,7 +1920,7 @@
                     '<span style="font-size:.8rem;color:var(--text-dim);margin-right:.5rem">' +
                         (a.xpReward ? '+' + a.xpReward + ' XP' : '') + (a.xpReward && a.coinReward ? ' · ' : '') + (a.coinReward ? '+' + a.coinReward.toLocaleString() + ' coins' : '') +
                     '</span>' +
-                    '<label class="switch" style="margin:0"><input type="checkbox"' + (disabled ? '' : ' checked') + ' onchange="toggleBuiltinAch(\'' + escHtml(a.id) + '\', this.checked)"><span class="slider"></span></label>' +
+                    '<label class="switch" style="margin:0"><input type="checkbox"' + (disabled ? '' : ' checked') + ' data-builtin-ach-id="' + escHtml(a.id) + '"><span class="slider"></span></label>' +
                 '</div>';
             }).join('');
         }
@@ -1933,7 +1952,7 @@
                         '</div>' +
                     '</div>' +
                     '<div class="store-card-actions">' +
-                        '<button class="btn btn-sm" onclick="openAchGrantModal(\'' + escHtml(a.id) + '\',\'' + escHtml(a.name) + '\')">Grant</button>' +
+                        '<button class="btn btn-sm" data-action="ach-grant" data-ach-id="' + escHtml(a.id) + '" data-ach-name="' + escHtml(a.name) + '">Grant</button>' +
                         '<button class="btn btn-sm" onclick="openAchModal(' + i + ')">Edit</button>' +
                         '<button class="btn btn-sm btn-danger" onclick="deleteCustomAch(' + i + ')">Remove</button>' +
                     '</div>' +
@@ -2021,7 +2040,7 @@
                 } else {
                     resultsEl.innerHTML = members.map(function(m) {
                         return '<div class="grant-member-option" style="padding:.45rem .75rem;cursor:pointer;font-size:.88rem;display:flex;align-items:center;gap:.5rem;" ' +
-                            'onmousedown="selectGrantMember(\'' + escHtml(m.id) + '\',\'' + escHtml(m.displayName || m.username) + '\')">' +
+                            'data-action="member-select" data-member-id="' + escHtml(m.id) + '" data-member-name="' + escHtml(m.displayName || m.username) + '">' +
                             (m.avatarURL ? '<img src="' + escHtml(m.avatarURL) + '" style="width:22px;height:22px;border-radius:50%;">' : '') +
                             '<span>' + escHtml(m.displayName || m.username) + '</span>' +
                             '<span style="color:var(--text-dim);margin-left:auto;font-size:.8rem">' + escHtml(m.id) + '</span>' +
@@ -2479,7 +2498,7 @@
                             srcName + ' → ' + tgtName + ' · Daily at ' + hh + ':' + mm + ' UTC · Last run: ' + escHtml(lastRun) +
                         '</div>' +
                     '</div>' +
-                    '<button class="btn btn-danger btn-sm" onclick="deleteSummaryJob(\'' + escHtml(job._id) + '\')">Remove</button>';
+                    '<button class="btn btn-danger btn-sm" data-action="summary-delete" data-job-id="' + escHtml(job._id) + '">Remove</button>';
                 container.appendChild(div);
             });
         }
@@ -2605,7 +2624,7 @@
                         '<strong>' + escHtml(p.personaName) + '</strong> <span style="color:var(--text-mute);font-size:.85rem;">(' + chanName + ')</span>' +
                         '<div style="color:var(--text-mute);font-size:.82rem;margin-top:.2rem;">' + escHtml(preview) + '</div>' +
                     '</div>' +
-                    '<button class="btn btn-danger btn-sm" onclick="removePersona(\'' + escHtml(p.channelId) + '\')">Remove</button>';
+                    '<button class="btn btn-danger btn-sm" data-action="persona-remove" data-channel-id="' + escHtml(p.channelId) + '">Remove</button>';
                 container.appendChild(div);
             });
         }
@@ -2764,12 +2783,12 @@
                             (srv.enabled ? '' : ' <span style="color:var(--text-mute);font-size:.8rem;">(disabled)</span>') +
                             '<div style="color:var(--text-mute);font-size:.82rem;margin-top:.2rem;word-break:break-all;">' + escHtml(srv.url) + '</div>' +
                             '<div style="color:var(--text-mute);font-size:.78rem;margin-top:.15rem;">' + escHtml(bits.join(' · ')) + '</div>' +
-                            '<div class="mcp-test-result" id="mcp-test-' + escHtml(srv.name) + '"></div>' +
+                            '<div class="mcp-test-result"></div>' +
                         '</div>' +
                         '<div style="display:flex;gap:.4rem;flex-wrap:wrap;">' +
-                            '<button class="btn btn-sm" onclick="testMcpServer(\'' + escHtml(srv.name) + '\')">Test</button>' +
-                            '<button class="btn btn-sm" onclick="editMcpServer(\'' + escHtml(srv.name) + '\')">Edit</button>' +
-                            '<button class="btn btn-danger btn-sm" onclick="removeMcpServer(\'' + escHtml(srv.name) + '\')">Remove</button>' +
+                            '<button class="btn btn-sm" data-action="mcp-test" data-server-name="' + escHtml(srv.name) + '">Test</button>' +
+                            '<button class="btn btn-sm" data-action="mcp-edit" data-server-name="' + escHtml(srv.name) + '">Edit</button>' +
+                            '<button class="btn btn-danger btn-sm" data-action="mcp-remove" data-server-name="' + escHtml(srv.name) + '">Remove</button>' +
                         '</div>';
                     container.appendChild(div);
                 });
@@ -2906,9 +2925,11 @@
             }
         }
 
-        async function testMcpServer(name) {
+        // `out` is located relative to the clicked button rather than by an id
+        // built from the server name — a name is operator-supplied text and does
+        // not survive round-tripping through an id selector.
+        async function testMcpServer(name, out) {
             var guildId = '<%= guild.id %>';
-            var out = mcpEl('mcp-test-' + name);
             if (out) { out.className = 'mcp-test-result'; out.textContent = 'Testing…'; }
             try {
                 var resp = await fetch('/api/guild/' + guildId + '/mcp-servers/' + encodeURIComponent(name) + '/test', { method: 'POST' });

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -328,6 +328,16 @@ const userSchema = new Schema({
     updatedAt: { type: Date, default: Date.now }
 });
 
+// Optimistic concurrency is a SAME-PATH guard only: Mongoose bumps `__v` on
+// `save()` and nowhere else, so the version check fires when one `save()` races
+// another `save()`. It does NOT fire when a `save()` races a
+// `findOneAndUpdate` / `updateOne` / `$inc` — those leave `__v` untouched, and
+// most economy writes take that atomic path. Do not read a document, mutate it,
+// and `save()` it expecting this to protect a balance or a counter; express the
+// change as a guarded `$inc` instead.
+//
+// For the save-vs-save half, `src/utils/versionRetry.js` has the shared
+// `isVersionError` / `withVersionRetry` helpers.
 userSchema.set('optimisticConcurrency', true);
 
 userSchema.index({ userId: 1, guildId: 1 }, { unique: true });

--- a/src/utils/versionRetry.js
+++ b/src/utils/versionRetry.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const { delay } = require('./delay');
+
+// ── Optimistic concurrency helpers ───────────────────────────────────────────
+//
+// The User schema sets `optimisticConcurrency`, but Mongoose only bumps `__v` on
+// `save()`. `findOneAndUpdate` / `updateOne` / `$inc` leave the version alone, so
+// the guard fires on save-vs-save only — it says nothing about a save racing an
+// atomic write. See the note on `userSchema.set('optimisticConcurrency', true)`.
+//
+// These helpers give the save-vs-save half one definition of "this write lost the
+// race" and one place that decides how to retry, in place of ad-hoc
+// `err.name === 'VersionError'` branches scattered across the handlers.
+
+const DEFAULT_ATTEMPTS  = 3;
+const DEFAULT_BACKOFF_MS = 25;
+
+/**
+ * True when a write failed because the document was modified between the read
+ * and the save. Mongoose reports this as a `VersionError`.
+ */
+function isVersionError(err) {
+    return !!err && err.name === 'VersionError';
+}
+
+/**
+ * Re-read → mutate → save, retrying the whole unit when the save loses a version
+ * race.
+ *
+ * Only use this where the mutation is a pure function of the freshly loaded
+ * document. A handler that has already rolled dice, awarded a reward, or sent a
+ * message cannot be replayed — its mutation is not derivable from the document
+ * alone, and re-running it would roll or award twice. Those call sites should
+ * keep reporting the conflict to the user, using `isVersionError` to detect it.
+ *
+ * @param {() => Promise<object|null>} load   Re-reads the document. Called once per attempt.
+ * @param {(doc: object, attempt: number) => any} mutate  Applies the change. Return
+ *        `false` to abort without saving (the precondition no longer holds).
+ * @param {{attempts?: number, backoffMs?: number, label?: string}} [opts]
+ * @returns {Promise<object|null>} The saved document, or null if `load` found
+ *          nothing or `mutate` aborted.
+ * @throws  The last `VersionError` if every attempt lost, or any other error verbatim.
+ */
+async function withVersionRetry(load, mutate, opts = {}) {
+    const attempts  = opts.attempts  ?? DEFAULT_ATTEMPTS;
+    const backoffMs = opts.backoffMs ?? DEFAULT_BACKOFF_MS;
+    const label     = opts.label     ?? 'save';
+
+    let lastErr = null;
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+        const doc = await load();
+        if (!doc) return null;
+
+        if ((await mutate(doc, attempt)) === false) return null;
+
+        try {
+            await doc.save();
+            return doc;
+        } catch (err) {
+            if (!isVersionError(err)) throw err;
+            lastErr = err;
+            if (attempt < attempts) await delay(backoffMs * attempt);
+        }
+    }
+
+    console.warn(`[versionRetry] ${label} lost ${attempts} version races; giving up`);
+    throw lastErr;
+}
+
+module.exports = { isVersionError, withVersionRetry, DEFAULT_ATTEMPTS };

--- a/tests/escHtml.test.js
+++ b/tests/escHtml.test.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+
+const { escHtml } = require('../src/dashboard/public/esc-html');
+
+const VIEW = fs.readFileSync(path.join(__dirname, '../src/dashboard/views/guild-settings.ejs'), 'utf8');
+
+describe('escHtml', () => {
+    it('escapes the characters that break out of an attribute', () => {
+        expect(escHtml(`&<>"'\``)).toBe('&amp;&lt;&gt;&quot;&#39;&#96;');
+    });
+
+    it('neutralises the reported nickname payload in a single-quoted attribute', () => {
+        const payload = "');fetch('/api/guild/1/achievements/grant',{method:'POST'})//";
+        const attr = `data-member-name='${escHtml(payload)}'`;
+        expect(attr).not.toContain("'" + ')');   // no raw quote to close the attribute
+        expect(escHtml(payload)).not.toMatch(/'/);
+    });
+
+    it('renders falsy-but-real values instead of dropping them', () => {
+        // The old third copy returned '' for anything falsy, so a 0 vanished.
+        expect(escHtml(0)).toBe('0');
+        expect(escHtml(false)).toBe('false');
+        expect(escHtml(null)).toBe('');
+        expect(escHtml(undefined)).toBe('');
+    });
+
+    it('escapes idempotently-unsafe input without double-decoding', () => {
+        expect(escHtml('&amp;')).toBe('&amp;amp;');
+    });
+});
+
+describe('guild-settings.ejs', () => {
+    it('defines escHtml once, in the shared script', () => {
+        expect(VIEW).not.toMatch(/function\s+escHtml/);
+        expect(VIEW).toContain('<script src="/esc-html.js"></script>');
+    });
+
+    it('never concatenates escaped values into an inline event handler', () => {
+        // An on*="" attribute is HTML-decoded before it is parsed as JS, so
+        // escHtml cannot protect a JS string literal built this way.
+        const inlineHandlerWithEscHtml = /\son[a-z]+="[^"]*'\s*\+\s*escHtml\(/;
+        expect(VIEW).not.toMatch(inlineHandlerWithEscHtml);
+    });
+
+    it('wires the member-search dropdown through dataset, not an inline handler', () => {
+        expect(VIEW).toContain('data-action="member-select"');
+        expect(VIEW).not.toContain('onmousedown="selectGrantMember');
+        expect(VIEW).toContain("selectGrantMember(el.dataset.memberId, el.dataset.memberName)");
+    });
+});

--- a/tests/giftItemTransfer.test.js
+++ b/tests/giftItemTransfer.test.js
@@ -19,8 +19,11 @@ function mockMatches(doc, query) {
     if (!doc) return false;
     const elem = query.inventory?.$elemMatch;
     if (elem) {
-        const slot = doc.inventory.find(s => s.itemId === elem.itemId);
-        if (!slot || slot.quantity < elem.quantity.$gte) return false;
+        const idx = doc.inventory.findIndex(
+            s => s.itemId === elem.itemId && s.quantity >= elem.quantity.$gte
+        );
+        if (idx === -1) return false;
+        doc._matchedIndex = idx;
     }
     const byItem = query['inventory.itemId'];
     if (byItem !== undefined) {
@@ -34,14 +37,18 @@ function mockApplyUpdate(doc, update, options = {}) {
     if (update.$inc) {
         for (const [path, delta] of Object.entries(update.$inc)) {
             if (path === 'inventory.$[slot].quantity') {
+                // An arrayFilter hits EVERY matching element — that is the bug.
                 const itemId = options.arrayFilters[0]['slot.itemId'];
-                doc.inventory.find(s => s.itemId === itemId).quantity += delta;
-                mockWrites.push({ user: doc.userId, itemId, delta });
+                doc.inventory.filter(s => s.itemId === itemId).forEach((s) => {
+                    s.quantity += delta;
+                    mockWrites.push({ user: doc.userId, itemId, delta });
+                });
             } else if (path === 'inventory.$.quantity') {
-                // The positional operator binds to the 'inventory.itemId' filter.
-                const itemId = doc._matchedItemId;
-                doc.inventory.find(s => s.itemId === itemId).quantity += delta;
-                mockWrites.push({ user: doc.userId, itemId, delta });
+                // The positional operator binds to the FIRST element the query
+                // matched, whether that came from $elemMatch or 'inventory.itemId'.
+                const slot = doc.inventory[doc._matchedIndex];
+                slot.quantity += delta;
+                mockWrites.push({ user: doc.userId, itemId: slot.itemId, delta });
             } else {
                 doc[path] = (doc[path] ?? 0) + delta;
             }
@@ -75,8 +82,8 @@ jest.mock('../src/models/User', () => ({
             mockStore[query.userId] = doc;
         }
         if (!mockMatches(doc, query)) return null;
-        if (query['inventory.itemId'] !== undefined) {
-            doc._matchedItemId = query['inventory.itemId']?.$ne ?? query['inventory.itemId'];
+        if (query['inventory.itemId'] !== undefined && query['inventory.itemId'].$ne === undefined) {
+            doc._matchedIndex = doc.inventory.findIndex(s => s.itemId === query['inventory.itemId']);
         }
         if (mockFailCreditFor && doc.userId === mockFailCreditFor && (update.$inc || update.$push)) {
             throw new Error('simulated write failure');
@@ -124,7 +131,10 @@ function buildInteraction({ itemId = 'pet_food', quantity = 1 } = {}) {
 
 function mockTotalHeld(itemId) {
     return Object.values(mockStore).reduce(
-        (sum, u) => sum + (u.inventory.find(s => s.itemId === itemId)?.quantity ?? 0), 0
+        (sum, u) => sum + u.inventory
+            .filter(s => s.itemId === itemId)
+            .reduce((n, s) => n + s.quantity, 0),
+        0
     );
 }
 
@@ -197,4 +207,37 @@ test('gifting more than you hold moves nothing', async () => {
     expect(mockStore.sender.inventory).toEqual([{ itemId: 'pet_food', quantity: 3 }]);
     expect(mockStore.recipient.inventory).toEqual([]);
     expect(state.replies.at(-1).content).toContain("don't have 9x");
+});
+
+test('a duplicate slot for the same item is not double-debited', async () => {
+    // Several writers $push without checking for an existing slot, so two slots
+    // for one itemId is a reachable state. An arrayFilter would decrement both.
+    mockStore.sender.inventory = [
+        { itemId: 'pet_food', quantity: 3 },
+        { itemId: 'pet_food', quantity: 4 },
+    ];
+    const { interaction } = buildInteraction({ quantity: 2 });
+    await giftCommand.execute(interaction);
+
+    expect(mockStore.sender.inventory).toEqual([
+        { itemId: 'pet_food', quantity: 1 },
+        { itemId: 'pet_food', quantity: 4 },   // untouched
+    ]);
+    expect(mockStore.recipient.inventory).toEqual([{ itemId: 'pet_food', quantity: 2 }]);
+    expect(mockTotalHeld('pet_food')).toBe(7); // 3 + 4 conserved
+});
+
+test('a slot too small to cover the gift is skipped for one that can', async () => {
+    mockStore.sender.inventory = [
+        { itemId: 'pet_food', quantity: 1 },
+        { itemId: 'pet_food', quantity: 6 },
+    ];
+    const { interaction } = buildInteraction({ quantity: 4 });
+    await giftCommand.execute(interaction);
+
+    expect(mockStore.sender.inventory).toEqual([
+        { itemId: 'pet_food', quantity: 1 },
+        { itemId: 'pet_food', quantity: 2 },
+    ]);
+    expect(mockTotalHeld('pet_food')).toBe(7);
 });

--- a/tests/giftItemTransfer.test.js
+++ b/tests/giftItemTransfer.test.js
@@ -1,0 +1,200 @@
+'use strict';
+
+// /gift item used to write both sides with Promise.all([sender.save(), recipient.save()]):
+// if the sender's save lost and the recipient's won, the item was duplicated.
+// These tests drive the transfer against an in-memory User mockStore that implements
+// the specific query shapes the command issues.
+
+let mockStore;   // userId -> document
+let mockWrites;  // ordered log of the inventory mockWrites the command performed
+
+function mockFindDoc(query) {
+    const doc = mockStore[query.userId];
+    if (!doc || doc.guildId !== query.guildId) return null;
+    return doc;
+}
+
+// Handles only the query shapes gift.js uses.
+function mockMatches(doc, query) {
+    if (!doc) return false;
+    const elem = query.inventory?.$elemMatch;
+    if (elem) {
+        const slot = doc.inventory.find(s => s.itemId === elem.itemId);
+        if (!slot || slot.quantity < elem.quantity.$gte) return false;
+    }
+    const byItem = query['inventory.itemId'];
+    if (byItem !== undefined) {
+        const present = doc.inventory.some(s => s.itemId === (byItem?.$ne ?? byItem));
+        if (byItem?.$ne !== undefined ? present : !present) return false;
+    }
+    return true;
+}
+
+function mockApplyUpdate(doc, update, options = {}) {
+    if (update.$inc) {
+        for (const [path, delta] of Object.entries(update.$inc)) {
+            if (path === 'inventory.$[slot].quantity') {
+                const itemId = options.arrayFilters[0]['slot.itemId'];
+                doc.inventory.find(s => s.itemId === itemId).quantity += delta;
+                mockWrites.push({ user: doc.userId, itemId, delta });
+            } else if (path === 'inventory.$.quantity') {
+                // The positional operator binds to the 'inventory.itemId' filter.
+                const itemId = doc._matchedItemId;
+                doc.inventory.find(s => s.itemId === itemId).quantity += delta;
+                mockWrites.push({ user: doc.userId, itemId, delta });
+            } else {
+                doc[path] = (doc[path] ?? 0) + delta;
+            }
+        }
+    }
+    if (update.$push?.inventory) {
+        const { itemId, quantity } = update.$push.inventory;
+        doc.inventory.push({ itemId, quantity });
+        mockWrites.push({ user: doc.userId, itemId, delta: quantity });
+    }
+    if (update.$pull?.inventory) {
+        const { itemId, quantity } = update.$pull.inventory;
+        doc.inventory = doc.inventory.filter(
+            s => !(s.itemId === itemId && s.quantity <= quantity.$lte)
+        );
+    }
+}
+
+// Set from a test to make the recipient's credit fail.
+let mockFailCreditFor = null;
+
+jest.mock('../src/models/User', () => ({
+    findOne: jest.fn((query) => {
+        const doc = mockFindDoc(query);
+        return { lean: async () => doc, then: (res, rej) => Promise.resolve(doc).then(res, rej) };
+    }),
+    findOneAndUpdate: jest.fn(async (query, update, options = {}) => {
+        let doc = mockFindDoc(query);
+        if (!doc && options.upsert) {
+            doc = { userId: query.userId, guildId: query.guildId, balance: 0, inventory: [], activeEffects: [] };
+            mockStore[query.userId] = doc;
+        }
+        if (!mockMatches(doc, query)) return null;
+        if (query['inventory.itemId'] !== undefined) {
+            doc._matchedItemId = query['inventory.itemId']?.$ne ?? query['inventory.itemId'];
+        }
+        if (mockFailCreditFor && doc.userId === mockFailCreditFor && (update.$inc || update.$push)) {
+            throw new Error('simulated write failure');
+        }
+        mockApplyUpdate(doc, update, options);
+        return doc;
+    }),
+    updateOne: jest.fn(async (query, update, options = {}) => {
+        let doc = mockFindDoc(query);
+        if (!doc && options.upsert) {
+            doc = { userId: query.userId, guildId: query.guildId, balance: 0, inventory: [], activeEffects: [] };
+            mockStore[query.userId] = doc;
+        }
+        if (doc) mockApplyUpdate(doc, update, options);
+        return {};
+    }),
+}));
+
+jest.mock('../src/models/Guild', () => ({
+    findOne: jest.fn(async () => ({ guildId: 'g1', economy: { currency: '💰', enabled: true } })),
+}));
+
+jest.mock('../src/utils/logTransaction', () => ({ logTransaction: jest.fn() }));
+
+const giftCommand = require('../src/commands/economy/gift.js');
+
+const OLD_ACCOUNT = Date.now() - 365 * 24 * 60 * 60 * 1000;
+
+function buildInteraction({ itemId = 'pet_food', quantity = 1 } = {}) {
+    const state = { replies: [], followUps: [] };
+    const interaction = {
+        guild: { id: 'g1' },
+        guildId: 'g1',
+        user: { id: 'sender', username: 'sender', createdTimestamp: OLD_ACCOUNT },
+        options: {
+            getUser: () => ({ id: 'recipient', username: 'recipient', bot: false, createdTimestamp: OLD_ACCOUNT }),
+            getString: (name) => (name === 'type' ? 'item' : name === 'item' ? itemId : null),
+            getInteger: (name) => (name === 'quantity' ? quantity : null),
+        },
+        reply: jest.fn(async (p) => { state.replies.push(p); }),
+        followUp: jest.fn(async (p) => { state.followUps.push(p); }),
+    };
+    return { interaction, state };
+}
+
+function mockTotalHeld(itemId) {
+    return Object.values(mockStore).reduce(
+        (sum, u) => sum + (u.inventory.find(s => s.itemId === itemId)?.quantity ?? 0), 0
+    );
+}
+
+beforeEach(() => {
+    mockFailCreditFor = null;
+    mockWrites = [];
+    mockStore = {
+        sender:    { userId: 'sender',    guildId: 'g1', balance: 0, inventory: [{ itemId: 'pet_food', quantity: 3 }], activeEffects: [] },
+        recipient: { userId: 'recipient', guildId: 'g1', balance: 0, inventory: [], activeEffects: [] },
+    };
+    jest.clearAllMocks();
+});
+
+test('a successful gift moves the item exactly once', async () => {
+    const { interaction } = buildInteraction({ quantity: 2 });
+    await giftCommand.execute(interaction);
+
+    expect(mockStore.sender.inventory).toEqual([{ itemId: 'pet_food', quantity: 1 }]);
+    expect(mockStore.recipient.inventory).toEqual([{ itemId: 'pet_food', quantity: 2 }]);
+    expect(mockTotalHeld('pet_food')).toBe(3); // conserved — nothing created or destroyed
+    expect(mockWrites).toEqual([
+        { user: 'sender',    itemId: 'pet_food', delta: -2 },
+        { user: 'recipient', itemId: 'pet_food', delta: 2 },
+    ]);
+});
+
+test('gifting the whole stack removes the empty slot', async () => {
+    const { interaction } = buildInteraction({ quantity: 3 });
+    await giftCommand.execute(interaction);
+
+    expect(mockStore.sender.inventory).toEqual([]);
+    expect(mockStore.recipient.inventory).toEqual([{ itemId: 'pet_food', quantity: 3 }]);
+    expect(mockTotalHeld('pet_food')).toBe(3);
+});
+
+test('the recipient credit is a delta, so a concurrent slot is not clobbered', async () => {
+    mockStore.recipient.inventory = [{ itemId: 'pet_food', quantity: 5 }];
+    const { interaction } = buildInteraction({ quantity: 2 });
+    await giftCommand.execute(interaction);
+
+    expect(mockStore.recipient.inventory).toEqual([{ itemId: 'pet_food', quantity: 7 }]);
+    expect(mockTotalHeld('pet_food')).toBe(8);
+});
+
+test('a failed credit rolls the debit back instead of duplicating the item', async () => {
+    mockFailCreditFor = 'recipient';
+    const { interaction, state } = buildInteraction({ quantity: 2 });
+    await giftCommand.execute(interaction);
+
+    expect(mockStore.recipient.inventory).toEqual([]);
+    expect(mockStore.sender.inventory).toEqual([{ itemId: 'pet_food', quantity: 3 }]);
+    expect(mockTotalHeld('pet_food')).toBe(3); // no duplication, no loss
+    expect(state.replies.at(-1).content).toContain('your item was returned');
+});
+
+test('a rolled-back gift of a whole stack restores the slot', async () => {
+    mockFailCreditFor = 'recipient';
+    const { interaction } = buildInteraction({ quantity: 3 });
+    await giftCommand.execute(interaction);
+
+    expect(mockStore.sender.inventory).toEqual([{ itemId: 'pet_food', quantity: 3 }]);
+    expect(mockTotalHeld('pet_food')).toBe(3);
+});
+
+test('gifting more than you hold moves nothing', async () => {
+    const { interaction, state } = buildInteraction({ quantity: 9 });
+    await giftCommand.execute(interaction);
+
+    expect(mockWrites).toEqual([]);
+    expect(mockStore.sender.inventory).toEqual([{ itemId: 'pet_food', quantity: 3 }]);
+    expect(mockStore.recipient.inventory).toEqual([]);
+    expect(state.replies.at(-1).content).toContain("don't have 9x");
+});

--- a/tests/petRenameRetry.test.js
+++ b/tests/petRenameRetry.test.js
@@ -15,6 +15,9 @@ function mockVersionError() {
     return err;
 }
 
+// Called before each save attempt, so a test can reorder the roster mid-retry.
+let mockBeforeSave;
+
 function mockBuildDoc(pets) {
     return {
         userId: 'u1',
@@ -24,7 +27,9 @@ function mockBuildDoc(pets) {
         markModified: jest.fn(),
         async save() {
             this.saves++;
-            if (this.saves <= mockSaveFails) throw mockVersionError();
+            const failing = this.saves <= mockSaveFails;
+            if (failing && mockBeforeSave) mockBeforeSave(this);
+            if (failing) throw mockVersionError();
         },
     };
 }
@@ -72,7 +77,8 @@ function buildInteraction(sub, slot) {
 beforeEach(() => {
     mockSaveFails = 0;
     mockLoads = 0;
-    mockDoc = mockBuildDoc([{ petId: 'dog', name: 'Buddy', slotRef: null }]);
+    mockBeforeSave = null;
+    mockDoc = mockBuildDoc([{ _id: 'pet_a', petId: 'dog', name: 'Buddy' }]);
     jest.clearAllMocks();
 });
 
@@ -111,4 +117,23 @@ test('renaming a slot that is not there reports no such pet, not a conflict', as
 
     expect(mockDoc.saves).toBe(0);
     expect(state.replies.at(-1).content).not.toContain('Edit conflict');
+});
+
+test('a roster reordered mid-retry still renames the pet the user picked', async () => {
+    // Slot refs are positional. If a concurrent write reorders the roster
+    // between attempts, replaying the raw slot ref would rename a different pet,
+    // so the first attempt pins the pet by its stable _id.
+    mockDoc = mockBuildDoc([
+        { _id: 'pet_a', petId: 'dog', name: 'Buddy' },
+        { _id: 'pet_b', petId: 'cat', name: 'Mittens' },
+    ]);
+    mockSaveFails = 1;
+    mockBeforeSave = (doc) => { doc.pets.reverse(); };  // Mittens is now slot 0
+
+    const { interaction } = buildInteraction('rename', '0');
+    await petCommand.execute(interaction);
+
+    const byId = Object.fromEntries(mockDoc.pets.map(p => [p._id, p.name]));
+    expect(byId.pet_a).toBe('Rex');       // the pet at slot 0 when the user asked
+    expect(byId.pet_b).toBe('Mittens');   // untouched
 });

--- a/tests/petRenameRetry.test.js
+++ b/tests/petRenameRetry.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+// /pet rename and /pet release are pure re-read → mutate → save units, so they
+// now replay through withVersionRetry instead of bouncing a version conflict
+// back to the user. These tests drive both through a User model whose save()
+// can be made to lose a version race.
+
+let mockDoc;        // the document resolveUser hands back
+let mockSaveFails;  // how many save() calls fail with a VersionError before one lands
+let mockLoads;      // how many times the command re-read the user
+
+function mockVersionError() {
+    const err = new Error('No matching document found for id "u1" version 1');
+    err.name = 'VersionError';
+    return err;
+}
+
+function mockBuildDoc(pets) {
+    return {
+        userId: 'u1',
+        guildId: 'g1',
+        pets,
+        saves: 0,
+        markModified: jest.fn(),
+        async save() {
+            this.saves++;
+            if (this.saves <= mockSaveFails) throw mockVersionError();
+        },
+    };
+}
+
+jest.mock('../src/models/User', () => {
+    const model = {
+        DECEASED_PET_LIMIT: 5,
+        findOneAndUpdate: jest.fn(async () => { mockLoads++; return mockDoc; }),
+        findOne: jest.fn(async () => mockDoc),
+        find: jest.fn(async () => []),
+        countDocuments: jest.fn(async () => 0),
+    };
+    return model;
+});
+
+jest.mock('../src/utils/grindProfile', () => ({ attachGrind: jest.fn(async (u) => u) }));
+jest.mock('../src/models/Guild', () => ({ findOne: jest.fn(async () => ({ guildId: 'g1' })) }));
+
+const petCommand = require('../src/commands/economy/pet.js');
+
+function buildInteraction(sub, slot) {
+    const state = { replies: [] };
+    return {
+        state,
+        interaction: {
+            guild: { id: 'g1' },
+            guildId: 'g1',
+            user: { id: 'u1', username: 'tester' },
+            member: {},
+            client: {},
+            options: {
+                getSubcommand: () => sub,
+                get: (name) => (name === 'slot' ? { value: slot } : null),
+                getString: (name) => (name === 'name' ? 'Rex' : null),
+            },
+            reply: jest.fn(async (p) => { state.replies.push(p); }),
+            editReply: jest.fn(async (p) => { state.replies.push(p); }),
+            followUp: jest.fn(async (p) => { state.replies.push(p); }),
+            replied: false,
+            deferred: false,
+        },
+    };
+}
+
+beforeEach(() => {
+    mockSaveFails = 0;
+    mockLoads = 0;
+    mockDoc = mockBuildDoc([{ petId: 'dog', name: 'Buddy', slotRef: null }]);
+    jest.clearAllMocks();
+});
+
+test('rename writes the new name', async () => {
+    const { interaction, state } = buildInteraction('rename', '0');
+    await petCommand.execute(interaction);
+
+    expect(mockDoc.pets[0].name).toBe('Rex');
+    expect(state.replies.at(-1).content).toContain('Rex');
+});
+
+test('rename replays after a lost version race instead of asking the user to retry', async () => {
+    mockSaveFails = 1;
+    const { interaction, state } = buildInteraction('rename', '0');
+    await petCommand.execute(interaction);
+
+    expect(mockLoads).toBe(2);          // re-read before the second attempt
+    expect(mockDoc.saves).toBe(2);
+    expect(mockDoc.pets[0].name).toBe('Rex');
+    expect(state.replies.at(-1).content).toContain('Rex');
+    expect(state.replies.at(-1).content).not.toContain('conflict');
+});
+
+test('rename reports a conflict once the retries are spent', async () => {
+    mockSaveFails = Infinity;
+    const { interaction, state } = buildInteraction('rename', '0');
+    await petCommand.execute(interaction);
+
+    expect(mockDoc.pets[0].name).toBe('Rex'); // local only — nothing persisted
+    expect(state.replies.at(-1).content).toContain('Edit conflict');
+});
+
+test('renaming a slot that is not there reports no such pet, not a conflict', async () => {
+    const { interaction, state } = buildInteraction('rename', '7');
+    await petCommand.execute(interaction);
+
+    expect(mockDoc.saves).toBe(0);
+    expect(state.replies.at(-1).content).not.toContain('Edit conflict');
+});

--- a/tests/robBalanceWrite.test.js
+++ b/tests/robBalanceWrite.test.js
@@ -37,6 +37,14 @@ function mockGuardsPass(doc, query) {
 }
 
 function mockApply(doc, update) {
+    // Aggregation-pipeline update: [{ $set: { field: { $max: [0, { $add: [...] }] } } }]
+    if (Array.isArray(update)) {
+        for (const [field, expr] of Object.entries(update[0].$set)) {
+            const delta = expr.$max[1].$add[1];
+            doc[field] = Math.max(0, (doc[field] ?? 0) + delta);
+        }
+        return;
+    }
     for (const [path, value] of Object.entries(update.$set ?? {})) {
         if (path.includes('.')) continue; // nested trap/effect paths are not asserted here
         doc[path] = value;
@@ -68,8 +76,11 @@ jest.mock('../src/models/User', () => ({
     }),
     updateOne: jest.fn(async (query, update = {}) => {
         const doc = mockFindDoc(query);
-        if (doc) { mockUpdates.push({ userId: doc.userId, query, update }); mockApply(doc, update); }
-        return {};
+        if (Object.keys(update).length && mockBeforeWrite) mockBeforeWrite(query, update);
+        if (!doc || !mockGuardsPass(doc, query)) return { matchedCount: 0 };
+        mockUpdates.push({ userId: doc.userId, query, update });
+        mockApply(doc, update);
+        return { matchedCount: 1 };
     }),
 }));
 
@@ -182,4 +193,67 @@ test('the victim write stays a delta too', async () => {
     const victimWrite = mockUpdates.find(u => u.userId === 'victim' && u.update.$inc);
     expect(victimWrite.update.$set).not.toHaveProperty('balance');
     expect(victimWrite.update.$inc.balance).toBeLessThan(0);
+});
+
+describe('rollback when the victim write fails', () => {
+    // Force the victim update to find nothing, which is what drives the compensator.
+    function blockVictimWrite() {
+        mockBeforeWrite = (query) => {
+            if (query.userId === 'victim') mockStore.victim.lastRobbedAt = new Date();
+        };
+    }
+
+    test('the reversal is clamped so spending mid-heist cannot go negative', async () => {
+        // Success path: the robber is credited, so the reversal is a debit. If the
+        // robber spends the haul before the compensator runs, a raw $inc of
+        // -stolen would leave a negative balance.
+        blockVictimWrite();
+        const priorHook = mockBeforeWrite;
+        mockBeforeWrite = (query, update) => {
+            priorHook(query, update);
+            // The clamped reversal is a pipeline update — drain right before it.
+            if (Array.isArray(update) && query.userId === 'robber') {
+                mockStore.robber.balance = 0;
+            }
+        };
+
+        const { interaction } = buildInteraction();
+        await robCommand.execute(interaction).catch(() => {});
+
+        expect(mockStore.robber.balance).toBe(0);
+        expect(mockStore.robber.balance).toBeGreaterThanOrEqual(0);
+    });
+
+    test('the cooldown slot is only handed back while it is still ours', async () => {
+        blockVictimWrite();
+        const { interaction } = buildInteraction();
+        await robCommand.execute(interaction).catch(() => {});
+
+        const restore = mockUpdates.find(u => u.update.$set && 'lastRob' in u.update.$set && u.userId === 'robber' && u.query.lastRob !== undefined);
+        expect(restore).toBeTruthy();
+        // The restore is conditional on the value this attempt wrote.
+        expect(restore.query.lastRob).toBeInstanceOf(Date);
+        expect(mockStore.robber.lastRob).toBeNull(); // handed back
+    });
+
+    test('a rob that started after ours keeps its cooldown', async () => {
+        blockVictimWrite();
+        const { interaction } = buildInteraction();
+        const foreign = new Date(Date.now() + 5_000);
+        const origBefore = mockStore.robber.balance;
+
+        // Another rob wins the slot after our write but before the compensator.
+        const priorHook = mockBeforeWrite;
+        mockBeforeWrite = (query, update) => {
+            priorHook(query, update);
+            if (query.userId === 'robber' && update.$set && 'lastRob' in update.$set && query.lastRob !== undefined) {
+                mockStore.robber.lastRob = foreign;
+            }
+        };
+
+        await robCommand.execute(interaction).catch(() => {});
+
+        expect(mockStore.robber.lastRob).toBe(foreign);   // not stomped
+        expect(mockStore.robber.balance).toBe(origBefore); // balance still reversed
+    });
 });

--- a/tests/robBalanceWrite.test.js
+++ b/tests/robBalanceWrite.test.js
@@ -1,0 +1,185 @@
+'use strict';
+
+// /rob used to write the robber's balance as an absolute $set guarded only by a
+// lastRob compare-and-set — so any credit landing between the read and the write
+// was silently erased. The victim side of the same function already used deltas.
+// These tests assert both sides now write deltas.
+
+let mockStore;   // userId -> document
+let mockUpdates; // ordered log of { userId, query, update }
+let mockBeforeWrite; // optional hook: fires just before an update is applied
+
+function mockFindDoc(query) {
+    const doc = mockStore[query.userId];
+    return doc && doc.guildId === query.guildId ? doc : null;
+}
+
+// Only the guard shapes rob.js builds.
+function mockGuardsPass(doc, query) {
+    if (query.lastRob !== undefined && String(doc.lastRob ?? '') !== String(query.lastRob ?? '')) return false;
+    if (query.balance?.$gte !== undefined && (doc.balance ?? 0) < query.balance.$gte) return false;
+    if (query.bank?.$gte !== undefined && (doc.bank ?? 0) < query.bank.$gte) return false;
+    const trapAfter = query['trap.expiresAt']?.$gt;
+    if (trapAfter !== undefined && !(doc.trap?.expiresAt && new Date(doc.trap.expiresAt) > trapAfter)) return false;
+    if (query.$or) {
+        const ok = query.$or.some((clause) => {
+            if ('lastRob' in clause) return clause.lastRob === null ? (doc.lastRob ?? null) === null : true;
+            if ('lastRobbedAt' in clause) {
+                if (clause.lastRobbedAt === null) return (doc.lastRobbedAt ?? null) === null;
+                const before = clause.lastRobbedAt.$lte;
+                return doc.lastRobbedAt && new Date(doc.lastRobbedAt) <= before;
+            }
+            return true;
+        });
+        if (!ok) return false;
+    }
+    return true;
+}
+
+function mockApply(doc, update) {
+    for (const [path, value] of Object.entries(update.$set ?? {})) {
+        if (path.includes('.')) continue; // nested trap/effect paths are not asserted here
+        doc[path] = value;
+    }
+    for (const [path, delta] of Object.entries(update.$inc ?? {})) {
+        doc[path] = (doc[path] ?? 0) + delta;
+    }
+}
+
+jest.mock('../src/models/User', () => ({
+    findOne: jest.fn((query) => {
+        const doc = mockFindDoc(query);
+        const copy = doc ? { ...doc } : null;
+        return { lean: async () => copy, then: (res, rej) => Promise.resolve(copy).then(res, rej) };
+    }),
+    findOneAndUpdate: jest.fn(async (query, update = {}, options = {}) => {
+        let doc = mockFindDoc(query);
+        if (!doc && options.upsert) {
+            doc = { userId: query.userId, guildId: query.guildId, balance: 0, bank: 0, inventory: [], activeEffects: [], pets: [] };
+            mockStore[query.userId] = doc;
+        }
+        if (Object.keys(update).length && mockBeforeWrite) mockBeforeWrite(query, update);
+        if (!doc || !mockGuardsPass(doc, query)) return null;
+        if (Object.keys(update).length) {
+            mockUpdates.push({ userId: doc.userId, query, update });
+            mockApply(doc, update);
+        }
+        return { ...doc };
+    }),
+    updateOne: jest.fn(async (query, update = {}) => {
+        const doc = mockFindDoc(query);
+        if (doc) { mockUpdates.push({ userId: doc.userId, query, update }); mockApply(doc, update); }
+        return {};
+    }),
+}));
+
+jest.mock('../src/models/Guild', () => ({
+    findOne: jest.fn(async () => ({ guildId: 'g1', economy: { currency: '💰', enabled: true, robEnabled: true, robMinWallet: 100, robFailFineRate: 0.2 } })),
+}));
+
+jest.mock('../src/services/effectsService', () => ({
+    hasEffect: jest.fn(() => false),
+    consumeEffect: jest.fn(),
+    timeRemaining: jest.fn(() => '0m'),
+}));
+
+jest.mock('../src/services/achievementService', () => ({
+    checkAndAward: jest.fn(async () => []),
+    announceAchievements: jest.fn(),
+}));
+
+jest.mock('../src/services/petService', () => ({ getTotalBonus: jest.fn(() => 0) }));
+jest.mock('../src/utils/delay', () => ({ delay: jest.fn(async () => {}) }));
+
+const robCommand = require('../src/commands/economy/rob.js');
+
+const OLD_ACCOUNT = Date.now() - 365 * 24 * 60 * 60 * 1000;
+
+function buildInteraction() {
+    const state = { replies: [], editReplies: [] };
+    const interaction = {
+        guild: { id: 'g1' },
+        guildId: 'g1',
+        user: { id: 'robber', username: 'robber', createdTimestamp: OLD_ACCOUNT },
+        member: {},
+        client: {},
+        options: { getUser: () => ({ id: 'victim', username: 'victim', bot: false, createdTimestamp: OLD_ACCOUNT }) },
+        reply: jest.fn(async (p) => { state.replies.push(p); }),
+        editReply: jest.fn(async (p) => { state.editReplies.push(p); }),
+        replied: false,
+        deferred: false,
+    };
+    return { interaction, state };
+}
+
+function robberWrite() {
+    return mockUpdates.find(u => u.userId === 'robber');
+}
+
+beforeEach(() => {
+    mockUpdates = [];
+    mockBeforeWrite = null;
+    mockStore = {
+        robber: { userId: 'robber', guildId: 'g1', balance: 1000, bank: 0, lastRob: null, successfulRobs: 0, failedRobs: 0, inventory: [], activeEffects: [], pets: [] },
+        victim: { userId: 'victim', guildId: 'g1', balance: 5000, bank: 0, lastRobbedAt: null, inventory: [], activeEffects: [], pets: [] },
+    };
+    jest.clearAllMocks();
+    jest.spyOn(Math, 'random').mockReturnValue(0.2); // < 0.40 success chance, min steal roll
+});
+
+afterEach(() => { Math.random.mockRestore(); });
+
+test('a successful rob credits the robber with $inc, never an absolute $set', async () => {
+    const { interaction } = buildInteraction();
+    await robCommand.execute(interaction);
+
+    const write = robberWrite();
+    expect(write).toBeTruthy();
+    expect(write.update.$set).not.toHaveProperty('balance');
+    expect(write.update.$inc.balance).toBeGreaterThan(0);
+    expect(write.update.$inc.successfulRobs).toBe(1);
+    expect(write.update.$set.lastRob).toBeInstanceOf(Date);
+});
+
+test("a credit landing mid-heist survives the robber's write", async () => {
+    // A payout lands after the command read the robber but before it commits.
+    const original = mockStore.robber.balance;
+    let injected = false;
+    mockBeforeWrite = (query, update) => {
+        if (!injected && query.userId === 'robber' && update.$inc?.balance !== undefined) {
+            injected = true;
+            mockStore.robber.balance += 750;
+        }
+    };
+
+    const { interaction } = buildInteraction();
+    await robCommand.execute(interaction);
+
+    expect(injected).toBe(true);
+    const stolen = robberWrite().update.$inc.balance;
+    // The delta write preserves the concurrent credit; an absolute $set of the
+    // stale (read + stolen) value would have thrown the 750 away.
+    expect(mockStore.robber.balance).toBe(original + 750 + stolen);
+});
+
+test('a failed rob debits the robber with a guarded $inc', async () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.99); // above the 0.40 success chance
+    const { interaction } = buildInteraction();
+    await robCommand.execute(interaction);
+
+    const write = robberWrite();
+    expect(write.update.$set).not.toHaveProperty('balance');
+    expect(write.update.$inc.balance).toBeLessThan(0);
+    expect(write.update.$inc.failedRobs).toBe(1);
+    // The lastRob CAS says nothing about balance, so the debit carries its own guard.
+    expect(write.query.balance.$gte).toBe(-write.update.$inc.balance);
+});
+
+test('the victim write stays a delta too', async () => {
+    const { interaction } = buildInteraction();
+    await robCommand.execute(interaction);
+
+    const victimWrite = mockUpdates.find(u => u.userId === 'victim' && u.update.$inc);
+    expect(victimWrite.update.$set).not.toHaveProperty('balance');
+    expect(victimWrite.update.$inc.balance).toBeLessThan(0);
+});

--- a/tests/versionRetry.test.js
+++ b/tests/versionRetry.test.js
@@ -1,0 +1,99 @@
+const { isVersionError, withVersionRetry } = require('../src/utils/versionRetry');
+
+function versionError() {
+    const err = new Error('No matching document found for id "x" version 3');
+    err.name = 'VersionError';
+    return err;
+}
+
+// Minimal stand-in for a Mongoose document: save() fails with a VersionError for
+// the first `failures` calls, then succeeds.
+function fakeDoc(failures = 0) {
+    const doc = {
+        value: 0,
+        saves: 0,
+        async save() {
+            doc.saves++;
+            if (doc.saves <= failures) throw versionError();
+        },
+    };
+    return doc;
+}
+
+describe('isVersionError', () => {
+    it('recognises a Mongoose VersionError', () => {
+        expect(isVersionError(versionError())).toBe(true);
+    });
+
+    it('rejects anything else, including null', () => {
+        expect(isVersionError(new Error('boom'))).toBe(false);
+        expect(isVersionError(null)).toBe(false);
+        expect(isVersionError(undefined)).toBe(false);
+    });
+});
+
+describe('withVersionRetry', () => {
+    it('saves once when there is no conflict', async () => {
+        const doc = fakeDoc(0);
+        const saved = await withVersionRetry(() => doc, d => { d.value = 1; });
+        expect(saved).toBe(doc);
+        expect(doc.saves).toBe(1);
+        expect(doc.value).toBe(1);
+    });
+
+    it('re-reads and re-applies the mutation on a lost version race', async () => {
+        const docs = [fakeDoc(1), fakeDoc(0)];
+        let loads = 0;
+        const saved = await withVersionRetry(
+            () => docs[loads++],
+            d => { d.value = 42; },
+            { backoffMs: 0 }
+        );
+        expect(loads).toBe(2);
+        expect(saved).toBe(docs[1]);      // the fresh read is what got saved
+        expect(docs[1].value).toBe(42);   // and the mutation was re-applied to it
+    });
+
+    it('throws the last VersionError once the attempts are spent', async () => {
+        const doc = fakeDoc(Infinity);
+        await expect(
+            withVersionRetry(() => doc, () => {}, { attempts: 3, backoffMs: 0 })
+        ).rejects.toMatchObject({ name: 'VersionError' });
+        expect(doc.saves).toBe(3);
+    });
+
+    it('rethrows non-version errors immediately without retrying', async () => {
+        const doc = {
+            saves: 0,
+            async save() { this.saves++; throw new Error('connection reset'); },
+        };
+        await expect(
+            withVersionRetry(() => doc, () => {}, { backoffMs: 0 })
+        ).rejects.toThrow('connection reset');
+        expect(doc.saves).toBe(1);
+    });
+
+    it('returns null without saving when the loader finds nothing', async () => {
+        const mutate = jest.fn();
+        expect(await withVersionRetry(() => null, mutate)).toBeNull();
+        expect(mutate).not.toHaveBeenCalled();
+    });
+
+    it('returns null without saving when the mutation aborts', async () => {
+        const doc = fakeDoc(0);
+        expect(await withVersionRetry(() => doc, () => false)).toBeNull();
+        expect(doc.saves).toBe(0);
+    });
+
+    it('passes the attempt number to the mutation', async () => {
+        const docs = [fakeDoc(1), fakeDoc(0)];
+        let loads = 0;
+        const attempts = [];
+        await withVersionRetry(
+            () => docs[loads++],
+            (_doc, attempt) => { attempts.push(attempt); },
+            { backoffMs: 0 }
+        );
+        expect(attempts).toEqual([1, 2]);
+    });
+});


### PR DESCRIPTION
## Summary

This PR fixes three critical concurrency bugs where database writes could lose data or duplicate items when operations raced against each other. The fixes introduce atomic write patterns, delta-based updates, and a retry mechanism for optimistic concurrency conflicts.

## Key Changes

**Gift command (`src/commands/economy/gift.js`)**
- Replaced parallel `Promise.all([sender.save(), recipient.save()])` with sequential atomic writes
- Sender is debited first using `findOneAndUpdate` with `$elemMatch` guard to ensure the item exists with sufficient quantity
- Recipient is credited using a new `addInventoryItem()` helper that atomically bumps existing slots or pushes new ones, preventing duplicate slots from concurrent credits
- If recipient credit fails, sender debit is rolled back by re-crediting the sender
- Empty inventory slots are cleaned up after debit

**Rob command (`src/commands/economy/rob.js`)**
- Changed robber's balance write from absolute `$set` to delta-based `$inc`
- Added balance guard (`balance.$gte`) to prevent debits when balance has changed
- Robber's success/failed counters now use `$inc` instead of `$set`
- Victim's balance write already used deltas; now robber side matches this pattern
- Distinguishes between lastRob CAS failure (duplicate rob) and balance change (concurrent credit) in error handling

**Pet command (`src/commands/economy/pet.js`)**
- Integrated new `withVersionRetry()` helper for `rename` and `release` subcommands
- These operations are pure functions of the freshly-read document, so lost version races can be replayed instead of bouncing back to the user
- Replaced ad-hoc `err.name === 'VersionError'` checks with `isVersionError()` helper throughout

**New utilities**
- `src/utils/versionRetry.js`: Provides `isVersionError()` and `withVersionRetry()` for handling optimistic concurrency conflicts
  - `isVersionError()` detects Mongoose VersionError
  - `withVersionRetry()` re-reads, re-applies mutation, and retries save on version conflicts (up to 3 attempts by default)
  - Only suitable for mutations that are pure functions of the loaded document
- `src/dashboard/public/esc-html.js`: Centralized HTML escaper for dashboard views
  - Escapes `&<>"'` `` to prevent both attribute breakout and inline handler injection
  - Replaces three scattered copies in `guild-settings.ejs`

**Dashboard security (`src/dashboard/views/guild-settings.ejs`)**
- Removed three duplicate `escHtml()` function definitions
- Imported shared `esc-html.js` script
- Refactored inline event handlers to use delegated `click` listener with `data-*` attributes
- Prevents XSS via attacker-controlled values (member nicknames, achievement names, MCP server names) that were previously concatenated into `onclick=""` attributes

**User model documentation (`src/models/User.js`)**
- Added clarifying comment on optimistic concurrency: `__v` is only bumped on `save()`, not on `findOneAndUpdate`/`updateOne`/`$inc`, so version guards only protect save-vs-save races

## Notable Implementation Details

- The gift command's `addInventoryItem()` helper uses a three-step pattern: try to bump existing slot, try to push new slot with guard against concurrent creation, then bump if the guard lost
- Rob command's balance guard is only applied on debit (`robberBalDelta < 0`), allowing credits to land freely
- Version retry mechanism includes exponential backoff (25ms × attempt number) to reduce thundering herd on conflicts
- Dashboard refactoring uses `dataset` to pass untrusted values, preventing HTML-decode-then-JS-parse attacks on inline handlers

## Tests Added

- `tests/giftItemTransfer.test.js`: 6 tests covering successful transfer, stack removal, concurrent slot handling, rollback on credit failure, and validation
- `tests/robBalanceWrite.test.js`: 4 tests verifying delta writes, concurrent credit survival, failed rob debit, and

https://claude.ai/code/session_01Q4yVtKyQ4sySh2CEuhCedz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for exploration, fishing, hunting, mining, pet, season, gifting, and robbery actions during simultaneous updates.
  * Item gifts now transfer quantities safely, prevent duplication or loss, and correctly restore items when a transfer fails.
  * Robbery outcomes now preserve concurrent balance changes and clearly report conflicting balance updates.
  * Pet renaming and releasing recover more reliably from temporary save conflicts.

* **Security**
  * Strengthened dashboard HTML escaping and removed unsafe inline action handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->