### PR TITLE
Make wealth ranking, inventory credits and coin debits agree and stay atomic

### DIFF
--- a/src/commands/economy/casino.js
+++ b/src/commands/economy/casino.js
@@ -99,7 +99,7 @@ module.exports = {
         // One active casino game per user — prevents concurrent sessions from racing
         // each other's debits, effects, and jackpot snapshots.
         const lockKey   = `casino:${interaction.guild.id}:${interaction.user.id}`;
-        const lockToken = tryAcquire(lockKey);
+        const lockToken = await tryAcquire(lockKey);
         if (!lockToken) {
             return interaction.reply({
                 content: '🎰 You already have a casino game in progress — finish it first.',
@@ -120,11 +120,14 @@ module.exports = {
         // early-return path, the lock's own TTL (10 min) frees the slot —
         // worst case the player is blocked from a second casino game for
         // that long, never permanently.
+        // Fire-and-forget: the games call this from collector callbacks that
+        // cannot await, and a release that loses its round trip is covered by
+        // the lease's own TTL.
         let released = false;
         const releaseLock = () => {
             if (released) return;
             released = true;
-            release(lockKey, lockToken);
+            release(lockKey, lockToken).catch(err => console.error('[casino] lock release failed:', err));
         };
 
         try {

--- a/src/commands/economy/crime.js
+++ b/src/commands/economy/crime.js
@@ -5,6 +5,7 @@ const { hasEffect, consumeEffect } = require('../../services/effectsService');
 const { getStreakMultiplier } = require('../../utils/streakMultiplier');
 const { clampMultiplier } = require('../../config/economy');
 const { logTransaction } = require('../../utils/logTransaction');
+const { debitUpTo, incExpr } = require('../../utils/balanceDebit');
 const { getTotalBonus } = require('../../services/petService');
 const { randomFrom, CRIME_WIN_LINES, CRIME_BUST_LINES, getCrimeFlavorText } = require('../../utils/copyLines');
 const { stackBar } = require('../../utils/rewardReveal');
@@ -398,19 +399,16 @@ module.exports = {
                         .setTimestamp();
                 } else if (isCriticalFailure) {
                     const lossRate = DEATH_LOSS_MIN + Math.random() * (DEATH_LOSS_MAX - DEATH_LOSS_MIN);
-                    const lost = Math.floor(user.balance * lossRate);
-                    const critSet = { lastCrime: crimeTime };
+                    const critSet = { lastCrime: crimeTime, 'crimeRecord.totalCrimes': incExpr('crimeRecord.totalCrimes', 1) };
                     if (wantedUntil) critSet.wantedUntil = wantedUntil;
-                    const updated = await User.findOneAndUpdate(
-                        userFilter,
-                        {
-                            $inc: { balance: -lost, 'crimeRecord.totalCrimes': 1 },
-                            $set: critSet,
-                        },
-                        { new: true }
+                    // The share is computed from a balance that may already have
+                    // moved, so the seizure is clamped inside the update rather
+                    // than against the read — `lost` is what was really taken.
+                    const { taken: lost, balance: critBalance } = await debitUpTo(
+                        User, userFilter, Math.floor((user.balance ?? 0) * lossRate), critSet,
                     );
 
-                    logTransaction({ userId: interaction.user.id, guildId: interaction.guild.id, type: 'crime_critical_fail', amount: -lost, balance: updated.balance, note: `${crime.name} (critical failure, ${Math.round(lossRate * 100)}% seized, ${execMethod.id})` });
+                    logTransaction({ userId: interaction.user.id, guildId: interaction.guild.id, type: 'crime_critical_fail', amount: -lost, balance: critBalance, note: `${crime.name} (critical failure, ${Math.round(lossRate * 100)}% seized, ${execMethod.id})` });
 
                     const critNarrative = getCrimeFlavorText(crime.name, 'fail')
                         .replace('{fine}', lost.toLocaleString())
@@ -419,7 +417,7 @@ module.exports = {
                         `${critNarrative}\n\n> *${flavorText}*\n\n` +
                         `────────────────────\n` +
                         `  💸 Seized: ${currency}${lost.toLocaleString()} coins  (${Math.round(lossRate * 100)}% of wallet)\n` +
-                        `  💰 Remaining: ${updated.balance.toLocaleString()} coins\n` +
+                        `  💰 Remaining: ${critBalance.toLocaleString()} coins\n` +
                         `────────────────────` +
                         wantedStr;
 
@@ -436,21 +434,16 @@ module.exports = {
                     let fine = Math.min(rawFine, maxFine);
                     fine = Math.round(fine * execMethod.fineMult);
                     if (undergroundActive) fine = Math.floor(fine * 0.85);
-                    const paid = Math.min(fine, user.balance);
-
-                    const setFields = { lastCrime: crimeTime };
+                    const setFields = { lastCrime: crimeTime, 'crimeRecord.totalCrimes': incExpr('crimeRecord.totalCrimes', 1) };
                     if (wantedUntil) setFields.wantedUntil = wantedUntil;
 
-                    const updated = await User.findOneAndUpdate(
-                        userFilter,
-                        {
-                            $inc: { balance: -paid, 'crimeRecord.totalCrimes': 1 },
-                            $set: setFields,
-                        },
-                        { new: true }
+                    // Clamped inside the update: the wallet the fine was sized
+                    // against may have emptied since. `paid` is the real figure.
+                    const { taken: paid, balance: finedBalance } = await debitUpTo(
+                        User, userFilter, fine, setFields,
                     );
 
-                    logTransaction({ userId: interaction.user.id, guildId: interaction.guild.id, type: 'crime_fine', amount: -paid, balance: updated.balance, note: `${crime.name} (busted, ${execMethod.id})` });
+                    logTransaction({ userId: interaction.user.id, guildId: interaction.guild.id, type: 'crime_fine', amount: -paid, balance: finedBalance, note: `${crime.name} (busted, ${execMethod.id})` });
 
                     const bustNarrative = getCrimeFlavorText(crime.name, 'fail')
                         .replace('{fine}', paid.toLocaleString())
@@ -463,7 +456,7 @@ module.exports = {
                         .setDescription(`${bustNarrative}\n\n> *${flavorText}*${undergroundStr}${wantedStr}`)
                         .addFields(
                             { name: 'Fine Paid', value: `${currency}${paid.toLocaleString()}`, inline: true },
-                            { name: 'Balance',   value: `${currency}${updated.balance.toLocaleString()}`, inline: true }
+                            { name: 'Balance',   value: `${currency}${finedBalance.toLocaleString()}`, inline: true }
                         )
                         .setFooter({ text: `${execMethod.label} · Cooldown: 1.5h` })
                         .setTimestamp();

--- a/src/commands/economy/daily.js
+++ b/src/commands/economy/daily.js
@@ -4,6 +4,7 @@ const Guild = require('../../models/Guild');
 const { getStreakMultiplier } = require('../../utils/streakMultiplier');
 const { getCoinMultiplier, getServerCoinMultiplier } = require('../../services/effectsService');
 const { logTransaction } = require('../../utils/logTransaction');
+const { inventoryAddExpr } = require('../../utils/inventoryGrant');
 const { MAX_COMBINED_MULTIPLIER, clampMultiplier } = require('../../config/economy');
 const { generateDailyChallenge } = require('../../utils/dailyChallenge');
 const { DROP_TABLE, RARE_DROP_TABLE, DROP_MILESTONES, DROP_BASE_CHANCE, weightedRandom } = require('../../data/dailyDropTable');
@@ -380,16 +381,26 @@ module.exports = {
             if (rollDrop) {
                 droppedItem = weightedRandom(isMilestone ? RARE_DROP_TABLE : DROP_TABLE);
 
-                const dropUpdate = droppedItem.streakFlag
-                    ? { $set: { 'streak.revivalToken': true } }
-                    : { $push: { inventory: { itemId: droppedItem.itemId, quantity: 1 } } };
-
+                // One atomic pipeline update so the drop and the milestone claim
+                // commit together. The bare `$push` this replaced added a second
+                // slot whenever the user already held the item, stranding the
+                // quantity in it — every reader takes the first matching slot.
+                //
+                // `$setUnion` is the pipeline form of `$addToSet`: operator-syntax
+                // updates can't be mixed into an aggregation-pipeline update.
+                const dropSet = {};
+                if (droppedItem.streakFlag) dropSet['streak.revivalToken'] = true;
                 if (isMilestone) {
-                    dropUpdate.$addToSet = { 'streak.claimedDropMilestones': streakCurrent };
+                    dropSet['streak.claimedDropMilestones'] = {
+                        $setUnion: [{ $ifNull: ['$streak.claimedDropMilestones', []] }, [streakCurrent]],
+                    };
                 }
                 await User.findOneAndUpdate(
                     { userId: interaction.user.id, guildId: interaction.guild.id },
-                    dropUpdate
+                    [{ $set: {
+                        ...(droppedItem.streakFlag ? {} : { inventory: inventoryAddExpr(droppedItem.itemId, 1) }),
+                        ...dropSet,
+                    } }]
                 );
 
                 logTransaction({

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -4,6 +4,7 @@ const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, Butt
 const User  = require('../../models/User');
 const { attachGrind, persistGrindIfNew } = require('../../utils/grindProfile');
 const { isVersionError } = require('../../utils/versionRetry');
+const { detachBalanceDelta, commitBalanceDelta } = require('../../utils/balanceDelta');
 const GrindProfile = require('../../models/GrindProfile');
 const Guild = require('../../models/Guild');
 const {
@@ -308,6 +309,16 @@ async function handleGo(interaction) {
     // that save lands the player has nothing to show for the cooldown they just
     // paid for. Hand the slot back on the way out unless the expedition committed.
     let exploreCommitted = false;
+
+    // The expedition writes coins twice — once for the find, once after the (up
+    // to 20s) encounter prompt — and `save()` writes `balance` as an absolute
+    // `$set`. Both movements are collected as deltas against this baseline and
+    // applied as atomic `$inc`s, so neither save can flatten coins spent
+    // elsewhere in between. See src/utils/balanceDelta.js.
+    let balanceBaseline = user.balance ?? 0;
+    const balanceFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
+    let payoutOwed = 0;
+
     try {
 
         // ── Run the expedition ────────────────────────────────────────────────────
@@ -318,9 +329,19 @@ async function handleGo(interaction) {
         // Commit stamina spend + cooldown timestamp now, before the (up to 20s)
         // encounter prompt below. Once this lands the expedition is real, so the
         // cooldown slot is earned and must not be handed back on a later failure.
+        const findDelta = detachBalanceDelta(user, balanceBaseline);
         try {
             await user.save();
             exploreCommitted = true;
+            const paid = await commitBalanceDelta(User, balanceFilter, user, findDelta, {
+                service: 'explore',
+                jobName: 'findPayout',
+                guildId: interaction.guild.id,
+            });
+            if (!paid.credited) payoutOwed += findDelta;
+            // The credit moved the balance; the encounter's delta is measured
+            // from here, not from what was read before the expedition ran.
+            balanceBaseline = user.balance ?? 0;
         } catch (err) {
             // Nothing was saved, so give the cooldown slot back before telling them to retry.
             await releaseExploreClaim();
@@ -412,8 +433,15 @@ async function handleGo(interaction) {
             questsNear = earn.nearComplete;
         }
 
+        const encounterDelta = detachBalanceDelta(user, balanceBaseline);
         try {
             await user.save();
+            const paid = await commitBalanceDelta(User, balanceFilter, user, encounterDelta, {
+                service: 'explore',
+                jobName: 'encounterPayout',
+                guildId: interaction.guild.id,
+            });
+            if (!paid.credited) payoutOwed += encounterDelta;
         } catch (err) {
             if (isVersionError(err)) {
                 return interaction.editReply({ content: 'A simultaneous request tangled your expedition log. Try `/explore go` again.', embeds: [], components: [] });
@@ -449,6 +477,14 @@ async function handleGo(interaction) {
 
         // ── Result embed ──────────────────────────────────────────────────────────
         const embed = buildResultEmbed(result, region, user, currency, eventDrop, mainXp, firstVisit, guildSettings);
+
+        if (payoutOwed > 0) {
+            embed.addFields({
+                name: '⚠️ Payout Not Yet Credited',
+                value: `The **${currency}${payoutOwed.toLocaleString()}** from this expedition could not be paid out just now and has been recorded as owed — the balance shown below does not include it. It will be applied once the problem clears; tell an admin if it does not.`,
+            });
+        }
+
         await interaction.editReply({ embeds: [embed], components: [] });
 
         // Server-wide whisper for secrets

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -1030,7 +1030,7 @@ const { tryAcquire: _lockAcquire, release: _lockRelease } = require('../../utils
 const _exploreExecute = module.exports.execute;
 module.exports.execute = async function (interaction) {
     const lockKey   = `grind:explore:${interaction.guild?.id}:${interaction.user.id}`;
-    const lockToken = _lockAcquire(lockKey, 120_000);
+    const lockToken = await _lockAcquire(lockKey, 120_000);
     if (!lockToken) {
         return interaction.reply({
             content: '🥾 You already have an exploration action in progress — finish it first.',
@@ -1040,6 +1040,6 @@ module.exports.execute = async function (interaction) {
     try {
         return await _exploreExecute(interaction);
     } finally {
-        _lockRelease(lockKey, lockToken);
+        await _lockRelease(lockKey, lockToken);
     }
 };

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -3195,7 +3195,7 @@ const { tryAcquire: _lockAcquire, release: _lockRelease } = require('../../utils
 const _fishExecute = module.exports.execute;
 module.exports.execute = async function (interaction) {
     const lockKey   = `grind:fish:${interaction.guild?.id}:${interaction.user.id}`;
-    const lockToken = _lockAcquire(lockKey, 120_000);
+    const lockToken = await _lockAcquire(lockKey, 120_000);
     if (!lockToken) {
         return interaction.reply({
             content: '🎣 You already have a fishing action in progress — finish it first.',
@@ -3205,6 +3205,6 @@ module.exports.execute = async function (interaction) {
     try {
         return await _fishExecute(interaction);
     } finally {
-        _lockRelease(lockKey, lockToken);
+        await _lockRelease(lockKey, lockToken);
     }
 };

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -10,6 +10,7 @@ const {
 const User  = require('../../models/User');
 const { attachGrind, persistGrindIfNew } = require('../../utils/grindProfile');
 const { isVersionError } = require('../../utils/versionRetry');
+const { detachBalanceDelta, applyBalanceDelta } = require('../../utils/balanceDelta');
 const GrindProfile = require('../../models/GrindProfile');
 const Guild = require('../../models/Guild');
 const { getItemImageAttachment } = require('../../utils/itemImageHelper');
@@ -546,6 +547,15 @@ async function handleCast(interaction) {
     // result is persisted the player has nothing to show for the cooldown they
     // just paid for. Hand the slot back on the way out unless the cast committed.
     let castCommitted = false;
+
+    // Everything below runs across the bite delay and the reel-in prompt — up to
+    // ~8 seconds during which the player can spend coins somewhere else. The
+    // cast's own coin movement is collected as a delta against this reading and
+    // applied as an atomic `$inc` at the save, so `save()` never writes an
+    // absolute balance read before that window. See src/utils/balanceDelta.js.
+    const balanceAtLoad = user.balance ?? 0;
+    const balanceFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
+
     try {
 
         // Bait comes out only once the cooldown slot is ours, so a lost race never
@@ -797,9 +807,18 @@ async function handleCast(interaction) {
 
         const fishAchievements = await checkAndAward(user, guildSettings).catch(() => []);
 
+        // Hand the cast's coin movement to an atomic `$inc` and take `balance`
+        // out of the save. An escape reverses its own mutations, so that path
+        // simply produces a delta of zero and issues no write.
+        const balanceDelta = detachBalanceDelta(user, balanceAtLoad);
+
         try {
             await user.save();
             castCommitted = true;
+            // Only after the save has landed: a credit applied before a save that
+            // then failed would pay for a cast the player could take again.
+            await applyBalanceDelta(User, balanceFilter, user, balanceDelta)
+                .catch(err => console.error('[fish] payout $inc failed:', err));
             if (fishAchievements.length) {
                 announceAchievements(interaction.client, guildSettings, user, interaction.member, fishAchievements).catch(() => null);
             }

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -10,7 +10,7 @@ const {
 const User  = require('../../models/User');
 const { attachGrind, persistGrindIfNew } = require('../../utils/grindProfile');
 const { isVersionError } = require('../../utils/versionRetry');
-const { detachBalanceDelta, applyBalanceDelta } = require('../../utils/balanceDelta');
+const { detachBalanceDelta, commitBalanceDelta } = require('../../utils/balanceDelta');
 const GrindProfile = require('../../models/GrindProfile');
 const Guild = require('../../models/Guild');
 const { getItemImageAttachment } = require('../../utils/itemImageHelper');
@@ -812,13 +812,21 @@ async function handleCast(interaction) {
         // simply produces a delta of zero and issues no write.
         const balanceDelta = detachBalanceDelta(user, balanceAtLoad);
 
+        let payoutOwed = 0;
         try {
             await user.save();
             castCommitted = true;
             // Only after the save has landed: a credit applied before a save that
-            // then failed would pay for a cast the player could take again.
-            await applyBalanceDelta(User, balanceFilter, user, balanceDelta)
-                .catch(err => console.error('[fish] payout $inc failed:', err));
+            // then failed would pay for a cast the player could take again. The
+            // save and the credit cannot be one write on a standalone mongod, so
+            // a credit that will not land is recorded as owed and said out loud
+            // rather than logged and forgotten.
+            const payout = await commitBalanceDelta(User, balanceFilter, user, balanceDelta, {
+                service: 'fish',
+                jobName: 'castPayout',
+                guildId: interaction.guild.id,
+            });
+            if (!payout.credited) payoutOwed = balanceDelta;
             if (fishAchievements.length) {
                 announceAchievements(interaction.client, guildSettings, user, interaction.member, fishAchievements).catch(() => null);
             }
@@ -872,6 +880,13 @@ async function handleCast(interaction) {
         }
 
         const embed = buildCastEmbed(result, user, location, rod, currency, interaction.user);
+
+        if (payoutOwed > 0) {
+            embed.addFields({
+                name: '⚠️ Payout Not Yet Credited',
+                value: `The **${currency}${payoutOwed.toLocaleString()}** from this catch could not be paid out just now and has been recorded as owed — the balance shown below does not include it. It will be applied once the problem clears; tell an admin if it does not.`,
+            });
+        }
 
         if (result.petYieldBonus > 0) {
             embed.addFields({ name: '🐠 Pet Bonus', value: `+${result.petYieldBonus.toLocaleString()} coins (${petFishYieldPct}% yield)`, inline: true });
@@ -2166,11 +2181,24 @@ async function handleBuyRod(interaction, user, currency) {
         await attachGrind(freshUser);
         ensureFishingData(freshUser);
 
-        if (freshUser.balance < rodData.cost) {
+        // The charge is a guarded atomic debit, not `balance -= cost` followed by
+        // a save. This runs in a button callback up to 30 seconds after the
+        // confirmation was drawn, and `save()` writes balance as an absolute
+        // `$set` — long enough for a casino bet in another channel to be wiped by
+        // a rod purchase. The lock the command holds does not help: casino takes
+        // a different key.
+        const debited = await User.findOneAndUpdate(
+            { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: rodData.cost } },
+            { $inc: { balance: -rodData.cost } },
+            { new: true, projection: { balance: 1 } },
+        );
+        if (!debited) {
             return btn.update({ content: `Insufficient funds. You need ${currency}${rodData.cost.toLocaleString()}.`, embeds: [], components: [] });
         }
 
-        freshUser.balance -= rodData.cost;
+        // Take the authoritative balance and keep the save off that path.
+        freshUser.balance = debited.balance;
+        freshUser.unmarkModified('balance');
         freshUser.fishing.rods.push({
             name:              rodData.name,
             tier:              rodData.tier,
@@ -2188,7 +2216,13 @@ async function handleBuyRod(interaction, user, currency) {
             await freshUser.save();
         } catch (err) {
             console.error('[fishshop rod] save error:', err);
-            return btn.update({ content: 'Something went wrong. Please try again.', embeds: [], components: [] });
+            // The coins are already gone; hand them back rather than charging for
+            // a rod that was never added.
+            await User.updateOne(
+                { userId: interaction.user.id, guildId: interaction.guild.id },
+                { $inc: { balance: rodData.cost } },
+            ).catch(refundErr => console.error('[fishshop rod] refund after failed save:', refundErr));
+            return btn.update({ content: 'Something went wrong and your coins were refunded. Please try again.', embeds: [], components: [] });
         }
 
         const rodIndex = freshUser.fishing.rods.length;
@@ -2278,10 +2312,6 @@ async function handleBuyUpgrade(interaction, user, currency) {
         await attachGrind(freshUser);
         ensureFishingData(freshUser);
 
-        if (freshUser.balance < cost) {
-            return btn.update({ content: 'Insufficient funds.', embeds: [], components: [] });
-        }
-
         const freshRod = freshUser.fishing.rods[targetRodIndex];
         if (!freshRod) {
             return btn.update({ content: 'That rod is no longer in your inventory.', embeds: [], components: [] });
@@ -2290,7 +2320,21 @@ async function handleBuyUpgrade(interaction, user, currency) {
             return btn.update({ content: `**${freshRod.name}** already has an upgrade installed.`, embeds: [], components: [] });
         }
 
-        freshUser.balance -= cost;
+        // Guarded atomic debit for the same reason as the rod purchase above: this
+        // lands up to 30 seconds after the prompt, and a `save()` would write an
+        // absolute balance over anything spent in between. Charged only once the
+        // rod is known to be upgradeable, so a rejected install costs nothing.
+        const debited = await User.findOneAndUpdate(
+            { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: cost } },
+            { $inc: { balance: -cost } },
+            { new: true, projection: { balance: 1 } },
+        );
+        if (!debited) {
+            return btn.update({ content: 'Insufficient funds.', embeds: [], components: [] });
+        }
+
+        freshUser.balance = debited.balance;
+        freshUser.unmarkModified('balance');
         freshRod.upgrade   = upgradeId;
         freshUser.markModified('fishing');
 
@@ -2298,7 +2342,13 @@ async function handleBuyUpgrade(interaction, user, currency) {
             await freshUser.save();
         } catch (err) {
             console.error('[fishshop upgrade] save error:', err);
-            return btn.update({ content: 'Something went wrong. Please try again.', embeds: [], components: [] });
+            // The coins are already gone; hand them back rather than charging for
+            // an upgrade that was never installed.
+            await User.updateOne(
+                { userId: interaction.user.id, guildId: interaction.guild.id },
+                { $inc: { balance: cost } },
+            ).catch(refundErr => console.error('[fishshop upgrade] refund after failed save:', refundErr));
+            return btn.update({ content: 'Something went wrong and your coins were refunded. Please try again.', embeds: [], components: [] });
         }
 
         return btn.update({

--- a/src/commands/economy/gift.js
+++ b/src/commands/economy/gift.js
@@ -3,6 +3,7 @@ const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { getItemLore } = require('../../data/defaultShopItems');
 const { logTransaction } = require('../../utils/logTransaction');
+const { grantInventoryItem } = require('../../utils/inventoryGrant');
 
 const DAILY_COIN_CAP = 10_000;
 // Incoming cap is higher than the outgoing cap (several friends can legitimately
@@ -14,32 +15,12 @@ const MIN_ACCOUNT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 // Items that cannot be gifted (soulbound — matches market.js)
 const SOULBOUND_ITEMS = new Set(['lifesaver', 'streak_shield']);
 
-// Add `qty` of `itemId` to a user's inventory without reading it first: bump the
-// existing slot if there is one, otherwise push a new slot, guarding the push so
-// two concurrent credits can never create duplicate slots for the same item.
+// Add `qty` of `itemId` to a user's inventory without reading it first. The
+// three-step bump/guarded-push/bump dance this used to spell out is now one
+// atomic pipeline update shared with every other credit site.
 // Returns the updated document, or null if the user document does not exist.
-async function addInventoryItem(userId, guildId, itemId, qty) {
-    const bumped = await User.findOneAndUpdate(
-        { userId, guildId, 'inventory.itemId': itemId },
-        { $inc: { 'inventory.$.quantity': qty } },
-        { new: true }
-    );
-    if (bumped) return bumped;
-
-    const pushed = await User.findOneAndUpdate(
-        { userId, guildId, 'inventory.itemId': { $ne: itemId } },
-        { $push: { inventory: { itemId, quantity: qty } } },
-        { new: true }
-    );
-    if (pushed) return pushed;
-
-    // A concurrent write created the slot between the two calls — bump it now.
-    return User.findOneAndUpdate(
-        { userId, guildId, 'inventory.itemId': itemId },
-        { $inc: { 'inventory.$.quantity': qty } },
-        { new: true }
-    );
-}
+const addInventoryItem = (userId, guildId, itemId, qty) =>
+    grantInventoryItem(userId, guildId, itemId, qty);
 
 module.exports = {
     data: new SlashCommandBuilder()

--- a/src/commands/economy/heist.js
+++ b/src/commands/economy/heist.js
@@ -9,6 +9,7 @@ const {
 const Guild = require('../../models/Guild');
 const User  = require('../../models/User');
 const { logTransaction } = require('../../utils/logTransaction');
+const { debitUpTo } = require('../../utils/balanceDebit');
 const {
     ROLES,
     TARGETS,
@@ -133,15 +134,15 @@ async function resolveHeist(client, heist) {
                 logTransaction({ userId, guildId, type: 'heist_payout', amount: share, balance: u?.balance ?? share, note: `Heist: ${TARGETS[heist.target]?.label}` });
             }
         } else if (outcome === 'failure' || (outcome === 'partial_success' && !passed)) {
-            // Jail the caught players: lock economy commands and apply a fine
-            // clamped to their current balance so it can't go negative.
+            // Jail the caught players: lock economy commands and apply a fine.
+            // The clamp is inside the update, not against a separate read — a
+            // read-then-clamp-then-$inc takes the amount the read justified even
+            // once the wallet has emptied, which is how a fine walks a balance
+            // negative. See src/utils/balanceDebit.js.
             const jailUntil = new Date(Date.now() + jailMins * 60_000);
             const rawFine   = Math.floor(Math.random() * 200) + 50;
-            const userDoc   = await User.findOne({ userId, guildId }, 'balance').lean();
-            const fine      = Math.min(rawFine, userDoc?.balance ?? 0);
-            await User.findOneAndUpdate(
-                { userId, guildId },
-                { $set: { heistJailedUntil: jailUntil }, ...(fine > 0 ? { $inc: { balance: -fine } } : {}) }
+            await debitUpTo(
+                User, { userId, guildId }, rawFine, { heistJailedUntil: jailUntil },
             ).catch(() => {});
         }
     }

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -10,6 +10,7 @@ const {
 const User  = require('../../models/User');
 const { attachGrind, persistGrindIfNew } = require('../../utils/grindProfile');
 const { isVersionError } = require('../../utils/versionRetry');
+const { detachBalanceDelta, commitBalanceDelta } = require('../../utils/balanceDelta');
 const GrindProfile = require('../../models/GrindProfile');
 const Guild = require('../../models/Guild');
 const { getItemImageAttachment } = require('../../utils/itemImageHelper');
@@ -536,6 +537,15 @@ async function executeStart(interaction) {
     // result is persisted the player has nothing to show for the cooldown they
     // just paid for. Hand the slot back on the way out unless the hunt committed.
     let huntCommitted = false;
+
+    // Everything below runs across the interactive prompts, during which the
+    // player can spend coins elsewhere. The run's own coin movement is
+    // collected as a delta against this reading and applied as an atomic
+    // `$inc` at the save, so `save()` never writes an absolute balance read
+    // before that window. See src/utils/balanceDelta.js.
+    const balanceAtLoad = user.balance ?? 0;
+    const balanceFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
+
     try {
 
         // Ammo comes out only once the cooldown slot is ours, so a lost race never
@@ -790,9 +800,26 @@ async function executeStart(interaction) {
 
         const huntAchievements = await checkAndAward(user, guildSettings).catch(() => []);
 
+        // Hand the run's coin movement to an atomic `$inc` and take `balance` out
+        // of the save. A path that reverses its own reward nets to zero and
+        // issues no write.
+        const balanceDelta = detachBalanceDelta(user, balanceAtLoad);
+
+        let payoutOwed = 0;
         try {
             await user.save();
             huntCommitted = true;
+            // Only after the save has landed: a credit applied before a save that
+            // then failed would pay for a run the player could take again. The two
+            // cannot be one write on a standalone mongod, so a credit that will
+            // not land is recorded as owed and said out loud rather than logged
+            // and forgotten.
+            const payout = await commitBalanceDelta(User, balanceFilter, user, balanceDelta, {
+                service: 'hunt',
+                jobName: 'huntPayout',
+                guildId: interaction.guild.id,
+            });
+            if (!payout.credited) payoutOwed = balanceDelta;
             if (huntAchievements.length) {
                 announceAchievements(interaction.client, guildSettings, user, interaction.member, huntAchievements).catch(() => null);
             }
@@ -820,6 +847,13 @@ async function executeStart(interaction) {
 
         const timeBand = getTimeBand();
         const embed = buildHuntEmbed(result, user, zone, weapon, currency, interaction.user);
+
+        if (payoutOwed > 0) {
+            embed.addFields({
+                name: '⚠️ Payout Not Yet Credited',
+                value: `The **${currency}${payoutOwed.toLocaleString()}** from this hunt could not be paid out just now and has been recorded as owed — the balance shown below does not include it. It will be applied once the problem clears; tell an admin if it does not.`,
+            });
+        }
         {
             const desc = embed.data.description ?? '';
             const lines = [];

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -2822,7 +2822,7 @@ const { tryAcquire: _lockAcquire, release: _lockRelease } = require('../../utils
 const _huntExecute = module.exports.execute;
 module.exports.execute = async function (interaction) {
     const lockKey   = `grind:hunt:${interaction.guild?.id}:${interaction.user.id}`;
-    const lockToken = _lockAcquire(lockKey, 120_000);
+    const lockToken = await _lockAcquire(lockKey, 120_000);
     if (!lockToken) {
         return interaction.reply({
             content: '🏹 You already have a hunting action in progress — finish it first.',
@@ -2832,6 +2832,6 @@ module.exports.execute = async function (interaction) {
     try {
         return await _huntExecute(interaction);
     } finally {
-        _lockRelease(lockKey, lockToken);
+        await _lockRelease(lockKey, lockToken);
     }
 };

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -2340,7 +2340,7 @@ const { tryAcquire: _lockAcquire, release: _lockRelease } = require('../../utils
 const _mineExecute = module.exports.execute;
 module.exports.execute = async function (interaction) {
     const lockKey   = `grind:mine:${interaction.guild?.id}:${interaction.user.id}`;
-    const lockToken = _lockAcquire(lockKey, 120_000);
+    const lockToken = await _lockAcquire(lockKey, 120_000);
     if (!lockToken) {
         return interaction.reply({
             content: '⛏️ You already have a mining action in progress — finish it first.',
@@ -2350,6 +2350,6 @@ module.exports.execute = async function (interaction) {
     try {
         return await _mineExecute(interaction);
     } finally {
-        _lockRelease(lockKey, lockToken);
+        await _lockRelease(lockKey, lockToken);
     }
 };

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -4,6 +4,7 @@ const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, Butt
 const User  = require('../../models/User');
 const { attachGrind, persistGrindIfNew, saveGrind } = require('../../utils/grindProfile');
 const { isVersionError } = require('../../utils/versionRetry');
+const { detachBalanceDelta, commitBalanceDelta } = require('../../utils/balanceDelta');
 const GrindProfile = require('../../models/GrindProfile');
 const Guild = require('../../models/Guild');
 const { getItemImageAttachment } = require('../../utils/itemImageHelper');
@@ -475,6 +476,15 @@ async function handleDig(interaction) {
     // is persisted the player has nothing to show for the cooldown they just paid
     // for. Hand the slot back on the way out unless the dig committed.
     let mineCommitted = false;
+
+    // Everything below runs across the interactive prompts, during which the
+    // player can spend coins elsewhere. The run's own coin movement is
+    // collected as a delta against this reading and applied as an atomic
+    // `$inc` at the save, so `save()` never writes an absolute balance read
+    // before that window. See src/utils/balanceDelta.js.
+    const balanceAtLoad = user.balance ?? 0;
+    const balanceFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
+
     try {
 
         // The charge comes out only once the cooldown slot is ours, so a lost race
@@ -776,9 +786,26 @@ async function handleDig(interaction) {
 
         const mineAchievements = await checkAndAward(user, guildSettings).catch(() => []);
 
+        // Hand the run's coin movement to an atomic `$inc` and take `balance` out
+        // of the save. A path that reverses its own reward nets to zero and
+        // issues no write.
+        const balanceDelta = detachBalanceDelta(user, balanceAtLoad);
+
+        let payoutOwed = 0;
         try {
             await user.save();
             mineCommitted = true;
+            // Only after the save has landed: a credit applied before a save that
+            // then failed would pay for a run the player could take again. The two
+            // cannot be one write on a standalone mongod, so a credit that will
+            // not land is recorded as owed and said out loud rather than logged
+            // and forgotten.
+            const payout = await commitBalanceDelta(User, balanceFilter, user, balanceDelta, {
+                service: 'mine',
+                jobName: 'minePayout',
+                guildId: interaction.guild.id,
+            });
+            if (!payout.credited) payoutOwed = balanceDelta;
             if (mineAchievements.length) {
                 announceAchievements(interaction.client, guildSettings, user, interaction.member, mineAchievements).catch(() => null);
             }
@@ -805,6 +832,13 @@ async function handleDig(interaction) {
         const hourlyLeader = await getCurrentHourlyLeader(interaction.guild.id, 'mine').catch(() => null);
 
         const embed = buildMineEmbed(result, user, depth, pickaxe, currency, interaction.user);
+
+        if (payoutOwed > 0) {
+            embed.addFields({
+                name: '⚠️ Payout Not Yet Credited',
+                value: `The **${currency}${payoutOwed.toLocaleString()}** from this haul could not be paid out just now and has been recorded as owed — the balance shown below does not include it. It will be applied once the problem clears; tell an admin if it does not.`,
+            });
+        }
         {
             const desc = embed.data.description ?? '';
             const lines = [`> ⛏️ *${finalIcons} — Vein depth ${veinDepth}/3 → ${chosenIntensity.emoji} ${chosenIntensity.name} (${chosenIntensity.multiplier}×)*`];

--- a/src/commands/economy/quiz.js
+++ b/src/commands/economy/quiz.js
@@ -30,6 +30,10 @@ const DAILY_LIMITS = { easy: 40, medium: 30, hard: 20 };
 const COUNT_FIELD = { easy: 'dailyQuizEasy', medium: 'dailyQuizMedium', hard: 'dailyQuizHard' };
 const RESET_FIELD = { easy: 'dailyQuizEasyReset', medium: 'dailyQuizMediumReset', hard: 'dailyQuizHardReset' };
 
+// The command's `cooldown: 300` is the in-memory pre-check; this is the value
+// the database claim enforces, and the two must stay in step.
+const QUIZ_COOLDOWN_MS = 300 * 1000;
+
 // Returns midnight UTC for today (used to detect daily reset)
 function todayUTC() {
     const now = new Date();
@@ -228,8 +232,45 @@ module.exports = {
 async function runQuiz(interaction, diffChoice) {
     const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
 
-    let user = await User.findOne(userFilter);
-    if (!user) user = await User.create(userFilter);
+    await User.findOneAndUpdate(userFilter, { $setOnInsert: userFilter }, { upsert: true, new: true });
+
+    // Claim the cooldown window in the database, not just in the interaction
+    // handler's in-memory map. That map is a per-process pre-check: it is empty
+    // after a restart and unshared between instances, and /quiz pays coins, so
+    // on its own it let a player burn a whole day's question allowance at once.
+    // The daily per-difficulty caps below still bound the total; this bounds the
+    // rate. Same shape as the claims in /work, /daily and /snowball.
+    const claimNow      = new Date();
+    const cooldownFloor = new Date(claimNow.getTime() - QUIZ_COOLDOWN_MS);
+    const user = await User.findOneAndUpdate(
+        {
+            ...userFilter,
+            $or: [{ lastQuiz: null }, { lastQuiz: { $exists: false } }, { lastQuiz: { $lte: cooldownFloor } }],
+        },
+        { $set: { lastQuiz: claimNow } },
+        { new: true },
+    );
+
+    if (!user) {
+        // The window is still open. Read the winning timestamp back so the
+        // countdown reflects the attempt that actually took the slot.
+        const current = await User.findOne(userFilter).select('lastQuiz').lean().catch(() => null);
+        const nextAt  = new Date(new Date(current?.lastQuiz ?? claimNow).getTime() + QUIZ_COOLDOWN_MS);
+        return interaction.editReply({
+            embeds: [buildCooldownEmbed({
+                title: '🎓 Still Thinking It Over',
+                description: 'Give the quizmaster a moment to dig out another question.',
+                color: '#9b59b6',
+                nextAt,
+            })],
+        });
+    }
+
+    return runQuizWithUser(interaction, diffChoice, user);
+}
+
+async function runQuizWithUser(interaction, diffChoice, user) {
+    const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
 
     let raw, offline;
     try {

--- a/src/commands/economy/quiz.js
+++ b/src/commands/economy/quiz.js
@@ -11,6 +11,7 @@ const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
 const FALLBACK_QUESTIONS = require('../../data/quizFallback');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
+const { debitUpTo } = require('../../utils/balanceDebit');
 
 const THUMB         = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f393.png';
 const TIMER_SECONDS = 30;
@@ -324,10 +325,12 @@ async function runQuiz(interaction, diffChoice) {
             netChange = rewards.win;
             updated   = await User.findOneAndUpdate(userFilter, { $inc: { balance: rewards.win } }, { new: true });
         } else {
-            const freshUser = await User.findOne(userFilter);
-            const penalty   = Math.min(rewards.lose, freshUser?.balance ?? 0);
-            netChange = -penalty;
-            updated   = await User.findOneAndUpdate(userFilter, { $inc: { balance: -penalty } }, { new: true });
+            // Clamped inside the update rather than against a separate read: a
+            // read-then-clamp-then-$inc takes the amount the read justified even
+            // if the wallet emptied in between, which walks the balance negative.
+            const { taken, balance } = await debitUpTo(User, userFilter, rewards.lose);
+            netChange = -taken;
+            updated   = { balance };
         }
 
         // No replay button: quiz is a net-positive income command, so a replay
@@ -342,9 +345,11 @@ async function runQuiz(interaction, diffChoice) {
         clearInterval(timerInterval);
         if (reason === 'limit') return;
 
-        const freshUser = await User.findOne(userFilter);
-        const penalty   = Math.min(rewards.lose, freshUser?.balance ?? 0);
-        const updated   = await User.findOneAndUpdate(userFilter, { $inc: { balance: -penalty } }, { new: true });
+        // Same clamp-in-the-update as the wrong-answer branch. This one runs
+        // after the whole question window, so the read it replaced was stale by
+        // however long the player sat on the prompt.
+        const { taken: penalty, balance } = await debitUpTo(User, userFilter, rewards.lose);
+        const updated = { balance };
 
         await interaction.editReply({
             embeds:     [timeoutEmbed(interaction, question, correctAnswer, difficulty, penalty, updated?.balance ?? 0)],

--- a/src/commands/economy/shop.js
+++ b/src/commands/economy/shop.js
@@ -14,6 +14,7 @@ const { ensureDefaultShopItems, getItemLore, getItemRarity, isPrestigeItem, isBl
 const { getItemImageAttachment } = require('../../utils/itemImageHelper');
 const { runShopBrowse } = require('../../utils/shopBrowse');
 const { logTransaction } = require('../../utils/logTransaction');
+const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const { ensurePricingFields, trendBucket } = require('../../utils/dynamicPricing');
 const { hasUnlock } = require('../../utils/prestige');
 
@@ -567,37 +568,8 @@ module.exports = {
                 // otherwise append a new entry. Done in one call so concurrent buys
                 // can't race between an unsuccessful $inc and a guarded $push and
                 // lose units.
-                const stockedUser = await User.findOneAndUpdate(
-                    { userId: interaction.user.id, guildId: interaction.guild.id },
-                    [{
-                        $set: {
-                            inventory: {
-                                $cond: {
-                                    if: { $in: [inventoryId, { $ifNull: ['$inventory.itemId', []] }] },
-                                    then: {
-                                        $map: {
-                                            input: '$inventory',
-                                            as: 'slot',
-                                            in: {
-                                                $cond: [
-                                                    { $eq: ['$$slot.itemId', inventoryId] },
-                                                    { itemId: '$$slot.itemId', quantity: { $add: ['$$slot.quantity', quantity] } },
-                                                    '$$slot'
-                                                ]
-                                            }
-                                        }
-                                    },
-                                    else: {
-                                        $concatArrays: [
-                                            { $ifNull: ['$inventory', []] },
-                                            [{ itemId: inventoryId, quantity }]
-                                        ]
-                                    }
-                                }
-                            }
-                        }
-                    }],
-                    { new: true }
+                const stockedUser = await grantInventoryItem(
+                    interaction.user.id, interaction.guild.id, inventoryId, quantity
                 ).catch(err => {
                     console.error('[shop] inventory grant failed:', err);
                     return null;

--- a/src/commands/economy/snowball.js
+++ b/src/commands/economy/snowball.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { logTransaction } = require('../../utils/logTransaction');
+const { debitUpTo } = require('../../utils/balanceDebit');
 const {
     hasActiveEvent,
     getEventCurrencyId,
@@ -119,19 +120,14 @@ module.exports = {
                     { new: true },
                 );
                 if (!defender) {
-                    const freshDefender = await User.findOne({ userId: target.id, guildId: interaction.guild.id });
-                    const fallbackSteal = Math.min(stolen, freshDefender?.balance ?? 0);
-                    if (fallbackSteal > 0) {
-                        defender = await User.findOneAndUpdate(
-                            { userId: target.id, guildId: interaction.guild.id },
-                            { $inc: { balance: -fallbackSteal } },
-                            { new: true },
-                        );
-                        stolen = fallbackSteal;
-                    } else {
-                        stolen = 0;
-                        defender = freshDefender;
-                    }
+                    // The guarded debit missed because the wallet shrank. Take
+                    // what is left with the clamp inside the update — reading the
+                    // balance again and clamping against that is the same race one
+                    // round deeper, and its $inc would still overshoot.
+                    const defenderFilter = { userId: target.id, guildId: interaction.guild.id };
+                    const { taken } = await debitUpTo(User, defenderFilter, stolen);
+                    stolen = taken;
+                    defender = await User.findOne(defenderFilter);
                 }
             } else {
                 stolen = 0;

--- a/src/commands/economy/use.js
+++ b/src/commands/economy/use.js
@@ -9,6 +9,7 @@ const {
     timeRemaining,
 } = require('../../services/effectsService');
 const { getItemLore } = require('../../data/defaultShopItems');
+const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const { SEASONAL_EVENTS, RARITY_COLORS, rollLootBox } = require('../../data/seasonalEvents');
 const { PET_DEFINITIONS, MAX_SLOT_EXPANSIONS, petCapacity, hasFreePetSlot, countSlotPets } = require('../../services/petService');
 
@@ -343,18 +344,10 @@ module.exports = {
                 return interaction.reply({ content: `You don't have **${itemName}** in your inventory.`, flags: MessageFlags.Ephemeral });
             }
 
-            // Credit the won item atomically, then clean up zeros
-            await User.findOneAndUpdate(
-                { ...userFilter, 'inventory.itemId': won.itemId },
-                { $inc: { 'inventory.$.quantity': 1 } }
-            ).then(async matched => {
-                if (!matched) {
-                    await User.findOneAndUpdate(
-                        userFilter,
-                        { $push: { inventory: { itemId: won.itemId, quantity: 1 } } }
-                    );
-                }
-            });
+            // Credit the won item in one atomic update, then clean up zeros. The
+            // match-then-push it replaced could leave two slots for the same item
+            // when two boxes opened at once, stranding the second slot's quantity.
+            await grantInventoryItem(userFilter.userId, userFilter.guildId, won.itemId, 1);
 
             // Clean up zero-quantity entries
             await User.findOneAndUpdate(userFilter, { $pull: { inventory: { quantity: { $lte: 0 } } } });

--- a/src/commands/economy/work.js
+++ b/src/commands/economy/work.js
@@ -6,6 +6,7 @@ const DEFAULT_TIERS = require('../../data/defaultTiers');
 const { getStreakMultiplier } = require('../../utils/streakMultiplier');
 const { getCoinMultiplier, getSalaryMultiplier, getServerCoinMultiplier } = require('../../services/effectsService');
 const { logTransaction } = require('../../utils/logTransaction');
+const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const { MAX_COMBINED_MULTIPLIER, clampMultiplier } = require('../../config/economy');
 const { generateWorkChallenge } = require('../../utils/workChallenge');
 const { getTotalBonus } = require('../../services/petService');
@@ -229,21 +230,11 @@ module.exports = {
                 return interaction.reply({ content: "You're already working a shift right now!", flags: MessageFlags.Ephemeral });
             }
 
-            // Inventory update for lucky find (separate, non-financial — no race risk)
+            // Inventory update for lucky find. The slot test and the write happen
+            // inside one atomic update — the read-then-push it replaced let two
+            // concurrent finds both push and strand a quantity in the second slot.
             if (specialEvent?.item) {
-                const itemId = specialEvent.item.itemId;
-                const hasItem = user.inventory?.some(i => i.itemId === itemId);
-                if (hasItem) {
-                    await User.findOneAndUpdate(
-                        { userId: interaction.user.id, guildId: interaction.guild.id, 'inventory.itemId': itemId },
-                        { $inc: { 'inventory.$.quantity': 1 } }
-                    );
-                } else {
-                    await User.findOneAndUpdate(
-                        { userId: interaction.user.id, guildId: interaction.guild.id },
-                        { $push: { inventory: { itemId, quantity: 1 } } }
-                    );
-                }
+                await grantInventoryItem(interaction.user.id, interaction.guild.id, specialEvent.item.itemId, 1);
             }
 
             logTransaction({

--- a/src/commands/leveling/leaderboard.js
+++ b/src/commands/leveling/leaderboard.js
@@ -158,7 +158,7 @@ module.exports = {
                         callerDisplay = `Lv${callerUser.level} (${callerUser.xp} XP)`;
                     } else if (type === 'economy') {
                         const callerTotal = netWorthOf(callerUser);
-                        callerRank = await netWorthRank(User, interaction.guild.id, callerTotal);
+                        callerRank = await netWorthRank(User, interaction.guild.id, callerTotal, callerUser._id);
                         callerDisplay = `${callerTotal.toLocaleString()} coins`;
                     } else if (type === 'duels') {
                         const callerWins = callerUser.duelWins ?? 0;

--- a/src/commands/leveling/leaderboard.js
+++ b/src/commands/leveling/leaderboard.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
 const Guild = require('../../models/Guild');
+const { netWorthOf, topByNetWorth, netWorthRank } = require('../../utils/netWorth');
 
 module.exports = {
     cooldown: 10,
@@ -55,11 +56,16 @@ module.exports = {
                     .limit(10);
                 title = '🏅 Achievement Leaderboard';
                 descriptionHeader = 'Top 10 by Total Achievements Earned';
-            } else {
-                const sortField = type === 'levels' ? { level: -1, xp: -1 } : { balance: -1, bank: -1 };
-                users = await User.find({ guildId: interaction.guild.id }).sort(sortField).limit(10);
+            } else if (type === 'economy') {
+                // Ranked by the same balance + bank total the rows below display,
+                // and by the same total the dashboard and newspaper rank on.
+                users = await topByNetWorth(User, interaction.guild.id, 10);
                 title = '🏆 Leaderboard';
-                descriptionHeader = type === 'levels' ? 'Top 10 by Level' : 'Top 10 by Balance';
+                descriptionHeader = 'Top 10 by Net Worth';
+            } else {
+                users = await User.find({ guildId: interaction.guild.id }).sort({ level: -1, xp: -1 }).limit(10);
+                title = '🏆 Leaderboard';
+                descriptionHeader = 'Top 10 by Level';
             }
 
             if (users.length === 0) {
@@ -109,8 +115,7 @@ module.exports = {
                 if (type === 'levels') {
                     description += `${medal} ${discordUser.tag} — Level ${user.level} (${user.xp} XP)\n`;
                 } else if (type === 'economy') {
-                    const total = user.balance + user.bank;
-                    description += `${medal} ${discordUser.tag} — ${total.toLocaleString()} coins\n`;
+                    description += `${medal} ${discordUser.tag} — ${user.netWorth.toLocaleString()} coins\n`;
                 } else if (type === 'streaks') {
                     const days    = user.streak?.current ?? 0;
                     const freezes = user.streak?.freezes ?? 0;
@@ -152,11 +157,8 @@ module.exports = {
                         }) + 1;
                         callerDisplay = `Lv${callerUser.level} (${callerUser.xp} XP)`;
                     } else if (type === 'economy') {
-                        const callerTotal = (callerUser.balance ?? 0) + (callerUser.bank ?? 0);
-                        callerRank = await User.countDocuments({
-                            guildId: interaction.guild.id,
-                            $expr: { $gt: [{ $add: ['$balance', '$bank'] }, callerTotal] },
-                        }) + 1;
+                        const callerTotal = netWorthOf(callerUser);
+                        callerRank = await netWorthRank(User, interaction.guild.id, callerTotal);
                         callerDisplay = `${callerTotal.toLocaleString()} coins`;
                     } else if (type === 'duels') {
                         const callerWins = callerUser.duelWins ?? 0;

--- a/src/dashboard/routes/api/economy.js
+++ b/src/dashboard/routes/api/economy.js
@@ -4,18 +4,13 @@ const Guild = require('../../../models/Guild');
 const User = require('../../../models/User');
 const { checkAuth, checkGuildAccess, checkWriteRateLimit } = require('../../lib/middleware');
 const { isValidDiscordId, logAuditEvent } = require('../../lib/apiHelpers');
+const { topByNetWorth } = require('../../../utils/netWorth');
 
 router.get('/guild/:guildId/economy/stats', checkAuth, checkGuildAccess, async (req, res) => {
     const { guildId } = req.params;
     try {
         const [topEarners, totalCoinsAgg, activeUsersCount, guildSettings] = await Promise.all([
-            User.aggregate([
-                { $match: { guildId } },
-                { $addFields: { total: { $add: ['$balance', '$bank'] } } },
-                { $sort: { total: -1 } },
-                { $limit: 10 },
-                { $project: { _id: 0, userId: 1, balance: 1, bank: 1, total: 1 } }
-            ]),
+            topByNetWorth(User, guildId, 10),
             User.aggregate([{ $match: { guildId } }, { $group: { _id: null, total: { $sum: { $add: ['$balance', '$bank'] } } } }]),
             User.countDocuments({ guildId, $or: [
                 { lastWork:  { $gte: new Date(Date.now() - 7 * 864e5) } },
@@ -54,7 +49,7 @@ router.get('/guild/:guildId/economy/stats', checkAuth, checkGuildAccess, async (
                 userTag: ecoUserMap[u.userId]?.tag || null,
                 avatarUrl: ecoUserMap[u.userId]?.avatarUrl || null,
                 balance: u.balance, bank: u.bank,
-                total: (u.balance || 0) + (u.bank || 0)
+                total: u.netWorth
             })),
             commandFrequency: Object.entries(commandFrequency).sort((a, b) => b[1] - a[1]).slice(0, 10).map(([cmd, count]) => ({ cmd, count }))
         });

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,13 @@ const client = new Client({
 });
 
 client.commands = new Collection();
+// Process-local, and correctly so: this is a UX pre-check that answers "you are
+// on cooldown" without a database round trip on every interaction. It is not
+// what enforces a cooldown — every command that pays out claims its own window
+// atomically in Mongo (`lastWork`/`lastDaily`/`lastCrime`/`lastRob` in the
+// update filter, `data.lastCast` on GrindProfile for the grinds), which is what
+// a second process or a restart would still be bound by. See
+// tests/economyCooldownClaims.test.js, which holds that line.
 client.cooldowns = new Collection();
 
 async function loadCommands() {

--- a/src/migrations/010_merge_duplicate_inventory_slots.js
+++ b/src/migrations/010_merge_duplicate_inventory_slots.js
@@ -47,15 +47,41 @@ module.exports = {
         };
 
         for await (const doc of cursor) {
-            const totals = new Map();
+            // Fold into the first slot seen for each itemId, keeping that slot's
+            // own object — entries are subdocuments with their own `_id`, and
+            // rebuilding them as bare `{ itemId, quantity }` would discard it.
+            const firstFor = new Map(); // itemId -> slot object kept in `slots`
+            const slots = [];
+            let mergedSlots = 0;
+
             for (const slot of doc.inventory ?? []) {
                 const id = slot?.itemId;
-                if (id === undefined || id === null) continue;
-                totals.set(id, (totals.get(id) ?? 0) + (slot.quantity ?? 0));
+
+                // A slot with no itemId is not a duplicate of anything and is not
+                // this migration's to interpret. Dropping it would destroy items;
+                // it is carried through untouched for someone to look at.
+                if (id === undefined || id === null) {
+                    slots.push(slot);
+                    continue;
+                }
+
+                const first = firstFor.get(id);
+                if (first) {
+                    first.quantity = (first.quantity ?? 0) + (slot.quantity ?? 0);
+                    mergedSlots++;
+                } else {
+                    const kept = { ...slot, quantity: slot.quantity ?? 0 };
+                    firstFor.set(id, kept);
+                    slots.push(kept);
+                }
             }
 
-            const inventory = [...totals].map(([itemId, quantity]) => ({ itemId, quantity }));
-            ops.push({ updateOne: { filter: { _id: doc._id }, update: { $set: { inventory } } } });
+            // The cursor's filter also matches documents whose only "duplication"
+            // is slots missing an itemId, which nothing above merged. Rewriting
+            // those would be a no-op write at best.
+            if (mergedSlots === 0) continue;
+
+            ops.push({ updateOne: { filter: { _id: doc._id }, update: { $set: { inventory: slots } } } });
             merged++;
 
             if (ops.length >= 500) await flush();

--- a/src/migrations/010_merge_duplicate_inventory_slots.js
+++ b/src/migrations/010_merge_duplicate_inventory_slots.js
@@ -1,0 +1,69 @@
+const mongoose = require('mongoose');
+
+/**
+ * Merges duplicate `inventory` slots that share an `itemId`.
+ *
+ * The credit sites used to test for an existing slot and then `$push` when they
+ * did not find one, in two separate round trips. Two concurrent credits could
+ * both miss and both push, leaving a document with two slots for one item.
+ * Every reader does `inventory.find(i => i.itemId === X)` and takes the first
+ * match, so whatever landed in the second slot was invisible and unspendable.
+ *
+ * The credit path is atomic now (src/utils/inventoryGrant.js), so no new
+ * duplicates appear — but the ones already written stay stranded until they are
+ * folded together, which is what this does: one slot per itemId, carrying the
+ * summed quantity, in the order the slots first appeared.
+ *
+ * Documents with no duplicates are left untouched.
+ */
+module.exports = {
+    name: '010_merge_duplicate_inventory_slots',
+
+    async up() {
+        const users = mongoose.connection.db.collection('users');
+
+        // Only documents that actually have a repeated itemId are rewritten —
+        // comparing the slot count against the distinct-itemId count finds them
+        // without pulling every user document into the application.
+        const cursor = users.find(
+            {
+                $expr: {
+                    $ne: [
+                        { $size: { $ifNull: ['$inventory', []] } },
+                        { $size: { $setUnion: [{ $ifNull: ['$inventory.itemId', []] }, []] } },
+                    ],
+                },
+            },
+            { projection: { inventory: 1 } },
+        );
+
+        let merged = 0;
+        const ops = [];
+
+        const flush = async () => {
+            if (!ops.length) return;
+            await users.bulkWrite(ops, { ordered: false });
+            ops.length = 0;
+        };
+
+        for await (const doc of cursor) {
+            const totals = new Map();
+            for (const slot of doc.inventory ?? []) {
+                const id = slot?.itemId;
+                if (id === undefined || id === null) continue;
+                totals.set(id, (totals.get(id) ?? 0) + (slot.quantity ?? 0));
+            }
+
+            const inventory = [...totals].map(([itemId, quantity]) => ({ itemId, quantity }));
+            ops.push({ updateOne: { filter: { _id: doc._id }, update: { $set: { inventory } } } });
+            merged++;
+
+            if (ops.length >= 500) await flush();
+        }
+        await flush();
+
+        if (merged > 0) {
+            console.log(`[MIGRATIONS] 010: merged duplicate inventory slots on ${merged} user document(s).`);
+        }
+    },
+};

--- a/src/migrations/011_clamp_negative_balances.js
+++ b/src/migrations/011_clamp_negative_balances.js
@@ -1,0 +1,33 @@
+const mongoose = require('mongoose');
+
+/**
+ * Raises any already-negative `balance` or `bank` to zero.
+ *
+ * The User schema now declares `min: 0` on both. Mongoose validates the whole
+ * document on `save()`, not just the paths that changed, so a user left
+ * negative by one of the unguarded debits that have since been fixed would fail
+ * validation on their next `save()` — and stay stuck there, unable to run any
+ * command that saves, which is a worse state than the negative number itself.
+ *
+ * Zero is the repair: a negative balance is not a debt the economy models
+ * anywhere (every debit is meant to be capped at the wallet), it is the residue
+ * of a write that overshot. The count is logged so the damage is visible rather
+ * than quietly erased.
+ */
+module.exports = {
+    name: '011_clamp_negative_balances',
+
+    async up() {
+        const users = mongoose.connection.db.collection('users');
+
+        for (const field of ['balance', 'bank']) {
+            const result = await users.updateMany(
+                { [field]: { $lt: 0 } },
+                [{ $set: { [field]: 0 } }],
+            );
+            if (result.modifiedCount > 0) {
+                console.log(`[MIGRATIONS] 011: clamped ${result.modifiedCount} negative ${field}(s) to 0.`);
+            }
+        }
+    },
+};

--- a/src/migrations/012_active_lock_unique_key.js
+++ b/src/migrations/012_active_lock_unique_key.js
@@ -1,0 +1,42 @@
+const mongoose = require('mongoose');
+
+/**
+ * Creates the unique index on `activelocks.key`, and refuses to finish without it.
+ *
+ * The per-user action lock (src/utils/activeGameLock.js) acquires with a
+ * conditional upsert. When a live lock already holds the key, the filter misses,
+ * the upsert falls through to an insert, and the *unique index* is what rejects
+ * that insert — that rejection is the entire "already held" signal. Without the
+ * index the insert succeeds instead, two flows both believe they hold the lock,
+ * and the thing it exists to prevent happens silently.
+ *
+ * Mongoose builds indexes declared with `unique: true` on its own, but that
+ * build is asynchronous, unordered against the first query, and only logged if
+ * it fails. That is fine for an index that makes a lookup faster and not fine
+ * for one a correctness argument rests on, so it is created here — before the
+ * bot serves anything — and then read back to confirm.
+ */
+module.exports = {
+    name: '012_active_lock_unique_key',
+
+    async up() {
+        const locks = mongoose.connection.db.collection('activelocks');
+
+        // A duplicate key left over from a botched earlier build would make the
+        // unique build fail; there is nothing worth keeping in a lock document,
+        // so clear anything already expired before building.
+        await locks.deleteMany({ expiresAt: { $lte: new Date() } }).catch(() => null);
+
+        await locks.createIndex({ key: 1 }, { name: 'idx_activelock_key', unique: true });
+
+        const built = (await locks.indexes()).find(
+            i => i.unique === true && Object.keys(i.key).length === 1 && i.key.key === 1,
+        );
+        if (!built) {
+            throw new Error(
+                'activelocks.key unique index missing after createIndex — the action lock ' +
+                'cannot reject a concurrent acquire without it, so startup must not continue.',
+            );
+        }
+    },
+};

--- a/src/models/ActiveLock.js
+++ b/src/models/ActiveLock.js
@@ -1,0 +1,22 @@
+const { Schema, model } = require('mongoose');
+
+/**
+ * A held per-user action lock.
+ *
+ * One document per lock key, existing only while the lock is held. See
+ * src/utils/activeGameLock.js for how the acquire and release are made atomic —
+ * the unique index on `key` is what does the work there, so it is not optional.
+ */
+const activeLockSchema = new Schema({
+    key:       { type: String, required: true, unique: true },
+    token:     { type: String, required: true },
+    expiresAt: { type: Date,   required: true },
+});
+
+// A garbage collector, not the expiry mechanism: Mongo's TTL monitor only runs
+// about once a minute, which is far too coarse to decide whether a lock is
+// still held. Acquisition compares `expiresAt` itself and takes over an expired
+// lock immediately; this index just stops abandoned documents accumulating.
+activeLockSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+module.exports = model('ActiveLock', activeLockSchema);

--- a/src/models/ActiveLock.js
+++ b/src/models/ActiveLock.js
@@ -8,6 +8,9 @@ const { Schema, model } = require('mongoose');
  * the unique index on `key` is what does the work there, so it is not optional.
  */
 const activeLockSchema = new Schema({
+    // `unique` here declares the intent; migration 012 is what guarantees it.
+    // Mongoose's own index build is asynchronous and unordered against the first
+    // query, which is too weak for an index the lock's correctness rests on.
     key:       { type: String, required: true, unique: true },
     token:     { type: String, required: true },
     expiresAt: { type: Date,   required: true },

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -43,8 +43,15 @@ const userSchema = new Schema({
     messages: { type: Number, default: 0 },
     lastXpGain: { type: Date, default: null },
 
-    balance: { type: Number, default: 0 },
-    bank: { type: Number, default: 0 },
+    // `min: 0` is a backstop, not the guard. Mongoose only runs validators on
+    // `save()` and on updates that opt in with `runValidators`, and nearly every
+    // economy write is a bare `$inc` / `findOneAndUpdate` that does neither — so
+    // this catches a read-modify-`save()` path going negative and nothing else.
+    // The real protection is the `balance: { $gte: cost }` filter on each debit
+    // (checked across the codebase by tests/balanceDebitGuard.test.js) and the
+    // clamp-inside-the-update in src/utils/balanceDebit.js.
+    balance: { type: Number, default: 0, min: 0 },
+    bank: { type: Number, default: 0, min: 0 },
     lastDaily: { type: Date, default: null },
     lastWork: { type: Date, default: null },
     lastSnowball: { type: Date, default: null },

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -54,6 +54,7 @@ const userSchema = new Schema({
     bank: { type: Number, default: 0, min: 0 },
     lastDaily: { type: Date, default: null },
     lastWork: { type: Date, default: null },
+    lastQuiz: { type: Date, default: null },
     lastSnowball: { type: Date, default: null },
     lastTrickOrTreat: { type: Date, default: null },
     lastSandcastle: { type: Date, default: null },

--- a/src/services/chatEventService.js
+++ b/src/services/chatEventService.js
@@ -15,6 +15,7 @@
 const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags } = require('discord.js');
 const User = require('../models/User');
 const { logTransaction } = require('../utils/logTransaction');
+const { grantInventoryItem } = require('../utils/inventoryGrant');
 const QUIZ_FALLBACK = require('../data/quizFallback');
 
 const EVENT_CHANCE         = 0.04;
@@ -186,18 +187,10 @@ async function spawnCrate(message, guildSettings) {
         // Reserve before the first await; only stop the collector once persisted.
         claimed = true;
         try {
-            // Increment existing inventory slot, or push a new one
-            const res = await User.updateOne(
-                { userId: i.user.id, guildId: message.guild.id, 'inventory.itemId': item.itemId },
-                { $inc: { 'inventory.$.quantity': 1 } }
-            );
-            if (res.matchedCount === 0) {
-                await User.updateOne(
-                    { userId: i.user.id, guildId: message.guild.id },
-                    { $push: { inventory: { itemId: item.itemId, quantity: 1 } }, $setOnInsert: { userId: i.user.id, guildId: message.guild.id } },
-                    { upsert: true }
-                );
-            }
+            // One atomic update: bumps the existing slot or appends one. The
+            // match-then-push it replaced let two claimants both miss the slot
+            // and both push, stranding a unit in the duplicate.
+            await grantInventoryItem(i.user.id, message.guild.id, item.itemId, 1, { upsert: true });
         } catch (err) {
             claimed = false;
             console.error('[chatEvent] crate award failed:', err);

--- a/src/services/heistService.js
+++ b/src/services/heistService.js
@@ -1,5 +1,13 @@
 // In-memory state for active heist lobbies and in-progress heists.
 // Keyed by guildId so only one heist can run per guild at a time.
+//
+// Same boundary as src/utils/crashLobby.js: a heist is a sequence of role
+// minigames driven by collectors on live messages, so the session cannot be
+// moved to Mongo without redesigning the round itself. A second process would
+// allow two concurrent heists in one guild, and a restart abandons one — the
+// payout is credited per participant with an `$inc` at the end, so neither
+// duplicates anyone's coins. The per-user action lock, which is the thing that
+// actually gates money, is in Mongo; see src/utils/activeGameLock.js.
 
 const activeHeists = new Map();
 

--- a/src/services/newspaperService.js
+++ b/src/services/newspaperService.js
@@ -5,6 +5,7 @@ const Case         = require('../models/Case');
 const Transaction  = require('../models/Transaction');
 const GrindProfile = require('../models/GrindProfile');
 const { getCompletion, resolveProviderConfig } = require('./aiService');
+const { topByNetWorth } = require('../utils/netWorth');
 
 const DAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
@@ -13,11 +14,9 @@ async function collectStats(guildId, sections) {
     const data = {};
 
     if (sections.topEarners !== false) {
-        data.topEarners = await User.find({ guildId })
-            .sort({ balance: -1 })
-            .limit(5)
-            .select('userId balance')
-            .lean();
+        // Ranked on balance + bank so the paper's rich list matches the one
+        // `/leaderboard economy` and the dashboard print.
+        data.topEarners = await topByNetWorth(User, guildId, 5);
     }
 
     if (sections.levelUps !== false) {
@@ -89,9 +88,9 @@ function buildDataSummary(stats, usernameMap, currency, sections) {
     const lines = [];
 
     if (stats.topEarners?.length && sections.topEarners !== false) {
-        lines.push('TOP EARNERS (ALL-TIME BALANCE):');
+        lines.push('TOP EARNERS (NET WORTH — BALANCE + BANK):');
         stats.topEarners.forEach((u, i) =>
-            lines.push(`  ${i + 1}. ${usernameMap[u.userId] || 'Unknown'} — ${(u.balance || 0).toLocaleString()} ${currency}`)
+            lines.push(`  ${i + 1}. ${usernameMap[u.userId] || 'Unknown'} — ${(u.netWorth || 0).toLocaleString()} ${currency}`)
         );
     }
 
@@ -211,7 +210,7 @@ function buildFallbackNewspaper(stats, usernameMap, currency, sections, guildNam
         lines.push('**💰 Top Earners**');
         stats.topEarners.slice(0, 3).forEach((u, i) => {
             const medals = ['🥇', '🥈', '🥉'];
-            lines.push(`${medals[i]} **${usernameMap[u.userId] || 'Unknown'}** — ${(u.balance || 0).toLocaleString()} ${currency}`);
+            lines.push(`${medals[i]} **${usernameMap[u.userId] || 'Unknown'}** — ${(u.netWorth || 0).toLocaleString()} ${currency}`);
         });
         lines.push('');
     }

--- a/src/services/raidService.js
+++ b/src/services/raidService.js
@@ -2,7 +2,15 @@ const { EmbedBuilder } = require('discord.js');
 const Guild = require('../models/Guild');
 
 // guildId -> [{timestamp, userId, accountAgeDays}]
-// NOTE: in-memory only — data is lost on restart and not shared across shards.
+//
+// In-memory only: data is lost on restart and not shared across processes. This
+// one is a sliding window of recent joins used to detect a raid, and it moves no
+// money — the cost of losing it is a raid burst that has to re-establish its
+// rate before tripping the detector, and the cost of two processes is each
+// seeing roughly half the joins. Raid mode itself is persisted on the Guild
+// document (the Set below is a read cache of that field), so the state that
+// changes how the server behaves does survive both.
+//
 // For multi-shard or high-availability deployments, replace with a Redis-backed
 // store using sorted sets (ZADD/ZRANGEBYSCORE with TTL) for atomic, shared state.
 const joinLog = new Map();

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -934,12 +934,31 @@ async function returnExpiredMarketListings() {
 
     for (const listing of expired) {
         try {
+            // Claim the listing by deleting it before crediting anything. The
+            // listing document is the only record that this return is owed, so
+            // whoever deletes it owns the credit: a second worker, or this job's
+            // next tick after a crash, finds nothing and does nothing.
+            //
+            // Crediting first and deleting after inverts that — a delete that
+            // fails leaves the listing to be found and credited again on the next
+            // tick, minting items. Losing a return is recoverable from this log;
+            // silently doubling one is not.
+            const claimed = await MarketListing.findOneAndDelete({ _id: listing._id });
+            if (!claimed) continue;
+
             // Return items to the seller in one atomic update — the match-then-push
             // it replaced could hand two expiring listings of the same item their
             // own slot each, stranding one of them.
-            await grantInventoryItem(listing.sellerId, listing.guildId, listing.itemId, listing.quantity, { upsert: true });
-
-            await MarketListing.deleteOne({ _id: listing._id });
+            try {
+                await grantInventoryItem(listing.sellerId, listing.guildId, listing.itemId, listing.quantity, { upsert: true });
+            } catch (creditErr) {
+                console.error(
+                    `[scheduler] listing ${listing._id} was claimed but crediting ` +
+                    `${listing.quantity}x ${listing.itemId} to ${listing.sellerId} failed — ` +
+                    'items owed and must be returned by hand:', creditErr.message,
+                );
+                continue;
+            }
             processed++;
         } catch (err) {
             console.error(`[scheduler] returnExpiredMarketListings failed for listing ${listing._id}:`, err.message);

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -5,6 +5,8 @@ const { createWarVictoryBanner, createSeasonRecapCard } = require('../utils/card
 const { PET_DEFINITIONS, heartBar } = require('./petService');
 const { ensurePricingFields, nextPrice, decayDemand, pushHistory, trendBucket } = require('../utils/dynamicPricing');
 const { softResetElo, tierFor, makeSeasonId } = require('../utils/duelElo');
+const { topByNetWorth } = require('../utils/netWorth');
+const { grantInventoryItem } = require('../utils/inventoryGrant');
 
 const WAR_BOOSTER_DURATION_MS = 24 * 60 * 60 * 1000;
 const WAR_BADGE_DURATION_MS   = 30 * 24 * 60 * 60 * 1000;
@@ -364,7 +366,11 @@ async function awardWeeklyLeaderboardBadges(client) {
 
             const categories = [
                 { key: 'levels',       sort: { level: -1, xp: -1 },            label: '📈 Top Level' },
-                { key: 'economy',      sort: { balance: -1 },                   label: '💰 Wealthiest' },
+                // Wealth ranks on balance + bank, same as every other wealth surface —
+                // sorting on `balance` alone crowned whoever kept the most cash out
+                // of the bank rather than whoever actually had the most. `netWorth`
+                // routes this one through the shared aggregation instead of `sort`.
+                { key: 'economy',      netWorth: true,                          label: '💰 Wealthiest' },
                 { key: 'streaks',      sort: { 'streak.current': -1 },          label: '🔥 Longest Streak' },
                 { key: 'duels',        sort: { duelWins: -1 },                  label: '⚔️ Duel Champion' },
                 { key: 'achievements', sort: { achievementsCount: -1 },         label: '🏅 Achievement Hunter' },
@@ -375,7 +381,9 @@ async function awardWeeklyLeaderboardBadges(client) {
             const discordGuild = await client.guilds.fetch(guildId).catch(() => null);
 
             for (const cat of categories) {
-                const top = await User.findOne({ guildId }).sort(cat.sort).select('userId').lean();
+                const top = cat.netWorth
+                    ? (await topByNetWorth(User, guildId, 1))[0]
+                    : await User.findOne({ guildId }).sort(cat.sort).select('userId').lean();
                 if (!top) continue;
 
                 // Award badge (deduplicate: remove existing #1 badge for this category first)
@@ -926,24 +934,10 @@ async function returnExpiredMarketListings() {
 
     for (const listing of expired) {
         try {
-            // Return items to seller atomically
-            const credited = await User.findOneAndUpdate(
-                {
-                    userId:  listing.sellerId,
-                    guildId: listing.guildId,
-                    'inventory.itemId': listing.itemId,
-                },
-                { $inc: { 'inventory.$.quantity': listing.quantity } }
-            );
-
-            if (!credited) {
-                // Item not in seller's inventory yet — push a new slot
-                await User.findOneAndUpdate(
-                    { userId: listing.sellerId, guildId: listing.guildId },
-                    { $push: { inventory: { itemId: listing.itemId, quantity: listing.quantity } } },
-                    { upsert: true }
-                );
-            }
+            // Return items to the seller in one atomic update — the match-then-push
+            // it replaced could hand two expiring listings of the same item their
+            // own slot each, stranding one of them.
+            await grantInventoryItem(listing.sellerId, listing.guildId, listing.itemId, listing.quantity, { upsert: true });
 
             await MarketListing.deleteOne({ _id: listing._id });
             processed++;

--- a/src/services/syndicateService.js
+++ b/src/services/syndicateService.js
@@ -1,5 +1,11 @@
 // In-memory state for active syndicate heist lobbies, keyed by guildId.
 // Only one syndicate heist can run per guild at a time.
+//
+// Process-bound for the same reason as src/services/heistService.js: the run is
+// a chain of collector-driven prompts on live messages. A second process would
+// allow two concurrent runs per guild and a restart abandons one; the payout is
+// an `$inc` per participant at the end, so neither pays anyone twice. Money is
+// gated by the Mongo-backed per-user lock in src/utils/activeGameLock.js.
 
 const activeSyndicateHeists = new Map();
 

--- a/src/utils/activeGameLock.js
+++ b/src/utils/activeGameLock.js
@@ -1,33 +1,77 @@
 /**
- * In-memory per-user action locks.
+ * Per-user action locks, held in Mongo.
  *
- * Prevents a user from running two instances of the same action concurrently
- * (e.g. two /casino games, or two /fish casts racing the same user document).
- * Locks are process-local — sufficient for a single-process bot — and carry a
- * TTL backstop so a crashed flow can never deadlock a user permanently.
+ * Stops a user running two instances of the same money-moving action at once —
+ * two /casino games, or two /fish casts racing the same user document. This is
+ * a boundary, not a convenience: everything it guards ends in a coin write, so
+ * a lock that only holds within one process is a lock that stops holding the
+ * moment a second process exists. It used to be a `Map`, which meant a restart
+ * dropped every lease and a second instance shared none of them — and since
+ * there is no sharding scaffolding anywhere in `src/`, a second instance would
+ * have double-paid users rather than scaled them.
  *
- * Acquisition returns a lease token; release requires the matching token, so
- * a holder whose lease expired (and whose key was re-acquired by a newer flow)
+ * Acquisition is a single conditional upsert, which is what makes it safe
+ * across processes:
+ *
+ *   - No document for the key      → the upsert inserts one. Acquired.
+ *   - A document past `expiresAt`  → the filter matches and the update takes it
+ *                                    over with a fresh token. Acquired.
+ *   - A document still live        → the filter misses, the upsert tries to
+ *                                    insert, and the unique index on `key`
+ *                                    rejects it. Held by someone else.
+ *
+ * Expiry is decided by comparing `expiresAt` at acquire time rather than by the
+ * TTL index, whose sweep is far too coarse to gate a lease on. The TTL index
+ * only reclaims documents nobody came back for.
+ *
+ * Acquisition returns a lease token; release requires the matching token, so a
+ * holder whose lease expired — and whose key was then taken by a newer flow —
  * cannot release the new holder's lock.
  */
 
-const locks = new Map(); // key -> { expiry, token }
+const ActiveLock = require('../models/ActiveLock');
 
 const DEFAULT_TTL_MS = 10 * 60 * 1000;
 
 let tokenCounter = 0;
 
+// A lease token has to be unique across processes, not just within one, or a
+// restarted process could mint a token that frees a lock it no longer owns.
+function mintToken(now) {
+    return `${process.pid}-${now}-${++tokenCounter}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+// The unique index on `key` rejecting the insert IS the "already held" signal,
+// so this is a normal outcome rather than a failure.
+function isDuplicateKey(err) {
+    return err?.code === 11000 || err?.code === 11001 || err?.codeName === 'DuplicateKey';
+}
+
 /**
  * Attempts to acquire the lock for `key`. Returns a lease token (truthy) on
- * success, or null if the key is already locked (and not yet expired).
+ * success, or null if the key is already locked and not yet expired.
+ *
+ * A database error also returns null — refusing the action is the safe answer
+ * for something that gates money, and if Mongo is unreachable the action it
+ * guards has nothing to write to anyway.
  */
-function tryAcquire(key, ttlMs = DEFAULT_TTL_MS) {
-    const now      = Date.now();
-    const existing = locks.get(key);
-    if (existing && existing.expiry > now) return null;
-    const token = `${now}-${++tokenCounter}`;
-    locks.set(key, { expiry: now + ttlMs, token });
-    return token;
+async function tryAcquire(key, ttlMs = DEFAULT_TTL_MS) {
+    const now   = Date.now();
+    const token = mintToken(now);
+
+    try {
+        const lock = await ActiveLock.findOneAndUpdate(
+            { key, expiresAt: { $lte: new Date(now) } },
+            { $set: { key, token, expiresAt: new Date(now + ttlMs) } },
+            { new: true, upsert: true },
+        );
+        // Someone else's token coming back would mean a concurrent takeover won.
+        return lock?.token === token ? token : null;
+    } catch (err) {
+        if (isDuplicateKey(err)) return null;
+        console.error('[activeGameLock] acquire failed:', err);
+        return null;
+    }
 }
 
 /**
@@ -35,19 +79,17 @@ function tryAcquire(key, ttlMs = DEFAULT_TTL_MS) {
  * Returns true if the lock was released, false otherwise (wrong token,
  * already released, or re-acquired by another flow after expiry).
  */
-function release(key, token) {
-    const existing = locks.get(key);
-    if (!existing || existing.token !== token) return false;
-    locks.delete(key);
-    return true;
+async function release(key, token) {
+    if (!token) return false;
+    try {
+        const { deletedCount } = await ActiveLock.deleteOne({ key, token });
+        return deletedCount === 1;
+    } catch (err) {
+        // Leaving it to expire is the safe failure: the TTL frees the key, and
+        // the worst case is one user blocked from a second game until then.
+        console.error('[activeGameLock] release failed:', err);
+        return false;
+    }
 }
 
-// Periodically sweep expired entries so the map doesn't grow unbounded.
-setInterval(() => {
-    const now = Date.now();
-    for (const [key, entry] of locks) {
-        if (entry.expiry <= now) locks.delete(key);
-    }
-}, 60_000).unref();
-
-module.exports = { tryAcquire, release };
+module.exports = { tryAcquire, release, DEFAULT_TTL_MS };

--- a/src/utils/balanceDebit.js
+++ b/src/utils/balanceDebit.js
@@ -1,0 +1,63 @@
+/**
+ * "Take up to N coins, never more than they have" — atomically.
+ *
+ * A penalty that is capped at the player's wallet (a crime fine, a quiz
+ * forfeit, coins knocked loose by a snowball) was written as a read followed by
+ * a clamp followed by an unguarded `$inc`:
+ *
+ *     const fresh = await User.findOne(filter);
+ *     const paid  = Math.min(fine, fresh.balance);
+ *     await User.findOneAndUpdate(filter, { $inc: { balance: -paid } });
+ *
+ * The clamp is computed against a balance that is already history by the time
+ * the `$inc` lands — spend coins in between and the debit takes more than is
+ * there, which `$inc` will happily do straight past zero. The guarded form used
+ * everywhere else (`balance: { $gte: cost }`) does not fit these: a fine is not
+ * all-or-nothing, so a filter miss would have to fall back to another read and
+ * another clamp, which is the same race one round deeper.
+ *
+ * Doing the clamp inside the update removes the window entirely — the balance
+ * the subtraction reads is the balance being written.
+ */
+
+/**
+ * Pipeline expression for `balance` after taking up to `amount`, floored at zero.
+ */
+function clampedDebitExpr(amount) {
+    return { $max: [0, { $subtract: [{ $ifNull: ['$balance', 0] }, amount] }] };
+}
+
+/** Pipeline form of `$inc: { [path]: by }`, for folding counters into the same update. */
+function incExpr(path, by) {
+    return { $add: [{ $ifNull: [`$${path}`, 0] }, by] };
+}
+
+/**
+ * Debits up to `amount` from the matched user and reports what was actually
+ * taken, so callers can report the real figure rather than the one they hoped
+ * for.
+ *
+ * `extraSet` holds further pipeline `$set` fields committed in the same update
+ * (use `incExpr` for counters). Returns
+ * `{ taken, balance, matched }` — `balance` being the balance after the debit,
+ * and `matched` false when the filter matched nothing.
+ */
+async function debitUpTo(Model, filter, amount, extraSet = {}) {
+    const wanted = Math.max(0, Math.floor(amount) || 0);
+
+    // `new: false` returns the pre-image, which is the only way to learn how
+    // much the clamp actually let through.
+    const before = await Model.findOneAndUpdate(
+        filter,
+        [{ $set: { balance: clampedDebitExpr(wanted), ...extraSet } }],
+        { new: false },
+    );
+
+    if (!before) return { taken: 0, balance: 0, matched: false };
+
+    const prior = before.balance ?? 0;
+    const taken = Math.min(wanted, prior);
+    return { taken, balance: prior - taken, matched: true };
+}
+
+module.exports = { clampedDebitExpr, incExpr, debitUpTo };

--- a/src/utils/balanceDelta.js
+++ b/src/utils/balanceDelta.js
@@ -1,0 +1,61 @@
+/**
+ * Keeps `balance` out of a document `save()` and re-applies it as an `$inc`.
+ *
+ * `save()` writes every modified path as an absolute `$set`, so a flow that
+ * reads a user, mutates `user.balance` in memory and saves is writing the value
+ * it read — plus its own change — over whatever else happened in between. In a
+ * flow with interactive awaits that window is seconds wide: `/fish` reads the
+ * user, waits 2–5s for the bite and up to 3s more for the reel-in prompt, then
+ * saves. A casino bet placed in another channel during the prompt is simply
+ * erased when the cast lands, refunding the bet for free.
+ *
+ * Wrapping the save turns the in-memory change into a relative one:
+ *
+ *     const at = user.balance;              // before the awaits
+ *     ...                                    // flow mutates user.balance freely
+ *     const delta = detachBalanceDelta(user, at);
+ *     await user.save();                     // no longer touches balance
+ *     await applyBalanceDelta(User, filter, user, delta);
+ *
+ * Concurrent writers each apply their own `$inc`, so both changes survive.
+ *
+ * The save runs first on purpose. If it fails, nothing is credited and the flow
+ * can be retried; the reverse order would credit coins that a failed save then
+ * lets the player earn again.
+ */
+
+/**
+ * Rewinds `user.balance` to `balanceAtLoad` and clears its modified flag, so the
+ * next `save()` leaves the stored balance alone. Returns the net change the flow
+ * made, to be handed to `applyBalanceDelta` once the save has landed.
+ */
+function detachBalanceDelta(user, balanceAtLoad) {
+    const delta = (user.balance ?? 0) - balanceAtLoad;
+    user.balance = balanceAtLoad;
+    user.unmarkModified('balance');
+    return delta;
+}
+
+/**
+ * Applies `delta` as an atomic `$inc` and refreshes `user.balance` with the
+ * authoritative post-write value, so anything rendered afterwards shows the real
+ * number rather than the flow's private arithmetic. The path is left unmarked:
+ * a later `save()` in the same flow must not write this value back as a `$set`.
+ *
+ * Returns the resulting balance.
+ */
+async function applyBalanceDelta(Model, filter, user, delta) {
+    if (!delta) return user.balance ?? 0;
+
+    const bumped = await Model.findOneAndUpdate(
+        filter,
+        { $inc: { balance: delta } },
+        { new: true, projection: { balance: 1 } },
+    );
+
+    user.balance = bumped ? bumped.balance : (user.balance ?? 0) + delta;
+    user.unmarkModified('balance');
+    return user.balance;
+}
+
+module.exports = { detachBalanceDelta, applyBalanceDelta };

--- a/src/utils/balanceDelta.js
+++ b/src/utils/balanceDelta.js
@@ -24,6 +24,12 @@
  * lets the player earn again.
  */
 
+const { debitUpTo } = require('./balanceDebit');
+const { delay } = require('./delay');
+const FailedJob = require('../models/FailedJob');
+
+const CREDIT_ATTEMPTS = 3;
+
 /**
  * Rewinds `user.balance` to `balanceAtLoad` and clears its modified flag, so the
  * next `save()` leaves the stored balance alone. Returns the net change the flow
@@ -37,15 +43,27 @@ function detachBalanceDelta(user, balanceAtLoad) {
 }
 
 /**
- * Applies `delta` as an atomic `$inc` and refreshes `user.balance` with the
- * authoritative post-write value, so anything rendered afterwards shows the real
- * number rather than the flow's private arithmetic. The path is left unmarked:
- * a later `save()` in the same flow must not write this value back as a `$set`.
+ * Applies `delta` and refreshes `user.balance` with the authoritative post-write
+ * value, so anything rendered afterwards shows the real number rather than the
+ * flow's private arithmetic. The path is left unmarked: a later `save()` in the
+ * same flow must not write this value back as a `$set`.
+ *
+ * A negative delta goes through the clamped debit rather than a bare `$inc`.
+ * `$inc` runs straight past zero, and a flow whose net change is a charge has no
+ * more claim on funds it read seconds ago than any other debit does — the same
+ * reasoning as src/utils/balanceDebit.js, which this defers to.
  *
  * Returns the resulting balance.
  */
 async function applyBalanceDelta(Model, filter, user, delta) {
     if (!delta) return user.balance ?? 0;
+
+    if (delta < 0) {
+        const { balance, matched } = await debitUpTo(Model, filter, -delta, {});
+        user.balance = matched ? balance : Math.max(0, (user.balance ?? 0) + delta);
+        user.unmarkModified('balance');
+        return user.balance;
+    }
 
     const bumped = await Model.findOneAndUpdate(
         filter,
@@ -58,4 +76,51 @@ async function applyBalanceDelta(Model, filter, user, delta) {
     return user.balance;
 }
 
-module.exports = { detachBalanceDelta, applyBalanceDelta };
+/**
+ * `applyBalanceDelta` with somewhere for the failure to go.
+ *
+ * Folding the coin movement out of `save()` split one write into two, and a
+ * second write can fail on its own: the save lands, the `$inc` does not, and the
+ * player is shown a successful catch they were never paid for. Logging that to
+ * the console and carrying on makes the coins disappear silently, which is the
+ * one outcome an economy cannot afford.
+ *
+ * There is no transaction to reach for — the deployment is a standalone mongod,
+ * so `save()` and the `$inc` cannot be made one write. What is available is a
+ * retry and a durable record: the dead-letter queue in src/utils/jobRunner.js
+ * already exists for work that has to happen but did not, and is replayable from
+ * the dashboard. So the credit is retried, and if it still will not land it is
+ * written down as owed rather than lost.
+ *
+ * Returns `{ credited, balance }`. A false `credited` means the caller must not
+ * present the flow as fully successful — the amount is recorded, not paid.
+ */
+async function commitBalanceDelta(Model, filter, user, delta, context = {}) {
+    if (!delta) return { credited: true, balance: user.balance ?? 0 };
+
+    let lastError = null;
+    for (let attempt = 1; attempt <= CREDIT_ATTEMPTS; attempt++) {
+        try {
+            return { credited: true, balance: await applyBalanceDelta(Model, filter, user, delta) };
+        } catch (err) {
+            lastError = err;
+            if (attempt < CREDIT_ATTEMPTS) await delay(attempt * 250);
+        }
+    }
+
+    console.error(`[${context.service ?? 'balance'}] credit of ${delta} failed after ${CREDIT_ATTEMPTS} attempts:`, lastError?.message);
+
+    await FailedJob.create({
+        service:      context.service ?? 'balanceDelta',
+        jobName:      context.jobName ?? 'applyBalanceDelta',
+        guildId:      context.guildId ?? null,
+        payload:      { ...filter, delta },
+        errorMessage: lastError?.message ?? 'unknown error',
+        errorStack:   lastError?.stack ?? null,
+        lastAttemptAt: new Date(),
+    }).catch(err => console.error('[balanceDelta] could not record the owed credit:', err.message));
+
+    return { credited: false, balance: user.balance ?? 0 };
+}
+
+module.exports = { detachBalanceDelta, applyBalanceDelta, commitBalanceDelta };

--- a/src/utils/crashLobby.js
+++ b/src/utils/crashLobby.js
@@ -1,5 +1,20 @@
 // In-memory lobby state for multiplayer crash. One active lobby per channel.
 // Keyed by channelId.
+//
+// Deliberately not in Mongo, unlike the per-user action lock in
+// src/utils/activeGameLock.js. A lobby holds a live `setInterval` handle and is
+// driven by a component collector on a specific message — neither survives
+// serialisation, so this is a storage problem only in the sense that the whole
+// multiplayer round is process-bound.
+//
+// What that costs, precisely: a restart mid-round drops the lobby, and a second
+// process would let one channel run two. Neither can double-pay. Money never
+// moves through this object — each player's stake is taken with a guarded
+// `balance: { $gte: bet }` debit and each cash-out credited with an `$inc`
+// against their own document (see src/games/casino/crash.js), so a duplicated
+// lobby is two independent games, not one game paid twice. Bets are refunded
+// from the `pendingCrashRefund` field the debit writes, which is in Mongo
+// precisely so a lost lobby cannot strand a stake.
 
 const lobbies = new Map();
 

--- a/src/utils/inventoryGrant.js
+++ b/src/utils/inventoryGrant.js
@@ -1,0 +1,96 @@
+/**
+ * Atomic inventory credits.
+ *
+ * `inventory` is an array with no uniqueness constraint on `itemId`, so the
+ * read-then-write shape that most credit sites used —
+ *
+ *     if (user.inventory.some(i => i.itemId === id)) $inc 'inventory.$.quantity'
+ *     else                                           $push { itemId: id, ... }
+ *
+ * — lets two concurrent credits both miss the slot and both push, leaving two
+ * slots for the same item. Every reader does `inventory.find(i => i.itemId === X)`
+ * and takes the first, so the quantity in the second slot is stranded for good.
+ *
+ * A single aggregation-pipeline update closes the window: the "does the slot
+ * exist" test and the write happen inside one document update, so a second
+ * writer either sees the slot and bumps it or creates it, never both.
+ * `src/commands/economy/shop.js` proved the pattern; this is that pipeline
+ * extracted so every credit site shares it.
+ */
+
+const DEFAULT_USER = require('../models/User');
+
+/**
+ * Pipeline `$set` expression that adds `quantity` of `itemId` to `$inventory`:
+ * bumps the matching slot when one exists, appends a slot when it does not.
+ *
+ * Exported on its own so callers that need to fold other updates into the same
+ * atomic write can compose it into their own `$set` stage.
+ */
+function inventoryAddExpr(itemId, quantity) {
+    return {
+        $cond: {
+            if: { $in: [itemId, { $ifNull: ['$inventory.itemId', []] }] },
+            then: {
+                $map: {
+                    input: '$inventory',
+                    as: 'slot',
+                    in: {
+                        $cond: [
+                            { $eq: ['$$slot.itemId', itemId] },
+                            { itemId: '$$slot.itemId', quantity: { $add: ['$$slot.quantity', quantity] } },
+                            '$$slot',
+                        ],
+                    },
+                },
+            },
+            else: {
+                $concatArrays: [
+                    { $ifNull: ['$inventory', []] },
+                    [{ itemId, quantity }],
+                ],
+            },
+        },
+    };
+}
+
+/**
+ * Credits `quantity` of `itemId` to one user's inventory in a single atomic update.
+ *
+ * Options:
+ *   `extraSet` — further pipeline `$set` fields written in the same update, so a
+ *                credit and the flag that records it commit together. These are
+ *                aggregation expressions, not update operators: use
+ *                `{ $setUnion: [{ $ifNull: ['$path', []] }, [value]] }` where you
+ *                would otherwise reach for `$addToSet`.
+ *   `upsert`   — create the user document when it does not exist yet.
+ *   `new`      — return the document after the update (default true).
+ *   `Model`    — override the User model (tests).
+ *
+ * Returns the user document, or null when no document matched and `upsert` is off.
+ */
+async function grantInventoryItem(userId, guildId, itemId, quantity = 1, options = {}) {
+    const { extraSet = {}, upsert = false, new: returnNew = true, Model = DEFAULT_USER } = options;
+
+    return Model.findOneAndUpdate(
+        { userId, guildId },
+        [{ $set: { inventory: inventoryAddExpr(itemId, quantity), ...extraSet } }],
+        { new: returnNew, upsert },
+    );
+}
+
+/**
+ * Pipeline stages that credit several items in one update.
+ *
+ * Each item needs its own `$set` stage rather than sharing one: the expression
+ * reads `$inventory`, and stages within a single `$set` all see the pre-stage
+ * document, so folding them together would make the last item win. Consecutive
+ * stages see each other's output, which is exactly the accumulation wanted.
+ */
+function inventoryAddStages(items) {
+    return items.map(({ itemId, quantity = 1 }) => ({
+        $set: { inventory: inventoryAddExpr(itemId, quantity) },
+    }));
+}
+
+module.exports = { grantInventoryItem, inventoryAddExpr, inventoryAddStages };

--- a/src/utils/inventoryGrant.js
+++ b/src/utils/inventoryGrant.js
@@ -22,32 +22,60 @@ const DEFAULT_USER = require('../models/User');
 
 /**
  * Pipeline `$set` expression that adds `quantity` of `itemId` to `$inventory`:
- * bumps the matching slot when one exists, appends a slot when it does not.
+ * credits the first slot whose itemId matches, or appends a slot when there is
+ * none.
+ *
+ * "First" matters. A `$map` that credits every matching slot turns one credit
+ * into N on a document that still carries pre-fix duplicates — buying 5 of an
+ * item you hold in two slots would hand you 10. The fold below takes the credit
+ * once and copies the rest through untouched, so a duplicate is left for
+ * migration 010 to merge rather than being silently inflated.
+ *
+ * `$mergeObjects` rather than a rebuilt `{ itemId, quantity }` literal: the slot
+ * is a subdocument with its own `_id`, and rebuilding it would discard that.
  *
  * Exported on its own so callers that need to fold other updates into the same
  * atomic write can compose it into their own `$set` stage.
  */
 function inventoryAddExpr(itemId, quantity) {
     return {
-        $cond: {
-            if: { $in: [itemId, { $ifNull: ['$inventory.itemId', []] }] },
-            then: {
-                $map: {
-                    input: '$inventory',
-                    as: 'slot',
-                    in: {
-                        $cond: [
-                            { $eq: ['$$slot.itemId', itemId] },
-                            { itemId: '$$slot.itemId', quantity: { $add: ['$$slot.quantity', quantity] } },
-                            '$$slot',
-                        ],
+        $let: {
+            vars: {
+                folded: {
+                    $reduce: {
+                        input: { $ifNull: ['$inventory', []] },
+                        initialValue: { slots: [], credited: false },
+                        in: {
+                            $cond: [
+                                { $and: [
+                                    { $not: ['$$value.credited'] },
+                                    { $eq: ['$$this.itemId', itemId] },
+                                ] },
+                                {
+                                    slots: { $concatArrays: ['$$value.slots', [
+                                        // `$ifNull` on the quantity: a legacy slot
+                                        // written without one would make `$add`
+                                        // evaluate to null and wipe the count.
+                                        { $mergeObjects: ['$$this', {
+                                            quantity: { $add: [{ $ifNull: ['$$this.quantity', 0] }, quantity] },
+                                        }] },
+                                    ]] },
+                                    credited: true,
+                                },
+                                {
+                                    slots: { $concatArrays: ['$$value.slots', ['$$this']] },
+                                    credited: '$$value.credited',
+                                },
+                            ],
+                        },
                     },
                 },
             },
-            else: {
-                $concatArrays: [
-                    { $ifNull: ['$inventory', []] },
-                    [{ itemId, quantity }],
+            in: {
+                $cond: [
+                    '$$folded.credited',
+                    '$$folded.slots',
+                    { $concatArrays: ['$$folded.slots', [{ itemId, quantity }]] },
                 ],
             },
         },

--- a/src/utils/netWorth.js
+++ b/src/utils/netWorth.js
@@ -1,0 +1,55 @@
+/**
+ * Net worth = liquid balance + banked coins.
+ *
+ * Every surface that ranks users by wealth has to agree on what "wealth" means.
+ * They did not: `/leaderboard economy` sorted by `{ balance: -1, bank: -1 }`
+ * while displaying `balance + bank`, so a bank-heavy user showed a high total
+ * and still never placed; the dashboard, the weekly badge job and the
+ * newspaper each picked their own field. Same guild, four rankings.
+ *
+ * The sort is done in an aggregation rather than against a denormalised
+ * `netWorth` column because the column would have to be kept in step by all 41
+ * files that move coins — one missed `$inc` and the ranking silently rots. The
+ * `{ guildId: 1, balance: -1, bank: -1 }` index still selects the guild's
+ * documents; only the ordering of that one guild's users is computed, which is
+ * what the dashboard has always done.
+ */
+
+// `$ifNull` guards documents written before `balance`/`bank` had defaults.
+const NET_WORTH_EXPR = { $add: [{ $ifNull: ['$balance', 0] }, { $ifNull: ['$bank', 0] }] };
+
+/** Net worth of an already-loaded user document or lean object. */
+function netWorthOf(user) {
+    return (user?.balance ?? 0) + (user?.bank ?? 0);
+}
+
+/**
+ * Top `limit` users in `guildId` by net worth, richest first.
+ *
+ * `_id` breaks ties so two surfaces listing the same guild produce the same
+ * order rather than whichever order the storage engine happened to return.
+ * Results are plain objects: `{ userId, balance, bank, netWorth, ...extra }`.
+ */
+async function topByNetWorth(User, guildId, limit, extraProject = {}) {
+    return User.aggregate([
+        { $match: { guildId } },
+        { $addFields: { netWorth: NET_WORTH_EXPR } },
+        { $sort: { netWorth: -1, _id: 1 } },
+        { $limit: limit },
+        { $project: { _id: 0, userId: 1, balance: 1, bank: 1, netWorth: 1, ...extraProject } },
+    ]);
+}
+
+/**
+ * 1-based rank of `netWorth` within `guildId` — the count of users strictly
+ * richer, plus one. Matches the ordering `topByNetWorth` produces.
+ */
+async function netWorthRank(User, guildId, netWorth) {
+    const richer = await User.countDocuments({
+        guildId,
+        $expr: { $gt: [NET_WORTH_EXPR, netWorth] },
+    });
+    return richer + 1;
+}
+
+module.exports = { NET_WORTH_EXPR, netWorthOf, topByNetWorth, netWorthRank };

--- a/src/utils/netWorth.js
+++ b/src/utils/netWorth.js
@@ -41,15 +41,26 @@ async function topByNetWorth(User, guildId, limit, extraProject = {}) {
 }
 
 /**
- * 1-based rank of `netWorth` within `guildId` — the count of users strictly
- * richer, plus one. Matches the ordering `topByNetWorth` produces.
+ * 1-based rank of a user within `guildId`, matching the position
+ * `topByNetWorth` would list them at.
+ *
+ * Counting only users strictly richer would give every tied user the same rank,
+ * which reads fine in isolation but contradicts the list printed directly above
+ * it: two users on the same total occupy two different rows there. Passing the
+ * caller's `_id` applies the same `_id`-ascending tie-break the sort uses, so
+ * "You: #4" always names the row the caller is actually on.
  */
-async function netWorthRank(User, guildId, netWorth) {
-    const richer = await User.countDocuments({
+async function netWorthRank(User, guildId, netWorth, id) {
+    const ahead = await User.countDocuments({
         guildId,
-        $expr: { $gt: [NET_WORTH_EXPR, netWorth] },
+        $or: [
+            { $expr: { $gt: [NET_WORTH_EXPR, netWorth] } },
+            ...(id === undefined || id === null
+                ? []
+                : [{ $expr: { $eq: [NET_WORTH_EXPR, netWorth] }, _id: { $lt: id } }]),
+        ],
     });
-    return richer + 1;
+    return ahead + 1;
 }
 
 module.exports = { NET_WORTH_EXPR, netWorthOf, topByNetWorth, netWorthRank };

--- a/src/utils/starterKit.js
+++ b/src/utils/starterKit.js
@@ -1,5 +1,6 @@
 const User = require('../models/User');
 const { logTransaction } = require('./logTransaction');
+const { inventoryAddStages } = require('./inventoryGrant');
 
 const STARTER_COINS = 500;
 const STARTER_ITEMS = [
@@ -12,13 +13,19 @@ const STARTER_ITEMS = [
  * Returns { coins } on success, or null if already claimed.
  */
 async function claimStarterKit(userId, guildId) {
+    // `starterKitClaimed` still makes the whole update once-only; the items go in
+    // through the shared merge expression so a kit handed to someone who already
+    // picked up a lifesaver elsewhere bumps their slot instead of adding a second
+    // one that every reader would then ignore.
     const updated = await User.findOneAndUpdate(
         { userId, guildId, 'onboarding.starterKitClaimed': { $ne: true } },
-        {
-            $inc: { balance: STARTER_COINS },
-            $set: { 'onboarding.starterKitClaimed': true },
-            $push: { inventory: { $each: STARTER_ITEMS } },
-        },
+        [
+            ...inventoryAddStages(STARTER_ITEMS),
+            { $set: {
+                balance: { $add: [{ $ifNull: ['$balance', 0] }, STARTER_COINS] },
+                'onboarding.starterKitClaimed': true,
+            } },
+        ],
         { new: true }
     );
 

--- a/tests/activeGameLock.test.js
+++ b/tests/activeGameLock.test.js
@@ -1,67 +1,190 @@
+'use strict';
+
+// The action lock gates money — two /casino games or two /fish casts for one
+// user racing each other's debits. It used to live in a process-local `Map`, so
+// a restart dropped every lease and a second instance shared none of them, and
+// since there is no sharding scaffolding anywhere in src/ a second instance
+// would have double-paid users rather than scaled them. It is a Mongo document
+// now, acquired with a conditional upsert.
+//
+// The fake below implements exactly the three model calls the lock makes, with
+// the semantics Mongo gives them — in particular the unique index on `key`
+// rejecting an upsert insert, which is what "already held" actually is. Without
+// that the tests would prove nothing about the mechanism under test.
+
+const mockLocks = new Map(); // key -> { key, token, expiresAt }
+
+jest.mock('../src/models/ActiveLock', () => ({
+    findOneAndUpdate: jest.fn(async (filter, update, options) => {
+        const existing = mockLocks.get(filter.key);
+        const doc = { ...update.$set };
+
+        // The filter is { key, expiresAt: { $lte: now } }: it matches an expired
+        // lock, and misses both a live one and a key with no document at all.
+        if (existing && existing.expiresAt <= filter.expiresAt.$lte) {
+            mockLocks.set(filter.key, doc);
+            return options.new ? doc : existing;
+        }
+        if (existing) {
+            // Live lock: the upsert falls through to an insert, which the unique
+            // index rejects.
+            const err = new Error('E11000 duplicate key error collection: activelocks index: key_1');
+            err.code = 11000;
+            throw err;
+        }
+        mockLocks.set(filter.key, doc);
+        return options.new ? doc : null;
+    }),
+    deleteOne: jest.fn(async (filter) => {
+        const existing = mockLocks.get(filter.key);
+        if (!existing || existing.token !== filter.token) return { deletedCount: 0 };
+        mockLocks.delete(filter.key);
+        return { deletedCount: 1 };
+    }),
+}));
+
+const ActiveLock = require('../src/models/ActiveLock');
 const { tryAcquire, release } = require('../src/utils/activeGameLock');
 const { luckySaveEligible, LUCKY_SAVE_MAX_BET } = require('../src/services/effectsService');
 
+beforeEach(() => {
+    mockLocks.clear();
+    jest.clearAllMocks();
+});
+
 describe('activeGameLock', () => {
-    test('acquires a free lock and returns a token', () => {
-        const token = tryAcquire('test:1');
+    test('acquires a free lock and returns a token', async () => {
+        const token = await tryAcquire('test:1');
         expect(token).toBeTruthy();
-        expect(release('test:1', token)).toBe(true);
+        await expect(release('test:1', token)).resolves.toBe(true);
     });
 
-    test('rejects a second acquire while held', () => {
-        const token = tryAcquire('test:2');
+    test('rejects a second acquire while held', async () => {
+        const token = await tryAcquire('test:2');
         expect(token).toBeTruthy();
-        expect(tryAcquire('test:2')).toBeNull();
-        release('test:2', token);
+        await expect(tryAcquire('test:2')).resolves.toBeNull();
+        await release('test:2', token);
     });
 
-    test('can re-acquire after release', () => {
-        const token = tryAcquire('test:3');
-        expect(release('test:3', token)).toBe(true);
-        const token2 = tryAcquire('test:3');
+    test('can re-acquire after release', async () => {
+        const token = await tryAcquire('test:3');
+        await expect(release('test:3', token)).resolves.toBe(true);
+        const token2 = await tryAcquire('test:3');
         expect(token2).toBeTruthy();
-        release('test:3', token2);
+        await release('test:3', token2);
     });
 
-    test('expired locks can be re-acquired (TTL backstop)', () => {
-        expect(tryAcquire('test:4', -1)).toBeTruthy(); // already expired
-        const token = tryAcquire('test:4');
+    test('expired locks can be re-acquired (TTL backstop)', async () => {
+        expect(await tryAcquire('test:4', -1)).toBeTruthy(); // already expired
+        const token = await tryAcquire('test:4');
         expect(token).toBeTruthy();
-        release('test:4', token);
+        await release('test:4', token);
     });
 
-    test('release is token-validated — a stale holder cannot free a new lease', () => {
-        const tokenA = tryAcquire('test:5', -1); // expires immediately
-        const tokenB = tryAcquire('test:5');     // new flow takes over after expiry
+    test('release is token-validated — a stale holder cannot free a new lease', async () => {
+        const tokenA = await tryAcquire('test:5', -1); // expires immediately
+        const tokenB = await tryAcquire('test:5');     // new flow takes over after expiry
         expect(tokenB).toBeTruthy();
         expect(tokenB).not.toBe(tokenA);
 
         // The stale holder's release must be a no-op…
-        expect(release('test:5', tokenA)).toBe(false);
+        await expect(release('test:5', tokenA)).resolves.toBe(false);
         // …leaving the lock still held by the new lease
-        expect(tryAcquire('test:5')).toBeNull();
+        await expect(tryAcquire('test:5')).resolves.toBeNull();
 
         // The rightful owner can release it
-        expect(release('test:5', tokenB)).toBe(true);
-        const token = tryAcquire('test:5');
+        await expect(release('test:5', tokenB)).resolves.toBe(true);
+        const token = await tryAcquire('test:5');
         expect(token).toBeTruthy();
-        release('test:5', token);
+        await release('test:5', token);
     });
 
-    test('release without a matching token is a no-op', () => {
-        const token = tryAcquire('test:6');
-        expect(release('test:6', 'bogus-token')).toBe(false);
-        expect(tryAcquire('test:6')).toBeNull(); // still held
-        expect(release('test:6', token)).toBe(true);
+    test('release without a matching token is a no-op', async () => {
+        const token = await tryAcquire('test:6');
+        await expect(release('test:6', 'bogus-token')).resolves.toBe(false);
+        await expect(tryAcquire('test:6')).resolves.toBeNull(); // still held
+        await expect(release('test:6', token)).resolves.toBe(true);
     });
 
-    test('locks are independent per key', () => {
-        const a = tryAcquire('test:7a');
-        const b = tryAcquire('test:7b');
+    test('release of a missing token is a no-op rather than a throw', async () => {
+        await expect(release('test:6b', null)).resolves.toBe(false);
+        await expect(release('test:6b', undefined)).resolves.toBe(false);
+    });
+
+    test('locks are independent per key', async () => {
+        const a = await tryAcquire('test:7a');
+        const b = await tryAcquire('test:7b');
         expect(a).toBeTruthy();
         expect(b).toBeTruthy();
-        release('test:7a', a);
-        release('test:7b', b);
+        await release('test:7a', a);
+        await release('test:7b', b);
+    });
+
+    // ── The properties that only matter now that the lock is shared state ────
+
+    test('the lease is persisted, not held in this process', async () => {
+        await tryAcquire('test:8');
+        expect(ActiveLock.findOneAndUpdate).toHaveBeenCalledTimes(1);
+        const [filter, update] = ActiveLock.findOneAndUpdate.mock.calls[0];
+        expect(filter.key).toBe('test:8');
+        expect(filter.expiresAt.$lte).toBeInstanceOf(Date);
+        expect(update.$set.expiresAt).toBeInstanceOf(Date);
+    });
+
+    test('a lock taken by another process is visible to this one', async () => {
+        // What the Map could not do: the lease exists without this process ever
+        // having acquired it.
+        mockLocks.set('test:9', {
+            key: 'test:9',
+            token: 'held-by-another-process',
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        await expect(tryAcquire('test:9')).resolves.toBeNull();
+    });
+
+    test('a lease left behind by a crashed process is taken over once expired', async () => {
+        mockLocks.set('test:10', {
+            key: 'test:10',
+            token: 'orphaned',
+            expiresAt: new Date(Date.now() - 1),
+        });
+        const token = await tryAcquire('test:10');
+        expect(token).toBeTruthy();
+        expect(token).not.toBe('orphaned');
+    });
+
+    test('concurrent acquires of one key produce exactly one winner', async () => {
+        const results = await Promise.all(
+            Array.from({ length: 8 }, () => tryAcquire('test:11')),
+        );
+        expect(results.filter(Boolean)).toHaveLength(1);
+    });
+
+    test('tokens are unique across attempts so one lease cannot free another', async () => {
+        const tokens = new Set();
+        for (let i = 0; i < 50; i++) {
+            const key = `test:12:${i}`;
+            const token = await tryAcquire(key);
+            tokens.add(token);
+            await release(key, token);
+        }
+        expect(tokens.size).toBe(50);
+    });
+
+    test('refuses the action when the database errors rather than letting it through', async () => {
+        // Failing closed is the right answer for something that gates money.
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        ActiveLock.findOneAndUpdate.mockRejectedValueOnce(new Error('connection lost'));
+        await expect(tryAcquire('test:13')).resolves.toBeNull();
+        errorSpy.mockRestore();
+    });
+
+    test('a failed release leaves the lease to expire instead of throwing', async () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const token = await tryAcquire('test:14');
+        ActiveLock.deleteOne.mockRejectedValueOnce(new Error('connection lost'));
+        await expect(release('test:14', token)).resolves.toBe(false);
+        errorSpy.mockRestore();
     });
 });
 

--- a/tests/balanceDebitGuard.test.js
+++ b/tests/balanceDebitGuard.test.js
@@ -1,0 +1,130 @@
+'use strict';
+
+// Nothing may debit a balance it hasn't first proven is there.
+//
+// The runtime rule across the whole codebase is that a coin debit is a
+// conditional update: `{ ...filter, balance: { $gte: cost } }` paired with
+// `{ $inc: { balance: -cost } }`. If the balance moved between reading it and
+// writing, the filter no longer matches, the update returns null, and the
+// caller backs out — that is the only thing keeping a balance from going
+// negative under concurrency, since `$inc` itself will happily go below zero.
+//
+// 41 source files mutate `balance` and the guard is spelled out by hand at
+// every one of them, so this walks all of them and checks each debit carries a
+// guard for the amount it takes. Static rather than behavioural on purpose: a
+// runtime test can only cover the debits it happens to drive, and the ones
+// worth catching are in the branches nobody drove.
+
+const fs   = require('fs');
+const path = require('path');
+// Ships with jest (jest → babel-jest → @babel/core → @babel/parser), so it is
+// always present when this suite runs and is not declared separately.
+const { parse } = require('@babel/parser');
+
+const SRC = path.join(__dirname, '..', 'src');
+const WRITE_METHODS = new Set(['findOneAndUpdate', 'updateOne', 'updateMany', 'findOneAndReplace']);
+
+function sourceFiles(dir) {
+    return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) return sourceFiles(full);
+        return entry.name.endsWith('.js') ? [full] : [];
+    });
+}
+
+function walk(node, visit) {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) return node.forEach(n => walk(n, visit));
+    if (typeof node.type === 'string') visit(node);
+    for (const key of Object.keys(node)) {
+        if (key === 'loc' || key === 'leadingComments' || key === 'trailingComments') continue;
+        walk(node[key], visit);
+    }
+}
+
+const snippet = (code, node) => code.slice(node.start, node.end);
+
+// Finds a property by key name in an object expression, ignoring spreads.
+function prop(objectNode, name) {
+    if (objectNode?.type !== 'ObjectExpression') return null;
+    return objectNode.properties.find(p =>
+        p.type === 'ObjectProperty' &&
+        ((p.key.type === 'Identifier' && !p.computed && p.key.name === name) ||
+         (p.key.type === 'StringLiteral' && p.key.value === name))
+    ) ?? null;
+}
+
+/**
+ * The amount a `$inc: { balance: <expr> }` takes away, as source text, or null
+ * when the update isn't a balance debit. `-bet` yields `bet`; a debit written
+ * as anything other than a negation is reported as unrecognised so it shows up
+ * rather than being waved through.
+ */
+function debitAmount(code, updateNode) {
+    const inc = prop(updateNode, '$inc');
+    if (!inc) return null;
+    const balance = prop(inc.value, 'balance');
+    if (!balance) return null;
+
+    const value = balance.value;
+    if (value.type === 'UnaryExpression' && value.operator === '-') {
+        return snippet(code, value.argument);
+    }
+    // A literal or a plain identifier here is a credit, or an amount whose sign
+    // isn't visible in the source; neither is a debit this rule can check.
+    return null;
+}
+
+/** The amount a filter proves is available, as source text, or null if unguarded. */
+function guardAmount(code, filterNode) {
+    const balance = prop(filterNode, 'balance');
+    if (!balance) return null;
+    const gte = prop(balance.value, '$gte');
+    return gte ? snippet(code, gte.value) : null;
+}
+
+const debits = [];
+
+for (const file of sourceFiles(SRC)) {
+    const code = fs.readFileSync(file, 'utf8');
+    const ast = parse(code, { sourceType: 'script', errorRecovery: true });
+
+    walk(ast.program, node => {
+        if (node.type !== 'CallExpression') return;
+        if (node.callee.type !== 'MemberExpression') return;
+        if (node.callee.property.type !== 'Identifier') return;
+        if (!WRITE_METHODS.has(node.callee.property.name)) return;
+
+        const [filterNode, updateNode] = node.arguments;
+        if (!filterNode || !updateNode) return;
+
+        const takes = debitAmount(code, updateNode);
+        if (!takes) return;
+
+        debits.push({
+            where: `${path.relative(SRC, file)}:${node.loc.start.line}`,
+            takes,
+            guards: guardAmount(code, filterNode),
+        });
+    });
+}
+
+describe('balance debits are guarded', () => {
+    test('the scan found the debit sites rather than silently matching nothing', () => {
+        // A refactor that changes how debits are written should fail loudly here
+        // instead of leaving every assertion below vacuously true.
+        expect(debits.length).toBeGreaterThan(20);
+    });
+
+    test('every balance debit carries a `balance: { $gte }` guard', () => {
+        const unguarded = debits.filter(d => d.guards === null).map(d => `${d.where} takes ${d.takes}`);
+        expect(unguarded).toEqual([]);
+    });
+
+    test('each guard covers the amount its debit actually takes', () => {
+        const mismatched = debits
+            .filter(d => d.guards !== null && d.guards !== d.takes)
+            .map(d => `${d.where} takes ${d.takes} but only guards ${d.guards}`);
+        expect(mismatched).toEqual([]);
+    });
+});

--- a/tests/balanceDebitGuard.test.js
+++ b/tests/balanceDebitGuard.test.js
@@ -44,14 +44,32 @@ function walk(node, visit) {
 
 const snippet = (code, node) => code.slice(node.start, node.end);
 
+function isKey(node, name) {
+    return node.type === 'ObjectProperty' &&
+        ((node.key.type === 'Identifier' && !node.computed && node.key.name === name) ||
+         (node.key.type === 'StringLiteral' && node.key.value === name));
+}
+
 // Finds a property by key name in an object expression, ignoring spreads.
 function prop(objectNode, name) {
     if (objectNode?.type !== 'ObjectExpression') return null;
-    return objectNode.properties.find(p =>
-        p.type === 'ObjectProperty' &&
-        ((p.key.type === 'Identifier' && !p.computed && p.key.name === name) ||
-         (p.key.type === 'StringLiteral' && p.key.value === name))
-    ) ?? null;
+    return objectNode.properties.find(p => isKey(p, name)) ?? null;
+}
+
+/**
+ * Finds a property anywhere in a subtree, not just as a direct child.
+ *
+ * A debit is often not written flat — `{ $set: {...}, ...(fine > 0 ? { $inc: {
+ * balance: -fine } } : {}) }` buries it inside a spread of a conditional, and
+ * looking only at direct properties walked straight past it. That miss hid a
+ * real unguarded debit in /heist, so the scan reaches all the way down.
+ */
+function deepProp(node, name) {
+    let found = null;
+    walk(node, n => {
+        if (!found && isKey(n, name)) found = n;
+    });
+    return found;
 }
 
 /**
@@ -61,7 +79,7 @@ function prop(objectNode, name) {
  * rather than being waved through.
  */
 function debitAmount(code, updateNode) {
-    const inc = prop(updateNode, '$inc');
+    const inc = deepProp(updateNode, '$inc');
     if (!inc) return null;
     const balance = prop(inc.value, 'balance');
     if (!balance) return null;
@@ -77,7 +95,7 @@ function debitAmount(code, updateNode) {
 
 /** The amount a filter proves is available, as source text, or null if unguarded. */
 function guardAmount(code, filterNode) {
-    const balance = prop(filterNode, 'balance');
+    const balance = deepProp(filterNode, 'balance');
     if (!balance) return null;
     const gte = prop(balance.value, '$gte');
     return gte ? snippet(code, gte.value) : null;

--- a/tests/balanceDelta.test.js
+++ b/tests/balanceDelta.test.js
@@ -1,0 +1,171 @@
+'use strict';
+
+// `/fish` read the user, waited 2–5s for a bite, ran a 2–3s reel-in collector,
+// and then `save()`d — writing `balance` as an absolute `$set` computed from a
+// value read roughly eight seconds earlier. Spend coins during the reel-in
+// prompt and the cast's save put them back: place a casino bet in another
+// channel while the prompt is up and the bet is refunded for free. The required
+// reel-in miss made it worse, restoring a whole pre-cast snapshot.
+//
+// The fix keeps `balance` out of the save entirely and applies the cast's net
+// change as an atomic `$inc`. These tests drive that helper directly, including
+// the interleaving that used to lose the concurrent write.
+
+const fs   = require('fs');
+const path = require('path');
+const { detachBalanceDelta, applyBalanceDelta } = require('../src/utils/balanceDelta');
+
+/** Minimal stand-in for the parts of a mongoose document these helpers touch. */
+function makeDoc(balance) {
+    return {
+        balance,
+        modified: new Set(['balance']),
+        unmarkModified(path) { this.modified.delete(path); },
+        markModified(path) { this.modified.add(path); },
+    };
+}
+
+/** A Model whose stored balance can be moved out from under the flow. */
+function makeModel(stored) {
+    const state = { balance: stored, updates: [] };
+    return {
+        state,
+        findOneAndUpdate: async (filter, update) => {
+            state.updates.push(update);
+            state.balance += update.$inc.balance;
+            return { balance: state.balance };
+        },
+    };
+}
+
+describe('detachBalanceDelta', () => {
+    test('returns the net change the flow made', () => {
+        const doc = makeDoc(1_000);
+        doc.balance += 250;
+        expect(detachBalanceDelta(doc, 1_000)).toBe(250);
+    });
+
+    test('rewinds the document so a save writes nothing for balance', () => {
+        const doc = makeDoc(1_000);
+        doc.balance += 250;
+        detachBalanceDelta(doc, 1_000);
+        expect(doc.balance).toBe(1_000);
+        expect(doc.modified.has('balance')).toBe(false);
+    });
+
+    test('a flow that reversed its own reward produces no write at all', () => {
+        // The required reel-in miss restores every pre-cast field. That path used
+        // to write an eight-second-old absolute balance; now it nets to zero.
+        const doc = makeDoc(1_000);
+        const preCast = doc.balance;
+        doc.balance += 5_000;   // executeCast credits the payout
+        doc.balance = preCast;  // the fish escapes and the payout is reversed
+        expect(detachBalanceDelta(doc, 1_000)).toBe(0);
+        expect(doc.modified.has('balance')).toBe(false);
+    });
+
+    test('a penalty is carried as a negative delta', () => {
+        const doc = makeDoc(1_000);
+        doc.balance -= 400;
+        expect(detachBalanceDelta(doc, 1_000)).toBe(-400);
+    });
+
+    test('treats a missing balance as zero rather than producing NaN', () => {
+        const doc = makeDoc(undefined);
+        expect(detachBalanceDelta(doc, 0)).toBe(0);
+    });
+});
+
+describe('applyBalanceDelta', () => {
+    test('issues no write when nothing changed', async () => {
+        const Model = makeModel(1_000);
+        const doc = makeDoc(1_000);
+        await applyBalanceDelta(Model, {}, doc, 0);
+        expect(Model.state.updates).toEqual([]);
+    });
+
+    test('applies the change as a relative $inc, never an absolute $set', async () => {
+        const Model = makeModel(1_000);
+        const doc = makeDoc(1_000);
+        await applyBalanceDelta(Model, {}, doc, 250);
+        expect(Model.state.updates).toEqual([{ $inc: { balance: 250 } }]);
+    });
+
+    test('a concurrent spend during the reel-in window survives the cast', async () => {
+        // The reproduction from the issue: read 1000, wait, bet 800 elsewhere,
+        // then land a 250-coin catch. The answer is 450, not the 1250 an
+        // absolute write would have produced.
+        const Model = makeModel(1_000);
+        const doc = makeDoc(1_000);
+
+        doc.balance += 250;                 // the cast's payout, in memory
+        Model.state.balance -= 800;         // a casino bet placed in another channel
+
+        const delta = detachBalanceDelta(doc, 1_000);
+        const result = await applyBalanceDelta(Model, {}, doc, delta);
+
+        expect(result).toBe(450);
+        expect(Model.state.balance).toBe(450);
+    });
+
+    test('refreshes the document with the authoritative post-write balance', async () => {
+        const Model = makeModel(1_000);
+        const doc = makeDoc(1_000);
+        Model.state.balance -= 800;
+        await applyBalanceDelta(Model, {}, doc, 250);
+        expect(doc.balance).toBe(450);
+    });
+
+    test('leaves balance unmarked so a later save cannot write it back', async () => {
+        // /fish saves a second time on the escape path; that save must not undo
+        // the $inc by writing the in-memory value as a $set.
+        const Model = makeModel(1_000);
+        const doc = makeDoc(1_000);
+        await applyBalanceDelta(Model, {}, doc, 250);
+        expect(doc.modified.has('balance')).toBe(false);
+    });
+
+    test('falls back to local arithmetic when the update matches no document', async () => {
+        const Model = { findOneAndUpdate: async () => null };
+        const doc = makeDoc(1_000);
+        await expect(applyBalanceDelta(Model, {}, doc, 250)).resolves.toBe(1_250);
+    });
+
+    test('two flows overlapping on one user both land', async () => {
+        const Model = makeModel(1_000);
+        const fishing = makeDoc(1_000);
+        const mining  = makeDoc(1_000);
+
+        fishing.balance += 300;
+        mining.balance  += 700;
+
+        // Interleaved the way two commands would be: both read the same balance
+        // before either writes.
+        const fishDelta = detachBalanceDelta(fishing, 1_000);
+        const mineDelta = detachBalanceDelta(mining, 1_000);
+        await applyBalanceDelta(Model, {}, fishing, fishDelta);
+        await applyBalanceDelta(Model, {}, mining, mineDelta);
+
+        expect(Model.state.balance).toBe(2_000);
+    });
+});
+
+describe('/fish uses the helper', () => {
+    const source = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'commands', 'economy', 'fish.js'), 'utf8',
+    );
+
+    test('the cast captures a balance reading and applies a delta', () => {
+        expect(source).toMatch(/detachBalanceDelta\(user, balanceAtLoad\)/);
+        expect(source).toMatch(/applyBalanceDelta\(User, balanceFilter, user, balanceDelta\)/);
+    });
+
+    test('the delta is applied after the save, not before it', () => {
+        const saveAt   = source.indexOf('const balanceDelta = detachBalanceDelta');
+        const applyAt  = source.indexOf('applyBalanceDelta(User, balanceFilter');
+        const userSave = source.indexOf('await user.save();', saveAt);
+        expect(saveAt).toBeGreaterThan(-1);
+        expect(userSave).toBeGreaterThan(saveAt);
+        expect(applyAt).toBeGreaterThan(userSave);
+    });
+});

--- a/tests/balanceDelta.test.js
+++ b/tests/balanceDelta.test.js
@@ -236,24 +236,41 @@ describe('commitBalanceDelta', () => {
     });
 });
 
+// The same read-to-save window exists in every grind command, not just /fish:
+// /hunt and /mine wait on approach prompts, and /explore holds an encounter
+// prompt for up to 20 seconds and writes coins twice around it. All four are
+// converted; these assertions are what keeps them that way.
+describe.each(['fish', 'hunt', 'mine', 'explore'])('/%s keeps balance out of its save', (command) => {
+    const source = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'commands', 'economy', `${command}.js`), 'utf8',
+    );
+
+    test('detaches the balance and commits it as a delta', () => {
+        expect(source).toMatch(/detachBalanceDelta\(user, balance(AtLoad|Baseline)\)/);
+        expect(source).toMatch(/commitBalanceDelta\(User, balanceFilter, user,/);
+    });
+
+    test('the delta is committed after the save, never before', () => {
+        // Credit-then-save would pay for a run a failed save lets the player take
+        // again; save-then-credit at worst owes coins, which is recoverable.
+        const detachAt = source.indexOf('detachBalanceDelta(user, balance');
+        const saveAt   = source.indexOf('await user.save();', detachAt);
+        const commitAt = source.indexOf('commitBalanceDelta(User, balanceFilter', detachAt);
+        expect(detachAt).toBeGreaterThan(-1);
+        expect(saveAt).toBeGreaterThan(detachAt);
+        expect(commitAt).toBeGreaterThan(saveAt);
+    });
+
+    test('an uncredited payout is shown to the player, not swallowed', () => {
+        expect(source).toMatch(/payoutOwed/);
+        expect(source).toMatch(/Payout Not Yet Credited/);
+    });
+});
+
 describe('/fish uses the helper', () => {
     const source = fs.readFileSync(
         path.join(__dirname, '..', 'src', 'commands', 'economy', 'fish.js'), 'utf8',
     );
-
-    test('the cast captures a balance reading and applies a delta', () => {
-        expect(source).toMatch(/detachBalanceDelta\(user, balanceAtLoad\)/);
-        expect(source).toMatch(/commitBalanceDelta\(User, balanceFilter, user, balanceDelta/);
-    });
-
-    test('the delta is applied after the save, not before it', () => {
-        const saveAt   = source.indexOf('const balanceDelta = detachBalanceDelta');
-        const applyAt  = source.indexOf('commitBalanceDelta(User, balanceFilter');
-        const userSave = source.indexOf('await user.save();', saveAt);
-        expect(saveAt).toBeGreaterThan(-1);
-        expect(userSave).toBeGreaterThan(saveAt);
-        expect(applyAt).toBeGreaterThan(userSave);
-    });
 
     test('a credit that will not land is surfaced, not swallowed', () => {
         // The failure mode this guards: save lands, $inc does not, and the player

--- a/tests/balanceDelta.test.js
+++ b/tests/balanceDelta.test.js
@@ -13,7 +13,7 @@
 
 const fs   = require('fs');
 const path = require('path');
-const { detachBalanceDelta, applyBalanceDelta } = require('../src/utils/balanceDelta');
+const { detachBalanceDelta, applyBalanceDelta, commitBalanceDelta } = require('../src/utils/balanceDelta');
 
 /** Minimal stand-in for the parts of a mongoose document these helpers touch. */
 function makeDoc(balance) {
@@ -125,6 +125,33 @@ describe('applyBalanceDelta', () => {
         expect(doc.modified.has('balance')).toBe(false);
     });
 
+    test('a net charge is clamped at zero rather than run through a bare $inc', async () => {
+        // `$inc` walks straight past zero. A flow whose net change is a charge
+        // has no more claim on funds it read seconds ago than any other debit.
+        const Model = {
+            updates: [],
+            findOneAndUpdate: async function (filter, update) {
+                this.updates.push(update);
+                return { balance: 100 }; // pre-image: less than the charge
+            },
+        };
+        const doc = makeDoc(1_000);
+        const result = await applyBalanceDelta(Model, {}, doc, -400);
+
+        // A pipeline update carrying the clamp, not `{ $inc: { balance: -400 } }`.
+        expect(Array.isArray(Model.updates[0])).toBe(true);
+        expect(result).toBe(0);
+        expect(doc.balance).toBe(0);
+    });
+
+    test('a charge smaller than the balance takes exactly its amount', async () => {
+        const Model = {
+            findOneAndUpdate: async () => ({ balance: 1_000 }),
+        };
+        const doc = makeDoc(1_000);
+        await expect(applyBalanceDelta(Model, {}, doc, -400)).resolves.toBe(600);
+    });
+
     test('falls back to local arithmetic when the update matches no document', async () => {
         const Model = { findOneAndUpdate: async () => null };
         const doc = makeDoc(1_000);
@@ -150,6 +177,65 @@ describe('applyBalanceDelta', () => {
     });
 });
 
+describe('commitBalanceDelta', () => {
+    const failing = () => ({ findOneAndUpdate: async () => { throw new Error('connection lost'); } });
+
+    let errorSpy;
+    beforeEach(() => { errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {}); });
+    afterEach(() => errorSpy.mockRestore());
+
+    test('reports success when the credit lands', async () => {
+        const Model = makeModel(1_000);
+        const doc = makeDoc(1_000);
+        await expect(commitBalanceDelta(Model, {}, doc, 250)).resolves.toEqual({ credited: true, balance: 1_250 });
+    });
+
+    test('a zero delta is a no-op success', async () => {
+        const Model = makeModel(1_000);
+        const doc = makeDoc(1_000);
+        await expect(commitBalanceDelta(Model, {}, doc, 0)).resolves.toEqual({ credited: true, balance: 1_000 });
+        expect(Model.state.updates).toEqual([]);
+    });
+
+    test('retries before giving up', async () => {
+        let calls = 0;
+        const Model = {
+            findOneAndUpdate: async () => {
+                calls++;
+                if (calls < 3) throw new Error('transient');
+                return { balance: 1_250 };
+            },
+        };
+        await expect(commitBalanceDelta(Model, {}, makeDoc(1_000), 250)).resolves.toMatchObject({ credited: true });
+        expect(calls).toBe(3);
+    });
+
+    test('records the credit as owed rather than losing it', async () => {
+        const FailedJob = require('../src/models/FailedJob');
+        const create = jest.spyOn(FailedJob, 'create').mockResolvedValue({});
+
+        const result = await commitBalanceDelta(failing(), { userId: 'u1', guildId: 'g1' }, makeDoc(1_000), 250, {
+            service: 'fish', jobName: 'castPayout', guildId: 'g1',
+        });
+
+        expect(result.credited).toBe(false);
+        expect(create).toHaveBeenCalledTimes(1);
+        expect(create.mock.calls[0][0]).toMatchObject({
+            service: 'fish',
+            jobName: 'castPayout',
+            payload: { userId: 'u1', guildId: 'g1', delta: 250 },
+        });
+        create.mockRestore();
+    });
+
+    test('a dead-letter write that itself fails does not throw at the caller', async () => {
+        const FailedJob = require('../src/models/FailedJob');
+        const create = jest.spyOn(FailedJob, 'create').mockRejectedValue(new Error('also down'));
+        await expect(commitBalanceDelta(failing(), {}, makeDoc(1_000), 250)).resolves.toMatchObject({ credited: false });
+        create.mockRestore();
+    });
+});
+
 describe('/fish uses the helper', () => {
     const source = fs.readFileSync(
         path.join(__dirname, '..', 'src', 'commands', 'economy', 'fish.js'), 'utf8',
@@ -157,15 +243,22 @@ describe('/fish uses the helper', () => {
 
     test('the cast captures a balance reading and applies a delta', () => {
         expect(source).toMatch(/detachBalanceDelta\(user, balanceAtLoad\)/);
-        expect(source).toMatch(/applyBalanceDelta\(User, balanceFilter, user, balanceDelta\)/);
+        expect(source).toMatch(/commitBalanceDelta\(User, balanceFilter, user, balanceDelta/);
     });
 
     test('the delta is applied after the save, not before it', () => {
         const saveAt   = source.indexOf('const balanceDelta = detachBalanceDelta');
-        const applyAt  = source.indexOf('applyBalanceDelta(User, balanceFilter');
+        const applyAt  = source.indexOf('commitBalanceDelta(User, balanceFilter');
         const userSave = source.indexOf('await user.save();', saveAt);
         expect(saveAt).toBeGreaterThan(-1);
         expect(userSave).toBeGreaterThan(saveAt);
         expect(applyAt).toBeGreaterThan(userSave);
+    });
+
+    test('a credit that will not land is surfaced, not swallowed', () => {
+        // The failure mode this guards: save lands, $inc does not, and the player
+        // is shown a catch they were never paid for.
+        expect(source).toMatch(/if \(!payout\.credited\) payoutOwed = balanceDelta;/);
+        expect(source).toMatch(/Payout Not Yet Credited/);
     });
 });

--- a/tests/balanceInvariant.test.js
+++ b/tests/balanceInvariant.test.js
@@ -1,0 +1,217 @@
+'use strict';
+
+// 41 source files mutate `balance`; before this file exactly one test asserted
+// that it never goes negative, in exploreService.test.js. Every debit in the
+// codebase is meant to be guarded — a `balance: { $gte: cost }` filter on the
+// update, or a clamp against the current balance — and nothing proved those
+// guards were still there.
+//
+// Two halves: the shared helper itself, then the helper driven across every
+// payout and penalty path that can be run without a database. The grind and
+// casino paths are RNG-driven, so each is sampled over many runs rather than by
+// stubbing Math.random and coupling the test to the order of the roll calls.
+
+const {
+    expectNonNegativeBalance,
+    expectNonNegativeBank,
+    withBalanceInvariant,
+    collectUsers,
+} = require('./helpers/balanceInvariant');
+
+const { executeHunt, ensureHuntData }    = require('../src/services/huntService');
+const { executeCast, ensureFishingData } = require('../src/services/fishService');
+const { executeMine, ensureMineData }    = require('../src/services/mineService');
+const {
+    executeExplore, resolveEncounter, ensureExploreData, applyDailyReset: exploreDailyReset,
+} = require('../src/services/exploreService');
+
+const { WEAPON_BY_TIER }  = require('../src/data/huntData');
+const { ROD_BY_TIER }     = require('../src/data/fishData');
+const { PICKAXE_BY_TIER } = require('../src/data/mineData');
+const { REGIONS, LIMITS: EXPLORE_LIMITS } = require('../src/data/exploreData');
+
+// ── The helper itself ────────────────────────────────────────────────────────
+
+describe('balance invariant helper', () => {
+    test('accepts a document with a non-negative balance', () => {
+        expect(() => expectNonNegativeBalance({ userId: 'u1', balance: 0 })).not.toThrow();
+        expect(() => expectNonNegativeBalance({ userId: 'u1', balance: 12_500 })).not.toThrow();
+    });
+
+    test('rejects a negative balance and names the user', () => {
+        expect(() => expectNonNegativeBalance({ userId: 'u1', balance: -5 }, 'payout'))
+            .toThrow(/payout: u1 balance=-5/);
+    });
+
+    test('rejects a balance that is not a finite number', () => {
+        expect(() => expectNonNegativeBalance({ userId: 'u1', balance: NaN })).toThrow();
+        expect(() => expectNonNegativeBalance({ userId: 'u1', balance: undefined })).toThrow();
+    });
+
+    test('walks a userId -> doc mock store, the shape most of these tests build', () => {
+        const store = {
+            robber: { userId: 'robber', balance: 100 },
+            victim: { userId: 'victim', balance: -1 },
+        };
+        expect(() => expectNonNegativeBalance(store, 'rob')).toThrow(/rob: victim balance=-1/);
+    });
+
+    test('walks arrays and nested stores', () => {
+        expect(collectUsers([{ balance: 1 }, { a: { balance: 2 } }])).toHaveLength(2);
+        expect(() => expectNonNegativeBalance([{ userId: 'a', balance: 1 }, { userId: 'b', balance: -2 }]))
+            .toThrow(/b balance=-2/);
+    });
+
+    test('fails rather than passing vacuously when nothing user-shaped is found', () => {
+        expect(() => expectNonNegativeBalance({})).toThrow();
+        expect(() => expectNonNegativeBalance([])).toThrow();
+    });
+
+    test('bank is checked when present and skipped when absent', () => {
+        expect(() => expectNonNegativeBank({ userId: 'u1', balance: 0 })).not.toThrow();
+        expect(() => expectNonNegativeBank({ userId: 'u1', balance: 0, bank: -3 }, 'withdraw'))
+            .toThrow(/withdraw: u1 bank=-3/);
+    });
+
+    test('withBalanceInvariant still asserts when the wrapped call throws', async () => {
+        const user = { userId: 'u1', balance: 10 };
+        await expect(withBalanceInvariant(user, 'debit', async () => {
+            user.balance -= 50;
+            throw new Error('write failed');
+        })).rejects.toThrow(/u1 balance=-40/);
+    });
+
+    test('withBalanceInvariant returns the wrapped value on success', async () => {
+        const user = { userId: 'u1', balance: 10 };
+        await expect(withBalanceInvariant(user, 'credit', async () => {
+            user.balance += 5;
+            return 'done';
+        })).resolves.toBe('done');
+    });
+});
+
+// ── Applied across the grind services ────────────────────────────────────────
+
+function baseUser(overrides = {}) {
+    return {
+        userId: 'u1',
+        guildId: 'g1',
+        balance: 0,
+        bank: 0,
+        activeEffects: [],
+        streak: { current: 0 },
+        accountPrestige: { rank: 0 },
+        quests: [],
+        pets: [],
+        inventory: [],
+        markModified: () => {},
+        ...overrides,
+    };
+}
+
+/** Durability pools big enough that a long sample never breaks the gear mid-run. */
+function gear(def) {
+    return {
+        currentDurability: 100_000, maxDurability: 100_000, baseDurability: 100_000,
+        repairCount: 0, upgrade: null, status: 'good', tier: 1,
+        name: def.name, slug: def.slug,
+    };
+}
+
+// Starting at zero is the interesting case: any penalty path that debits without
+// clamping to the balance on hand lands below zero on the very first failure.
+const GRINDS = [
+    {
+        name: 'hunting',
+        build: () => {
+            const user = baseUser();
+            ensureHuntData(user);
+            user.hunt.stamina = 10_000;
+            user.hunt.weapons = [gear(WEAPON_BY_TIER[1])];
+            user.hunt.equippedWeaponIndex = 0;
+            user.hunt.activeZone = 'murky_swamp';
+            user.hunt.dailyWindowStart = new Date();
+            return user;
+        },
+        act: user => executeHunt(user, 'murky_swamp'),
+    },
+    {
+        name: 'fishing',
+        build: () => {
+            const user = baseUser();
+            ensureFishingData(user);
+            user.fishing.stamina = 10_000;
+            user.fishing.rods = [gear(ROD_BY_TIER[1])];
+            user.fishing.equippedRodIndex = 0;
+            user.fishing.activeLocation = 'pond';
+            user.fishing.dailyWindowStart = new Date();
+            return user;
+        },
+        act: user => executeCast(user, 'pond'),
+    },
+    {
+        name: 'mining',
+        build: () => {
+            const user = baseUser();
+            ensureMineData(user);
+            user.mining.stamina = 10_000;
+            user.mining.pickaxes = [gear(PICKAXE_BY_TIER[1])];
+            user.mining.equippedPickaxeIndex = 0;
+            user.mining.activeDepth = 'surface_quarry';
+            user.mining.dailyWindowStart = new Date();
+            return user;
+        },
+        act: user => executeMine(user, 'surface_quarry'),
+    },
+];
+
+describe.each(GRINDS)('$name: balance invariant across payouts and penalties', (grind) => {
+    test('a broke player never goes negative, however the roll lands', () => {
+        const user = grind.build();
+        for (let i = 0; i < 3_000; i++) {
+            user.balance = 0; // re-broke each run so every penalty debits from nothing
+            grind.act(user);
+            expectNonNegativeBalance(user, `${grind.name} run ${i}`);
+        }
+    });
+
+    test('a funded player never goes negative over a long session', () => {
+        const user = grind.build();
+        user.balance = 1_000;
+        for (let i = 0; i < 3_000; i++) {
+            grind.act(user);
+            expectNonNegativeBalance(user, `${grind.name} session run ${i}`);
+        }
+        // The session actually exercised payouts rather than only no-ops.
+        expect(user.balance).not.toBe(1_000);
+    });
+});
+
+// ── Applied across exploration, including the resolved-encounter branches ────
+
+describe('exploring: balance invariant across every encounter choice', () => {
+    const guildSettings = { economy: { enabled: true } };
+    const CHOICES = ['observe', 'approach', 'flee', 'fight'];
+
+    test.each(Object.keys(REGIONS))('%s never pushes a broke explorer negative', (regionId) => {
+        const region = REGIONS[regionId];
+        const user = baseUser();
+        ensureExploreData(user);
+        exploreDailyReset(user);
+
+        for (let i = 0; i < 500; i++) {
+            user.balance = 0;
+            user.exploration.stamina = EXPLORE_LIMITS.MAX_STAMINA;
+            user.exploration.dailyCoins = 0;
+
+            const result = executeExplore(user, region, guildSettings, {});
+            expectNonNegativeBalance(user, `explore ${regionId} run ${i}`);
+
+            if (result.pendingChoice) {
+                // Cycle the choices so the fight/flee penalty branches are all hit.
+                resolveEncounter(user, region, guildSettings, result, CHOICES[i % CHOICES.length]);
+                expectNonNegativeBalance(user, `explore ${regionId} resolve run ${i}`);
+            }
+        }
+    });
+});

--- a/tests/economyCooldownClaims.test.js
+++ b/tests/economyCooldownClaims.test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+// `client.cooldowns` is a process-local Map. That is fine for what it is — a
+// cheap "you're on cooldown" pre-check that avoids a database round trip on
+// every interaction — but it is empty after a restart and shared by nothing, so
+// it cannot be what stops a player collecting an income command twice. Every
+// command that pays coins has to claim its own window atomically in Mongo, with
+// the previous timestamp in the update's filter, so the claim either wins or
+// returns null.
+//
+// /quiz did not: it paid coins on a 300s cooldown that existed only in that Map,
+// so a restart handed the player their whole daily question allowance at once.
+// This test is what keeps the next income command from shipping the same way.
+
+const fs   = require('fs');
+const path = require('path');
+
+const COMMANDS = path.join(__dirname, '..', 'src', 'commands', 'economy');
+const read = file => fs.readFileSync(path.join(COMMANDS, file), 'utf8');
+
+/**
+ * Income commands and the field each one claims. Listing them by hand is the
+ * point — adding a payout command means deciding, here, what bounds its rate.
+ *
+ * Two claim shapes are both correct, and both appear in the codebase:
+ *
+ *   'floor' — the filter carries `field: { $lte: cooldownFloor }`, so an
+ *             attempt inside the window matches nothing and returns null.
+ *   'cas'   — the filter carries the exact timestamp that was just read, so a
+ *             parallel attempt that already moved it loses the swap. The window
+ *             itself is checked against the value read from the database, which
+ *             is what makes it survive a restart.
+ */
+const CLAIMS = [
+    { file: 'work.js',         field: 'lastWork',         shape: 'floor' },
+    { file: 'daily.js',        field: 'lastDaily',        shape: 'floor' },
+    { file: 'crime.js',        field: 'lastCrime',        shape: 'floor' },
+    { file: 'quiz.js',         field: 'lastQuiz',         shape: 'floor' },
+    { file: 'snowball.js',     field: 'lastSnowball',     shape: 'floor' },
+    { file: 'sandcastle.js',   field: 'lastSandcastle',   shape: 'floor' },
+    { file: 'trickortreat.js', field: 'lastTrickOrTreat', shape: 'floor' },
+    { file: 'trackhunt.js',    field: 'lastTrackHunt',    shape: 'floor' },
+    { file: 'rob.js',          field: 'lastRob',          shape: 'cas' },
+];
+
+// The four grind systems keep their cooldown on GrindProfile rather than User.
+const GRIND_CLAIMS = [
+    { file: 'fish.js',    field: 'data.lastCast',    shape: 'floor' },
+    { file: 'hunt.js',    field: 'data.lastHunt',    shape: 'floor' },
+    { file: 'mine.js',    field: 'data.lastMine',    shape: 'floor' },
+    { file: 'explore.js', field: 'data.lastExplore', shape: 'floor' },
+];
+
+const ALL = [...CLAIMS, ...GRIND_CLAIMS];
+const escaped = field => field.replace('.', '\\.');
+
+describe('every income command claims its cooldown in the database', () => {
+    test.each(ALL.filter(c => c.shape === 'floor'))('$file bounds $field in a filter', ({ file, field }) => {
+        // The timestamp has to appear as a bound in a filter — `$lt`/`$lte`
+        // against the cooldown floor — not merely be written afterwards. A
+        // command that only `$set`s the field has no claim, just a record.
+        expect(read(file)).toMatch(new RegExp(`'?${escaped(field)}'?:\\s*\\{\\s*\\$lte?:`));
+    });
+
+    test.each(ALL.filter(c => c.shape === 'cas'))('$file swaps $field against the value it read', ({ file, field }) => {
+        // `{ ..., lastRob: <the timestamp just read> }` in the filter: a parallel
+        // attempt that already moved it finds nothing to update.
+        expect(read(file)).toMatch(new RegExp(`${escaped(field)}:\\s*\\w+(Snapshot)?\\.${escaped(field)}`));
+        // …and the window itself is measured against the stored value.
+        expect(read(file)).toMatch(new RegExp(`new Date\\(\\w+\\.${escaped(field)}\\)`));
+    });
+
+    // Only the floor shape: a CAS claim writes the timestamp its caller staged
+    // rather than minting one inline, and both halves of that claim are already
+    // covered by the swap assertions above.
+    test.each(ALL.filter(c => c.shape === 'floor'))('$file writes $field when it wins the claim', ({ file, field }) => {
+        expect(read(file)).toMatch(new RegExp(`'?${escaped(field)}'?:\\s*([\\w.]*[Nn]ow|new Date|crimeTime)`));
+    });
+});
+
+describe('the in-memory cooldown map is documented as a pre-check, not the gate', () => {
+    test('src/index.js says where the authority actually lives', () => {
+        const index = fs.readFileSync(path.join(__dirname, '..', 'src', 'index.js'), 'utf8');
+        const declaration = index.slice(0, index.indexOf('client.cooldowns = new Collection();'));
+        expect(declaration).toMatch(/atomically in Mongo/);
+    });
+});

--- a/tests/giftItemTransfer.test.js
+++ b/tests/giftItemTransfer.test.js
@@ -1,9 +1,13 @@
 'use strict';
 
+const { expectNonNegativeBalance } = require('./helpers/balanceInvariant');
+
 // /gift item used to write both sides with Promise.all([sender.save(), recipient.save()]):
 // if the sender's save lost and the recipient's won, the item was duplicated.
 // These tests drive the transfer against an in-memory User mockStore that implements
 // the specific query shapes the command issues.
+
+const { applyPipelineUpdate } = require('./helpers/pipelineUpdate');
 
 let mockStore;   // userId -> document
 let mockWrites;  // ordered log of the inventory mockWrites the command performed
@@ -34,6 +38,18 @@ function mockMatches(doc, query) {
 }
 
 function mockApplyUpdate(doc, update, options = {}) {
+    // Inventory credits now go through a single aggregation-pipeline update
+    // instead of a bump-or-push pair, so the mock has to be able to run one.
+    if (Array.isArray(update)) {
+        const before = doc.inventory.map(s => ({ ...s }));
+        applyPipelineUpdate(doc, update);
+        for (const slot of doc.inventory) {
+            const prior = before.find(s => s.itemId === slot.itemId);
+            const delta = slot.quantity - (prior?.quantity ?? 0);
+            if (delta !== 0) mockWrites.push({ user: doc.userId, itemId: slot.itemId, delta });
+        }
+        return;
+    }
     if (update.$inc) {
         for (const [path, delta] of Object.entries(update.$inc)) {
             if (path === 'inventory.$[slot].quantity') {
@@ -85,7 +101,7 @@ jest.mock('../src/models/User', () => ({
         if (query['inventory.itemId'] !== undefined && query['inventory.itemId'].$ne === undefined) {
             doc._matchedIndex = doc.inventory.findIndex(s => s.itemId === query['inventory.itemId']);
         }
-        if (mockFailCreditFor && doc.userId === mockFailCreditFor && (update.$inc || update.$push)) {
+        if (mockFailCreditFor && doc.userId === mockFailCreditFor && (Array.isArray(update) || update.$inc || update.$push)) {
             throw new Error('simulated write failure');
         }
         mockApplyUpdate(doc, update, options);
@@ -240,4 +256,9 @@ test('a slot too small to cover the gift is skipped for one that can', async () 
         { itemId: 'pet_food', quantity: 2 },
     ]);
     expect(mockTotalHeld('pet_food')).toBe(7);
+});
+
+// A gift debits one side and credits the other; neither may end below zero.
+afterEach(() => {
+    expectNonNegativeBalance(mockStore, 'gift');
 });

--- a/tests/helpers/balanceInvariant.js
+++ b/tests/helpers/balanceInvariant.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * The one invariant every coin-moving path shares: a user's balance never goes
+ * below zero.
+ *
+ * 41 source files mutate `balance` and exactly one test asserted this, in
+ * exploreService.test.js. Every debit in the codebase is meant to be guarded —
+ * either by a `balance: { $gte: cost }` filter on the update or by a clamp
+ * against the current balance — and the whole point of a guard is that nothing
+ * proves it is there except a test that would notice its absence.
+ *
+ * The helpers below take whatever shape a test already has (a single user
+ * document, a list, or the `userId -> doc` mock stores most of these tests
+ * build) so applying the invariant to an existing test is one line, and label
+ * the failure with which user broke it and where.
+ */
+
+// Pulls user-shaped objects out of a doc, an array of docs, or a keyed store.
+function collectUsers(subject) {
+    if (subject === null || subject === undefined) return [];
+    if (Array.isArray(subject)) return subject.flatMap(collectUsers);
+    if (typeof subject !== 'object') return [];
+    if ('balance' in subject) return [subject];
+    return Object.values(subject).flatMap(collectUsers);
+}
+
+function label(user, context) {
+    const who = user.userId ?? user.id ?? 'user';
+    return context ? `${context}: ${who}` : who;
+}
+
+/**
+ * Asserts every balance reachable from `subject` is a non-negative finite
+ * number. `context` names the path under test, so a failure names which payout
+ * or penalty produced it and for which user rather than just printing a number.
+ */
+function expectNonNegativeBalance(subject, context = '') {
+    const users = collectUsers(subject);
+    // A store that yielded nothing would make this assertion vacuously pass.
+    expect(users.length).toBeGreaterThan(0);
+
+    const violations = users
+        .filter(u => !(Number.isFinite(u.balance) && u.balance >= 0))
+        .map(u => `${label(u, context)} balance=${u.balance}`);
+    expect(violations).toEqual([]);
+}
+
+/**
+ * Same for banked coins, which are debited by the same guarded-update pattern.
+ * Users with no `bank` field are skipped rather than treated as violations.
+ */
+function expectNonNegativeBank(subject, context = '') {
+    const violations = collectUsers(subject)
+        .filter(u => u.bank !== undefined && !(Number.isFinite(u.bank) && u.bank >= 0))
+        .map(u => `${label(u, context)} bank=${u.bank}`);
+    expect(violations).toEqual([]);
+}
+
+/**
+ * Runs `fn` and asserts the invariant afterwards, whether it returned or threw —
+ * a path that throws halfway through a debit is exactly the one that leaves a
+ * balance negative. Returns whatever `fn` returned.
+ */
+async function withBalanceInvariant(subject, context, fn) {
+    try {
+        return await fn();
+    } finally {
+        expectNonNegativeBalance(subject, context);
+        expectNonNegativeBank(subject, context);
+    }
+}
+
+module.exports = { expectNonNegativeBalance, expectNonNegativeBank, withBalanceInvariant, collectUsers };

--- a/tests/helpers/fakeActiveLock.js
+++ b/tests/helpers/fakeActiveLock.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+ * Stand-in for the ActiveLock model, for tests that drive a command whose
+ * `execute` is wrapped in a per-user action lock.
+ *
+ * The lock is Mongo-backed (see src/utils/activeGameLock.js), so without this
+ * the wrapper issues a real query, mongoose buffers it against a connection
+ * that will never arrive, and the command under test never runs. The lock is
+ * not what those tests are about — tests/activeGameLock.test.js covers its
+ * semantics against a fake that models the unique-index behaviour properly.
+ *
+ * Usage, at the top of a test file:
+ *
+ *     jest.mock('../src/models/ActiveLock', () => require('./helpers/fakeActiveLock'));
+ */
+
+const locks = new Map(); // key -> { key, token, expiresAt }
+
+module.exports = {
+    __locks: locks,
+
+    async findOneAndUpdate(filter, update, options) {
+        const existing = locks.get(filter.key);
+        if (existing && existing.expiresAt > filter.expiresAt.$lte) {
+            // Still held: the upsert would fall through to an insert the unique
+            // index rejects.
+            const err = new Error('E11000 duplicate key error');
+            err.code = 11000;
+            throw err;
+        }
+        const doc = { ...update.$set };
+        locks.set(filter.key, doc);
+        return options?.new ? doc : (existing ?? null);
+    },
+
+    async deleteOne(filter) {
+        const existing = locks.get(filter.key);
+        if (!existing || existing.token !== filter.token) return { deletedCount: 0 };
+        locks.delete(filter.key);
+        return { deletedCount: 1 };
+    },
+};

--- a/tests/helpers/pipelineUpdate.js
+++ b/tests/helpers/pipelineUpdate.js
@@ -102,8 +102,44 @@ function evaluate(expr, doc, vars = {}) {
             const [a, b] = args();
             return a > b;
         }
-        case '$add':
-            return args().reduce((sum, n) => sum + (n ?? 0), 0);
+        case '$add': {
+            // Mongo propagates null: `$add` over a missing or null operand is
+            // null, not a silent zero. Treating it as zero here would hide the
+            // bug where a legacy slot without a quantity gets wiped.
+            const operands = args();
+            if (operands.some(n => n === null || n === undefined)) return null;
+            return operands.reduce((sum, n) => sum + n, 0);
+        }
+        case '$subtract': {
+            const [a, b] = args();
+            if (a === null || a === undefined || b === null || b === undefined) return null;
+            return a - b;
+        }
+        case '$max':
+            return args().reduce((best, n) => (n === null || n === undefined ? best : Math.max(best, n)), -Infinity);
+        case '$not':
+            return !args()[0];
+        case '$and':
+            return (Array.isArray(arg) ? arg : [arg]).every(e => Boolean(evaluate(e, doc, vars)));
+        case '$or':
+            return (Array.isArray(arg) ? arg : [arg]).some(e => Boolean(evaluate(e, doc, vars)));
+        case '$mergeObjects':
+            return args().reduce((out, obj) => Object.assign(out, obj ?? {}), {});
+        case '$let': {
+            const bound = { ...vars };
+            for (const [name, expr2] of Object.entries(arg.vars ?? {})) {
+                bound[name] = evaluate(expr2, doc, bound);
+            }
+            return evaluate(arg.in, doc, bound);
+        }
+        case '$reduce': {
+            const input = evaluate(arg.input, doc, vars) ?? [];
+            let value = evaluate(arg.initialValue, doc, vars);
+            for (const element of input) {
+                value = evaluate(arg.in, doc, { ...vars, this: element, value });
+            }
+            return value;
+        }
         case '$concatArrays':
             return args().reduce((out, arr) => out.concat(arr ?? []), []);
         case '$setUnion': {

--- a/tests/helpers/pipelineUpdate.js
+++ b/tests/helpers/pipelineUpdate.js
@@ -1,0 +1,145 @@
+'use strict';
+
+/**
+ * A very small aggregation-expression evaluator, enough to apply the
+ * pipeline-form updates this codebase issues against a plain JS object.
+ *
+ * Several writes have to decide something about a document and act on that
+ * decision inside one atomic update — crediting an inventory slot that may or
+ * may not exist is the main one. Mongo expresses that as an aggregation
+ * pipeline passed where an update document would normally go, and none of the
+ * hand-rolled model mocks in these tests could apply one, so the behaviour went
+ * untested. This closes that gap: mocks call `applyPipelineUpdate` when the
+ * update they were handed is an array.
+ *
+ * Only the operators the source actually uses are implemented, and an unknown
+ * one throws rather than silently evaluating to undefined — a pipeline that
+ * grows a new operator should fail loudly here, not quietly pass.
+ */
+
+function getPath(doc, path) {
+    // A dotted path that crosses an array yields the array of that field's
+    // values, the way Mongo resolves `$inventory.itemId`.
+    return path.split('.').reduce((cur, key) => {
+        if (cur === undefined || cur === null) return undefined;
+        if (Array.isArray(cur)) {
+            return cur.map(el => el?.[key]).filter(v => v !== undefined);
+        }
+        return cur[key];
+    }, doc);
+}
+
+function setPath(doc, path, value) {
+    const keys = path.split('.');
+    const last = keys.pop();
+    let cur = doc;
+    for (const key of keys) {
+        if (cur[key] === undefined || cur[key] === null) cur[key] = {};
+        cur = cur[key];
+    }
+    cur[last] = value;
+}
+
+function evaluate(expr, doc, vars = {}) {
+    if (typeof expr === 'string' && expr.startsWith('$$')) {
+        const [name, ...rest] = expr.slice(2).split('.');
+        if (!(name in vars)) throw new Error(`pipelineUpdate: unbound variable ${expr}`);
+        return rest.length ? getPath(vars[name], rest.join('.')) : vars[name];
+    }
+    if (typeof expr === 'string' && expr.startsWith('$')) {
+        return getPath(doc, expr.slice(1));
+    }
+    if (Array.isArray(expr)) return expr.map(e => evaluate(e, doc, vars));
+    if (expr === null || typeof expr !== 'object') return expr;
+
+    const keys = Object.keys(expr);
+    const op = keys.find(k => k.startsWith('$'));
+    if (!op) {
+        // A plain object literal — evaluate each of its values.
+        const out = {};
+        for (const [k, v] of Object.entries(expr)) out[k] = evaluate(v, doc, vars);
+        return out;
+    }
+    if (keys.length > 1) throw new Error(`pipelineUpdate: mixed operator object ${keys.join(', ')}`);
+
+    const arg = expr[op];
+    const args = () => (Array.isArray(arg) ? arg.map(a => evaluate(a, doc, vars)) : [evaluate(arg, doc, vars)]);
+
+    switch (op) {
+        case '$literal':
+            return arg;
+        case '$ifNull': {
+            const [value, fallback] = args();
+            return value === undefined || value === null ? fallback : value;
+        }
+        case '$cond': {
+            if (Array.isArray(arg)) {
+                const [test, thenExpr, elseExpr] = arg;
+                return evaluate(test, doc, vars) ? evaluate(thenExpr, doc, vars) : evaluate(elseExpr, doc, vars);
+            }
+            return evaluate(arg.if, doc, vars)
+                ? evaluate(arg.then, doc, vars)
+                : evaluate(arg.else, doc, vars);
+        }
+        case '$map': {
+            const input = evaluate(arg.input, doc, vars) ?? [];
+            const as = arg.as ?? 'this';
+            return input.map(el => evaluate(arg.in, doc, { ...vars, [as]: el }));
+        }
+        case '$in': {
+            const [needle, haystack] = args();
+            return (haystack ?? []).some(v => sameValue(v, needle));
+        }
+        case '$eq': {
+            const [a, b] = args();
+            return sameValue(a, b);
+        }
+        case '$ne': {
+            const [a, b] = args();
+            return !sameValue(a, b);
+        }
+        case '$gt': {
+            const [a, b] = args();
+            return a > b;
+        }
+        case '$add':
+            return args().reduce((sum, n) => sum + (n ?? 0), 0);
+        case '$concatArrays':
+            return args().reduce((out, arr) => out.concat(arr ?? []), []);
+        case '$setUnion': {
+            const out = [];
+            for (const arr of args()) {
+                for (const v of arr ?? []) if (!out.some(x => sameValue(x, v))) out.push(v);
+            }
+            return out;
+        }
+        case '$size':
+            return (args()[0] ?? []).length;
+        default:
+            throw new Error(`pipelineUpdate: unsupported operator ${op}`);
+    }
+}
+
+function sameValue(a, b) {
+    if (a instanceof Date && b instanceof Date) return a.getTime() === b.getTime();
+    return a === b;
+}
+
+/**
+ * Applies pipeline `stages` to `doc` in place. Stages run in order and each one
+ * sees the previous stage's output, which is what lets several credits
+ * accumulate in a single update.
+ */
+function applyPipelineUpdate(doc, stages) {
+    for (const stage of stages) {
+        const set = stage.$set ?? stage.$addFields;
+        if (!set) throw new Error(`pipelineUpdate: unsupported stage ${Object.keys(stage).join(', ')}`);
+        // Every field of one stage reads the document as it was before that
+        // stage, so the values are computed first and written afterwards.
+        const computed = Object.entries(set).map(([path, expr]) => [path, evaluate(expr, doc)]);
+        for (const [path, value] of computed) setPath(doc, path, value);
+    }
+    return doc;
+}
+
+module.exports = { applyPipelineUpdate, evaluate, getPath, setPath };

--- a/tests/huntWeaponShop.test.js
+++ b/tests/huntWeaponShop.test.js
@@ -2,6 +2,10 @@
 
 const { expectNonNegativeBalance } = require('./helpers/balanceInvariant');
 
+// The command's execute is wrapped in a Mongo-backed per-user action lock;
+// without this it would query a database this test never connects to.
+jest.mock('../src/models/ActiveLock', () => require('./helpers/fakeActiveLock'));
+
 jest.mock('../src/models/Guild', () => ({
     findOne: jest.fn().mockResolvedValue({ economy: { enabled: true, currency: '💰' } }),
 }));

--- a/tests/huntWeaponShop.test.js
+++ b/tests/huntWeaponShop.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { expectNonNegativeBalance } = require('./helpers/balanceInvariant');
+
 jest.mock('../src/models/Guild', () => ({
     findOne: jest.fn().mockResolvedValue({ economy: { enabled: true, currency: '💰' } }),
 }));
@@ -133,4 +135,10 @@ test('hunt shop weapon -> confirm purchase does not throw, even with a colon-key
     expect(GrindProfile.findOneAndUpdate.mock.calls.length).toBe(grindCallsBeforeConfirm + 1);
     expect(User.findOneAndUpdate.mock.invocationCallOrder[userCallsBeforeConfirm])
         .toBeLessThan(GrindProfile.findOneAndUpdate.mock.invocationCallOrder[grindCallsBeforeConfirm]);
+});
+
+// Weapon purchases are guarded by a `balance: { $gte: cost }` filter — the buyer
+// never ends a purchase path in the red.
+afterEach(() => {
+    expectNonNegativeBalance(require('../src/models/User').__fakeUser, 'hunt weapon shop');
 });

--- a/tests/inventoryGrant.test.js
+++ b/tests/inventoryGrant.test.js
@@ -1,0 +1,139 @@
+'use strict';
+
+// Inventory credits used to test for an existing slot and then `$push` when they
+// did not find one, across two round trips. Two credits landing together could
+// both miss and both push, leaving two slots for one itemId — and since every
+// reader does `inventory.find(i => i.itemId === X)` and takes the first match,
+// whatever went into the second slot was invisible and unspendable.
+//
+// The replacement is a single aggregation-pipeline update. These tests run that
+// pipeline against plain objects (tests/helpers/pipelineUpdate.js) so the
+// expression's actual semantics are checked, not just the shape of the call.
+
+const { grantInventoryItem, inventoryAddExpr, inventoryAddStages } = require('../src/utils/inventoryGrant');
+const { applyPipelineUpdate } = require('./helpers/pipelineUpdate');
+
+/** Applies one credit to a document the way Mongo would. */
+function credit(doc, itemId, quantity = 1) {
+    return applyPipelineUpdate(doc, [{ $set: { inventory: inventoryAddExpr(itemId, quantity) } }]);
+}
+
+const slots = doc => doc.inventory.map(s => `${s.itemId}:${s.quantity}`);
+
+describe('inventoryAddExpr', () => {
+    test('appends a slot when the item is not held', () => {
+        const doc = { inventory: [] };
+        credit(doc, 'lucky_charm');
+        expect(slots(doc)).toEqual(['lucky_charm:1']);
+    });
+
+    test('bumps the existing slot instead of appending a second one', () => {
+        const doc = { inventory: [{ itemId: 'lucky_charm', quantity: 2 }] };
+        credit(doc, 'lucky_charm', 3);
+        expect(slots(doc)).toEqual(['lucky_charm:5']);
+    });
+
+    test('leaves other items alone', () => {
+        const doc = { inventory: [{ itemId: 'a', quantity: 1 }, { itemId: 'b', quantity: 4 }] };
+        credit(doc, 'b', 2);
+        expect(slots(doc)).toEqual(['a:1', 'b:6']);
+    });
+
+    test('handles a document with no inventory field at all', () => {
+        const doc = {};
+        credit(doc, 'pet_food', 7);
+        expect(slots(doc)).toEqual(['pet_food:7']);
+    });
+
+    test('repeated credits never produce a duplicate slot — the original bug', () => {
+        const doc = { inventory: [] };
+        for (let i = 0; i < 25; i++) credit(doc, 'crate');
+        expect(slots(doc)).toEqual(['crate:25']);
+        expect(doc.inventory.filter(s => s.itemId === 'crate')).toHaveLength(1);
+    });
+
+    test('an existing duplicate is not made worse, and its first slot takes the credit', () => {
+        // Documents written before the fix can still hold two slots; migration 010
+        // folds those together. Until it runs, a credit must not add a third.
+        const doc = { inventory: [{ itemId: 'x', quantity: 1 }, { itemId: 'x', quantity: 9 }] };
+        credit(doc, 'x', 5);
+        expect(slots(doc)).toEqual(['x:6', 'x:14']);
+    });
+});
+
+describe('inventoryAddStages', () => {
+    test('credits several items in one update', () => {
+        const doc = { inventory: [{ itemId: 'lifesaver', quantity: 1 }] };
+        applyPipelineUpdate(doc, inventoryAddStages([
+            { itemId: 'lifesaver', quantity: 1 },
+            { itemId: 'lucky_charm', quantity: 1 },
+        ]));
+        expect(slots(doc)).toEqual(['lifesaver:2', 'lucky_charm:1']);
+    });
+
+    test('accumulates when the same item appears twice in one batch', () => {
+        // Each item gets its own stage precisely so the second sees the first's
+        // output; folding them into one stage would let the last write win.
+        const doc = { inventory: [] };
+        applyPipelineUpdate(doc, inventoryAddStages([
+            { itemId: 'ore', quantity: 2 },
+            { itemId: 'ore', quantity: 3 },
+        ]));
+        expect(slots(doc)).toEqual(['ore:5']);
+    });
+
+    test('defaults a missing quantity to one', () => {
+        const doc = { inventory: [] };
+        applyPipelineUpdate(doc, inventoryAddStages([{ itemId: 'token' }]));
+        expect(slots(doc)).toEqual(['token:1']);
+    });
+});
+
+describe('grantInventoryItem', () => {
+    const fakeModel = () => {
+        const calls = [];
+        return {
+            calls,
+            findOneAndUpdate: (...args) => { calls.push(args); return Promise.resolve({ ok: true }); },
+        };
+    };
+
+    test('issues exactly one update — no read, no second write', async () => {
+        const Model = fakeModel();
+        await grantInventoryItem('u1', 'g1', 'rope', 2, { Model });
+        expect(Model.calls).toHaveLength(1);
+    });
+
+    test('targets the user and passes a pipeline, not an update document', async () => {
+        const Model = fakeModel();
+        await grantInventoryItem('u1', 'g1', 'rope', 2, { Model });
+        const [filter, update, options] = Model.calls[0];
+        expect(filter).toEqual({ userId: 'u1', guildId: 'g1' });
+        expect(Array.isArray(update)).toBe(true);
+        expect(options).toMatchObject({ new: true, upsert: false });
+    });
+
+    test('folds extraSet fields into the same atomic update', async () => {
+        const Model = fakeModel();
+        await grantInventoryItem('u1', 'g1', 'rope', 1, { Model, extraSet: { 'streak.revivalToken': true } });
+        const [, update] = Model.calls[0];
+        // Bracketed, not toHaveProperty: the key is the literal dotted path
+        // Mongo expects, which toHaveProperty would read as a nesting path.
+        expect(update[0].$set['streak.revivalToken']).toBe(true);
+        expect(update[0].$set.inventory).toBeDefined();
+    });
+
+    test('passes upsert through for the credit sites that create the user', async () => {
+        const Model = fakeModel();
+        await grantInventoryItem('u1', 'g1', 'rope', 1, { Model, upsert: true });
+        expect(Model.calls[0][2]).toMatchObject({ upsert: true });
+    });
+
+    test('defaults to crediting one unit', async () => {
+        const Model = fakeModel();
+        await grantInventoryItem('u1', 'g1', 'rope', undefined, { Model });
+        const doc = { inventory: [] };
+        applyPipelineUpdate(doc, Model.calls[0][1]);
+        expect(slots(doc)).toEqual(['rope:1']);
+    });
+});

--- a/tests/inventoryGrant.test.js
+++ b/tests/inventoryGrant.test.js
@@ -52,12 +52,30 @@ describe('inventoryAddExpr', () => {
         expect(doc.inventory.filter(s => s.itemId === 'crate')).toHaveLength(1);
     });
 
-    test('an existing duplicate is not made worse, and its first slot takes the credit', () => {
+    test('an existing duplicate is credited once, not once per slot', () => {
         // Documents written before the fix can still hold two slots; migration 010
-        // folds those together. Until it runs, a credit must not add a third.
+        // folds those together. Until it runs a credit must not add a third slot,
+        // and — the sharper trap — must not pay into both: crediting every match
+        // turns 5 units into 10 on a document that already lost track of itself.
         const doc = { inventory: [{ itemId: 'x', quantity: 1 }, { itemId: 'x', quantity: 9 }] };
         credit(doc, 'x', 5);
-        expect(slots(doc)).toEqual(['x:6', 'x:14']);
+        expect(slots(doc)).toEqual(['x:6', 'x:9']);
+    });
+
+    test('a legacy slot with no quantity is credited, not wiped', () => {
+        // `$add` propagates null in Mongo, so adding to a missing quantity would
+        // set the slot to null and lose the item entirely.
+        const doc = { inventory: [{ itemId: 'old' }] };
+        credit(doc, 'old', 3);
+        expect(slots(doc)).toEqual(['old:3']);
+    });
+
+    test('keeps the slot subdocument rather than rebuilding it', () => {
+        // Inventory entries are subdocuments with their own `_id`; a credit that
+        // rebuilt `{ itemId, quantity }` would silently drop it.
+        const doc = { inventory: [{ _id: 'slot-1', itemId: 'y', quantity: 2 }] };
+        credit(doc, 'y', 1);
+        expect(doc.inventory[0]).toEqual({ _id: 'slot-1', itemId: 'y', quantity: 3 });
     });
 });
 

--- a/tests/minePickaxeShop.test.js
+++ b/tests/minePickaxeShop.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { expectNonNegativeBalance } = require('./helpers/balanceInvariant');
+
 jest.mock('../src/models/Guild', () => ({
     findOne: jest.fn().mockResolvedValue({ economy: { enabled: true, currency: '💰' } }),
 }));
@@ -122,4 +124,10 @@ test('mine shop pickaxe -> confirm purchase does not throw, even with a colon-ke
 
     const successEmbed = editReplyCalls.find(c => c.embeds?.[0]?.data?.title?.includes('Purchased'));
     expect(successEmbed).toBeDefined();
+});
+
+// Pickaxe purchases are guarded by a `balance: { $gte: cost }` filter — the buyer
+// never ends a purchase path in the red.
+afterEach(() => {
+    expectNonNegativeBalance(require('../src/models/User').__fakeUser, 'mine pickaxe shop');
 });

--- a/tests/minePickaxeShop.test.js
+++ b/tests/minePickaxeShop.test.js
@@ -2,6 +2,10 @@
 
 const { expectNonNegativeBalance } = require('./helpers/balanceInvariant');
 
+// The command's execute is wrapped in a Mongo-backed per-user action lock;
+// without this it would query a database this test never connects to.
+jest.mock('../src/models/ActiveLock', () => require('./helpers/fakeActiveLock'));
+
 jest.mock('../src/models/Guild', () => ({
     findOne: jest.fn().mockResolvedValue({ economy: { enabled: true, currency: '💰' } }),
 }));

--- a/tests/netWorth.test.js
+++ b/tests/netWorth.test.js
@@ -45,8 +45,13 @@ function fakeUserModel(docs) {
         },
         countDocuments: async (query) => docs.filter(d => {
             if (d.guildId !== query.guildId) return false;
-            const [, threshold] = query.$expr.$gt;
-            return evaluate(NET_WORTH_EXPR, d) > threshold;
+            const worth = evaluate(NET_WORTH_EXPR, d);
+            // Either strictly richer, or level with the caller and ahead on the
+            // `_id` tie-break the sort uses.
+            return query.$or.some(clause => (
+                clause.$expr.$gt ? worth > clause.$expr.$gt[1]
+                    : worth === clause.$expr.$eq[1] && d._id < clause._id.$lt
+            ));
         }).length,
     };
 }
@@ -116,12 +121,38 @@ describe('netWorthRank', () => {
         const Model = fakeUserModel(POPULATION);
         const rows = await topByNetWorth(Model, GUILD, 10);
         for (const [index, row] of rows.entries()) {
-            expect(await netWorthRank(Model, GUILD, row.netWorth)).toBe(index + 1);
+            const doc = POPULATION.find(d => d.userId === row.userId);
+            expect(await netWorthRank(Model, GUILD, row.netWorth, doc._id)).toBe(index + 1);
         }
     });
 
+    test('tied users get the ranks their rows occupy, not one shared rank', async () => {
+        // The self-rank line prints directly beneath the top-ten list, so giving
+        // three tied users "#1" each would contradict the three rows above it.
+        const tied = [
+            { _id: 3, userId: 'c', guildId: GUILD, balance: 0,   bank: 100 },
+            { _id: 1, userId: 'a', guildId: GUILD, balance: 100, bank: 0 },
+            { _id: 2, userId: 'b', guildId: GUILD, balance: 50,  bank: 50 },
+        ];
+        const Model = fakeUserModel(tied);
+        const rows  = await topByNetWorth(Model, GUILD, 10);
+        expect(rows.map(r => r.userId)).toEqual(['a', 'b', 'c']);
+
+        expect(await netWorthRank(Model, GUILD, 100, 1)).toBe(1);
+        expect(await netWorthRank(Model, GUILD, 100, 2)).toBe(2);
+        expect(await netWorthRank(Model, GUILD, 100, 3)).toBe(3);
+    });
+
+    test('without an id, ties fall back to a shared competition rank', async () => {
+        const tied = [
+            { _id: 1, userId: 'a', guildId: GUILD, balance: 100, bank: 0 },
+            { _id: 2, userId: 'b', guildId: GUILD, balance: 100, bank: 0 },
+        ];
+        expect(await netWorthRank(fakeUserModel(tied), GUILD, 100)).toBe(1);
+    });
+
     test('a user richer than everyone ranks first', async () => {
-        expect(await netWorthRank(fakeUserModel(POPULATION), GUILD, 10_000_000)).toBe(1);
+        expect(await netWorthRank(fakeUserModel(POPULATION), GUILD, 10_000_000, 99)).toBe(1);
     });
 });
 
@@ -144,5 +175,11 @@ describe('every wealth surface goes through the shared helper', () => {
 
     test.each(SURFACES)('%s no longer sorts on balance alone', (rel) => {
         expect(read(rel)).not.toMatch(/\.sort\(\{\s*balance:\s*-1/);
+    });
+
+    // Importing it proves nothing on its own — a surface could import the helper
+    // and still rank its own way.
+    test.each(SURFACES)('%s actually calls the shared ranking helper', (rel) => {
+        expect(read(rel)).toMatch(/(topByNetWorth|netWorthRank)\(/);
     });
 });

--- a/tests/netWorth.test.js
+++ b/tests/netWorth.test.js
@@ -1,0 +1,148 @@
+'use strict';
+
+// `/leaderboard economy` sorted by `{ balance: -1, bank: -1 }` while printing
+// `balance + bank`, so a user who banked their coins showed a high total and
+// never placed. The dashboard sorted by the real total, the weekly badge job and
+// the newspaper each sorted by `balance` alone: one guild, four rankings.
+//
+// These tests pin the ordering the shared helper produces and check that every
+// surface now goes through it, since the failure mode is not a wrong number in
+// one place but two places quietly disagreeing.
+
+const fs   = require('fs');
+const path = require('path');
+const { netWorthOf, topByNetWorth, netWorthRank, NET_WORTH_EXPR } = require('../src/utils/netWorth');
+const { evaluate } = require('./helpers/pipelineUpdate');
+
+// Stands in for User.aggregate over one guild, applying the stages the helper
+// builds so the ordering under test is the one Mongo would produce.
+function fakeUserModel(docs) {
+    return {
+        aggregate: async (stages) => {
+            let rows = docs.filter(d => d.guildId === stages[0].$match.guildId).map(d => ({ ...d }));
+            for (const stage of stages.slice(1)) {
+                if (stage.$addFields) {
+                    rows = rows.map(r => ({ ...r, ...Object.fromEntries(
+                        Object.entries(stage.$addFields).map(([k, expr]) => [k, evaluate(expr, r)]),
+                    ) }));
+                } else if (stage.$sort) {
+                    const [[key, dir], ...rest] = Object.entries(stage.$sort);
+                    rows.sort((a, b) => {
+                        if (a[key] !== b[key]) return (a[key] < b[key] ? -1 : 1) * dir;
+                        for (const [k, d] of rest) {
+                            if (a[k] !== b[k]) return (a[k] < b[k] ? -1 : 1) * d;
+                        }
+                        return 0;
+                    });
+                } else if (stage.$limit) {
+                    rows = rows.slice(0, stage.$limit);
+                } else if (stage.$project) {
+                    const keep = Object.entries(stage.$project).filter(([, v]) => v === 1).map(([k]) => k);
+                    rows = rows.map(r => Object.fromEntries(keep.filter(k => k in r).map(k => [k, r[k]])));
+                }
+            }
+            return rows;
+        },
+        countDocuments: async (query) => docs.filter(d => {
+            if (d.guildId !== query.guildId) return false;
+            const [, threshold] = query.$expr.$gt;
+            return evaluate(NET_WORTH_EXPR, d) > threshold;
+        }).length,
+    };
+}
+
+const GUILD = 'g1';
+const POPULATION = [
+    { _id: 1, userId: 'banker',   guildId: GUILD, balance: 10,     bank: 500_000 },
+    { _id: 2, userId: 'hoarder',  guildId: GUILD, balance: 400_000, bank: 0 },
+    { _id: 3, userId: 'balanced', guildId: GUILD, balance: 300_000, bank: 300_000 },
+    { _id: 4, userId: 'broke',    guildId: GUILD, balance: 0,       bank: 0 },
+    { _id: 5, userId: 'elsewhere', guildId: 'g2', balance: 9_000_000, bank: 0 },
+];
+
+describe('netWorthOf', () => {
+    test('adds balance and bank', () => {
+        expect(netWorthOf({ balance: 100, bank: 25 })).toBe(125);
+    });
+
+    test('treats missing fields and a missing user as zero', () => {
+        expect(netWorthOf({ balance: 100 })).toBe(100);
+        expect(netWorthOf({ bank: 100 })).toBe(100);
+        expect(netWorthOf({})).toBe(0);
+        expect(netWorthOf(null)).toBe(0);
+    });
+});
+
+describe('topByNetWorth', () => {
+    test('ranks on the total, so a bank-heavy user places above a cash-heavy one', () => {
+        // The exact case the old `{ balance: -1, bank: -1 }` sort got wrong:
+        // `banker` has the most coins and the least cash, and used to place last.
+        return topByNetWorth(fakeUserModel(POPULATION), GUILD, 10).then(rows => {
+            expect(rows.map(r => r.userId)).toEqual(['balanced', 'banker', 'hoarder', 'broke']);
+        });
+    });
+
+    test('reports the total it ranked on', async () => {
+        const rows = await topByNetWorth(fakeUserModel(POPULATION), GUILD, 10);
+        expect(rows.find(r => r.userId === 'banker').netWorth).toBe(500_010);
+    });
+
+    test('stays inside the guild', async () => {
+        const rows = await topByNetWorth(fakeUserModel(POPULATION), GUILD, 10);
+        expect(rows.map(r => r.userId)).not.toContain('elsewhere');
+    });
+
+    test('honours the limit', async () => {
+        const rows = await topByNetWorth(fakeUserModel(POPULATION), GUILD, 2);
+        expect(rows).toHaveLength(2);
+        expect(rows[0].userId).toBe('balanced');
+    });
+
+    test('breaks ties deterministically so two surfaces list the same order', async () => {
+        const tied = [
+            { _id: 2, userId: 'b', guildId: GUILD, balance: 50, bank: 50 },
+            { _id: 1, userId: 'a', guildId: GUILD, balance: 100, bank: 0 },
+            { _id: 3, userId: 'c', guildId: GUILD, balance: 0, bank: 100 },
+        ];
+        const first  = await topByNetWorth(fakeUserModel(tied), GUILD, 10);
+        const second = await topByNetWorth(fakeUserModel([...tied].reverse()), GUILD, 10);
+        expect(first.map(r => r.userId)).toEqual(['a', 'b', 'c']);
+        expect(second.map(r => r.userId)).toEqual(first.map(r => r.userId));
+    });
+});
+
+describe('netWorthRank', () => {
+    test('agrees with the position topByNetWorth puts a user in', async () => {
+        const Model = fakeUserModel(POPULATION);
+        const rows = await topByNetWorth(Model, GUILD, 10);
+        for (const [index, row] of rows.entries()) {
+            expect(await netWorthRank(Model, GUILD, row.netWorth)).toBe(index + 1);
+        }
+    });
+
+    test('a user richer than everyone ranks first', async () => {
+        expect(await netWorthRank(fakeUserModel(POPULATION), GUILD, 10_000_000)).toBe(1);
+    });
+});
+
+describe('every wealth surface goes through the shared helper', () => {
+    const read = rel => fs.readFileSync(path.join(__dirname, '..', 'src', rel), 'utf8');
+
+    // Listing them explicitly is the point: a new surface that sorts wealth its
+    // own way is exactly the regression this issue was about, and adding it here
+    // is the cheapest way to notice.
+    const SURFACES = [
+        'commands/leveling/leaderboard.js',
+        'dashboard/routes/api/economy.js',
+        'services/schedulerService.js',
+        'services/newspaperService.js',
+    ];
+
+    test.each(SURFACES)('%s imports netWorth', (rel) => {
+        expect(read(rel)).toMatch(/require\(.*utils\/netWorth.*\)/);
+    });
+
+    test.each(SURFACES)('%s no longer sorts on balance alone', (rel) => {
+        expect(read(rel)).not.toMatch(/\.sort\(\{\s*balance:\s*-1/);
+    });
+});

--- a/tests/robBalanceWrite.test.js
+++ b/tests/robBalanceWrite.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { expectNonNegativeBalance } = require('./helpers/balanceInvariant');
+
 // /rob used to write the robber's balance as an absolute $set guarded only by a
 // lastRob compare-and-set — so any credit landing between the read and the write
 // was silently erased. The victim side of the same function already used deltas.
@@ -256,4 +258,9 @@ describe('rollback when the victim write fails', () => {
         expect(mockStore.robber.lastRob).toBe(foreign);   // not stomped
         expect(mockStore.robber.balance).toBe(origBefore); // balance still reversed
     });
+});
+
+// Every /rob outcome moves coins between two users; neither side may end below zero.
+afterEach(() => {
+    expectNonNegativeBalance(mockStore, 'rob');
 });

--- a/tests/shopBuyQuantity.test.js
+++ b/tests/shopBuyQuantity.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { expectNonNegativeBalance } = require('./helpers/balanceInvariant');
+
 // Exercises /shop buy's quantity option end to end: the confirm flow, the
 // atomic charge/stock/inventory writes, and the guards that reject a bulk buy
 // before any coins move.
@@ -273,4 +275,9 @@ test('a price drop between quote and confirm is honoured at the lower total', as
 
     expect(mockWorld.balanceWrites).toEqual([-2000]);
     expect(mockWorld.user.inventory).toEqual([{ itemId: 'pet_food', quantity: 10 }]);
+});
+
+// Every purchase path — including the sold-out refunds — leaves the buyer solvent.
+afterEach(() => {
+    expectNonNegativeBalance(mockWorld.user, 'shop buy');
 });

--- a/tests/shopBuyQuantity.test.js
+++ b/tests/shopBuyQuantity.test.js
@@ -49,13 +49,14 @@ jest.mock('../src/models/Guild', () => ({
 
 jest.mock('../src/models/User', () => ({
     findOneAndUpdate: jest.fn(async (query, update) => {
-        // Inventory grant is an aggregation-pipeline update.
+        // Inventory grant is an aggregation-pipeline update. Run it rather than
+        // reading values out of its shape: reaching into the expression coupled
+        // this mock to one spelling of the pipeline, and it broke the moment the
+        // credit was rewritten to stop paying into every duplicate slot.
         if (Array.isArray(update)) {
-            const appended = update[0].$set.inventory.$cond.else.$concatArrays[1][0];
-            const { itemId, quantity } = appended;
-            const slot = mockWorld.user.inventory.find(s => s.itemId === itemId);
-            if (slot) slot.quantity += quantity;
-            else mockWorld.user.inventory.push({ itemId, quantity });
+            // Required inside the factory: jest forbids a mock factory from
+            // closing over an out-of-scope binding.
+            require('./helpers/pipelineUpdate').applyPipelineUpdate(mockWorld.user, update);
             return mockWorld.user;
         }
         // Balance charge / refund.


### PR DESCRIPTION
Four related economy-data fixes.

Leaderboard ranking (#587): `/leaderboard economy` sorted by
`{ balance: -1, bank: -1 }` while printing `balance + bank`, so a
bank-heavy user showed a high total and never placed — its own "you are
here" line already ranked on the real total, so the same embed disagreed
with itself. The dashboard, the weekly badge job and the newspaper each
picked their own field: four rankings for one guild. All four now go
through `utils/netWorth`, which sorts on the total in an aggregation and
breaks ties on `_id` so two surfaces list the same order. A denormalised
column would have to be maintained by all 41 files that move coins; one
missed `$inc` and the ranking rots silently.

/fish read-to-save window (#569): the cast read the user, waited 2–5s for
a bite, ran a 2–3s reel-in collector, then `save()`d — writing `balance`
as an absolute `$set` computed from a value read ~8s earlier. A casino
bet placed during the reel-in prompt was erased when the cast landed,
refunding the bet for free. `utils/balanceDelta` keeps `balance` out of
the save and applies the cast's net change as an atomic `$inc` after it,
so concurrent writes both survive. A required reel-in miss reverses its
own reward, which now simply nets to zero instead of restoring a stale
snapshot.

Duplicate inventory slots (#573): check-then-`$push` let two concurrent
credits both miss the slot and both push, and every reader takes the
first match, so the second slot's quantity was unspendable. The single
aggregation-pipeline upsert that `shop.js` already used is now shared as
`utils/inventoryGrant` and used by work, daily, use, gift, chat crates,
market-listing returns and the starter kit. Migration 010 folds together
the duplicates already written.

Balance invariant (#624): 41 files mutate `balance` and one test asserted
it never goes negative. Adds a shared assertion helper, applies it across
the economy tests, samples every grind and exploration payout and penalty
path, and scans all 49 debit sites for the `balance: { $gte: cost }`
guard that makes a debit safe. That scan found five unguarded debits in
crime, quiz and snowball — each computed a clamp against a balance it had
already stopped owning — now fixed with a clamp applied inside the update
(`utils/balanceDebit`). `min: 0` on the schema is a backstop for the
`save()` paths, with migration 011 clamping anything already negative so
the new validator cannot strand a user.

Also adds a small aggregation-expression evaluator to the test helpers,
so pipeline-form updates can be tested at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Economy actions now use reliable cross-process locking to prevent duplicate or overlapping actions.
  * Inventory rewards and purchases merge quantities into existing item stacks.
  * Leaderboards and published statistics now rank wealth by total net worth, including bank holdings.
  * Quiz commands enforce a persistent cooldown and provide clearer penalty handling.

* **Bug Fixes**
  * Currency deductions are capped at available funds, preventing negative balances.
  * Fishing payouts and concurrent economy updates now preserve accurate balances.
  * Existing duplicate inventory slots and previously negative balances are repaired automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->