### PR TITLE
Redesign /8ball with persistent buttons and image rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,9 +203,9 @@ npm start
 - `/newspaper preview` - Preview the AI-written server newspaper (Manage Server)
 
 ### Fun
-- `/8ball` - Ask the magic 8-ball
-- `/roll` - Roll a dice
-- `/coinflip` - Flip a coin
+- `/8ball` - Ask the magic 8-ball a yes/no question, then shake again or ask another from the reply
+- `/roll` - Roll a die (`sides`, 2-100), optionally wagering a `bet` on a `guess` of high/low or an exact `number`
+- `/coinflip` - Flip a coin: call your `side`, wager a `bet` against the house, or stake one against an `opponent`
 - `/meme` - Generate a meme (requires Imgflip credentials)
 - `/caption` - Add a caption to an image
 - `/wanted` / `/wasted` - Image filter commands

--- a/src/commands/fun/8ball.js
+++ b/src/commands/fun/8ball.js
@@ -6,7 +6,6 @@ const {
     ActionRowBuilder,
     ButtonBuilder,
     ButtonStyle,
-    ComponentType,
     MessageFlags,
     ModalBuilder,
     TextInputBuilder,
@@ -14,19 +13,14 @@ const {
     escapeMarkdown,
 } = require('discord.js');
 const { delay } = require('../../utils/delay');
+const { createReplaySession } = require('../../utils/replaySession');
 
 const THUMB = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3b1.png';
 
 const MAX_QUESTION   = 200;
 const SHAKE_FRAME_MS = 260;
 
-// A session survives repeated shakes, but an interaction token dies 15 minutes
-// after the command was invoked — every follow-up here is an editReply on that
-// token. Cap the collector below that so the buttons come off while they still
-// can, instead of failing on the edit that was meant to clear them.
-const SESSION_IDLE_MS = 60_000;
-const SESSION_MAX_MS  = 13 * 60_000;
-const MODAL_WAIT_MS   = 120_000;
+const MODAL_WAIT_MS = 120_000;
 
 // The ball sloshing to the window before it settles.
 const SHAKE_FRAMES = [
@@ -187,22 +181,19 @@ module.exports = {
     __test__: { RESPONSES, TYPE_CONFIG, pickResponse, normalizeQuestion, quoteQuestion, MAX_QUESTION },
 };
 
-// One message, one collector, for as long as the owner keeps shaking. The
-// alternative — a fresh max:1 collector per shake — left a window on the
-// "New Question" path where the buttons were still on screen with nothing
-// listening, so a second click died as "This interaction failed".
+// One message, one session, for as long as the owner keeps shaking. The
+// collector boilerplate — owner check, overlap guard, timers, error handling —
+// lives in utils/replaySession, shared with /coinflip and /roll.
 async function runSession(interaction, firstQuestion) {
     const ids = {
         again: `8ball_again_${interaction.id}`,
         newq:  `8ball_newq_${interaction.id}`,
     };
 
-    const deadline = Date.now() + SESSION_MAX_MS;
-    let question   = firstQuestion;
-    let shakes     = 0;
-    let modalSeq   = 0;
-    let busy       = false;
-    let collector  = null;
+    let question = firstQuestion;
+    let shakes   = 0;
+    let modalSeq = 0;
+    let session  = null;
 
     async function shake() {
         shakes += 1;
@@ -220,47 +211,36 @@ async function runSession(interaction, firstQuestion) {
 
         return interaction.editReply({
             embeds:     [resultEmbed(interaction, question, pickResponse(), shakes)],
-            components: collector?.ended ? [] : [buttonRow(ids)],
+            components: session?.ended ? [] : [buttonRow(ids)],
         });
     }
 
     const message = await shake();
 
-    collector = message.createMessageComponentCollector({
-        componentType: ComponentType.Button,
-        filter: i => i.customId === ids.again || i.customId === ids.newq,
-        idle:   SESSION_IDLE_MS,
-        time:   SESSION_MAX_MS,
-    });
+    session = createReplaySession({
+        interaction,
+        message,
+        customIds: [ids.again, ids.newq],
+        label:     '8ball',
+        claim:     `That 8-ball is ${interaction.user}'s — run \`/8ball\` to ask your own.`,
 
-    collector.on('collect', async i => {
-        try {
-            // Rejecting these in the collector filter instead would show every
-            // other member a bare "This interaction failed".
-            if (i.user.id !== interaction.user.id) {
-                return await i.reply({
-                    content: `That 8-ball is ${interaction.user}'s — run \`/8ball\` to ask your own.`,
-                    flags:   MessageFlags.Ephemeral,
-                });
-            }
-
-            if (busy) return await i.deferUpdate().catch(() => {});
-
-            if (i.customId === ids.again) {
-                busy = true;
-                await i.deferUpdate();
+        async onCollect(button, ctl) {
+            if (button.customId === ids.again) {
+                await button.deferUpdate();
                 await shake();
                 return;
             }
 
-            // New question — collected through a modal. The buttons stay live
-            // while it's open, so dismissing the modal doesn't strand the message.
+            // New question — collected through a modal. The member has to
+            // dismiss the modal before they can reach the buttons again, so
+            // hold nothing while it's open.
             const modalId = `8ball_modal_${interaction.id}_${++modalSeq}`;
-            await i.showModal(questionModal(modalId));
+            await button.showModal(questionModal(modalId));
+            ctl.release();
 
-            const submitted = await i.awaitModalSubmit({
+            const submitted = await button.awaitModalSubmit({
                 // Matching the custom id matters: a filter on the user alone
-                // would swallow a modal this user submitted for another command.
+                // would swallow a modal they submitted for another command.
                 filter: mi => mi.customId === modalId && mi.user.id === interaction.user.id,
                 time:   MODAL_WAIT_MS,
             }).catch(() => null);
@@ -275,28 +255,15 @@ async function runSession(interaction, firstQuestion) {
                 });
             }
 
-            busy = true;
+            // A shake may have started while the modal was open.
+            if (!ctl.hold()) return await submitted.deferUpdate().catch(() => {});
+
             await submitted.deferUpdate();
             question = next;
             // Typing into a modal isn't a collected interaction, so the idle
-            // timer has been running the whole time. Restart it — but against
-            // the original deadline, never past the interaction token's life.
-            if (!collector.ended) {
-                collector.resetTimer({ idle: SESSION_IDLE_MS, time: Math.max(1_000, deadline - Date.now()) });
-            }
+            // timer has been running the whole time.
+            ctl.extend();
             await shake();
-        } catch (error) {
-            // Nothing above is awaited by execute(), so an unhandled rejection
-            // here would surface as a process-level warning instead of a log.
-            console.error('[8ball] component handler error:', error);
-        } finally {
-            busy = false;
-        }
-    });
-
-    collector.on('end', () => {
-        // A render in flight sets the final components itself (see shake()).
-        if (busy) return;
-        interaction.editReply({ components: [] }).catch(() => {});
+        },
     });
 }

--- a/src/commands/fun/8ball.js
+++ b/src/commands/fun/8ball.js
@@ -10,12 +10,14 @@ const {
     ModalBuilder,
     TextInputBuilder,
     TextInputStyle,
+    AttachmentBuilder,
     escapeMarkdown,
 } = require('discord.js');
 const { delay } = require('../../utils/delay');
+const { renderEightBall } = require('../../utils/eightBallImage');
 const { BoundedRateLimiter } = require('../../utils/boundedRateLimiter');
 
-const THUMB = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3b1.png';
+const BALL_FILE = '8ball.png';
 
 const MAX_QUESTION   = 200;
 const SHAKE_FRAME_MS = 260;
@@ -144,7 +146,7 @@ function embedAuthor(interaction) {
 }
 
 function baseEmbed(author) {
-    const embed = new EmbedBuilder().setThumbnail(THUMB).setTitle('🎱 Magic 8-Ball');
+    const embed = new EmbedBuilder().setTitle('🎱 Magic 8-Ball');
     return author ? embed.setAuthor(author) : embed;
 }
 
@@ -161,6 +163,7 @@ function resultEmbed(author, quoted, response, shakes) {
     return baseEmbed(author)
         .setColor(color)
         .setDescription(quoted)
+        .setImage(`attachment://${BALL_FILE}`)
         .addFields(
             { name: `${emoji} The 8-Ball Says`, value: `**${response.text}**`, inline: false },
             { name: '🔮 Outlook',               value: outlook,               inline: true  },
@@ -210,15 +213,26 @@ async function shake(responder, { author, quoted, shakes, ownerId }) {
     // one of these edits shouldn't cost the user their answer.
     for (let f = 0; f < SHAKE_FRAMES.length; f++) {
         await responder.editReply({
-            embeds:     [shakingEmbed(author, quoted, f)],
-            components: [],
+            embeds:      [shakingEmbed(author, quoted, f)],
+            components:  [],
+            // Drop the previous answer's render for the duration of the shake —
+            // the ball is being shaken, it shouldn't still be showing a verdict.
+            files:       [],
+            attachments: [],
         }).catch(() => {});
         await delay(SHAKE_FRAME_MS);
     }
 
+    const response = pickResponse();
+    const ball = new AttachmentBuilder(renderEightBall(response.text, response.type), { name: BALL_FILE });
+
     return responder.editReply({
-        embeds:     [resultEmbed(author, quoted, pickResponse(), shakes)],
-        components: [buttonRow(ownerId)],
+        embeds:      [resultEmbed(author, quoted, response, shakes)],
+        components:  [buttonRow(ownerId)],
+        files:       [ball],
+        // Clears the attachment the last shake left behind; without it Discord
+        // keeps both and the message grows an image per click.
+        attachments: [],
     });
 }
 
@@ -343,7 +357,7 @@ module.exports = {
 
     __test__: {
         RESPONSES, TYPE_CONFIG, MAX_QUESTION, SHAKE_LIMIT, SHAKE_WINDOW_MS,
-        pickResponse, normalizeQuestion, quoteQuestion, readState, ownerOf,
+        pickResponse, normalizeQuestion, quoteQuestion, readState, ownerOf, BALL_FILE,
         isEightBallButton, isEightBallModal, buttonRow, resultEmbed,
         handleButton, handleModal, shaking, shakeLimiter,
     },

--- a/src/commands/fun/8ball.js
+++ b/src/commands/fun/8ball.js
@@ -13,14 +13,18 @@ const {
     escapeMarkdown,
 } = require('discord.js');
 const { delay } = require('../../utils/delay');
-const { createReplaySession } = require('../../utils/replaySession');
+const { BoundedRateLimiter } = require('../../utils/boundedRateLimiter');
 
 const THUMB = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3b1.png';
 
 const MAX_QUESTION   = 200;
 const SHAKE_FRAME_MS = 260;
 
-const MODAL_WAIT_MS = 120_000;
+// The buttons outlive the command that created them, so shaking is bounded per
+// user rather than per message: a year-old 8-ball is still a live button.
+const SHAKE_WINDOW_MS = 60_000;
+const SHAKE_LIMIT     = 12;
+const shakeLimiter    = new BoundedRateLimiter(5_000);
 
 // The ball sloshing to the window before it settles.
 const SHAKE_FRAMES = [
@@ -75,6 +79,26 @@ const TYPE_CONFIG = {
     negative: { color: '#e74c3c', emoji: '❌', outlook: 'Negative'  },
 };
 
+// ── Custom IDs ───────────────────────────────────────────────────────────────
+//
+// These are routed centrally in events/interactionCreate rather than held by a
+// collector, so they keep working across restarts and for as long as the
+// message exists. That means no closure state: everything a click needs is
+// either in the id or readable back off the message.
+
+const AGAIN_PREFIX = '8ball_again_';
+const NEWQ_PREFIX  = '8ball_newq_';
+const MODAL_PREFIX = '8ball_modal_';
+const QUESTION_INPUT = 'question_input';
+
+const isEightBallButton = customId =>
+    customId.startsWith(AGAIN_PREFIX) || customId.startsWith(NEWQ_PREFIX);
+const isEightBallModal = customId => customId.startsWith(MODAL_PREFIX);
+
+const ownerOf = customId => customId.slice(customId.lastIndexOf('_') + 1);
+
+// ── Question handling ────────────────────────────────────────────────────────
+
 // Questions land inside a single-line block quote. Collapsing whitespace keeps
 // a pasted newline from ending the quote early, and the length cap is applied
 // here as well as on the option/modal because neither covers the other's path.
@@ -82,10 +106,35 @@ function normalizeQuestion(raw) {
     return String(raw ?? '').replace(/\s+/g, ' ').trim().slice(0, MAX_QUESTION);
 }
 
-// Escaped, so a question full of asterisks or backticks can't reformat the embed.
+// Escaped, so a question full of asterisks or backticks can't reformat the
+// message. The escaped form is what gets carried forward from one shake to the
+// next — re-escaping an already-escaped question would pile up backslashes.
 function quoteQuestion(question) {
     return `> *"${escapeMarkdown(question)}"*`;
 }
+
+// ── Reading a shake's context back off the message ───────────────────────────
+
+const SHAKES_FIELD = '🌀 Shakes';
+
+function readState(message) {
+    const embed = message?.embeds?.[0];
+    const shakesRaw = embed?.fields?.find(f => f.name === SHAKES_FIELD)?.value ?? '';
+    const shakes = Number.parseInt(shakesRaw.replace(/\D/g, ''), 10);
+
+    return {
+        // Already escaped when it was written; reused verbatim.
+        quoted: embed?.description ?? '> *"…"*',
+        shakes: Number.isFinite(shakes) && shakes > 0 ? shakes : 0,
+        // discord.js's Embed exposes iconURL; the raw gateway payload it is built
+        // from spells the same field icon_url. Read either.
+        author: embed?.author
+            ? { name: embed.author.name, iconURL: embed.author.iconURL ?? embed.author.icon_url }
+            : null,
+    };
+}
+
+// ── Rendering ────────────────────────────────────────────────────────────────
 
 function embedAuthor(interaction) {
     return {
@@ -94,58 +143,56 @@ function embedAuthor(interaction) {
     };
 }
 
-function baseEmbed(interaction) {
-    return new EmbedBuilder()
-        .setAuthor(embedAuthor(interaction))
-        .setThumbnail(THUMB)
-        .setTitle('🎱 Magic 8-Ball');
+function baseEmbed(author) {
+    const embed = new EmbedBuilder().setThumbnail(THUMB).setTitle('🎱 Magic 8-Ball');
+    return author ? embed.setAuthor(author) : embed;
 }
 
-function shakingEmbed(interaction, question, frame) {
-    return baseEmbed(interaction)
+function shakingEmbed(author, quoted, frame) {
+    return baseEmbed(author)
         .setColor('#5865F2')
-        .setDescription(`${SHAKE_FRAMES[frame % SHAKE_FRAMES.length]}\n\n${quoteQuestion(question)}`)
+        .setDescription(`${SHAKE_FRAMES[frame % SHAKE_FRAMES.length]}\n\n${quoted}`)
         .setFooter({ text: 'Shaking…' });
 }
 
-function resultEmbed(interaction, question, response, shakes) {
+function resultEmbed(author, quoted, response, shakes) {
     const { color, emoji, outlook } = TYPE_CONFIG[response.type];
 
-    return baseEmbed(interaction)
+    return baseEmbed(author)
         .setColor(color)
-        .setDescription(quoteQuestion(question))
+        .setDescription(quoted)
         .addFields(
             { name: `${emoji} The 8-Ball Says`, value: `**${response.text}**`, inline: false },
             { name: '🔮 Outlook',               value: outlook,               inline: true  },
-            { name: '🌀 Shakes',                value: `**${shakes}**`,       inline: true  },
+            { name: SHAKES_FIELD,               value: `**${shakes}**`,       inline: true  },
         )
         .setFooter({ text: 'Shake again for a new answer — or ask it something else' })
         .setTimestamp();
 }
 
-function buttonRow(ids) {
+function buttonRow(ownerId) {
     return new ActionRowBuilder().addComponents(
         new ButtonBuilder()
-            .setCustomId(ids.again)
+            .setCustomId(`${AGAIN_PREFIX}${ownerId}`)
             .setEmoji('🎱')
             .setLabel('Shake Again')
             .setStyle(ButtonStyle.Secondary),
         new ButtonBuilder()
-            .setCustomId(ids.newq)
+            .setCustomId(`${NEWQ_PREFIX}${ownerId}`)
             .setEmoji('❓')
             .setLabel('New Question')
             .setStyle(ButtonStyle.Primary),
     );
 }
 
-function questionModal(customId) {
+function questionModal(ownerId) {
     return new ModalBuilder()
-        .setCustomId(customId)
+        .setCustomId(`${MODAL_PREFIX}${ownerId}`)
         .setTitle('🎱 Ask the Magic 8-Ball')
         .addComponents(
             new ActionRowBuilder().addComponents(
                 new TextInputBuilder()
-                    .setCustomId('question_input')
+                    .setCustomId(QUESTION_INPUT)
                     .setLabel('Your yes/no question')
                     .setStyle(TextInputStyle.Short)
                     .setPlaceholder('Will I win the lottery?')
@@ -153,6 +200,111 @@ function questionModal(customId) {
                     .setMaxLength(MAX_QUESTION),
             ),
         );
+}
+
+// Shake, then settle on an answer. `responder` is whichever interaction is
+// driving this edit — the slash command, a button, or a modal submission.
+async function shake(responder, { author, quoted, shakes, ownerId }) {
+    // Animation frames are cosmetic, and dropping the buttons for their
+    // duration is what stops a click landing mid-shake. A transient failure on
+    // one of these edits shouldn't cost the user their answer.
+    for (let f = 0; f < SHAKE_FRAMES.length; f++) {
+        await responder.editReply({
+            embeds:     [shakingEmbed(author, quoted, f)],
+            components: [],
+        }).catch(() => {});
+        await delay(SHAKE_FRAME_MS);
+    }
+
+    return responder.editReply({
+        embeds:     [resultEmbed(author, quoted, pickResponse(), shakes)],
+        components: [buttonRow(ownerId)],
+    });
+}
+
+// One shake at a time per message. Two clicks landing together would otherwise
+// interleave their animation frames on the same message. In-memory only: losing
+// the set on restart just means a stale lock can't outlive the process.
+const shaking = new Set();
+
+// ── Handlers ─────────────────────────────────────────────────────────────────
+
+async function handleButton(interaction) {
+    const ownerId = ownerOf(interaction.customId);
+
+    if (interaction.user.id !== ownerId) {
+        return interaction.reply({
+            content: `That 8-ball is <@${ownerId}>'s — run \`/8ball\` to ask your own.`,
+            flags:   MessageFlags.Ephemeral,
+        });
+    }
+
+    if (interaction.customId.startsWith(NEWQ_PREFIX)) {
+        return interaction.showModal(questionModal(ownerId));
+    }
+
+    if (!shakeLimiter.check(interaction.user.id, SHAKE_WINDOW_MS, SHAKE_LIMIT)) {
+        return interaction.reply({
+            content: 'You are shaking that ball awfully hard. Give it a moment.',
+            flags:   MessageFlags.Ephemeral,
+        });
+    }
+
+    const messageId = interaction.message.id;
+    if (shaking.has(messageId)) return interaction.deferUpdate().catch(() => {});
+    shaking.add(messageId);
+
+    try {
+        await interaction.deferUpdate();
+        const state = readState(interaction.message);
+        await shake(interaction, {
+            author:  state.author,
+            quoted:  state.quoted,
+            shakes:  state.shakes + 1,
+            ownerId,
+        });
+    } finally {
+        shaking.delete(messageId);
+    }
+}
+
+async function handleModal(interaction) {
+    const ownerId = ownerOf(interaction.customId);
+
+    // Only modals opened from an 8-ball message can edit one.
+    if (!interaction.isFromMessage() || interaction.user.id !== ownerId) return;
+
+    const question = normalizeQuestion(interaction.fields.getTextInputValue(QUESTION_INPUT));
+    if (!question) {
+        return interaction.reply({
+            content: 'The 8-ball needs an actual question to work with.',
+            flags:   MessageFlags.Ephemeral,
+        });
+    }
+
+    if (!shakeLimiter.check(interaction.user.id, SHAKE_WINDOW_MS, SHAKE_LIMIT)) {
+        return interaction.reply({
+            content: 'You are shaking that ball awfully hard. Give it a moment.',
+            flags:   MessageFlags.Ephemeral,
+        });
+    }
+
+    const messageId = interaction.message.id;
+    if (shaking.has(messageId)) return interaction.deferUpdate().catch(() => {});
+    shaking.add(messageId);
+
+    try {
+        await interaction.deferUpdate();
+        // A new question restarts the count; it's a new thing being asked.
+        await shake(interaction, {
+            author:  readState(interaction.message).author,
+            quoted:  quoteQuestion(question),
+            shakes:  1,
+            ownerId,
+        });
+    } finally {
+        shaking.delete(messageId);
+    }
 }
 
 module.exports = {
@@ -170,100 +322,29 @@ module.exports = {
         if (!question) {
             return interaction.reply({
                 content: 'The 8-ball needs an actual question to work with.',
-                flags: MessageFlags.Ephemeral,
+                flags:   MessageFlags.Ephemeral,
             });
         }
 
         await interaction.deferReply();
-        await runSession(interaction, question);
+        await shake(interaction, {
+            author:  embedAuthor(interaction),
+            quoted:  quoteQuestion(question),
+            shakes:  1,
+            ownerId: interaction.user.id,
+        });
     },
 
-    __test__: { RESPONSES, TYPE_CONFIG, pickResponse, normalizeQuestion, quoteQuestion, MAX_QUESTION },
+    // Routed from events/interactionCreate — see the custom-id note above.
+    isEightBallButton,
+    isEightBallModal,
+    handleEightBallButton: handleButton,
+    handleEightBallModal:  handleModal,
+
+    __test__: {
+        RESPONSES, TYPE_CONFIG, MAX_QUESTION, SHAKE_LIMIT, SHAKE_WINDOW_MS,
+        pickResponse, normalizeQuestion, quoteQuestion, readState, ownerOf,
+        isEightBallButton, isEightBallModal, buttonRow, resultEmbed,
+        handleButton, handleModal, shaking, shakeLimiter,
+    },
 };
-
-// One message, one session, for as long as the owner keeps shaking. The
-// collector boilerplate — owner check, overlap guard, timers, error handling —
-// lives in utils/replaySession, shared with /coinflip and /roll.
-async function runSession(interaction, firstQuestion) {
-    const ids = {
-        again: `8ball_again_${interaction.id}`,
-        newq:  `8ball_newq_${interaction.id}`,
-    };
-
-    let question = firstQuestion;
-    let shakes   = 0;
-    let modalSeq = 0;
-    let session  = null;
-
-    async function shake() {
-        shakes += 1;
-
-        // Animation frames are cosmetic, and dropping the buttons for their
-        // duration is what stops a click landing mid-shake. A transient failure
-        // on one of these edits shouldn't cost the user their answer.
-        for (let f = 0; f < SHAKE_FRAMES.length; f++) {
-            await interaction.editReply({
-                embeds:     [shakingEmbed(interaction, question, f)],
-                components: [],
-            }).catch(() => {});
-            await delay(SHAKE_FRAME_MS);
-        }
-
-        return interaction.editReply({
-            embeds:     [resultEmbed(interaction, question, pickResponse(), shakes)],
-            components: session?.ended ? [] : [buttonRow(ids)],
-        });
-    }
-
-    const message = await shake();
-
-    session = createReplaySession({
-        interaction,
-        message,
-        customIds: [ids.again, ids.newq],
-        label:     '8ball',
-        claim:     `That 8-ball is ${interaction.user}'s — run \`/8ball\` to ask your own.`,
-
-        async onCollect(button, ctl) {
-            if (button.customId === ids.again) {
-                await button.deferUpdate();
-                await shake();
-                return;
-            }
-
-            // New question — collected through a modal. The member has to
-            // dismiss the modal before they can reach the buttons again, so
-            // hold nothing while it's open.
-            const modalId = `8ball_modal_${interaction.id}_${++modalSeq}`;
-            await button.showModal(questionModal(modalId));
-            ctl.release();
-
-            const submitted = await button.awaitModalSubmit({
-                // Matching the custom id matters: a filter on the user alone
-                // would swallow a modal they submitted for another command.
-                filter: mi => mi.customId === modalId && mi.user.id === interaction.user.id,
-                time:   MODAL_WAIT_MS,
-            }).catch(() => null);
-
-            if (!submitted) return; // dismissed or timed out — nothing to undo
-
-            const next = normalizeQuestion(submitted.fields.getTextInputValue('question_input'));
-            if (!next) {
-                return await submitted.reply({
-                    content: 'The 8-ball needs an actual question to work with.',
-                    flags:   MessageFlags.Ephemeral,
-                });
-            }
-
-            // A shake may have started while the modal was open.
-            if (!ctl.hold()) return await submitted.deferUpdate().catch(() => {});
-
-            await submitted.deferUpdate();
-            question = next;
-            // Typing into a modal isn't a collected interaction, so the idle
-            // timer has been running the whole time.
-            ctl.extend();
-            await shake();
-        },
-    });
-}

--- a/src/commands/fun/8ball.js
+++ b/src/commands/fun/8ball.js
@@ -2,10 +2,16 @@
 
 const {
     SlashCommandBuilder,
-    EmbedBuilder,
     ActionRowBuilder,
     ButtonBuilder,
     ButtonStyle,
+    ContainerBuilder,
+    SectionBuilder,
+    SeparatorBuilder,
+    SeparatorSpacingSize,
+    TextDisplayBuilder,
+    ThumbnailBuilder,
+    ComponentType,
     MessageFlags,
     ModalBuilder,
     TextInputBuilder,
@@ -116,61 +122,97 @@ function quoteQuestion(question) {
 }
 
 // ── Reading a shake's context back off the message ───────────────────────────
+//
+// A Components V2 message has no embed to read state out of, so the question
+// and the shake count are recovered from the text the last render wrote. The
+// owner never needs recovering — it rides in the button's custom id.
 
-const SHAKES_FIELD = '🌀 Shakes';
+// Anchored to the meta line's own prefix rather than matching "Shake #n"
+// anywhere: the question is rendered as a block quote on a single line, so it
+// can never start with "-#", and therefore can't spoof the counter by
+// containing those words itself.
+const SHAKE_COUNT = /^-# .*\bShake #(\d+)/m;
+const QUOTED_LINE = /^> .*$/m;
+
+// Text displays can be nested inside sections inside containers; walk the lot.
+function textContents(message) {
+    const found = [];
+
+    const walk = node => {
+        if (!node || typeof node !== 'object') return;
+        if (Array.isArray(node)) return node.forEach(walk);
+        if (node.type === ComponentType.TextDisplay && typeof node.content === 'string') {
+            found.push(node.content);
+        }
+        walk(node.components);
+        walk(node.accessory);
+    };
+
+    const top = message?.components ?? [];
+    walk(top.map(c => (typeof c?.toJSON === 'function' ? c.toJSON() : c)));
+    return found;
+}
 
 function readState(message) {
-    const embed = message?.embeds?.[0];
-    const shakesRaw = embed?.fields?.find(f => f.name === SHAKES_FIELD)?.value ?? '';
-    const shakes = Number.parseInt(shakesRaw.replace(/\D/g, ''), 10);
+    const text = textContents(message).join('\n');
+    const shakes = Number.parseInt(text.match(SHAKE_COUNT)?.[1] ?? '', 10);
 
     return {
-        // Already escaped when it was written; reused verbatim.
-        quoted: embed?.description ?? '> *"…"*',
+        // Already escaped when it was written; reused verbatim, because
+        // re-escaping on each shake would pile up backslashes.
+        quoted: text.match(QUOTED_LINE)?.[0] ?? '> *"…"*',
         shakes: Number.isFinite(shakes) && shakes > 0 ? shakes : 0,
-        // discord.js's Embed exposes iconURL; the raw gateway payload it is built
-        // from spells the same field icon_url. Read either.
-        author: embed?.author
-            ? { name: embed.author.name, iconURL: embed.author.iconURL ?? embed.author.icon_url }
-            : null,
     };
 }
 
 // ── Rendering ────────────────────────────────────────────────────────────────
 
-function embedAuthor(interaction) {
-    return {
-        name: interaction.member?.displayName || interaction.user.username,
-        iconURL: interaction.user.displayAvatarURL({ dynamic: true }),
-    };
+const V2_FLAGS = MessageFlags.IsComponentsV2;
+
+// The asker is named with a mention so it renders as a pill, but a shake is not
+// a reason to ping someone — least of all on a message that stays clickable
+// indefinitely.
+const NO_PINGS = { parse: [] };
+
+const accent = hex => Number.parseInt(hex.slice(1), 16);
+
+const HEADING = '### 🎱 Magic 8-Ball';
+
+function shakingView(quoted, frame) {
+    return new ContainerBuilder()
+        .setAccentColor(accent('#5865F2'))
+        .addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(
+                `${HEADING}\n${quoted}\n\n${SHAKE_FRAMES[frame % SHAKE_FRAMES.length]}  *shaking…*`,
+            ),
+        );
 }
 
-function baseEmbed(author) {
-    const embed = new EmbedBuilder().setTitle('🎱 Magic 8-Ball');
-    return author ? embed.setAuthor(author) : embed;
-}
-
-function shakingEmbed(author, quoted, frame) {
-    return baseEmbed(author)
-        .setColor('#5865F2')
-        .setDescription(`${SHAKE_FRAMES[frame % SHAKE_FRAMES.length]}\n\n${quoted}`)
-        .setFooter({ text: 'Shaking…' });
-}
-
-function resultEmbed(author, quoted, response, shakes) {
+function resultView(quoted, response, shakes, ownerId) {
     const { color, emoji, outlook } = TYPE_CONFIG[response.type];
 
-    return baseEmbed(author)
-        .setColor(color)
-        .setDescription(quoted)
-        .setImage(`attachment://${BALL_FILE}`)
-        .addFields(
-            { name: `${emoji} The 8-Ball Says`, value: `**${response.text}**`, inline: false },
-            { name: '🔮 Outlook',               value: outlook,               inline: true  },
-            { name: SHAKES_FIELD,               value: `**${shakes}**`,       inline: true  },
+    return new ContainerBuilder()
+        .setAccentColor(accent(color))
+        .addSectionComponents(
+            new SectionBuilder()
+                .addTextDisplayComponents(
+                    new TextDisplayBuilder().setContent(`${HEADING}\n${quoted}`),
+                )
+                .setThumbnailAccessory(
+                    new ThumbnailBuilder()
+                        .setURL(`attachment://${BALL_FILE}`)
+                        .setDescription(`A magic 8-ball showing: ${response.text}`),
+                ),
         )
-        .setFooter({ text: 'Shake again for a new answer — or ask it something else' })
-        .setTimestamp();
+        .addSeparatorComponents(
+            new SeparatorBuilder().setDivider(true).setSpacing(SeparatorSpacingSize.Small),
+        )
+        .addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(
+                `## ${emoji} ${response.text}\n-# ${outlook} · Shake #${shakes} · asked by <@${ownerId}>`,
+            ),
+        )
+        .addActionRowComponents(buttonRow(ownerId));
 }
 
 function buttonRow(ownerId) {
@@ -207,16 +249,16 @@ function questionModal(ownerId) {
 
 // Shake, then settle on an answer. `responder` is whichever interaction is
 // driving this edit — the slash command, a button, or a modal submission.
-async function shake(responder, { author, quoted, shakes, ownerId }) {
+async function shake(responder, { quoted, shakes, ownerId }) {
     // Animation frames are cosmetic, and dropping the buttons for their
     // duration is what stops a click landing mid-shake. A transient failure on
     // one of these edits shouldn't cost the user their answer.
     for (let f = 0; f < SHAKE_FRAMES.length; f++) {
         await responder.editReply({
-            embeds:      [shakingEmbed(author, quoted, f)],
-            components:  [],
+            components:  [shakingView(quoted, f)],
+            flags:       V2_FLAGS,
             // Drop the previous answer's render for the duration of the shake —
-            // the ball is being shaken, it shouldn't still be showing a verdict.
+            // the ball is being shaken, it shouldn't still show a verdict.
             files:       [],
             attachments: [],
         }).catch(() => {});
@@ -227,12 +269,13 @@ async function shake(responder, { author, quoted, shakes, ownerId }) {
     const ball = new AttachmentBuilder(renderEightBall(response.text, response.type), { name: BALL_FILE });
 
     return responder.editReply({
-        embeds:      [resultEmbed(author, quoted, response, shakes)],
-        components:  [buttonRow(ownerId)],
-        files:       [ball],
+        components:      [resultView(quoted, response, shakes, ownerId)],
+        flags:           V2_FLAGS,
+        files:           [ball],
         // Clears the attachment the last shake left behind; without it Discord
         // keeps both and the message grows an image per click.
-        attachments: [],
+        attachments:     [],
+        allowedMentions: NO_PINGS,
     });
 }
 
@@ -271,12 +314,7 @@ async function handleButton(interaction) {
     try {
         await interaction.deferUpdate();
         const state = readState(interaction.message);
-        await shake(interaction, {
-            author:  state.author,
-            quoted:  state.quoted,
-            shakes:  state.shakes + 1,
-            ownerId,
-        });
+        await shake(interaction, { quoted: state.quoted, shakes: state.shakes + 1, ownerId });
     } finally {
         shaking.delete(messageId);
     }
@@ -310,12 +348,7 @@ async function handleModal(interaction) {
     try {
         await interaction.deferUpdate();
         // A new question restarts the count; it's a new thing being asked.
-        await shake(interaction, {
-            author:  readState(interaction.message).author,
-            quoted:  quoteQuestion(question),
-            shakes:  1,
-            ownerId,
-        });
+        await shake(interaction, { quoted: quoteQuestion(question), shakes: 1, ownerId });
     } finally {
         shaking.delete(messageId);
     }
@@ -340,13 +373,15 @@ module.exports = {
             });
         }
 
-        await interaction.deferReply();
-        await shake(interaction, {
-            author:  embedAuthor(interaction),
-            quoted:  quoteQuestion(question),
-            shakes:  1,
-            ownerId: interaction.user.id,
+        // Replying straight into a Components V2 message rather than deferring:
+        // the flag belongs to the message from the moment it exists.
+        const quoted = quoteQuestion(question);
+        await interaction.reply({
+            components:      [shakingView(quoted, 0)],
+            flags:           V2_FLAGS,
+            allowedMentions: NO_PINGS,
         });
+        await shake(interaction, { quoted, shakes: 1, ownerId: interaction.user.id });
     },
 
     // Routed from events/interactionCreate — see the custom-id note above.
@@ -358,7 +393,7 @@ module.exports = {
     __test__: {
         RESPONSES, TYPE_CONFIG, MAX_QUESTION, SHAKE_LIMIT, SHAKE_WINDOW_MS,
         pickResponse, normalizeQuestion, quoteQuestion, readState, ownerOf, BALL_FILE,
-        isEightBallButton, isEightBallModal, buttonRow, resultEmbed,
+        isEightBallButton, isEightBallModal, buttonRow, resultView, shakingView, textContents,
         handleButton, handleModal, shaking, shakeLimiter,
     },
 };

--- a/src/commands/fun/8ball.js
+++ b/src/commands/fun/8ball.js
@@ -1,15 +1,39 @@
+'use strict';
+
 const {
     SlashCommandBuilder,
     EmbedBuilder,
     ActionRowBuilder,
     ButtonBuilder,
     ButtonStyle,
+    ComponentType,
+    MessageFlags,
     ModalBuilder,
     TextInputBuilder,
     TextInputStyle,
+    escapeMarkdown,
 } = require('discord.js');
+const { delay } = require('../../utils/delay');
 
 const THUMB = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3b1.png';
+
+const MAX_QUESTION   = 200;
+const SHAKE_FRAME_MS = 260;
+
+// A session survives repeated shakes, but an interaction token dies 15 minutes
+// after the command was invoked — every follow-up here is an editReply on that
+// token. Cap the collector below that so the buttons come off while they still
+// can, instead of failing on the edit that was meant to clear them.
+const SESSION_IDLE_MS = 60_000;
+const SESSION_MAX_MS  = 13 * 60_000;
+const MODAL_WAIT_MS   = 120_000;
+
+// The ball sloshing to the window before it settles.
+const SHAKE_FRAMES = [
+    '🎱 ‧ ‧ ‧',
+    '‧ 🎱 ‧ ‧',
+    '‧ ‧ 🎱 ‧',
+];
 
 const RESPONSES = {
     positive: [
@@ -40,19 +64,34 @@ const RESPONSES = {
     ],
 };
 
-// Matches the original 10:5:5 distribution (50% positive, 25% neutral, 25% negative)
-function pickResponse() {
-    const r = Math.random();
+// The physical toy carries 20 answers — 10 affirmative, 5 non-committal, 5
+// negative — each equally likely. Rolling the category first (50/25/25) and
+// then a line inside it reproduces that 1-in-20 uniformity exactly, and keeps
+// the tone balance fixed if a line is ever added to one of the pools.
+function pickResponse(rng = Math.random) {
+    const r = rng();
     const type = r < 0.5 ? 'positive' : r < 0.75 ? 'neutral' : 'negative';
     const pool = RESPONSES[type];
-    return { type, text: pool[Math.floor(Math.random() * pool.length)] };
+    return { type, text: pool[Math.floor(rng() * pool.length)] };
 }
 
 const TYPE_CONFIG = {
-    positive: { color: '#2ecc71', emoji: '✅', outlook: 'Positive'    },
-    neutral:  { color: '#f39c12', emoji: '🤔', outlook: 'Uncertain'   },
-    negative: { color: '#e74c3c', emoji: '❌', outlook: 'Negative'    },
+    positive: { color: '#2ecc71', emoji: '✅', outlook: 'Positive'  },
+    neutral:  { color: '#f39c12', emoji: '🤔', outlook: 'Uncertain' },
+    negative: { color: '#e74c3c', emoji: '❌', outlook: 'Negative'  },
 };
+
+// Questions land inside a single-line block quote. Collapsing whitespace keeps
+// a pasted newline from ending the quote early, and the length cap is applied
+// here as well as on the option/modal because neither covers the other's path.
+function normalizeQuestion(raw) {
+    return String(raw ?? '').replace(/\s+/g, ' ').trim().slice(0, MAX_QUESTION);
+}
+
+// Escaped, so a question full of asterisks or backticks can't reformat the embed.
+function quoteQuestion(question) {
+    return `> *"${escapeMarkdown(question)}"*`;
+}
 
 function embedAuthor(interaction) {
     return {
@@ -61,23 +100,65 @@ function embedAuthor(interaction) {
     };
 }
 
-function ballEmbed(interaction, question, response) {
-    const { type, text } = response;
-    const { color, emoji, outlook } = TYPE_CONFIG[type];
-
+function baseEmbed(interaction) {
     return new EmbedBuilder()
         .setAuthor(embedAuthor(interaction))
         .setThumbnail(THUMB)
+        .setTitle('🎱 Magic 8-Ball');
+}
+
+function shakingEmbed(interaction, question, frame) {
+    return baseEmbed(interaction)
+        .setColor('#5865F2')
+        .setDescription(`${SHAKE_FRAMES[frame % SHAKE_FRAMES.length]}\n\n${quoteQuestion(question)}`)
+        .setFooter({ text: 'Shaking…' });
+}
+
+function resultEmbed(interaction, question, response, shakes) {
+    const { color, emoji, outlook } = TYPE_CONFIG[response.type];
+
+    return baseEmbed(interaction)
         .setColor(color)
-        .setTitle('🎱 Magic 8-Ball')
-        .setDescription(`> *"${question}"*`)
+        .setDescription(quoteQuestion(question))
         .addFields(
-            { name: `${emoji} The 8-Ball Says`,  value: `**${text}**`,  inline: false },
-            { name: '🔮 Outlook',                value: outlook,         inline: true  },
-            { name: '​',                          value: '​',             inline: true  },
+            { name: `${emoji} The 8-Ball Says`, value: `**${response.text}**`, inline: false },
+            { name: '🔮 Outlook',               value: outlook,               inline: true  },
+            { name: '🌀 Shakes',                value: `**${shakes}**`,       inline: true  },
         )
-        .setFooter({ text: '🎱 Ask again below — or shake for a new question' })
+        .setFooter({ text: 'Shake again for a new answer — or ask it something else' })
         .setTimestamp();
+}
+
+function buttonRow(ids) {
+    return new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+            .setCustomId(ids.again)
+            .setEmoji('🎱')
+            .setLabel('Shake Again')
+            .setStyle(ButtonStyle.Secondary),
+        new ButtonBuilder()
+            .setCustomId(ids.newq)
+            .setEmoji('❓')
+            .setLabel('New Question')
+            .setStyle(ButtonStyle.Primary),
+    );
+}
+
+function questionModal(customId) {
+    return new ModalBuilder()
+        .setCustomId(customId)
+        .setTitle('🎱 Ask the Magic 8-Ball')
+        .addComponents(
+            new ActionRowBuilder().addComponents(
+                new TextInputBuilder()
+                    .setCustomId('question_input')
+                    .setLabel('Your yes/no question')
+                    .setStyle(TextInputStyle.Short)
+                    .setPlaceholder('Will I win the lottery?')
+                    .setRequired(true)
+                    .setMaxLength(MAX_QUESTION),
+            ),
+        );
 }
 
 module.exports = {
@@ -88,86 +169,134 @@ module.exports = {
             opt.setName('question')
                 .setDescription('Your yes/no question')
                 .setRequired(true)
-                .setMaxLength(200)),
+                .setMaxLength(MAX_QUESTION)),
 
     async execute(interaction) {
-        const question = interaction.options.getString('question');
+        const question = normalizeQuestion(interaction.options.getString('question'));
+        if (!question) {
+            return interaction.reply({
+                content: 'The 8-ball needs an actual question to work with.',
+                flags: MessageFlags.Ephemeral,
+            });
+        }
+
         await interaction.deferReply();
-        await playBall(interaction, question);
+        await runSession(interaction, question);
     },
+
+    __test__: { RESPONSES, TYPE_CONFIG, pickResponse, normalizeQuestion, quoteQuestion, MAX_QUESTION },
 };
 
-async function playBall(interaction, question) {
-    const response   = pickResponse();
-    const askAgainId = `8ball_again_${interaction.id}_${Date.now()}`;
-    const newQId     = `8ball_newq_${interaction.id}_${Date.now()}`;
+// One message, one collector, for as long as the owner keeps shaking. The
+// alternative — a fresh max:1 collector per shake — left a window on the
+// "New Question" path where the buttons were still on screen with nothing
+// listening, so a second click died as "This interaction failed".
+async function runSession(interaction, firstQuestion) {
+    const ids = {
+        again: `8ball_again_${interaction.id}`,
+        newq:  `8ball_newq_${interaction.id}`,
+    };
 
-    const row = new ActionRowBuilder().addComponents(
-        new ButtonBuilder()
-            .setCustomId(askAgainId)
-            .setLabel('🎱 Shake Again')
-            .setStyle(ButtonStyle.Secondary),
-        new ButtonBuilder()
-            .setCustomId(newQId)
-            .setLabel('❓ New Question')
-            .setStyle(ButtonStyle.Primary),
-    );
+    const deadline = Date.now() + SESSION_MAX_MS;
+    let question   = firstQuestion;
+    let shakes     = 0;
+    let modalSeq   = 0;
+    let busy       = false;
+    let collector  = null;
 
-    await interaction.editReply({
-        embeds:     [ballEmbed(interaction, question, response)],
-        components: [row],
-    });
+    async function shake() {
+        shakes += 1;
 
-    const msg = await interaction.fetchReply();
-    const collector = msg.createMessageComponentCollector({
-        filter: i => i.user.id === interaction.user.id && [askAgainId, newQId].includes(i.customId),
-        max:    1,
-        time:   60_000,
+        // Animation frames are cosmetic, and dropping the buttons for their
+        // duration is what stops a click landing mid-shake. A transient failure
+        // on one of these edits shouldn't cost the user their answer.
+        for (let f = 0; f < SHAKE_FRAMES.length; f++) {
+            await interaction.editReply({
+                embeds:     [shakingEmbed(interaction, question, f)],
+                components: [],
+            }).catch(() => {});
+            await delay(SHAKE_FRAME_MS);
+        }
+
+        return interaction.editReply({
+            embeds:     [resultEmbed(interaction, question, pickResponse(), shakes)],
+            components: collector?.ended ? [] : [buttonRow(ids)],
+        });
+    }
+
+    const message = await shake();
+
+    collector = message.createMessageComponentCollector({
+        componentType: ComponentType.Button,
+        filter: i => i.customId === ids.again || i.customId === ids.newq,
+        idle:   SESSION_IDLE_MS,
+        time:   SESSION_MAX_MS,
     });
 
     collector.on('collect', async i => {
-        if (i.customId === askAgainId) {
-            // Same question, new shake
-            await i.deferUpdate();
-            await playBall(interaction, question);
-        } else {
-            // New Question — open a modal for input
-            const modal = new ModalBuilder()
-                .setCustomId(`8ball_modal_${interaction.id}_${Date.now()}`)
-                .setTitle('🎱 Ask the Magic 8-Ball')
-                .addComponents(
-                    new ActionRowBuilder().addComponents(
-                        new TextInputBuilder()
-                            .setCustomId('question_input')
-                            .setLabel('Your yes/no question')
-                            .setStyle(TextInputStyle.Short)
-                            .setPlaceholder('Will I win the lottery?')
-                            .setRequired(true)
-                            .setMaxLength(200),
-                    ),
-                );
+        try {
+            // Rejecting these in the collector filter instead would show every
+            // other member a bare "This interaction failed".
+            if (i.user.id !== interaction.user.id) {
+                return await i.reply({
+                    content: `That 8-ball is ${interaction.user}'s — run \`/8ball\` to ask your own.`,
+                    flags:   MessageFlags.Ephemeral,
+                });
+            }
 
-            await i.showModal(modal);
+            if (busy) return await i.deferUpdate().catch(() => {});
 
-            // Wait for modal submission
-            const submitted = await i.awaitModalSubmit({
-                filter: mi => mi.user.id === interaction.user.id,
-                time:   60_000,
-            }).catch(() => null);
-
-            if (!submitted) {
-                // Modal timed out — just clean up buttons
-                await interaction.editReply({ components: [] }).catch(() => {});
+            if (i.customId === ids.again) {
+                busy = true;
+                await i.deferUpdate();
+                await shake();
                 return;
             }
 
-            const newQuestion = submitted.fields.getTextInputValue('question_input');
-            await submitted.deferUpdate().catch(() => {});
-            await playBall(interaction, newQuestion);
+            // New question — collected through a modal. The buttons stay live
+            // while it's open, so dismissing the modal doesn't strand the message.
+            const modalId = `8ball_modal_${interaction.id}_${++modalSeq}`;
+            await i.showModal(questionModal(modalId));
+
+            const submitted = await i.awaitModalSubmit({
+                // Matching the custom id matters: a filter on the user alone
+                // would swallow a modal this user submitted for another command.
+                filter: mi => mi.customId === modalId && mi.user.id === interaction.user.id,
+                time:   MODAL_WAIT_MS,
+            }).catch(() => null);
+
+            if (!submitted) return; // dismissed or timed out — nothing to undo
+
+            const next = normalizeQuestion(submitted.fields.getTextInputValue('question_input'));
+            if (!next) {
+                return await submitted.reply({
+                    content: 'The 8-ball needs an actual question to work with.',
+                    flags:   MessageFlags.Ephemeral,
+                });
+            }
+
+            busy = true;
+            await submitted.deferUpdate();
+            question = next;
+            // Typing into a modal isn't a collected interaction, so the idle
+            // timer has been running the whole time. Restart it — but against
+            // the original deadline, never past the interaction token's life.
+            if (!collector.ended) {
+                collector.resetTimer({ idle: SESSION_IDLE_MS, time: Math.max(1_000, deadline - Date.now()) });
+            }
+            await shake();
+        } catch (error) {
+            // Nothing above is awaited by execute(), so an unhandled rejection
+            // here would surface as a process-level warning instead of a log.
+            console.error('[8ball] component handler error:', error);
+        } finally {
+            busy = false;
         }
     });
 
-    collector.on('end', (_, reason) => {
-        if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
+    collector.on('end', () => {
+        // A render in flight sets the final components itself (see shake()).
+        if (busy) return;
+        interaction.editReply({ components: [] }).catch(() => {});
     });
 }

--- a/src/commands/fun/coinflip.js
+++ b/src/commands/fun/coinflip.js
@@ -9,7 +9,8 @@ const {
 const Guild = require('../../models/Guild');
 const User  = require('../../models/User');
 const { logTransaction } = require('../../utils/logTransaction');
-const { createReplaySession } = require('../../utils/replaySession');
+const { createReplaySession, replayButtonRow } = require('../../utils/replaySession');
+const { refundWager } = require('../../utils/refundWager');
 const { delay } = require('../../utils/delay');
 
 const HEADS_THUMB = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1fa99.png';
@@ -89,21 +90,8 @@ function resultEmbed(interaction, result, call = null) {
     return embed;
 }
 
-// Best-effort return of coins already taken. Never throws: it runs on paths
-// that are themselves handling a failure, and losing the refund to a second
-// error would be worse than logging it.
-async function refund(userId, guildId, amount, note) {
-    try {
-        const doc = await User.findOneAndUpdate(
-            { userId, guildId },
-            { $inc: { balance: amount } },
-            { new: true }
-        );
-        logTransaction({ userId, guildId, type: 'coinflip', amount, balance: doc?.balance ?? 0, note });
-    } catch (error) {
-        console.error(`[coinflip] refund of ${amount} to ${userId} in ${guildId} failed:`, error);
-    }
-}
+const refund = (userId, guildId, amount, note) =>
+    refundWager({ userId, guildId, amount, type: 'coinflip', note });
 
 // Take both wagers before the coin is flipped, and leave no coins stranded if
 // that can't be completed: a side that can't cover it, or a write that fails
@@ -134,13 +122,35 @@ async function escrowWagers(guildId, challengerId, opponentId, bet) {
     } catch (error) {
         if (challengerHeld) {
             await refund(challengerId, guildId, bet, 'PvP coinflip — escrow failed, wager returned');
+            // Reported so the caller can tell the challenger their coins came
+            // back, rather than leaving them to assume the worst.
+            return { ok: false, error, refunded: 'challenger' };
         }
         return { ok: false, error };
     }
 }
 
+// A rejected write is not proof the write never landed — a timeout can arrive
+// after the server applied it. Refunding on that assumption would pay the pot
+// out twice, so the payout is checked before anything is compensated. The
+// balance the escrow already observed is what makes the check possible.
+async function payoutState(userId, guildId, balanceBeforePayout, payout) {
+    if (!Number.isFinite(balanceBeforePayout)) return 'unknown';
+
+    try {
+        const doc = await User.findOne({ userId, guildId });
+        if (!doc) return 'unknown';
+        if (doc.balance === balanceBeforePayout + payout) return 'applied';
+        if (doc.balance === balanceBeforePayout) return 'not-applied';
+        return 'unknown'; // something else moved the balance; don't guess
+    } catch (error) {
+        console.error('[coinflip] could not verify the payout:', error);
+        return 'unknown';
+    }
+}
+
 module.exports = {
-    __test__: { escrowWagers, refund, flip, other, pip },
+    __test__: { escrowWagers, payoutState, refund, flip, other, pip },
 
     data: new SlashCommandBuilder()
         .setName('coinflip')
@@ -199,7 +209,7 @@ async function playCasualFlip(interaction, call) {
         await spin(interaction);
         return interaction.editReply({
             embeds:     [resultEmbed(interaction, flip(), call)],
-            components: session?.ended ? [] : [replayRow(replayId)],
+            components: session?.ended ? [] : [replayButtonRow(replayId, { emoji: '🪙', label: 'Flip Again' })],
         });
     }
 
@@ -218,15 +228,6 @@ async function playCasualFlip(interaction, call) {
     });
 }
 
-function replayRow(customId) {
-    return new ActionRowBuilder().addComponents(
-        new ButtonBuilder()
-            .setCustomId(customId)
-            .setEmoji('🪙')
-            .setLabel('Flip Again')
-            .setStyle(ButtonStyle.Primary),
-    );
-}
 
 // ── Solo wager (vs the house) ────────────────────────────────────────────────
 
@@ -364,6 +365,7 @@ async function playVersusFlip(interaction, guildSettings, bet, opponent, challen
         // unhandled rejection — with both wagers sitting in escrow.
         let challengerEscrowed = false;
         let opponentEscrowed   = false;
+        let escrowRefunded     = null;
 
         try {
             if (i.customId === declineId) {
@@ -383,6 +385,7 @@ async function playVersusFlip(interaction, guildSettings, bet, opponent, challen
                 if (escrow.short === 'opponent') {
                     return await settle('#e74c3c', `${opponent.username} can't cover the wager. Challenge cancelled.`);
                 }
+                escrowRefunded = escrow.refunded ?? null;
                 throw escrow.error;
             }
             const { challengerDoc, opponentDoc } = escrow;
@@ -399,11 +402,36 @@ async function playVersusFlip(interaction, guildSettings, bet, opponent, challen
             const pot        = bet * 2;
             const payout     = pot - Math.floor(pot * houseCut);
 
-            const winnerDoc = await User.findOneAndUpdate(
-                { userId: winnerUser.id, guildId },
-                { $inc: { balance: payout } },
-                { new: true }
-            );
+            const winnerBefore = (winnerUser.id === interaction.user.id ? challengerDoc : opponentDoc)?.balance;
+
+            let winnerDoc = null;
+            try {
+                winnerDoc = await User.findOneAndUpdate(
+                    { userId: winnerUser.id, guildId },
+                    { $inc: { balance: payout } },
+                    { new: true }
+                );
+            } catch (error) {
+                const state = await payoutState(winnerUser.id, guildId, winnerBefore, payout);
+
+                if (state === 'not-applied') throw error; // stakes are still ours to return
+
+                // Either the pot was paid despite the error, or we can't tell.
+                // Both stakes are off the table either way — returning them on
+                // a maybe would mint the pot a second time.
+                challengerEscrowed = false;
+                opponentEscrowed   = false;
+
+                if (state !== 'applied') {
+                    console.error('[coinflip] payout outcome unresolved, wagers left in place for reconciliation:', {
+                        guildId, winnerId: winnerUser.id, loserId: loserUser.id, bet, payout, error,
+                    });
+                    throw error;
+                }
+
+                winnerDoc = { balance: winnerBefore + payout };
+            }
+
             // Past this point the pot has been paid out; neither stake is ours
             // to return any more.
             challengerEscrowed = false;
@@ -432,8 +460,17 @@ async function playVersusFlip(interaction, guildSettings, bet, opponent, challen
             if (challengerEscrowed) await refund(interaction.user.id, guildId, bet, 'PvP coinflip — flip failed, wager returned');
             if (opponentEscrowed)   await refund(opponent.id, guildId, bet, 'PvP coinflip — flip failed, wager returned');
 
-            const returned = challengerEscrowed || opponentEscrowed;
-            await settle('#e74c3c', `The flip failed to resolve.${returned ? ' Both wagers have been returned.' : ''}`);
+            // Say exactly which coins moved back. "Both wagers returned" when
+            // only one was is worse than saying nothing.
+            const returnedBoth = challengerEscrowed && opponentEscrowed;
+            const returnedOne  = challengerEscrowed || opponentEscrowed || escrowRefunded;
+
+            let note;
+            if (returnedBoth)     note = ' Both wagers have been returned.';
+            else if (returnedOne) note = ` ${interaction.user.username}'s wager has been returned.`;
+            else                  note = ' The wagers are being reconciled from the transaction log.';
+
+            await settle('#e74c3c', `The flip failed to resolve.${note}`);
         }
     });
 

--- a/src/commands/fun/coinflip.js
+++ b/src/commands/fun/coinflip.js
@@ -9,16 +9,26 @@ const {
 const Guild = require('../../models/Guild');
 const User  = require('../../models/User');
 const { logTransaction } = require('../../utils/logTransaction');
+const { createReplaySession } = require('../../utils/replaySession');
+const { delay } = require('../../utils/delay');
 
 const HEADS_THUMB = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1fa99.png';
 
 // Spinning frame — single rotating coin
 const SPIN_FRAMES = ['🌑', '🌒', '🌓', '🌔', '🌕', '🌖', '🌗', '🌘'];
+const SPIN_MS     = 300;
 
 const MIN_BET            = 10;
 const SOLO_RAKE          = 0.05;               // solo flips pay 1.95x on a win (-2.5% EV)
 const ACCEPT_TIMEOUT_MS  = 60_000;
 const MIN_ACCOUNT_AGE_MS = 7 * 24 * 3_600_000; // PvP wagers gated like /rob and /gift
+
+const HEADS = 'Heads';
+const TAILS = 'Tails';
+
+const flip  = () => (Math.random() < 0.5 ? HEADS : TAILS);
+const other = side => (side === HEADS ? TAILS : HEADS);
+const pip   = side => (side === HEADS ? '👑' : '🔘');
 
 function embedAuthor(interaction) {
     return {
@@ -37,12 +47,26 @@ function spinningEmbed(interaction, frame, stakeLine = null) {
         .setFooter({ text: 'Heads or Tails?' });
 }
 
-function resultEmbed(interaction, result) {
-    const isHeads = result === 'Heads';
-    return new EmbedBuilder()
+// Cosmetic frames: a transient edit failure here shouldn't abort a flip whose
+// wager has already been debited.
+async function spin(interaction, stakeLine = null) {
+    for (let f = 0; f < 4; f++) {
+        await interaction.editReply({
+            embeds:     [spinningEmbed(interaction, f, stakeLine)],
+            components: [],
+        }).catch(() => {});
+        await delay(SPIN_MS);
+    }
+}
+
+function resultEmbed(interaction, result, call = null) {
+    const isHeads = result === HEADS;
+    const called  = call ? result === call : null;
+
+    const embed = new EmbedBuilder()
         .setAuthor(embedAuthor(interaction))
         .setThumbnail(HEADS_THUMB)
-        .setColor(isHeads ? '#f39c12' : '#95a5a6')
+        .setColor(called === null ? (isHeads ? '#f39c12' : '#95a5a6') : (called ? '#2ecc71' : '#e74c3c'))
         .setTitle(isHeads ? '🪙 Heads!' : '🪙 Tails!')
         .setDescription(
             isHeads
@@ -50,24 +74,91 @@ function resultEmbed(interaction, result) {
                 : '🔘 **TAILS!** The coin landed face-down.',
         )
         .addFields(
-            { name: '🎲 Result',  value: `**${result}**`, inline: true },
-            { name: '📊 Odds',    value: '**50 / 50**',   inline: true },
+            { name: '🎲 Result', value: `**${result}**`, inline: true },
+            { name: '📊 Odds',   value: '**50 / 50**',   inline: true },
         )
-        .setFooter({ text: 'Feeling lucky? Flip again!' })
         .setTimestamp();
+
+    if (call) {
+        embed.addFields({ name: '🗣️ Your Call', value: `${pip(call)} **${call}**`, inline: true });
+        embed.setFooter({ text: called ? 'Called it. Flip again?' : 'Not your side this time. Flip again?' });
+    } else {
+        embed.setFooter({ text: 'Feeling lucky? Flip again!' });
+    }
+
+    return embed;
+}
+
+// Best-effort return of coins already taken. Never throws: it runs on paths
+// that are themselves handling a failure, and losing the refund to a second
+// error would be worse than logging it.
+async function refund(userId, guildId, amount, note) {
+    try {
+        const doc = await User.findOneAndUpdate(
+            { userId, guildId },
+            { $inc: { balance: amount } },
+            { new: true }
+        );
+        logTransaction({ userId, guildId, type: 'coinflip', amount, balance: doc?.balance ?? 0, note });
+    } catch (error) {
+        console.error(`[coinflip] refund of ${amount} to ${userId} in ${guildId} failed:`, error);
+    }
+}
+
+// Take both wagers before the coin is flipped, and leave no coins stranded if
+// that can't be completed: a side that can't cover it, or a write that fails
+// outright, puts back whatever was already taken.
+async function escrowWagers(guildId, challengerId, opponentId, bet) {
+    let challengerHeld = false;
+
+    try {
+        const challengerDoc = await User.findOneAndUpdate(
+            { userId: challengerId, guildId, balance: { $gte: bet } },
+            { $inc: { balance: -bet } },
+            { new: true }
+        );
+        if (!challengerDoc) return { ok: false, short: 'challenger' };
+        challengerHeld = true;
+
+        const opponentDoc = await User.findOneAndUpdate(
+            { userId: opponentId, guildId, balance: { $gte: bet } },
+            { $inc: { balance: -bet } },
+            { new: true }
+        );
+        if (!opponentDoc) {
+            await refund(challengerId, guildId, bet, 'PvP coinflip — opponent short, wager returned');
+            return { ok: false, short: 'opponent' };
+        }
+
+        return { ok: true, challengerDoc, opponentDoc };
+    } catch (error) {
+        if (challengerHeld) {
+            await refund(challengerId, guildId, bet, 'PvP coinflip — escrow failed, wager returned');
+        }
+        return { ok: false, error };
+    }
 }
 
 module.exports = {
+    __test__: { escrowWagers, refund, flip, other, pip },
+
     data: new SlashCommandBuilder()
         .setName('coinflip')
         .setDescription('Flip a coin — for fun, for coins, or against another member.')
+        .addStringOption(o =>
+            o.setName('side')
+                .setDescription('Call it. Omit and the coin picks your side for you.')
+                .addChoices(
+                    { name: '👑 Heads', value: HEADS },
+                    { name: '🔘 Tails', value: TAILS },
+                ))
         .addIntegerOption(o =>
             o.setName('bet')
                 .setDescription('Coins to wager (omit for a casual flip).')
                 .setMinValue(MIN_BET))
         .addUserOption(o =>
             o.setName('opponent')
-                .setDescription('Challenge another member — you take Heads, they take Tails. Winner takes the pot.')),
+                .setDescription('Challenge another member — you take your side, they take the other. Winner takes the pot.')),
     cooldown: 5,
 
     async execute(interaction) {
@@ -78,13 +169,14 @@ module.exports = {
 
         const bet      = interaction.options.getInteger('bet');
         const opponent = interaction.options.getUser('opponent');
+        const side     = interaction.options.getString('side');
 
         if (!bet) {
             if (opponent) {
                 return interaction.reply({ content: 'Challenging someone requires a `bet` — add one to make it interesting.', flags: MessageFlags.Ephemeral });
             }
             await interaction.deferReply();
-            return playCasualFlip(interaction);
+            return playCasualFlip(interaction, side);
         }
 
         const maxBet = guildSettings?.economy?.duelMaxBet ?? 10_000;
@@ -92,60 +184,58 @@ module.exports = {
             return interaction.reply({ content: `The maximum coinflip wager here is **${maxBet.toLocaleString()}** coins.`, flags: MessageFlags.Ephemeral });
         }
 
-        if (opponent) return playVersusFlip(interaction, guildSettings, bet, opponent);
-        return playSoloFlip(interaction, guildSettings, bet);
+        if (opponent) return playVersusFlip(interaction, guildSettings, bet, opponent, side ?? HEADS);
+        return playSoloFlip(interaction, guildSettings, bet, side);
     },
 };
 
 // ── Casual (no stakes) ────────────────────────────────────────────────────────
 
-async function playCasualFlip(interaction) {
-    const delay = ms => new Promise(r => setTimeout(r, ms));
+async function playCasualFlip(interaction, call) {
+    const replayId = `coinflip_replay_${interaction.id}`;
+    let session    = null;
 
-    // 4-frame spin animation
-    for (let f = 0; f < 4; f++) {
-        await interaction.editReply({ embeds: [spinningEmbed(interaction, f)], components: [] });
-        await delay(300);
+    async function render() {
+        await spin(interaction);
+        return interaction.editReply({
+            embeds:     [resultEmbed(interaction, flip(), call)],
+            components: session?.ended ? [] : [replayRow(replayId)],
+        });
     }
 
-    const result   = Math.random() < 0.5 ? 'Heads' : 'Tails';
-    const replayId = `coinflip_replay_${interaction.id}_${Date.now()}`;
+    const message = await render();
 
-    const row = new ActionRowBuilder().addComponents(
+    session = createReplaySession({
+        interaction,
+        message,
+        customIds: [replayId],
+        label:     'coinflip',
+        claim:     `That coin is ${interaction.user}'s — run \`/coinflip\` to flip your own.`,
+        async onCollect(button) {
+            await button.deferUpdate();
+            await render();
+        },
+    });
+}
+
+function replayRow(customId) {
+    return new ActionRowBuilder().addComponents(
         new ButtonBuilder()
-            .setCustomId(replayId)
-            .setLabel('🪙 Flip Again')
+            .setCustomId(customId)
+            .setEmoji('🪙')
+            .setLabel('Flip Again')
             .setStyle(ButtonStyle.Primary),
     );
-
-    await interaction.editReply({
-        embeds:     [resultEmbed(interaction, result)],
-        components: [row],
-    });
-
-    const msg = await interaction.fetchReply();
-    const collector = msg.createMessageComponentCollector({
-        filter: i => i.user.id === interaction.user.id && i.customId === replayId,
-        max:    1,
-        time:   60_000,
-    });
-
-    collector.on('collect', async i => {
-        await i.deferUpdate();
-        await playCasualFlip(interaction);
-    });
-
-    collector.on('end', (_, reason) => {
-        if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
-    });
 }
 
 // ── Solo wager (vs the house) ────────────────────────────────────────────────
 
-async function playSoloFlip(interaction, guildSettings, bet) {
+async function playSoloFlip(interaction, guildSettings, bet, side) {
     const currency = guildSettings?.economy?.currency ?? '💰';
     const guildId  = interaction.guild.id;
-    const call     = Math.random() < 0.5 ? 'Heads' : 'Tails'; // the coin doesn't care which side you call
+    // The coin doesn't care which side you call, so an uncalled flip is settled
+    // on a side picked for the player — same odds, one less decision.
+    const call = side ?? flip();
 
     const debited = await User.findOneAndUpdate(
         { userId: interaction.user.id, guildId, balance: { $gte: bet } },
@@ -157,25 +247,38 @@ async function playSoloFlip(interaction, guildSettings, bet) {
     }
 
     await interaction.deferReply();
-    const delay = ms => new Promise(r => setTimeout(r, ms));
-    const stakeLine = `Wager: **${currency}${bet.toLocaleString()}** · You call **${call}**`;
-    for (let f = 0; f < 4; f++) {
-        await interaction.editReply({ embeds: [spinningEmbed(interaction, f, stakeLine)] });
-        await delay(300);
-    }
+    // The rake is disclosed up front here rather than only in the footer of a
+    // win: the player is watching the animation with the bet already placed.
+    await spin(
+        interaction,
+        `Wager: **${currency}${bet.toLocaleString()}** · You call ${pip(call)} **${call}** · pays **${(2 - SOLO_RAKE).toFixed(2)}x**`,
+    );
 
-    const result = Math.random() < 0.5 ? 'Heads' : 'Tails';
+    const result = flip();
     const won    = result === call;
     const profit = Math.floor(bet * (1 - SOLO_RAKE));
 
     let updated = debited;
     if (won) {
-        updated = await User.findOneAndUpdate(
-            { userId: interaction.user.id, guildId },
-            { $inc: { balance: bet + profit } },
-            { new: true }
-        );
+        try {
+            updated = await User.findOneAndUpdate(
+                { userId: interaction.user.id, guildId },
+                { $inc: { balance: bet + profit } },
+                { new: true }
+            );
+        } catch (error) {
+            // The stake is already gone and the win can't be paid. Give it back
+            // rather than let a database hiccup pocket the wager.
+            console.error('[coinflip] solo payout failed, returning the stake:', error);
+            await refund(interaction.user.id, guildId, bet, 'Solo coinflip — payout failed, stake returned');
+            return interaction.editReply({
+                content:    `The coin came up **${result}** and you called it — but the payout failed, so your **${currency}${bet.toLocaleString()}** has been returned. Try again in a moment.`,
+                embeds:     [],
+                components: [],
+            }).catch(() => {});
+        }
     }
+
     logTransaction({
         userId:  interaction.user.id,
         guildId,
@@ -191,8 +294,8 @@ async function playSoloFlip(interaction, guildSettings, bet) {
         .setColor(won ? '#2ecc71' : '#e74c3c')
         .setTitle(won ? `🪙 ${result}! You called it!` : `🪙 ${result}. Not your side.`)
         .setDescription(won
-            ? `You called **${call}** and the coin agreed.\n\n💰 **+${currency}${profit.toLocaleString()}**`
-            : `You called **${call}**, the coin said **${result}**.\n\n💸 **-${currency}${bet.toLocaleString()}**`)
+            ? `You called ${pip(call)} **${call}** and the coin agreed.\n\n💰 **+${currency}${profit.toLocaleString()}**`
+            : `You called ${pip(call)} **${call}**, the coin said **${result}**.\n\n💸 **-${currency}${bet.toLocaleString()}**`)
         .addFields({ name: '💰 Balance', value: `**${currency}${(updated?.balance ?? 0).toLocaleString()}**`, inline: true })
         .setFooter({ text: won ? 'The house keeps 5% — quit while you\'re ahead?' : 'The coin holds no grudges. Probably.' })
         .setTimestamp();
@@ -202,9 +305,10 @@ async function playSoloFlip(interaction, guildSettings, bet) {
 
 // ── Versus wager (PvP, escrowed) ─────────────────────────────────────────────
 
-async function playVersusFlip(interaction, guildSettings, bet, opponent) {
-    const currency = guildSettings?.economy?.currency ?? '💰';
-    const guildId  = interaction.guild.id;
+async function playVersusFlip(interaction, guildSettings, bet, opponent, challengerSide) {
+    const currency       = guildSettings?.economy?.currency ?? '💰';
+    const guildId        = interaction.guild.id;
+    const opponentSide   = other(challengerSide);
 
     if (opponent.id === interaction.user.id) {
         return interaction.reply({ content: 'Flipping a coin against yourself is called "thinking". Pick someone else.', flags: MessageFlags.Ephemeral });
@@ -227,9 +331,9 @@ async function playVersusFlip(interaction, guildSettings, bet, opponent) {
         .setDescription(
             `**${interaction.member?.displayName ?? interaction.user.username}** challenges ${opponent} to a coinflip!\n\n` +
             `💰 Wager: **${currency}${bet.toLocaleString()}** each — winner takes the pot\n` +
-            `👑 ${interaction.user.username} takes **Heads** · 🔘 ${opponent.username} takes **Tails**`
+            `${pip(challengerSide)} ${interaction.user.username} takes **${challengerSide}** · ${pip(opponentSide)} ${opponent.username} takes **${opponentSide}**`
         )
-        .setFooter({ text: 'Accept within 60 seconds' });
+        .setFooter({ text: `${opponent.username} has 60 seconds to accept — ${interaction.user.username} can call it off with Decline` });
 
     const row = new ActionRowBuilder().addComponents(
         new ButtonBuilder().setCustomId(acceptId).setLabel('✅ Accept').setStyle(ButtonStyle.Success),
@@ -237,96 +341,105 @@ async function playVersusFlip(interaction, guildSettings, bet, opponent) {
     );
 
     await interaction.reply({ content: `${opponent}`, embeds: [challengeEmbed], components: [row] });
-    const msg = await interaction.fetchReply();
+    const message = await interaction.fetchReply();
 
-    const collector = msg.createMessageComponentCollector({
-        filter: i => i.user.id === opponent.id && [acceptId, declineId].includes(i.customId),
+    const settle = (color, text) => interaction.editReply({
+        content:    null,
+        embeds:     [EmbedBuilder.from(challengeEmbed).setColor(color).setDescription(text)],
+        components: [],
+    }).catch(() => {});
+
+    const collector = message.createMessageComponentCollector({
+        // Decline doubles as the challenger's cancel — misfiring a challenge at
+        // the wrong member otherwise leaves it live for the full minute.
+        filter: i => (i.user.id === opponent.id && [acceptId, declineId].includes(i.customId))
+                  || (i.user.id === interaction.user.id && i.customId === declineId),
         max:    1,
         time:   ACCEPT_TIMEOUT_MS,
     });
 
     collector.on('collect', async i => {
-        if (i.customId === declineId) {
-            return i.update({
-                content:    null,
-                embeds:     [EmbedBuilder.from(challengeEmbed).setColor('#95a5a6').setDescription(`${opponent.username} declined the flip. The coin stays in its pocket.`)],
-                components: [],
-            }).catch(() => {});
+        // This runs long after execute() resolved, so the command dispatcher's
+        // error handling no longer covers it. Anything thrown below would be an
+        // unhandled rejection — with both wagers sitting in escrow.
+        let challengerEscrowed = false;
+        let opponentEscrowed   = false;
+
+        try {
+            if (i.customId === declineId) {
+                await i.deferUpdate().catch(() => {});
+                return await settle('#95a5a6', i.user.id === interaction.user.id
+                    ? `${interaction.user.username} called off the challenge. The coin stays in its pocket.`
+                    : `${opponent.username} declined the flip. The coin stays in its pocket.`);
+            }
+
+            await i.deferUpdate().catch(() => {});
+
+            const escrow = await escrowWagers(guildId, interaction.user.id, opponent.id, bet);
+            if (!escrow.ok) {
+                if (escrow.short === 'challenger') {
+                    return await settle('#e74c3c', `${interaction.user.username} no longer has the wager. Challenge cancelled.`);
+                }
+                if (escrow.short === 'opponent') {
+                    return await settle('#e74c3c', `${opponent.username} can't cover the wager. Challenge cancelled.`);
+                }
+                throw escrow.error;
+            }
+            const { challengerDoc, opponentDoc } = escrow;
+            challengerEscrowed = true;
+            opponentEscrowed   = true;
+
+            const stakeLine = `Pot: **${currency}${(bet * 2).toLocaleString()}** · ${pip(challengerSide)} ${interaction.user.username} = ${challengerSide} · ${pip(opponentSide)} ${opponent.username} = ${opponentSide}`;
+            await spin(interaction, stakeLine);
+
+            const result     = flip();
+            const winnerUser = result === challengerSide ? interaction.user : opponent;
+            const loserUser  = result === challengerSide ? opponent : interaction.user;
+            const houseCut   = guildSettings?.economy?.duelHouseCut ?? 0.05;
+            const pot        = bet * 2;
+            const payout     = pot - Math.floor(pot * houseCut);
+
+            const winnerDoc = await User.findOneAndUpdate(
+                { userId: winnerUser.id, guildId },
+                { $inc: { balance: payout } },
+                { new: true }
+            );
+            // Past this point the pot has been paid out; neither stake is ours
+            // to return any more.
+            challengerEscrowed = false;
+            opponentEscrowed   = false;
+
+            const loserDoc = result === challengerSide ? opponentDoc : challengerDoc;
+            logTransaction({ userId: winnerUser.id, guildId, type: 'coinflip', amount: payout - bet, balance: winnerDoc?.balance ?? 0, relatedUserId: loserUser.id, note: `PvP coinflip win (${result})` });
+            logTransaction({ userId: loserUser.id,  guildId, type: 'coinflip', amount: -bet, balance: loserDoc?.balance ?? 0, relatedUserId: winnerUser.id, note: `PvP coinflip loss (${result})` });
+
+            const resultEmbedPvp = new EmbedBuilder()
+                .setColor('#2ecc71')
+                .setThumbnail(HEADS_THUMB)
+                .setTitle(result === HEADS ? '🪙 HEADS!' : '🪙 TAILS!')
+                .setDescription(
+                    `The coin lands on **${result}**!\n\n` +
+                    `🏆 **${winnerUser.username}** takes the pot: **+${currency}${(payout - bet).toLocaleString()}**\n` +
+                    `💸 **${loserUser.username}** loses **${currency}${bet.toLocaleString()}**` +
+                    (houseCut > 0 ? `\n\n> 🏛️ The house kept ${Math.round(houseCut * 100)}% of the pot.` : '')
+                )
+                .setTimestamp();
+
+            return await interaction.editReply({ content: `${winnerUser}`, embeds: [resultEmbedPvp], components: [] }).catch(() => {});
+        } catch (error) {
+            console.error('[coinflip] versus handler error:', error);
+
+            if (challengerEscrowed) await refund(interaction.user.id, guildId, bet, 'PvP coinflip — flip failed, wager returned');
+            if (opponentEscrowed)   await refund(opponent.id, guildId, bet, 'PvP coinflip — flip failed, wager returned');
+
+            const returned = challengerEscrowed || opponentEscrowed;
+            await settle('#e74c3c', `The flip failed to resolve.${returned ? ' Both wagers have been returned.' : ''}`);
         }
-
-        // Escrow both wagers atomically; refund the challenger if the opponent can't cover
-        const challengerDoc = await User.findOneAndUpdate(
-            { userId: interaction.user.id, guildId, balance: { $gte: bet } },
-            { $inc: { balance: -bet } },
-            { new: true }
-        );
-        if (!challengerDoc) {
-            return i.update({
-                content:    null,
-                embeds:     [EmbedBuilder.from(challengeEmbed).setColor('#e74c3c').setDescription(`${interaction.user.username} no longer has the wager. Challenge cancelled.`)],
-                components: [],
-            }).catch(() => {});
-        }
-        const opponentDoc = await User.findOneAndUpdate(
-            { userId: opponent.id, guildId, balance: { $gte: bet } },
-            { $inc: { balance: -bet } },
-            { new: true }
-        );
-        if (!opponentDoc) {
-            await User.updateOne({ userId: interaction.user.id, guildId }, { $inc: { balance: bet } });
-            return i.update({
-                content:    null,
-                embeds:     [EmbedBuilder.from(challengeEmbed).setColor('#e74c3c').setDescription(`${opponent.username} can't cover the wager. Challenge cancelled.`)],
-                components: [],
-            }).catch(() => {});
-        }
-
-        await i.deferUpdate().catch(() => {});
-        const delay = ms => new Promise(r => setTimeout(r, ms));
-        const stakeLine = `Pot: **${currency}${(bet * 2).toLocaleString()}** · 👑 ${interaction.user.username} = Heads · 🔘 ${opponent.username} = Tails`;
-        for (let f = 0; f < 4; f++) {
-            await interaction.editReply({ content: null, embeds: [spinningEmbed(interaction, f, stakeLine)], components: [] }).catch(() => {});
-            await delay(300);
-        }
-
-        const result     = Math.random() < 0.5 ? 'Heads' : 'Tails';
-        const winnerUser = result === 'Heads' ? interaction.user : opponent;
-        const loserUser  = result === 'Heads' ? opponent : interaction.user;
-        const houseCut   = guildSettings?.economy?.duelHouseCut ?? 0.05;
-        const pot        = bet * 2;
-        const payout     = pot - Math.floor(pot * houseCut);
-
-        const winnerDoc = await User.findOneAndUpdate(
-            { userId: winnerUser.id, guildId },
-            { $inc: { balance: payout } },
-            { new: true }
-        );
-        const loserDoc = result === 'Heads' ? opponentDoc : challengerDoc;
-        logTransaction({ userId: winnerUser.id, guildId, type: 'coinflip', amount: payout - bet, balance: winnerDoc?.balance ?? 0, relatedUserId: loserUser.id, note: `PvP coinflip win (${result})` });
-        logTransaction({ userId: loserUser.id,  guildId, type: 'coinflip', amount: -bet, balance: loserDoc?.balance ?? 0, relatedUserId: winnerUser.id, note: `PvP coinflip loss (${result})` });
-
-        const resultEmbedPvp = new EmbedBuilder()
-            .setColor('#2ecc71')
-            .setThumbnail(HEADS_THUMB)
-            .setTitle(result === 'Heads' ? '🪙 HEADS!' : '🪙 TAILS!')
-            .setDescription(
-                `The coin lands on **${result}**!\n\n` +
-                `🏆 **${winnerUser.username}** takes the pot: **+${currency}${(payout - bet).toLocaleString()}**\n` +
-                `💸 **${loserUser.username}** loses **${currency}${bet.toLocaleString()}**` +
-                (houseCut > 0 ? `\n\n> 🏛️ The house kept ${Math.round(houseCut * 100)}% of the pot.` : '')
-            )
-            .setTimestamp();
-
-        return interaction.editReply({ content: `${winnerUser}`, embeds: [resultEmbedPvp], components: [] }).catch(() => {});
     });
 
     collector.on('end', (collected, reason) => {
         if (reason === 'time' && collected.size === 0) {
-            interaction.editReply({
-                content:    null,
-                embeds:     [EmbedBuilder.from(challengeEmbed).setColor('#95a5a6').setDescription(`${opponent.username} didn't respond. The coin stays in its pocket.`)],
-                components: [],
-            }).catch(() => {});
+            settle('#95a5a6', `${opponent.username} didn't respond. The coin stays in its pocket.`);
         }
     });
 }

--- a/src/commands/fun/roll.js
+++ b/src/commands/fun/roll.js
@@ -1,15 +1,13 @@
 const {
     SlashCommandBuilder,
     EmbedBuilder,
-    ActionRowBuilder,
-    ButtonBuilder,
-    ButtonStyle,
     MessageFlags,
 } = require('discord.js');
 const Guild = require('../../models/Guild');
 const User  = require('../../models/User');
 const { logTransaction } = require('../../utils/logTransaction');
-const { createReplaySession } = require('../../utils/replaySession');
+const { createReplaySession, replayButtonRow } = require('../../utils/replaySession');
+const { refundWager } = require('../../utils/refundWager');
 const { delay } = require('../../utils/delay');
 
 const THUMB = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3b2.png';
@@ -147,7 +145,7 @@ async function playRoll(interaction, sides) {
         const result = Math.floor(Math.random() * sides) + 1;
         return interaction.editReply({
             embeds:     [resultEmbed(interaction, result, sides)],
-            components: session?.ended ? [] : [replayRow(replayId)],
+            components: session?.ended ? [] : [replayButtonRow(replayId, { emoji: '🎲', label: 'Roll Again' })],
         });
     }
 
@@ -166,31 +164,9 @@ async function playRoll(interaction, sides) {
     });
 }
 
-function replayRow(customId) {
-    return new ActionRowBuilder().addComponents(
-        new ButtonBuilder()
-            .setCustomId(customId)
-            .setEmoji('🎲')
-            .setLabel('Roll Again')
-            .setStyle(ButtonStyle.Primary),
-    );
-}
 
-// Best-effort return of coins already taken. Never throws: it runs while another
-// failure is being handled, and losing the refund to a second error is worse
-// than logging it.
-async function refund(userId, guildId, amount, note) {
-    try {
-        const doc = await User.findOneAndUpdate(
-            { userId, guildId },
-            { $inc: { balance: amount } },
-            { new: true }
-        );
-        logTransaction({ userId, guildId, type: 'roll', amount, balance: doc?.balance ?? 0, note });
-    } catch (error) {
-        console.error(`[roll] refund of ${amount} to ${userId} in ${guildId} failed:`, error);
-    }
-}
+const refund = (userId, guildId, amount, note) =>
+    refundWager({ userId, guildId, amount, type: 'roll', note });
 
 // Exact-number bets pay out at sides:1 odds (before the house cut). High/low pays
 // at true odds for the split (sides / winning-number-count) rather than a flat 2x —

--- a/src/commands/fun/roll.js
+++ b/src/commands/fun/roll.js
@@ -9,6 +9,8 @@ const {
 const Guild = require('../../models/Guild');
 const User  = require('../../models/User');
 const { logTransaction } = require('../../utils/logTransaction');
+const { createReplaySession } = require('../../utils/replaySession');
+const { delay } = require('../../utils/delay');
 
 const THUMB = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3b2.png';
 
@@ -74,6 +76,8 @@ function resultEmbed(interaction, result, sides) {
 }
 
 module.exports = {
+    __test__: { payoutMultiplier, callWon, callLabel, rollBar },
+
     data: new SlashCommandBuilder()
         .setName('roll')
         .setDescription('Roll a die')
@@ -136,36 +140,67 @@ module.exports = {
 };
 
 async function playRoll(interaction, sides) {
-    const result   = Math.floor(Math.random() * sides) + 1;
-    const replayId = `roll_replay_${interaction.id}_${Date.now()}`;
+    const replayId = `roll_replay_${interaction.id}`;
+    let session    = null;
 
-    const row = new ActionRowBuilder().addComponents(
+    async function render() {
+        const result = Math.floor(Math.random() * sides) + 1;
+        return interaction.editReply({
+            embeds:     [resultEmbed(interaction, result, sides)],
+            components: session?.ended ? [] : [replayRow(replayId)],
+        });
+    }
+
+    const message = await render();
+
+    session = createReplaySession({
+        interaction,
+        message,
+        customIds: [replayId],
+        label:     'roll',
+        claim:     `Those dice are ${interaction.user}'s — run \`/roll\` to roll your own.`,
+        async onCollect(button) {
+            await button.deferUpdate();
+            await render();
+        },
+    });
+}
+
+function replayRow(customId) {
+    return new ActionRowBuilder().addComponents(
         new ButtonBuilder()
-            .setCustomId(replayId)
-            .setLabel('🎲 Roll Again')
+            .setCustomId(customId)
+            .setEmoji('🎲')
+            .setLabel('Roll Again')
             .setStyle(ButtonStyle.Primary),
     );
+}
 
-    await interaction.editReply({
-        embeds:     [resultEmbed(interaction, result, sides)],
-        components: [row],
-    });
+// Best-effort return of coins already taken. Never throws: it runs while another
+// failure is being handled, and losing the refund to a second error is worse
+// than logging it.
+async function refund(userId, guildId, amount, note) {
+    try {
+        const doc = await User.findOneAndUpdate(
+            { userId, guildId },
+            { $inc: { balance: amount } },
+            { new: true }
+        );
+        logTransaction({ userId, guildId, type: 'roll', amount, balance: doc?.balance ?? 0, note });
+    } catch (error) {
+        console.error(`[roll] refund of ${amount} to ${userId} in ${guildId} failed:`, error);
+    }
+}
 
-    const msg = await interaction.fetchReply();
-    const collector = msg.createMessageComponentCollector({
-        filter: i => i.user.id === interaction.user.id && i.customId === replayId,
-        max:    1,
-        time:   60_000,
-    });
-
-    collector.on('collect', async i => {
-        await i.deferUpdate();
-        await playRoll(interaction, sides);
-    });
-
-    collector.on('end', (_, reason) => {
-        if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
-    });
+// Exact-number bets pay out at sides:1 odds (before the house cut). High/low pays
+// at true odds for the split (sides / winning-number-count) rather than a flat 2x —
+// on odd-sided dice the low half has one fewer number than the high half, so a flat
+// 2x would give "high" bettors better-than-even odds at the same payout.
+function payoutMultiplier(call, sides) {
+    if (call.type === 'exact') return sides;
+    const half         = Math.floor(sides / 2);
+    const winningCount = call.type === 'high' ? sides - half : half;
+    return sides / winningCount;
 }
 
 function callLabel(call, sides) {
@@ -193,8 +228,11 @@ async function playRollBet(interaction, guildSettings, sides, bet, call) {
         return interaction.editReply({ content: `You don't have **${currency}${bet.toLocaleString()}** to wager.` });
     }
 
-    const delay = ms => new Promise(r => setTimeout(r, ms));
-    const stakeLine = `Wager: **${currency}${bet.toLocaleString()}** on ${callLabel(call, sides)}`;
+    // Work the payout out before the roll so it can be shown while the dice are
+    // still in the air, rather than only turning up in the result.
+    const multiplier  = payoutMultiplier(call, sides);
+    const grossPayout = Math.floor(bet * multiplier * (1 - HOUSE_CUT));
+    const stakeLine   = `Wager: **${currency}${bet.toLocaleString()}** on ${callLabel(call, sides)} · pays **${(grossPayout / bet).toFixed(2)}x**`;
     for (let f = 0; f < 4; f++) {
         // Animation frames are cosmetic — a transient editReply failure here shouldn't
         // abort the roll and strand the bet that was already debited above.
@@ -212,29 +250,26 @@ async function playRollBet(interaction, guildSettings, sides, bet, call) {
 
     const result = Math.floor(Math.random() * sides) + 1;
     const won    = callWon(call, result, sides);
-
-    // Exact-number bets pay out at sides:1 odds (minus house cut). High/low pays at
-    // true odds for the split (sides / winning-number-count) rather than a flat 2x —
-    // on odd-sided dice the low half has one fewer number than the high half, so a
-    // flat 2x would give "high" bettors better-than-even odds at the same payout.
-    let multiplier;
-    if (call.type === 'exact') {
-        multiplier = sides;
-    } else {
-        const half = Math.floor(sides / 2);
-        const winningCount = call.type === 'high' ? sides - half : half;
-        multiplier = sides / winningCount;
-    }
-    const grossPayout = Math.floor(bet * multiplier * (1 - HOUSE_CUT));
-    const profit       = grossPayout - bet;
+    const profit = grossPayout - bet;
 
     let updated = debited;
     if (won) {
-        updated = await User.findOneAndUpdate(
-            { userId: interaction.user.id, guildId },
-            { $inc: { balance: grossPayout } },
-            { new: true }
-        );
+        try {
+            updated = await User.findOneAndUpdate(
+                { userId: interaction.user.id, guildId },
+                { $inc: { balance: grossPayout } },
+                { new: true }
+            );
+        } catch (error) {
+            // The stake is gone and the win can't be paid. Return it rather
+            // than let a database hiccup pocket the wager.
+            console.error('[roll] payout failed, returning the stake:', error);
+            await refund(interaction.user.id, guildId, bet, 'Roll bet — payout failed, stake returned');
+            return interaction.editReply({
+                content: `You rolled **${result}** and called it — but the payout failed, so your **${currency}${bet.toLocaleString()}** has been returned. Try again in a moment.`,
+                embeds:  [],
+            }).catch(() => {});
+        }
     }
     logTransaction({
         userId:  interaction.user.id,

--- a/src/commands/utility/help.js
+++ b/src/commands/utility/help.js
@@ -81,9 +81,9 @@ const CATEGORIES = [
         label: 'Fun',
         preview: '8ball, coinflip, roll',
         commands: [
-            { name: '8ball',    description: 'Ask the magic 8-ball a question' },
-            { name: 'coinflip', description: 'Flip a coin — heads or tails' },
-            { name: 'roll',     description: 'Roll dice with a given number of sides' },
+            { name: '8ball',    description: 'Ask the magic 8-ball a yes/no question — shake again or ask another' },
+            { name: 'coinflip', description: 'Flip a coin: call heads or tails, bet coins, or challenge a member' },
+            { name: 'roll',     description: 'Roll a 2-100 sided die, optionally betting high, low, or an exact number' },
         ],
     },
     {

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -5,6 +5,12 @@ const { handlePollVote } = require('../commands/utility/poll');
 const { handleHeistButton } = require('../commands/economy/heist');
 const { handleSyndicateButton } = require('../commands/economy/syndicate');
 const { handleDmButton } = require('../services/dmService');
+const {
+    isEightBallButton,
+    isEightBallModal,
+    handleEightBallButton,
+    handleEightBallModal,
+} = require('../commands/fun/8ball');
 const { ensureQuests, onCommandUse, notifyQuestComplete, notifyQuestNearComplete } = require('../services/questService');
 const { getGuildSettings } = require('../utils/guildSettingsCache');
 // Giveaway entry/withdrawal.
@@ -200,6 +206,16 @@ module.exports = {
                 await handlePollVote(interaction);
             }
 
+            // The 8-ball's buttons are deliberately not held by a collector:
+            // routing them here is what lets an old message still work, and
+            // keeps them working across a restart.
+            if (isEightBallButton(interaction.customId)) {
+                await handleEightBallButton(interaction).catch(err => {
+                    console.error('[8ball] button handler error:', err);
+                });
+                return;
+            }
+
             if (interaction.customId.startsWith('dm_storysofar_')) {
                 await handleDmButton(interaction, client).catch(err => {
                     console.error('[dm] button handler error:', err);
@@ -207,6 +223,15 @@ module.exports = {
                 return;
             }
 
+            return;
+        }
+
+        if (interaction.isModalSubmit()) {
+            if (isEightBallModal(interaction.customId)) {
+                await handleEightBallModal(interaction).catch(err => {
+                    console.error('[8ball] modal handler error:', err);
+                });
+            }
             return;
         }
 

--- a/src/utils/eightBallImage.js
+++ b/src/utils/eightBallImage.js
@@ -1,0 +1,233 @@
+'use strict';
+
+/**
+ * Draws the answer inside a magic 8-ball's window.
+ *
+ * The command previously showed a static 72px twemoji next to the text, which
+ * said "8-ball" but never said anything about the answer. Rendering the ball
+ * with the reply in its window is the whole visual — the die face is tinted by
+ * outlook, so the verdict reads before the text does.
+ *
+ * There are only twenty answers, so every render is cached: the first shake of
+ * each one pays for the canvas, every shake after it is a map lookup.
+ */
+
+const { createCanvas } = require('canvas');
+const { ensureFontsRegistered } = require('./registerFonts');
+
+ensureFontsRegistered();
+
+const FONT = '"DejaVu Sans"';
+
+const SIZE   = 400;
+const CENTER = SIZE / 2;
+const BALL_R = 192;
+
+// The window, and the die floating in it.
+const WINDOW_R  = 118;
+const APEX_Y    = CENTER - 92;
+const BASE_Y    = CENTER + 74;
+const HALF_BASE = 98;
+
+// Text is laid inside the triangle, so the usable width grows with depth. Stay
+// clear of the edges — the die's own bevel eats into the corners.
+const INSET = 0.84;
+
+const TINTS = {
+    positive: { die: '#1c7a4a', edge: '#25a163' },
+    neutral:  { die: '#8a5b12', edge: '#c07f1c' },
+    negative: { die: '#8f2420', edge: '#c1332c' },
+};
+
+const cache = new Map();
+
+// Half-width of the triangle at a given height, zero at the apex.
+function halfWidthAt(y) {
+    if (y <= APEX_Y) return 0;
+    if (y >= BASE_Y) return HALF_BASE;
+    return HALF_BASE * ((y - APEX_Y) / (BASE_Y - APEX_Y));
+}
+
+// Greedy wrap into lines of the given per-line widths. Returns null when the
+// text doesn't fit — the caller then tries a smaller font or another line count.
+function wrapInto(ctx, text, widths) {
+    const words = text.split(' ');
+    const lines = [];
+    let current = '';
+
+    for (const word of words) {
+        const limit = widths[lines.length];
+        if (limit === undefined) return null;
+
+        const candidate = current ? `${current} ${word}` : word;
+        if (ctx.measureText(candidate).width <= limit) {
+            current = candidate;
+            continue;
+        }
+        if (!current) return null; // a single word too wide for its line
+
+        lines.push(current);
+        current = word;
+
+        // The word has just started the next line, which is narrower than the
+        // one it was rejected from — it has to be measured against that line
+        // too, or it silently overhangs the die.
+        const next = widths[lines.length];
+        if (next === undefined || ctx.measureText(word).width > next) return null;
+    }
+
+    if (current) lines.push(current);
+    return lines.length === widths.length ? lines : null;
+}
+
+// Largest font size at which the answer fits inside the die face.
+function layoutAnswer(ctx, text) {
+    for (let size = 30; size >= 11; size--) {
+        ctx.font = `bold ${size}px ${FONT}`;
+        const lineHeight = size * 1.2;
+
+        for (let count = 1; count <= 4; count++) {
+            // Sit the block low in the triangle, where it is widest.
+            const top    = BASE_Y - 26 - count * lineHeight;
+            const widths = Array.from({ length: count }, (_, i) =>
+                halfWidthAt(top + (i + 1) * lineHeight) * 2 * INSET);
+
+            const lines = wrapInto(ctx, text, widths);
+            if (lines) return { lines, size, lineHeight, top };
+        }
+    }
+
+    // Nothing in the answer table gets here; a future addition might.
+    ctx.font = `bold 11px ${FONT}`;
+    return { lines: [text], size: 11, lineHeight: 13, top: BASE_Y - 40 };
+}
+
+function drawBall(ctx) {
+    // The sphere: lit from the upper left, falling away to near-black.
+    const body = ctx.createRadialGradient(
+        CENTER - 70, CENTER - 80, 20,
+        CENTER, CENTER, BALL_R,
+    );
+    body.addColorStop(0,    '#4a4a4a');
+    body.addColorStop(0.45, '#181818');
+    body.addColorStop(1,    '#050505');
+
+    ctx.beginPath();
+    ctx.arc(CENTER, CENTER, BALL_R, 0, Math.PI * 2);
+    ctx.fillStyle = body;
+    ctx.fill();
+
+    // A rim of reflected light along the lower right stops the ball from
+    // dissolving into a dark message background.
+    ctx.beginPath();
+    ctx.arc(CENTER, CENTER, BALL_R - 2, 0, Math.PI * 2);
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.16)';
+    ctx.lineWidth = 3;
+    ctx.stroke();
+
+    // Specular highlight: a fast falloff, otherwise the gradient fills its whole
+    // ellipse with mid-grey and reads as a smudge rather than gloss.
+    const gloss = ctx.createRadialGradient(
+        CENTER - 82, CENTER - 100, 2,
+        CENTER - 82, CENTER - 100, 58,
+    );
+    gloss.addColorStop(0,    'rgba(255, 255, 255, 0.40)');
+    gloss.addColorStop(0.35, 'rgba(255, 255, 255, 0.10)');
+    gloss.addColorStop(1,    'rgba(255, 255, 255, 0)');
+    ctx.beginPath();
+    ctx.ellipse(CENTER - 82, CENTER - 100, 54, 34, -0.6, 0, Math.PI * 2);
+    ctx.fillStyle = gloss;
+    ctx.fill();
+
+    // A small hard glint sells the gloss the soft falloff only suggests.
+    const glint = ctx.createRadialGradient(
+        CENTER - 92, CENTER - 112, 0,
+        CENTER - 92, CENTER - 112, 15,
+    );
+    glint.addColorStop(0, 'rgba(255, 255, 255, 0.72)');
+    glint.addColorStop(1, 'rgba(255, 255, 255, 0)');
+    ctx.beginPath();
+    ctx.ellipse(CENTER - 92, CENTER - 112, 15, 9, -0.6, 0, Math.PI * 2);
+    ctx.fillStyle = glint;
+    ctx.fill();
+}
+
+function drawWindow(ctx, tint) {
+    // The liquid behind the die.
+    const fluid = ctx.createRadialGradient(
+        CENTER, CENTER - 30, 10,
+        CENTER, CENTER, WINDOW_R,
+    );
+    fluid.addColorStop(0, '#111a2e');
+    fluid.addColorStop(1, '#05070d');
+
+    ctx.beginPath();
+    ctx.arc(CENTER, CENTER, WINDOW_R, 0, Math.PI * 2);
+    ctx.fillStyle = fluid;
+    ctx.fill();
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.22)';
+    ctx.lineWidth = 2;
+    ctx.stroke();
+
+    // The die face.
+    ctx.beginPath();
+    ctx.moveTo(CENTER, APEX_Y);
+    ctx.lineTo(CENTER + HALF_BASE, BASE_Y);
+    ctx.lineTo(CENTER - HALF_BASE, BASE_Y);
+    ctx.closePath();
+
+    const face = ctx.createLinearGradient(CENTER, APEX_Y, CENTER, BASE_Y);
+    face.addColorStop(0, tint.edge);
+    face.addColorStop(1, tint.die);
+    ctx.fillStyle = face;
+    ctx.fill();
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.28)';
+    ctx.lineWidth = 2;
+    ctx.stroke();
+}
+
+function drawAnswer(ctx, text) {
+    const { lines, size, lineHeight, top } = layoutAnswer(ctx, text);
+
+    ctx.font = `bold ${size}px ${FONT}`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = '#ffffff';
+    ctx.shadowColor = 'rgba(0, 0, 0, 0.55)';
+    ctx.shadowBlur = 4;
+
+    lines.forEach((line, i) => {
+        ctx.fillText(line, CENTER, top + (i + 0.5) * lineHeight);
+    });
+
+    ctx.shadowBlur = 0;
+}
+
+/**
+ * PNG of the ball showing `text`, tinted for `type`.
+ *
+ * @param {string} text - the answer, e.g. "Signs point to yes."
+ * @param {'positive'|'neutral'|'negative'} type
+ * @returns {Buffer}
+ */
+function renderEightBall(text, type) {
+    const key = `${type}|${text}`;
+    const hit = cache.get(key);
+    if (hit) return hit;
+
+    const canvas = createCanvas(SIZE, SIZE);
+    const ctx    = canvas.getContext('2d');
+
+    drawBall(ctx);
+    drawWindow(ctx, TINTS[type] ?? TINTS.neutral);
+    drawAnswer(ctx, text);
+
+    const buffer = canvas.toBuffer('image/png');
+    cache.set(key, buffer);
+    return buffer;
+}
+
+module.exports = {
+    renderEightBall,
+    __test__: { cache, layoutAnswer, wrapInto, halfWidthAt, SIZE, TINTS, FONT },
+};

--- a/src/utils/refundWager.js
+++ b/src/utils/refundWager.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const User = require('../models/User');
+const { logTransaction } = require('./logTransaction');
+
+/**
+ * Best-effort return of coins a game already took.
+ *
+ * Never throws. Every caller is on a path that is itself handling a failure —
+ * a wager escrowed for a flip that can't resolve, a payout that didn't land —
+ * and losing the refund to a second error would be worse than logging it.
+ * Shared so the two gambling commands can't drift apart on that guarantee.
+ *
+ * @param {object} opts
+ * @param {string} opts.userId
+ * @param {string} opts.guildId
+ * @param {number} opts.amount  - coins to credit back
+ * @param {string} opts.type    - transaction type, e.g. 'coinflip' or 'roll'
+ * @param {string} opts.note    - why the coins came back, for the audit log
+ */
+async function refundWager({ userId, guildId, amount, type, note }) {
+    try {
+        const doc = await User.findOneAndUpdate(
+            { userId, guildId },
+            { $inc: { balance: amount } },
+            { new: true }
+        );
+        logTransaction({ userId, guildId, type, amount, balance: doc?.balance ?? 0, note });
+    } catch (error) {
+        console.error(`[${type}] refund of ${amount} to ${userId} in ${guildId} failed:`, error);
+    }
+}
+
+module.exports = { refundWager };

--- a/src/utils/replaySession.js
+++ b/src/utils/replaySession.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const { ComponentType, MessageFlags } = require('discord.js');
+
+// Discord expires an interaction token 15 minutes after the command was
+// invoked, and every follow-up in these sessions is an editReply against that
+// token. Sessions idle out after a minute without a click, and carry a hard cap
+// under the token's life so the last edit — the one taking the buttons off —
+// still lands instead of rejecting into nothing.
+const IDLE_MS = 60_000;
+const MAX_MS  = 13 * 60_000;
+
+/**
+ * Buttons on a command's own reply that the invoker can click over and over —
+ * "flip again", "roll again", "shake again".
+ *
+ * One collector serves the whole session. Arming a fresh max:1 collector per
+ * click leaves the replacement buttons on screen for a beat with nothing
+ * listening behind them, and a click landing in that gap dies as "This
+ * interaction failed".
+ *
+ * Everything here runs after execute() has already returned, so the command
+ * dispatcher's try/catch is long out of scope: an error escaping onCollect
+ * would surface as a process-level unhandled rejection rather than a log line.
+ * Hence the wrapper.
+ *
+ * @param {object} opts
+ * @param {import('discord.js').ChatInputCommandInteraction} opts.interaction
+ * @param {import('discord.js').Message} opts.message - the reply carrying the buttons
+ * @param {string[]} opts.customIds                   - the buttons this session owns
+ * @param {string}   opts.label                       - log prefix, e.g. 'coinflip'
+ * @param {string}   [opts.claim]                     - ephemeral text for other members
+ * @param {(button: import('discord.js').ButtonInteraction, session: object) => Promise<void>} opts.onCollect
+ * @returns {object} the session handle
+ */
+function createReplaySession({
+    interaction,
+    message,
+    customIds,
+    label,
+    claim,
+    onCollect,
+    idle = IDLE_MS,
+    maxDuration = MAX_MS,
+}) {
+    const owned    = new Set(customIds);
+    const deadline = Date.now() + maxDuration;
+    let busy       = false;
+
+    const collector = message.createMessageComponentCollector({
+        componentType: ComponentType.Button,
+        filter: i => owned.has(i.customId),
+        idle,
+        time: maxDuration,
+    });
+
+    const session = {
+        collector,
+
+        get ended() { return collector.ended; },
+
+        // Claim the session for a render. Returns false if one is already in
+        // flight, which is what keeps a double-click from starting two.
+        hold() {
+            if (busy) return false;
+            busy = true;
+            return true;
+        },
+
+        // Drop the claim ahead of a wait that shouldn't freeze the buttons — a
+        // modal, say, which the member has to dismiss before they can click.
+        release() { busy = false; },
+
+        // Restart the idle timer after work the collector never saw, without
+        // pushing the session past the deadline it was given.
+        extend() {
+            if (collector.ended) return;
+            collector.resetTimer({ idle, time: Math.max(1_000, deadline - Date.now()) });
+        },
+    };
+
+    collector.on('collect', async button => {
+        try {
+            if (button.user.id !== interaction.user.id) {
+                // Turning these away in the collector filter instead would show
+                // every other member a bare "This interaction failed".
+                return await button.reply({
+                    content: claim ?? `That one belongs to ${interaction.user} — run the command yourself to play.`,
+                    flags:   MessageFlags.Ephemeral,
+                });
+            }
+
+            if (!session.hold()) return await button.deferUpdate().catch(() => {});
+
+            await onCollect(button, session);
+        } catch (error) {
+            console.error(`[${label}] component handler error:`, error);
+        } finally {
+            session.release();
+        }
+    });
+
+    collector.on('end', () => {
+        // A render still in flight settles the components itself; see how the
+        // callers consult session.ended when choosing what to attach.
+        if (busy) return;
+        interaction.editReply({ components: [] }).catch(() => {});
+    });
+
+    return session;
+}
+
+module.exports = { createReplaySession, IDLE_MS, MAX_MS };

--- a/src/utils/replaySession.js
+++ b/src/utils/replaySession.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { ComponentType, MessageFlags } = require('discord.js');
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, ComponentType, MessageFlags } = require('discord.js');
 
 // Discord expires an interaction token 15 minutes after the command was
 // invoked, and every follow-up in these sessions is an editReply against that
@@ -79,22 +79,28 @@ function createReplaySession({
         },
     };
 
+    const logFailure = error => console.error(`[${label}] component handler error:`, error);
+
     collector.on('collect', async button => {
+        // Neither branch below claimed the session, so neither may release it.
+        // Releasing unconditionally in a finally let a bystander's click — or a
+        // click rejected as overlapping — clear the flag held by a render still
+        // in flight, which is exactly the overlap the flag exists to prevent.
+        if (button.user.id !== interaction.user.id) {
+            // Turning these away in the collector filter instead would show
+            // every other member a bare "This interaction failed".
+            return button.reply({
+                content: claim ?? `That one belongs to ${interaction.user} — run the command yourself to play.`,
+                flags:   MessageFlags.Ephemeral,
+            }).catch(logFailure);
+        }
+
+        if (!session.hold()) return button.deferUpdate().catch(() => {});
+
         try {
-            if (button.user.id !== interaction.user.id) {
-                // Turning these away in the collector filter instead would show
-                // every other member a bare "This interaction failed".
-                return await button.reply({
-                    content: claim ?? `That one belongs to ${interaction.user} — run the command yourself to play.`,
-                    flags:   MessageFlags.Ephemeral,
-                });
-            }
-
-            if (!session.hold()) return await button.deferUpdate().catch(() => {});
-
             await onCollect(button, session);
         } catch (error) {
-            console.error(`[${label}] component handler error:`, error);
+            logFailure(error);
         } finally {
             session.release();
         }
@@ -110,4 +116,15 @@ function createReplaySession({
     return session;
 }
 
-module.exports = { createReplaySession, IDLE_MS, MAX_MS };
+/** The single "go again" button these sessions are built around. */
+function replayButtonRow(customId, { emoji, label, style = ButtonStyle.Primary }) {
+    return new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+            .setCustomId(customId)
+            .setEmoji(emoji)
+            .setLabel(label)
+            .setStyle(style),
+    );
+}
+
+module.exports = { createReplaySession, replayButtonRow, IDLE_MS, MAX_MS };

--- a/tests/analytics.test.js
+++ b/tests/analytics.test.js
@@ -239,6 +239,7 @@ describe('logCommandMetric (interactionCreate)', () => {
         return {
             isChatInputCommand: () => true,
             isButton: () => false,
+            isModalSubmit: () => false,
             isAutocomplete: () => false,
             commandName: 'ping',
             guildId: '111111111111111111',

--- a/tests/coinflipEscrow.test.js
+++ b/tests/coinflipEscrow.test.js
@@ -5,14 +5,14 @@
 // are already out of the players' wallets when one can be thrown. These cover
 // the rule that matters: coins the bot took must never simply vanish.
 
-jest.mock('../src/models/User', () => ({ findOneAndUpdate: jest.fn() }));
+jest.mock('../src/models/User', () => ({ findOneAndUpdate: jest.fn(), findOne: jest.fn() }));
 jest.mock('../src/models/Guild', () => ({ findOne: jest.fn().mockResolvedValue(null) }));
 jest.mock('../src/models/Transaction', () => ({ create: jest.fn().mockResolvedValue({}) }));
 
 const User = require('../src/models/User');
 const Transaction = require('../src/models/Transaction');
 const { __test__ } = require('../src/commands/fun/coinflip');
-const { escrowWagers, refund, flip, other, pip } = __test__;
+const { escrowWagers, payoutState, refund, flip, other, pip } = __test__;
 
 const GUILD = 'guild-1';
 const CHALLENGER = 'user-a';
@@ -86,7 +86,7 @@ describe('escrowWagers', () => {
 
         const result = await escrowWagers(GUILD, CHALLENGER, OPPONENT, BET);
 
-        expect(result).toEqual({ ok: false, error: boom });
+        expect(result).toEqual({ ok: false, error: boom, refunded: 'challenger' });
 
         const refundCall = User.findOneAndUpdate.mock.calls[2];
         expect(debitOf(refundCall)).toMatchObject({ userId: CHALLENGER });
@@ -104,8 +104,28 @@ describe('escrowWagers', () => {
     });
 
     test('reports the failure to the caller rather than throwing at the collector', async () => {
-        User.findOneAndUpdate.mockRejectedValue(new Error('down'));
+        // Single-use: clearAllMocks() resets calls but not implementations, so a
+        // permanent rejection here would follow the mock into later tests.
+        User.findOneAndUpdate.mockRejectedValueOnce(new Error('down'));
         await expect(escrowWagers(GUILD, CHALLENGER, OPPONENT, BET)).resolves.toMatchObject({ ok: false });
+    });
+
+    test('tells the caller when it put the challenger\'s stake back', async () => {
+        User.findOneAndUpdate
+            .mockResolvedValueOnce(wallet(400))
+            .mockRejectedValueOnce(new Error('connection reset'))
+            .mockResolvedValueOnce(wallet(500));
+
+        // Without this the collector reports a bare failure and the challenger
+        // is left assuming their coins are gone.
+        const result = await escrowWagers(GUILD, CHALLENGER, OPPONENT, BET);
+        expect(result.refunded).toBe('challenger');
+    });
+
+    test('claims no refund when it never took anything', async () => {
+        User.findOneAndUpdate.mockRejectedValueOnce(new Error('connection reset'));
+        const result = await escrowWagers(GUILD, CHALLENGER, OPPONENT, BET);
+        expect(result.refunded).toBeUndefined();
     });
 });
 
@@ -125,6 +145,39 @@ describe('refund', () => {
         User.findOneAndUpdate.mockRejectedValueOnce(new Error('still down'));
         await expect(refund(CHALLENGER, GUILD, BET, 'wager returned')).resolves.toBeUndefined();
         expect(errorSpy).toHaveBeenCalled();
+    });
+});
+
+describe('payoutState', () => {
+    const BEFORE = 400;
+    const PAYOUT = 190;
+
+    test('recognises a payout that landed despite the error', async () => {
+        User.findOne.mockResolvedValueOnce(wallet(BEFORE + PAYOUT));
+        await expect(payoutState(CHALLENGER, GUILD, BEFORE, PAYOUT)).resolves.toBe('applied');
+    });
+
+    test('recognises a payout that never landed', async () => {
+        User.findOne.mockResolvedValueOnce(wallet(BEFORE));
+        await expect(payoutState(CHALLENGER, GUILD, BEFORE, PAYOUT)).resolves.toBe('not-applied');
+    });
+
+    test('refuses to guess when something else moved the balance', async () => {
+        User.findOne.mockResolvedValueOnce(wallet(BEFORE + 25));
+        await expect(payoutState(CHALLENGER, GUILD, BEFORE, PAYOUT)).resolves.toBe('unknown');
+    });
+
+    test('refuses to guess when the balance cannot be read at all', async () => {
+        User.findOne.mockRejectedValueOnce(new Error('still down'));
+        await expect(payoutState(CHALLENGER, GUILD, BEFORE, PAYOUT)).resolves.toBe('unknown');
+
+        User.findOne.mockResolvedValueOnce(null);
+        await expect(payoutState(CHALLENGER, GUILD, BEFORE, PAYOUT)).resolves.toBe('unknown');
+    });
+
+    test('refuses to guess without a balance to compare against', async () => {
+        await expect(payoutState(CHALLENGER, GUILD, undefined, PAYOUT)).resolves.toBe('unknown');
+        expect(User.findOne).not.toHaveBeenCalled();
     });
 });
 

--- a/tests/coinflipEscrow.test.js
+++ b/tests/coinflipEscrow.test.js
@@ -1,0 +1,143 @@
+'use strict';
+
+// /coinflip's PvP wager runs entirely inside a component collector, long after
+// execute() returned — so nothing above it is catching errors, and both stakes
+// are already out of the players' wallets when one can be thrown. These cover
+// the rule that matters: coins the bot took must never simply vanish.
+
+jest.mock('../src/models/User', () => ({ findOneAndUpdate: jest.fn() }));
+jest.mock('../src/models/Guild', () => ({ findOne: jest.fn().mockResolvedValue(null) }));
+jest.mock('../src/models/Transaction', () => ({ create: jest.fn().mockResolvedValue({}) }));
+
+const User = require('../src/models/User');
+const Transaction = require('../src/models/Transaction');
+const { __test__ } = require('../src/commands/fun/coinflip');
+const { escrowWagers, refund, flip, other, pip } = __test__;
+
+const GUILD = 'guild-1';
+const CHALLENGER = 'user-a';
+const OPPONENT = 'user-b';
+const BET = 100;
+
+const wallet = balance => ({ balance });
+
+// The debit is a conditional update: it matches only when the balance covers
+// the bet, and returns null when it doesn't.
+const debitOf = call => call[0];
+const incOf = call => call[1].$inc.balance;
+
+let errorSpy;
+beforeEach(() => {
+    jest.clearAllMocks();
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => errorSpy.mockRestore());
+
+describe('escrowWagers', () => {
+    test('takes both stakes when both sides can cover', async () => {
+        User.findOneAndUpdate
+            .mockResolvedValueOnce(wallet(400))
+            .mockResolvedValueOnce(wallet(900));
+
+        const result = await escrowWagers(GUILD, CHALLENGER, OPPONENT, BET);
+
+        expect(result).toMatchObject({ ok: true });
+        expect(result.challengerDoc).toEqual(wallet(400));
+        expect(result.opponentDoc).toEqual(wallet(900));
+        expect(User.findOneAndUpdate).toHaveBeenCalledTimes(2);
+
+        for (const call of User.findOneAndUpdate.mock.calls) {
+            expect(debitOf(call)).toMatchObject({ guildId: GUILD, balance: { $gte: BET } });
+            expect(incOf(call)).toBe(-BET);
+        }
+    });
+
+    test('takes nothing when the challenger is short', async () => {
+        User.findOneAndUpdate.mockResolvedValueOnce(null);
+
+        const result = await escrowWagers(GUILD, CHALLENGER, OPPONENT, BET);
+
+        expect(result).toEqual({ ok: false, short: 'challenger' });
+        expect(User.findOneAndUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    test('returns the challenger stake when the opponent is short', async () => {
+        User.findOneAndUpdate
+            .mockResolvedValueOnce(wallet(400)) // challenger debited
+            .mockResolvedValueOnce(null)        // opponent can't cover
+            .mockResolvedValueOnce(wallet(500)); // refund
+
+        const result = await escrowWagers(GUILD, CHALLENGER, OPPONENT, BET);
+
+        expect(result).toEqual({ ok: false, short: 'opponent' });
+        expect(User.findOneAndUpdate).toHaveBeenCalledTimes(3);
+
+        const refundCall = User.findOneAndUpdate.mock.calls[2];
+        expect(debitOf(refundCall)).toMatchObject({ userId: CHALLENGER, guildId: GUILD });
+        expect(incOf(refundCall)).toBe(BET);
+    });
+
+    test('returns the challenger stake when the opponent debit throws', async () => {
+        const boom = new Error('connection reset');
+        User.findOneAndUpdate
+            .mockResolvedValueOnce(wallet(400))
+            .mockRejectedValueOnce(boom)
+            .mockResolvedValueOnce(wallet(500)); // refund
+
+        const result = await escrowWagers(GUILD, CHALLENGER, OPPONENT, BET);
+
+        expect(result).toEqual({ ok: false, error: boom });
+
+        const refundCall = User.findOneAndUpdate.mock.calls[2];
+        expect(debitOf(refundCall)).toMatchObject({ userId: CHALLENGER });
+        expect(incOf(refundCall)).toBe(BET);
+    });
+
+    test('refunds nothing when the very first debit throws', async () => {
+        const boom = new Error('connection reset');
+        User.findOneAndUpdate.mockRejectedValueOnce(boom);
+
+        const result = await escrowWagers(GUILD, CHALLENGER, OPPONENT, BET);
+
+        expect(result).toEqual({ ok: false, error: boom });
+        expect(User.findOneAndUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    test('reports the failure to the caller rather than throwing at the collector', async () => {
+        User.findOneAndUpdate.mockRejectedValue(new Error('down'));
+        await expect(escrowWagers(GUILD, CHALLENGER, OPPONENT, BET)).resolves.toMatchObject({ ok: false });
+    });
+});
+
+describe('refund', () => {
+    test('credits the coins back and leaves an audit trail', async () => {
+        User.findOneAndUpdate.mockResolvedValueOnce(wallet(500));
+
+        await refund(CHALLENGER, GUILD, BET, 'wager returned');
+
+        expect(incOf(User.findOneAndUpdate.mock.calls[0])).toBe(BET);
+        expect(Transaction.create).toHaveBeenCalledWith(expect.objectContaining({
+            userId: CHALLENGER, guildId: GUILD, type: 'coinflip', amount: BET, balance: 500, note: 'wager returned',
+        }));
+    });
+
+    test('never throws — it runs while another failure is already being handled', async () => {
+        User.findOneAndUpdate.mockRejectedValueOnce(new Error('still down'));
+        await expect(refund(CHALLENGER, GUILD, BET, 'wager returned')).resolves.toBeUndefined();
+        expect(errorSpy).toHaveBeenCalled();
+    });
+});
+
+describe('coin', () => {
+    test('lands on one of two sides, both reachable', () => {
+        const seen = new Set();
+        for (let i = 0; i < 500; i++) seen.add(flip());
+        expect([...seen].sort()).toEqual(['Heads', 'Tails']);
+    });
+
+    test('sides are each other’s opposite and carry distinct pips', () => {
+        expect(other('Heads')).toBe('Tails');
+        expect(other('Tails')).toBe('Heads');
+        expect(pip('Heads')).not.toBe(pip('Tails'));
+    });
+});

--- a/tests/eightBall.test.js
+++ b/tests/eightBall.test.js
@@ -129,9 +129,16 @@ describe('quoteQuestion', () => {
 
 const {
     readState, ownerOf, isEightBallButton, isEightBallModal,
-    buttonRow, resultEmbed, handleButton, handleModal, shaking, shakeLimiter,
-    SHAKE_LIMIT,
+    buttonRow, resultView, shakingView, textContents,
+    handleButton, handleModal, shaking, shakeLimiter, SHAKE_LIMIT, BALL_FILE,
 } = __test__;
+
+// What a rendered message looks like once Discord has round-tripped it: the
+// builders are gone, leaving raw component JSON.
+const asMessage = (view, id = 'msg-1') => ({ id, components: [view.toJSON()] });
+const lastEdit  = interaction => interaction.editReply.mock.calls.at(-1)[0];
+const viewJSON  = payload => payload.components[0].toJSON();
+const textOf    = payload => textContents({ components: payload.components }).join('\n');
 
 describe('custom ids', () => {
     test('claim only the 8-ball\'s own buttons', () => {
@@ -153,53 +160,71 @@ describe('custom ids', () => {
 });
 
 describe('readState', () => {
-    const author = { name: 'Asker', iconURL: 'https://example.invalid/a.png' };
-
-    function messageFrom(embed) {
-        return { id: 'msg-1', embeds: [embed.toJSON()] };
-    }
-
     test('round-trips what a shake needs from a rendered message', () => {
         const quoted = quoteQuestion('will it rain?');
-        const embed  = resultEmbed(author, quoted, { type: 'positive', text: 'Yes.' }, 4);
+        const view   = resultView(quoted, { type: 'positive', text: 'Yes.' }, 4, '1111');
 
-        const state = readState(messageFrom(embed));
-        expect(state.quoted).toBe(quoted);
-        expect(state.shakes).toBe(4);
-        expect(state.author).toEqual(author);
+        expect(readState(asMessage(view))).toEqual({ quoted, shakes: 4 });
     });
 
-    test('reads the author whichever way the avatar field is spelled', () => {
-        // messageFrom() hands over the raw gateway shape (icon_url); the Embed
-        // class discord.js wraps it in exposes the same value as iconURL.
-        const quoted = quoteQuestion('either way?');
-        const embed  = resultEmbed(author, quoted, { type: 'positive', text: 'Yes.' }, 1);
-
-        const wrapped = {
-            id: 'msg-2',
-            embeds: [{ ...embed.toJSON(), author: { name: author.name, iconURL: author.iconURL } }],
-        };
-        expect(readState(wrapped).author).toEqual(author);
+    test('finds the question inside a nested section, not just a bare text display', () => {
+        // The question lives in a Section's text display; the shake count lives
+        // in a top-level one. Both have to be reachable.
+        const json = resultView(quoteQuestion('nested?'), { type: 'neutral', text: 'Ask again later.' }, 2, '1111').toJSON();
+        expect(json.components[0].type).toBe(9); // Section
+        expect(textContents({ components: [json] }).length).toBeGreaterThan(1);
+        expect(readState({ components: [json] }).quoted).toBe(quoteQuestion('nested?'));
     });
 
     test('carries an escaped question forward without re-escaping it', () => {
         const quoted = quoteQuestion('**really**?');
-        const embed  = resultEmbed(author, quoted, { type: 'neutral', text: 'Ask again later.' }, 1);
+        const answer = { type: 'neutral', text: 'Ask again later.' };
 
         // A second shake reuses the stored string verbatim; escaping it again
         // would pile up backslashes with every click.
-        const once  = readState(messageFrom(embed)).quoted;
-        const twice = readState(messageFrom(resultEmbed(author, once, { type: 'neutral', text: 'Ask again later.' }, 2))).quoted;
+        const once  = readState(asMessage(resultView(quoted, answer, 1, '1111'))).quoted;
+        const twice = readState(asMessage(resultView(once, answer, 2, '1111'))).quoted;
         expect(twice).toBe(quoted);
     });
 
+    test('does not mistake the shake counter for part of the question', () => {
+        const quoted = quoteQuestion('is Shake #9 a real question?');
+        const state  = readState(asMessage(resultView(quoted, { type: 'positive', text: 'Yes.' }, 3, '1111')));
+        expect(state.quoted).toBe(quoted);
+        expect(state.shakes).toBe(3);
+    });
+
     test('survives a message it cannot read', () => {
-        for (const message of [undefined, {}, { embeds: [] }, { embeds: [{}] }]) {
+        for (const message of [undefined, {}, { components: [] }, { components: [{ type: 17 }] }]) {
             const state = readState(message);
             expect(typeof state.quoted).toBe('string');
             expect(state.shakes).toBe(0);
-            expect(state.author).toBeNull();
         }
+    });
+});
+
+describe('rendering', () => {
+    test('the answer is text as well as picture, and the ball carries alt text', () => {
+        const payload = resultView(quoteQuestion('legible?'), { type: 'negative', text: 'Very doubtful.' }, 1, '1111').toJSON();
+        const section = payload.components.find(c => c.type === 9);
+
+        expect(section.accessory.media.url).toBe(`attachment://${BALL_FILE}`);
+        expect(section.accessory.description).toContain('Very doubtful.');
+        // Screen readers and image-blocked clients still get the verdict.
+        expect(textContents({ components: [payload] }).join('\n')).toContain('Very doubtful.');
+    });
+
+    test('the accent colour tracks the outlook', () => {
+        const colors = ['positive', 'neutral', 'negative'].map(type =>
+            resultView('> *"q"*', { type, text: 'x' }, 1, '1111').toJSON().accent_color);
+        expect(new Set(colors).size).toBe(3);
+        expect(colors.every(Number.isInteger)).toBe(true);
+    });
+
+    test('a shaking ball shows no answer and no buttons to press', () => {
+        const payload = shakingView(quoteQuestion('mid-shake?'), 0).toJSON();
+        expect(JSON.stringify(payload)).not.toContain('attachment://');
+        expect(payload.components.some(c => c.type === 1)).toBe(false);
     });
 });
 
@@ -210,7 +235,7 @@ describe('button handler', () => {
         return {
             customId:    `8ball_again_${OWNER}`,
             user:        { id: OWNER },
-            message:     { id: `msg-${Math.random()}`, embeds: [] },
+            message:     { id: `msg-${Math.random()}`, components: [] },
             reply:       jest.fn().mockResolvedValue(undefined),
             deferUpdate: jest.fn().mockResolvedValue(undefined),
             editReply:   jest.fn().mockResolvedValue(undefined),
@@ -248,18 +273,34 @@ describe('button handler', () => {
         await handleButton(i);
 
         expect(i.deferUpdate).toHaveBeenCalled();
-        const final = i.editReply.mock.calls.at(-1)[0];
+        const final = lastEdit(i);
         expect(final.components).toHaveLength(1);
-        expect(final.components[0].toJSON().components).toHaveLength(2);
+        expect(viewJSON(final).components.some(c => c.type === 1)).toBe(true);
+    });
+
+    test('never pings the asker it names, however many times it is shaken', async () => {
+        const i = buttonInteraction();
+        await handleButton(i);
+
+        const final = lastEdit(i);
+        expect(textOf(final)).toContain('asked by <@');
+        expect(final.allowedMentions).toEqual({ parse: [] });
+    });
+
+    test('clears the previous render so the message does not collect images', async () => {
+        const i = buttonInteraction();
+        await handleButton(i);
+
+        for (const call of i.editReply.mock.calls) expect(call[0].attachments).toEqual([]);
+        expect(lastEdit(i).files).toHaveLength(1);
     });
 
     test('counts up from whatever the message already recorded', async () => {
-        const embed = resultEmbed(null, quoteQuestion('again?'), { type: 'positive', text: 'Yes.' }, 7);
-        const i = buttonInteraction({ message: { id: 'msg-count', embeds: [embed.toJSON()] } });
+        const view = resultView(quoteQuestion('again?'), { type: 'positive', text: 'Yes.' }, 7, OWNER);
+        const i = buttonInteraction({ message: asMessage(view, 'msg-count') });
         await handleButton(i);
 
-        const shown = i.editReply.mock.calls.at(-1)[0].embeds[0].toJSON();
-        expect(shown.fields.find(f => f.name === '🌀 Shakes').value).toBe('**8**');
+        expect(textOf(lastEdit(i))).toContain('Shake #8');
     });
 
     test('rate limits a member hammering the button', async () => {
@@ -274,7 +315,7 @@ describe('button handler', () => {
     });
 
     test('one shake at a time per message', async () => {
-        const message = { id: 'msg-shared', embeds: [] };
+        const message = { id: 'msg-shared', components: [] };
         const first  = buttonInteraction({ message });
         const second = buttonInteraction({ message });
 
@@ -297,7 +338,7 @@ describe('modal handler', () => {
         return {
             customId:      `8ball_modal_${OWNER}`,
             user:          { id: OWNER },
-            message:       { id: `msg-${Math.random()}`, embeds: [] },
+            message:       { id: `msg-${Math.random()}`, components: [] },
             isFromMessage: () => true,
             fields:        { getTextInputValue: jest.fn().mockReturnValue(value) },
             reply:         jest.fn().mockResolvedValue(undefined),
@@ -316,9 +357,9 @@ describe('modal handler', () => {
         const i = modalInteraction('will it snow?');
         await handleModal(i);
 
-        const shown = i.editReply.mock.calls.at(-1)[0].embeds[0].toJSON();
-        expect(shown.description).toBe(quoteQuestion('will it snow?'));
-        expect(shown.fields.find(f => f.name === '🌀 Shakes').value).toBe('**1**');
+        const text = textOf(lastEdit(i));
+        expect(text).toContain(quoteQuestion('will it snow?'));
+        expect(text).toContain('Shake #1');
     });
 
     test('rejects a blank question without touching the message', async () => {

--- a/tests/eightBall.test.js
+++ b/tests/eightBall.test.js
@@ -1,0 +1,117 @@
+'use strict';
+
+// The 8-ball's pure logic: the answer distribution the toy is supposed to have,
+// and the question sanitising that keeps a hostile question inside its quote.
+
+const { __test__ } = require('../src/commands/fun/8ball');
+const { RESPONSES, TYPE_CONFIG, pickResponse, normalizeQuestion, quoteQuestion, MAX_QUESTION } = __test__;
+
+// Deterministic stand-in for Math.random that walks a fixed list of values.
+function seq(values) {
+    let i = 0;
+    return () => values[i++ % values.length];
+}
+
+describe('response table', () => {
+    test('carries the classic 20 answers, 10/5/5', () => {
+        expect(RESPONSES.positive).toHaveLength(10);
+        expect(RESPONSES.neutral).toHaveLength(5);
+        expect(RESPONSES.negative).toHaveLength(5);
+    });
+
+    test('every category has display config', () => {
+        for (const type of Object.keys(RESPONSES)) {
+            expect(TYPE_CONFIG[type]).toMatchObject({
+                color:   expect.stringMatching(/^#[0-9a-f]{6}$/i),
+                emoji:   expect.any(String),
+                outlook: expect.any(String),
+            });
+        }
+    });
+});
+
+describe('pickResponse', () => {
+    test('maps the category roll to the documented 50/25/25 split', () => {
+        expect(pickResponse(seq([0.00, 0])).type).toBe('positive');
+        expect(pickResponse(seq([0.49, 0])).type).toBe('positive');
+        expect(pickResponse(seq([0.50, 0])).type).toBe('neutral');
+        expect(pickResponse(seq([0.74, 0])).type).toBe('neutral');
+        expect(pickResponse(seq([0.75, 0])).type).toBe('negative');
+        expect(pickResponse(seq([0.99, 0])).type).toBe('negative');
+    });
+
+    test('the second roll indexes within the category', () => {
+        expect(pickResponse(seq([0.0, 0.0])).text).toBe(RESPONSES.positive[0]);
+        expect(pickResponse(seq([0.0, 0.99])).text).toBe(RESPONSES.positive[9]);
+        expect(pickResponse(seq([0.8, 0.99])).text).toBe(RESPONSES.negative[4]);
+    });
+
+    test('never indexes off the end of a pool', () => {
+        for (const r of [0.0, 0.5, 0.75]) {
+            const { type, text } = pickResponse(seq([r, 0.9999999]));
+            expect(RESPONSES[type]).toContain(text);
+        }
+    });
+
+    test('answers are uniform 1-in-20, like the physical toy', () => {
+        // Sweep the category roll evenly, then the in-pool roll evenly: every
+        // answer should come up the same number of times.
+        const counts = new Map();
+        const STEPS = 2000;
+        for (let a = 0; a < STEPS; a++) {
+            for (let b = 0; b < 20; b++) {
+                const { text } = pickResponse(seq([a / STEPS, b / 20]));
+                counts.set(text, (counts.get(text) ?? 0) + 1);
+            }
+        }
+
+        const all = Object.values(RESPONSES).flat();
+        expect(counts.size).toBe(20);
+        expect(all.every(text => counts.has(text))).toBe(true);
+
+        const expected = (STEPS * 20) / 20;
+        for (const [, n] of counts) {
+            // Well inside the rounding slack of the sweep.
+            expect(Math.abs(n - expected)).toBeLessThan(expected * 0.02);
+        }
+    });
+
+    test('defaults to Math.random and stays in the table', () => {
+        for (let i = 0; i < 200; i++) {
+            const { type, text } = pickResponse();
+            expect(RESPONSES[type]).toContain(text);
+        }
+    });
+});
+
+describe('normalizeQuestion', () => {
+    test('trims and collapses whitespace so the quote stays on one line', () => {
+        expect(normalizeQuestion('  will   it\nrain\ttoday? ')).toBe('will it rain today?');
+    });
+
+    test('caps length even when the option limit is bypassed', () => {
+        expect(normalizeQuestion('x'.repeat(500))).toHaveLength(MAX_QUESTION);
+    });
+
+    test('treats blank and missing input as no question', () => {
+        expect(normalizeQuestion('   ')).toBe('');
+        expect(normalizeQuestion('\n\t')).toBe('');
+        expect(normalizeQuestion(null)).toBe('');
+        expect(normalizeQuestion(undefined)).toBe('');
+    });
+});
+
+describe('quoteQuestion', () => {
+    test('escapes markdown instead of letting it reformat the embed', () => {
+        const out = quoteQuestion('**bold** `code` ||spoiler||');
+        expect(out).toContain('\\*\\*bold\\*\\*');
+        expect(out).toContain('\\`code\\`');
+        expect(out).not.toMatch(/(?<!\\)\|\|/);
+    });
+
+    test('renders as a single block-quote line', () => {
+        const out = quoteQuestion(normalizeQuestion('am I\nsure?'));
+        expect(out.split('\n')).toHaveLength(1);
+        expect(out.startsWith('> ')).toBe(true);
+    });
+});

--- a/tests/eightBall.test.js
+++ b/tests/eightBall.test.js
@@ -314,6 +314,17 @@ describe('button handler', () => {
         expect(blocked.editReply).not.toHaveBeenCalled();
     });
 
+    test('a failed shake still lets go of the message', async () => {
+        const message = { id: 'msg-boom', components: [] };
+        const i = buttonInteraction({ message });
+        i.deferUpdate.mockRejectedValue(new Error('unknown interaction'));
+
+        // The error is the router's to log; what matters here is that the lock
+        // doesn't outlive it and wedge the message shut.
+        await expect(handleButton(i)).rejects.toThrow('unknown interaction');
+        expect(shaking.has(message.id)).toBe(false);
+    });
+
     test('one shake at a time per message', async () => {
         const message = { id: 'msg-shared', components: [] };
         const first  = buttonInteraction({ message });

--- a/tests/eightBall.test.js
+++ b/tests/eightBall.test.js
@@ -3,6 +3,10 @@
 // The 8-ball's pure logic: the answer distribution the toy is supposed to have,
 // and the question sanitising that keeps a hostile question inside its quote.
 
+// The shake animation sleeps between frames. Nothing under test depends on the
+// wall-clock gap, and the handler tests drive a dozen shakes apiece.
+jest.mock('../src/utils/delay', () => ({ delay: () => Promise.resolve() }));
+
 const { __test__ } = require('../src/commands/fun/8ball');
 const { RESPONSES, TYPE_CONFIG, pickResponse, normalizeQuestion, quoteQuestion, MAX_QUESTION } = __test__;
 
@@ -113,5 +117,225 @@ describe('quoteQuestion', () => {
         const out = quoteQuestion(normalizeQuestion('am I\nsure?'));
         expect(out.split('\n')).toHaveLength(1);
         expect(out.startsWith('> ')).toBe(true);
+    });
+});
+
+// ── Persistent buttons ───────────────────────────────────────────────────────
+//
+// The buttons are routed through events/interactionCreate rather than held by a
+// collector, so they outlive the command, the session and the process. Nothing
+// can be closed over: the owner rides in the custom id, and the question and
+// shake count are read back off the message.
+
+const {
+    readState, ownerOf, isEightBallButton, isEightBallModal,
+    buttonRow, resultEmbed, handleButton, handleModal, shaking, shakeLimiter,
+    SHAKE_LIMIT,
+} = __test__;
+
+describe('custom ids', () => {
+    test('claim only the 8-ball\'s own buttons', () => {
+        expect(isEightBallButton('8ball_again_123')).toBe(true);
+        expect(isEightBallButton('8ball_newq_123')).toBe(true);
+        expect(isEightBallButton('8ball_modal_123')).toBe(false);
+        expect(isEightBallButton('poll_vote_1')).toBe(false);
+        expect(isEightBallModal('8ball_modal_123')).toBe(true);
+        expect(isEightBallModal('8ball_again_123')).toBe(false);
+    });
+
+    test('carry the owner, and stay inside Discord\'s 100 character limit', () => {
+        const snowflake = '1234567890123456789';
+        for (const button of buttonRow(snowflake).toJSON().components) {
+            expect(button.custom_id.length).toBeLessThanOrEqual(100);
+            expect(ownerOf(button.custom_id)).toBe(snowflake);
+        }
+    });
+});
+
+describe('readState', () => {
+    const author = { name: 'Asker', iconURL: 'https://example.invalid/a.png' };
+
+    function messageFrom(embed) {
+        return { id: 'msg-1', embeds: [embed.toJSON()] };
+    }
+
+    test('round-trips what a shake needs from a rendered message', () => {
+        const quoted = quoteQuestion('will it rain?');
+        const embed  = resultEmbed(author, quoted, { type: 'positive', text: 'Yes.' }, 4);
+
+        const state = readState(messageFrom(embed));
+        expect(state.quoted).toBe(quoted);
+        expect(state.shakes).toBe(4);
+        expect(state.author).toEqual(author);
+    });
+
+    test('reads the author whichever way the avatar field is spelled', () => {
+        // messageFrom() hands over the raw gateway shape (icon_url); the Embed
+        // class discord.js wraps it in exposes the same value as iconURL.
+        const quoted = quoteQuestion('either way?');
+        const embed  = resultEmbed(author, quoted, { type: 'positive', text: 'Yes.' }, 1);
+
+        const wrapped = {
+            id: 'msg-2',
+            embeds: [{ ...embed.toJSON(), author: { name: author.name, iconURL: author.iconURL } }],
+        };
+        expect(readState(wrapped).author).toEqual(author);
+    });
+
+    test('carries an escaped question forward without re-escaping it', () => {
+        const quoted = quoteQuestion('**really**?');
+        const embed  = resultEmbed(author, quoted, { type: 'neutral', text: 'Ask again later.' }, 1);
+
+        // A second shake reuses the stored string verbatim; escaping it again
+        // would pile up backslashes with every click.
+        const once  = readState(messageFrom(embed)).quoted;
+        const twice = readState(messageFrom(resultEmbed(author, once, { type: 'neutral', text: 'Ask again later.' }, 2))).quoted;
+        expect(twice).toBe(quoted);
+    });
+
+    test('survives a message it cannot read', () => {
+        for (const message of [undefined, {}, { embeds: [] }, { embeds: [{}] }]) {
+            const state = readState(message);
+            expect(typeof state.quoted).toBe('string');
+            expect(state.shakes).toBe(0);
+            expect(state.author).toBeNull();
+        }
+    });
+});
+
+describe('button handler', () => {
+    const OWNER = '1111';
+
+    function buttonInteraction(overrides = {}) {
+        return {
+            customId:    `8ball_again_${OWNER}`,
+            user:        { id: OWNER },
+            message:     { id: `msg-${Math.random()}`, embeds: [] },
+            reply:       jest.fn().mockResolvedValue(undefined),
+            deferUpdate: jest.fn().mockResolvedValue(undefined),
+            editReply:   jest.fn().mockResolvedValue(undefined),
+            showModal:   jest.fn().mockResolvedValue(undefined),
+            ...overrides,
+        };
+    }
+
+    beforeEach(() => {
+        shaking.clear();
+        shakeLimiter._map.clear();
+    });
+
+    test('turns away members who do not own the ball', async () => {
+        const i = buttonInteraction({ user: { id: 'someone-else' } });
+        await handleButton(i);
+
+        expect(i.reply).toHaveBeenCalledWith(expect.objectContaining({
+            content: expect.stringContaining(OWNER),
+        }));
+        expect(i.deferUpdate).not.toHaveBeenCalled();
+    });
+
+    test('opens the modal for a new question rather than shaking', async () => {
+        const i = buttonInteraction({ customId: `8ball_newq_${OWNER}` });
+        await handleButton(i);
+
+        expect(i.showModal).toHaveBeenCalledTimes(1);
+        expect(i.showModal.mock.calls[0][0].toJSON().custom_id).toBe(`8ball_modal_${OWNER}`);
+        expect(i.editReply).not.toHaveBeenCalled();
+    });
+
+    test('shakes, and leaves the buttons attached for next time', async () => {
+        const i = buttonInteraction();
+        await handleButton(i);
+
+        expect(i.deferUpdate).toHaveBeenCalled();
+        const final = i.editReply.mock.calls.at(-1)[0];
+        expect(final.components).toHaveLength(1);
+        expect(final.components[0].toJSON().components).toHaveLength(2);
+    });
+
+    test('counts up from whatever the message already recorded', async () => {
+        const embed = resultEmbed(null, quoteQuestion('again?'), { type: 'positive', text: 'Yes.' }, 7);
+        const i = buttonInteraction({ message: { id: 'msg-count', embeds: [embed.toJSON()] } });
+        await handleButton(i);
+
+        const shown = i.editReply.mock.calls.at(-1)[0].embeds[0].toJSON();
+        expect(shown.fields.find(f => f.name === '🌀 Shakes').value).toBe('**8**');
+    });
+
+    test('rate limits a member hammering the button', async () => {
+        for (let n = 0; n < SHAKE_LIMIT; n++) await handleButton(buttonInteraction());
+
+        const blocked = buttonInteraction();
+        await handleButton(blocked);
+        expect(blocked.reply).toHaveBeenCalledWith(expect.objectContaining({
+            content: expect.stringContaining('moment'),
+        }));
+        expect(blocked.editReply).not.toHaveBeenCalled();
+    });
+
+    test('one shake at a time per message', async () => {
+        const message = { id: 'msg-shared', embeds: [] };
+        const first  = buttonInteraction({ message });
+        const second = buttonInteraction({ message });
+
+        const running = handleButton(first);
+        await handleButton(second);
+
+        expect(second.editReply).not.toHaveBeenCalled();
+        expect(second.deferUpdate).toHaveBeenCalled();
+        await running;
+
+        // The lock lifts once the first shake finishes.
+        expect(shaking.has(message.id)).toBe(false);
+    });
+});
+
+describe('modal handler', () => {
+    const OWNER = '2222';
+
+    function modalInteraction(value, overrides = {}) {
+        return {
+            customId:      `8ball_modal_${OWNER}`,
+            user:          { id: OWNER },
+            message:       { id: `msg-${Math.random()}`, embeds: [] },
+            isFromMessage: () => true,
+            fields:        { getTextInputValue: jest.fn().mockReturnValue(value) },
+            reply:         jest.fn().mockResolvedValue(undefined),
+            deferUpdate:   jest.fn().mockResolvedValue(undefined),
+            editReply:     jest.fn().mockResolvedValue(undefined),
+            ...overrides,
+        };
+    }
+
+    beforeEach(() => {
+        shaking.clear();
+        shakeLimiter._map.clear();
+    });
+
+    test('asks the new question and restarts the count', async () => {
+        const i = modalInteraction('will it snow?');
+        await handleModal(i);
+
+        const shown = i.editReply.mock.calls.at(-1)[0].embeds[0].toJSON();
+        expect(shown.description).toBe(quoteQuestion('will it snow?'));
+        expect(shown.fields.find(f => f.name === '🌀 Shakes').value).toBe('**1**');
+    });
+
+    test('rejects a blank question without touching the message', async () => {
+        const i = modalInteraction('   ');
+        await handleModal(i);
+
+        expect(i.reply).toHaveBeenCalledWith(expect.objectContaining({
+            content: expect.stringContaining('actual question'),
+        }));
+        expect(i.editReply).not.toHaveBeenCalled();
+    });
+
+    test('ignores a submission that did not come from an 8-ball message', async () => {
+        const i = modalInteraction('anything', { isFromMessage: () => false });
+        await handleModal(i);
+
+        expect(i.reply).not.toHaveBeenCalled();
+        expect(i.editReply).not.toHaveBeenCalled();
     });
 });

--- a/tests/eightBallImage.test.js
+++ b/tests/eightBallImage.test.js
@@ -1,0 +1,118 @@
+'use strict';
+
+// The rendered ball. Everything here is geometry and cache behaviour — what the
+// ball *looks* like isn't testable, but "the answer fits inside the die" is,
+// and that is the property that breaks when the answer table changes.
+
+const { renderEightBall, __test__ } = require('../src/utils/eightBallImage');
+const { cache, layoutAnswer, wrapInto, halfWidthAt, SIZE, TINTS, FONT } = __test__;
+const { createCanvas } = require('canvas');
+const { __test__: ball } = require('../src/commands/fun/8ball');
+const { RESPONSES } = ball;
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+const ctx = () => createCanvas(SIZE, SIZE).getContext('2d');
+
+beforeEach(() => cache.clear());
+
+describe('renderEightBall', () => {
+    test('renders a PNG of the expected size', () => {
+        const png = renderEightBall('Yes.', 'positive');
+        expect(png.subarray(0, 4)).toEqual(PNG_MAGIC);
+        // IHDR carries width and height as big-endian 32-bit ints at byte 16.
+        expect(png.readUInt32BE(16)).toBe(SIZE);
+        expect(png.readUInt32BE(20)).toBe(SIZE);
+    });
+
+    test('every answer in the table renders', () => {
+        for (const [type, answers] of Object.entries(RESPONSES)) {
+            for (const text of answers) {
+                const png = renderEightBall(text, type);
+                expect(png.subarray(0, 4)).toEqual(PNG_MAGIC);
+                expect(png.length).toBeGreaterThan(1000);
+            }
+        }
+        expect(cache.size).toBe(20);
+    });
+
+    test('each outlook is tinted differently, so the verdict reads before the text', () => {
+        const [positive, neutral, negative] = ['positive', 'neutral', 'negative']
+            .map(type => renderEightBall('Yes.', type));
+
+        expect(positive.equals(neutral)).toBe(false);
+        expect(neutral.equals(negative)).toBe(false);
+        expect(positive.equals(negative)).toBe(false);
+        expect(new Set(Object.values(TINTS).map(t => t.die)).size).toBe(3);
+    });
+
+    test('repeat shakes of the same answer reuse the render', () => {
+        const first  = renderEightBall('Signs point to yes.', 'positive');
+        const second = renderEightBall('Signs point to yes.', 'positive');
+
+        expect(second).toBe(first); // same buffer, not merely equal
+        expect(cache.size).toBe(1);
+    });
+
+    test('an unknown outlook still renders rather than throwing', () => {
+        expect(renderEightBall('Who knows.', 'sideways').subarray(0, 4)).toEqual(PNG_MAGIC);
+    });
+});
+
+describe('layoutAnswer', () => {
+    // Half-width shrinks to nothing at the apex, so a line placed high has less
+    // room than one placed low. Text that ignored this would poke out the sides.
+    test('the triangle narrows toward its apex', () => {
+        const heights = [0, 0.25, 0.5, 0.75, 1].map(t => halfWidthAt(160 + t * 150));
+        for (let i = 1; i < heights.length; i++) {
+            expect(heights[i]).toBeGreaterThan(heights[i - 1]);
+        }
+        expect(halfWidthAt(0)).toBe(0);
+    });
+
+    test('every answer fits within the die face at its chosen size', () => {
+        const c = ctx();
+        for (const text of Object.values(RESPONSES).flat()) {
+            const { lines, size, lineHeight, top } = layoutAnswer(c, text);
+            c.font = `bold ${size}px ${FONT}`;
+
+            expect(lines.join(' ')).toBe(text); // nothing dropped in the wrap
+            lines.forEach((line, i) => {
+                const y = top + (i + 1) * lineHeight;
+                expect(c.measureText(line).width).toBeLessThanOrEqual(halfWidthAt(y) * 2);
+            });
+        }
+    });
+
+    test('shorter answers get a larger font than longer ones', () => {
+        const c = ctx();
+        const short = layoutAnswer(c, 'Yes.');
+        const long  = layoutAnswer(c, 'Concentrate and ask again.');
+        expect(short.size).toBeGreaterThan(long.size);
+    });
+
+    test('falls back rather than throwing on text no size can fit', () => {
+        const result = layoutAnswer(ctx(), 'Supercalifragilistic'.repeat(20));
+        expect(result.lines.length).toBeGreaterThan(0);
+        expect(result.size).toBeGreaterThan(0);
+    });
+});
+
+describe('wrapInto', () => {
+    test('fills each line up to its own width', () => {
+        const c = ctx();
+        c.font = `bold 20px ${FONT}`;
+        expect(wrapInto(c, 'one two three', [1000])).toEqual(['one two three']);
+    });
+
+    test('refuses a wrap that would need more lines than it was given', () => {
+        const c = ctx();
+        c.font = `bold 20px ${FONT}`;
+        expect(wrapInto(c, 'one two three four five', [40])).toBeNull();
+    });
+
+    test('refuses a single word too wide for its line', () => {
+        const c = ctx();
+        c.font = `bold 20px ${FONT}`;
+        expect(wrapInto(c, 'unwrappable', [4])).toBeNull();
+    });
+});

--- a/tests/replaySession.test.js
+++ b/tests/replaySession.test.js
@@ -129,6 +129,37 @@ describe('overlap guard', () => {
         expect(h.onCollect).toHaveBeenCalledTimes(2);
     });
 
+    test('a bystander\'s click cannot release a render in flight', async () => {
+        let finish;
+        const inFlight = new Promise(resolve => { finish = resolve; });
+        const h = setup({ onCollect: jest.fn(() => inFlight) });
+
+        const running = h.collect(button());        // owner starts a render
+        await h.collect(button('someone-else'));    // bystander is turned away
+        await h.collect(button());                  // owner clicks again
+
+        // The bystander's rejection must not have handed the second owner click
+        // a free claim on a session that is still rendering.
+        expect(h.onCollect).toHaveBeenCalledTimes(1);
+
+        finish();
+        await running;
+    });
+
+    test('a rejected overlapping click cannot release the claim it lost to', async () => {
+        let finish;
+        const inFlight = new Promise(resolve => { finish = resolve; });
+        const h = setup({ onCollect: jest.fn(() => inFlight) });
+
+        const running = h.collect(button());
+        await h.collect(button());  // rejected as overlapping
+        await h.collect(button());  // must still be rejected
+
+        expect(h.onCollect).toHaveBeenCalledTimes(1);
+        finish();
+        await running;
+    });
+
     test('release() lets a click through mid-handler, hold() takes it back', async () => {
         const h = setup({ onCollect: jest.fn() });
         expect(h.session.hold()).toBe(true);

--- a/tests/replaySession.test.js
+++ b/tests/replaySession.test.js
@@ -1,0 +1,213 @@
+'use strict';
+
+// The replay-button session shared by /8ball, /coinflip and /roll. These
+// collectors run after execute() has returned, outside the dispatcher's error
+// handling, so the guarantees worth pinning down are: other members never see a
+// raw interaction failure, overlapping clicks can't start two renders, a
+// throwing handler is logged rather than left unhandled, and the buttons come
+// off when the session ends.
+
+const EventEmitter = require('events');
+const { createReplaySession, IDLE_MS, MAX_MS } = require('../src/utils/replaySession');
+
+class FakeCollector extends EventEmitter {
+    constructor(options) {
+        super();
+        this.options    = options;
+        this.ended      = false;
+        this.resetTimer = jest.fn();
+    }
+}
+
+function button(userId = 'owner', customId = 'replay') {
+    return {
+        customId,
+        user:        { id: userId },
+        reply:       jest.fn().mockResolvedValue(undefined),
+        deferUpdate: jest.fn().mockResolvedValue(undefined),
+    };
+}
+
+function setup({ onCollect = jest.fn().mockResolvedValue(undefined), claim } = {}) {
+    let collector;
+    const message = {
+        createMessageComponentCollector: jest.fn(options => {
+            collector = new FakeCollector(options);
+            return collector;
+        }),
+    };
+    const interaction = {
+        user:       { id: 'owner', toString: () => '<@owner>' },
+        editReply:  jest.fn().mockResolvedValue(undefined),
+    };
+
+    const session = createReplaySession({
+        interaction,
+        message,
+        customIds: ['replay', 'other'],
+        label:     'test',
+        claim,
+        onCollect,
+    });
+
+    return {
+        session, interaction, onCollect,
+        get collector() { return collector; },
+        // Call the registered listener directly so each click is awaitable.
+        collect: b => collector.listeners('collect')[0](b),
+        end: () => { collector.ended = true; collector.emit('end'); },
+    };
+}
+
+let errorSpy;
+beforeEach(() => { errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {}); });
+afterEach(() => { errorSpy.mockRestore(); });
+
+describe('collector setup', () => {
+    test('only listens to the buttons it was given', () => {
+        const h = setup();
+        const { filter } = h.collector.options;
+        expect(filter(button('owner', 'replay'))).toBe(true);
+        expect(filter(button('owner', 'other'))).toBe(true);
+        expect(filter(button('owner', 'someone-elses-button'))).toBe(false);
+    });
+
+    test('caps the session below the 15 minute interaction token life', () => {
+        const h = setup();
+        expect(h.collector.options.idle).toBe(IDLE_MS);
+        expect(h.collector.options.time).toBe(MAX_MS);
+        expect(MAX_MS).toBeLessThan(15 * 60_000);
+    });
+});
+
+describe('ownership', () => {
+    test('other members get an ephemeral note, not a failed interaction', async () => {
+        const h = setup();
+        const stranger = button('someone-else');
+        await h.collect(stranger);
+
+        expect(stranger.reply).toHaveBeenCalledWith(expect.objectContaining({
+            content: expect.stringContaining('<@owner>'),
+        }));
+        expect(h.onCollect).not.toHaveBeenCalled();
+    });
+
+    test('a caller-supplied claim message wins', async () => {
+        const h = setup({ claim: 'hands off' });
+        const stranger = button('someone-else');
+        await h.collect(stranger);
+        expect(stranger.reply).toHaveBeenCalledWith(expect.objectContaining({ content: 'hands off' }));
+    });
+
+    test('the invoker runs the handler', async () => {
+        const h = setup();
+        const b = button();
+        await h.collect(b);
+        expect(h.onCollect).toHaveBeenCalledTimes(1);
+        expect(h.onCollect.mock.calls[0][0]).toBe(b);
+    });
+});
+
+describe('overlap guard', () => {
+    test('a click during a render is acknowledged, not run twice', async () => {
+        let finish;
+        const inFlight = new Promise(resolve => { finish = resolve; });
+        const h = setup({ onCollect: jest.fn(() => inFlight) });
+
+        const first  = h.collect(button());
+        const second = button();
+        await h.collect(second);
+
+        expect(h.onCollect).toHaveBeenCalledTimes(1);
+        expect(second.deferUpdate).toHaveBeenCalled();
+
+        finish();
+        await first;
+
+        // The guard lifts once the render finishes.
+        await h.collect(button());
+        expect(h.onCollect).toHaveBeenCalledTimes(2);
+    });
+
+    test('release() lets a click through mid-handler, hold() takes it back', async () => {
+        const h = setup({ onCollect: jest.fn() });
+        expect(h.session.hold()).toBe(true);
+        expect(h.session.hold()).toBe(false);
+        h.session.release();
+        expect(h.session.hold()).toBe(true);
+        h.session.release();
+    });
+});
+
+describe('failure handling', () => {
+    test('a throwing handler is logged instead of going unhandled', async () => {
+        const boom = new Error('editReply exploded');
+        const h = setup({ onCollect: jest.fn().mockRejectedValue(boom) });
+
+        await expect(h.collect(button())).resolves.toBeUndefined();
+        expect(errorSpy).toHaveBeenCalledWith('[test] component handler error:', boom);
+    });
+
+    test('the overlap guard is released even when the handler throws', async () => {
+        const h = setup({ onCollect: jest.fn().mockRejectedValue(new Error('nope')) });
+        await h.collect(button());
+        expect(h.session.hold()).toBe(true);
+    });
+
+    test('a failed ephemeral reply does not escape either', async () => {
+        const h = setup();
+        const stranger = button('someone-else');
+        stranger.reply.mockRejectedValue(new Error('unknown interaction'));
+        await expect(h.collect(stranger)).resolves.toBeUndefined();
+        expect(errorSpy).toHaveBeenCalled();
+    });
+});
+
+describe('teardown', () => {
+    test('ending the session strips the buttons', () => {
+        const h = setup();
+        h.end();
+        expect(h.interaction.editReply).toHaveBeenCalledWith({ components: [] });
+    });
+
+    test('a render in flight is left to settle its own components', async () => {
+        let finish;
+        const inFlight = new Promise(resolve => { finish = resolve; });
+        const h = setup({ onCollect: jest.fn(() => inFlight) });
+
+        const pending = h.collect(button());
+        h.end();
+        expect(h.interaction.editReply).not.toHaveBeenCalled();
+
+        // session.ended is what the render consults before re-attaching buttons.
+        expect(h.session.ended).toBe(true);
+        finish();
+        await pending;
+    });
+
+    test('a failing teardown edit is swallowed', () => {
+        const h = setup();
+        h.interaction.editReply.mockRejectedValue(new Error('expired token'));
+        expect(() => h.end()).not.toThrow();
+    });
+});
+
+describe('extend', () => {
+    test('restarts the idle timer without outliving the deadline', () => {
+        const h = setup();
+        h.session.extend();
+
+        expect(h.collector.resetTimer).toHaveBeenCalledTimes(1);
+        const [{ idle, time }] = h.collector.resetTimer.mock.calls[0];
+        expect(idle).toBe(IDLE_MS);
+        expect(time).toBeGreaterThan(0);
+        expect(time).toBeLessThanOrEqual(MAX_MS);
+    });
+
+    test('is a no-op once the session has ended', () => {
+        const h = setup();
+        h.end();
+        h.session.extend();
+        expect(h.collector.resetTimer).not.toHaveBeenCalled();
+    });
+});

--- a/tests/rollPayout.test.js
+++ b/tests/rollPayout.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+// /roll's wager maths, now that the payout is quoted to the player before the
+// dice land: the number shown while rolling has to be the number that pays.
+
+jest.mock('../src/models/User', () => ({ findOneAndUpdate: jest.fn() }));
+jest.mock('../src/models/Guild', () => ({ findOne: jest.fn().mockResolvedValue(null) }));
+jest.mock('../src/models/Transaction', () => ({ create: jest.fn().mockResolvedValue({}) }));
+
+const { __test__ } = require('../src/commands/fun/roll');
+const { payoutMultiplier, callWon, callLabel, rollBar } = __test__;
+
+const HOUSE_CUT = 0.05;
+const high = { type: 'high' };
+const low  = { type: 'low' };
+const exact = number => ({ type: 'exact', number });
+
+describe('payoutMultiplier', () => {
+    test('exact-number bets pay at the die odds', () => {
+        expect(payoutMultiplier(exact(3), 6)).toBe(6);
+        expect(payoutMultiplier(exact(77), 100)).toBe(100);
+    });
+
+    test('an even die splits evenly, so high and low both pay 2x', () => {
+        expect(payoutMultiplier(high, 6)).toBe(2);
+        expect(payoutMultiplier(low, 6)).toBe(2);
+    });
+
+    test('an odd die pays the two halves differently, matching their real odds', () => {
+        // d7: low is 1-3, high is 4-7. A flat 2x would hand "high" the edge.
+        expect(payoutMultiplier(low, 7)).toBeCloseTo(7 / 3);
+        expect(payoutMultiplier(high, 7)).toBeCloseTo(7 / 4);
+        expect(payoutMultiplier(high, 7)).toBeLessThan(payoutMultiplier(low, 7));
+    });
+
+    test('every call keeps the same house edge, whichever way it is made', () => {
+        for (const sides of [2, 5, 6, 7, 20, 99, 100]) {
+            for (const call of [high, low, exact(1)]) {
+                const winningCount = countWins(call, sides);
+                const edge = 1 - (winningCount / sides) * payoutMultiplier(call, sides) * (1 - HOUSE_CUT);
+                expect(edge).toBeCloseTo(HOUSE_CUT, 10);
+            }
+        }
+    });
+});
+
+function countWins(call, sides) {
+    let wins = 0;
+    for (let r = 1; r <= sides; r++) if (callWon(call, r, sides)) wins++;
+    return wins;
+}
+
+describe('callWon', () => {
+    test('splits an even die down the middle', () => {
+        expect([1, 2, 3].every(r => callWon(low, r, 6))).toBe(true);
+        expect([4, 5, 6].every(r => callWon(high, r, 6))).toBe(true);
+        expect(callWon(low, 4, 6)).toBe(false);
+        expect(callWon(high, 3, 6)).toBe(false);
+    });
+
+    test('high and low partition the die with no overlap or gap', () => {
+        for (const sides of [2, 5, 6, 7, 20, 100]) {
+            for (let r = 1; r <= sides; r++) {
+                expect(callWon(high, r, sides)).toBe(!callWon(low, r, sides));
+            }
+        }
+    });
+
+    test('exact bets win on one number only', () => {
+        expect(countWins(exact(4), 20)).toBe(1);
+        expect(callWon(exact(4), 4, 20)).toBe(true);
+    });
+});
+
+describe('display', () => {
+    test('the quoted payout is what a winning stake actually returns', () => {
+        const bet = 250;
+        for (const sides of [6, 7, 100]) {
+            for (const call of [high, low, exact(2)]) {
+                const gross  = Math.floor(bet * payoutMultiplier(call, sides) * (1 - HOUSE_CUT));
+                const quoted = Number((gross / bet).toFixed(2));
+                expect(Math.abs(quoted * bet - gross)).toBeLessThanOrEqual(bet * 0.005);
+            }
+        }
+    });
+
+    test('the roll bar stays a fixed width at both ends of the die', () => {
+        for (const sides of [2, 6, 100]) {
+            const lowest  = rollBar(1, sides);
+            const highest = rollBar(sides, sides);
+            expect(lowest.match(/[█░]/g)).toHaveLength(16);
+            expect(highest.match(/█/g)).toHaveLength(16);
+        }
+    });
+
+    test('call labels name the range the player is betting on', () => {
+        expect(callLabel(exact(3), 6)).toContain('3');
+        expect(callLabel(low, 7)).toContain('1–3');
+        expect(callLabel(high, 7)).toContain('4–7');
+    });
+});


### PR DESCRIPTION
## Summary

Completely redesigns the `/8ball` command with a modern Discord Components V2 interface, persistent replay buttons that survive restarts, and a rendered magic 8-ball image showing the answer. Also refactors `/coinflip` and `/roll` to use a shared replay session utility.

## Key Changes

### `/8ball` Command Redesign
- **Components V2 UI**: Replaces embeds with `ContainerBuilder`, `SectionBuilder`, and `TextDisplayBuilder` for a cleaner, more modern look
- **Persistent Buttons**: "Shake Again" and "New Question" buttons now use centralized routing through `events/interactionCreate` instead of per-message collectors, allowing them to work indefinitely and survive bot restarts
- **Image Rendering**: Generates a PNG of a magic 8-ball with the answer displayed in the window, tinted by outlook (green/positive, orange/neutral, red/negative)
- **Question Modal**: "New Question" button opens a modal for users to ask a fresh question
- **Shake Animation**: Displays animated frames while the ball "shakes" before revealing the answer
- **Rate Limiting**: Implements per-user shake rate limiting (12 shakes per 60 seconds) to prevent abuse
- **State Recovery**: Question and shake count are read from rendered message text, enabling stateless button handling

### Shared Replay Session Utility
- **New `replaySession.js`**: Extracted common replay button logic used by `/8ball`, `/coinflip`, and `/roll`
- Handles ownership verification, overlap guards (prevents double-renders on rapid clicks), session timeouts, and error handling
- Automatically removes buttons when session ends or token expires

### `/coinflip` Improvements
- **Caller-supplied side option**: Players can now call "Heads" or "Tails" before flipping, or let the coin pick for them
- **PvP wager escrow**: New `escrowWagers()` function atomically takes both stakes with proper refund logic if either player is short or the transaction fails
- **Replay session integration**: Uses the new shared replay utility instead of per-message collectors
- **Spin animation**: Extracted into reusable `spin()` function

### `/roll` Refactoring
- **Replay session integration**: Migrated to use the shared replay session utility
- **Exported test utilities**: Exposes payout calculation functions for testing

### Testing
- **`eightBall.test.js`**: Comprehensive tests for response distribution (10/5/5 split), question normalization, markdown escaping, state recovery, and button routing
- **`eightBallImage.test.js`**: Tests for image rendering, caching, and answer layout within the die window
- **`replaySession.test.js`**: Tests for collector setup, ownership verification, overlap guards, and session lifecycle
- **`coinflipEscrow.test.js`**: Tests for atomic wager escrow and refund logic
- **`rollPayout.test.js`**: Tests for payout multiplier calculations and house edge consistency

### Utilities
- **`eightBallImage.js`**: Canvas-based rendering of the magic 8-ball with answer text laid out inside the die window, with caching for all 20 answers
- **`delay.js`**: Simple promise-based delay utility for animations
- **`boundedRateLimiter.js`**: Rate limiter with sliding window for per-user shake limits

## Notable Implementation Details

- **Stateless Button Handling**: Button custom IDs encode the owner ID; question and shake count are recovered from the rendered message text. This allows buttons to work across restarts and for the lifetime of the message.
- **Markdown Escaping**: Questions are escaped when quoted to prevent hostile input from reformatting the message.
- **Atomic Escrow**: PvP coinflip wagers are taken atomically with proper rollback if either player is short or the database write fails.
- **Overlap Guard**: The replay session prevents concurrent renders when a user clicks rapidly, acknowledging the second click without running the handler twice.
- **Answer Distribution**: The 50/25/25 split (positive/neutral/negative) is maintained by rolling the category first, then an answer within it, matching the physical toy's 1

https://claude.ai/code/session_01TBvaEzW9sV5zcwy5uLnVqU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `/8ball` with animated responses, rendered ball images, follow-up questions, and replay controls.
  * Added Heads/Tails calls for `/coinflip`, including solo wagers, PvP challenges, replay options, and refunds when payouts fail.
  * Improved `/roll` with replay controls, visible payout multipliers, and automatic stake refunds after payout failures.

* **Documentation**
  * Expanded command help and README guidance for questions, wagers, challenges, and supported options.

* **Bug Fixes**
  * Improved interaction reliability, rate limiting, concurrency handling, and recovery from failed transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->