### PR TITLE
Optimize dashboard queries and add read rate limiting

### DIFF
--- a/src/dashboard/lib/aggregateCache.js
+++ b/src/dashboard/lib/aggregateCache.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * Short-TTL memo for the dashboard's collection-wide aggregations.
+ *
+ * The analytics panels are built from queries that touch every user in a guild:
+ * the net-worth leaderboard sorts on a computed field, so no index can serve the
+ * ordering, and the coin/message totals are `$group`s with nothing to narrow
+ * them. Each of those is affordable once. What made them expensive is that
+ * nothing stopped them running again on the very next request — opening two
+ * panels, or leaving a tab refreshing, re-ran the same scan against unchanged
+ * data.
+ *
+ * A denormalised column would remove the scan outright, and for net worth that
+ * was considered and rejected: keeping it in step would fall on all 41 files
+ * that move coins, and one missed `$inc` rots the ranking silently (see
+ * src/utils/netWorth.js). Caching costs a bounded amount of staleness instead,
+ * and the numbers involved — total coins in circulation, this week's top ten —
+ * do not become wrong in thirty seconds.
+ *
+ * Concurrent callers on a cold key share one query rather than each starting
+ * their own. That matters more than the hit rate: without it, N simultaneous
+ * requests are N simultaneous full scans, which is precisely the shape of the
+ * read-flood the rate limiter also guards against.
+ */
+
+const DEFAULT_TTL_MS = 30_000;
+
+// The map is keyed by guild, so it grows with the number of guilds an operator's
+// admins actually visit. The cap turns that into a ceiling anyway; eviction is
+// FIFO by insertion order, which `Map` preserves.
+const MAX_ENTRIES = 1_000;
+
+const entries = new Map();
+
+/**
+ * Returns the memoised result of `fn`, running it only when no fresh value is
+ * cached and no identical call is already in flight.
+ *
+ * A rejected call is not cached — the next caller retries rather than being
+ * handed the failure for the rest of the TTL.
+ */
+async function cachedAggregate(key, fn, ttlMs = DEFAULT_TTL_MS) {
+    const now = Date.now();
+    const hit = entries.get(key);
+
+    if (hit) {
+        if (hit.pending) return hit.pending;
+        if (hit.expiresAt > now) return hit.value;
+        entries.delete(key);
+    }
+
+    const pending = (async () => {
+        const value = await fn();
+        // Only replace the placeholder if it is still ours: an `invalidate` during
+        // the query means the caller knows the data moved, and this result predates
+        // that knowledge.
+        if (entries.get(key)?.pending === pending) {
+            entries.set(key, { value, expiresAt: Date.now() + ttlMs });
+        }
+        return value;
+    })();
+
+    pending.catch(() => {
+        if (entries.get(key)?.pending === pending) entries.delete(key);
+    });
+
+    if (entries.size >= MAX_ENTRIES) entries.delete(entries.keys().next().value);
+    entries.set(key, { pending });
+
+    return pending;
+}
+
+/** Drops one key, for callers that have just made its value wrong. */
+function invalidate(key) {
+    entries.delete(key);
+}
+
+/**
+ * Drops every key whose prefix matches. Keys are `<guildId>:<name>` precisely so
+ * one guild's entries can be dropped without touching another's.
+ */
+function invalidatePrefix(prefix) {
+    for (const key of entries.keys()) {
+        if (key.startsWith(prefix)) entries.delete(key);
+    }
+}
+
+/** Exposed for tests. */
+function __reset() {
+    entries.clear();
+}
+
+module.exports = { cachedAggregate, invalidate, invalidatePrefix, DEFAULT_TTL_MS, __reset };

--- a/src/dashboard/lib/middleware.js
+++ b/src/dashboard/lib/middleware.js
@@ -9,6 +9,17 @@ const writeRateLimiter = new BoundedRateLimiter(10_000);
 // Clean up stale entries every minute (was every 5 min — tightened to reduce memory growth window)
 setInterval(() => writeRateLimiter.cleanup(WRITE_RL_WINDOW_MS), 60 * 1000).unref();
 
+// Reads were unlimited on the assumption that a GET is cheap. Several are not:
+// /stats and /insights each run collection-wide aggregations over a guild's users
+// and hydrate a thousand moderation cases, so an authenticated admin looping them
+// costs the bot far more than it costs the caller — and the container has 1 GB.
+// The ceiling is deliberately well above what the dashboard itself asks for; a
+// page load fires a handful of GETs, not a hundred.
+const READ_RL_WINDOW_MS = 60 * 1000;
+const READ_RL_LIMIT = 120;
+const readRateLimiter = new BoundedRateLimiter(10_000);
+setInterval(() => readRateLimiter.cleanup(READ_RL_WINDOW_MS), 60 * 1000).unref();
+
 function checkAuth(req, res, next) {
     if (req.isAuthenticated()) return next();
     res.status(401).json({ error: 'Unauthorized' });
@@ -36,6 +47,17 @@ function checkWriteRateLimit(req, res, next) {
     next();
 }
 
+// Counted per session where there is one, per address otherwise. Unauthenticated
+// callers are not rejected here — the routes' own checkAuth answers that, and
+// doing it in the limiter would only change which status code a scanner sees.
+function checkReadRateLimit(req, res, next) {
+    const key = req.user?.id ? `u:${req.user.id}` : `ip:${req.ip}`;
+    if (!readRateLimiter.check(key, READ_RL_WINDOW_MS, READ_RL_LIMIT)) {
+        return res.status(429).json({ error: 'Too many requests. Please slow down.' });
+    }
+    next();
+}
+
 // M2: CSRF origin validation for all state-changing API requests.
 // Complements sameSite: 'lax' cookies — rejects cross-origin POST/PUT/DELETE that
 // carry an Origin header pointing to a different host than the dashboard.
@@ -56,4 +78,4 @@ function checkAnyGuildAdmin(req, res, next) {
     next();
 }
 
-module.exports = { checkAuth, checkGuildAccess, checkWriteRateLimit, checkCsrfOrigin, checkAnyGuildAdmin };
+module.exports = { checkAuth, checkGuildAccess, checkWriteRateLimit, checkReadRateLimit, checkCsrfOrigin, checkAnyGuildAdmin };

--- a/src/dashboard/routes/api.js
+++ b/src/dashboard/routes/api.js
@@ -1,16 +1,19 @@
 const express = require('express');
 const router = express.Router();
 const { computeRetention } = require('../lib/apiHelpers');
-const { checkCsrfOrigin } = require('../lib/middleware');
+const { checkCsrfOrigin, checkReadRateLimit } = require('../lib/middleware');
 
-// Origin validation for every state-changing API request, applied once here
-// rather than per-route. It was previously listed on a handful of routes and
-// silently missing from the rest (autorole, knowledge base, reaction roles,
-// RSS, summary jobs, leveling, achievements, personas, item images), which is
-// exactly the kind of gap a per-route opt-in produces. Mounting it centrally
-// means a newly added route is covered by default.
+// Origin validation for every state-changing API request, and a rate limit on
+// every read, applied once here rather than per-route. Origin validation was
+// previously listed on a handful of routes and silently missing from the rest
+// (autorole, knowledge base, reaction roles, RSS, summary jobs, leveling,
+// achievements, personas, item images), which is exactly the kind of gap a
+// per-route opt-in produces; the read limit had no per-route opt-in to be
+// missing from at all. Mounting both centrally means a newly added route is
+// covered by default.
 router.use((req, res, next) => {
-    if (req.method === 'GET' || req.method === 'HEAD' || req.method === 'OPTIONS') return next();
+    if (req.method === 'OPTIONS') return next();
+    if (req.method === 'GET' || req.method === 'HEAD') return checkReadRateLimit(req, res, next);
     return checkCsrfOrigin(req, res, next);
 });
 

--- a/src/dashboard/routes/api/economy.js
+++ b/src/dashboard/routes/api/economy.js
@@ -5,14 +5,28 @@ const User = require('../../../models/User');
 const { checkAuth, checkGuildAccess, checkWriteRateLimit } = require('../../lib/middleware');
 const { isValidDiscordId, logAuditEvent } = require('../../lib/apiHelpers');
 const { topByNetWorth } = require('../../../utils/netWorth');
+const { cachedAggregate, invalidatePrefix } = require('../../lib/aggregateCache');
+
+// A full Guild document carries every shop item's image Buffer and the
+// 3000-entry analytics.commandUsage array. This route reads command names out of
+// the second and nothing at all out of the first.
+const ECONOMY_GUILD_FIELDS = 'analytics.commandUsage';
 
 router.get('/guild/:guildId/economy/stats', checkAuth, checkGuildAccess, async (req, res) => {
     const { guildId } = req.params;
     try {
+        // The net-worth ranking sorts on a field the aggregation computes, so no index
+        // can serve the ordering — it is a scan of the guild's users every time, as
+        // are the two `$group`s beside it. Memoised on a short TTL so a dashboard
+        // that opens two panels, or a tab left refreshing, does not re-run all three
+        // against data that has not moved. See lib/aggregateCache.
         const [topEarners, totalCoinsAgg, activeUsersCount, guildSettings] = await Promise.all([
-            topByNetWorth(User, guildId, 10),
-            User.aggregate([{ $match: { guildId } }, { $group: { _id: null, total: { $sum: { $add: ['$balance', '$bank'] } } } }]),
-            User.countDocuments({ guildId, $or: [
+            cachedAggregate(`${guildId}:economy:top`, () => topByNetWorth(User, guildId, 10)),
+            cachedAggregate(`${guildId}:economy:total`, () => User.aggregate([
+                { $match: { guildId } },
+                { $group: { _id: null, total: { $sum: { $add: ['$balance', '$bank'] } } } }
+            ])),
+            cachedAggregate(`${guildId}:economy:active`, () => User.countDocuments({ guildId, $or: [
                 { lastWork:  { $gte: new Date(Date.now() - 7 * 864e5) } },
                 { lastDaily: { $gte: new Date(Date.now() - 7 * 864e5) } },
                 { lastFish:  { $gte: new Date(Date.now() - 7 * 864e5) } },
@@ -20,8 +34,8 @@ router.get('/guild/:guildId/economy/stats', checkAuth, checkGuildAccess, async (
                 { lastCrime: { $gte: new Date(Date.now() - 7 * 864e5) } },
                 { lastHeist: { $gte: new Date(Date.now() - 7 * 864e5) } },
                 { lastRob:   { $gte: new Date(Date.now() - 7 * 864e5) } }
-            ] }),
-            Guild.findOne({ guildId }).lean()
+            ] })),
+            Guild.findOne({ guildId }).select(ECONOMY_GUILD_FIELDS).lean()
         ]);
 
         const commandUsage = guildSettings?.analytics?.commandUsage || [];
@@ -91,6 +105,9 @@ router.post('/guild/:guildId/economy/adjust', checkAuth, checkGuildAccess, check
         }
 
         const user = await User.findOneAndUpdate(filter, update, { upsert: true, new: true, setDefaultsOnInsert: true });
+        // An admin who has just moved someone's coins expects to see it, and a
+        // thirty-second-old total would read as the adjustment not having applied.
+        invalidatePrefix(`${guildId}:`);
         await logAuditEvent(req, guildId, 'economy_adjust', { targetUserId: String(userId), action, amount: amount ?? null });
         res.json({ success: true, balance: user.balance, bank: user.bank, economyFrozen: user.economyFrozen });
     } catch (error) {

--- a/src/dashboard/routes/api/stats.js
+++ b/src/dashboard/routes/api/stats.js
@@ -5,21 +5,39 @@ const User = require('../../../models/User');
 const Case = require('../../../models/Case');
 const { checkAuth, checkGuildAccess } = require('../../lib/middleware');
 const { computeRetention, median, parseChannelIdFromJumpUrl } = require('../../lib/apiHelpers');
+const { cachedAggregate } = require('../../lib/aggregateCache');
+
+// A full Guild document carries the 3000-entry analytics.commandUsage array, the
+// analytics this route is actually after — and every shop item's image Buffer,
+// which it is not. Naming the fields keeps the second group out of the response
+// path entirely.
+const STATS_GUILD_FIELDS = 'analytics welcome moderation leveling economy rssFeeds';
+
+// Moderation cases are read for four aggregates over five fields. Hydrating a
+// thousand full case documents to compute them is the expensive half of this
+// route.
+const CASE_FIELDS = 'type createdAt resolvedAt evidence.jumpUrl';
 
 router.get('/guild/:guildId/stats', checkAuth, checkGuildAccess, async (req, res) => {
     const { guildId } = req.params;
 
     try {
-        const totalUsers = await User.countDocuments({ guildId });
-        const totalMessages = await User.aggregate([
-            { $match: { guildId } },
-            { $group: { _id: null, total: { $sum: '$messages' } } }
+        // Every one of these touches the guild's whole user collection, and the page
+        // that calls this route also calls /economy/stats, which asks two of the same
+        // questions. Memoised so that costs one scan, not five.
+        const [totalUsers, totalMessages, topLevels, guildSettings] = await Promise.all([
+            cachedAggregate(`${guildId}:stats:users`, () => User.countDocuments({ guildId })),
+            cachedAggregate(`${guildId}:stats:messages`, () => User.aggregate([
+                { $match: { guildId } },
+                { $group: { _id: null, total: { $sum: '$messages' } } }
+            ])),
+            cachedAggregate(`${guildId}:stats:topLevels`, () => User.find({ guildId })
+                .select('userId level xp')
+                .sort({ level: -1, xp: -1 })
+                .limit(10)
+                .lean()),
+            Guild.findOne({ guildId }).select(STATS_GUILD_FIELDS).lean()
         ]);
-
-        const topLevels = await User.find({ guildId })
-            .sort({ level: -1, xp: -1 })
-            .limit(10);
-        const guildSettings = await Guild.findOne({ guildId });
         const memberEvents = guildSettings?.analytics?.memberEvents || [];
         const commandUsage = guildSettings?.analytics?.commandUsage || [];
 
@@ -71,16 +89,20 @@ router.get('/guild/:guildId/stats', checkAuth, checkGuildAccess, async (req, res
 
         // Economy stats summary
         const [ecoTotalAgg, ecoActiveCount] = await Promise.all([
-            User.aggregate([{ $match: { guildId } }, { $group: { _id: null, total: { $sum: { $add: ['$balance', '$bank'] } }, avgXp: { $avg: '$xp' } } }]),
-            User.countDocuments({ guildId, $or: [
-                { lastWork:  { $gte: new Date(now30 - 7 * 864e5) } },
-                { lastDaily: { $gte: new Date(now30 - 7 * 864e5) } },
-                { lastFish:  { $gte: new Date(now30 - 7 * 864e5) } },
-                { lastMine:  { $gte: new Date(now30 - 7 * 864e5) } },
-                { lastCrime: { $gte: new Date(now30 - 7 * 864e5) } },
-                { lastHeist: { $gte: new Date(now30 - 7 * 864e5) } },
-                { lastRob:   { $gte: new Date(now30 - 7 * 864e5) } }
-            ] })
+            cachedAggregate(`${guildId}:stats:ecoTotal`, () => User.aggregate([
+                { $match: { guildId } },
+                { $group: { _id: null, total: { $sum: { $add: ['$balance', '$bank'] } }, avgXp: { $avg: '$xp' } } }
+            ])),
+            // Same question, same key as /economy/stats asks it under.
+            cachedAggregate(`${guildId}:economy:active`, () => User.countDocuments({ guildId, $or: [
+                { lastWork:  { $gte: new Date(Date.now() - 7 * 864e5) } },
+                { lastDaily: { $gte: new Date(Date.now() - 7 * 864e5) } },
+                { lastFish:  { $gte: new Date(Date.now() - 7 * 864e5) } },
+                { lastMine:  { $gte: new Date(Date.now() - 7 * 864e5) } },
+                { lastCrime: { $gte: new Date(Date.now() - 7 * 864e5) } },
+                { lastHeist: { $gte: new Date(Date.now() - 7 * 864e5) } },
+                { lastRob:   { $gte: new Date(Date.now() - 7 * 864e5) } }
+            ] }))
         ]);
 
         res.json({
@@ -124,7 +146,7 @@ router.get('/guild/:guildId/insights', checkAuth, checkGuildAccess, async (req, 
     const { guildId } = req.params;
 
     try {
-        const guildSettings = await Guild.findOne({ guildId });
+        const guildSettings = await Guild.findOne({ guildId }).select('guildId analytics').lean();
         if (!guildSettings) return res.status(404).json({ error: 'Guild not found' });
 
         const memberEvents = guildSettings?.analytics?.memberEvents || [];
@@ -143,7 +165,7 @@ router.get('/guild/:guildId/insights', checkAuth, checkGuildAccess, async (req, 
         const topActiveHours = [...hourMap].sort((a, b) => b.count - a.count).slice(0, 5);
 
         // Toxic channel hotspot proxy from moderation case evidence jump URLs.
-        const recentCases = await Case.find({ guildId }).sort({ createdAt: -1 }).limit(1000);
+        const recentCases = await Case.find({ guildId }).select(CASE_FIELDS).sort({ createdAt: -1 }).limit(1000).lean();
         const channelToxicity = new Map();
         for (const c of recentCases) {
             const channelId = parseChannelIdFromJumpUrl(c?.evidence?.jumpUrl) || 'unknown';
@@ -174,13 +196,37 @@ router.get('/guild/:guildId/insights', checkAuth, checkGuildAccess, async (req, 
             .slice(-6);
 
         // Newcomer conversion after 7/30 days based on user activity.
-        const now = Date.now();
-        const users = await User.find({ guildId }).select('createdAt messages level');
-        const cohort7 = users.filter(u => u.createdAt && (now - new Date(u.createdAt).getTime()) >= 7 * 864e5);
-        const cohort30 = users.filter(u => u.createdAt && (now - new Date(u.createdAt).getTime()) >= 30 * 864e5);
-        const isConverted = (u) => (u.messages || 0) >= 20 || (u.level || 0) >= 2;
-        const converted7 = cohort7.filter(isConverted).length;
-        const converted30 = cohort30.filter(isConverted).length;
+        //
+        // Counted in the pipeline rather than by pulling every user in the guild into
+        // the process and filtering the array four times. The old shape was the one
+        // unbounded read on this route: four counts, and the peak memory to produce
+        // them grew with the size of the server.
+        //
+        // The 30-day cohort is a subset of the 7-day one, so a single `$match` on the
+        // wider window feeds both; `$match` on `createdAt` also drops the documents
+        // the array filters were rejecting for having no `createdAt` at all.
+        const [cohorts] = await cachedAggregate(`${guildId}:insights:cohorts`, () => User.aggregate([
+            { $match: { guildId, createdAt: { $lte: new Date(Date.now() - 7 * 864e5) } } },
+            { $set: {
+                inCohort30: { $lte: ['$createdAt', new Date(Date.now() - 30 * 864e5)] },
+                converted: { $or: [
+                    { $gte: [{ $ifNull: ['$messages', 0] }, 20] },
+                    { $gte: [{ $ifNull: ['$level', 0] }, 2] }
+                ] }
+            } },
+            { $group: {
+                _id: null,
+                cohort7:     { $sum: 1 },
+                converted7:  { $sum: { $cond: ['$converted', 1, 0] } },
+                cohort30:    { $sum: { $cond: ['$inCohort30', 1, 0] } },
+                converted30: { $sum: { $cond: [{ $and: ['$inCohort30', '$converted'] }, 1, 0] } }
+            } }
+        ]));
+
+        const cohort7Size  = cohorts?.cohort7 ?? 0;
+        const cohort30Size = cohorts?.cohort30 ?? 0;
+        const converted7   = cohorts?.converted7 ?? 0;
+        const converted30  = cohorts?.converted30 ?? 0;
 
         res.json({
             retention: {
@@ -203,8 +249,8 @@ router.get('/guild/:guildId/insights', checkAuth, checkGuildAccess, async (req, 
             },
             newcomerConversion: {
                 definition: 'Converted = at least 20 messages or level 2+',
-                days7: { cohortSize: cohort7.length, converted: converted7, pct: cohort7.length ? Number(((converted7 / cohort7.length) * 100).toFixed(1)) : 0 },
-                days30: { cohortSize: cohort30.length, converted: converted30, pct: cohort30.length ? Number(((converted30 / cohort30.length) * 100).toFixed(1)) : 0 }
+                days7: { cohortSize: cohort7Size, converted: converted7, pct: cohort7Size ? Number(((converted7 / cohort7Size) * 100).toFixed(1)) : 0 },
+                days30: { cohortSize: cohort30Size, converted: converted30, pct: cohort30Size ? Number(((converted30 / cohort30Size) * 100).toFixed(1)) : 0 }
             }
         });
     } catch (error) {

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -101,6 +101,9 @@ module.exports = {
                 }
             }
 
+            // One read of the author's user document serves the whole handler:
+            // handleLeveling mutates it and hands it back unsaved, handleStreakAndQuests
+            // keeps mutating that same document and performs the single write.
             let sharedUser = null;
             if (guildSettings?.leveling.enabled) {
                 sharedUser = await handleLeveling(message, guildSettings);
@@ -108,7 +111,9 @@ module.exports = {
 
             if (guildSettings?.moderation.enabled) {
                 const blocked = await handleAutoModeration(message, guildSettings);
-                if (blocked) return;
+                // A blocked message never reaches the streak/quest write, so the XP
+                // handleLeveling applied has nothing to ride along on.
+                if (blocked) return await flushPendingUser(sharedUser);
             }
 
             await handleSuggestions(message, guildSettings);
@@ -120,9 +125,11 @@ module.exports = {
             // Natural language reminders — available to everyone, any channel
             await handleNLReminder(message);
 
-            // Streak + quests — fetch independently to avoid operating on a stale,
-            // already-saved Mongoose document from handleLeveling.
-            await handleStreakAndQuests(message, guildSettings);
+            // Streak + quests — reuses the document handleLeveling already loaded and
+            // saves it once. It reports whether that write landed; when it bailed out
+            // early or threw before saving, the XP still has to be persisted.
+            const persisted = await handleStreakAndQuests(message, guildSettings, sharedUser);
+            if (!persisted) await flushPendingUser(sharedUser);
 
             // Ambient chat events (airdrops, crates, trivia) — fire-and-forget
             maybeTriggerChatEvent(message, guildSettings).catch(() => {});
@@ -133,10 +140,27 @@ module.exports = {
     }
 };
 
-async function handleStreakAndQuests(message, guildSettings, existingUser = null) {
+// Backstop for the paths that never reach the streak/quest write: the XP applied
+// by handleLeveling lives only in memory until something saves the document.
+// Only called when that write is known not to have happened, so it can never race
+// the fire-and-forget saves (wealth milestones, achievements) that follow it.
+async function flushPendingUser(user) {
+    if (!user?.isModified?.()) return;
     try {
-        let user = existingUser ?? await User.findOne({ userId: message.author.id, guildId: message.guild.id });
-        if (!user) return;
+        await user.save();
+    } catch (err) {
+        console.error('Pending user save error:', err.message);
+    }
+}
+
+async function handleStreakAndQuests(message, guildSettings, existingUser = null) {
+    // Reported back to the caller so it knows whether the XP handleLeveling
+    // applied has been persisted. Set only once the write has actually landed —
+    // a failure after that point still leaves the document saved.
+    let persisted = false;
+    try {
+        const user = existingUser ?? await User.findOne({ userId: message.author.id, guildId: message.guild.id });
+        if (!user) return false;
 
         // Every coin this path awards — streak milestones, quest completions — is
         // folded into one `$inc` at the save below. `save()` writes `balance` as an
@@ -210,6 +234,7 @@ async function handleStreakAndQuests(message, guildSettings, existingUser = null
             jobName: 'streakAndQuestRewards',
             guildId: message.guild.id,
         });
+        persisted = true;
 
         // Check wealth milestones after any coins may have been awarded (streak rewards, etc.)
         checkAndBroadcastWealthMilestone(message.client, guildSettings, user, message.channel).catch(() => {});
@@ -241,14 +266,19 @@ async function handleStreakAndQuests(message, guildSettings, existingUser = null
     } catch (err) {
         console.error('Streak/quest error:', err);
     }
+    return persisted;
 }
 
+// Applies levelling XP in memory and returns the document without saving it.
+// The caller hands the same document to handleStreakAndQuests, which mutates it
+// further and issues the one write that covers both — a second fetch and a second
+// save of the same user on every message is what this avoids.
 async function handleLeveling(message, guildSettings) {
     if (!guildSettings?.leveling?.rewardsEnabled) return null;
     if (guildSettings.leveling?.noXpChannelIds?.includes(message.channel.id)) return null;
     if (message.member?.roles?.cache?.some(role => guildSettings.leveling?.noXpRoleIds?.includes(role.id))) return null;
 
-    let user = await User.findOne({ userId: message.author.id, guildId: message.guild.id });
+    const user = await User.findOne({ userId: message.author.id, guildId: message.guild.id });
 
     const now = Date.now();
     // Return the user even when XP is on cooldown so handleStreakAndQuests can reuse it
@@ -298,7 +328,8 @@ async function handleLeveling(message, guildSettings) {
             await announceLevelUp(user, guildSettings, message.member, message.guild, message.channel);
         }
 
-        await user.save();
+        // Standings are computed from the in-memory values, so they do not need
+        // the write to have landed first.
         checkRivalry(message.client, message.guild, user).catch(() => {});
         return user;
     } else {

--- a/src/services/rssService.js
+++ b/src/services/rssService.js
@@ -117,7 +117,10 @@ async function fetchSendableChannel(client, channelId) {
 }
 async function checkRssFeeds(client) {
     try {
-        const guilds = await Guild.find({ 'rssFeeds.0': { $exists: true } });
+        // Projected and lean: a full Guild document carries the 3000-entry
+        // analytics.commandUsage array and every shop item's image Buffer, none of
+        // which this job reads.
+        const guilds = await Guild.find({ 'rssFeeds.0': { $exists: true } }, 'guildId rssFeeds').lean();
 
         for (const guild of guilds) {
             for (const feed of guild.rssFeeds) {
@@ -147,8 +150,13 @@ async function checkRssFeeds(client) {
                             await channel.send({ embeds: [embed] });
                         }
 
-                        feed.lastPublished = itemDate;
-                        await guild.save();
+                        // Targets the one subdocument rather than rewriting the whole
+                        // rssFeeds array, which is also what `guild.save()` on a
+                        // projected document could not do.
+                        await Guild.updateOne(
+                            { guildId: guild.guildId, 'rssFeeds._id': feed._id },
+                            { $set: { 'rssFeeds.$.lastPublished': itemDate } }
+                        );
                     }
                 } catch (error) {
                     console.error(`Error parsing RSS feed ${feed.url}:`, error);
@@ -303,7 +311,7 @@ function scheduleProfileJob(client, guildId, profile) {
 }
 
 function scheduleDailyNews(client) {
-    Guild.find({}).then(guilds => {
+    Guild.find({}, 'guildId dailyNewsProfiles dailyNews').lean().then(guilds => {
         for (const guild of guilds) {
             const profiles = getDailyNewsProfiles(guild)
                 .filter(profile => profile.enabled && Array.isArray(profile.feeds) && profile.feeds.length > 0);

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -854,10 +854,16 @@ async function resolveRankedSeasons(client) {
 // large balances inflate the economy unboundedly.
 const INTEREST_BEARING_CAP = 100_000;
 
+// Users are credited in batches rather than one document at a time. A guild with
+// tens of thousands of bankers would otherwise cost that many sequential round
+// trips, and holding every op in one array before sending it trades the round
+// trips for an equally unbounded amount of memory.
+const INTEREST_BATCH_SIZE = 1_000;
+
 async function applyBankInterest(client) {
     const { EmbedBuilder } = require('discord.js');
     const { isDistrictActive } = require('./districtService');
-    const { logTransaction } = require('../utils/logTransaction');
+    const Transaction = require('../models/Transaction');
 
     const now     = new Date();
     const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
@@ -884,19 +890,38 @@ async function applyBankInterest(client) {
 
             if (!isDistrictActive(guildDoc, 'bank')) continue;
 
-            const users = await User.find({ guildId, bank: { $gt: 0 } });
+            // Projected and lean: the credit needs three fields, and hydrating full
+            // user documents for the whole guild is what makes this job expensive.
+            const users = await User.find({ guildId, bank: { $gt: 0 } })
+                .select('userId bank balance')
+                .lean();
+
+            const note = `5% weekly bank interest (Bank district active, first ${INTEREST_BEARING_CAP.toLocaleString()} coins)`;
             let totalInterestPaid = 0;
+            let credits = [];
+            let ledger  = [];
+
+            const flush = async () => {
+                if (!credits.length) return;
+                await User.bulkWrite(credits, { ordered: false });
+                // The ledger is written after the credit for the same reason the rest of
+                // the economy does it in that order: an entry with no matching credit
+                // claims coins nobody was paid.
+                await Transaction.insertMany(ledger, { ordered: false })
+                    .catch(err => console.error('[scheduler] bank interest ledger write failed:', err.message));
+                credits = [];
+                ledger  = [];
+            };
 
             for (const user of users) {
                 const interest = Math.floor(Math.min(user.bank, INTEREST_BEARING_CAP) * 0.05);
                 if (interest <= 0) continue;
-                await User.findOneAndUpdate(
-                    { _id: user._id },
-                    { $inc: { bank: interest } }
-                );
-                logTransaction({ userId: user.userId, guildId, type: 'bank_interest', amount: interest, balance: user.balance, note: `5% weekly bank interest (Bank district active, first ${INTEREST_BEARING_CAP.toLocaleString()} coins)` });
+                credits.push({ updateOne: { filter: { _id: user._id }, update: { $inc: { bank: interest } } } });
+                ledger.push({ userId: user.userId, guildId, type: 'bank_interest', amount: interest, balance: user.balance, note });
                 totalInterestPaid += interest;
+                if (credits.length >= INTEREST_BATCH_SIZE) await flush();
             }
+            await flush();
 
             if (totalInterestPaid <= 0) continue;
 

--- a/src/services/seasonalEventService.js
+++ b/src/services/seasonalEventService.js
@@ -9,7 +9,10 @@ async function checkSeasonalEvents(client) {
     const now = new Date();
     const currentSeasonal = getActiveSeasonalEvent();
 
-    const guilds = await Guild.find({}).lean();
+    // Hourly, across every guild. Projected because a full Guild document drags in
+    // the 3000-entry analytics.commandUsage array and the shop's image Buffers, and
+    // this job reads none of it — only the active event and where to announce it.
+    const guilds = await Guild.find({}, 'guildId activeEvent economy.announcementChannelId').lean();
 
     for (const guild of guilds) {
         const discordGuild = client.guilds.cache.get(guild.guildId);

--- a/tests/aggregateCache.test.js
+++ b/tests/aggregateCache.test.js
@@ -1,0 +1,127 @@
+'use strict';
+
+// The dashboard's analytics panels are built from queries that read every user in
+// a guild — a sort on a computed field that no index can serve, and two `$group`s
+// with nothing to narrow them. Running each of those once is affordable; what was
+// not affordable is that nothing stopped them running again on the next request.
+//
+// So what these tests pin is not "the value came back" but the three properties
+// that make the memo worth having: a second caller inside the window does not
+// reach the database, concurrent cold callers share one query rather than each
+// starting their own, and a failure is not what the next thirty seconds of
+// callers are handed.
+
+const { cachedAggregate, invalidate, invalidatePrefix, __reset } = require('../src/dashboard/lib/aggregateCache');
+
+beforeEach(() => __reset());
+
+// A query that counts how many times it was actually run, and can be held open
+// so two callers are provably in flight at the same time.
+function countingQuery(value = 'result') {
+    let release;
+    const gate = new Promise(resolve => { release = resolve; });
+    const fn = jest.fn(async () => {
+        await gate;
+        return value;
+    });
+    return { fn, release: () => release() };
+}
+
+describe('cachedAggregate', () => {
+    test('runs the query once and serves the second caller from the memo', async () => {
+        const fn = jest.fn().mockResolvedValue(42);
+
+        expect(await cachedAggregate('g1:economy:total', fn)).toBe(42);
+        expect(await cachedAggregate('g1:economy:total', fn)).toBe(42);
+
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    test('two callers on a cold key share one query rather than starting two', async () => {
+        const { fn, release } = countingQuery('shared');
+
+        const first  = cachedAggregate('g1:economy:top', fn);
+        const second = cachedAggregate('g1:economy:top', fn);
+        release();
+
+        expect(await first).toBe('shared');
+        expect(await second).toBe('shared');
+        // The point of the single-flight: N simultaneous requests on a cold key are
+        // otherwise N simultaneous full scans, which is the read-flood shape exactly.
+        expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    test('re-runs the query once the TTL has passed', async () => {
+        const fn = jest.fn().mockResolvedValueOnce('first').mockResolvedValueOnce('second');
+
+        expect(await cachedAggregate('g1:stats:users', fn, 5)).toBe('first');
+        await new Promise(resolve => setTimeout(resolve, 20));
+        expect(await cachedAggregate('g1:stats:users', fn, 5)).toBe('second');
+
+        expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    test('does not cache a rejection — the next caller retries', async () => {
+        const fn = jest.fn()
+            .mockRejectedValueOnce(new Error('mongo is having a moment'))
+            .mockResolvedValueOnce('recovered');
+
+        await expect(cachedAggregate('g1:stats:messages', fn)).rejects.toThrow('mongo is having a moment');
+        // A cached failure would hand every caller the error for the rest of the TTL,
+        // turning one blip into thirty seconds of a broken panel.
+        expect(await cachedAggregate('g1:stats:messages', fn)).toBe('recovered');
+        expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    test('a rejection does not evict a value another key already holds', async () => {
+        const good = jest.fn().mockResolvedValue('kept');
+        await cachedAggregate('g1:economy:total', good);
+
+        await expect(cachedAggregate('g1:economy:top', jest.fn().mockRejectedValue(new Error('nope'))))
+            .rejects.toThrow('nope');
+
+        expect(await cachedAggregate('g1:economy:total', good)).toBe('kept');
+        expect(good).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('invalidation', () => {
+    test('invalidate drops one key', async () => {
+        const fn = jest.fn().mockResolvedValueOnce('before').mockResolvedValueOnce('after');
+
+        await cachedAggregate('g1:economy:total', fn);
+        invalidate('g1:economy:total');
+
+        expect(await cachedAggregate('g1:economy:total', fn)).toBe('after');
+    });
+
+    test('invalidatePrefix drops one guild without touching another', async () => {
+        const mine   = jest.fn().mockResolvedValueOnce('mine-before').mockResolvedValueOnce('mine-after');
+        const theirs = jest.fn().mockResolvedValue('theirs');
+
+        await cachedAggregate('111:economy:total', mine);
+        await cachedAggregate('222:economy:total', theirs);
+
+        // Keys are `<guildId>:<name>` so that this is possible at all: an admin
+        // adjusting coins in one guild must not flush every other guild's panels.
+        invalidatePrefix('111:');
+
+        expect(await cachedAggregate('111:economy:total', mine)).toBe('mine-after');
+        expect(await cachedAggregate('222:economy:total', theirs)).toBe('theirs');
+        expect(theirs).toHaveBeenCalledTimes(1);
+    });
+
+    test('a query already in flight when its key is invalidated is not stored', async () => {
+        const { fn, release } = countingQuery('stale');
+        const fresh = jest.fn().mockResolvedValue('fresh');
+
+        const inFlight = cachedAggregate('g1:economy:total', fn);
+        invalidate('g1:economy:total');
+        release();
+        await inFlight;
+
+        // The in-flight result predates whatever made the caller invalidate, so it
+        // must not become the cached answer.
+        expect(await cachedAggregate('g1:economy:total', fresh)).toBe('fresh');
+    });
+});

--- a/tests/bankInterestBatch.test.js
+++ b/tests/bankInterestBatch.test.js
@@ -1,0 +1,155 @@
+'use strict';
+
+// The weekly Bank-district payout used to hydrate every banking user in a guild
+// as a full Mongoose document, then issue one `findOneAndUpdate` and one
+// `Transaction.create` per user. Weekly cadence bounds how often that hurts, but
+// a large install still serialises thousands of round trips behind one cron tick.
+//
+// These tests pin the shape of the replacement — projected, lean, batched — and,
+// just as importantly, that it still pays exactly what the old loop paid.
+
+jest.mock('discord.js', () => ({
+    EmbedBuilder: class {
+        setColor() { return this; }
+        setTitle() { return this; }
+        setDescription() { return this; }
+        setFooter() { return this; }
+        setTimestamp() { return this; }
+    },
+}));
+
+jest.mock('../src/models/Guild', () => ({ find: jest.fn(), findOneAndUpdate: jest.fn(), updateOne: jest.fn() }));
+jest.mock('../src/models/User',  () => ({ find: jest.fn(), bulkWrite: jest.fn() }));
+jest.mock('../src/models/Transaction', () => ({ insertMany: jest.fn() }));
+jest.mock('../src/services/districtService', () => ({ isDistrictActive: jest.fn(() => true) }));
+
+const Guild       = require('../src/models/Guild');
+const User        = require('../src/models/User');
+const Transaction = require('../src/models/Transaction');
+const { applyBankInterest } = require('../src/services/schedulerService');
+
+const INTEREST_BEARING_CAP = 100_000;
+
+// Records which query modifiers the job asked for, so the projection and `lean()`
+// are assertable rather than merely present in the source.
+function stubUserFind(docs) {
+    const calls = { select: null, lean: false };
+    User.find.mockImplementation(() => {
+        const chain = {
+            select(fields) { calls.select = fields; return chain; },
+            lean() { calls.lean = true; return Promise.resolve(docs); },
+            then(resolve, reject) { return Promise.resolve(docs).then(resolve, reject); },
+        };
+        return chain;
+    });
+    return calls;
+}
+
+function bankers(count, bank = 1_000) {
+    return Array.from({ length: count }, (_, i) => ({
+        _id: `id${i}`, userId: `u${i}`, bank, balance: 0,
+    }));
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    Guild.find.mockReturnValue({ lean: () => Promise.resolve([{ guildId: 'g1', economy: {} }]) });
+    // A non-null return is the job's signal that it won the weekly claim.
+    Guild.findOneAndUpdate.mockResolvedValue({ guildId: 'g1' });
+    User.bulkWrite.mockResolvedValue({});
+    Transaction.insertMany.mockResolvedValue([]);
+});
+
+describe('applyBankInterest', () => {
+    test('reads only the three fields it needs, and does not hydrate documents', async () => {
+        const calls = stubUserFind(bankers(3));
+
+        await applyBankInterest({});
+
+        expect(calls.select).toBe('userId bank balance');
+        expect(calls.lean).toBe(true);
+    });
+
+    test('credits every user in one bulkWrite instead of one update each', async () => {
+        stubUserFind(bankers(3, 2_000));
+
+        await applyBankInterest({});
+
+        expect(User.bulkWrite).toHaveBeenCalledTimes(1);
+        const [ops] = User.bulkWrite.mock.calls[0];
+        expect(ops).toHaveLength(3);
+        expect(ops[0]).toEqual({ updateOne: { filter: { _id: 'id0' }, update: { $inc: { bank: 100 } } } });
+    });
+
+    test('writes the ledger in one insertMany instead of one create each', async () => {
+        stubUserFind(bankers(2, 2_000));
+
+        await applyBankInterest({});
+
+        expect(Transaction.insertMany).toHaveBeenCalledTimes(1);
+        const [entries] = Transaction.insertMany.mock.calls[0];
+        expect(entries).toHaveLength(2);
+        expect(entries[0]).toMatchObject({
+            userId: 'u0', guildId: 'g1', type: 'bank_interest', amount: 100, balance: 0,
+        });
+    });
+
+    test('credits before it writes the ledger — an entry with no credit claims coins nobody got', async () => {
+        stubUserFind(bankers(1, 2_000));
+        const order = [];
+        User.bulkWrite.mockImplementation(async () => { order.push('credit'); return {}; });
+        Transaction.insertMany.mockImplementation(async () => { order.push('ledger'); return []; });
+
+        await applyBankInterest({});
+
+        expect(order).toEqual(['credit', 'ledger']);
+    });
+
+    test('a failed ledger write does not take the payout down with it', async () => {
+        stubUserFind(bankers(1, 2_000));
+        Transaction.insertMany.mockRejectedValue(new Error('ledger unavailable'));
+        const err = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        await expect(applyBankInterest({})).resolves.toBeUndefined();
+
+        expect(User.bulkWrite).toHaveBeenCalledTimes(1);
+        expect(err).toHaveBeenCalled();
+        err.mockRestore();
+    });
+
+    test('sends in batches, so the op array does not grow with the guild', async () => {
+        stubUserFind(bankers(2_500, 2_000));
+
+        await applyBankInterest({});
+
+        // 1000 + 1000 + 500: holding all 2500 ops before sending would trade the
+        // round trips for an equally unbounded amount of memory.
+        expect(User.bulkWrite.mock.calls.map(([ops]) => ops.length)).toEqual([1000, 1000, 500]);
+        expect(Transaction.insertMany.mock.calls.map(([rows]) => rows.length)).toEqual([1000, 1000, 500]);
+    });
+
+    test('still caps the interest-bearing balance, and still skips users it rounds to zero', async () => {
+        stubUserFind([
+            { _id: 'rich', userId: 'rich', bank: 10 * INTEREST_BEARING_CAP, balance: 0 },
+            { _id: 'dust', userId: 'dust', bank: 19, balance: 0 },
+        ]);
+
+        await applyBankInterest({});
+
+        const [ops] = User.bulkWrite.mock.calls[0];
+        // 5% of the cap, not 5% of the balance; and floor(19 * 0.05) === 0 buys
+        // nobody an op.
+        expect(ops).toEqual([
+            { updateOne: { filter: { _id: 'rich' }, update: { $inc: { bank: INTEREST_BEARING_CAP * 0.05 } } } },
+        ]);
+    });
+
+    test('writes nothing at all when no user earns anything', async () => {
+        stubUserFind([{ _id: 'dust', userId: 'dust', bank: 5, balance: 0 }]);
+
+        await applyBankInterest({});
+
+        expect(User.bulkWrite).not.toHaveBeenCalled();
+        expect(Transaction.insertMany).not.toHaveBeenCalled();
+    });
+});

--- a/tests/dashboardReadRateLimit.test.js
+++ b/tests/dashboardReadRateLimit.test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+// `checkWriteRateLimit` covered POST/PUT/DELETE on the assumption that a GET is
+// cheap. Several dashboard GETs are not: /stats and /insights each run
+// collection-wide aggregations over a guild's users and read a thousand
+// moderation cases, and the container they run in has 1 GB. An authenticated
+// guild admin looping either one spends far more of the bot's memory than of
+// their own time.
+//
+// These tests cover the limiter itself and the wiring, because the wiring is the
+// half that rots: a read limit listed per-route is a limit the next route added
+// will not have.
+
+const fs   = require('fs');
+const path = require('path');
+const { checkReadRateLimit } = require('../src/dashboard/lib/middleware');
+
+const READ_RL_LIMIT = 120;
+
+function makeRes() {
+    return {
+        statusCode: null,
+        body: null,
+        status(code) { this.statusCode = code; return this; },
+        json(payload) { this.body = payload; return this; },
+    };
+}
+
+// Distinct per test so one test's spent budget is not another's starting point —
+// the limiter's window is a minute and its state is module-level.
+let seq = 0;
+const freshUser = () => ({ id: `user-${++seq}` });
+
+describe('checkReadRateLimit', () => {
+    test('allows reads up to the limit and rejects the one after', () => {
+        const req = { user: freshUser(), ip: '10.0.0.1' };
+        const next = jest.fn();
+
+        for (let i = 0; i < READ_RL_LIMIT; i++) checkReadRateLimit(req, makeRes(), next);
+        expect(next).toHaveBeenCalledTimes(READ_RL_LIMIT);
+
+        const res = makeRes();
+        checkReadRateLimit(req, res, next);
+
+        expect(next).toHaveBeenCalledTimes(READ_RL_LIMIT);
+        expect(res.statusCode).toBe(429);
+        expect(res.body).toEqual({ error: 'Too many requests. Please slow down.' });
+    });
+
+    test('counts per user, so one admin exhausting the budget does not lock out another', () => {
+        const loud  = { user: freshUser(), ip: '10.0.0.1' };
+        const quiet = { user: freshUser(), ip: '10.0.0.1' };
+
+        for (let i = 0; i <= READ_RL_LIMIT; i++) checkReadRateLimit(loud, makeRes(), jest.fn());
+
+        const res = makeRes();
+        const next = jest.fn();
+        checkReadRateLimit(quiet, res, next);
+
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(res.statusCode).toBeNull();
+    });
+
+    test('falls back to the address when there is no session', () => {
+        const req = { ip: `192.0.2.${++seq}` };
+        const next = jest.fn();
+
+        for (let i = 0; i < READ_RL_LIMIT; i++) checkReadRateLimit(req, makeRes(), next);
+        const res = makeRes();
+        checkReadRateLimit(req, res, next);
+
+        expect(res.statusCode).toBe(429);
+    });
+
+    test('does not answer 401 itself — that is the routes\' checkAuth to give', () => {
+        const res = makeRes();
+        const next = jest.fn();
+
+        checkReadRateLimit({ ip: `198.51.100.${++seq}` }, res, next);
+
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(res.statusCode).toBeNull();
+    });
+
+    test('a user key cannot be spoofed by an address, or the reverse', () => {
+        const id = `collide-${++seq}`;
+        for (let i = 0; i <= READ_RL_LIMIT; i++) {
+            checkReadRateLimit({ user: { id } }, makeRes(), jest.fn());
+        }
+
+        const res = makeRes();
+        checkReadRateLimit({ ip: id }, res, jest.fn());
+
+        expect(res.statusCode).toBeNull();
+    });
+});
+
+// Origin validation was previously opted into per route and silently missing from
+// nine of them. The read limit is mounted in the same place for the same reason,
+// so this reads the mount rather than trusting that every route remembered.
+describe('the API router applies it to every read', () => {
+    const source = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'dashboard', 'routes', 'api.js'), 'utf8',
+    );
+    // Everything up to the first sub-router mount: middleware placed after a mount
+    // does not run for it.
+    const beforeMounts = source.slice(0, source.indexOf("router.use(settingsRouter)"));
+
+    test('routes GET and HEAD through the read limiter', () => {
+        expect(beforeMounts).toContain('checkReadRateLimit');
+        expect(beforeMounts).toMatch(/req\.method === 'GET'[\s\S]*checkReadRateLimit/);
+    });
+
+    test('still routes state-changing methods through origin validation', () => {
+        expect(beforeMounts).toMatch(/return checkCsrfOrigin\(req, res, next\)/);
+    });
+
+    test('mounts both before any sub-router, so no route can be added outside them', () => {
+        expect(source.indexOf('router.use((req, res, next)'))
+            .toBeLessThan(source.indexOf("router.use(settingsRouter)"));
+    });
+});

--- a/tests/guildScanProjection.test.js
+++ b/tests/guildScanProjection.test.js
@@ -1,0 +1,170 @@
+'use strict';
+
+// A Guild document is an 813-line schema whose arrays are the expensive part: up
+// to 3000 `analytics.commandUsage` subdocuments, and one image `Buffer` per shop
+// item. A caller that scans the whole collection without a projection pulls all
+// of that into the process for every guild the bot is in, to read two fields.
+//
+// The scan below is the part that keeps working. Whichever caller is added next
+// will be a `Guild.find({})` written by someone who had no reason to know what
+// the schema drags along, and a projection is invisible by omission.
+
+const fs   = require('fs');
+const path = require('path');
+// Ships with jest (jest → babel-jest → @babel/core → @babel/parser), so it is
+// always present when this suite runs and is not declared separately.
+const { parse } = require('@babel/parser');
+
+const SRC = path.join(__dirname, '..', 'src');
+
+function jsFiles(dir) {
+    return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) return jsFiles(full);
+        return entry.isFile() && entry.name.endsWith('.js') ? [full] : [];
+    });
+}
+
+function walk(node, visit) {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) { for (const child of node) walk(child, visit); return; }
+    if (typeof node.type === 'string') visit(node);
+    for (const key of Object.keys(node)) {
+        if (key === 'loc') continue;
+        walk(node[key], visit);
+    }
+}
+
+// `Guild.find({})` — an empty filter is the collection scan; anything narrower is
+// the caller's own business.
+function unprojectedScans(file) {
+    const ast = parse(fs.readFileSync(file, 'utf8'), {
+        sourceType: 'unambiguous',
+        plugins: ['optionalChaining', 'nullishCoalescingOperator', 'classProperties'],
+    });
+
+    const found = [];
+    walk(ast.program, node => {
+        if (node.type !== 'CallExpression') return;
+        const callee = node.callee;
+        if (callee?.type !== 'MemberExpression') return;
+        if (callee.object?.name !== 'Guild' || callee.property?.name !== 'find') return;
+
+        const [filter, projection] = node.arguments;
+        if (filter?.type !== 'ObjectExpression' || filter.properties.length > 0) return;
+        if (!projection) found.push({ file: path.relative(SRC, file), line: node.loc.start.line });
+    });
+    return found;
+}
+
+describe('collection-wide Guild scans', () => {
+    test('every Guild.find({}) names the fields it needs', () => {
+        const offenders = jsFiles(SRC).flatMap(unprojectedScans);
+        expect(offenders.map(o => `${o.file}:${o.line}`)).toEqual([]);
+    });
+
+    test('and none of them asks for analytics or the shop', () => {
+        // The two arrays that make an unprojected scan expensive. A projection that
+        // names either is a projection that did not help.
+        const projections = jsFiles(SRC).flatMap(file => {
+            const source = fs.readFileSync(file, 'utf8');
+            return [...source.matchAll(/Guild\.find\(\{\},\s*'([^']*)'/g)].map(m => m[1]);
+        });
+
+        expect(projections.length).toBeGreaterThan(0);
+        for (const fields of projections) {
+            expect(fields.split(/\s+/)).not.toContain('analytics');
+            expect(fields.split(/\s+/)).not.toContain('shop');
+        }
+    });
+});
+
+// The RSS feed check is not a `Guild.find({})` — it filters to guilds that have
+// feeds — but it ran on the same hydrated documents, and its write was a
+// `guild.save()` that rewrote the whole feed array to move one date. Those two
+// facts are linked: a projected document is exactly the one `guild.save()` cannot
+// be trusted with, so the write had to become a targeted one.
+describe('the RSS feed check', () => {
+    let Guild;
+    let checkRssFeeds;
+
+    beforeEach(() => {
+        jest.resetModules();
+        jest.doMock('discord.js', () => ({
+            EmbedBuilder: class {
+                setColor() { return this; }
+                setTitle() { return this; }
+                setURL() { return this; }
+                setDescription() { return this; }
+                setTimestamp() { return this; }
+                setThumbnail() { return this; }
+            },
+        }));
+        jest.doMock('rss-parser', () => class {
+            parseString() {
+                return Promise.resolve({
+                    items: [{ title: 'A post', link: 'https://example.com/a', pubDate: '2030-01-01T00:00:00Z' }],
+                });
+            }
+        });
+        // Feed URLs are operator-supplied, so the real fetch is the SSRF-safe one;
+        // it has its own suite, and this one must not reach the network.
+        jest.doMock('../src/utils/safeFeedFetch', () => ({ safeFetchFeed: jest.fn().mockResolvedValue('<rss/>') }));
+        jest.doMock('../src/models/Guild', () => ({ find: jest.fn(), updateOne: jest.fn() }));
+        jest.doMock('../src/utils/jobRunner', () => ({ runJob: jest.fn() }));
+
+        Guild = require('../src/models/Guild');
+        ({ checkRssFeeds } = require('../src/services/rssService'));
+    });
+
+    afterEach(() => jest.resetModules());
+
+    function stubFind(guilds) {
+        const seen = {};
+        Guild.find.mockImplementation((filter, projection) => {
+            seen.filter = filter;
+            seen.projection = projection;
+            return { lean: () => Promise.resolve(guilds) };
+        });
+        Guild.updateOne.mockResolvedValue({});
+        return seen;
+    }
+
+    test('asks for only the feeds, and takes them lean', async () => {
+        const seen = stubFind([]);
+
+        await checkRssFeeds({});
+
+        expect(seen.projection).toBe('guildId rssFeeds');
+    });
+
+    test('moves the published date with a targeted update, not a whole-document save', async () => {
+        stubFind([{
+            guildId: 'g1',
+            rssFeeds: [{ _id: 'feed1', url: 'https://example.com/rss', channelId: 'chan1', lastPublished: null }],
+        }]);
+
+        await checkRssFeeds({ channels: { fetch: jest.fn().mockResolvedValue(null) } });
+
+        expect(Guild.updateOne).toHaveBeenCalledTimes(1);
+        const [filter, update] = Guild.updateOne.mock.calls[0];
+        expect(filter).toEqual({ guildId: 'g1', 'rssFeeds._id': 'feed1' });
+        expect(update.$set['rssFeeds.$.lastPublished']).toEqual(new Date('2030-01-01T00:00:00Z'));
+    });
+
+    test('leaves the date alone when the feed has nothing newer', async () => {
+        stubFind([{
+            guildId: 'g1',
+            rssFeeds: [{
+                _id: 'feed1',
+                url: 'https://example.com/rss',
+                channelId: 'chan1',
+                lastPublished: new Date('2031-01-01T00:00:00Z'),
+            }],
+        }]);
+
+        await checkRssFeeds({ channels: { fetch: jest.fn().mockResolvedValue(null) } });
+
+        expect(Guild.updateOne).not.toHaveBeenCalled();
+    });
+});

--- a/tests/helpers/pipelineUpdate.js
+++ b/tests/helpers/pipelineUpdate.js
@@ -50,6 +50,10 @@ function evaluate(expr, doc, vars = {}) {
         return getPath(doc, expr.slice(1));
     }
     if (Array.isArray(expr)) return expr.map(e => evaluate(e, doc, vars));
+    // A `Date` is an operand, not an expression object. Falling through would find
+    // no `$`-prefixed key on it and rebuild it as an empty literal, so every
+    // comparison against a date would quietly evaluate against `{}`.
+    if (expr instanceof Date) return expr;
     if (expr === null || typeof expr !== 'object') return expr;
 
     const keys = Object.keys(expr);
@@ -101,6 +105,14 @@ function evaluate(expr, doc, vars = {}) {
         case '$gt': {
             const [a, b] = args();
             return a > b;
+        }
+        case '$gte': {
+            const [a, b] = args();
+            return a >= b;
+        }
+        case '$lte': {
+            const [a, b] = args();
+            return a <= b;
         }
         case '$add': {
             // Mongo propagates null: `$add` over a missing or null operand is

--- a/tests/messageCreateSharedUser.test.js
+++ b/tests/messageCreateSharedUser.test.js
@@ -1,0 +1,266 @@
+'use strict';
+
+// `handleLeveling` fetched the author's user document, mutated it, saved it, and
+// returned it into a variable nobody read. `handleStreakAndQuests` then issued
+// the identical `findOne` and saved the same user a second time — two reads and
+// two writes of one document on every message the bot sees, plus a window
+// between them in which each save could undo the other's fields.
+//
+// The parameter to thread it through already existed; the call site just did not
+// use it. These tests pin that it now does, and that nothing that used to be
+// persisted stopped being persisted on the way.
+
+jest.mock('../src/models/User',     () => ({ findOne: jest.fn(), create: jest.fn() }));
+jest.mock('../src/models/Guild',    () => ({ create: jest.fn() }));
+jest.mock('../src/models/Case',     () => ({ findOne: jest.fn().mockResolvedValue(null), countDocuments: jest.fn().mockResolvedValue(0) }));
+jest.mock('../src/models/Reminder', () => ({ create: jest.fn() }));
+
+jest.mock('../src/services/aiService',      () => ({ handleAIChat: jest.fn() }));
+jest.mock('../src/utils/logger',            () => ({ logModeration: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../src/services/rivalryService', () => ({ checkRivalry: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../src/services/chatEventService', () => ({ maybeTriggerChatEvent: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../src/utils/wealthMilestone',   () => ({ checkAndBroadcastWealthMilestone: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../src/services/achievementService', () => ({
+    checkAndAward: jest.fn().mockResolvedValue([]),
+    announceAchievements: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../src/utils/streakMultiplier', () => ({
+    getStreakMultiplier: jest.fn(() => 1),
+    checkNewMilestones: jest.fn(() => []),
+}));
+jest.mock('../src/services/effectsService', () => ({
+    hasEffect: jest.fn(() => false),
+    consumeEffect: jest.fn(),
+    getXpMultiplier: jest.fn(() => 1),
+    getServerXpMultiplier: jest.fn(() => 1),
+}));
+jest.mock('../src/services/questService', () => ({
+    ensureQuests: jest.fn().mockResolvedValue({ assignedNewDaily: false }),
+    onMessage: jest.fn().mockResolvedValue({ completed: [], nearComplete: [] }),
+    onStreakUpdate: jest.fn().mockResolvedValue({ completed: [], nearComplete: [] }),
+    notifyQuestComplete: jest.fn().mockResolvedValue(undefined),
+    notifyQuestNearComplete: jest.fn().mockResolvedValue(undefined),
+    notifyDailyQuestReset: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../src/utils/applyXpGain', () => ({
+    applyXpGain: jest.fn((user, amount) => {
+        user.xp = (user.xp || 0) + amount;
+        return { leveled: false, newLevel: user.level, gained: amount };
+    }),
+    announceLevelUp: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../src/utils/guildSettingsCache', () => ({ getGuildSettings: jest.fn() }));
+// Stands in for the real helper, which folds `balance` out of the save and
+// re-applies it as an `$inc`. What matters here is that it is the thing that
+// saves, and that it saves once.
+jest.mock('../src/utils/balanceDelta', () => ({
+    saveWithBalanceDelta: jest.fn(async (Model, user) => {
+        await user.save();
+        return { credited: true, balance: user.balance ?? 0 };
+    }),
+}));
+
+const User  = require('../src/models/User');
+const { getGuildSettings } = require('../src/utils/guildSettingsCache');
+const { saveWithBalanceDelta } = require('../src/utils/balanceDelta');
+const { ensureQuests } = require('../src/services/questService');
+const { checkRivalry } = require('../src/services/rivalryService');
+const messageCreate = require('../src/events/messageCreate');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Tracks modification the way a Mongoose document does, because the flush that
+// backstops the bail-out paths is gated on `isModified()`.
+function makeUserDoc(overrides = {}) {
+    const doc = {
+        _id: 'doc1',
+        userId: 'author1',
+        guildId: 'guild1',
+        xp: 0,
+        level: 0,
+        messages: 0,
+        balance: 0,
+        dailyMessages: 0,
+        lastXpGain: null,
+        streak: { current: 3, longest: 3, lastActive: new Date('2020-01-01'), claimedMilestones: [] },
+        pets: [],
+        _dirty: false,
+        isModified() { return this._dirty; },
+        ...overrides,
+    };
+    doc.save = jest.fn(async () => { doc._dirty = false; doc.savedXp = doc.xp; });
+    // Every field the handlers assign goes through here in a real document.
+    return new Proxy(doc, {
+        set(target, prop, value) {
+            if (prop !== '_dirty' && prop !== 'savedXp') target._dirty = true;
+            target[prop] = value;
+            return true;
+        },
+    });
+}
+
+function makeSettings(overrides = {}) {
+    return {
+        ai: { enabled: false },
+        leveling: { enabled: true, rewardsEnabled: true, xpRate: 1, noXpChannelIds: [], noXpRoleIds: [] },
+        moderation: { enabled: false },
+        suggestions: { enabled: false },
+        bibleVerse: { autoRespond: false },
+        ...overrides,
+    };
+}
+
+function makeMessage(content = 'hello there') {
+    const channel = {
+        id: 'chan1',
+        send: jest.fn().mockResolvedValue({ delete: jest.fn().mockResolvedValue(undefined) }),
+    };
+    return {
+        id: 'msg1',
+        url: 'https://discord.com/channels/guild1/chan1/msg1',
+        content,
+        author: { id: 'author1', bot: false, toString: () => '<@author1>' },
+        attachments: new Map(),
+        mentions: { has: () => false },
+        member: {
+            id: 'author1',
+            permissions: { has: () => false },
+            roles: { cache: { some: () => false } },
+            bannable: false, kickable: false, moderatable: false,
+        },
+        guild: { id: 'guild1', name: 'Guild One' },
+        channel,
+        client: { user: { id: 'bot1' } },
+        delete: jest.fn().mockResolvedValue(undefined),
+    };
+}
+
+const run = (message) => messageCreate.execute(message, { user: { id: 'bot1' } });
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    getGuildSettings.mockResolvedValue(makeSettings());
+});
+
+// ---------------------------------------------------------------------------
+
+describe('a message that earns XP', () => {
+    test('reads the author once, not once per handler', async () => {
+        User.findOne.mockResolvedValue(makeUserDoc());
+
+        await run(makeMessage());
+
+        expect(User.findOne).toHaveBeenCalledTimes(1);
+    });
+
+    test('saves the author once', async () => {
+        const doc = makeUserDoc();
+        User.findOne.mockResolvedValue(doc);
+
+        await run(makeMessage());
+
+        expect(doc.save).toHaveBeenCalledTimes(1);
+    });
+
+    test('the streak handler works on the very document the leveling handler loaded', async () => {
+        const doc = makeUserDoc();
+        User.findOne.mockResolvedValue(doc);
+
+        await run(makeMessage());
+
+        expect(saveWithBalanceDelta).toHaveBeenCalledTimes(1);
+        expect(saveWithBalanceDelta.mock.calls[0][1]).toBe(doc);
+    });
+
+    test('the one save carries the XP the leveling handler applied', async () => {
+        const doc = makeUserDoc();
+        User.findOne.mockResolvedValue(doc);
+
+        await run(makeMessage());
+
+        // The regression this guards: dropping handleLeveling's save without
+        // threading its document through would silently stop XP being persisted.
+        expect(doc.savedXp).toBeGreaterThan(0);
+        expect(doc.messages).toBe(1);
+    });
+
+    test('rivalry standings are still checked', async () => {
+        User.findOne.mockResolvedValue(makeUserDoc());
+
+        await run(makeMessage());
+
+        expect(checkRivalry).toHaveBeenCalledTimes(1);
+    });
+
+    test('a user on XP cooldown is still handed to the streak handler', async () => {
+        const doc = makeUserDoc({ lastXpGain: new Date() });
+        User.findOne.mockResolvedValue(doc);
+
+        await run(makeMessage());
+
+        expect(User.findOne).toHaveBeenCalledTimes(1);
+        expect(saveWithBalanceDelta.mock.calls[0][1]).toBe(doc);
+    });
+});
+
+describe('when the single write does not happen', () => {
+    test('XP still lands if the streak handler throws before saving', async () => {
+        const doc = makeUserDoc();
+        User.findOne.mockResolvedValue(doc);
+        ensureQuests.mockRejectedValueOnce(new Error('quest service is down'));
+        const err = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        await run(makeMessage());
+
+        expect(saveWithBalanceDelta).not.toHaveBeenCalled();
+        expect(doc.save).toHaveBeenCalledTimes(1);
+        expect(doc.savedXp).toBeGreaterThan(0);
+        err.mockRestore();
+    });
+
+    test('XP still lands when auto-moderation blocks the message', async () => {
+        // The block path schedules a 5s cleanup of its own warning message; faked so
+        // it does not outlive the test.
+        jest.useFakeTimers();
+        const doc = makeUserDoc();
+        // applyAutoModAction loads its own document for the behaviour score; the
+        // levelling document is the first one handed out.
+        const modDoc = makeUserDoc({ _id: 'doc2', behaviorScore: 0, lastScoreDecay: null });
+        User.findOne.mockResolvedValueOnce(doc).mockResolvedValue(modDoc);
+        getGuildSettings.mockResolvedValue(makeSettings({
+            moderation: { enabled: true, autoModEnabled: true, linkFilter: true },
+        }));
+
+        await run(makeMessage('look at https://example.com'));
+
+        expect(saveWithBalanceDelta).not.toHaveBeenCalled();
+        expect(doc.save).toHaveBeenCalledTimes(1);
+        expect(doc.savedXp).toBeGreaterThan(0);
+        jest.useRealTimers();
+    });
+
+    test('the flush is a no-op once the streak write has landed', async () => {
+        const doc = makeUserDoc();
+        User.findOne.mockResolvedValue(doc);
+
+        await run(makeMessage());
+
+        // A second save here would race the fire-and-forget writes that follow the
+        // first one — wealth milestones and achievements both save the same document.
+        expect(doc.save).toHaveBeenCalledTimes(1);
+    });
+
+    test('no document, no write', async () => {
+        User.findOne.mockResolvedValue(null);
+        User.create.mockResolvedValue(makeUserDoc());
+        getGuildSettings.mockResolvedValue(makeSettings({
+            leveling: { enabled: true, rewardsEnabled: false },
+        }));
+
+        await run(makeMessage());
+
+        expect(saveWithBalanceDelta).not.toHaveBeenCalled();
+    });
+});

--- a/tests/statsInsightsQueries.test.js
+++ b/tests/statsInsightsQueries.test.js
@@ -1,0 +1,279 @@
+'use strict';
+
+// /insights loaded every user in the guild — `User.find({ guildId })` with no
+// limit — to produce four numbers, then filtered the resulting array four times.
+// Beside it, a thousand moderation cases were hydrated as full documents to read
+// five fields off each. Neither is a problem in a guild of forty; both are a way
+// to spend the container's 1 GB in a guild of forty thousand, and the route had
+// no rate limit to make repeating it expensive for the caller.
+//
+// The counting moved into the pipeline. That is worth testing precisely because
+// it is a rewrite of arithmetic that was previously plain JavaScript: the shape
+// is cheaper, and it has to still produce the same four numbers.
+
+const express = require('express');
+const { evaluate } = require('./helpers/pipelineUpdate');
+
+jest.mock('../src/models/Guild', () => ({ findOne: jest.fn() }));
+jest.mock('../src/models/User',  () => ({ aggregate: jest.fn(), find: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../src/models/Case',  () => ({ find: jest.fn() }));
+jest.mock('../src/dashboard/lib/middleware', () => ({
+    checkAuth: (req, _res, next) => { req.user = { id: 'admin-1' }; next(); },
+    checkGuildAccess: (_req, _res, next) => next(),
+}));
+
+const Guild = require('../src/models/Guild');
+const User  = require('../src/models/User');
+const Case  = require('../src/models/Case');
+const { __reset } = require('../src/dashboard/lib/aggregateCache');
+const statsRouter = require('../src/dashboard/routes/api/stats');
+
+let server;
+let baseUrl;
+
+// ---------------------------------------------------------------------------
+// Just enough of an aggregation runner for the stages this route issues. It
+// reuses the shared expression evaluator, which throws on an operator it does
+// not know — a pipeline that grows one should fail here rather than quietly
+// return a different number.
+// ---------------------------------------------------------------------------
+function runPipeline(docs, stages) {
+    let rows = docs.map(d => ({ ...d }));
+    for (const stage of stages) {
+        if (stage.$match) {
+            rows = rows.filter(row => Object.entries(stage.$match).every(([field, cond]) => {
+                if (cond && typeof cond === 'object' && !(cond instanceof Date)) {
+                    return Object.entries(cond).every(([op, operand]) => {
+                        // Mongo brackets range comparisons by BSON type: a `$lte` against
+                        // a date never matches a document whose field is null or absent,
+                        // however cheerfully JavaScript would coerce it to zero.
+                        if (operand instanceof Date && !(row[field] instanceof Date)) return false;
+                        return evaluate({ [op]: [`$${field}`, operand] }, row);
+                    });
+                }
+                return row[field] === cond;
+            }));
+        } else if (stage.$set || stage.$addFields) {
+            const set = stage.$set ?? stage.$addFields;
+            rows = rows.map(row => ({
+                ...row,
+                ...Object.fromEntries(Object.entries(set).map(([k, expr]) => [k, evaluate(expr, row)])),
+            }));
+        } else if (stage.$group) {
+            const { _id, ...accumulators } = stage.$group;
+            if (_id !== null) throw new Error('test runner only groups the whole set');
+            const out = { _id: null };
+            for (const [field, acc] of Object.entries(accumulators)) {
+                out[field] = rows.reduce((sum, row) => sum + evaluate(acc.$sum, row), 0);
+            }
+            rows = rows.length ? [out] : [];
+        } else {
+            throw new Error(`test runner: unsupported stage ${Object.keys(stage).join(', ')}`);
+        }
+    }
+    return rows;
+}
+
+// The array logic /insights used before the rewrite, kept verbatim as the oracle.
+function legacyCohorts(docs, now) {
+    const cohort7  = docs.filter(u => u.createdAt && (now - new Date(u.createdAt).getTime()) >= 7 * 864e5);
+    const cohort30 = docs.filter(u => u.createdAt && (now - new Date(u.createdAt).getTime()) >= 30 * 864e5);
+    const isConverted = u => (u.messages || 0) >= 20 || (u.level || 0) >= 2;
+    return {
+        cohort7: cohort7.length,
+        converted7: cohort7.filter(isConverted).length,
+        cohort30: cohort30.length,
+        converted30: cohort30.filter(isConverted).length,
+    };
+}
+
+const daysAgo = n => new Date(Date.now() - n * 864e5);
+
+// ---------------------------------------------------------------------------
+
+function stubCaseFind(docs = []) {
+    const seen = {};
+    Case.find.mockImplementation(() => {
+        const chain = {
+            select(fields) { seen.select = fields; return chain; },
+            sort() { return chain; },
+            limit(n) { seen.limit = n; return chain; },
+            lean() { seen.lean = true; return Promise.resolve(docs); },
+        };
+        return chain;
+    });
+    return seen;
+}
+
+function stubGuildFindOne(doc) {
+    const seen = {};
+    Guild.findOne.mockImplementation(() => ({
+        select(fields) { seen.select = fields; return this; },
+        lean: () => Promise.resolve(doc),
+    }));
+    return seen;
+}
+
+function stubUserFind(docs = []) {
+    User.find.mockImplementation(() => {
+        const chain = {
+            select() { return chain; },
+            sort() { return chain; },
+            limit() { return chain; },
+            lean() { return Promise.resolve(docs); },
+        };
+        return chain;
+    });
+}
+
+const get = async (path) => {
+    const resp = await fetch(baseUrl + path);
+    return { status: resp.status, body: await resp.json() };
+};
+
+beforeAll(async () => {
+    const app = express();
+    app.use('/api', statsRouter);
+    await new Promise(resolve => { server = app.listen(0, resolve); });
+    baseUrl = `http://127.0.0.1:${server.address().port}/api`;
+});
+
+afterAll(async () => {
+    await new Promise(resolve => server.close(resolve));
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    __reset();
+    stubUserFind([]);
+    User.countDocuments.mockResolvedValue(0);
+    User.aggregate.mockResolvedValue([]);
+    stubGuildFindOne({ guildId: 'g1', analytics: { memberEvents: [], commandUsage: [] } });
+    stubCaseFind([]);
+});
+
+// ---------------------------------------------------------------------------
+
+describe('/insights newcomer conversion', () => {
+    const population = [
+        { guildId: 'g1', createdAt: daysAgo(45), messages: 50, level: 1 },  // 30d cohort, converted on messages
+        { guildId: 'g1', createdAt: daysAgo(40), messages: 0,  level: 5 },  // 30d cohort, converted on level
+        { guildId: 'g1', createdAt: daysAgo(31), messages: 3,  level: 1 },  // 30d cohort, not converted
+        { guildId: 'g1', createdAt: daysAgo(10), messages: 20, level: 0 },  // 7d cohort only, converted on the boundary
+        { guildId: 'g1', createdAt: daysAgo(8),  messages: 19, level: 1 },  // 7d cohort only, one message short
+        { guildId: 'g1', createdAt: daysAgo(2),  messages: 99, level: 9 },  // too new for either cohort
+        { guildId: 'g1', createdAt: null,        messages: 99, level: 9 },  // no join date at all
+        { guildId: 'g2', createdAt: daysAgo(60), messages: 99, level: 9 },  // another guild entirely
+    ];
+
+    beforeEach(() => {
+        User.aggregate.mockImplementation(async stages => runPipeline(population, stages));
+    });
+
+    test('counts the same four numbers the array filters produced', async () => {
+        const expected = legacyCohorts(population.filter(u => u.guildId === 'g1'), Date.now());
+        const { body } = await get('/guild/g1/insights');
+
+        expect(body.newcomerConversion.days7).toMatchObject({
+            cohortSize: expected.cohort7, converted: expected.converted7,
+        });
+        expect(body.newcomerConversion.days30).toMatchObject({
+            cohortSize: expected.cohort30, converted: expected.converted30,
+        });
+    });
+
+    test('and those numbers are the ones the fixture was built to produce', async () => {
+        const { body } = await get('/guild/g1/insights');
+
+        // Spelled out so a change in the pipeline cannot be rubber-stamped by an
+        // oracle that drifted along with it.
+        expect(body.newcomerConversion.days7).toEqual({ cohortSize: 5, converted: 3, pct: 60 });
+        expect(body.newcomerConversion.days30).toEqual({ cohortSize: 3, converted: 2, pct: 66.7 });
+    });
+
+    test('never asks the database for the documents themselves', async () => {
+        await get('/guild/g1/insights');
+
+        // The unbounded `User.find({ guildId })` this replaced is the whole point:
+        // peak memory grew with the size of the server, to compute four integers.
+        expect(User.find).not.toHaveBeenCalled();
+        expect(User.aggregate).toHaveBeenCalledTimes(1);
+    });
+
+    test('narrows to the wider cohort in the match, not in the process', async () => {
+        await get('/guild/g1/insights');
+
+        const [stages] = User.aggregate.mock.calls[0];
+        expect(stages[0].$match.guildId).toBe('g1');
+        expect(stages[0].$match.createdAt.$lte).toBeInstanceOf(Date);
+    });
+
+    test('reports zeroes rather than dividing by an empty cohort', async () => {
+        User.aggregate.mockResolvedValue([]);
+
+        const { body } = await get('/guild/g1/insights');
+
+        expect(body.newcomerConversion.days7).toEqual({ cohortSize: 0, converted: 0, pct: 0 });
+        expect(body.newcomerConversion.days30).toEqual({ cohortSize: 0, converted: 0, pct: 0 });
+    });
+});
+
+describe('/insights reads', () => {
+    test('takes moderation cases projected and lean, still capped at 1000', async () => {
+        const seen = stubCaseFind([]);
+
+        await get('/guild/g1/insights');
+
+        expect(seen.select).toBe('type createdAt resolvedAt evidence.jumpUrl');
+        expect(seen.lean).toBe(true);
+        expect(seen.limit).toBe(1000);
+    });
+
+    test('asks the guild for analytics and not for the shop', async () => {
+        const seen = stubGuildFindOne({ guildId: 'g1', analytics: { memberEvents: [], commandUsage: [] } });
+
+        await get('/guild/g1/insights');
+
+        expect(seen.select).toBe('guildId analytics');
+    });
+
+    test('still 404s a guild that is not there', async () => {
+        stubGuildFindOne(null);
+
+        const { status } = await get('/guild/nope/insights');
+
+        expect(status).toBe(404);
+    });
+});
+
+describe('/stats', () => {
+    test('runs each collection-wide read once across repeated requests', async () => {
+        await get('/guild/g1/stats');
+        await get('/guild/g1/stats');
+
+        // Two `$group`s over every user in the guild, a count, and a sort — the cost
+        // of the panel is the same whether it is opened once or left refreshing.
+        expect(User.aggregate).toHaveBeenCalledTimes(2);   // totalMessages + ecoTotal
+        expect(User.countDocuments).toHaveBeenCalledTimes(2); // totalUsers + active
+        expect(User.find).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not serve one guild the other guild\'s numbers', async () => {
+        User.countDocuments.mockResolvedValueOnce(11).mockResolvedValue(0);
+        const first = await get('/guild/g1/stats');
+        User.countDocuments.mockResolvedValueOnce(22).mockResolvedValue(0);
+        const second = await get('/guild/g2/stats');
+
+        expect(first.body.totalUsers).toBe(11);
+        expect(second.body.totalUsers).toBe(22);
+    });
+
+    test('asks the guild for the fields it reads and not the shop images', async () => {
+        const seen = stubGuildFindOne({ guildId: 'g1', analytics: { memberEvents: [], commandUsage: [] } });
+
+        await get('/guild/g1/stats');
+
+        expect(seen.select.split(/\s+/)).not.toContain('shop');
+        expect(seen.select).toContain('analytics');
+    });
+});


### PR DESCRIPTION
## Summary

This PR optimizes expensive dashboard queries and adds read rate limiting to prevent memory exhaustion from repeated collection-wide aggregations. The changes address performance issues where unauthenticated or authenticated users could repeatedly trigger full-guild scans that consume significant memory.

## Key Changes

- **Query Optimization**: Replaced unbounded `User.find()` calls with aggregation pipelines that compute results in the database rather than hydrating full documents in memory
  - `/stats` endpoint now uses `$group` stages to count users and sum messages instead of loading all documents
  - `/insights` endpoint moved newcomer cohort filtering into the aggregation pipeline
  - Removed unnecessary document hydration for moderation case aggregates

- **Projection Enforcement**: Added field projections to all collection-wide queries to exclude expensive fields
  - Guild queries now exclude `analytics.commandUsage` array (up to 3000 entries) and shop item image Buffers
  - User queries select only required fields for each operation
  - Added static analysis test to prevent future unprojected `Guild.find({})` calls

- **Caching Layer**: Implemented `aggregateCache` module with 30-second TTL memoization
  - Concurrent requests on cold keys share a single database query instead of each starting their own
  - Failed queries are not cached, allowing automatic retry on next request
  - Prevents read-flood scenarios where N simultaneous requests trigger N full scans

- **Read Rate Limiting**: Added `checkReadRateLimit` middleware (120 requests/minute per user)
  - Applied globally to all API routes via the main router
  - Counts per authenticated user, falls back to IP address for unauthenticated requests
  - Complements existing write rate limiting to protect against memory exhaustion

- **Batch Operations**: Refactored bank interest payout to use `bulkWrite` and `insertMany`
  - Replaces sequential `findOneAndUpdate` + `Transaction.create` per user with batched operations
  - Reduces round trips from O(n) to O(n/1000) for large guilds

- **Message Handler Optimization**: Unified user document loading in `messageCreate` event
  - `handleLeveling` and `handleStreakAndQuests` now share a single user document fetch
  - Eliminates duplicate reads and potential race conditions between saves
  - Added `flushPendingUser` helper to persist XP when message is blocked by moderation

## Testing

Added comprehensive test suites covering:
- Pipeline aggregation correctness matching legacy array-based logic
- Query projection and lean() enforcement
- Cache behavior (TTL, concurrent requests, failure handling)
- Read rate limiter functionality and per-route application
- Shared user document threading through message handlers
- Bank interest batch operation correctness

https://claude.ai/code/session_015DhwjzZoyAt5GhvQH6HvJM