### PR TITLE
Fix four hunt defects, and give every zone's trophies somewhere to go

### DIFF
--- a/src/commands/economy/craft.js
+++ b/src/commands/economy/craft.js
@@ -8,7 +8,8 @@ const { CRAFT_RECIPES: HUNT_RECIPES, CONSUMABLES: HUNT_CONSUMABLES, MATERIAL_NAM
 const { CRAFT_RECIPES: MINE_RECIPES, CONSUMABLES: MINE_CONSUMABLES, MATERIAL_NAMES: MINE_MAT_NAMES } = require('../../data/mineData');
 const { FISH_CRAFT_RECIPES, CONSUMABLES: FISH_CONSUMABLES, MATERIAL_NAMES: FISH_MAT_NAMES } = require('../../data/fishData');
 const { CROSS_CRAFT_RECIPES, CROSS_CONSUMABLES } = require('../../data/crossSystemData');
-const { ensureHuntData } = require('../../services/huntService');
+const { ensureHuntData, FIELD_TROPHY_FLAGS } = require('../../services/huntService');
+const { FIELD_TROPHIES } = require('../../data/huntData');
 const { ensureMineData } = require('../../services/mineService');
 const { ensureFishingData } = require('../../services/fishService');
 
@@ -149,7 +150,12 @@ module.exports = {
                 }));
             }
 
-            const huntLines  = recipeLines(HUNT_RECIPES,  { luckyPaw: h.luckyPaw });
+            // Every unique hunt upgrade the player already owns, so /craft list can
+            // mark it rather than offering a recipe that will be refused.
+            const huntOwned = { luckyPaw: h.luckyPaw };
+            for (const flag of FIELD_TROPHY_FLAGS) huntOwned[flag] = Boolean(h[flag]);
+
+            const huntLines  = recipeLines(HUNT_RECIPES, huntOwned);
             const mineLines  = recipeLines(MINE_RECIPES);
             const fishLines  = recipeLines(FISH_CRAFT_RECIPES, { luckyHook: f.luckyHook });
             const crossLines = recipeLines(CROSS_CRAFT_RECIPES, { precisionScope: h.precisionScope });
@@ -187,6 +193,9 @@ module.exports = {
                 if (recipe.output.id === 'luckyPaw'       && h.luckyPaw)       return interaction.reply({ content: 'You already have the **🐾 Lucky Paw** upgrade!',       flags: MessageFlags.Ephemeral });
                 if (recipe.output.id === 'luckyHook'      && f.luckyHook)      return interaction.reply({ content: 'You already have the **🎣 Lucky Hook** upgrade!',      flags: MessageFlags.Ephemeral });
                 if (recipe.output.id === 'precisionScope' && h.precisionScope) return interaction.reply({ content: 'You already have the **🔭 Precision Scope** upgrade!', flags: MessageFlags.Ephemeral });
+                if (FIELD_TROPHY_FLAGS.includes(recipe.output.id) && h[recipe.output.id]) {
+                    return interaction.reply({ content: `You already have the **${recipe.emoji} ${recipe.name}** upgrade!`, flags: MessageFlags.Ephemeral });
+                }
             }
 
             // Stack limit guards
@@ -258,6 +267,9 @@ module.exports = {
                 if (out.id === 'precisionScope') {
                     h.precisionScope = true;
                     outputDesc = '🔭 **Precision Scope** — permanently +2% rarity boost on all hunts!';
+                } else if (FIELD_TROPHY_FLAGS.includes(out.id)) {
+                    h[out.id] = true;
+                    outputDesc = `${recipe.emoji} **${recipe.name}** — ${FIELD_TROPHIES[out.id].effect}!`;
                 }
 
             } else if (out.type === 'mine_consumable') {

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -21,7 +21,7 @@ const {
     CONSUMABLES, AMMO_PACKS,
     WEAPON_TIERS, WEAPON_BY_SLUG, WEAPON_UPGRADES,
     HUNTER_LEVELS, PRESTIGE_BONUSES, HUNT_QUEST_TEMPLATES,
-    ANIMAL_TRAITS, MATERIAL_NAMES
+    ANIMAL_TRAITS, MATERIAL_NAMES, FIELD_TROPHIES
 } = require('../../data/huntData');
 const { checkAndAward, announceAchievements } = require('../../services/achievementService');
 const { TIER_NUM, TIER_RIBBON } = require('../../data/materialRarity');
@@ -50,7 +50,7 @@ const {
     rollApexType,
     resolveApexEncounter,
     apexNerveAfter,
-    APEX_NERVE_MAX,
+    apexNerveMax,
     getRarePityThreshold,
     applyPayoutModifiers
 } = require('../../services/huntService');
@@ -965,8 +965,9 @@ async function executeStart(interaction) {
 
             const buildApexPhaseEmbed = (phaseIndex, prevResults) => {
                 const phase  = apexType.phases[phaseIndex];
-                const nerve     = apexNerveAfter(prevResults);
-                const nerveBar  = '❤️'.repeat(nerve) + '🖤'.repeat(APEX_NERVE_MAX - nerve);
+                const nerveMax  = apexNerveMax(user);
+                const nerve     = apexNerveAfter(prevResults, user);
+                const nerveBar  = '❤️'.repeat(nerve) + '🖤'.repeat(nerveMax - nerve);
                 const histLines = prevResults.map((p, i) => {
                     const icon = p.correct ? '✅' : p.chosen === 'safe' ? '🛡️' : '❌';
                     return `Phase ${i + 1}: ${icon}`;
@@ -1540,6 +1541,9 @@ async function executeProfile(interaction) {
         embed.addFields(buildTrophyField(h.trophies));
     }
 
+    const fieldTrophies = buildFieldTrophyField(h);
+    if (fieldTrophies) embed.addFields(fieldTrophies);
+
     // Cross-system synergies
     const activeSynergies = getActiveSynergies(userData);
     if (activeSynergies.length > 0) {
@@ -1574,6 +1578,28 @@ async function executeProfile(interaction) {
  * stops working entirely at around 56 unique trophies. Show the best ones first
  * (mythic before pristine before good) and count the rest.
  */
+/**
+ * The permanent upgrades a hunter has earned — the progression that carries on
+ * past Level 50 and Prestige 5. Null when they have none yet, so the profile
+ * doesn't carry an empty field.
+ */
+function buildFieldTrophyField(h) {
+    const owned = Object.entries(FIELD_TROPHIES)
+        .filter(([flag]) => h[flag])
+        .map(([, t]) => `${t.emoji} **${t.name}** — ${t.effect}`);
+
+    if (h.luckyPaw)       owned.unshift('🐾 **Lucky Paw** — +1% critical hit chance');
+    if (h.precisionScope) owned.unshift('🔭 **Precision Scope** — +2% rarity boost');
+    if (!owned.length) return null;
+
+    const total = Object.keys(FIELD_TROPHIES).length + 2;
+    return {
+        name:   `🎖️ Permanent Upgrades (${owned.length}/${total})`,
+        value:  owned.join('\n'),
+        inline: false,
+    };
+}
+
 const TROPHY_RANK = { '🟣': 0, '🔷': 1, '🟢': 2 };
 const TROPHY_FIELD_BUDGET = 1024;
 
@@ -1901,9 +1927,11 @@ async function executeInv(interaction, sub) {
             .setTitle('🪨 Crafting Materials')
             .setDescription(entries.length ? entries.join('\n') : 'No materials yet. Hunt rare+ animals to find special drops!');
 
-        if (!entries.length) {
-            embed.setFooter({ text: 'Tip: Use bait from /hunt shop to boost rare animal chances' });
-        }
+        embed.setFooter({
+            text: entries.length
+                ? 'Every material feeds a recipe — see /craft list. Each zone ends in a permanent Field Trophy.'
+                : 'Tip: Use bait from /hunt shop to boost rare animal chances',
+        });
 
         return interaction.reply({ embeds: [embed] });
     }
@@ -2986,7 +3014,7 @@ async function checkGrandPrestige(client, user, guild, guildId) {
 
 // Test hooks. The command loader only looks for `data` and `execute`
 // (src/index.js), so extra exports are inert at runtime.
-module.exports.__test__ = { buildHuntEmbed, buildBonusLines, buildTrophyField };
+module.exports.__test__ = { buildHuntEmbed, buildBonusLines, buildTrophyField, buildFieldTrophyField };
 
 // ── Per-user action lock ──────────────────────────────────────────────────────
 // Hunting mutates the user document with read-modify-write saves, so concurrent

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -1524,7 +1524,7 @@ async function executeProfile(interaction) {
     embed.addFields({ name: '🗺️ Unlocked Zones', value: zoneList || 'Beginner Forest only', inline: true });
 
     if (h.trophies?.length) {
-        embed.addFields({ name: '🏆 Trophies', value: h.trophies.join(', '), inline: true });
+        embed.addFields(buildTrophyField(h.trophies));
     }
 
     // Cross-system synergies
@@ -1551,6 +1551,39 @@ async function executeProfile(interaction) {
 
     embed.setTimestamp();
     return interaction.reply({ embeds: [embed] });
+}
+
+/**
+ * The trophy case, clamped to Discord's 1024-character field limit.
+ *
+ * Trophies accumulate forever and are never pruned, so a veteran hunter's list
+ * outgrows the field and Discord rejects the whole profile embed — the command
+ * stops working entirely at around 56 unique trophies. Show the best ones first
+ * (mythic before pristine before good) and count the rest.
+ */
+const TROPHY_RANK = { '🟣': 0, '🔷': 1, '🟢': 2 };
+const TROPHY_FIELD_BUDGET = 1024;
+
+function buildTrophyField(trophies) {
+    const ranked = trophies.slice().sort((a, b) =>
+        (TROPHY_RANK[a.slice(0, 2)] ?? 9) - (TROPHY_RANK[b.slice(0, 2)] ?? 9));
+
+    const shown = [];
+    let used = 0;
+    for (const trophy of ranked) {
+        // +2 for the ", " separator, and leave room for the "+N more" tail.
+        const tail = `, +${ranked.length - shown.length} more`;
+        if (used + trophy.length + 2 + tail.length > TROPHY_FIELD_BUDGET) break;
+        used += trophy.length + (shown.length ? 2 : 0);
+        shown.push(trophy);
+    }
+
+    const hidden = ranked.length - shown.length;
+    return {
+        name:   `🏆 Trophies (${ranked.length})`,
+        value:  shown.join(', ') + (hidden > 0 ? `, +${hidden} more` : ''),
+        inline: true,
+    };
 }
 
 function buildXpBar(h, toNext) {
@@ -2940,7 +2973,7 @@ async function checkGrandPrestige(client, user, guild, guildId) {
 
 // Test hooks. The command loader only looks for `data` and `execute`
 // (src/index.js), so extra exports are inert at runtime.
-module.exports.__test__ = { buildHuntEmbed, buildBonusLines };
+module.exports.__test__ = { buildHuntEmbed, buildBonusLines, buildTrophyField };
 
 // ── Per-user action lock ──────────────────────────────────────────────────────
 // Hunting mutates the user document with read-modify-write saves, so concurrent

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -30,6 +30,7 @@ const {
     ensureHuntData,
     applyStaminaRegen,
     applyDailyReset,
+    msUntilDailyReset,
     msUntilNextStamina,
     getMaxStamina,
     executeHunt,
@@ -48,6 +49,9 @@ const {
     applyXp,
     rollApexType,
     resolveApexEncounter,
+    apexNerveAfter,
+    APEX_NERVE_MAX,
+    getRarePityThreshold,
     applyPayoutModifiers
 } = require('../../services/huntService');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
@@ -448,8 +452,9 @@ async function executeStart(interaction) {
         const regenMs = msUntilNextStamina(user);
         const nextAt  = new Date(Date.now() + regenMs);
         const sinceRare = h.sinceRare ?? 0;
+        const pityCap   = getRarePityThreshold(zone);
         const pityStat  = sinceRare >= 5
-            ? `🎯 ${sinceRare} hunts since last Rare+ • next rare guaranteed around hunt ~50`
+            ? `🎯 ${sinceRare} hunts since last Rare+ • guaranteed at ${pityCap} in ${zone.name}`
             : null;
         return interaction.reply({
             embeds: [buildCooldownEmbed({
@@ -458,7 +463,7 @@ async function executeStart(interaction) {
                 color: '#5a8a3c',
                 nextAt,
                 pityStat,
-                nextRewardPreview: 'Full stamina = 10 hunts · Rare+ drops guaranteed by hunt ~50',
+                nextRewardPreview: `Full stamina = ${getMaxStamina(user)} hunts · Rare+ guaranteed after ${pityCap} dry hunts here`,
             })],
             flags: MessageFlags.Ephemeral,
         });
@@ -960,8 +965,8 @@ async function executeStart(interaction) {
 
             const buildApexPhaseEmbed = (phaseIndex, prevResults) => {
                 const phase  = apexType.phases[phaseIndex];
-                const nerve  = 3 - prevResults.filter(p => !p.correct && p.chosen !== 'safe').length;
-                const nerveBar  = '❤️'.repeat(nerve) + '🖤'.repeat(3 - nerve);
+                const nerve     = apexNerveAfter(prevResults);
+                const nerveBar  = '❤️'.repeat(nerve) + '🖤'.repeat(APEX_NERVE_MAX - nerve);
                 const histLines = prevResults.map((p, i) => {
                     const icon = p.correct ? '✅' : p.chosen === 'safe' ? '🛡️' : '❌';
                     return `Phase ${i + 1}: ${icon}`;
@@ -979,7 +984,7 @@ async function executeStart(interaction) {
                         (histLines ? `${histLines}\n\n` : '') +
                         `**Choose your move — NOW:**`
                     )
-                    .setFooter({ text: `⏱️ 30 seconds per phase • Outcomes: 3/3=1.5x bonus | 2/3=1x | 1/3=0.4x | 0/3=Nothing` });
+                    .setFooter({ text: `⏱️ 30 seconds per phase • 3/3=1.5x bonus | 2/3=1x | 1/3=0.4x • A wrong read costs 2 nerve — at 0 it escapes. Backing off is safe but never counts.` });
             };
 
             const buildPhaseRow = (phaseIndex) => {
@@ -1153,7 +1158,9 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
         const color = isCrit ? '#FFD700' : TIER_COLORS[tier];
 
         const tierLabel = tier.charAt(0).toUpperCase() + tier.slice(1);
-        const payoutDisplay = cappedByHard ? `~~${currency}${finalPayout}~~ (daily cap reached)` : `**${currency}${finalPayout.toLocaleString()}**`;
+        const payoutDisplay = cappedByHard
+            ? `~~${currency}${(result.forfeitedPayout ?? 0).toLocaleString()}~~\n*Daily cap reached — resets in ${formatMs(msUntilDailyReset(h))}*`
+            : `**${currency}${finalPayout.toLocaleString()}**`;
 
         const qualityLabel = trophyQuality
             ? `${trophyQuality.emoji} **${trophyQuality.label}** (×${trophyQuality.multiplier.toFixed(2)})`
@@ -1231,7 +1238,7 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
         embed.addFields({ name: 'Balance', value: balanceLine, inline: true }, { name: 'Hunter XP', value: xpLine, inline: true });
 
         const sinceRareNow = user.hunt.sinceRare ?? 0;
-        if (sinceRareNow >= 5) embed.addFields(buildPityField(user));
+        if (sinceRareNow >= 5) embed.addFields(buildPityField(user, zone));
 
         embed.setFooter({ text: `Cooldown: 45s • ${buildActiveConsumablesLine(user)}` });
         embed.setTimestamp();
@@ -1304,7 +1311,7 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
     }
 
     const sinceRareNow = user.hunt.sinceRare ?? 0;
-    if (sinceRareNow >= 5) embed.addFields(buildPityField(user));
+    if (sinceRareNow >= 5) embed.addFields(buildPityField(user, zone));
 
     embed.setFooter({ text: 'Tip: Use consumables from /hunt shop to boost your success chance' });
     embed.setTimestamp();
@@ -1352,9 +1359,15 @@ function buildFailureTitle(severityId) {
     return { clean_miss: '💨 Miss!', spooked: '😰 Spooked!', jammed: '🔧 Jammed!', injured: '🤕 Injured!' }[severityId] ?? '❌ Failed Hunt';
 }
 
-function buildPityField(user) {
+// Heat bands as a fraction of the zone's own threshold — the numbers used to be
+// hardcoded against a flat 50, which no longer holds now that each zone sets its
+// own.
+const PITY_HOT_FRACTION  = 0.80;
+const PITY_WARM_FRACTION = 0.50;
+
+function buildPityField(user, zone) {
     const sinceRare  = user.hunt.sinceRare ?? 0;
-    const threshold  = LIMITS.RARE_PITY_GUARANTEE;
+    const threshold  = getRarePityThreshold(zone);
     const filled     = Math.min(sinceRare, threshold);
     const barLen     = 16;
     const filledLen  = Math.round((filled / threshold) * barLen);
@@ -1364,10 +1377,10 @@ function buildPityField(user) {
     if (sinceRare >= threshold) {
         heat  = '⚡';
         label = `**GUARANTEED NEXT HUNT**`;
-    } else if (sinceRare >= 41) {
+    } else if (sinceRare >= threshold * PITY_HOT_FRACTION) {
         heat  = '🔥';
         label = `Getting hot — ~${threshold - sinceRare} more`;
-    } else if (sinceRare >= 26) {
+    } else if (sinceRare >= threshold * PITY_WARM_FRACTION) {
         heat  = '🌡️';
         label = `Warming up — ~${threshold - sinceRare} more`;
     } else {

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -52,6 +52,7 @@ const {
     apexNerveAfter,
     apexNerveMax,
     getRarePityThreshold,
+    getDiminishingReturns,
     applyPayoutModifiers
 } = require('../../services/huntService');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
@@ -1212,6 +1213,9 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
             embed.addFields({ name: '⚡ Trait Effects', value: effectLines, inline: false });
         }
 
+        const dailyToll = buildDailyTollField(result, user, currency);
+        if (dailyToll) embed.addFields(dailyToll);
+
         if (specialDrop) {
             embed.addFields({ name: '🎁 Special Drop!', value: `You found **${specialDrop.name}**!`, inline: false });
         }
@@ -1348,6 +1352,40 @@ function buildBonusLines(result, petYieldPct, petXpPct) {
     }
 
     return lines;
+}
+
+/**
+ * What the day's own limits took out of this payout, and when they lift.
+ *
+ * The soft cap halves every payout past 80k and diminishing returns cut it by up
+ * to 45% more, so a heavy session's rewards could shrink by nearly three
+ * quarters with nothing on screen to explain it — it read as bad luck, or as a
+ * silent nerf. Only the hard cap ever said anything. Null when nothing bit.
+ */
+function buildDailyTollField(result, user, currency) {
+    const report = result.dailyReport;
+    if (!report || report.lostToDaily <= 0) return null;
+
+    const h = user.hunt;
+    const lines = [];
+
+    if (report.dimReturns) {
+        const pct = Math.round((1 - report.dimReturns.multiplier) * 100);
+        lines.push(`📉 **Diminishing returns** −${pct}% · ${h.dailyHunts} hunts today (past ${report.dimReturns.threshold})`
+            + (report.dimReturns.nextAt
+                ? `\n> Drops again at ${report.dimReturns.nextAt} hunts.`
+                : ''));
+    }
+    if (report.softCapped) {
+        lines.push(`🪙 **Daily soft cap** −50% · past ${currency}${LIMITS.DAILY_SOFT_CAP.toLocaleString()} earned today`);
+    }
+    if (report.headroomClamped) {
+        lines.push(`🧱 **Hard cap in sight** — only ${currency}${Math.max(0, LIMITS.DAILY_HARD_CAP - h.dailyCoins).toLocaleString()} of headroom left`);
+    }
+
+    lines.push(`*Worth ${currency}${report.grossPayout.toLocaleString()} on a fresh day — ${currency}${report.lostToDaily.toLocaleString()} withheld. Resets in ${formatMs(msUntilDailyReset(h))}.*`);
+
+    return { name: '⚖️ Daily Limits', value: lines.join('\n'), inline: false };
 }
 
 function buildBrokenWeaponNote(weapon) {
@@ -1560,10 +1598,10 @@ async function executeProfile(interaction) {
         });
     }
 
+    if (isSelf) embed.addFields(buildTodayField(h, currency));
+
     if (prestige === 0 && h.level >= 50) {
         embed.setFooter({ text: 'Max level reached! Use /hunt prestige to reset and unlock new bonuses.' });
-    } else if (isSelf) {
-        embed.setFooter({ text: `Daily: ${h.dailyHunts} hunts · ${currency}${h.dailyCoins.toLocaleString()} earned (cap: ${currency}${LIMITS.DAILY_HARD_CAP.toLocaleString()})` });
     }
 
     embed.setTimestamp();
@@ -1623,6 +1661,38 @@ function buildTrophyField(trophies) {
         value:  shown.join(', ') + (hidden > 0 ? `, +${hidden} more` : ''),
         inline: true,
     };
+}
+
+/**
+ * Where today's earnings stand against the limits that quietly throttle them.
+ *
+ * The profile used to report only the hard cap, so a hunter had no way to see
+ * the −50% soft cap or the diminishing-returns band coming before it landed.
+ */
+function buildTodayField(h, currency) {
+    const dim   = getDiminishingReturns(h.dailyHunts ?? 0);
+    const coins = h.dailyCoins ?? 0;
+
+    const barLen    = 12;
+    const filledLen = Math.min(barLen, Math.round((coins / LIMITS.DAILY_HARD_CAP) * barLen));
+    const bar       = '█'.repeat(filledLen) + '░'.repeat(barLen - filledLen);
+
+    const lines = [
+        `\`${bar}\` ${currency}${coins.toLocaleString()} / ${currency}${LIMITS.DAILY_HARD_CAP.toLocaleString()}`,
+        `🏹 ${(h.dailyHunts ?? 0).toLocaleString()} hunts · payout ×${dim.multiplier.toFixed(2)}`,
+    ];
+
+    if (dim.nextAt) {
+        lines.push(`📉 Drops to ×${dim.nextMultiplier.toFixed(2)} at ${dim.nextAt} hunts`);
+    }
+    if (coins >= LIMITS.DAILY_SOFT_CAP) {
+        lines.push(`🪙 Past the soft cap — payouts halved`);
+    } else {
+        lines.push(`🪙 Soft cap (−50%) at ${currency}${LIMITS.DAILY_SOFT_CAP.toLocaleString()}`);
+    }
+    lines.push(`🕛 Resets in ${formatMs(msUntilDailyReset(h))}`);
+
+    return { name: '📅 Today', value: lines.join('\n'), inline: false };
 }
 
 function buildXpBar(h, toNext) {
@@ -3014,7 +3084,7 @@ async function checkGrandPrestige(client, user, guild, guildId) {
 
 // Test hooks. The command loader only looks for `data` and `execute`
 // (src/index.js), so extra exports are inert at runtime.
-module.exports.__test__ = { buildHuntEmbed, buildBonusLines, buildTrophyField, buildFieldTrophyField };
+module.exports.__test__ = { buildHuntEmbed, buildBonusLines, buildTrophyField, buildFieldTrophyField, buildDailyTollField, buildTodayField };
 
 // ── Per-user action lock ──────────────────────────────────────────────────────
 // Hunting mutates the user document with read-modify-write saves, so concurrent

--- a/src/data/huntData.js
+++ b/src/data/huntData.js
@@ -207,6 +207,7 @@ const ZONES = {
         unlockLevel: 1, unlockCost: 0, defaultUnlocked: true,
         difficultyMod: 0.00, payoutBonus: 0.00,
         tierWeights: { common: 52, uncommon: 30, rare: 13, epic: 4, legendary: 1, event: 0 },
+        rarePity: 35,   // dry-streak mercy: ~1-in-150 tail at 18% rare+
         description: 'A peaceful forest perfect for new hunters.',
         zoneMaterials: ['rabbits_foot', 'feather', 'down_feather', 'acorn_cache', 'wolf_pelt', 'badger_pelt', 'antler_fragment', 'elk_antler', 'bear_claw', 'moose_rack', 'striped_pelt', 'hardwood_chip', 'crow_feather', 'opossum_pelt']
     },
@@ -215,6 +216,7 @@ const ZONES = {
         unlockLevel: 10, unlockCost: 3000, defaultUnlocked: false,
         difficultyMod: -0.05, payoutBonus: 0.00,
         tierWeights: { common: 42, uncommon: 30, rare: 18, epic: 7, legendary: 2.5, event: 0.5 },
+        rarePity: 21,   // dry-streak mercy: ~1-in-150 tail at 28% rare+
         description: 'Harsh and unforgiving terrain with exotic wildlife.',
         zoneMaterials: ['venom_sac', 'scorpion_claw', 'coyote_fang', 'hyena_fang', 'sand_pelt', 'jackrabbit_foot', 'scavenger_feather', 'lion_tooth']
     },
@@ -223,6 +225,7 @@ const ZONES = {
         unlockLevel: 20, unlockCost: 12000, defaultUnlocked: false,
         difficultyMod: -0.08, payoutBonus: 0.00,
         tierWeights: { common: 35, uncommon: 28, rare: 22, epic: 11, legendary: 3.5, event: 0.5 },
+        rarePity: 15,   // dry-streak mercy: ~1-in-150 tail at 37% rare+
         description: 'Freezing wilderness where rare creatures roam.',
         zoneMaterials: ['mammoth_tusk', 'arctic_fox_pelt', 'wolverine_fur', 'polar_claw', 'saber_fang', 'snowy_feather', 'caribou_antler', 'lynx_fang', 'thick_hide']
     },
@@ -231,6 +234,7 @@ const ZONES = {
         unlockLevel: 30, unlockCost: 30000, defaultUnlocked: false,
         difficultyMod: -0.10, payoutBonus: 0.00,
         tierWeights: { common: 32, uncommon: 27, rare: 22, epic: 13, legendary: 5, event: 1 },
+        rarePity: 14,   // dry-streak mercy: ~1-in-150 tail at 41% rare+
         description: 'Mysterious marshlands hiding dangerous prey.',
         zoneMaterials: ['swamp_scale', 'swamp_gland', 'cottonmouth_venom', 'gator_hide', 'marsh_feather', 'hog_tusk', 'shadow_pelt', 'beaver_pelt', 'slick_skin']
     },
@@ -239,6 +243,7 @@ const ZONES = {
         unlockLevel: 50, unlockCost: 75000, defaultUnlocked: false,
         difficultyMod: -0.12, payoutBonus: 0.20,
         tierWeights: { common: 15, uncommon: 22, rare: 28, epic: 22, legendary: 12, event: 1 },
+        rarePity: 8,   // dry-streak mercy: ~1-in-150 tail at 63% rare+
         description: 'The ultimate hunting ground. Master hunters only.',
         zoneMaterials: ['ancient_relic', 'spirit_essence', 'spirit_pelt', 'ram_horn', 'dire_wolf_fang', 'primal_claw', 'obsidian_antler', 'storm_feather', 'ember_fang', 'megaloceros_crown']
     }
@@ -825,7 +830,7 @@ const LIMITS = {
     STAMINA_TONICS_PER_DAY:  2,
     PITY_CONSECUTIVE_FAILS:  4,             // pity starts on the Nth straight fail, +15% per further fail, max 4 stacks
     PITY_BONUS_PER_STACK:    0.15,
-    RARE_PITY_GUARANTEE:     50             // sinceRare threshold for guaranteed rare+
+    RARE_PITY_GUARANTEE:     35             // fallback sinceRare threshold; zones set their own `rarePity`
 };
 
 // ─── PRESTIGE BONUSES ────────────────────────────────────────────────────────

--- a/src/data/huntData.js
+++ b/src/data/huntData.js
@@ -830,7 +830,8 @@ const LIMITS = {
     STAMINA_TONICS_PER_DAY:  2,
     PITY_CONSECUTIVE_FAILS:  4,             // pity starts on the Nth straight fail, +15% per further fail, max 4 stacks
     PITY_BONUS_PER_STACK:    0.15,
-    RARE_PITY_GUARANTEE:     35             // fallback sinceRare threshold; zones set their own `rarePity`
+    RARE_PITY_GUARANTEE:     35,            // fallback sinceRare threshold; zones set their own `rarePity`
+    TOTEM_EVENT_WEIGHT:      0.5            // Stormcaller's Totem: event weight added in every zone
 };
 
 // ─── PRESTIGE BONUSES ────────────────────────────────────────────────────────
@@ -1007,7 +1008,196 @@ const CRAFT_RECIPES = {
         ],
         output: { type: 'permanent', id: 'luckyPaw' },
         unique: true
+    },
+
+    // ── Zone bulk sinks ──────────────────────────────────────────────────────
+    // Repeatable recipes so a zone's ordinary drops keep flowing somewhere. Every
+    // zone's drop table used to dead-end: only the starter zone's materials fed
+    // any recipe, so the deeper a hunter pushed the more worthless their loot
+    // became. These give each zone's spare trophies an ongoing purpose.
+    fletched_rounds_60x: {
+        id: 'fletched_rounds_60x', name: 'Fletched Rounds ×60', emoji: '🪶',
+        description: 'Fletch 60 iron rounds from feathers and hardwood',
+        ingredients: [
+            { material: 'down_feather',  qty: 3 },
+            { material: 'crow_feather',  qty: 3 },
+            { material: 'hardwood_chip', qty: 2 }
+        ],
+        output: { type: 'ammo', id: 'iron_shot', qty: 60 }
+    },
+    trailcraft_focus_5x: {
+        id: 'trailcraft_focus_5x', name: "Hunter's Focus ×5", emoji: '🎯',
+        description: "Sharpen your instincts from a scavenger's spoils",
+        ingredients: [
+            { material: 'lion_tooth',  qty: 2 },
+            { material: 'slick_skin',  qty: 3 },
+            { material: 'bandit_mask', qty: 1 }
+        ],
+        output: { type: 'consumable', id: 'hunters_focus', qty: 5 }
+    },
+    desert_bait_2x: {
+        id: 'desert_bait_2x', name: 'Premium Bait ×2', emoji: '🎣',
+        description: 'Cure desert spoils into potent bait',
+        ingredients: [
+            { material: 'jackrabbit_foot',   qty: 3 },
+            { material: 'scavenger_feather', qty: 3 },
+            { material: 'hyena_fang',        qty: 2 }
+        ],
+        output: { type: 'consumable', id: 'premium_bait', qty: 2 }
+    },
+    tundra_repair_2x: {
+        id: 'tundra_repair_2x', name: 'Repair Kit (Large) ×2', emoji: '🔨',
+        description: 'Bone and horn worked into heavy repair kits',
+        ingredients: [
+            { material: 'caribou_antler', qty: 2 },
+            { material: 'mountain_horn',  qty: 2 },
+            { material: 'snowy_feather',  qty: 3 }
+        ],
+        output: { type: 'consumable', id: 'repair_kit_large', qty: 2 }
+    },
+    composite_rounds_40x: {
+        id: 'composite_rounds_40x', name: 'Composite Rounds ×40', emoji: '🔵',
+        description: 'Forge 40 composite rounds from apex fangs and claws',
+        ingredients: [
+            { material: 'saber_fang',    qty: 2 },
+            { material: 'polar_claw',    qty: 2 },
+            { material: 'wolverine_fur', qty: 2 }
+        ],
+        output: { type: 'ammo', id: 'composite_round', qty: 40 }
+    },
+    swamp_charm_2x: {
+        id: 'swamp_charm_2x', name: 'Luck Charm ×2', emoji: '🍀',
+        description: 'Marsh tokens bound into charms',
+        ingredients: [
+            { material: 'marsh_feather', qty: 3 },
+            { material: 'hog_tusk',      qty: 2 },
+            { material: 'swamp_scale',   qty: 3 }
+        ],
+        output: { type: 'consumable', id: 'luck_charm', qty: 2 }
+    },
+    titanium_rounds_40x: {
+        id: 'titanium_rounds_40x', name: 'Titanium Rounds ×40', emoji: '💎',
+        description: 'Forge 40 titanium rounds from summit trophies',
+        ingredients: [
+            { material: 'dire_wolf_fang', qty: 2 },
+            { material: 'ancient_relic',  qty: 2 },
+            { material: 'primal_claw',    qty: 1 }
+        ],
+        output: { type: 'ammo', id: 'titanium_round', qty: 40 }
+    },
+    summit_scroll_3x: {
+        id: 'summit_scroll_3x', name: 'XP Scroll ×3', emoji: '📜',
+        description: 'Transcribe the summit hunt onto scrolls',
+        ingredients: [
+            { material: 'ram_horn',           qty: 2 },
+            { material: 'megaloceros_crown',  qty: 1 },
+            { material: 'shadow_pelt',        qty: 2 }
+        ],
+        output: { type: 'consumable', id: 'xp_scroll', qty: 3 }
+    },
+
+    // ── Field Trophies: one permanent per zone ───────────────────────────────
+    // Terminal sinks for each zone's signature materials, and the progression
+    // that used to stop dead at Level 50 / Prestige 5. Each is crafted once.
+    woodland_instinct: {
+        id: 'woodland_instinct', name: 'Woodland Instinct', emoji: '🌿',
+        description: 'A permanent upgrade granting +1 max stamina',
+        ingredients: [
+            { material: 'opossum_pelt',  qty: 4 },
+            { material: 'striped_pelt',  qty: 4 },
+            { material: 'hardwood_chip', qty: 3 }
+        ],
+        output: { type: 'hunt_permanent', id: 'woodlandInstinct' },
+        unique: true
+    },
+    venom_ward: {
+        id: 'venom_ward', name: 'Venom Ward', emoji: '🦂',
+        description: 'A permanent upgrade — venomous prey no longer costs extra stamina',
+        ingredients: [
+            { material: 'venom_sac',     qty: 3 },
+            { material: 'scorpion_claw', qty: 4 },
+            { material: 'sand_pelt',     qty: 3 }
+        ],
+        output: { type: 'hunt_permanent', id: 'venomWard' },
+        unique: true
+    },
+    insulated_kit: {
+        id: 'insulated_kit', name: 'Insulated Kit', emoji: '🧊',
+        description: 'A permanent upgrade reducing durability loss by 1 per hunt (minimum 1)',
+        ingredients: [
+            { material: 'thick_hide',      qty: 3 },
+            { material: 'arctic_fox_pelt', qty: 3 },
+            { material: 'mammoth_tusk',    qty: 2 }
+        ],
+        output: { type: 'hunt_permanent', id: 'insulatedKit' },
+        unique: true
+    },
+    swampwalkers_charm: {
+        id: 'swampwalkers_charm', name: "Swampwalker's Charm", emoji: '🐊',
+        description: 'A permanent upgrade — pack prey no longer savages your weapon, and aggressive prey injures you half as often',
+        ingredients: [
+            { material: 'gator_hide',        qty: 3 },
+            { material: 'swamp_gland',       qty: 3 },
+            { material: 'cottonmouth_venom', qty: 3 }
+        ],
+        output: { type: 'hunt_permanent', id: 'swampwalkersCharm' },
+        unique: true
+    },
+    apex_predators_mark: {
+        id: 'apex_predators_mark', name: "Apex Predator's Mark", emoji: '⛰️',
+        description: 'A permanent upgrade — survive one extra misread in every apex duel',
+        ingredients: [
+            { material: 'primal_claw',     qty: 2 },
+            { material: 'obsidian_antler', qty: 2 },
+            { material: 'storm_feather',   qty: 2 },
+            { material: 'ember_fang',      qty: 2 }
+        ],
+        output: { type: 'hunt_permanent', id: 'apexPredatorsMark' },
+        unique: true
+    },
+    stormcallers_totem: {
+        id: 'stormcallers_totem', name: "Stormcaller's Totem", emoji: '⚡',
+        description: 'A permanent upgrade — mythical prey stalks every zone you hunt',
+        ingredients: [
+            { material: 'thunderfeather', qty: 2 },
+            { material: 'spectral_bone',  qty: 2 },
+            { material: 'ancient_claw',   qty: 2 }
+        ],
+        output: { type: 'hunt_permanent', id: 'stormcallersTotem' },
+        unique: true
     }
+};
+
+// ─── FIELD TROPHIES ──────────────────────────────────────────────────────────
+// Permanent, once-only upgrades crafted from a single zone's materials. Keyed by
+// the flag stored on user.hunt, so /craft and /hunt profile describe them the
+// same way.
+
+const FIELD_TROPHIES = {
+    woodlandInstinct: {
+        emoji: '🌿', name: 'Woodland Instinct', zone: 'beginner_forest',
+        effect: 'permanently +1 max stamina',
+    },
+    venomWard: {
+        emoji: '🦂', name: 'Venom Ward', zone: 'desert_wastes',
+        effect: 'venomous prey no longer costs you extra stamina',
+    },
+    insulatedKit: {
+        emoji: '🧊', name: 'Insulated Kit', zone: 'arctic_tundra',
+        effect: 'permanently -1 durability loss per hunt',
+    },
+    swampwalkersCharm: {
+        emoji: '🐊', name: "Swampwalker's Charm", zone: 'murky_swamp',
+        effect: 'pack prey no longer savages your weapon, and aggressive prey injures you half as often',
+    },
+    apexPredatorsMark: {
+        emoji: '⛰️', name: "Apex Predator's Mark", zone: 'legendary_peaks',
+        effect: 'one extra misread before an apex duel breaks your nerve',
+    },
+    stormcallersTotem: {
+        emoji: '⚡', name: "Stormcaller's Totem", zone: null,
+        effect: 'mythical prey now stalks every zone you hunt',
+    },
 };
 
 // ─── HUNT DAILY QUEST TEMPLATES ───────────────────────────────────────────────
@@ -1238,6 +1428,7 @@ module.exports = {
     PRESTIGE_BONUSES,
     MATERIAL_NAMES,
     CRAFT_RECIPES,
+    FIELD_TROPHIES,
     HUNT_QUEST_TEMPLATES,
     TROPHY_QUALITIES,
     APEX_TYPES

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -12,7 +12,8 @@ const {
     PRESTIGE_BONUSES,
     HUNT_QUEST_TEMPLATES,
     TROPHY_QUALITIES,
-    APEX_TYPES
+    APEX_TYPES,
+    FIELD_TROPHIES
 } = require('../data/huntData');
 const { hasEffect, consumeEffect, getEffect, getGatheringYieldEffect, EFFECT_CONFIGS } = require('./effectsService');
 const { getStreakMultiplier } = require('../utils/streakMultiplier');
@@ -25,6 +26,11 @@ const DANGEROUS_ZONE_IDS = new Set(['desert_wastes', 'arctic_tundra', 'murky_swa
 const HUNT_DEATH_RATE = 0.08;
 
 const DAILY_QUEST_COUNT = 3;
+
+// Field Trophies: permanent, once-only upgrades crafted from a zone's own
+// materials. Each zone's drop table terminates in one of these, which is what
+// gives the deeper zones' trophies a reason to exist.
+const FIELD_TROPHY_FLAGS = Object.keys(FIELD_TROPHIES);
 
 // ─── INIT ────────────────────────────────────────────────────────────────────
 
@@ -61,6 +67,10 @@ function ensureHuntData(user) {
     if (h.activeXpScroll       == null) h.activeXpScroll       = false;
     if (h.luckyPaw             == null) h.luckyPaw             = false;
     if (h.precisionScope       == null) h.precisionScope       = false;
+    // Field Trophies — one permanent per zone, crafted from that zone's materials.
+    for (const flag of FIELD_TROPHY_FLAGS) {
+        if (h[flag] == null) h[flag] = false;
+    }
     if (h.totalHunts           == null) h.totalHunts           = 0;
     if (h.successfulHunts      == null) h.successfulHunts      = 0;
     if (h.totalEarned          == null) h.totalEarned          = 0;
@@ -86,7 +96,8 @@ function getMaxStamina(user) {
     const prestige = user.hunt?.prestige ?? 0;
     const bonus = PRESTIGE_BONUSES[Math.min(prestige, PRESTIGE_BONUSES.length - 1)]?.staminaBonus ?? 0;
     const synergyBonus = getHuntSynergyStaminaBonus(user);
-    return LIMITS.MAX_STAMINA_BASE + bonus + synergyBonus;
+    const trophyBonus  = user.hunt?.woodlandInstinct ? 1 : 0;
+    return LIMITS.MAX_STAMINA_BASE + bonus + synergyBonus + trophyBonus;
 }
 
 /**
@@ -375,6 +386,12 @@ function rollTier(user, zone) {
         w.rare  += shift;
     }
 
+    // Stormcaller's Totem: mythical prey stalks every zone, including the starter
+    // forest where the event weight is otherwise zero.
+    if (h.stormcallersTotem) {
+        w.event = (w.event ?? 0) + LIMITS.TOTEM_EVENT_WEIGHT;
+    }
+
     // Precision Scope permanent upgrade (+2% rarity boost)
     if (h.precisionScope) {
         const scopeShift = w.common * 0.02;
@@ -518,13 +535,17 @@ function applyPayoutModifiers(user, rawPayout, zone, options = {}) {
 
 /**
  * Deducts durability from a weapon after a hunt.
- * Reinforced stock upgrade reduces loss by 1 (min 1).
+ *
+ * The reinforced stock upgrade and `extraReduction` (the Insulated Kit field
+ * trophy) each shave a point off; the floor of 1 applies once, after both, so
+ * owning them together is worth more than either alone.
  */
-function applyDurabilityLoss(weapon, baseLoss) {
+function applyDurabilityLoss(weapon, baseLoss, extraReduction = 0) {
     let loss = baseLoss;
     if (weapon.upgrade === 'reinforced_stock') {
-        loss = Math.max(1, loss - WEAPON_UPGRADES.reinforced_stock.effect.durabilityReduction);
+        loss -= WEAPON_UPGRADES.reinforced_stock.effect.durabilityReduction;
     }
+    loss = Math.max(1, loss - extraReduction);
     weapon.currentDurability = Math.max(0, weapon.currentDurability - loss);
     updateWeaponStatus(weapon);
 }
@@ -798,6 +819,9 @@ function executeHunt(user, zoneId, options = {}) {
     const baitBefore  = h.activeBait;
     const charmBefore = h.activeCharm;
 
+    // Insulated Kit shaves a point off every durability hit, win or lose.
+    const insulation = h.insulatedKit ? 1 : 0;
+
     const result = {
         success,
         animal,
@@ -861,17 +885,23 @@ function executeHunt(user, zoneId, options = {}) {
             durLoss += 1;
             result.traitEffects.push({ trait: 'giant', msg: 'The sheer mass of the beast wore your weapon harder.' });
         }
-        applyDurabilityLoss(weapon, durLoss);
+        applyDurabilityLoss(weapon, durLoss, insulation);
         result.durabilityLost = durLoss;
 
-        // Trait: venomous — costs an extra stamina
+        // Trait: venomous — costs an extra stamina, unless warded
         if (traits.includes('venomous')) {
-            h.stamina = Math.max(0, h.stamina - 1);
-            result.traitEffects.push({ trait: 'venomous', msg: 'Its venom sapped your strength (-1 extra stamina).' });
+            if (h.venomWard) {
+                result.traitEffects.push({ trait: 'venomous', msg: '🦂 Your Venom Ward neutralised the toxin — no stamina lost.' });
+            } else {
+                h.stamina = Math.max(0, h.stamina - 1);
+                result.traitEffects.push({ trait: 'venomous', msg: 'Its venom sapped your strength (-1 extra stamina).' });
+            }
         }
 
-        // Trait: aggressive — 30% chance to injure even on success
-        if (traits.includes('aggressive') && Math.random() < 0.30) {
+        // Trait: aggressive — 30% chance to injure even on success, halved by the
+        // Swampwalker's Charm
+        const injuryChance = h.swampwalkersCharm ? 0.15 : 0.30;
+        if (traits.includes('aggressive') && Math.random() < injuryChance) {
             h.injuryUntil = new Date(Date.now() + LIMITS.INJURY_PENALTY_MS);
             result.traitEffects.push({ trait: 'aggressive', msg: 'It lashed out while falling, injuring you (+15 min cooldown).' });
         }
@@ -929,10 +959,14 @@ function executeHunt(user, zoneId, options = {}) {
         // Trait: pack_hunter — extra durability damage on failure
         let failDurLoss = severity.durLoss;
         if (traits.includes('pack_hunter')) {
-            failDurLoss += 3;
-            result.traitEffects.push({ trait: 'pack_hunter', msg: 'The pack descended on you, battering your weapon.' });
+            if (h.swampwalkersCharm) {
+                result.traitEffects.push({ trait: 'pack_hunter', msg: "🐊 The pack circled but kept its distance — your Swampwalker's Charm held them off." });
+            } else {
+                failDurLoss += 3;
+                result.traitEffects.push({ trait: 'pack_hunter', msg: 'The pack descended on you, battering your weapon.' });
+            }
         }
-        applyDurabilityLoss(weapon, failDurLoss);
+        applyDurabilityLoss(weapon, failDurLoss, insulation);
         result.durabilityLost = failDurLoss;
 
         if (severity.injuryMs > 0) {
@@ -1132,17 +1166,26 @@ function rollApexType() {
 const APEX_NERVE_MAX  = 3;
 const APEX_NERVE_COST = 2;
 
+/**
+ * How much nerve a hunter brings to a duel. The Apex Predator's Mark is worth a
+ * whole extra misread — granting a single point would round away to nothing,
+ * since nerve is only ever spent two at a time.
+ */
+function apexNerveMax(user) {
+    return APEX_NERVE_MAX + (user?.hunt?.apexPredatorsMark ? APEX_NERVE_COST : 0);
+}
+
 /** Nerve left after the given phase results. */
-function apexNerveAfter(phaseResults) {
+function apexNerveAfter(phaseResults, user) {
     const misreads = phaseResults.filter(p => !p.correct && p.chosen !== 'safe').length;
-    return Math.max(0, APEX_NERVE_MAX - misreads * APEX_NERVE_COST);
+    return Math.max(0, apexNerveMax(user) - misreads * APEX_NERVE_COST);
 }
 
 /**
  * Resolve the played phases. 'safe' never costs nerve; a wrong aggressive
  * choice does. Returns { phaseResults, nerve } — at 0 nerve you lose the duel.
  */
-function resolveApexPhases(apexType, choicesMade) {
+function resolveApexPhases(apexType, choicesMade, user) {
     const phaseResults = [];
     for (let i = 0; i < choicesMade.length; i++) {
         const phase   = apexType.phases[i];
@@ -1150,7 +1193,7 @@ function resolveApexPhases(apexType, choicesMade) {
         const correct = chosen === phase.correct;
         phaseResults.push({ correct, chosen, correctChoice: phase.correct });
     }
-    return { phaseResults, nerve: apexNerveAfter(phaseResults) };
+    return { phaseResults, nerve: apexNerveAfter(phaseResults, user) };
 }
 
 /**
@@ -1161,7 +1204,7 @@ function resolveApexEncounter(user, animal, tier, choicesMade, apexType, weaponI
     const idx    = weaponIndex ?? user.hunt.equippedWeaponIndex;
     const weapon = user.hunt?.weapons[idx];
     const at     = apexType ?? rollApexType();
-    const { phaseResults, nerve } = resolveApexPhases(at, choicesMade);
+    const { phaseResults, nerve } = resolveApexPhases(at, choicesMade, user);
 
     const correctCount = phaseResults.filter(p => p.correct).length;
     const broken       = nerve <= 0;
@@ -1226,7 +1269,9 @@ module.exports = {
     rollApexType,
     resolveApexEncounter,
     apexNerveAfter,
+    apexNerveMax,
     APEX_NERVE_MAX,
+    FIELD_TROPHY_FLAGS,
     assignDailyHuntQuests,
     updateHuntQuestProgress,
     formatMs,

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -451,6 +451,25 @@ function rollFailureSeverity() {
 
 // ─── PAYOUT CALCULATION ───────────────────────────────────────────────────────
 
+// Payout decay by daily hunt count, steepest band first.
+const DIM_RETURNS_BANDS = [
+    { threshold: LIMITS.DIM_RETURNS_THRESHOLD_3, multiplier: 0.55 },
+    { threshold: LIMITS.DIM_RETURNS_THRESHOLD_2, multiplier: 0.70 },
+    { threshold: LIMITS.DIM_RETURNS_THRESHOLD_1, multiplier: 0.85 },
+];
+
+/** The diminishing-returns band a hunter is in, and where the next one starts. */
+function getDiminishingReturns(dailyHunts) {
+    const band = DIM_RETURNS_BANDS.find(b => dailyHunts >= b.threshold);
+    const next = [...DIM_RETURNS_BANDS].reverse().find(b => dailyHunts < b.threshold);
+    return {
+        multiplier: band?.multiplier ?? 1,
+        threshold:  band?.threshold ?? 0,
+        nextAt:     next?.threshold ?? null,
+        nextMultiplier: next?.multiplier ?? null,
+    };
+}
+
 /**
  * Applies anti-exploit modifiers to a raw payout:
  *   - Prestige payout bonus
@@ -477,14 +496,14 @@ function applyPayoutModifiers(user, rawPayout, zone, options = {}) {
     const presBonus = PRESTIGE_BONUSES[p].payoutBonus;
     if (presBonus > 0) payout *= (1 + presBonus);
 
+    // What the kill is worth before the day's own penalties take their cut. Kept
+    // so the embed can show the hunter what was taken and why — a payout that
+    // quietly shrinks by up to 72% reads as bad luck or a stealth nerf.
+    const grossPayout = Math.round(payout);
+
     // Diminishing returns based on daily hunt count
-    if (h.dailyHunts >= LIMITS.DIM_RETURNS_THRESHOLD_3) {
-        payout *= 0.55;
-    } else if (h.dailyHunts >= LIMITS.DIM_RETURNS_THRESHOLD_2) {
-        payout *= 0.70;
-    } else if (h.dailyHunts >= LIMITS.DIM_RETURNS_THRESHOLD_1) {
-        payout *= 0.85;
-    }
+    const dimReturns = getDiminishingReturns(h.dailyHunts);
+    payout *= dimReturns.multiplier;
 
     payout = Math.round(payout);
 
@@ -492,7 +511,7 @@ function applyPayoutModifiers(user, rawPayout, zone, options = {}) {
     // kill was worth so the embed can name the forfeited amount instead of
     // striking through a zero.
     if (h.dailyCoins >= LIMITS.DAILY_HARD_CAP) {
-        return { adjustedPayout: 0, cappedByHard: true, forfeitedPayout: payout };
+        return { adjustedPayout: 0, cappedByHard: true, forfeitedPayout: grossPayout };
     }
 
     // Applies the daily soft cap and clamps to the headroom left under the hard cap.
@@ -503,9 +522,29 @@ function applyPayoutModifiers(user, rawPayout, zone, options = {}) {
     const basePayout    = settle(payout);
     const doubledPayout = settle(payout * 2);
 
+    /** Which of the day's penalties actually bit, and by how much. */
+    const reportFor = (net, doubled) => {
+        const gross = doubled ? grossPayout * 2 : grossPayout;
+        return {
+            grossPayout: gross,
+            dimReturns:  dimReturns.multiplier < 1 ? dimReturns : null,
+            softCapped,
+            // The headroom clamp only shows up as its own line when it took more
+            // than the soft cap already had.
+            headroomClamped: net < (softCapped ? Math.round((doubled ? payout * 2 : payout) * 0.50)
+                                              : (doubled ? payout * 2 : payout)),
+            lostToDaily: Math.max(0, gross - net),
+        };
+    };
+
     // A doubling already paid for earlier this hunt — no second charge.
     if (options.reuseGatheringYield) {
-        return { adjustedPayout: doubledPayout, cappedByHard: false, gatheringYield: null };
+        return {
+            adjustedPayout: doubledPayout,
+            cappedByHard:   false,
+            gatheringYield: null,
+            dailyReport:    reportFor(doubledPayout, true),
+        };
     }
 
     // Silvered Talisman / Voidsteel Cache: 2x yield, consume 1 charge from whichever
@@ -525,10 +564,16 @@ function applyPayoutModifiers(user, rawPayout, zone, options = {}) {
                 emoji:       cfg?.emoji ?? '✨',
                 chargesLeft: getEffect(user, gatherEffect)?.charges ?? 0,
             },
+            dailyReport: reportFor(doubledPayout, true),
         };
     }
 
-    return { adjustedPayout: basePayout, cappedByHard: false, gatheringYield: null };
+    return {
+        adjustedPayout: basePayout,
+        cappedByHard:   false,
+        gatheringYield: null,
+        dailyReport:    reportFor(basePayout, false),
+    };
 }
 
 // ─── DURABILITY ───────────────────────────────────────────────────────────────
@@ -858,7 +903,7 @@ function executeHunt(user, zoneId, options = {}) {
             result.traitEffects.push({ trait: 'enraged', msg: 'Its fury drove the prize higher (+25% payout).' });
         }
 
-        const { adjustedPayout, cappedByHard, gatheringYield, forfeitedPayout } = applyPayoutModifiers(user, payoutBeforeMods, zone);
+        const { adjustedPayout, cappedByHard, gatheringYield, forfeitedPayout, dailyReport } = applyPayoutModifiers(user, payoutBeforeMods, zone);
 
         // Special drop
         let specialDrop = null;
@@ -938,6 +983,7 @@ function executeHunt(user, zoneId, options = {}) {
             levelUp: lvResult.leveledUp ? lvResult : null,
             cappedByHard,
             forfeitedPayout,
+            dailyReport,
             gatheringYield,
             streakMult
         });
@@ -1253,6 +1299,7 @@ module.exports = {
     getRarePityThreshold,
     rollFailureSeverity,
     applyPayoutModifiers,
+    getDiminishingReturns,
     applyDurabilityLoss,
     updateWeaponStatus,
     isCondemned,

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -131,6 +131,13 @@ function msUntilNextStamina(user) {
 
 // ─── DAILY WINDOW ────────────────────────────────────────────────────────────
 
+/** Ms until the rolling 24h daily window rolls over (0 if it already has). */
+function msUntilDailyReset(h) {
+    if (!h?.dailyWindowStart) return 0;
+    const elapsed = Date.now() - h.dailyWindowStart.getTime();
+    return Math.max(0, LIMITS.DAILY_WINDOW_MS - elapsed);
+}
+
 /**
  * Resets daily counters if the rolling 24h window has expired.
  * Also resets the stamina tonic daily limit.
@@ -304,6 +311,19 @@ function randInt(min, max) {
 // ─── TIER ROLL ───────────────────────────────────────────────────────────────
 
 /**
+ * How many hunts without a rare+ kill before the zone guarantees one.
+ *
+ * Scaled per zone rather than flat: a single global threshold tuned for the
+ * starter zone's 18% rare+ rate is unreachable everywhere else — at Legendary
+ * Peaks' 63% a 50-hunt dry streak is a 1-in-10^16 event, so the promise the
+ * pity bar makes would never once be kept. Each zone's number is set so a dry
+ * streak is a comparably rare tail event wherever you hunt.
+ */
+function getRarePityThreshold(zone) {
+    return zone?.rarePity ?? LIMITS.RARE_PITY_GUARANTEE;
+}
+
+/**
  * Rolls an animal tier from the zone's weighted table.
  * Bait consumables shift weight from common → rare/epic tiers.
  */
@@ -364,8 +384,9 @@ function rollTier(user, zone) {
         w.legendary += scopeShift * 0.1;
     }
 
-    // Pity guarantee: at sinceRare threshold, force rare+ by zeroing out common/uncommon
-    if ((user.hunt.sinceRare ?? 0) >= LIMITS.RARE_PITY_GUARANTEE) {
+    // Pity guarantee: at the zone's sinceRare threshold, force rare+ by zeroing out
+    // common/uncommon.
+    if ((user.hunt.sinceRare ?? 0) >= getRarePityThreshold(zone)) {
         w.common   = 0;
         w.uncommon = 0;
         if ((w.rare ?? 0) + (w.epic ?? 0) + (w.legendary ?? 0) + (w.event ?? 0) === 0) {
@@ -450,9 +471,11 @@ function applyPayoutModifiers(user, rawPayout, zone, options = {}) {
 
     payout = Math.round(payout);
 
-    // Hard cap: zero coins — check before consuming item charges
+    // Hard cap: zero coins — check before consuming item charges. Report what the
+    // kill was worth so the embed can name the forfeited amount instead of
+    // striking through a zero.
     if (h.dailyCoins >= LIMITS.DAILY_HARD_CAP) {
-        return { adjustedPayout: 0, cappedByHard: true };
+        return { adjustedPayout: 0, cappedByHard: true, forfeitedPayout: payout };
     }
 
     // Applies the daily soft cap and clamps to the headroom left under the hard cap.
@@ -811,7 +834,7 @@ function executeHunt(user, zoneId, options = {}) {
             result.traitEffects.push({ trait: 'enraged', msg: 'Its fury drove the prize higher (+25% payout).' });
         }
 
-        const { adjustedPayout, cappedByHard, gatheringYield } = applyPayoutModifiers(user, payoutBeforeMods, zone);
+        const { adjustedPayout, cappedByHard, gatheringYield, forfeitedPayout } = applyPayoutModifiers(user, payoutBeforeMods, zone);
 
         // Special drop
         let specialDrop = null;
@@ -884,6 +907,7 @@ function executeHunt(user, zoneId, options = {}) {
             specialDrop, xpEarned: xpGain,
             levelUp: lvResult.leveledUp ? lvResult : null,
             cappedByHard,
+            forfeitedPayout,
             gatheringYield,
             streakMult
         });
@@ -1099,23 +1123,34 @@ function rollApexType() {
     return APEX_TYPES[keys[Math.floor(Math.random() * keys.length)]];
 }
 
+// Nerve: the duel's second axis. A wrong aggressive read costs two, so two bad
+// guesses end the fight outright even if the third phase lands — which is what
+// makes the 'safe' option a real hedge rather than a slower way to lose. At one
+// nerve per wrong guess the bar could never reach 0 without also leaving zero
+// correct phases, so it decided nothing and the hunter watched a health bar that
+// was pure decoration.
+const APEX_NERVE_MAX  = 3;
+const APEX_NERVE_COST = 2;
+
+/** Nerve left after the given phase results. */
+function apexNerveAfter(phaseResults) {
+    const misreads = phaseResults.filter(p => !p.correct && p.chosen !== 'safe').length;
+    return Math.max(0, APEX_NERVE_MAX - misreads * APEX_NERVE_COST);
+}
+
 /**
  * Resolve the played phases. 'safe' never costs nerve; a wrong aggressive
  * choice does. Returns { phaseResults, nerve } — at 0 nerve you lose the duel.
  */
 function resolveApexPhases(apexType, choicesMade) {
-    let nerve = 3;
     const phaseResults = [];
     for (let i = 0; i < choicesMade.length; i++) {
         const phase   = apexType.phases[i];
         const chosen  = choicesMade[i];
         const correct = chosen === phase.correct;
-        if (!correct && chosen !== 'safe') {
-            nerve = Math.max(0, nerve - 1);
-        }
         phaseResults.push({ correct, chosen, correctChoice: phase.correct });
     }
-    return { phaseResults, nerve };
+    return { phaseResults, nerve: apexNerveAfter(phaseResults) };
 }
 
 /**
@@ -1167,10 +1202,12 @@ module.exports = {
     applyStaminaRegen,
     msUntilNextStamina,
     applyDailyReset,
+    msUntilDailyReset,
     calculateSuccessChance,
     calculateCritChance,
     rollTier,
     rollAnimal,
+    getRarePityThreshold,
     rollFailureSeverity,
     applyPayoutModifiers,
     applyDurabilityLoss,
@@ -1188,6 +1225,8 @@ module.exports = {
     executeHunt,
     rollApexType,
     resolveApexEncounter,
+    apexNerveAfter,
+    APEX_NERVE_MAX,
     assignDailyHuntQuests,
     updateHuntQuestProgress,
     formatMs,

--- a/tests/huntApexNerve.test.js
+++ b/tests/huntApexNerve.test.js
@@ -1,0 +1,128 @@
+'use strict';
+
+const {
+    resolveApexEncounter,
+    apexNerveAfter,
+    APEX_NERVE_MAX,
+    getRarePityThreshold,
+    msUntilDailyReset,
+    applyPayoutModifiers,
+} = require('../src/services/huntService');
+const { APEX_TYPES, ZONES, ZONE_LIST, LIMITS } = require('../src/data/huntData');
+
+const APEX = APEX_TYPES.dire_alpha;   // strategy: 'match'
+const ANIMAL = { payoutMin: 100, payoutMax: 100 };
+
+function duel(choices) {
+    const user = { hunt: { equippedWeaponIndex: -1, weapons: [] }, markModified() {} };
+    return resolveApexEncounter(user, ANIMAL, 'legendary', choices, APEX, -1);
+}
+
+describe('apex nerve', () => {
+    it('busts the duel on two misreads even when a phase landed', () => {
+        // One correct read, two wrong aggressive reads: nerve is spent, so the
+        // apex escapes despite the hit. This is the case that used to pay out.
+        const result = duel(['match', 'hold', 'hold']);
+        expect(result.correctCount).toBe(1);
+        expect(result.outcome).toBe('escaped');
+        expect(result.bonusPayout).toBe(0);
+    });
+
+    it('lets backing off preserve a partial reward', () => {
+        // Same single correct read, but the hunter hedged instead of guessing
+        // wrong a second time.
+        const result = duel(['match', 'hold', 'safe']);
+        expect(result.correctCount).toBe(1);
+        expect(result.outcome).toBe('survived');
+        expect(result.bonusPayout).toBeGreaterThan(0);
+    });
+
+    it('never charges nerve for backing off', () => {
+        const results = [
+            { correct: false, chosen: 'safe' },
+            { correct: false, chosen: 'safe' },
+            { correct: false, chosen: 'safe' },
+        ];
+        expect(apexNerveAfter(results)).toBe(APEX_NERVE_MAX);
+    });
+
+    it('still rewards a flawless read', () => {
+        const result = duel(['match', 'match', 'match']);
+        expect(result.outcome).toBe('perfect');
+        expect(apexNerveAfter(result.phaseResults)).toBe(APEX_NERVE_MAX);
+    });
+
+    it('reports zero nerve exactly when the duel was lost to misreads', () => {
+        for (const choices of [['match', 'hold', 'hold'], ['hold', 'hold', 'match']]) {
+            const result = duel(choices);
+            expect(apexNerveAfter(result.phaseResults)).toBe(0);
+            expect(result.outcome).toBe('escaped');
+        }
+    });
+});
+
+describe('rare pity threshold', () => {
+    it('is set explicitly for every zone', () => {
+        for (const zone of ZONE_LIST) {
+            expect(typeof zone.rarePity).toBe('number');
+            expect(getRarePityThreshold(zone)).toBe(zone.rarePity);
+        }
+    });
+
+    it('falls back to the global limit for a zone that sets none', () => {
+        expect(getRarePityThreshold({})).toBe(LIMITS.RARE_PITY_GUARANTEE);
+        expect(getRarePityThreshold(undefined)).toBe(LIMITS.RARE_PITY_GUARANTEE);
+    });
+
+    it('is reachable in every zone, not just the starter one', () => {
+        // A dry streak should be a rare-but-real tail event wherever you hunt.
+        // The flat 50 it replaced was a 1-in-10^16 event at Legendary Peaks.
+        const SUCCESS_RATE = 0.75;
+        for (const zone of ZONE_LIST) {
+            const weights  = zone.tierWeights;
+            const total    = Object.values(weights).reduce((a, b) => a + b, 0);
+            const rarePlus = (weights.rare + weights.epic + weights.legendary + weights.event) / total;
+            const pDry     = Math.pow(1 - SUCCESS_RATE * rarePlus, zone.rarePity);
+            expect(1 / pDry).toBeLessThan(2000);
+        }
+    });
+
+    it('gets stricter as zones get richer', () => {
+        expect(ZONES.beginner_forest.rarePity).toBeGreaterThan(ZONES.desert_wastes.rarePity);
+        expect(ZONES.desert_wastes.rarePity).toBeGreaterThan(ZONES.arctic_tundra.rarePity);
+        expect(ZONES.murky_swamp.rarePity).toBeGreaterThan(ZONES.legendary_peaks.rarePity);
+    });
+});
+
+describe('daily hard cap reporting', () => {
+    function cappedUser() {
+        return {
+            balance: 0,
+            hunt: {
+                dailyCoins: LIMITS.DAILY_HARD_CAP + 1,
+                dailyHunts: 0,
+                prestige: 0,
+                dailyWindowStart: new Date(Date.now() - 6 * 3600_000),
+            },
+        };
+    }
+
+    it('names what the kill was worth instead of paying zero silently', () => {
+        const result = applyPayoutModifiers(cappedUser(), 4321, ZONES.beginner_forest);
+        expect(result.cappedByHard).toBe(true);
+        expect(result.adjustedPayout).toBe(0);
+        expect(result.forfeitedPayout).toBe(4321);
+    });
+
+    it('reports the time left on the rolling window', () => {
+        const h = cappedUser().hunt;
+        const remaining = msUntilDailyReset(h);
+        expect(remaining).toBeGreaterThan(17 * 3600_000);
+        expect(remaining).toBeLessThanOrEqual(18 * 3600_000);
+    });
+
+    it('reports no wait for a window that has not started', () => {
+        expect(msUntilDailyReset({ dailyWindowStart: null })).toBe(0);
+        expect(msUntilDailyReset(undefined)).toBe(0);
+    });
+});

--- a/tests/huntDailyLimits.test.js
+++ b/tests/huntDailyLimits.test.js
@@ -1,0 +1,168 @@
+'use strict';
+
+jest.mock('../src/models/Guild', () => ({ findOne: jest.fn().mockResolvedValue(null) }));
+jest.mock('../src/models/User', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../src/models/GrindProfile', () => ({ find: jest.fn(), findOneAndUpdate: jest.fn() }));
+
+const { applyPayoutModifiers, getDiminishingReturns } = require('../src/services/huntService');
+const { ZONES, LIMITS } = require('../src/data/huntData');
+const { __test__ } = require('../src/commands/economy/hunt');
+const { buildDailyTollField, buildTodayField } = __test__;
+
+const FRESH_WINDOW = () => new Date(Date.now() - 3600_000);
+
+function hunter({ hunts = 0, coins = 0 } = {}) {
+    return {
+        balance: 0,
+        hunt: { dailyHunts: hunts, dailyCoins: coins, prestige: 0, dailyWindowStart: FRESH_WINDOW() },
+    };
+}
+
+function payout(opts, raw = 1000) {
+    return applyPayoutModifiers(hunter(opts), raw, ZONES.beginner_forest);
+}
+
+describe('diminishing returns bands', () => {
+    it('is a clean multiplier below the first threshold', () => {
+        const dim = getDiminishingReturns(LIMITS.DIM_RETURNS_THRESHOLD_1 - 1);
+        expect(dim.multiplier).toBe(1);
+        expect(dim.nextAt).toBe(LIMITS.DIM_RETURNS_THRESHOLD_1);
+    });
+
+    it('steps down at each threshold', () => {
+        expect(getDiminishingReturns(LIMITS.DIM_RETURNS_THRESHOLD_1).multiplier).toBeCloseTo(0.85);
+        expect(getDiminishingReturns(LIMITS.DIM_RETURNS_THRESHOLD_2).multiplier).toBeCloseTo(0.70);
+        expect(getDiminishingReturns(LIMITS.DIM_RETURNS_THRESHOLD_3).multiplier).toBeCloseTo(0.55);
+    });
+
+    it('has nowhere further to fall in the last band', () => {
+        const dim = getDiminishingReturns(LIMITS.DIM_RETURNS_THRESHOLD_3 + 50);
+        expect(dim.nextAt).toBeNull();
+        expect(dim.nextMultiplier).toBeNull();
+    });
+
+    it('points at the next band from inside the current one', () => {
+        const dim = getDiminishingReturns(LIMITS.DIM_RETURNS_THRESHOLD_1 + 1);
+        expect(dim.threshold).toBe(LIMITS.DIM_RETURNS_THRESHOLD_1);
+        expect(dim.nextAt).toBe(LIMITS.DIM_RETURNS_THRESHOLD_2);
+        expect(dim.nextMultiplier).toBeCloseTo(0.70);
+    });
+});
+
+describe('payout reporting', () => {
+    it('reports nothing withheld on a fresh day', () => {
+        const { adjustedPayout, dailyReport } = payout({});
+        expect(adjustedPayout).toBe(1000);
+        expect(dailyReport.lostToDaily).toBe(0);
+        expect(dailyReport.dimReturns).toBeNull();
+        expect(dailyReport.softCapped).toBe(false);
+    });
+
+    it('names the diminishing-returns cut', () => {
+        const { adjustedPayout, dailyReport } = payout({ hunts: LIMITS.DIM_RETURNS_THRESHOLD_1 + 5 });
+        expect(adjustedPayout).toBe(850);
+        expect(dailyReport.grossPayout).toBe(1000);
+        expect(dailyReport.lostToDaily).toBe(150);
+        expect(dailyReport.dimReturns.multiplier).toBeCloseTo(0.85);
+    });
+
+    it('names the soft cap', () => {
+        const { adjustedPayout, dailyReport } = payout({ coins: LIMITS.DAILY_SOFT_CAP + 1000 });
+        expect(adjustedPayout).toBe(500);
+        expect(dailyReport.softCapped).toBe(true);
+        expect(dailyReport.lostToDaily).toBe(500);
+    });
+
+    it('accounts for both penalties stacking', () => {
+        const { adjustedPayout, dailyReport } = payout({
+            hunts: LIMITS.DIM_RETURNS_THRESHOLD_3 + 1,
+            coins: LIMITS.DAILY_SOFT_CAP + 1000,
+        });
+        // 1000 → x0.55 diminishing → 550 → halved by the soft cap → 275.
+        expect(adjustedPayout).toBe(275);
+        expect(dailyReport.dimReturns.multiplier).toBeCloseTo(0.55);
+        expect(dailyReport.softCapped).toBe(true);
+        expect(dailyReport.lostToDaily).toBe(725);
+    });
+
+    it('flags the headroom clamp only when it bites beyond the soft cap', () => {
+        const roomy = payout({ coins: LIMITS.DAILY_HARD_CAP - 5000 });
+        expect(roomy.dailyReport.headroomClamped).toBe(false);
+
+        const tight = payout({ coins: LIMITS.DAILY_HARD_CAP - 100 });
+        expect(tight.adjustedPayout).toBe(100);
+        expect(tight.dailyReport.headroomClamped).toBe(true);
+    });
+
+    it('reports the gross for a doubled payout in doubled terms', () => {
+        const user = hunter({ hunts: LIMITS.DIM_RETURNS_THRESHOLD_1 });
+        const result = applyPayoutModifiers(user, 1000, ZONES.beginner_forest, { reuseGatheringYield: true });
+        expect(result.adjustedPayout).toBe(1700);
+        expect(result.dailyReport.grossPayout).toBe(2000);
+        expect(result.dailyReport.lostToDaily).toBe(300);
+    });
+});
+
+describe('the Daily Limits embed field', () => {
+    function field(opts, raw = 1000) {
+        const user = hunter(opts);
+        const result = { dailyReport: payout(opts, raw).dailyReport };
+        return buildDailyTollField(result, user, '💰');
+    }
+
+    it('stays off when nothing was withheld', () => {
+        expect(field({})).toBeNull();
+    });
+
+    it('stays off when the hunt never reached the payout stage', () => {
+        expect(buildDailyTollField({}, hunter(), '💰')).toBeNull();
+    });
+
+    it('explains a diminishing-returns cut and where the next one lands', () => {
+        const f = field({ hunts: LIMITS.DIM_RETURNS_THRESHOLD_1 + 1 });
+        expect(f.value).toContain('Diminishing returns');
+        expect(f.value).toContain('−15%');
+        expect(f.value).toContain(String(LIMITS.DIM_RETURNS_THRESHOLD_2));
+    });
+
+    it('explains the soft cap and says what the kill was worth', () => {
+        const f = field({ coins: LIMITS.DAILY_SOFT_CAP + 1 });
+        expect(f.value).toContain('soft cap');
+        expect(f.value).toContain('💰1,000');   // gross
+        expect(f.value).toContain('💰500');     // withheld
+        expect(f.value).toMatch(/Resets in/);
+    });
+
+    it('fits Discord limits with every penalty active', () => {
+        const f = field({ hunts: 200, coins: LIMITS.DAILY_HARD_CAP - 50 }, 50_000);
+        expect(f.value.length).toBeLessThanOrEqual(1024);
+        expect(f.name.length).toBeLessThanOrEqual(256);
+    });
+});
+
+describe('the Today profile field', () => {
+    it('shows the wall before a hunter reaches it', () => {
+        const f = buildTodayField({ dailyHunts: 10, dailyCoins: 5000, dailyWindowStart: FRESH_WINDOW() }, '💰');
+        expect(f.value).toContain('×1.00');
+        expect(f.value).toContain(`Drops to ×0.85 at ${LIMITS.DIM_RETURNS_THRESHOLD_1} hunts`);
+        expect(f.value).toContain('Soft cap');
+    });
+
+    it('says plainly when the soft cap is already biting', () => {
+        const f = buildTodayField({ dailyHunts: 95, dailyCoins: 92_000, dailyWindowStart: FRESH_WINDOW() }, '💰');
+        expect(f.value).toContain('×0.70');
+        expect(f.value).toContain('payouts halved');
+    });
+
+    it('handles a hunter who has not hunted today', () => {
+        const f = buildTodayField({}, '💰');
+        expect(f.value).toContain('×1.00');
+        expect(f.value.length).toBeLessThanOrEqual(1024);
+    });
+
+    it('fits Discord limits at the hard cap', () => {
+        const f = buildTodayField({ dailyHunts: 500, dailyCoins: LIMITS.DAILY_HARD_CAP, dailyWindowStart: FRESH_WINDOW() }, '💰');
+        expect(f.value.length).toBeLessThanOrEqual(1024);
+        expect(f.value).toContain('█'.repeat(12));
+    });
+});

--- a/tests/huntEmbedFields.test.js
+++ b/tests/huntEmbedFields.test.js
@@ -23,6 +23,8 @@ function maximalUser() {
         hunt: {
             level: 25, xp: 13_000, prestige: 3, stamina: 7,
             consecutiveFails: 0, sinceRare: 49,
+            dailyHunts: 140, dailyCoins: 149_000,
+            dailyWindowStart: new Date(Date.now() - 3600_000),
             trophies: [], activeBait: 'premium_bait', activeBaitHuntsLeft: 1,
             activeCharm: 'luck_charm', activeCharmHuntsLeft: 1,
             activeFocus: true, activeXpScroll: true,
@@ -51,6 +53,15 @@ function maximalSuccessResult() {
         xpEarned: 260,
         levelUp: { oldLevel: 24, newLevel: 25 },
         cappedByHard: false,
+        // Every daily penalty biting at once, so the budget test counts the
+        // "Daily Limits" field too.
+        dailyReport: {
+            grossPayout: 15_000,
+            dimReturns:  { multiplier: 0.55, threshold: 120, nextAt: null, nextMultiplier: null },
+            softCapped:  true,
+            headroomClamped: true,
+            lostToDaily: 10_679,
+        },
         streakMult: 1.5,
         expiredBait: 'premium_bait',
         expiredCharm: 'luck_charm',

--- a/tests/huntEmbedFields.test.js
+++ b/tests/huntEmbedFields.test.js
@@ -165,3 +165,43 @@ describe('hunt failure embed field budget', () => {
         }
     });
 });
+
+describe('trophy case', () => {
+    const { buildTrophyField } = __test__;
+    const QUALITIES = TROPHY_QUALITIES.filter(q => q.id !== 'poor' && q.id !== 'normal');
+
+    /** Every trophy string the game can ever store, in discovery order. */
+    function everyTrophy() {
+        const all = [];
+        for (const animal of Object.values(ANIMALS)) {
+            for (const q of QUALITIES) all.push(`${q.emoji} ${q.label} ${animal.name}`);
+        }
+        return all;
+    }
+
+    it('keeps the field inside Discord limits for a full collection', () => {
+        const field = buildTrophyField(everyTrophy());
+        expect(field.value.length).toBeLessThanOrEqual(MAX_FIELD_VALUE);
+        expect(field.name.length).toBeLessThanOrEqual(MAX_FIELD_NAME);
+    });
+
+    it('reports the full count even when the list is trimmed', () => {
+        const all   = everyTrophy();
+        const field = buildTrophyField(all);
+        expect(field.name).toContain(String(all.length));
+        expect(field.value).toMatch(/\+\d+ more$/);
+    });
+
+    it('shows the best trophies first', () => {
+        const mythic   = `🟣 Mythic ${ANIMALS.rabbit.name}`;
+        const field    = buildTrophyField([...everyTrophy(), mythic].reverse());
+        expect(field.value.startsWith('🟣')).toBe(true);
+    });
+
+    it('lists a small collection in full with no tail', () => {
+        const few = ['🟢 Good Rabbit', '🔷 Pristine Wolf'];
+        const field = buildTrophyField(few);
+        expect(field.value).toBe('🔷 Pristine Wolf, 🟢 Good Rabbit');
+        expect(field.name).toBe('🏆 Trophies (2)');
+    });
+});

--- a/tests/huntMaterialSinks.test.js
+++ b/tests/huntMaterialSinks.test.js
@@ -1,0 +1,255 @@
+'use strict';
+
+jest.mock('../src/models/Guild', () => ({ findOne: jest.fn().mockResolvedValue(null) }));
+jest.mock('../src/models/User', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../src/models/GrindProfile', () => ({ find: jest.fn(), findOneAndUpdate: jest.fn() }));
+
+const {
+    ensureHuntData,
+    getMaxStamina,
+    applyDurabilityLoss,
+    apexNerveAfter,
+    apexNerveMax,
+    rollTier,
+    executeHunt,
+    FIELD_TROPHY_FLAGS,
+} = require('../src/services/huntService');
+const {
+    ANIMALS, CRAFT_RECIPES, FIELD_TROPHIES, ZONES, ZONE_LIST, LIMITS, WEAPON_BY_TIER,
+} = require('../src/data/huntData');
+const { CROSS_CRAFT_RECIPES } = require('../src/data/crossSystemData');
+const { __test__ } = require('../src/commands/economy/hunt');
+const { buildFieldTrophyField } = __test__;
+
+/** Every material any recipe can consume, hunt-side and cross-system. */
+function craftableMaterials() {
+    const used = new Set();
+    for (const recipe of [...Object.values(CRAFT_RECIPES), ...Object.values(CROSS_CRAFT_RECIPES)]) {
+        for (const ing of recipe.ingredients ?? []) used.add(ing.material);
+    }
+    return used;
+}
+
+/** Every material a hunt can actually drop. */
+function droppableMaterials() {
+    const drops = new Set();
+    for (const animal of Object.values(ANIMALS)) {
+        if (animal.specialDrop) drops.add(animal.specialDrop.itemId);
+    }
+    return drops;
+}
+
+describe('material sinks', () => {
+    it('leaves no droppable material without a recipe', () => {
+        const used = craftableMaterials();
+        const dead = [...droppableMaterials()].filter(m => !used.has(m));
+        expect(dead).toEqual([]);
+    });
+
+    it('gives every zone past the starter one a recipe fed by its own drops', () => {
+        const used = craftableMaterials();
+        for (const zone of ZONE_LIST) {
+            const fed = zone.zoneMaterials.filter(m => used.has(m));
+            expect(fed.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('never asks for a material that no animal drops', () => {
+        const drops = droppableMaterials();
+        const phantom = [];
+        for (const recipe of Object.values(CRAFT_RECIPES)) {
+            for (const ing of recipe.ingredients) {
+                if (!drops.has(ing.material)) phantom.push(`${recipe.id}:${ing.material}`);
+            }
+        }
+        expect(phantom).toEqual([]);
+    });
+});
+
+describe('field trophies', () => {
+    function hunter(overrides = {}) {
+        const user = { balance: 0, hunt: {}, markModified() {} };
+        ensureHuntData(user);
+        Object.assign(user.hunt, overrides);
+        return user;
+    }
+
+    it('defaults every flag to false for a new hunter', () => {
+        const user = hunter();
+        for (const flag of FIELD_TROPHY_FLAGS) expect(user.hunt[flag]).toBe(false);
+    });
+
+    it('has exactly one craftable recipe per trophy', () => {
+        for (const flag of FIELD_TROPHY_FLAGS) {
+            const recipes = Object.values(CRAFT_RECIPES).filter(r => r.output?.id === flag);
+            expect(recipes).toHaveLength(1);
+            expect(recipes[0].unique).toBe(true);
+            expect(recipes[0].output.type).toBe('hunt_permanent');
+        }
+    });
+
+    it('sources each zone-bound trophy from that zone\'s own materials', () => {
+        for (const [flag, trophy] of Object.entries(FIELD_TROPHIES)) {
+            if (!trophy.zone) continue;
+            const recipe = Object.values(CRAFT_RECIPES).find(r => r.output?.id === flag);
+            const zoneMats = ZONES[trophy.zone].zoneMaterials;
+            for (const ing of recipe.ingredients) {
+                expect(zoneMats).toContain(ing.material);
+            }
+        }
+    });
+
+    describe('Woodland Instinct', () => {
+        it('raises the stamina ceiling by one', () => {
+            const without = getMaxStamina(hunter());
+            const with_   = getMaxStamina(hunter({ woodlandInstinct: true }));
+            expect(with_).toBe(without + 1);
+        });
+    });
+
+    describe('Insulated Kit', () => {
+        const weapon = () => ({ tier: 4, baseDurability: 100, maxDurability: 100, currentDurability: 100 });
+
+        it('shaves a point off a durability hit', () => {
+            const w = weapon();
+            applyDurabilityLoss(w, 5, 1);
+            expect(w.currentDurability).toBe(96);
+        });
+
+        it('stacks with a reinforced stock', () => {
+            const w = { ...weapon(), upgrade: 'reinforced_stock' };
+            applyDurabilityLoss(w, 5, 1);
+            expect(w.currentDurability).toBe(97);
+        });
+
+        it('never reduces a hit below one point', () => {
+            const w = { ...weapon(), upgrade: 'reinforced_stock' };
+            applyDurabilityLoss(w, 1, 1);
+            expect(w.currentDurability).toBe(99);
+        });
+    });
+
+    describe("Apex Predator's Mark", () => {
+        it('grants a whole extra misread, not a point that rounds away', () => {
+            // Nerve is only ever spent two at a time, so +1 would buy nothing.
+            expect(apexNerveMax(hunter())).toBe(3);
+            expect(apexNerveMax(hunter({ apexPredatorsMark: true }))).toBe(5);
+        });
+
+        it('lets a marked hunter survive two misreads that would otherwise bust', () => {
+            const misreads = [
+                { correct: false, chosen: 'match' },
+                { correct: false, chosen: 'match' },
+            ];
+            expect(apexNerveAfter(misreads, hunter())).toBe(0);
+            expect(apexNerveAfter(misreads, hunter({ apexPredatorsMark: true }))).toBeGreaterThan(0);
+        });
+    });
+
+    describe("Stormcaller's Totem", () => {
+        it('puts mythical prey in the starter forest, which otherwise has none', () => {
+            expect(ZONES.beginner_forest.tierWeights.event).toBe(0);
+
+            const user = hunter({ stormcallersTotem: true, weapons: [], equippedWeaponIndex: -1 });
+            const tiers = new Set();
+            for (let i = 0; i < 20_000; i++) tiers.add(rollTier(user, ZONES.beginner_forest));
+            expect(tiers.has('event')).toBe(true);
+        });
+
+        it('leaves the starter forest free of mythical prey without it', () => {
+            const user = hunter({ weapons: [], equippedWeaponIndex: -1 });
+            for (let i = 0; i < 5_000; i++) {
+                expect(rollTier(user, ZONES.beginner_forest)).not.toBe('event');
+            }
+        });
+    });
+
+    describe("Venom Ward and Swampwalker's Charm", () => {
+        /** Run hunts until the trait under test has fired, collecting the messages. */
+        function traitMessages(overrides, zoneId, trait, runs = 4000) {
+            const messages = [];
+            for (let i = 0; i < runs; i++) {
+                const user = hunter({
+                    level: 50, stamina: 10, activeZone: zoneId, equippedWeaponIndex: 0,
+                    weapons: [{
+                        tier: 12, name: 'Altair Rifle', upgrade: null, repairCount: 0,
+                        baseDurability: 400, maxDurability: 400, currentDurability: 400, status: 'good',
+                    }],
+                    ...overrides,
+                });
+                const before = user.hunt.stamina;
+                const result = executeHunt(user, zoneId);
+                if (!result.traits?.includes(trait)) continue;
+                messages.push({
+                    success:      result.success,
+                    effects:      (result.traitEffects ?? []).map(e => e.msg),
+                    staminaSpent: before - user.hunt.stamina,
+                    durability:   result.durabilityLost,
+                });
+            }
+            return messages;
+        }
+
+        it('spares the extra stamina venomous prey normally costs', () => {
+            const plain  = traitMessages({}, 'murky_swamp', 'venomous').filter(m => m.success);
+            const warded = traitMessages({ venomWard: true }, 'murky_swamp', 'venomous').filter(m => m.success);
+
+            expect(plain.length).toBeGreaterThan(0);
+            expect(warded.length).toBeGreaterThan(0);
+
+            // Unwarded, a venomous kill costs the hunt's point plus one more.
+            expect(plain.some(m => m.staminaSpent === 2)).toBe(true);
+            // Warded, it never costs more than the hunt itself.
+            expect(warded.every(m => m.staminaSpent <= 1)).toBe(true);
+            expect(warded.some(m => m.effects.some(msg => msg.includes('Venom Ward')))).toBe(true);
+        });
+
+        it('keeps a pack from savaging the weapon on a failed hunt', () => {
+            const plain   = traitMessages({}, 'legendary_peaks', 'pack_hunter').filter(m => !m.success);
+            const charmed = traitMessages({ swampwalkersCharm: true }, 'legendary_peaks', 'pack_hunter').filter(m => !m.success);
+
+            expect(plain.length).toBeGreaterThan(0);
+            expect(charmed.length).toBeGreaterThan(0);
+
+            // The pack adds 3 durability damage on top of the failure severity,
+            // whose worst case is 5.
+            expect(plain.some(m => m.durability > 5)).toBe(true);
+            expect(charmed.every(m => m.durability <= 5)).toBe(true);
+            expect(charmed.some(m => m.effects.some(msg => msg.includes('Swampwalker')))).toBe(true);
+        });
+
+        it('halves how often aggressive prey injures a successful hunter', () => {
+            const plain   = traitMessages({}, 'murky_swamp', 'aggressive').filter(m => m.success);
+            const charmed = traitMessages({ swampwalkersCharm: true }, 'murky_swamp', 'aggressive').filter(m => m.success);
+
+            const injuryRate = rows =>
+                rows.filter(m => m.effects.some(msg => msg.includes('injuring you'))).length / rows.length;
+
+            expect(plain.length).toBeGreaterThan(100);
+            expect(charmed.length).toBeGreaterThan(100);
+            expect(injuryRate(charmed)).toBeLessThan(injuryRate(plain));
+        });
+    });
+});
+
+describe('permanent upgrade profile field', () => {
+    it('is omitted for a hunter who owns nothing', () => {
+        expect(buildFieldTrophyField({})).toBeNull();
+    });
+
+    it('lists what each owned upgrade does', () => {
+        const field = buildFieldTrophyField({ woodlandInstinct: true, luckyPaw: true });
+        expect(field.name).toContain('2/');
+        expect(field.value).toContain('Woodland Instinct');
+        expect(field.value).toContain('Lucky Paw');
+        expect(field.value).toContain(FIELD_TROPHIES.woodlandInstinct.effect);
+    });
+
+    it('stays inside Discord limits with every upgrade owned', () => {
+        const everything = { luckyPaw: true, precisionScope: true };
+        for (const flag of FIELD_TROPHY_FLAGS) everything[flag] = true;
+        const field = buildFieldTrophyField(everything);
+        expect(field.value.length).toBeLessThanOrEqual(1024);
+        expect(field.name.length).toBeLessThanOrEqual(256);
+    });
+});


### PR DESCRIPTION
## Summary

A review of `/hunt` after several months of live use. Four commits: one crash fix, three UI elements that reported numbers meaning something other than what they said, a set of material sinks, and disclosure of the daily limits that quietly throttle payouts.

Remaining review findings that aren't in this PR are filed as #739–#747.

## 1 — `/hunt profile` breaks for veteran hunters

`h.trophies` grows forever and was joined into a single embed field. Discord caps a field value at 1024 characters, which the list crosses at **56 unique trophies** (186 are possible). Past that the API rejects the embed and the command stops working entirely — for exactly the players who have played longest.

Now shows the best trophies first with a count and a `+N more` tail.

## 2 — Three UI elements that weren't telling the truth

**Apex nerve could never decide a duel.** A wrong read cost one of three nerve, so the bar only emptied when all three phases were wrong — which already lost on correct-count alone. Backing off was strictly dominated: it never counted and protected nothing. A misread now costs two, so two bad guesses end the fight even if the third lands, and hedging became a real choice. Verified across all 27 choice combinations.

**The rare pity guarantee was unreachable.** A flat threshold of 50 was tuned for the starter zone's 18% rare+ rate. At Legendary Peaks' 63%, a 50-hunt dry streak is a 1-in-10¹⁶ event — the bar counted toward a promise that would never once have been kept.

| Zone | rare+ | Old odds of reaching 50 | New threshold |
|---|---|---|---|
| Beginner Forest | 18% | ~1 in 4,000 | 35 |
| Desert Wastes | 28% | ~1 in 800,000 | 21 |
| Arctic Tundra | 37% | ~1 in 158 million | 15 |
| Murky Swamp | 41% | ~1 in 1.3 billion | 14 |
| Legendary Peaks | 63% | ~1 in 4×10¹⁶ | 8 |

Each zone now sets its own, tuned so a dry streak is a comparable ~1-in-150 tail event wherever you hunt.

**A hard-capped payout struck through a zero** — `~~💰0~~ (daily cap reached)`. It now names what the kill was worth and when the window rolls over.

## 3 — Material sinks

**32 of the 58 droppable materials fed no recipe, no pet and no sale** — and they were precisely the zone-exclusive drops from Desert Wastes, Arctic Tundra, Murky Swamp and Legendary Peaks. Every ingredient in the crafting table came from starter-forest animals, so progression inverted: the deeper a hunter pushed, the more worthless their loot became.

**Eight repeatable recipes** turn each zone's ordinary drops into tier-appropriate ammo and consumables.

**Six Field Trophies** — permanent, crafted once, each a terminal sink for one drop table:

| Trophy | Materials from | Effect |
|---|---|---|
| 🌿 Woodland Instinct | Beginner Forest | +1 max stamina |
| 🦂 Venom Ward | Desert Wastes | Venomous prey no longer costs extra stamina |
| 🧊 Insulated Kit | Arctic Tundra | −1 durability loss per hunt (floors at 1, stacks with reinforced stock) |
| 🐊 Swampwalker's Charm | Murky Swamp | Pack prey no longer savages the weapon; aggressive injury rate halved |
| ⛰️ Apex Predator's Mark | Legendary Peaks | One extra misread before a duel breaks your nerve |
| ⚡ Stormcaller's Totem | Event prey | Mythical prey stalks every zone, including the starter forest |

This also gives the game somewhere to go past Level 50 / Prestige 5, where progression previously stopped. Lucky Paw and Precision Scope already existed and are unchanged; they now appear alongside these in a Permanent Upgrades panel on `/hunt profile`.

## 4 — The daily limits now say what they take

The soft cap halves every payout past 80k and diminishing returns cut up to 45% more — together nearly three quarters of a payout, with nothing on screen to account for it. It read as bad luck or a stealth nerf. Only the hard cap ever said anything.

- A reduced hunt now carries a **⚖️ Daily Limits** field naming each cut, what the kill was worth on a fresh day, and the reset time.
- `/hunt profile` gains a **📅 Today** panel: current payout multiplier, the hunt count where it drops next, and progress toward both caps — so the wall is visible before a hunter walks into it.

## Testing

1156 tests pass across 76 suites. Three new suites:

- `huntMaterialSinks.test.js` — material flow, trophy recipes, and the trait mechanics driven through `executeHunt` rather than reimplemented
- `huntDailyLimits.test.js` — diminishing-returns bands, both caps, reporting accuracy including doubled payouts
- `huntApexNerve.test.js` — nerve spending, per-zone pity thresholds, hard-cap reporting

Two guards worth calling out: a test fails if any droppable material loses its last recipe, and the existing embed field-budget fixture was extended so the new Daily Limits field counts against Discord's 25-field cap.

The trait tests were mutation-checked — each fails when its feature is disabled, so they aren't tautologies.

## Note for review

**The Apex Predator's Mark started as a no-op and a test caught it.** It was specced as "+1 nerve", but nerve is only ever spent two at a time, so +1 rounded away to nothing. It now grants a full extra misread.

**The Stormcaller's Totem is the one balance call worth a second opinion.** It adds event-tier prey to every zone including Beginner Forest, which currently has none — roughly +20% expected payout there, though the daily caps bound it. It costs 6 event-tier materials that only drop from Thunderbird / Dire Bear / Ghost Stag, so gathering them is a long chase. The knob is `LIMITS.TOTEM_EVENT_WEIGHT` (currently `0.5`) if it reads too strong.