### PR TITLE
Stop a hung apt mirror from deciding the CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Without this a hung step runs until GitHub's 6-hour default. One did: an
+    # apt mirror stopped responding and the job sat for 49 minutes before anyone
+    # looked, with the tests never started. The suite itself takes ~10s.
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -32,10 +36,26 @@ jobs:
       # normally needs no toolchain. These headers are kept as a fallback: if a
       # future Node ABI or platform has no prebuild, node-gyp compiles from
       # source and needs them, and a missing header here is a confusing failure.
+      #
+      # Because it is a fallback, it must never be able to decide the run.
+      # `continue-on-error` is the point of this step's configuration, not the
+      # timeouts: a bounded step that still fails the job would turn every apt
+      # outage into a red PR, when the packages are usually not needed at all.
+      # If a build genuinely needs them, `npm ci` fails on the next step with a
+      # node-gyp error naming the missing header, which is the clearer signal.
+      #
+      # The apt options bound each mirror connection rather than letting it hang
+      # forever, which is the failure that prompted all of this.
       - name: Install native build dependencies for canvas (fallback path)
+        continue-on-error: true
+        timeout-minutes: 5
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          APT_OPTS: -o Acquire::Retries=3 -o Acquire::http::Timeout=15 -o Acquire::https::Timeout=15
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+          sudo apt-get $APT_OPTS update
+          sudo apt-get $APT_OPTS install -y \
+            libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
A CI job sat for 49 minutes on `apt-get update` and was still going when it was cancelled; a re-run hung at the identical step. The tests never started — they take about ten seconds — and nothing bounded the wait, so the job was on course for GitHub's six-hour default.

Three changes, in order of what actually matters:

`continue-on-error` on the apt step. This is a fallback path, as its own comment says: canvas 3.x ships prebuilt binaries for this runner, so the headers are only needed if a future Node ABI or platform has no prebuild. A step that is usually unnecessary should not be able to fail the run. Bounding it without this would only convert a hang into a red PR, which is faster but no more correct. When the headers are genuinely required, `npm ci` fails on the very next step with a node-gyp error naming the missing one — a better signal than an apt log.

Apt retry and connection timeouts, so a mirror that stops responding is abandoned rather than waited on indefinitely. This addresses the hang itself rather than its symptom.

A 20-minute job timeout as the backstop for everything else. It is not the fix; it is the thing that means the next unforeseen hang costs twenty minutes instead of six hours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration reliability with bounded test and dependency-installation timeouts.
  * Added retry handling for native dependency installation.
  * Dependency installation failures no longer block the overall test job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->