### PR TITLE
Redesign mining dig mechanics and add prestige system

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -287,6 +287,26 @@ Coal Tunnels down, and the Abyss adds two event ores of its own.
 Once a depth is unlocked it stays accessible for good — the level requirement is
 checked at purchase, not every dig.
 
+**A dig** is a risk choice followed by a vein read. You pick how hard to push —
+the choice is yours, and it is the only thing that sets the danger:
+
+| Push | Payout | Cave-in risk | Pickaxe wear |
+|---|---:|---:|---:|
+| ☀️ Surface | 0.7× | 0% | 1 |
+| 🪨 Shallow | 1.0× | 5% | 1 |
+| 🔩 Mid | 1.4× | 12% | 2 |
+| 💎 Deep | 2.0× | 20% | 3 |
+
+Then the tunnel shows you where the seam runs, the dust settles, and you call it.
+A correct read promotes the payout one rung — Deep pays the Abyss's **3×** — at the
+risk you already chose. 🌑 Abyss cannot be selected; it is only ever earned.
+
+Pass `intensity:` on the command to skip the prompt and dig straight away. An
+unanswered prompt repeats whatever you dug last.
+
+Cave in and you choose again: spend a blast charge to dig clear and keep the whole
+haul, multiplier included, or flee and lose it.
+
 **Miner prestige** (`/mine prestige`) opens at Miner Level 50 and runs to P5. Each
 rank resets Miner Level and XP and keeps everything else — pickaxes, unlocked
 depths, materials, consumables and lifetime stats:

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -269,6 +269,36 @@ crafting, pet food, and the market.
 /synergies             - Cross-system bonuses and progress toward them
 ```
 
+**Mining depths** gate the rarity ladder: each depth only ever yields ore it has
+a table for, so progression is what moves the top end.
+
+| Depth | Unlock | Best ore tier |
+|---|---|---|
+| 🪨 Surface Quarry | Level 1 | Rare |
+| 🖤 Coal Tunnels | Level 10 · 3,000 | Rare |
+| 🔩 Iron Mines | Level 20 · 12,000 | Epic |
+| 💠 Crystal Caves | Level 30 · 30,000 | Legendary |
+| 🌑 The Abyss | Level 50 · 75,000 | Legendary, +20% payout |
+
+The ⭐ Event tier sits above Legendary and is the rarest thing in the game. It is
+not part of the depth ladder — a Celestial Fragment can land anywhere from the
+Coal Tunnels down, and the Abyss adds two event ores of its own.
+
+Once a depth is unlocked it stays accessible for good — the level requirement is
+checked at purchase, not every dig.
+
+**Miner prestige** (`/mine prestige`) opens at Miner Level 50 and runs to P5. Each
+rank resets Miner Level and XP and keeps everything else — pickaxes, unlocked
+depths, materials, consumables and lifetime stats:
+
+| Rank | Grants (cumulative) |
+|---|---|
+| 🥉 P1 | +2% crit chance |
+| 🥈 P2 | +1 max stamina |
+| 🥇 P3 | +5% all payouts |
+| 🏆 P4 | +2% rarity boost |
+| 💎 P5 | +10% all payouts |
+
 **`/forge`** spends coins to have the configured AI provider invent a unique
 item, with cost and XP scaling by rarity tier:
 

--- a/src/commands/economy/craft.js
+++ b/src/commands/economy/craft.js
@@ -3,7 +3,6 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User  = require('../../models/User');
 const { attachGrind } = require('../../utils/grindProfile');
-const { tryAcquire: lockAcquire, release: lockRelease } = require('../../utils/activeGameLock');
 const Guild = require('../../models/Guild');
 const { CRAFT_RECIPES: HUNT_RECIPES, CONSUMABLES: HUNT_CONSUMABLES, MATERIAL_NAMES: HUNT_MAT_NAMES } = require('../../data/huntData');
 const { CRAFT_RECIPES: MINE_RECIPES, CONSUMABLES: MINE_CONSUMABLES, MATERIAL_NAMES: MINE_MAT_NAMES } = require('../../data/mineData');
@@ -310,20 +309,7 @@ module.exports = {
             user.markModified('hunt');
             user.markModified('mining');
             user.markModified('fishing');
-
-            // A grind profile is persisted by replacing its whole `data` document, so
-            // this save would overwrite a /mine raid's material transfer if one landed
-            // between the read above and here. The raid holds the defender's mining
-            // action lock for exactly that reason; take it here too so the spend and
-            // the transfer cannot interleave. The critical section is one save, so a
-            // short TTL is enough and a raider is never blocked for long.
-            const craftLockKey = `grind:mine:${interaction.guild.id}:${interaction.user.id}`;
-            const craftLock    = await lockAcquire(craftLockKey, 15_000);
-            try {
-                await user.save();
-            } finally {
-                if (craftLock) await lockRelease(craftLockKey, craftLock);
-            }
+            await user.save();
 
             const usedLines = recipe.ingredients.map(ing => {
                 const remaining = getMat(ing.material, ing.source);
@@ -349,5 +335,36 @@ module.exports = {
 
             return interaction.reply({ embeds: [embed] });
         }
+    }
+};
+
+
+// ── Per-user mining lock for the craft flow ───────────────────────────────────
+// Crafting spends mining materials, and a grind profile is persisted by replacing
+// its whole `data` document — so the lock has to cover the *read* as well as the
+// write. Taking it only around user.save() left the window that matters open: a
+// /mine raid landing between attachGrind and the save was simply overwritten by
+// the snapshot this flow had already loaded, and the raider kept their credit.
+//
+// So the whole `make` flow runs under the same key /mine holds, from before the
+// profiles are attached until after they are saved. `list` is read-only and is
+// left alone, so browsing recipes never blocks a raid.
+const { tryAcquire: _craftLockAcquire, release: _craftLockRelease } = require('../../utils/activeGameLock');
+const _craftExecute = module.exports.execute;
+module.exports.execute = async function (interaction) {
+    if (interaction.options.getSubcommand() !== 'make') return _craftExecute(interaction);
+
+    const lockKey   = `grind:mine:${interaction.guild?.id}:${interaction.user.id}`;
+    const lockToken = await _craftLockAcquire(lockKey, 60_000);
+    if (!lockToken) {
+        return interaction.reply({
+            content: '⛏️ You have a mining action in progress — finish it before crafting.',
+            flags: MessageFlags.Ephemeral,
+        }).catch(() => {});
+    }
+    try {
+        return await _craftExecute(interaction);
+    } finally {
+        await _craftLockRelease(lockKey, lockToken);
     }
 };

--- a/src/commands/economy/craft.js
+++ b/src/commands/economy/craft.js
@@ -3,6 +3,7 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User  = require('../../models/User');
 const { attachGrind } = require('../../utils/grindProfile');
+const { tryAcquire: lockAcquire, release: lockRelease } = require('../../utils/activeGameLock');
 const Guild = require('../../models/Guild');
 const { CRAFT_RECIPES: HUNT_RECIPES, CONSUMABLES: HUNT_CONSUMABLES, MATERIAL_NAMES: HUNT_MAT_NAMES } = require('../../data/huntData');
 const { CRAFT_RECIPES: MINE_RECIPES, CONSUMABLES: MINE_CONSUMABLES, MATERIAL_NAMES: MINE_MAT_NAMES } = require('../../data/mineData');
@@ -309,7 +310,20 @@ module.exports = {
             user.markModified('hunt');
             user.markModified('mining');
             user.markModified('fishing');
-            await user.save();
+
+            // A grind profile is persisted by replacing its whole `data` document, so
+            // this save would overwrite a /mine raid's material transfer if one landed
+            // between the read above and here. The raid holds the defender's mining
+            // action lock for exactly that reason; take it here too so the spend and
+            // the transfer cannot interleave. The critical section is one save, so a
+            // short TTL is enough and a raider is never blocked for long.
+            const craftLockKey = `grind:mine:${interaction.guild.id}:${interaction.user.id}`;
+            const craftLock    = await lockAcquire(craftLockKey, 15_000);
+            try {
+                await user.save();
+            } finally {
+                if (craftLock) await lockRelease(craftLockKey, craftLock);
+            }
 
             const usedLines = recipe.ingredients.map(ing => {
                 const remaining = getMat(ing.material, ing.source);

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -54,7 +54,7 @@ const {
 const { getCurrentWeather } = require('../../services/weatherService');
 const { FISH_TRAITS, TIME_OF_DAY_BONUSES, getTimeOfDay } = require('../../data/fishData');
 const { ensureHuntData } = require('../../services/huntService');
-const { TIER_NUM, TIER_RIBBON } = require('../../data/materialRarity');
+const { TIER_NUM, TIER_RIBBON, TIER_STARS } = require('../../data/materialRarity');
 const { randomFrom, FISH_MISS_POOL } = require('../../utils/copyLines');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
 const { stackBar } = require('../../utils/rewardReveal');
@@ -1129,7 +1129,7 @@ async function handleCast(interaction) {
         // Non-boss path: log big win after all payouts finalized
         if (result.success) {
             const bigWinThreshold = guildSettings?.economy?.bigWinThreshold ?? 50000;
-            if (result.finalPayout >= bigWinThreshold || result.tier === 'legendary') {
+            if (result.finalPayout >= bigWinThreshold || ['legendary', 'event'].includes(result.tier)) {
                 logBigWin({ guildId: interaction.guild.id, userId: interaction.user.id, username: interaction.user.username, amount: result.finalPayout, source: 'fish', details: { itemName: result.fish?.name, rarity: result.tier }, client: interaction.client });
             }
         }
@@ -1162,18 +1162,24 @@ async function handleCast(interaction) {
         // Staged loot reveal for rare+ drops
         await stagedLootReveal(interaction, result.success ? result.tier : null, embed);
 
-        if (result.success && ['epic', 'legendary'].includes(result.tier) && guildSettings?.economy?.announceRareDrops !== false) {
+        if (result.success && ['epic', 'legendary', 'event'].includes(result.tier) && guildSettings?.economy?.announceRareDrops !== false) {
             const announceChannelId = guildSettings?.economy?.announcementChannelId;
             const resolved = announceChannelId ? interaction.guild.channels.cache.get(announceChannelId) : null;
             const announceChannel = resolved?.isTextBased() ? resolved : interaction.channel;
-            const isLeg = result.tier === 'legendary';
+            const announceTier = TIER_NUM[result.tier] ?? 4;
+            const ANNOUNCE_COPY = {
+                4: { color: '#9c27b0', title: '🔮 Epic Catch!',             line: 'A remarkable catch.' },
+                5: { color: '#ff9800', title: '✨ Legendary Catch! ✨',      line: "That's incredibly rare." },
+                6: { color: '#e74c3c', title: '☄️ Mythical Catch! ☄️',      line: 'Sailors tell stories about this one.' },
+            };
+            const copy = ANNOUNCE_COPY[announceTier] ?? ANNOUNCE_COPY[4];
             const announcementEmbed = new EmbedBuilder()
-                .setColor(isLeg ? '#ff9800' : '#9c27b0')
-                .setTitle(isLeg ? '✨ Legendary Catch! ✨' : '🔮 Epic Catch!')
+                .setColor(copy.color)
+                .setTitle(copy.title)
                 .setDescription(
-                    `<@${interaction.user.id}> just pulled ${result.fish.emoji} **${result.fish.name}** [${isLeg ? '⭐⭐⭐⭐⭐' : '⭐⭐⭐⭐'}]\n` +
+                    `<@${interaction.user.id}> just pulled ${result.fish.emoji} **${result.fish.name}** [${TIER_STARS[announceTier]}]\n` +
                     `while fishing in the **${location.name}**.\n\n` +
-                    (isLeg ? `That's incredibly rare.` : `A remarkable catch.`)
+                    copy.line
                 )
                 .setTimestamp();
             announceChannel.send({ embeds: [announcementEmbed] }).catch(() => null);
@@ -1255,22 +1261,25 @@ function buildCastEmbed(result, user, location, rod, currency, discordUser) {
         const weatherNote  = buildWeatherNote(weather, location.id);
         const weatherBanner = weatherNote ? `> ${weatherNote}\n\n` : '';
 
-        // Tier-specific title decoration — each rarity bracket has a distinct visual signature
-        const embedTitle = isLegendary
+        // Tier-specific title decoration — each rarity bracket has a distinct visual
+        // signature. Event outranks legendary, so it is checked first, and both sit
+        // ahead of the crit decoration: a critical event catch is still an event catch.
+        const embedTitle = isEvent
+            ? `☄️🌊 MYTHICAL CATCH 🌊☄️`
+            : isLegendary
             ? `🌊✨ LEGENDARY CATCH ✨🌊`
             : isCrit
             ? `${fish.emoji} ✨ CRITICAL! ${fish.name}${sizeStr} ✨`
-            : isEvent
-            ? `🌟 ${fish.emoji} ${fish.name}${sizeStr} 🌟`
             : isEpic
             ? `⚡ ${fish.emoji} ${fish.name}${sizeStr} ⚡`
             : `${fish.emoji} ${fish.name}${sizeStr}`;
 
         // Tier-specific description — escalates in drama with rarity
-        const embedDesc = isLegendary
-            ? `${weatherBanner}${ribbon}\n\nYou pulled something impossible from the deep.\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  ${fish.emoji}  **${fish.name}**${sizeStr}  [⭐⭐⭐⭐⭐]\n  *${fish.flavor}*\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n\nAdded to your inventory.`
-            : isEvent
-            ? `${weatherBanner}${ribbon}\n\nSomething that shouldn't exist rises from below.\n\n*${fish.flavor}*`
+        const headlineStars = TIER_STARS[TIER_NUM[tier] ?? 5];
+        const embedDesc = isEvent
+            ? `${weatherBanner}${ribbon}\n\nSomething that shouldn't exist rises from below.\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  ${fish.emoji}  **${fish.name}**${sizeStr}  [${headlineStars}]\n  *${fish.flavor}*\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n\nAdded to your inventory.`
+            : isLegendary
+            ? `${weatherBanner}${ribbon}\n\nYou pulled something impossible from the deep.\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  ${fish.emoji}  **${fish.name}**${sizeStr}  [${headlineStars}]\n  *${fish.flavor}*\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n\nAdded to your inventory.`
             : isEpic
             ? `${weatherBanner}${ribbon}\n\nAn exceptional catch that tests every fibre of your rod.\n\n*${fish.flavor}*`
             : `${weatherBanner}${ribbon}\n\n*${fish.flavor}*`;

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -1243,7 +1243,10 @@ function buildCastEmbed(result, user, location, rod, currency, discordUser) {
 
         // Fish catch
         const { fish, tier, isCrit, critMultiplier, sizeLabel, specialDrop } = result;
-        const color      = isCrit ? '#FFD700' : TIER_COLORS[tier];
+        // An event catch keeps its own colour even on a critical: the tier is the
+        // rarer fact of the two, and the title already announces it as one. Without
+        // this a critical event drop rendered crit-gold under a MYTHICAL headline.
+        const color = tier === 'event' ? TIER_COLORS.event : isCrit ? '#FFD700' : TIER_COLORS[tier];
         const tierLabel  = tier.charAt(0).toUpperCase() + tier.slice(1);
         const weightStr  = result.weightLbs > 0 ? ` (${result.weightLbs} lbs)` : '';
         const sizeStr    = sizeLabel ? ` [${sizeLabel}${weightStr}]` : '';

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -346,20 +346,21 @@ async function stagedLootReveal(interaction, tier, finalEmbed) {
     } else {
         await interaction.editReply({ embeds: [fogEmbed] });
         await wait(1500);
-        const midColor = tierNum === 4 ? '#9c27b0' : '#ff9800';
-        const midTitle = tierNum === 4 ? '🔮 Something exceptional breaks the surface...' : '⚡ The line pulls taut with impossible force...';
-        const midTierLabel = tierNum === 4 ? 'EPIC' : 'LEGENDARY';
+        const midColor = tierNum === 6 ? '#e74c3c' : tierNum === 4 ? '#9c27b0' : '#ff9800';
+        const midTitle = tierNum === 6 ? '☄️ The water goes utterly still...' : tierNum === 4 ? '🔮 Something exceptional breaks the surface...' : '⚡ The line pulls taut with impossible force...';
+        const midTierLabel = tierNum === 6 ? 'EVENT' : tierNum === 4 ? 'EPIC' : 'LEGENDARY';
         const midEmbed = new EmbedBuilder()
             .setColor(midColor)
             .setTitle(midTitle)
             .setDescription(`━━━━━━━━━━━━━━━\n❓❓❓  **${midTierLabel}**  ❓❓❓\n━━━━━━━━━━━━━━━`);
         await interaction.editReply({ embeds: [midEmbed] });
         await wait(1500);
-        if (tierNum === 5) {
+        if (tierNum >= 5) {
+            const isEvent = tierNum === 6;
             const fanfareEmbed = new EmbedBuilder()
-                .setColor('#ff9800')
-                .setTitle('⚡ ✨ 𝗟 𝗘 𝗚 𝗘 𝗡 𝗗 𝗔 𝗥 𝗬 ✨ ⚡')
-                .setDescription('━━━━━━━━━━━━━━━\n*The ocean holds its breath. This catch defies all odds.*\n━━━━━━━━━━━━━━━');
+                .setColor(isEvent ? '#e74c3c' : '#ff9800')
+                .setTitle(isEvent ? '☄️ 🌊 𝗠 𝗬 𝗧 𝗛 𝗜 𝗖 𝗔 𝗟 🌊 ☄️' : '⚡ ✨ 𝗟 𝗘 𝗚 𝗘 𝗡 𝗗 𝗔 𝗥 𝗬 ✨ ⚡')
+                .setDescription(isEvent ? '━━━━━━━━━━━━━━━\n*Sailors tell stories about this one. Now you are the story.*\n━━━━━━━━━━━━━━━' : '━━━━━━━━━━━━━━━\n*The ocean holds its breath. This catch defies all odds.*\n━━━━━━━━━━━━━━━');
             await interaction.editReply({ embeds: [fanfareEmbed] });
             await wait(1500);
         }

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -2218,15 +2218,21 @@ async function executeQuests(interaction, sub) {
             });
         }
 
-        const remaining = user.quests.filter(q =>
-            q.questId.startsWith('hq_') &&
-            q.expiresAt?.getTime() > now &&
-            q.progress !== -1
-        ).length;
+        const liveQuests = user.quests.filter(q =>
+            q.questId.startsWith('hq_') && q.expiresAt?.getTime() > now
+        );
+        const remaining = liveQuests.filter(q => q.progress !== -1).length;
+
+        // A fresh batch is only assigned once the current one has expired — see the
+        // guard in assign*Quests. Say when that is rather than implying that playing
+        // again brings one sooner, which is what this footer used to promise.
+        const nextSetIn = liveQuests.length
+            ? formatExpiry(Math.min(...liveQuests.map(q => q.expiresAt.getTime())) - now)
+            : null;
 
         embed.setFooter({ text: remaining > 0
             ? `${remaining} quest(s) remaining — use /hunt quests view`
-            : 'All quests claimed! Hunt again to receive a fresh set.' });
+            : `All quests claimed! A fresh set arrives in ${nextSetIn ?? 'a few hours'}.` });
         embed.setTimestamp();
 
         return interaction.reply({ embeds: [embed] });

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -357,21 +357,22 @@ async function stagedLootReveal(interaction, tier, finalEmbed) {
         await interaction.editReply({ embeds: [fogEmbed] });
         await wait(1500);
         // Stage 2 — partial reveal
-        const midColor = tierNum === 4 ? '#9c27b0' : '#ff9800';
-        const midTitle = tierNum === 4 ? '🔮 Something exceptional emerges...' : '⚡ The air crackles with power...';
-        const midTierLabel = tierNum === 4 ? 'EPIC' : 'LEGENDARY';
+        const midColor = tierNum === 6 ? '#e74c3c' : tierNum === 4 ? '#9c27b0' : '#ff9800';
+        const midTitle = tierNum === 6 ? '☄️ Every animal in the forest has gone silent...' : tierNum === 4 ? '🔮 Something exceptional emerges...' : '⚡ The air crackles with power...';
+        const midTierLabel = tierNum === 6 ? 'EVENT' : tierNum === 4 ? 'EPIC' : 'LEGENDARY';
         const midEmbed = new EmbedBuilder()
             .setColor(midColor)
             .setTitle(midTitle)
             .setDescription(`━━━━━━━━━━━━━━━\n❓❓❓  **${midTierLabel}**  ❓❓❓\n━━━━━━━━━━━━━━━`);
         await interaction.editReply({ embeds: [midEmbed] });
         await wait(1500);
-        if (tierNum === 5) {
+        if (tierNum >= 5) {
             // Stage 3 — legendary fanfare
+            const isEvent = tierNum === 6;
             const fanfareEmbed = new EmbedBuilder()
-                .setColor('#ff9800')
-                .setTitle('⚡ ✨ 𝗟 𝗘 𝗚 𝗘 𝗡 𝗗 𝗔 𝗥 𝗬 ✨ ⚡')
-                .setDescription('━━━━━━━━━━━━━━━\n*The air crackles. This is once in a lifetime.*\n━━━━━━━━━━━━━━━');
+                .setColor(isEvent ? '#e74c3c' : '#ff9800')
+                .setTitle(isEvent ? '☄️ ⚡ 𝗠 𝗬 𝗧 𝗛 𝗜 𝗖 𝗔 𝗟 ⚡ ☄️' : '⚡ ✨ 𝗟 𝗘 𝗚 𝗘 𝗡 𝗗 𝗔 𝗥 𝗬 ✨ ⚡')
+                .setDescription(isEvent ? '━━━━━━━━━━━━━━━\n*Nothing like this has been seen in living memory.*\n━━━━━━━━━━━━━━━' : '━━━━━━━━━━━━━━━\n*The air crackles. This is once in a lifetime.*\n━━━━━━━━━━━━━━━');
             await interaction.editReply({ embeds: [fanfareEmbed] });
             await wait(1500);
         }

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -1167,7 +1167,10 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
 
     if (result.success) {
         const { animal, tier, traits, finalPayout, isCrit, critMultiplier, trophyQuality, specialDrop, xpEarned, levelUp, cappedByHard, traitEffects } = result;
-        const color = isCrit ? '#FFD700' : TIER_COLORS[tier];
+        // An event catch keeps its own colour even on a critical: the tier is the
+        // rarer fact of the two, and the title already announces it as one. Without
+        // this a critical event drop rendered crit-gold under a MYTHICAL headline.
+        const color = tier === 'event' ? TIER_COLORS.event : isCrit ? '#FFD700' : TIER_COLORS[tier];
 
         const tierLabel = tier.charAt(0).toUpperCase() + tier.slice(1);
         const payoutDisplay = cappedByHard

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -24,7 +24,7 @@ const {
     ANIMAL_TRAITS, MATERIAL_NAMES, FIELD_TROPHIES
 } = require('../../data/huntData');
 const { checkAndAward, announceAchievements } = require('../../services/achievementService');
-const { TIER_NUM, TIER_RIBBON } = require('../../data/materialRarity');
+const { TIER_NUM, TIER_RIBBON, TIER_STARS } = require('../../data/materialRarity');
 const { randomFrom, HUNT_EMPTY_LINES } = require('../../utils/copyLines');
 const {
     ensureHuntData,
@@ -858,7 +858,7 @@ async function executeStart(interaction) {
         // Log big win, then await hourly leader update and re-fetch for accurate footer
         if (result.success && result.finalPayout > 0) {
             const bigWinThreshold = guildSettings?.economy?.bigWinThreshold ?? 50000;
-            if (result.finalPayout >= bigWinThreshold || result.tier === 'legendary') {
+            if (result.finalPayout >= bigWinThreshold || ['legendary', 'event'].includes(result.tier)) {
                 logBigWin({ guildId: interaction.guild.id, userId: interaction.user.id, username: interaction.user.username, amount: result.finalPayout, source: 'hunt', details: { itemName: result.animal?.name, rarity: result.tier }, client: interaction.client });
             }
             await tryUpdateHourlyWinner({ guildId: interaction.guild.id, category: 'hunt', userId: interaction.user.id, username: interaction.user.username, value: result.finalPayout, details: result.animal ? `${result.animal.emoji} ${result.animal.name} (${currency}${result.finalPayout.toLocaleString()})` : null }).catch(() => null);
@@ -942,18 +942,24 @@ async function executeStart(interaction) {
         // Staged loot reveal for rare+ drops
         await stagedLootReveal(interaction, result.success ? result.tier : null, embed);
 
-        if (result.success && ['epic', 'legendary'].includes(result.tier) && guildSettings?.economy?.announceRareDrops !== false) {
+        if (result.success && ['epic', 'legendary', 'event'].includes(result.tier) && guildSettings?.economy?.announceRareDrops !== false) {
             const announceChannelId = guildSettings?.economy?.announcementChannelId;
             const resolved = announceChannelId ? interaction.guild.channels.cache.get(announceChannelId) : null;
             const announceChannel = resolved?.isTextBased() ? resolved : interaction.channel;
-            const isLeg = result.tier === 'legendary';
+            const announceTier = TIER_NUM[result.tier] ?? 4;
+            const ANNOUNCE_COPY = {
+                4: { color: '#9c27b0', title: '🔮 Epic Find!',              line: 'A rare moment in the wild.' },
+                5: { color: '#ff9800', title: '✨ Legendary Trophy! ✨',     line: 'Only a handful of hunters have ever managed that.' },
+                6: { color: '#e74c3c', title: '☄️ Mythical Quarry! ☄️',     line: 'Nothing like it has been seen in living memory.' },
+            };
+            const copy = ANNOUNCE_COPY[announceTier] ?? ANNOUNCE_COPY[4];
             const announcementEmbed = new EmbedBuilder()
-                .setColor(isLeg ? '#ff9800' : '#9c27b0')
-                .setTitle(isLeg ? '✨ Legendary Trophy! ✨' : '🔮 Epic Find!')
+                .setColor(copy.color)
+                .setTitle(copy.title)
                 .setDescription(
-                    `<@${interaction.user.id}> just brought down ${result.animal.emoji} **${result.animal.name}** [${isLeg ? '⭐⭐⭐⭐⭐' : '⭐⭐⭐⭐'}]\n` +
+                    `<@${interaction.user.id}> just brought down ${result.animal.emoji} **${result.animal.name}** [${TIER_STARS[announceTier]}]\n` +
                     `deep in the **${zone.name}**.\n\n` +
-                    (isLeg ? `Only a handful of hunters have ever managed that.` : `A rare moment in the wild.`)
+                    copy.line
                 )
                 .setTimestamp();
             announceChannel.send({ embeds: [announcementEmbed] }).catch(() => null);
@@ -1172,13 +1178,18 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
             ? `${trophyQuality.emoji} **${trophyQuality.label}** (×${trophyQuality.multiplier.toFixed(2)})`
             : '—';
 
-        const isLegendary = tier === 'legendary';
-        const ribbon = TIER_RIBBON(TIER_NUM[tier] ?? 1);
-        const embedTitle = isLegendary
-            ? `🌟✨ LEGENDARY FIND ✨🌟`
+        const tierNum    = TIER_NUM[tier] ?? 1;
+        const isEvent    = tier === 'event';
+        const isHeadline = tierNum >= 5;   // legendary and event both get the full treatment
+        const ribbon = TIER_RIBBON(tierNum);
+        const embedTitle = isHeadline
+            ? (isEvent ? `☄️⚡ MYTHICAL FIND ⚡☄️` : `🌟✨ LEGENDARY FIND ✨🌟`)
             : `${animal.emoji} ${isCrit ? '✨ CRITICAL! ' : ''}${trophyQuality ? trophyQuality.label + ' ' : ''}${animal.name}${isCrit ? ' ✨' : ''}`;
-        const embedDesc = isLegendary
-            ? `${ribbon}\n\nYou found something impossible in the wild.\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  ${animal.emoji}  **${animal.name}**  [⭐⭐⭐⭐⭐]\n  *${animal.flavor}*\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n\nAdded to your inventory.`
+        const headlineLede = isEvent
+            ? 'Something walked out of the treeline that has no business existing.'
+            : 'You found something impossible in the wild.';
+        const embedDesc = isHeadline
+            ? `${ribbon}\n\n${headlineLede}\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  ${animal.emoji}  **${animal.name}**  [${TIER_STARS[tierNum]}]\n  *${animal.flavor}*\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n\nAdded to your inventory.`
             : `${ribbon}\n\n*${animal.flavor}*`;
 
         const embed = new EmbedBuilder()

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -88,6 +88,11 @@ const UNLOCK_CHOICES   = DEPTH_LIST.filter(d => !d.defaultUnlocked).map(d => ({ 
 
 const PRESTIGE_BADGES = ['', '🥉', '🥈', '🥇', '🏆', '💎'];
 
+// Miner Level tops out at the end of the MINER_LEVELS ladder; prestige tops out at
+// the end of the bonus table. Both are derived so the two tables stay the authority.
+const MAX_MINER_LEVEL   = MINER_LEVELS.length;
+const MAX_MINE_PRESTIGE = PRESTIGE_BONUSES.length - 1;
+
 // Depth risk levels for the pre-dig selection prompt
 const INTENSITY_LEVELS = [
     { level: 1, name: 'Surface',  emoji: '☀️',  multiplier: 0.7, caveInRisk: 0.00, durLoss: 1 },
@@ -154,6 +159,9 @@ module.exports = {
                                 .setDescription('Quest to claim')
                                 .setRequired(true)
                                 .addChoices(...MINE_QUEST_TEMPLATES.map(t => ({ name: t.name, value: t.id }))))))
+        .addSubcommand(sub =>
+            sub.setName('prestige')
+                .setDescription('Reset your Miner Level for permanent bonuses (requires Miner Level 50)'))
         .addSubcommand(sub =>
             sub.setName('map')
                 .setDescription('View your persistent mine map — see every cell you have excavated.'))
@@ -242,6 +250,7 @@ module.exports = {
             if (sub === 'profile') return handleProfile(interaction);
             if (sub === 'map')     return handleMap(interaction);
             if (sub === 'raid')    return handleRaid(interaction);
+            if (sub === 'prestige') return handlePrestige(interaction);
         }
         if (group === 'inv')    return handleInv(interaction, sub);
         if (group === 'quests') return handleQuests(interaction, sub);
@@ -325,15 +334,16 @@ async function handleDig(interaction) {
     if (!depth) {
         return interaction.reply({ content: `Unknown depth \`${depthId}\`. Use \`/mine shop list\` to see available depths.`, flags: MessageFlags.Ephemeral });
     }
+    // Access is decided by `unlockedDepths` alone. The level requirement is enforced
+    // once, at `/mine shop unlock`; re-checking it here would lock a prestiged miner
+    // out of depths they already paid for, since prestige resets the level and the
+    // purchase is permanent.
     if (!m.unlockedDepths.includes(depthId)) {
+        const gate = depth.defaultUnlocked
+            ? ''
+            : ` (Miner Level ${depth.unlockLevel}, ${depth.unlockCost.toLocaleString()} coins)`;
         return interaction.reply({
-            content: `You haven't unlocked **${depth.name}** yet. Use \`/mine shop unlock\` to unlock it.`,
-            flags: MessageFlags.Ephemeral
-        });
-    }
-    if (m.level < depth.unlockLevel) {
-        return interaction.reply({
-            content: `You need to be Miner Level **${depth.unlockLevel}** to mine in **${depth.name}**.`,
+            content: `You haven't unlocked **${depth.name}** yet. Use \`/mine shop unlock\` to unlock it${gate}.`,
             flags: MessageFlags.Ephemeral
         });
     }
@@ -941,6 +951,187 @@ async function handleDig(interaction) {
     }
 }
 
+// ─── PRESTIGE ─────────────────────────────────────────────────────────────────
+//
+// The PRESTIGE_BONUSES table, the badge row and the "Prestige Bonuses" block on
+// /mine profile have all been in place since the mine shipped, but nothing ever
+// incremented mining.prestige — so Miner Level 50 was simply the end, and every
+// bonus in that table was unreachable. This is the way through.
+
+/** Formats one row of PRESTIGE_BONUSES as the lines a player sees. */
+function prestigeBonusLines(bonus) {
+    return [
+        bonus.critBonus    > 0 ? `+${Math.round(bonus.critBonus * 100)}% crit chance`   : null,
+        bonus.staminaBonus > 0 ? `+${bonus.staminaBonus} max stamina`                   : null,
+        bonus.payoutBonus  > 0 ? `+${Math.round(bonus.payoutBonus * 100)}% all payouts` : null,
+        bonus.rarityBonus  > 0 ? `+${Math.round(bonus.rarityBonus * 100)}% rarity boost`: null,
+    ].filter(Boolean);
+}
+
+async function handlePrestige(interaction) {
+    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    if (guildSettings?.economy?.enabled === false) {
+        return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
+    }
+
+    const user = await User.findOneAndUpdate(
+        { userId: interaction.user.id, guildId: interaction.guild.id },
+        { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
+        { upsert: true, new: true }
+    );
+    await attachGrind(user);
+    ensureMineData(user);
+
+    const m        = user.mining;
+    const prestige = m.prestige ?? 0;
+    const badge    = PRESTIGE_BADGES[Math.min(prestige, PRESTIGE_BADGES.length - 1)] ?? '';
+
+    if (prestige >= MAX_MINE_PRESTIGE) {
+        return interaction.reply({
+            embeds: [new EmbedBuilder()
+                .setColor('#f39c12')
+                .setTitle(`${badge} Maximum Prestige`)
+                .setDescription(`You are a **P${prestige} Master Miner** — the deepest rank there is.`)
+                .addFields({ name: 'Your Bonuses', value: prestigeBonusLines(PRESTIGE_BONUSES[prestige]).join('\n') || 'None' })
+                .setTimestamp()],
+        });
+    }
+
+    const nextBonus = PRESTIGE_BONUSES[prestige + 1];
+    const nextBadge = PRESTIGE_BADGES[prestige + 1] ?? '';
+
+    if (m.level < MAX_MINER_LEVEL) {
+        return interaction.reply({
+            embeds: [new EmbedBuilder()
+                .setColor('#b5651d')
+                .setTitle(`${badge} Miner Prestige — P${prestige}`)
+                .setDescription(
+                    `Reach **Miner Level ${MAX_MINER_LEVEL}** to ascend to ${nextBadge} **P${prestige + 1}**.\n` +
+                    `You're Level **${m.level}**.`
+                )
+                .addFields(
+                    { name: `${nextBadge} P${prestige + 1} would grant`, value: prestigeBonusLines(nextBonus).join('\n') || 'Nothing new', inline: true },
+                    { name: 'Progress',  value: `${m.xp.toLocaleString()} / ${MINER_LEVELS[MAX_MINER_LEVEL - 1].xpRequired.toLocaleString()} XP`, inline: true },
+                )
+                .setFooter({ text: 'Prestige keeps your pickaxes, depths, materials and stats — only Miner Level and XP reset.' })
+                .setTimestamp()],
+            flags: MessageFlags.Ephemeral,
+        });
+    }
+
+    // Losing the level also drops any synergy gated on it, so say so up front rather
+    // than letting a miner discover their stamina pool shrank after ascending.
+    const lostSynergies = getActiveSynergies(user)
+        .filter(syn => (syn.requirements.mining ?? 0) > 1)
+        .map(syn => `${syn.emoji} ${syn.name}`);
+
+    const confirmEmbed = new EmbedBuilder()
+        .setColor('#f39c12')
+        .setTitle(`${nextBadge} Ascend to Prestige ${prestige + 1}?`)
+        .setDescription(
+            `You've reached **Miner Level ${MAX_MINER_LEVEL}**. Ascending is permanent and cannot be undone.\n\n` +
+            `**Resets:** Miner Level → 1, Miner XP → 0\n` +
+            `**Keeps:** pickaxes, unlocked depths, materials, consumables, charges and every lifetime stat`
+        )
+        .addFields({ name: `${nextBadge} P${prestige + 1} bonuses`, value: prestigeBonusLines(nextBonus).join('\n') || 'Nothing new', inline: false });
+
+    if (lostSynergies.length) {
+        confirmEmbed.addFields({
+            name: '⚠️ Synergies you will drop until you re-level',
+            value: lostSynergies.join('\n'),
+            inline: false,
+        });
+    }
+    confirmEmbed.setFooter({ text: 'Confirmation expires in 30 seconds' });
+
+    const row = new ActionRowBuilder().addComponents(
+        new ButtonBuilder().setCustomId('mineprestige_confirm').setLabel('Ascend').setStyle(ButtonStyle.Success).setEmoji('⛏️'),
+        new ButtonBuilder().setCustomId('mineprestige_cancel').setLabel('Cancel').setStyle(ButtonStyle.Secondary).setEmoji('❌')
+    );
+
+    const response = await interaction.reply({ embeds: [confirmEmbed], components: [row], withResponse: true });
+    const reply = response.resource.message;
+    const collector = reply.createMessageComponentCollector({ time: 30_000 });
+
+    let actionPromise = null;
+    collector.on('collect', btn => {
+        if (btn.user.id !== interaction.user.id) {
+            return btn.reply({ content: 'This is not your confirmation.', flags: MessageFlags.Ephemeral });
+        }
+        collector.stop();
+
+        if (btn.customId === 'mineprestige_cancel') {
+            return btn.update({ content: 'Ascension cancelled.', embeds: [], components: [] });
+        }
+
+        actionPromise = (async () => {
+            try {
+                await btn.deferUpdate();
+
+                // Make sure the profile exists and carries the prestige field before the
+                // conditional update below tries to match on it.
+                await persistGrindIfNew(user, 'mining');
+                await saveGrind(user, ['mining']);
+
+                // Conditional so a second confirmation cannot ascend twice: the level
+                // requirement and the prestige rank both have to still hold.
+                const ascended = await GrindProfile.findOneAndUpdate(
+                    {
+                        userId: user.userId, guildId: user.guildId, system: 'mining',
+                        'data.level':    { $gte: MAX_MINER_LEVEL },
+                        'data.prestige': prestige,
+                    },
+                    { $set: { 'data.prestige': prestige + 1, 'data.level': 1, 'data.xp': 0 } },
+                    { new: true }
+                ).catch(err => { console.error('[mine prestige] ascend error:', err); return null; });
+
+                if (!ascended) {
+                    return interaction.editReply({
+                        content: 'Your miner changed while that confirmation was open — run `/mine prestige` again.',
+                        embeds: [], components: [],
+                    });
+                }
+
+                m.prestige = prestige + 1;
+                m.level    = 1;
+                m.xp       = 0;
+
+                const embed = new EmbedBuilder()
+                    .setColor('#f39c12')
+                    .setTitle(`${nextBadge} Prestige ${prestige + 1} — ${getLevelData(1).title} Again`)
+                    .setDescription(
+                        `You climb back to the surface, hand in your papers, and start over as a **P${prestige + 1}** miner.\n` +
+                        `The tunnels remember you — everything you own came back up with you.`
+                    )
+                    .addFields(
+                        { name: 'Permanent Bonuses', value: prestigeBonusLines(PRESTIGE_BONUSES[prestige + 1]).join('\n') || 'None', inline: true },
+                        { name: 'Miner Level',       value: `**${MAX_MINER_LEVEL}** → **1**`, inline: true },
+                        { name: 'Kept',              value: `${m.pickaxes.length} pickaxe(s) · ${m.unlockedDepths.length} depth(s)`, inline: true },
+                    )
+                    .setFooter({ text: prestige + 1 >= MAX_MINE_PRESTIGE
+                        ? 'That is the deepest rank there is.'
+                        : `Reach Miner Level ${MAX_MINER_LEVEL} again to ascend to P${prestige + 2}.` })
+                    .setTimestamp();
+
+                await interaction.editReply({ embeds: [embed], components: [] });
+            } catch (err) {
+                console.error('[mine prestige] error:', err);
+                interaction.editReply({ content: 'Something went wrong. Please try again.', embeds: [], components: [] }).catch(() => {});
+            }
+        })();
+    });
+
+    return new Promise(resolve => {
+        collector.on('end', async (_, reason) => {
+            if (reason === 'time') {
+                interaction.editReply({ content: 'Ascension timed out.', embeds: [], components: [] }).catch(() => {});
+            }
+            if (actionPromise) await actionPromise.catch(() => {});
+            resolve();
+        });
+    });
+}
+
 // ─── PROFILE ──────────────────────────────────────────────────────────────────
 
 async function handleProfile(interaction) {
@@ -1045,12 +1236,7 @@ async function handleProfile(interaction) {
     if (prestige > 0) {
         embed.addFields({
             name: `${badge} Prestige Bonuses`,
-            value: [
-                pBonus.critBonus    > 0 ? `+${Math.round(pBonus.critBonus    * 100)}% crit chance`  : null,
-                pBonus.staminaBonus > 0 ? `+${pBonus.staminaBonus} max stamina`                     : null,
-                pBonus.payoutBonus  > 0 ? `+${Math.round(pBonus.payoutBonus  * 100)}% all payouts`   : null,
-                pBonus.rarityBonus  > 0 ? `+${Math.round(pBonus.rarityBonus  * 100)}% rarity boost`  : null
-            ].filter(Boolean).join('\n') || 'None yet',
+            value: prestigeBonusLines(pBonus).join('\n') || 'None yet',
             inline: true
         });
     }
@@ -1077,8 +1263,10 @@ async function handleProfile(interaction) {
         });
     }
 
-    if (prestige === 0 && m.level >= 50) {
-        embed.setFooter({ text: 'Max level reached!' });
+    if (m.level >= MAX_MINER_LEVEL && prestige < MAX_MINE_PRESTIGE) {
+        embed.setFooter({ text: `Max Miner Level — use /mine prestige to ascend to P${prestige + 1}` });
+    } else if (prestige >= MAX_MINE_PRESTIGE && m.level >= MAX_MINER_LEVEL) {
+        embed.setFooter({ text: `${PRESTIGE_BADGES[MAX_MINE_PRESTIGE]} Fully prestiged Master Miner — nothing left to prove down there.` });
     } else if (isSelf) {
         embed.setFooter({ text: `Daily: ${m.dailyMines} mines · ${currency}${m.dailyCoins.toLocaleString()} earned (cap: ${currency}${LIMITS.DAILY_HARD_CAP.toLocaleString()})` });
     }

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -168,7 +168,7 @@ module.exports = {
                 .setDescription('View your persistent mine map — see every cell you have excavated.'))
         .addSubcommand(sub =>
             sub.setName('raid')
-                .setDescription('Raid another miner\'s mine and steal unprocessed ore (requires pickaxe equipped)')
+                .setDescription('Raid another miner and steal some of their crafting materials (requires pickaxe equipped)')
                 .addUserOption(o =>
                     o.setName('target')
                         .setDescription('The miner to raid')
@@ -1819,9 +1819,9 @@ async function handleShop(interaction, sub) {
             if (btn.user.id !== interaction.user.id) {
                 return btn.reply({ content: 'This is not your confirmation.', flags: MessageFlags.Ephemeral });
             }
-            collector.stop();
 
             if (btn.customId === 'minepickaxe_cancel') {
+                collector.stop();
                 return btn.update({ content: 'Purchase cancelled.', embeds: [], components: [] });
             }
 
@@ -1899,6 +1899,8 @@ async function handleShop(interaction, sub) {
                 interaction.editReply({ content: 'Something went wrong. Please try again.', embeds: [], components: [] }).catch(() => {});
             }
             })();
+
+            collector.stop();
         });
 
         return new Promise(resolve => {
@@ -2018,9 +2020,9 @@ async function handleShop(interaction, sub) {
             if (btn.user.id !== interaction.user.id) {
                 return btn.reply({ content: 'This is not your confirmation.', flags: MessageFlags.Ephemeral });
             }
-            collector.stop();
 
             if (btn.customId === 'minebuy_cancel') {
+                collector.stop();
                 return btn.update({ content: 'Purchase cancelled.', embeds: [], components: [] });
             }
 
@@ -2091,6 +2093,8 @@ async function handleShop(interaction, sub) {
                 interaction.editReply({ content: 'Something went wrong. Please try again.', embeds: [], components: [] }).catch(() => {});
             }
             })();
+
+            collector.stop();
         });
 
         return new Promise(resolve => {
@@ -2696,93 +2700,120 @@ async function handleRaid(interaction) {
         });
     }
 
-    // Execute the raid: move RAID_STEAL_MIN–RAID_STEAL_MAX of the defender's largest
-    // material piles across to the raider. The same `data.materials` map is debited
-    // and credited, so a raid transfers value rather than creating it.
-    // Defender is updated first; the shield CAS ($or on lastRaidReceived) and
-    // per-material $gte guards ensure only one raid commits atomically. Raider
-    // update follows sequentially with a cooldown CAS to block duplicate commands.
-    const stealFraction = RAID_STEAL_MIN + Math.random() * (RAID_STEAL_MAX - RAID_STEAL_MIN);
-    const stolen      = {};
-    const defenderInc = {};
-    const raiderInc   = {};
-
-    for (const { matId, take } of planRaidHaul(defender, stealFraction)) {
-        stolen[matId] = take;
-        defenderInc[`data.materials.${matId}`] = -take;
-        raiderInc[`data.materials.${matId}`]   = take;
-    }
-
-    // Make sure the raider's mining profile exists before the conditional commit below
-    await persistGrindIfNew(raider, 'mining');
-
-    // Condition: the defender still holds every material being taken; defender not
-    // under active shield. Without the $gte guards a raid racing a craft could push
-    // a material stock negative.
-    const defenderCond = { userId: defender.userId, guildId: interaction.guild.id, system: 'mining' };
-    for (const [matId, take] of Object.entries(stolen)) {
-        defenderCond[`data.materials.${matId}`] = { $gte: take };
-    }
-    defenderCond.$or = [
-        { 'data.lastRaidReceived': null },
-        { 'data.lastRaidReceived': { $lte: new Date(Date.now() - RAID_SHIELD_MS) } },
-    ];
-
-    const defenderResult = await GrindProfile.findOneAndUpdate(
-        defenderCond,
-        { $inc: defenderInc, $set: { 'data.lastRaidReceived': new Date() } }
-    ).catch(err => { console.error('[mine raid] defender save error:', err); return null; });
-
-    if (!defenderResult) {
+    // The transfer below is a pair of $inc updates, but a grind profile is saved as a
+    // whole `data` document (see utils/grindProfile) — so a defender part-way through
+    // their own /mine dig would write their pre-raid snapshot straight back over the
+    // debit, keeping their materials while the raider kept the credit. A dig holds
+    // this lock for its entire interactive run, which is seconds wide, so take the
+    // defender's lock for the transfer rather than racing it.
+    //
+    // tryAcquire never blocks, so two miners raiding each other simultaneously cannot
+    // deadlock — one or both are simply turned away.
+    const defenderLockKey = `grind:mine:${interaction.guild.id}:${defender.userId}`;
+    const defenderLock    = await _lockAcquire(defenderLockKey, 30_000);
+    if (!defenderLock) {
         return interaction.reply({
-            content: `**${targetUser.username}**'s stock shifted before you got in — nothing left to take. Try again shortly.`,
+            content: `**${targetUser.username}** is down in the mine right now — you can't get in behind them. Try again in a moment.`,
             flags: MessageFlags.Ephemeral
         });
     }
 
-    // The credit half of the transfer. Its result cannot be discarded: the debit
-    // above has already landed, and there is no transaction to tie the two together
-    // on a standalone mongod. If the credit does not land — the cooldown CAS lost a
-    // race, or the write errored — the materials would simply cease to exist while
-    // both players were told the raid succeeded. Put them back instead.
-    const credited = await GrindProfile.findOneAndUpdate(
-        {
-            userId: raider.userId,
-            guildId: interaction.guild.id,
-            system: 'mining',
-            $or: [
-                { 'data.lastRaidSent': null },
-                { 'data.lastRaidSent': { $lte: new Date(Date.now() - RAID_COOLDOWN_MS) } },
-            ],
-        },
-        { $inc: raiderInc, $set: { 'data.lastRaidSent': new Date() } }
-    ).catch(err => { console.error('[mine raid] raider save error:', err); return null; });
+    // The haul, declared out here because the embed and the defender's DM below
+    // both read it after the lock has been released.
+    const stolen = {};
 
-    if (!credited) {
-        // Compensate: hand the defender's materials back and restore the raid shield
-        // to what it was, so a failed raid does not leave them sheltered for an hour
-        // over a raid that never happened.
-        const rollback = {};
-        for (const [matId, take] of Object.entries(stolen)) rollback[`data.materials.${matId}`] = take;
-        await GrindProfile.updateOne(
-            { userId: defender.userId, guildId: interaction.guild.id, system: 'mining' },
-            { $inc: rollback, $set: { 'data.lastRaidReceived': defenderResult.data?.lastRaidReceived ?? null } }
-        ).catch(err => console.error('[mine raid] rollback failed — defender owed:', Object.keys(stolen).join(','), err));
+    try {
 
-        return interaction.reply({
-            content: 'Your raid was interrupted — nothing was taken, and nothing was lost. Try again in a moment.',
-            flags: MessageFlags.Ephemeral
-        });
+        // Execute the raid: move RAID_STEAL_MIN–RAID_STEAL_MAX of the defender's largest
+        // material piles across to the raider. The same `data.materials` map is debited
+        // and credited, so a raid transfers value rather than creating it.
+        // Defender is updated first; the shield CAS ($or on lastRaidReceived) and
+        // per-material $gte guards ensure only one raid commits atomically. Raider
+        // update follows sequentially with a cooldown CAS to block duplicate commands.
+        const stealFraction = RAID_STEAL_MIN + Math.random() * (RAID_STEAL_MAX - RAID_STEAL_MIN);
+        const defenderInc = {};
+        const raiderInc   = {};
+
+        for (const { matId, take } of planRaidHaul(defender, stealFraction)) {
+            stolen[matId] = take;
+            defenderInc[`data.materials.${matId}`] = -take;
+            raiderInc[`data.materials.${matId}`]   = take;
+        }
+
+        // Make sure the raider's mining profile exists before the conditional commit below
+        await persistGrindIfNew(raider, 'mining');
+
+        // Condition: the defender still holds every material being taken; defender not
+        // under active shield. Without the $gte guards a raid racing a craft could push
+        // a material stock negative.
+        const defenderCond = { userId: defender.userId, guildId: interaction.guild.id, system: 'mining' };
+        for (const [matId, take] of Object.entries(stolen)) {
+            defenderCond[`data.materials.${matId}`] = { $gte: take };
+        }
+        defenderCond.$or = [
+            { 'data.lastRaidReceived': null },
+            { 'data.lastRaidReceived': { $lte: new Date(Date.now() - RAID_SHIELD_MS) } },
+        ];
+
+        const defenderResult = await GrindProfile.findOneAndUpdate(
+            defenderCond,
+            { $inc: defenderInc, $set: { 'data.lastRaidReceived': new Date() } }
+        ).catch(err => { console.error('[mine raid] defender save error:', err); return null; });
+
+        if (!defenderResult) {
+            return interaction.reply({
+                content: `**${targetUser.username}**'s stock shifted before you got in — nothing left to take. Try again shortly.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        // The credit half of the transfer. Its result cannot be discarded: the debit
+        // above has already landed, and there is no transaction to tie the two together
+        // on a standalone mongod. If the credit does not land — the cooldown CAS lost a
+        // race, or the write errored — the materials would simply cease to exist while
+        // both players were told the raid succeeded. Put them back instead.
+        const credited = await GrindProfile.findOneAndUpdate(
+            {
+                userId: raider.userId,
+                guildId: interaction.guild.id,
+                system: 'mining',
+                $or: [
+                    { 'data.lastRaidSent': null },
+                    { 'data.lastRaidSent': { $lte: new Date(Date.now() - RAID_COOLDOWN_MS) } },
+                ],
+            },
+            { $inc: raiderInc, $set: { 'data.lastRaidSent': new Date() } }
+        ).catch(err => { console.error('[mine raid] raider save error:', err); return null; });
+
+        if (!credited) {
+            // Compensate: hand the defender's materials back and restore the raid shield
+            // to what it was, so a failed raid does not leave them sheltered for an hour
+            // over a raid that never happened.
+            const rollback = {};
+            for (const [matId, take] of Object.entries(stolen)) rollback[`data.materials.${matId}`] = take;
+            await GrindProfile.updateOne(
+                { userId: defender.userId, guildId: interaction.guild.id, system: 'mining' },
+                { $inc: rollback, $set: { 'data.lastRaidReceived': defenderResult.data?.lastRaidReceived ?? null } }
+            ).catch(err => console.error('[mine raid] rollback failed — defender owed:', Object.keys(stolen).join(','), err));
+
+            return interaction.reply({
+                content: 'Your raid was interrupted — nothing was taken, and nothing was lost. Try again in a moment.',
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+    } finally {
+        await _lockRelease(defenderLockKey, defenderLock);
     }
 
     const stolenLines = Object.entries(stolen).map(([id, qty]) => `• ${MATERIAL_NAMES[id] ?? id} ×${qty}`).join('\n');
-    const pct = Math.round(stealFraction * 100);
+    const stolenCount = Object.values(stolen).reduce((sum, qty) => sum + qty, 0);
 
     const embed = new EmbedBuilder()
         .setColor('#e67e22')
         .setTitle('⚔️ Mine Raided!')
         .setDescription(
-            `You broke into **${targetUser.username}**'s mine and made off with **${pct}%** of their exposed materials!\n\n` +
+            `You broke into **${targetUser.username}**'s mine and made off with **${stolenCount}** material${stolenCount === 1 ? '' : 's'}!\n\n` +
             `**Stolen:**\n${stolenLines}\n\n` +
             `*These are now yours to craft with.*`
         )
@@ -2797,7 +2828,7 @@ async function handleRaid(interaction) {
         .setTitle('⚠️ Your Mine Was Raided!')
         .setDescription(
             `**${interaction.user.username}** broke into your mine on **${interaction.guild.name}** ` +
-            `and stole **${pct}%** of your exposed crafting materials!\n\n` +
+            `and stole **${stolenCount}** of your crafting material${stolenCount === 1 ? '' : 's'}!\n\n` +
             `**Lost:**\n${stolenLines}\n\n` +
             `Get a **Mine Lock** (\`/mine shop buy item:mine_lock\` or \`/craft make mine_lock_from_obsidian\`) ` +
             `and arm it with \`/mine shop use item:mine_lock\` to block the next raid.`

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -1058,28 +1058,39 @@ async function handlePrestige(interaction) {
         if (btn.user.id !== interaction.user.id) {
             return btn.reply({ content: 'This is not your confirmation.', flags: MessageFlags.Ephemeral });
         }
-        collector.stop();
 
         if (btn.customId === 'mineprestige_cancel') {
+            collector.stop();
             return btn.update({ content: 'Ascension cancelled.', embeds: [], components: [] });
         }
 
+        // Assigned before collector.stop(): stop() emits 'end' synchronously, so an
+        // assignment after it would leave the handler below awaiting a null and let
+        // the command — and the per-user mining lock with it — resolve while this
+        // write was still in flight.
         actionPromise = (async () => {
             try {
                 await btn.deferUpdate();
 
-                // Make sure the profile exists and carries the prestige field before the
-                // conditional update below tries to match on it.
-                await persistGrindIfNew(user, 'mining');
-                await saveGrind(user, ['mining']);
+                // Nothing is written from the in-memory snapshot here. It was read
+                // before a 30-second confirmation window during which a raid, a craft
+                // or another dig may have moved this profile, and a save() would put
+                // all of that back. The ascension is the conditional update alone.
+                //
+                // `data.prestige` is absent on profiles that predate the field, so a
+                // first ascension has to match that shape too — ensureMineData only
+                // defaulted it in memory.
+                const rankMatches = prestige === 0
+                    ? [{ 'data.prestige': 0 }, { 'data.prestige': { $exists: false } }, { 'data.prestige': null }]
+                    : [{ 'data.prestige': prestige }];
 
                 // Conditional so a second confirmation cannot ascend twice: the level
                 // requirement and the prestige rank both have to still hold.
                 const ascended = await GrindProfile.findOneAndUpdate(
                     {
                         userId: user.userId, guildId: user.guildId, system: 'mining',
-                        'data.level':    { $gte: MAX_MINER_LEVEL },
-                        'data.prestige': prestige,
+                        'data.level': { $gte: MAX_MINER_LEVEL },
+                        $or: rankMatches,
                     },
                     { $set: { 'data.prestige': prestige + 1, 'data.level': 1, 'data.xp': 0 } },
                     { new: true }
@@ -1119,6 +1130,8 @@ async function handlePrestige(interaction) {
                 interaction.editReply({ content: 'Something went wrong. Please try again.', embeds: [], components: [] }).catch(() => {});
             }
         })();
+
+        collector.stop();
     });
 
     return new Promise(resolve => {
@@ -1263,10 +1276,14 @@ async function handleProfile(interaction) {
         });
     }
 
-    if (m.level >= MAX_MINER_LEVEL && prestige < MAX_MINE_PRESTIGE) {
-        embed.setFooter({ text: `Max Miner Level — use /mine prestige to ascend to P${prestige + 1}` });
-    } else if (prestige >= MAX_MINE_PRESTIGE && m.level >= MAX_MINER_LEVEL) {
+    // Only nudge the player who can act on it; someone else's maxed miner just gets
+    // the standing, and the daily-cap line stays a self-only stat either way.
+    if (m.level >= MAX_MINER_LEVEL && prestige >= MAX_MINE_PRESTIGE) {
         embed.setFooter({ text: `${PRESTIGE_BADGES[MAX_MINE_PRESTIGE]} Fully prestiged Master Miner — nothing left to prove down there.` });
+    } else if (isSelf && m.level >= MAX_MINER_LEVEL) {
+        embed.setFooter({ text: `Max Miner Level — use /mine prestige to ascend to P${prestige + 1}` });
+    } else if (m.level >= MAX_MINER_LEVEL) {
+        embed.setFooter({ text: 'Max Miner Level' });
     } else if (isSelf) {
         embed.setFooter({ text: `Daily: ${m.dailyMines} mines · ${currency}${m.dailyCoins.toLocaleString()} earned (cap: ${currency}${LIMITS.DAILY_HARD_CAP.toLocaleString()})` });
     }
@@ -1309,8 +1326,21 @@ async function handleInv(interaction, sub) {
             });
             // Nothing caps how many pickaxes a miner accumulates and each entry runs
             // ~85 characters, so a single field ran out of room around the twelfth one
-            // and Discord rejected the whole embed. Spill into continuation fields.
-            embed.addFields(...packFields('🪓 Pickaxes', lines));
+            // and Discord rejected the whole embed. Spill into continuation fields —
+            // but only so many: an embed also has a 6,000-character budget across all
+            // of its fields, which unbounded spilling would eventually blow instead.
+            const PICKAXE_FIELDS = 3;
+            const fields = packFields('🪓 Pickaxes', lines);
+            embed.addFields(...fields.slice(0, PICKAXE_FIELDS));
+            if (fields.length > PICKAXE_FIELDS) {
+                const shown = fields.slice(0, PICKAXE_FIELDS)
+                    .reduce((n, f) => n + f.value.split('\n').length / 2, 0);
+                embed.addFields({
+                    name: '…and more',
+                    value: `${Math.max(0, m.pickaxes.length - Math.round(shown))} further pickaxe(s) not shown — discard the dead ones with \`/mine inv discard\`.`,
+                    inline: false
+                });
+            }
 
             const junk = m.pickaxes.filter(p => p.status === 'broken' || p.status === 'condemned').length;
             if (junk > 0) {
@@ -2607,7 +2637,12 @@ async function handleRaid(interaction) {
         });
     }
 
-    await GrindProfile.findOneAndUpdate(
+    // The credit half of the transfer. Its result cannot be discarded: the debit
+    // above has already landed, and there is no transaction to tie the two together
+    // on a standalone mongod. If the credit does not land — the cooldown CAS lost a
+    // race, or the write errored — the materials would simply cease to exist while
+    // both players were told the raid succeeded. Put them back instead.
+    const credited = await GrindProfile.findOneAndUpdate(
         {
             userId: raider.userId,
             guildId: interaction.guild.id,
@@ -2618,7 +2653,24 @@ async function handleRaid(interaction) {
             ],
         },
         { $inc: raiderInc, $set: { 'data.lastRaidSent': new Date() } }
-    ).catch(err => console.error('[mine raid] raider save error:', err));
+    ).catch(err => { console.error('[mine raid] raider save error:', err); return null; });
+
+    if (!credited) {
+        // Compensate: hand the defender's materials back and restore the raid shield
+        // to what it was, so a failed raid does not leave them sheltered for an hour
+        // over a raid that never happened.
+        const rollback = {};
+        for (const [matId, take] of Object.entries(stolen)) rollback[`data.materials.${matId}`] = take;
+        await GrindProfile.updateOne(
+            { userId: defender.userId, guildId: interaction.guild.id, system: 'mining' },
+            { $inc: rollback, $set: { 'data.lastRaidReceived': defenderResult.data?.lastRaidReceived ?? null } }
+        ).catch(err => console.error('[mine raid] rollback failed — defender owed:', Object.keys(stolen).join(','), err));
+
+        return interaction.reply({
+            content: 'Your raid was interrupted — nothing was taken, and nothing was lost. Try again in a moment.',
+            flags: MessageFlags.Ephemeral
+        });
+    }
 
     const stolenLines = Object.entries(stolen).map(([id, qty]) => `• ${MATERIAL_NAMES[id] ?? id} ×${qty}`).join('\n');
     const pct = Math.round(stealFraction * 100);

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -2344,7 +2344,10 @@ function buildMineEmbed(result, user, depth, pickaxe, currency, discordUser) {
 
     if (result.success) {
         const { ore, tier, finalPayout, isCrit, critMultiplier, specialDrop, xpEarned, levelUp, cappedByHard } = result;
-        const color = isCrit ? '#FFD700' : TIER_COLORS[tier];
+        // An event catch keeps its own colour even on a critical: the tier is the
+        // rarer fact of the two, and the title already announces it as one. Without
+        // this a critical event drop rendered crit-gold under a MYTHICAL headline.
+        const color = tier === 'event' ? TIER_COLORS.event : isCrit ? '#FFD700' : TIER_COLORS[tier];
 
         const tierLabel = tier.charAt(0).toUpperCase() + tier.slice(1);
         // At the hard cap finalPayout is already 0, so the old strikethrough rendered

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -10,6 +10,7 @@ const GrindProfile = require('../../models/GrindProfile');
 const Guild = require('../../models/Guild');
 const { getItemImageAttachment } = require('../../utils/itemImageHelper');
 const { runShopBrowse }          = require('../../utils/shopBrowse');
+const { packFields }             = require('../../utils/embedFields');
 const {
     DEPTHS, DEPTH_LIST, TIER_COLORS, LIMITS, PICKAXE_BY_TIER,
     MATERIAL_NAMES, CONSUMABLES, BLAST_PACKS,
@@ -18,7 +19,7 @@ const {
     RAID_COOLDOWN_MS, RAID_SHIELD_MS, RAID_STEAL_MIN, RAID_STEAL_MAX
 } = require('../../data/mineData');
 const { checkAndAward, announceAchievements } = require('../../services/achievementService');
-const { TIER_NUM, TIER_RIBBON } = require('../../data/materialRarity');
+const { TIER_NUM, TIER_RIBBON, TIER_STARS } = require('../../data/materialRarity');
 const { randomFrom, MINE_CAVE_LINES } = require('../../utils/copyLines');
 const { getPityBonus, buildPityStreakField, PITY_COPY } = require('../../utils/pityBonus');
 const {
@@ -43,8 +44,10 @@ const {
     applyXp,
     updateMineMap,
     renderMineMap,
-    getOreStashSummary,
-    isOreStashEmpty
+    getRaidableMaterials,
+    hasRaidableMaterials,
+    planRaidHaul,
+    RAID_MAX_PER_MATERIAL
 } = require('../../services/mineService');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
 const { stackBar } = require('../../utils/rewardReveal');
@@ -124,6 +127,14 @@ module.exports = {
                 .addSubcommand(sub =>
                     sub.setName('equip')
                         .setDescription('Equip a pickaxe from your inventory')
+                        .addIntegerOption(o =>
+                            o.setName('slot')
+                                .setDescription('Pickaxe slot number (use /mine inv view to see slots)')
+                                .setRequired(true)
+                                .setMinValue(1)))
+                .addSubcommand(sub =>
+                    sub.setName('discard')
+                        .setDescription('Discard a broken or condemned pickaxe')
                         .addIntegerOption(o =>
                             o.setName('slot')
                                 .setDescription('Pickaxe slot number (use /mine inv view to see slots)')
@@ -258,20 +269,21 @@ async function stagedLootReveal(interaction, tier, finalEmbed) {
     } else {
         await interaction.editReply({ embeds: [fogEmbed] });
         await wait(1500);
-        const midColor = tierNum === 4 ? '#9c27b0' : '#ff9800';
-        const midTitle = tierNum === 4 ? '🔮 A rare vein reveals itself...' : '⚡ The tunnel fills with an impossible glow...';
-        const midTierLabel = tierNum === 4 ? 'EPIC' : 'LEGENDARY';
+        const midColor = tierNum === 6 ? '#e74c3c' : tierNum === 4 ? '#9c27b0' : '#ff9800';
+        const midTitle = tierNum === 6 ? '☄️ The rock itself begins to hum...' : tierNum === 4 ? '🔮 A rare vein reveals itself...' : '⚡ The tunnel fills with an impossible glow...';
+        const midTierLabel = tierNum === 6 ? 'EVENT' : tierNum === 4 ? 'EPIC' : 'LEGENDARY';
         const midEmbed = new EmbedBuilder()
             .setColor(midColor)
             .setTitle(midTitle)
             .setDescription(`━━━━━━━━━━━━━━━\n❓❓❓  **${midTierLabel}**  ❓❓❓\n━━━━━━━━━━━━━━━`);
         await interaction.editReply({ embeds: [midEmbed] });
         await wait(1500);
-        if (tierNum === 5) {
+        if (tierNum >= 5) {
+            const isEvent = tierNum === 6;
             const fanfareEmbed = new EmbedBuilder()
-                .setColor('#ff9800')
-                .setTitle('⚡ ✨ 𝗟 𝗘 𝗚 𝗘 𝗡 𝗗 𝗔 𝗥 𝗬 ✨ ⚡')
-                .setDescription('━━━━━━━━━━━━━━━\n*Miners dream of this their whole careers.*\n━━━━━━━━━━━━━━━');
+                .setColor(isEvent ? '#e74c3c' : '#ff9800')
+                .setTitle(isEvent ? '☄️ 🌋 𝗣 𝗥 𝗜 𝗠 𝗢 𝗥 𝗗 𝗜 𝗔 𝗟 🌋 ☄️' : '⚡ ✨ 𝗟 𝗘 𝗚 𝗘 𝗡 𝗗 𝗔 𝗥 𝗬 ✨ ⚡')
+                .setDescription(isEvent ? '━━━━━━━━━━━━━━━\n*This ore has no business existing. Nobody will believe you.*\n━━━━━━━━━━━━━━━' : '━━━━━━━━━━━━━━━\n*Miners dream of this their whole careers.*\n━━━━━━━━━━━━━━━');
             await interaction.editReply({ embeds: [fanfareEmbed] });
             await wait(1500);
         }
@@ -817,7 +829,7 @@ async function handleDig(interaction) {
         // Log big win, then await hourly leader update and re-fetch for accurate footer
         if (result.success && result.finalPayout > 0) {
             const bigWinThreshold = guildSettings?.economy?.bigWinThreshold ?? 50000;
-            if (result.finalPayout >= bigWinThreshold || result.tier === 'legendary') {
+            if (result.finalPayout >= bigWinThreshold || ['legendary', 'event'].includes(result.tier)) {
                 logBigWin({ guildId: interaction.guild.id, userId: interaction.user.id, username: interaction.user.username, amount: result.finalPayout, source: 'mine', details: { itemName: result.ore?.name, rarity: result.tier }, client: interaction.client });
             }
             await tryUpdateHourlyWinner({ guildId: interaction.guild.id, category: 'mine', userId: interaction.user.id, username: interaction.user.username, value: result.finalPayout, details: result.ore ? `${result.ore.emoji ?? ''} ${result.ore.name} (${currency}${result.finalPayout.toLocaleString()})`.trim() : `${currency}${result.finalPayout.toLocaleString()}` }).catch(() => null);
@@ -884,18 +896,24 @@ async function handleDig(interaction) {
         // Staged loot reveal for rare+ drops
         await stagedLootReveal(interaction, result.success ? result.tier : null, embed);
 
-        if (result.success && ['epic', 'legendary'].includes(result.tier) && guildSettings?.economy?.announceRareDrops !== false) {
+        if (result.success && ['epic', 'legendary', 'event'].includes(result.tier) && guildSettings?.economy?.announceRareDrops !== false) {
             const announceChannelId = guildSettings?.economy?.announcementChannelId;
             const resolved = announceChannelId ? interaction.guild.channels.cache.get(announceChannelId) : null;
             const announceChannel = resolved?.isTextBased() ? resolved : interaction.channel;
-            const isLeg = result.tier === 'legendary';
+            const announceTier = TIER_NUM[result.tier] ?? 4;
+            const ANNOUNCE_COPY = {
+                4: { color: '#9c27b0', title: '🔮 Epic Ore Unearthed!',      line: 'A rare find in these tunnels.' },
+                5: { color: '#ff9800', title: '✨ Legendary Strike! ✨',      line: 'That vein runs deep — and dangerous.' },
+                6: { color: '#e74c3c', title: '☄️ Primordial Strike! ☄️',    line: 'Ore like this is not supposed to exist. The whole server should know.' },
+            };
+            const copy = ANNOUNCE_COPY[announceTier] ?? ANNOUNCE_COPY[4];
             const announcementEmbed = new EmbedBuilder()
-                .setColor(isLeg ? '#ff9800' : '#9c27b0')
-                .setTitle(isLeg ? '✨ Legendary Strike! ✨' : '🔮 Epic Ore Unearthed!')
+                .setColor(copy.color)
+                .setTitle(copy.title)
                 .setDescription(
-                    `<@${interaction.user.id}> just unearthed ${result.ore.emoji} **${result.ore.name}** [${isLeg ? '⭐⭐⭐⭐⭐' : '⭐⭐⭐⭐'}]\n` +
+                    `<@${interaction.user.id}> just unearthed ${result.ore.emoji} **${result.ore.name}** [${TIER_STARS[announceTier]}]\n` +
                     `at the **${depth.name}** depth.\n\n` +
-                    (isLeg ? `That vein runs deep — and dangerous.` : `A rare find in these tunnels.`)
+                    copy.line
                 )
                 .setTimestamp();
             announceChannel.send({ embeds: [announcementEmbed] }).catch(() => null);
@@ -1101,7 +1119,19 @@ async function handleInv(interaction, sub) {
                 const upgradeStr = p.upgrade ? ` [${p.upgrade.replace(/_/g, ' ')}]` : '';
                 return `**Slot ${i + 1}**${isEquipped ? ' *(equipped)*' : ''} — ${p.name}${upgradeStr} ${pickaxeStatusEmoji(p.status)}\n> ${bar} ${p.currentDurability}/${p.maxDurability}`;
             });
-            embed.addFields({ name: '🪓 Pickaxes', value: lines.join('\n'), inline: false });
+            // Nothing caps how many pickaxes a miner accumulates and each entry runs
+            // ~85 characters, so a single field ran out of room around the twelfth one
+            // and Discord rejected the whole embed. Spill into continuation fields.
+            embed.addFields(...packFields('🪓 Pickaxes', lines));
+
+            const junk = m.pickaxes.filter(p => p.status === 'broken' || p.status === 'condemned').length;
+            if (junk > 0) {
+                embed.addFields({
+                    name: '🗑️ Unusable',
+                    value: `${junk} pickaxe${junk === 1 ? ' is' : 's are'} broken or condemned — clear ${junk === 1 ? 'it' : 'them'} out with \`/mine inv discard\`.`,
+                    inline: false
+                });
+            }
         }
 
         const chargeLines = BLAST_PACKS.map(b => {
@@ -1175,6 +1205,56 @@ async function handleInv(interaction, sub) {
                         { name: 'Status',     value: `${pickaxeStatusEmoji(pickaxe.status)} ${pickaxe.status}`, inline: true },
                         { name: 'Upgrade',    value: pickaxe.upgrade ? pickaxe.upgrade.replace(/_/g, ' ') : 'None', inline: true }
                     )
+                    .setTimestamp()
+            ]
+        });
+    }
+
+    if (sub === 'discard') {
+        const index = interaction.options.getInteger('slot') - 1;
+
+        if (index < 0 || index >= m.pickaxes.length) {
+            return interaction.reply({
+                content: `No pickaxe in slot ${index + 1}. You have ${m.pickaxes.length} pickaxe(s).`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        const pickaxe = m.pickaxes[index];
+        if (pickaxe.status !== 'broken' && pickaxe.status !== 'condemned') {
+            return interaction.reply({
+                content: `**${pickaxe.name}** is not broken or condemned. You can only discard unusable pickaxes.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
+        // Splicing shifts every later slot down by one, so the equipped index has to
+        // move with it or the miner silently ends up wielding a different pickaxe.
+        const wasEquipped = m.equippedPickaxeIndex === index;
+        m.pickaxes.splice(index, 1);
+
+        if (wasEquipped) {
+            m.equippedPickaxeIndex = m.pickaxes.length > 0 ? 0 : -1;
+        } else if (m.equippedPickaxeIndex > index) {
+            m.equippedPickaxeIndex -= 1;
+        }
+
+        user.markModified('mining');
+        await user.save();
+
+        const nowEquipped = m.pickaxes[m.equippedPickaxeIndex];
+        return interaction.reply({
+            embeds: [
+                new EmbedBuilder()
+                    .setColor('#e74c3c')
+                    .setTitle('🗑️ Pickaxe Discarded')
+                    .setDescription(
+                        `**${pickaxe.name}** has been discarded.` +
+                        (wasEquipped && nowEquipped ? `\nYou are now wielding **${nowEquipped.name}**.` : '')
+                    )
+                    .setFooter({ text: m.pickaxes.length === 0
+                        ? 'Buy a new pickaxe with /mine shop pickaxe'
+                        : 'Use /mine inv view to see your remaining pickaxes' })
                     .setTimestamp()
             ]
         });
@@ -1954,13 +2034,18 @@ function buildMineEmbed(result, user, depth, pickaxe, currency, discordUser) {
         const tierLabel = tier.charAt(0).toUpperCase() + tier.slice(1);
         const payoutDisplay = cappedByHard ? `~~${currency}${finalPayout}~~ (daily cap reached)` : `**${currency}${finalPayout.toLocaleString()}**`;
 
-        const isLegendary = tier === 'legendary';
-        const ribbon = TIER_RIBBON(TIER_NUM[tier] ?? 1);
-        const embedTitle = isLegendary
-            ? `⛏️✨ LEGENDARY STRIKE ✨⛏️`
+        const tierNum  = TIER_NUM[tier] ?? 1;
+        const isEvent  = tier === 'event';
+        const isHeadline = tierNum >= 5;   // legendary and event both get the full treatment
+        const ribbon = TIER_RIBBON(tierNum);
+        const embedTitle = isHeadline
+            ? (isEvent ? `☄️🌋 PRIMORDIAL STRIKE 🌋☄️` : `⛏️✨ LEGENDARY STRIKE ✨⛏️`)
             : `${ore.emoji} ${isCrit ? '✨ CRITICAL! ' : ''}${ore.name} ${isCrit ? '✨' : ''}`;
-        const embedDesc = isLegendary
-            ? `${ribbon}\n\nYou struck something impossible in the deep.\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  ${ore.emoji}  **${ore.name}**  [⭐⭐⭐⭐⭐]\n  *${ore.flavor}*\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n\nAdded to your inventory.`
+        const headlineLede = isEvent
+            ? 'You broke into something that should not be down there.'
+            : 'You struck something impossible in the deep.';
+        const embedDesc = isHeadline
+            ? `${ribbon}\n\n${headlineLede}\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  ${ore.emoji}  **${ore.name}**  [${TIER_STARS[tierNum]}]\n  *${ore.flavor}*\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n\nAdded to your inventory.`
             : `${ribbon}\n\n*${ore.flavor}*`;
 
         const embed = new EmbedBuilder()
@@ -2151,7 +2236,7 @@ async function handleMap(interaction) {
     // 0/3 correct pays 0.7× and 3/3 pays 2× (3× on a lucky break into the Abyss).
     const intensityHint = '0.7×–3.0×, set by your vein read';
 
-    const stashLines = getOreStashSummary(user).map(([id, qty]) => `${MATERIAL_NAMES[id] ?? id}: **${qty}**`);
+    const raidableLines = getRaidableMaterials(user).map(([id, qty]) => `${MATERIAL_NAMES[id] ?? id}: **${qty}**`);
 
     const embed = new EmbedBuilder()
         .setColor('#8B4513')
@@ -2165,10 +2250,10 @@ async function handleMap(interaction) {
                 inline: true
             },
             {
-                name: '📦 Unprocessed Ore Stash',
-                value: stashLines.length
-                    ? stashLines.join('\n') + '\n*Can be stolen by raiders!*'
-                    : 'Empty — ore stash fills as you mine veins.',
+                name: '📦 Exposed to Raiders',
+                value: raidableLines.length
+                    ? raidableLines.join('\n') + `\n*A raid takes up to ${RAID_MAX_PER_MATERIAL} of each — spend or craft them to shrink the pile.*`
+                    : 'Nothing exposed — raiders can only reach materials you hold 2+ of.',
                 inline: true
             },
             {
@@ -2283,14 +2368,16 @@ async function handleRaid(interaction) {
     }
 
     // Check if there's anything to steal
-    if (isOreStashEmpty(defender)) {
+    if (!hasRaidableMaterials(defender)) {
         return interaction.reply({
-            content: `**${targetUser.username}**'s ore stash is empty — nothing worth raiding.`,
+            content: `**${targetUser.username}** has nothing worth raiding — no material they hold more than one of.`,
             flags: MessageFlags.Ephemeral
         });
     }
 
-    // Execute the raid: steal RAID_STEAL_MIN–RAID_STEAL_MAX of each stash material.
+    // Execute the raid: move RAID_STEAL_MIN–RAID_STEAL_MAX of the defender's largest
+    // material piles across to the raider. The same `data.materials` map is debited
+    // and credited, so a raid transfers value rather than creating it.
     // Defender is updated first; the shield CAS ($or on lastRaidReceived) and
     // per-material $gte guards ensure only one raid commits atomically. Raider
     // update follows sequentially with a cooldown CAS to block duplicate commands.
@@ -2299,21 +2386,21 @@ async function handleRaid(interaction) {
     const defenderInc = {};
     const raiderInc   = {};
 
-    for (const [matId, qty] of Object.entries(defender.mining.oreStash ?? {})) {
-        if (qty <= 0) continue;
-        const take = Math.max(1, Math.floor(qty * stealFraction));
+    for (const { matId, take } of planRaidHaul(defender, stealFraction)) {
         stolen[matId] = take;
-        defenderInc[`data.oreStash.${matId}`] = -take;
-        raiderInc[`data.materials.${matId}`]  = take;
+        defenderInc[`data.materials.${matId}`] = -take;
+        raiderInc[`data.materials.${matId}`]   = take;
     }
 
     // Make sure the raider's mining profile exists before the conditional commit below
     await persistGrindIfNew(raider, 'mining');
 
-    // Condition: each stolen material still exists; defender not under active shield.
+    // Condition: the defender still holds every material being taken; defender not
+    // under active shield. Without the $gte guards a raid racing a craft could push
+    // a material stock negative.
     const defenderCond = { userId: defender.userId, guildId: interaction.guild.id, system: 'mining' };
     for (const [matId, take] of Object.entries(stolen)) {
-        defenderCond[`data.oreStash.${matId}`] = { $gte: take };
+        defenderCond[`data.materials.${matId}`] = { $gte: take };
     }
     defenderCond.$or = [
         { 'data.lastRaidReceived': null },
@@ -2327,7 +2414,7 @@ async function handleRaid(interaction) {
 
     if (!defenderResult) {
         return interaction.reply({
-            content: `**${targetUser.username}**'s ore stash was already raided — nothing left to take.`,
+            content: `**${targetUser.username}**'s stock shifted before you got in — nothing left to take. Try again shortly.`,
             flags: MessageFlags.Ephemeral
         });
     }
@@ -2352,10 +2439,11 @@ async function handleRaid(interaction) {
         .setColor('#e67e22')
         .setTitle('⚔️ Mine Raided!')
         .setDescription(
-            `You broke into **${targetUser.username}**'s mine and made off with **${pct}%** of their ore stash!\n\n` +
-            `**Stolen:**\n${stolenLines}`
+            `You broke into **${targetUser.username}**'s mine and made off with **${pct}%** of their exposed materials!\n\n` +
+            `**Stolen:**\n${stolenLines}\n\n` +
+            `*These are now yours to craft with.*`
         )
-        .setFooter({ text: `${targetUser.username} now has a 1-hour raid shield • Use /mine map to see your stash` })
+        .setFooter({ text: `${targetUser.username} now has a 1-hour raid shield • Use /mine map to see what of yours is exposed` })
         .setTimestamp();
 
     await interaction.reply({ embeds: [embed] });
@@ -2366,7 +2454,7 @@ async function handleRaid(interaction) {
         .setTitle('⚠️ Your Mine Was Raided!')
         .setDescription(
             `**${interaction.user.username}** broke into your mine on **${interaction.guild.name}** ` +
-            `and stole **${pct}%** of your ore stash!\n\n` +
+            `and stole **${pct}%** of your exposed crafting materials!\n\n` +
             `**Lost:**\n${stolenLines}\n\n` +
             `Get a **Mine Lock** (\`/mine shop buy item:mine_lock\` or \`/craft make mine_lock_from_obsidian\`) ` +
             `and arm it with \`/mine shop use item:mine_lock\` to block the next raid.`

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -614,7 +614,7 @@ async function handleDig(interaction) {
                     time: INTENSITY_PICK_MS,
                     max: 1,
                 });
-                col.on('collect', async i => { await i.deferUpdate(); resolve(i.customId); });
+                col.on('collect', async i => { await i.deferUpdate().catch(() => {}); resolve(i.customId); });
                 col.on('end', (_, reason) => { if (reason !== 'limit') resolve(null); });
             });
             pickedIntensity = CHOOSABLE_INTENSITY.find(l => `digint_${l.level}` === chosenId) ?? fallbackLevel;
@@ -666,7 +666,7 @@ async function handleDig(interaction) {
                 time: VEIN_ANSWER_MS,
                 max: 1,
             });
-            col.on('collect', async i => { await i.deferUpdate(); resolve(i.customId.replace('vein_', '')); });
+            col.on('collect', async i => { await i.deferUpdate().catch(() => {}); resolve(i.customId.replace('vein_', '')); });
             col.on('end', (_, reason) => { if (reason !== 'limit') resolve(null); });
         });
 
@@ -716,7 +716,7 @@ async function handleDig(interaction) {
                     `You have seconds to decide.\n\n` +
                     `⚡ **Ore at stake:** ${((result.caveInPayout ?? 0) + (result.caveInEscrow ?? 0)).toLocaleString()} coins` +
                     (result.caveInEscrow > 0
-                        ? ` *(includes the ${chosenIntensity.multiplier}× your vein read earned)*\n\n`
+                        ? ` *(includes the ${chosenIntensity.multiplier}× you ${chosenIntensity.promoted ? 'read out of the seam' : 'dug for'})*\n\n`
                         : `\n\n`) +
                     (chargesAvailable > 0
                         ? `💥 You have **${chargesAvailable}** blast charge${chargesAvailable !== 1 ? 's' : ''} — enough to blow an escape route.`
@@ -745,7 +745,7 @@ async function handleDig(interaction) {
                     time: 20_000,
                     max: 1,
                 });
-                col.on('collect', async i => { await i.deferUpdate(); resolve(i.customId.endsWith('_blast') ? 'blast' : 'abandon'); });
+                col.on('collect', async i => { await i.deferUpdate().catch(() => {}); resolve(i.customId.endsWith('_blast') ? 'blast' : 'abandon'); });
                 col.on('end', (_, reason) => { if (reason !== 'limit') resolve('abandon'); });
             });
 
@@ -836,6 +836,18 @@ async function handleDig(interaction) {
                 result.finalPayout         += bonus;
                 result.wildernessBonus      = bonus;
             }
+        }
+
+        // At the hard cap every yield bonus above is skipped (they all gate on a
+        // payout above zero), so `forfeited` holds only the ore's value before the
+        // intensity multiplier and the bonuses that would have followed it. Scale it
+        // by what would have applied, or the embed understates the loss several-fold.
+        if (result.cappedByHard && result.forfeited > 0) {
+            const wouldHaveApplied = (chosenIntensity?.multiplier ?? 1)
+                * (isFeaturedDepth ? 1 + FEATURED_PAYOUT_BONUS : 1)
+                * (petMineYieldPct > 0 ? 1 + petMineYieldPct / 100 : 1)
+                * (wildernessActive ? 1 + WILDERNESS_YIELD_BONUS : 1);
+            result.forfeited = Math.round(result.forfeited * wouldHaveApplied);
         }
 
         // bestPayout must reflect what the player actually walked away with, so this
@@ -1412,7 +1424,7 @@ async function handleInv(interaction, sub) {
                     .reduce((n, f) => n + f.value.split('\n').length / 2, 0);
                 embed.addFields({
                     name: '…and more',
-                    value: `${Math.max(0, m.pickaxes.length - Math.round(shown))} further pickaxe(s) not shown — discard the dead ones with \`/mine inv discard\`.`,
+                    value: `${Math.max(0, m.pickaxes.length - Math.round(shown))} further pickaxe(s) not shown. \`/mine inv discard\` clears broken and condemned ones.`,
                     inline: false
                 });
             }

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -44,6 +44,7 @@ const {
     applyXp,
     updateMineMap,
     renderMineMap,
+    msUntilDailyReset,
     getRaidableMaterials,
     hasRaidableMaterials,
     planRaidHaul,
@@ -664,7 +665,10 @@ async function handleDig(interaction) {
                     `━━━━━━━━━━━━━━━━━━━━━━━\n` +
                     `The tunnel is collapsing around you. Dust fills the air.\n` +
                     `You have seconds to decide.\n\n` +
-                    `⚡ **Ore at stake:** ${(result.caveInPayout ?? 0).toLocaleString()} coins\n\n` +
+                    `⚡ **Ore at stake:** ${((result.caveInPayout ?? 0) + (result.caveInEscrow ?? 0)).toLocaleString()} coins` +
+                    (result.caveInEscrow > 0
+                        ? ` *(includes the ${chosenIntensity.multiplier}× your vein read earned)*\n\n`
+                        : `\n\n`) +
                     (chargesAvailable > 0
                         ? `💥 You have **${chargesAvailable}** blast charge${chargesAvailable !== 1 ? 's' : ''} — enough to blow an escape route.`
                         : `⚠️ You have no blast charges — you'll have to run.`)
@@ -701,6 +705,20 @@ async function handleDig(interaction) {
                 if (chargeType) {
                     m.charges[chargeType] = chargesAvailable - 1;
                     user.markModified('mining');
+                }
+                // Digging clear releases the escrowed intensity bonus — the charge buys
+                // back the whole haul, multiplier included. Clamped to the daily hard
+                // cap the same way the uninterrupted path clamps it.
+                if (result.caveInEscrow > 0) {
+                    const remainingCap = Math.max(0, LIMITS.DAILY_HARD_CAP - m.dailyCoins);
+                    const bonus        = Math.min(result.caveInEscrow, remainingCap);
+                    if (bonus > 0) {
+                        user.balance       += bonus;
+                        m.totalEarned      += bonus;
+                        m.dailyCoins       += bonus;
+                        result.finalPayout  = (result.finalPayout ?? 0) + bonus;
+                        result.caveInBonusPaid = bonus;
+                    }
                 }
                 result.caveInEscaped = true;
             } else {
@@ -752,6 +770,7 @@ async function handleDig(interaction) {
                 user.mining.dailyCoins    += bonus;
                 result.finalPayout        += bonus;
                 result.petYieldBonus       = bonus;
+                result.petYieldPct         = petMineYieldPct;
             }
         }
 
@@ -857,7 +876,11 @@ async function handleDig(interaction) {
         {
             const desc = embed.data.description ?? '';
             const lines = [`> ⛏️ *${finalIcons} — Vein depth ${veinDepth}/3 → ${chosenIntensity.emoji} ${chosenIntensity.name} (${chosenIntensity.multiplier}×)*`];
-            if (result.caveIn && result.caveInEscaped) lines.push(`> 💥 *Cave-in! You used a blast charge — ore saved.*`);
+            if (result.caveIn && result.caveInEscaped) {
+                lines.push(result.caveInBonusPaid > 0
+                    ? `> 💥 *Cave-in! You blasted clear — ore saved, and the ${chosenIntensity.multiplier}× held.*`
+                    : `> 💥 *Cave-in! You used a blast charge — ore saved.*`);
+            }
             else if (result.caveIn) lines.push(`> 💥 *${randomFrom(MINE_CAVE_LINES)}*`);
             embed.setDescription(desc + '\n' + lines.join('\n'));
         }
@@ -1634,15 +1657,21 @@ async function handleQuests(interaction, sub) {
             });
         }
 
-        const remaining = user.quests.filter(q =>
-            q.questId.startsWith('mq_') &&
-            q.expiresAt?.getTime() > now &&
-            q.progress !== -1
-        ).length;
+        const liveQuests = user.quests.filter(q =>
+            q.questId.startsWith('mq_') && q.expiresAt?.getTime() > now
+        );
+        const remaining = liveQuests.filter(q => q.progress !== -1).length;
+
+        // A fresh batch is only assigned once the current one has expired — see the
+        // guard in assign*Quests. Say when that is rather than implying that playing
+        // again brings one sooner, which is what this footer used to promise.
+        const nextSetIn = liveQuests.length
+            ? formatExpiry(Math.min(...liveQuests.map(q => q.expiresAt.getTime())) - now)
+            : null;
 
         embed.setFooter({ text: remaining > 0
             ? `${remaining} quest(s) remaining — use /mine quests view`
-            : 'All quests claimed! Mine again to receive a fresh set.' });
+            : `All quests claimed! A fresh set arrives in ${nextSetIn ?? 'a few hours'}.` });
         embed.setTimestamp();
 
         return interaction.reply({ embeds: [embed] });
@@ -2250,7 +2279,12 @@ function buildMineEmbed(result, user, depth, pickaxe, currency, discordUser) {
         const color = isCrit ? '#FFD700' : TIER_COLORS[tier];
 
         const tierLabel = tier.charAt(0).toUpperCase() + tier.slice(1);
-        const payoutDisplay = cappedByHard ? `~~${currency}${finalPayout}~~ (daily cap reached)` : `**${currency}${finalPayout.toLocaleString()}**`;
+        // At the hard cap finalPayout is already 0, so the old strikethrough rendered
+        // as "~~0~~ (daily cap reached)" — it struck out the wrong number and never
+        // told the player what the cap had actually cost them.
+        const payoutDisplay = cappedByHard
+            ? `~~${currency}${(result.forfeited ?? 0).toLocaleString()}~~ → **${currency}0**`
+            : `**${currency}${finalPayout.toLocaleString()}**`;
 
         const tierNum  = TIER_NUM[tier] ?? 1;
         const isEvent  = tier === 'event';
@@ -2279,12 +2313,34 @@ function buildMineEmbed(result, user, depth, pickaxe, currency, discordUser) {
                 { name: 'Stamina',  value: buildStaminaLine(user),                  inline: true }
             );
 
+        // Every multiplicative factor that touched this haul, so the arithmetic on
+        // screen reconciles. This used to list streak and crit, multiply just those
+        // two, and then print the *final* payout — which also carried the intensity
+        // multiplier (up to 3x), the featured depth, the pet, the district and the
+        // Artificer bonus. Players saw "2.52x → +1,340" when the real stack was 5x.
         const mineMultEntries = [];
-        if ((result.streakMult ?? 1) > 1.0) mineMultEntries.push({ emoji: '🔥', label: `${(result.streakMult).toFixed(2)}x` });
-        if (isCrit)                          mineMultEntries.push({ emoji: '⚡', label: `${critMultiplier.toFixed(2)}x crit` });
-        if (mineMultEntries.length > 0) {
-            const mineCombined = (result.streakMult ?? 1) * critMultiplier;
-            embed.addFields({ name: '📈 Multipliers', value: stackBar(mineMultEntries, mineCombined, finalPayout, currency), inline: false });
+        let mineCombined = 1;
+        const addMult = (emoji, label, factor) => {
+            if (!(factor > 0) || Math.abs(factor - 1) < 0.005) return;
+            mineMultEntries.push({ emoji, label });
+            mineCombined *= factor;
+        };
+
+        const intensityMult = result.caveIn && !result.caveInBonusPaid ? 1 : (result.intensityLevel?.multiplier ?? 1);
+        addMult('🔥', `${(result.streakMult ?? 1).toFixed(2)}x`, result.streakMult ?? 1);
+        addMult('⚡', `${critMultiplier.toFixed(2)}x crit`, critMultiplier);
+        addMult(result.intensityLevel?.emoji ?? '⛏️', `${intensityMult.toFixed(2)}x depth`, intensityMult);
+        addMult('🌟', `${(1 + FEATURED_PAYOUT_BONUS).toFixed(2)}x featured`, result.featuredDepthBonus > 0 ? 1 + FEATURED_PAYOUT_BONUS : 1);
+        addMult('💎', `${(1 + (result.petYieldPct ?? 0) / 100).toFixed(2)}x pet`, result.petYieldBonus > 0 ? 1 + (result.petYieldPct ?? 0) / 100 : 1);
+        addMult('🌲', `${(1 + WILDERNESS_YIELD_BONUS).toFixed(2)}x district`, result.wildernessBonus > 0 ? 1 + WILDERNESS_YIELD_BONUS : 1);
+        addMult('⚒️', `${(1 + (result.artificerRate ?? 0)).toFixed(2)}x artificer`, 1 + (result.artificerRate ?? 0));
+        addMult('✨', '2.00x yield', result.gatheringYield ? 2 : 1);
+
+        if (mineMultEntries.length > 0 && finalPayout > 0) {
+            // What the stack itself contributed: the haul, less what a flat 1x roll of
+            // the same ore would have paid.
+            const stackGain = Math.max(0, finalPayout - Math.round(finalPayout / mineCombined));
+            embed.addFields({ name: '📈 Multipliers', value: stackBar(mineMultEntries, mineCombined, stackGain, currency), inline: false });
         }
 
         if (result.gatheringYield) {
@@ -2314,11 +2370,14 @@ function buildMineEmbed(result, user, depth, pickaxe, currency, discordUser) {
             embed.addFields({ name: '⚠️ Low Durability', value: `Your **${pickaxe.name}** is nearly worn out (${pickaxe.currentDurability}/${pickaxe.maxDurability}). Repair soon!`, inline: false });
         }
 
+        const throttleField = buildThrottleField(user, result, currency);
+        if (throttleField) embed.addFields(throttleField);
+
         embed.addFields(
             { name: 'Balance',   value: `${currency}${user.balance.toLocaleString()}`,   inline: true },
             { name: 'Miner XP',  value: buildXpLine(user),                               inline: true }
         );
-        embed.setFooter({ text: `Cooldown: 30s • ${buildActiveConsumablesLine(user)}` });
+        embed.setFooter({ text: `Cooldown: 30s • ${buildDailyProgressLine(user, currency)} • ${buildActiveConsumablesLine(user)}` });
         embed.setTimestamp();
         return embed;
     }
@@ -2369,6 +2428,43 @@ function buildMineEmbed(result, user, depth, pickaxe, currency, discordUser) {
     return embed;
 }
 
+/**
+ * A field explaining whichever daily throttle is currently biting, or null when none
+ * is. These are the three things that used to shrink a haul with nothing said: fatigue
+ * past DIM_RETURNS_THRESHOLD_1, the halving past DAILY_SOFT_CAP, and the hard cap.
+ */
+function buildThrottleField(user, result, currency) {
+    const m       = user.mining;
+    const resetIn = msUntilDailyReset(user);
+    const resetNote = resetIn == null ? '' : ` Resets in **${formatMs(resetIn)}**.`;
+
+    if (result.cappedByHard) {
+        return {
+            name: '🛑 Daily Cap Reached',
+            value: `You've earned the daily maximum of ${currency}${LIMITS.DAILY_HARD_CAP.toLocaleString()}. `
+                 + `This haul paid nothing.${resetNote}\nXP, materials and quest progress still count.`,
+            inline: false,
+        };
+    }
+
+    const notes = [];
+    if (result.softCapped) {
+        notes.push(`💰 Past ${currency}${LIMITS.DAILY_SOFT_CAP.toLocaleString()} today — **payouts are halved** until the window resets.`);
+    }
+    if ((result.fatigueMult ?? 1) < 1) {
+        notes.push(`😪 **${m.dailyMines}** digs today — **fatigue** has payouts at **${Math.round(result.fatigueMult * 100)}%**.`);
+    }
+    if (!notes.length) return null;
+
+    if (result.forfeited > 0) {
+        notes.push(`This dig gave up ${currency}${result.forfeited.toLocaleString()}.${resetNote}`);
+    } else if (resetNote) {
+        notes.push(resetNote.trim());
+    }
+
+    return { name: '⏳ Daily Throttle', value: notes.join('\n'), inline: false };
+}
+
 function buildFailureTitle(severityId) {
     return {
         clean_miss: '💨 Empty Vein!',
@@ -2389,6 +2485,13 @@ function buildXpLine(user) {
     const toNext = xpToNextLevel(m.level, m.xp);
     if (toNext === null) return `${m.xp.toLocaleString()} XP (MAX)`;
     return `${m.xp.toLocaleString()} XP (${toNext} to Lv.${m.level + 1})`;
+}
+
+/** Running daily earnings against the soft cap — the number the throttles key off. */
+function buildDailyProgressLine(user, currency) {
+    const earned = user.mining.dailyCoins ?? 0;
+    const compact = n => n >= 1000 ? `${(n / 1000).toFixed(n >= 10_000 ? 0 : 1)}k` : `${n}`;
+    return `Today: ${currency}${compact(earned)}/${compact(LIMITS.DAILY_SOFT_CAP)}`;
 }
 
 function buildActiveConsumablesLine(user) {

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -15,6 +15,7 @@ const {
     DEPTHS, DEPTH_LIST, TIER_COLORS, LIMITS, PICKAXE_BY_TIER,
     MATERIAL_NAMES, CONSUMABLES, BLAST_PACKS,
     PICKAXE_TIERS, PICKAXE_BY_SLUG, PICKAXE_UPGRADES,
+    CHOOSABLE_INTENSITY, DEFAULT_INTENSITY_LEVEL,
     MINER_LEVELS, PRESTIGE_BONUSES, MINE_QUEST_TEMPLATES,
     RAID_COOLDOWN_MS, RAID_SHIELD_MS, RAID_STEAL_MIN, RAID_STEAL_MAX
 } = require('../../data/mineData');
@@ -29,6 +30,7 @@ const {
     msUntilNextStamina,
     getMaxStamina,
     executeMine,
+    promoteIntensity,
     assignDailyMineQuests,
     updateMineQuestProgress,
     formatMs,
@@ -94,14 +96,12 @@ const PRESTIGE_BADGES = ['', '🥉', '🥈', '🥇', '🏆', '💎'];
 const MAX_MINER_LEVEL   = MINER_LEVELS.length;
 const MAX_MINE_PRESTIGE = PRESTIGE_BONUSES.length - 1;
 
-// Depth risk levels for the pre-dig selection prompt
-const INTENSITY_LEVELS = [
-    { level: 1, name: 'Surface',  emoji: '☀️',  multiplier: 0.7, caveInRisk: 0.00, durLoss: 1 },
-    { level: 2, name: 'Shallow',  emoji: '🪨',  multiplier: 1.0, caveInRisk: 0.05, durLoss: 1 },
-    { level: 3, name: 'Mid',      emoji: '🔩',  multiplier: 1.4, caveInRisk: 0.12, durLoss: 2 },
-    { level: 4, name: 'Deep',     emoji: '💎',  multiplier: 2.0, caveInRisk: 0.20, durLoss: 3 },
-    { level: 5, name: 'Abyss',    emoji: '🌑',  multiplier: 3.0, caveInRisk: 0.30, durLoss: 4 },
-];
+// Presentation timings for the pre-dig prompt and the vein read. The ladder itself
+// and the promotion rule live with the rest of the mine's rules, in mineData and
+// mineService.
+const INTENSITY_PICK_MS = 20_000;
+const VEIN_FLASH_MS     = 1_400;
+const VEIN_ANSWER_MS    = 10_000;
 
 module.exports = {
     cooldown: 5,
@@ -116,7 +116,15 @@ module.exports = {
                     o.setName('depth')
                         .setDescription('Depth to mine in (defaults to your active depth).')
                         .setRequired(false)
-                        .addChoices(...DEPTH_CHOICES)))
+                        .addChoices(...DEPTH_CHOICES))
+                .addIntegerOption(o =>
+                    o.setName('intensity')
+                        .setDescription('How hard to push. Higher pays more and risks a cave-in. Skips the prompt.')
+                        .setRequired(false)
+                        .addChoices(...CHOOSABLE_INTENSITY.map(l => ({
+                            name:  `${l.emoji} ${l.name} — ${l.multiplier}× payout, ${Math.round(l.caveInRisk * 100)}% cave-in`,
+                            value: l.level,
+                        })))))
         .addSubcommand(sub =>
             sub.setName('profile')
                 .setDescription("View your or another player's miner profile")
@@ -372,7 +380,7 @@ async function handleDig(interaction) {
                 description: 'You just came up from a dig.\nTake a short break before heading back down.',
                 color: '#b5651d',
                 nextAt,
-                nextRewardPreview: 'Read the vein 3/3 on your next dig and the haul pays 2× — 3× if it opens into the Abyss',
+                nextRewardPreview: 'Pick how hard to push next dig — up to 2×, and 3× if you read the vein right',
             })],
             flags: MessageFlags.Ephemeral,
         });
@@ -516,16 +524,15 @@ async function handleDig(interaction) {
             user.markModified('mining');
         }
 
-        // ── Vein-Following Puzzle ──────────────────────────────────────────────────
-        // 3 rounds of directional navigation through a mine tunnel.
-        // Each round: a 3×3 emoji grid shows the current position (⛏️) and a mineral
-        // trace in one of the 4 adjacent cells. Player picks the matching direction.
-        // Correct directions accumulate depth; final depth maps to intensity level.
-        //   0/3 correct → Surface  (0.7×, 0% cave-in)
-        //   1/3 correct → Shallow  (1.0×, 5% cave-in)
-        //   2/3 correct → Mid      (1.4×, 12% cave-in)
-        //   3/3 correct → Deep     (2.0×, 20% cave-in)
-        //   3/3 + lucky → Abyss    (3.0×, 30% cave-in)  10% chance on a perfect run
+        // ── Risk choice, then one vein read ────────────────────────────────────────
+        // The miner picks how hard to push; a correct vein read promotes the payout
+        // one rung without touching the risk they accepted.
+        //
+        // This replaced three rounds of a puzzle that displayed its own answer — the
+        // grid marked the ore cell with ✨ and asked which direction it was, so every
+        // attentive player scored 3/3 and every dig funnelled to Deep. The five-rung
+        // risk ladder existed but nothing ever chose from it, and the only way to dig
+        // more safely was to answer deliberately wrong, which nothing explained.
 
         const featured         = getDailyFeatured(interaction.guild.id);
         const isFeaturedDepth  = depthId === featured.mineDepth.id;
@@ -539,15 +546,17 @@ async function handleDig(interaction) {
             { id: 'E', label: '➡️ East',  row: 1, col: 2 },
         ];
 
-        // Build a 3×3 grid string highlighting the ore direction
+        /** The 3×3 tunnel view. With `oreDir` the trace shows; without it, it doesn't. */
         function buildGrid(oreDir) {
             const grid = [
                 ['🪨', '🪨', '🪨'],
                 ['🪨', '⛏️', '🪨'],
                 ['🪨', '🪨', '🪨'],
             ];
-            const d = DIRS.find(d => d.id === oreDir);
-            grid[d.row][d.col] = '✨';
+            if (oreDir) {
+                const d = DIRS.find(d => d.id === oreDir);
+                grid[d.row][d.col] = '✨';
+            }
             return grid.map(row => row.join(' ')).join('\n');
         }
 
@@ -555,89 +564,129 @@ async function handleDig(interaction) {
             ? `\n🌟 **Featured Depth!** +${Math.round(FEATURED_PAYOUT_BONUS * 100)}% payout active.`
             : '';
 
+        // Pushing hard for coins that the daily throttle will swallow is all risk and
+        // no reward, so say so before the choice rather than after the cave-in.
+        const throttleWarning =
+            m.dailyCoins >= LIMITS.DAILY_HARD_CAP
+                ? `\n🛑 **Daily cap reached** — this dig pays no coins. Cave-in risk is still real.`
+                : m.dailyCoins >= LIMITS.DAILY_SOFT_CAP
+                ? `\n⚠️ Past the daily soft cap — payouts are halved until it resets.`
+                : '';
+
+        // ── 1. How hard to push ────────────────────────────────────────────────────
+        const requestedIntensity = interaction.options.getInteger('intensity');
+        let pickedIntensity = CHOOSABLE_INTENSITY.find(l => l.level === requestedIntensity) ?? null;
+
+        const intensityRow = new ActionRowBuilder().addComponents(
+            ...CHOOSABLE_INTENSITY.map(l => new ButtonBuilder()
+                .setCustomId(`digint_${l.level}`)
+                .setLabel(`${l.name} · ${l.multiplier}× · ${Math.round(l.caveInRisk * 100)}%`)
+                .setEmoji(l.emoji)
+                .setStyle(l.level >= 4 ? ButtonStyle.Danger : l.level === 3 ? ButtonStyle.Primary : ButtonStyle.Secondary)
+            )
+        );
+
+        const fallbackLevel = CHOOSABLE_INTENSITY.find(l => l.level === (m.preferredIntensity ?? DEFAULT_INTENSITY_LEVEL))
+            ?? CHOOSABLE_INTENSITY.find(l => l.level === DEFAULT_INTENSITY_LEVEL);
+
         await interaction.reply({
             embeds: [new EmbedBuilder()
                 .setColor(isFeaturedDepth ? '#FFD700' : '#8B4513')
                 .setTitle(`⛏️ Entering ${depth.emoji} ${depth.name}…`)
                 .setDescription(
                     `*You lower yourself into the shaft. Dust settles. Your lamp catches a glint…*\n\n` +
-                    `**Follow the vein** — 3 rounds of directional choices. The deeper you follow it, the richer the haul.${featuredDepthNote}`
+                    (pickedIntensity
+                        ? `**${pickedIntensity.emoji} ${pickedIntensity.name}** — ${pickedIntensity.multiplier}× payout, ${Math.round(pickedIntensity.caveInRisk * 100)}% cave-in risk.`
+                        : `**How hard do you want to push?** Deeper pays more and risks bringing the roof down.`) +
+                    featuredDepthNote + throttleWarning
                 )
-                .setFooter({ text: `${timeBand.emoji} ${timeBand.label} · 15 seconds per choice — miss a round and you stop there.` })],
-            components: [],
+                .setFooter({ text: pickedIntensity
+                    ? `${timeBand.emoji} ${timeBand.label}`
+                    : `${timeBand.emoji} ${timeBand.label} · ${INTENSITY_PICK_MS / 1000}s to choose — defaults to ${fallbackLevel.name}. Pass \`intensity:\` to skip this.` })],
+            components: pickedIntensity ? [] : [intensityRow],
         });
         const mineMsg = await interaction.fetchReply();
-        await delay(1500);
 
-        let veinDepth = 0;
-        const roundLog = [];
+        if (!pickedIntensity) {
+            const chosenId = await new Promise(resolve => {
+                const col = mineMsg.createMessageComponentCollector({
+                    filter: i => i.user.id === interaction.user.id && i.customId.startsWith('digint_'),
+                    time: INTENSITY_PICK_MS,
+                    max: 1,
+                });
+                col.on('collect', async i => { await i.deferUpdate(); resolve(i.customId); });
+                col.on('end', (_, reason) => { if (reason !== 'limit') resolve(null); });
+            });
+            pickedIntensity = CHOOSABLE_INTENSITY.find(l => `digint_${l.level}` === chosenId) ?? fallbackLevel;
+        }
 
-        for (let round = 0; round < 3; round++) {
-            const oreDir  = DIRS[Math.floor(Math.random() * DIRS.length)];
-            const grid    = buildGrid(oreDir.id);
-            const prevLog = roundLog.map((r, i) => r ? `✅` : `❌`).join(' ');
+        // Remembered so the timeout default is the miner's own habit, not ours.
+        if (m.preferredIntensity !== pickedIntensity.level) {
+            m.preferredIntensity = pickedIntensity.level;
+            user.markModified('mining');
+        }
 
-            const veinEmbed = new EmbedBuilder()
+        // ── 2. One vein read, and a real one ───────────────────────────────────────
+        const oreDir = DIRS[Math.floor(Math.random() * DIRS.length)];
+
+        await interaction.editReply({
+            embeds: [new EmbedBuilder()
                 .setColor('#B8860B')
-                .setTitle(`⛏️ Vein Read — Round ${round + 1}/3`)
+                .setTitle('⛏️ Reading the vein…')
                 .setDescription(
-                    `${prevLog ? prevLog + '\n\n' : ''}` +
-                    `*Mineral trace spotted — which way does the vein run?*\n\n` +
-                    `\`\`\`\n${grid}\n\`\`\``
+                    `*A mineral trace catches the lamplight. Mark where it runs.*\n\n` +
+                    `\`\`\`\n${buildGrid(oreDir.id)}\n\`\`\``
                 )
-                .setFooter({ text: '15 seconds to choose a direction.' });
+                .setFooter({ text: 'Remember it — the dust is about to settle.' })],
+            components: [],
+        });
+        await delay(VEIN_FLASH_MS);
 
-            const dirRow = new ActionRowBuilder().addComponents(
+        await interaction.editReply({
+            embeds: [new EmbedBuilder()
+                .setColor('#8B4513')
+                .setTitle('⛏️ Which way did it run?')
+                .setDescription(
+                    `*Dust swallows the seam. Call it.*\n\n` +
+                    `\`\`\`\n${buildGrid(null)}\n\`\`\``
+                )
+                .setFooter({ text: `${VEIN_ANSWER_MS / 1000}s · a correct read pays one rung higher at the same risk.` })],
+            components: [new ActionRowBuilder().addComponents(
                 ...DIRS.map(d => new ButtonBuilder()
                     .setCustomId(`vein_${d.id}`)
                     .setLabel(d.label)
                     .setStyle(ButtonStyle.Primary)
                 )
-            );
+            )],
+        });
 
-            await interaction.editReply({ embeds: [veinEmbed], components: [dirRow] });
-
-            const picked = await new Promise(resolve => {
-                const col = mineMsg.createMessageComponentCollector({
-                    filter: i => i.user.id === interaction.user.id && i.customId.startsWith('vein_'),
-                    time: 15_000,
-                    max: 1,
-                });
-                col.on('collect', async i => { await i.deferUpdate(); resolve(i.customId.replace('vein_', '')); });
-                col.on('end',     (_, reason) => { if (reason !== 'limit') resolve(null); });
+        const picked = await new Promise(resolve => {
+            const col = mineMsg.createMessageComponentCollector({
+                filter: i => i.user.id === interaction.user.id && i.customId.startsWith('vein_'),
+                time: VEIN_ANSWER_MS,
+                max: 1,
             });
+            col.on('collect', async i => { await i.deferUpdate(); resolve(i.customId.replace('vein_', '')); });
+            col.on('end', (_, reason) => { if (reason !== 'limit') resolve(null); });
+        });
 
-            const correct = picked === oreDir.id;
-            roundLog.push(correct);
-            if (correct) veinDepth++;
+        const veinRead = picked === oreDir.id;
+        const chosenIntensity = veinRead ? promoteIntensity(pickedIntensity) : pickedIntensity;
 
-            const roundResult = new EmbedBuilder()
-                .setColor(correct ? '#00CC55' : picked ? '#CC4400' : '#888888')
-                .setTitle(correct ? '✅ Vein found!' : picked ? '❌ Dead end — rubble.' : '⏰ Hesitated…')
-                .setDescription(
-                    correct
-                        ? `You followed the vein **${oreDir.label}**. It runs deeper here.`
-                        : picked
-                        ? `The vein ran **${oreDir.label}** — you hit rubble instead.`
-                        : `The vein ran **${oreDir.label}** — you didn't move in time.`
-                );
-            await interaction.editReply({ embeds: [roundResult], components: [] });
-            if (round < 2) await delay(900);
-        }
-
-        // Map vein depth to intensity level
-        let intensityIndex = veinDepth; // 0→L1, 1→L2, 2→L3, 3→L4
-        if (veinDepth === 3 && Math.random() < 0.10) intensityIndex = 4; // lucky Abyss
-        const chosenIntensity = INTENSITY_LEVELS[intensityIndex];
-
-        const finalIcons = roundLog.map(r => r ? '✅' : '❌').join(' ');
         const confirmEmbed = new EmbedBuilder()
-            .setColor(chosenIntensity.level >= 4 ? '#FF4444' : chosenIntensity.level >= 3 ? '#FFA500' : '#00AA55')
-            .setTitle(`${chosenIntensity.emoji} Digging ${chosenIntensity.name}…`)
+            .setColor(veinRead ? '#00CC55' : picked ? '#CC4400' : '#888888')
+            .setTitle(veinRead
+                ? `✅ Vein read — digging ${chosenIntensity.emoji} ${chosenIntensity.name}`
+                : picked
+                ? `❌ Misread the seam — digging ${chosenIntensity.emoji} ${chosenIntensity.name}`
+                : `⏰ Too slow — digging ${chosenIntensity.emoji} ${chosenIntensity.name}`)
             .setDescription(
-                `${finalIcons}\n\n` +
-                `Vein depth reached: **${veinDepth}/3 correct**\n` +
-                `**${chosenIntensity.multiplier}×** payout  |  **${(chosenIntensity.caveInRisk * 100).toFixed(0)}%** cave-in risk`
+                (veinRead
+                    ? `The vein ran **${oreDir.label}** and you called it. The seam is richer than it looked.\n\n`
+                    : `The vein ran **${oreDir.label}**.\n\n`) +
+                `**${chosenIntensity.multiplier}×** payout` +
+                (veinRead ? ` *(up from ${pickedIntensity.multiplier}×)*` : '') +
+                `  |  **${(chosenIntensity.caveInRisk * 100).toFixed(0)}%** cave-in risk`
             );
         await interaction.editReply({ embeds: [confirmEmbed], components: [] });
 
@@ -875,7 +924,10 @@ async function handleDig(interaction) {
         }
         {
             const desc = embed.data.description ?? '';
-            const lines = [`> ⛏️ *${finalIcons} — Vein depth ${veinDepth}/3 → ${chosenIntensity.emoji} ${chosenIntensity.name} (${chosenIntensity.multiplier}×)*`];
+            const lines = [
+                `> ${chosenIntensity.emoji} *Dug **${chosenIntensity.name}** — ${chosenIntensity.multiplier}× at ${(chosenIntensity.caveInRisk * 100).toFixed(0)}% risk`
+                + (veinRead ? ` · vein read ✅ (up from ${pickedIntensity.multiplier}×)*` : `*`),
+            ];
             if (result.caveIn && result.caveInEscaped) {
                 lines.push(result.caveInBonusPaid > 0
                     ? `> 💥 *Cave-in! You blasted clear — ore saved, and the ${chosenIntensity.multiplier}× held.*`
@@ -2557,9 +2609,9 @@ async function handleMap(interaction) {
     const explored = (m.mineMap ?? []).filter(c => c !== 0).length;
     const total    = mapSize * mapSize;
 
-    // Yield multiplier comes from the vein-reading rounds, not from miner level:
-    // 0/3 correct pays 0.7× and 3/3 pays 2× (3× on a lucky break into the Abyss).
-    const intensityHint = '0.7×–3.0×, set by your vein read';
+    // Yield multiplier comes from the intensity the miner picks before digging, with
+    // a correct vein read promoting it one rung at the same risk.
+    const intensityHint = '0.7×–3.0×, set by the risk you choose';
 
     const raidableLines = getRaidableMaterials(user).map(([id, qty]) => `${MATERIAL_NAMES[id] ?? id}: **${qty}**`);
 

--- a/src/data/materialRarity.js
+++ b/src/data/materialRarity.js
@@ -67,17 +67,22 @@ const MATERIAL_RARITY = {
     void_essence:      { tier: 5, emoji: '🌑', label: 'Void Essence',        source: 'mine' }
 };
 
-const TIER_LABELS = { 1: 'Common', 2: 'Uncommon', 3: 'Rare', 4: 'Epic', 5: 'Legendary' };
-const TIER_STARS  = { 1: '⭐', 2: '⭐⭐', 3: '⭐⭐⭐', 4: '⭐⭐⭐⭐', 5: '⭐⭐⭐⭐⭐' };
-const TIER_COLORS = { 1: '#9e9e9e', 2: '#4caf50', 3: '#2196f3', 4: '#9c27b0', 5: '#ff9800' };
+// Tier 6 is the `event` rarity that hunt, fish and mine all roll (Thunderbird,
+// Leviathan, Void Ore …). No *material* sits at tier 6 — the event catches drop
+// tier-5 materials — but the catch itself outranks legendary, and every presentation
+// path keys off these tables, so the ladder has to carry the rung. Leaving it out is
+// what made the rarest drops in the game render as common.
+const TIER_LABELS = { 1: 'Common', 2: 'Uncommon', 3: 'Rare', 4: 'Epic', 5: 'Legendary', 6: 'Event' };
+const TIER_STARS  = { 1: '⭐', 2: '⭐⭐', 3: '⭐⭐⭐', 4: '⭐⭐⭐⭐', 5: '⭐⭐⭐⭐⭐', 6: '☀️☀️☀️☀️☀️' };
+const TIER_COLORS = { 1: '#9e9e9e', 2: '#4caf50', 3: '#2196f3', 4: '#9c27b0', 5: '#ff9800', 6: '#e74c3c' };
 
 // Maps tier name strings (used in hunt/fish/mine results) to numeric tier levels.
-const TIER_NUM = { common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5 };
+const TIER_NUM = { common: 1, uncommon: 2, rare: 3, epic: 4, legendary: 5, event: 6 };
 
-const RIBBON_DOTS = ['🟢', '🔵', '🟣', '🟡', '🌌'];
+const RIBBON_DOTS = ['🟢', '🔵', '🟣', '🟡', '🌌', '☄️'];
 
-// Returns the formatted rarity ribbon for a tier number (1–5).
-// e.g. TIER_RIBBON(3) → "🟢 ─ 🔵 ─ [🟣] ─ 🟡 ─ 🌌"
+// Returns the formatted rarity ribbon for a tier number (1–6).
+// e.g. TIER_RIBBON(3) → "🟢 ─ 🔵 ─ [🟣] ─ 🟡 ─ 🌌 ─ ☄️"
 function TIER_RIBBON(tier) {
     return RIBBON_DOTS.map((dot, i) => {
         const t = i + 1;

--- a/src/data/mineData.js
+++ b/src/data/mineData.js
@@ -474,6 +474,24 @@ const LIMITS = {
     PITY_BONUS_PER_STACK:    0.15
 };
 
+// ─── DIG INTENSITY ───────────────────────────────────────────────────────────
+//
+// How hard the miner pushes on a given dig: more payout for more chance of the roof
+// coming down, and more wear on the pickaxe either way.
+
+const INTENSITY_LEVELS = [
+    { level: 1, name: 'Surface',  emoji: '☀️',  multiplier: 0.7, caveInRisk: 0.00, durLoss: 1 },
+    { level: 2, name: 'Shallow',  emoji: '🪨',  multiplier: 1.0, caveInRisk: 0.05, durLoss: 1 },
+    { level: 3, name: 'Mid',      emoji: '🔩',  multiplier: 1.4, caveInRisk: 0.12, durLoss: 2 },
+    { level: 4, name: 'Deep',     emoji: '💎',  multiplier: 2.0, caveInRisk: 0.20, durLoss: 3 },
+    { level: 5, name: 'Abyss',    emoji: '🌑',  multiplier: 3.0, caveInRisk: 0.30, durLoss: 4 },
+];
+
+// The rungs a miner may choose before digging. The Abyss is not among them: its 3×
+// is what a correct vein read pays someone already working Deep, not a selection.
+const CHOOSABLE_INTENSITY     = INTENSITY_LEVELS.filter(l => l.level <= 4);
+const DEFAULT_INTENSITY_LEVEL = 2;
+
 // ─── PRESTIGE BONUSES ────────────────────────────────────────────────────────
 
 const PRESTIGE_BONUSES = [
@@ -728,6 +746,9 @@ module.exports = {
     MINER_LEVELS,
     TIER_COLORS,
     LIMITS,
+    INTENSITY_LEVELS,
+    CHOOSABLE_INTENSITY,
+    DEFAULT_INTENSITY_LEVEL,
     PRESTIGE_BONUSES,
     MATERIAL_NAMES,
     CRAFT_RECIPES,

--- a/src/data/mineData.js
+++ b/src/data/mineData.js
@@ -156,27 +156,36 @@ const CONSUMABLES = {
 };
 
 // ─── MINE DEPTHS ─────────────────────────────────────────────────────────────
+//
+// INVARIANT: a depth may only carry weight on a tier it actually has ore for.
+// Epic ore first appears at iron_mines and legendary at crystal_caves (matching
+// the mq_epic_1 / mq_legendary_1 quest level gates), so the three shallow depths
+// carry zero weight there. When those tiers were weighted anyway, rollOre fell
+// back to the unfiltered pool and the starter quarry handed out Abyss-only ore —
+// firing the server-wide legendary announcement and the rare-companion roll from
+// a level-1 depth. rollTier now enforces this at runtime too; the weights and the
+// guard are meant to agree.
 
 const DEPTHS = {
     surface_quarry: {
         id: 'surface_quarry', name: 'Surface Quarry', emoji: '🪨',
         unlockLevel: 1, unlockCost: 0, defaultUnlocked: true,
         difficultyMod: 0.00, payoutBonus: 0.00,
-        tierWeights: { common: 52, uncommon: 30, rare: 13, epic: 4, legendary: 1, event: 0 },
+        tierWeights: { common: 52, uncommon: 32, rare: 16, epic: 0, legendary: 0, event: 0 },
         description: 'A sunlit open-pit quarry. Great for beginners.'
     },
     coal_tunnels: {
         id: 'coal_tunnels', name: 'Coal Tunnels', emoji: '🖤',
         unlockLevel: 10, unlockCost: 3000, defaultUnlocked: false,
         difficultyMod: -0.05, payoutBonus: 0.00,
-        tierWeights: { common: 42, uncommon: 30, rare: 18, epic: 7, legendary: 2.5, event: 0.5 },
+        tierWeights: { common: 42, uncommon: 34.5, rare: 23, epic: 0, legendary: 0, event: 0.5 },
         description: 'Sooty tunnels that hide uncommon veins.'
     },
     iron_mines: {
         id: 'iron_mines', name: 'Iron Mines', emoji: '🔩',
         unlockLevel: 20, unlockCost: 12000, defaultUnlocked: false,
         difficultyMod: -0.08, payoutBonus: 0.00,
-        tierWeights: { common: 35, uncommon: 28, rare: 22, epic: 11, legendary: 3.5, event: 0.5 },
+        tierWeights: { common: 35, uncommon: 28, rare: 23.5, epic: 13, legendary: 0, event: 0.5 },
         description: 'Deep iron deposits where rare gems can form.'
     },
     crystal_caves: {

--- a/src/services/mineService.js
+++ b/src/services/mineService.js
@@ -9,6 +9,7 @@ const {
     ORES_BY_TIER,
     MINER_LEVELS,
     LIMITS,
+    INTENSITY_LEVELS,
     PRESTIGE_BONUSES,
     MINE_QUEST_TEMPLATES
 } = require('../data/mineData');
@@ -39,6 +40,9 @@ function ensureMineData(user) {
     if (m.lastMine           == null) m.lastMine            = null;
     if (m.injuryUntil        == null) m.injuryUntil         = null;
     if (m.activeDepth        == null) m.activeDepth         = 'surface_quarry';
+    // The intensity the miner last dug at, used as the default when the pre-dig
+    // prompt times out — so an unanswered prompt repeats their own habit.
+    if (m.preferredIntensity == null) m.preferredIntensity  = 2;
     if (!Array.isArray(m.unlockedDepths))       m.unlockedDepths      = ['surface_quarry'];
     if (m.equippedPickaxeIndex == null) m.equippedPickaxeIndex = -1;
     if (!Array.isArray(m.pickaxes))             m.pickaxes            = [];
@@ -616,6 +620,18 @@ function tickConsumables(user) {
     user.markModified('mining');
 }
 
+/**
+ * A correct vein read promotes the payout to the next rung's multiplier while the
+ * cave-in risk and durability cost stay where the miner put them. Reading the seam
+ * makes it richer; it does not make the tunnel more dangerous. Keeping the risk
+ * fixed is the point: the danger is chosen deliberately, and only ever by the
+ * player — never handed to them by the outcome of a minigame.
+ */
+function promoteIntensity(level) {
+    const next = INTENSITY_LEVELS.find(l => l.level === level.level + 1);
+    return next ? { ...level, multiplier: next.multiplier, promoted: true } : level;
+}
+
 // ─── FULL MINE EXECUTION ─────────────────────────────────────────────────────
 
 function executeMine(user, depthId, options = {}) {
@@ -1066,6 +1082,7 @@ module.exports = {
     applyXp,
     activateConsumable,
     tickConsumables,
+    promoteIntensity,
     executeMine,
     assignDailyMineQuests,
     updateMineQuestProgress,

--- a/src/services/mineService.js
+++ b/src/services/mineService.js
@@ -76,7 +76,6 @@ function ensureMineData(user) {
     }
     if (m.mineMapRow == null) m.mineMapRow = 5;
     if (m.mineMapCol == null) m.mineMapCol = 5;
-    if (!m.oreStash)          m.oreStash = {};
     if (m.mineLockActive == null) m.mineLockActive = false;
 
     user.markModified('mining');
@@ -215,6 +214,19 @@ function randInt(min, max) {
 
 // ─── TIER ROLL ───────────────────────────────────────────────────────────────
 
+// Ascending rarity. Also the order rollOre walks backwards when a tier turns out
+// to be unavailable at a depth.
+const TIER_ORDER = ['common', 'uncommon', 'rare', 'epic', 'legendary', 'event'];
+
+/** The ores of `tier` that this depth can actually produce. */
+function oresAtDepth(tier, depthId) {
+    return (ORES_BY_TIER[tier] ?? []).filter(o => o.depths.includes('all') || o.depths.includes(depthId));
+}
+
+function hasOreAtDepth(tier, depthId) {
+    return oresAtDepth(tier, depthId).length > 0;
+}
+
 function rollTier(user, depth) {
     const m = user.mining;
     const w = { ...depth.tierWeights };
@@ -264,23 +276,35 @@ function rollTier(user, depth) {
         w.rare  += shift;
     }
 
-    const tiers = ['common', 'uncommon', 'rare', 'epic', 'legendary', 'event'];
-    const items = tiers.map(t => ({ tier: t, weight: w[t] ?? 0 })).filter(i => i.weight > 0);
+    // Only tiers this depth actually has ore for are eligible. The weight table is
+    // written to agree (see the invariant on DEPTHS), but every boost above adds to
+    // w.rare/w.epic/w.legendary unconditionally, so a rarity boost would otherwise
+    // resurrect a tier the depth was never meant to produce. weightedRoll normalises
+    // by the surviving total, so dropping a tier redistributes rather than voids it.
+    const items = TIER_ORDER
+        .map(t => ({ tier: t, weight: w[t] ?? 0 }))
+        .filter(i => i.weight > 0 && hasOreAtDepth(i.tier, depth.id));
+
+    if (!items.length) return 'common';
     return weightedRoll(items).tier;
 }
 
 // ─── ORE ROLL ────────────────────────────────────────────────────────────────
 
+/**
+ * Picks an ore of `tier` from the depth's own pool. If the depth has no ore at that
+ * tier the roll steps *down* the ladder rather than reaching outside the depth —
+ * the old fallback used the unfiltered pool, which is how the starter quarry ended
+ * up handing out Abyss-only legendaries. Callers should read the returned ore's
+ * own `.tier`, since a downgrade makes it authoritative.
+ */
 function rollOre(tier, depthId) {
-    const pool = (ORES_BY_TIER[tier] ?? []).filter(o =>
-        o.depths.includes('all') || o.depths.includes(depthId)
-    );
-    if (!pool.length) {
-        const fallback = ORES_BY_TIER[tier];
-        if (!fallback?.length) return ORES_BY_TIER['common'][0];
-        return fallback[Math.floor(Math.random() * fallback.length)];
+    const start = TIER_ORDER.indexOf(tier);
+    for (let i = start < 0 ? 0 : start; i >= 0; i--) {
+        const pool = oresAtDepth(TIER_ORDER[i], depthId);
+        if (pool.length) return pool[Math.floor(Math.random() * pool.length)];
     }
-    return pool[Math.floor(Math.random() * pool.length)];
+    return ORES_BY_TIER['common'][0];
 }
 
 // ─── FAILURE SEVERITY ────────────────────────────────────────────────────────
@@ -588,9 +612,13 @@ function executeMine(user, depthId, options = {}) {
     const result = { success, xpEarned: 0, durabilityLost: 0, pickaxeBroke: false };
 
     if (success) {
-        const tier   = rollTier(user, depth);
-        const ore    = rollOre(tier, depthId ?? m.activeDepth);
-        const rawPayout = randInt(ore.payoutMin, ore.payoutMax);
+        const rolledTier = rollTier(user, depth);
+        const ore        = rollOre(rolledTier, depthId ?? m.activeDepth);
+        // The ore's own tier is authoritative: rollOre may have stepped down to stay
+        // inside the depth, and the find counters, quest progress, rarity ribbon and
+        // server announcement all have to describe the ore actually handed out.
+        const tier       = ore.tier;
+        const rawPayout  = randInt(ore.payoutMin, ore.payoutMax);
 
         const critChance     = calculateCritChance(user);
         const isCrit         = Math.random() < critChance;
@@ -863,12 +891,6 @@ function updateMineMap(user, result) {
         m.mineMap[idx] = CELL.CAVE_IN;
     } else if (result.success && result.ore) {
         m.mineMap[idx] = CELL.ORE;
-        // Accumulate ore stash for raiding
-        const matId = result.specialDrop?.itemId;
-        if (matId) {
-            if (!m.oreStash) m.oreStash = {};
-            m.oreStash[matId] = (m.oreStash[matId] ?? 0) + 1;
-        }
     } else {
         m.mineMap[idx] = CELL.DUG;
     }
@@ -909,15 +931,50 @@ function renderMineMap(user) {
     return rows.join('\n');
 }
 
-// ─── ORE STASH ────────────────────────────────────────────────────────────────
+// ─── RAIDABLE MATERIALS ───────────────────────────────────────────────────────
+//
+// Raiding used to take from a separate `oreStash` map that was written alongside
+// `materials` on every drop and never spent by its owner. That made a raid a pure
+// mint: the defender's real material pile — the one `/craft` spends — was untouched
+// while the raider was credited real materials out of nothing, and the Mine Lock
+// they were sold defended a pile that cost nothing to lose.
+//
+// Raids now move materials between two real stocks, so nothing is created. The
+// haul is bounded on both sides: only the defender's largest piles are exposed,
+// no single material gives up more than a few units, and a miner's last unit of
+// anything is never taken.
 
-function getOreStashSummary(user) {
-    const stash = user.mining?.oreStash ?? {};
-    return Object.entries(stash).filter(([, qty]) => qty > 0);
+const RAID_MAX_MATERIAL_TYPES = 5;
+const RAID_MAX_PER_MATERIAL   = 3;
+const RAID_MIN_HOLDING        = 2;
+
+/**
+ * The materials a raid could reach right now: the defender's biggest piles, minus
+ * anything they hold only one of. Sorted largest-first, then by id so the exposure
+ * a defender sees on `/mine map` is the same set a raider hits.
+ */
+function getRaidableMaterials(user) {
+    const materials = user.mining?.materials ?? {};
+    return Object.entries(materials)
+        .filter(([, qty]) => qty >= RAID_MIN_HOLDING)
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+        .slice(0, RAID_MAX_MATERIAL_TYPES);
 }
 
-function isOreStashEmpty(user) {
-    return getOreStashSummary(user).length === 0;
+function hasRaidableMaterials(user) {
+    return getRaidableMaterials(user).length > 0;
+}
+
+/**
+ * What a raid at `stealFraction` would take, as [{ matId, take }]. Every entry
+ * takes at least 1 (the pile is known to hold 2+) and at most RAID_MAX_PER_MATERIAL,
+ * so a long-standing miner's hoard can be chipped at but never cleaned out.
+ */
+function planRaidHaul(user, stealFraction) {
+    return getRaidableMaterials(user).map(([matId, qty]) => ({
+        matId,
+        take: Math.min(RAID_MAX_PER_MATERIAL, Math.max(1, Math.floor(qty * stealFraction))),
+    }));
 }
 
 module.exports = {
@@ -930,6 +987,7 @@ module.exports = {
     calculateCritChance,
     rollTier,
     rollOre,
+    hasOreAtDepth,
     rollFailureSeverity,
     applyPayoutModifiers,
     applyDurabilityLoss,
@@ -951,6 +1009,10 @@ module.exports = {
     durabilityBar,
     updateMineMap,
     renderMineMap,
-    getOreStashSummary,
-    isOreStashEmpty
+    getRaidableMaterials,
+    hasRaidableMaterials,
+    planRaidHaul,
+    RAID_MAX_MATERIAL_TYPES,
+    RAID_MAX_PER_MATERIAL,
+    RAID_MIN_HOLDING
 };

--- a/src/services/mineService.js
+++ b/src/services/mineService.js
@@ -10,6 +10,7 @@ const {
     MINER_LEVELS,
     LIMITS,
     INTENSITY_LEVELS,
+    DEFAULT_INTENSITY_LEVEL,
     PRESTIGE_BONUSES,
     MINE_QUEST_TEMPLATES
 } = require('../data/mineData');
@@ -42,7 +43,7 @@ function ensureMineData(user) {
     if (m.activeDepth        == null) m.activeDepth         = 'surface_quarry';
     // The intensity the miner last dug at, used as the default when the pre-dig
     // prompt times out — so an unanswered prompt repeats their own habit.
-    if (m.preferredIntensity == null) m.preferredIntensity  = 2;
+    if (m.preferredIntensity == null) m.preferredIntensity  = DEFAULT_INTENSITY_LEVEL;
     if (!Array.isArray(m.unlockedDepths))       m.unlockedDepths      = ['surface_quarry'];
     if (m.equippedPickaxeIndex == null) m.equippedPickaxeIndex = -1;
     if (!Array.isArray(m.pickaxes))             m.pickaxes            = [];

--- a/src/services/mineService.js
+++ b/src/services/mineService.js
@@ -325,8 +325,15 @@ function rollFailureSeverity() {
 // ─── PAYOUT CALCULATION ───────────────────────────────────────────────────────
 
 /**
- * Returns { adjustedPayout, cappedByHard, gatheringYield }, where gatheringYield
- * is { effect, label, emoji, chargesLeft } when a charge was spent here.
+ * Returns { adjustedPayout, cappedByHard, gatheringYield, forfeited, softCapped,
+ * fatigueMult }, where gatheringYield is { effect, label, emoji, chargesLeft } when
+ * a charge was spent here.
+ *
+ * The three throttles below — fatigue past DIM_RETURNS_THRESHOLD_1, the halving past
+ * DAILY_SOFT_CAP, and the DAILY_HARD_CAP floor — used to apply with nothing said. A
+ * player's haul quietly shrank by 15%, then 50%, then to zero with no explanation
+ * anywhere in the embed, which reads as the bot cheating rather than as a design.
+ * `forfeited` is what the cap swallowed, so the caller can show it.
  */
 function applyPayoutModifiers(user, rawPayout, depth) {
     const m = user.mining;
@@ -342,19 +349,20 @@ function applyPayoutModifiers(user, rawPayout, depth) {
     const artificerBonus = getArtificerMineYieldBonus(user);
     if (artificerBonus > 0) payout *= (1 + artificerBonus);
 
-    if (m.dailyMines >= LIMITS.DIM_RETURNS_THRESHOLD_3) {
-        payout *= 0.55;
-    } else if (m.dailyMines >= LIMITS.DIM_RETURNS_THRESHOLD_2) {
-        payout *= 0.70;
-    } else if (m.dailyMines >= LIMITS.DIM_RETURNS_THRESHOLD_1) {
-        payout *= 0.85;
-    }
+    const fatigueMult =
+        m.dailyMines >= LIMITS.DIM_RETURNS_THRESHOLD_3 ? 0.55 :
+        m.dailyMines >= LIMITS.DIM_RETURNS_THRESHOLD_2 ? 0.70 :
+        m.dailyMines >= LIMITS.DIM_RETURNS_THRESHOLD_1 ? 0.85 : 1.00;
+    payout *= fatigueMult;
 
     payout = Math.round(payout);
 
     // Hard cap: zero coins — check before consuming item charges
     if (m.dailyCoins >= LIMITS.DAILY_HARD_CAP) {
-        return { adjustedPayout: 0, cappedByHard: true, gatheringYield: null };
+        return {
+            adjustedPayout: 0, cappedByHard: true, gatheringYield: null,
+            forfeited: payout, softCapped: true, fatigueMult, artificerRate: artificerBonus,
+        };
     }
 
     // Applies the daily soft cap and clamps to the headroom left under the hard cap.
@@ -364,6 +372,7 @@ function applyPayoutModifiers(user, rawPayout, depth) {
 
     const basePayout    = settle(payout);
     const doubledPayout = settle(payout * 2);
+    const throttles     = { softCapped, fatigueMult, artificerRate: artificerBonus };
 
     // Silvered Talisman / Voidsteel Cache: 2x yield, consume 1 charge from whichever
     // is active. Only burn the charge when doubling actually pays more — within a
@@ -374,6 +383,8 @@ function applyPayoutModifiers(user, rawPayout, depth) {
         consumeEffect(user, gatherEffect);
         const cfg = EFFECT_CONFIGS[gatherEffect];
         return {
+            ...throttles,
+            forfeited:      Math.max(0, payout * 2 - doubledPayout),
             adjustedPayout: doubledPayout,
             cappedByHard:   false,
             gatheringYield: {
@@ -385,7 +396,23 @@ function applyPayoutModifiers(user, rawPayout, depth) {
         };
     }
 
-    return { adjustedPayout: basePayout, cappedByHard: false, gatheringYield: null };
+    return {
+        ...throttles,
+        forfeited:      Math.max(0, payout - basePayout),
+        adjustedPayout: basePayout,
+        cappedByHard:   false,
+        gatheringYield: null,
+    };
+}
+
+/**
+ * How long until the daily window — caps, fatigue and Energy Tonic allowance —
+ * rolls over. Null when the player has no window open yet.
+ */
+function msUntilDailyReset(user) {
+    const start = user.mining?.dailyWindowStart;
+    if (!start) return null;
+    return Math.max(0, LIMITS.DAILY_WINDOW_MS - (Date.now() - start.getTime()));
 }
 
 // ─── DURABILITY ───────────────────────────────────────────────────────────────
@@ -626,7 +653,10 @@ function executeMine(user, depthId, options = {}) {
 
         const streakMult = getStreakMultiplier(user.streak?.current ?? 0);
         const payoutBeforeMods = Math.round(rawPayout * critMultiplier * streakMult);
-        const { adjustedPayout, cappedByHard, gatheringYield } = applyPayoutModifiers(user, payoutBeforeMods, depth);
+        const {
+            adjustedPayout, cappedByHard, gatheringYield, forfeited, softCapped, fatigueMult,
+            artificerRate,
+        } = applyPayoutModifiers(user, payoutBeforeMods, depth);
 
         let specialDrop = null;
         const mineDropChance = (isCrit ? ore.specialDrop?.chance * 2 : ore.specialDrop?.chance ?? 0) * (options.marketplaceActive ? 1.10 : 1.0);
@@ -669,7 +699,10 @@ function executeMine(user, depthId, options = {}) {
             levelUp: lvResult.leveledUp ? lvResult : null,
             cappedByHard,
             gatheringYield,
-            streakMult
+            streakMult,
+            // What the daily throttles took, so the embed can account for it rather
+            // than leaving the player to notice their haul shrinking on its own.
+            forfeited, softCapped, fatigueMult, artificerRate,
         });
 
         if (pickaxe.currentDurability <= 0) result.pickaxeBroke = true;
@@ -717,10 +750,21 @@ function executeMine(user, depthId, options = {}) {
         const caveInBlocked = trapActive || ironWillBlocks;
 
         if (caveInRisk > 0 && Math.random() < caveInRisk && !caveInBlocked) {
-            // Cave-in: flag it and store at-risk payout; mine.js resolves interactively
+            // Cave-in: flag it and store at-risk payout; mine.js resolves interactively.
             result.caveIn        = true;
             result.caveInDur     = intensityDurLoss;
+            // What executeMine has already credited, and what mine.js reverses if the
+            // player flees.
             result.caveInPayout  = result.finalPayout ?? 0;
+            // The multiplier the vein read earned is held in escrow, not destroyed.
+            // Cave-in and the multiplier used to be exclusive branches, so reading the
+            // vein perfectly, caving in, and spending a blast charge to dig clear paid
+            // exactly the same as a one-in-three read — the charge bought back a haul
+            // stripped of the very bonus it was risked for. mine.js pays this out only
+            // on a successful escape.
+            result.caveInEscrow  = multiplier !== 1.0 && result.finalPayout
+                ? Math.round(result.finalPayout * (multiplier - 1.0))
+                : 0;
             // Durability loss applied here regardless of player choice
             applyDurabilityLoss(pickaxe, intensityDurLoss);
             if (pickaxe.currentDurability <= 0) { pickaxe.status = 'broken'; result.pickaxeBroke = true; }
@@ -990,6 +1034,7 @@ module.exports = {
     hasOreAtDepth,
     rollFailureSeverity,
     applyPayoutModifiers,
+    msUntilDailyReset,
     applyDurabilityLoss,
     updatePickaxeStatus,
     isCondemned,

--- a/src/services/mineService.js
+++ b/src/services/mineService.js
@@ -820,10 +820,30 @@ function assignDailyMineQuests(user) {
     const activeCount = user.quests.filter(q => q.questId.startsWith('mq_')).length;
     if (activeCount > 0) return;
 
-    const eligible = MINE_QUEST_TEMPLATES.filter(t =>
-        m.level >= t.minLevel &&
-        (t.type !== 'depth_mines' || m.unlockedDepths.includes(t.depth))
+    // Tier quests need a depth that can actually produce the tier, not just the level.
+    // Epic ore starts at the Iron Mines and legendary at the Crystal Caves, so a miner
+    // who has hit the level gate but not yet bought the depth would otherwise be handed
+    // a quest they cannot complete — which also blocks the next batch for a full day,
+    // since a batch is only reissued once the current one expires.
+    // The `event` tier is deliberately left out of these lists. It sits above
+    // legendary and technically satisfies every "or better" quest, but it is a ~0.5%
+    // freak roll at the shallow depths — treating it as a way to clear an epic quest
+    // would put the quest back on the board in all but name.
+    const QUEST_TIER_REQUIREMENT = {
+        rare_plus_finds:      ['rare', 'epic', 'legendary'],
+        epic_plus_finds:      ['epic', 'legendary'],
+        legendary_plus_finds: ['legendary'],
+    };
+    const canReachTier = tiers => m.unlockedDepths.some(depthId =>
+        tiers.some(tier => (DEPTHS[depthId]?.tierWeights?.[tier] ?? 0) > 0)
     );
+
+    const eligible = MINE_QUEST_TEMPLATES.filter(t => {
+        if (m.level < t.minLevel) return false;
+        if (t.type === 'depth_mines') return m.unlockedDepths.includes(t.depth);
+        const required = QUEST_TIER_REQUIREMENT[t.type];
+        return !required || canReachTier(required);
+    });
 
     const shuffled  = eligible.slice().sort(() => Math.random() - 0.5);
     const toAssign  = shuffled.slice(0, DAILY_QUEST_COUNT);

--- a/src/utils/grindProfile.js
+++ b/src/utils/grindProfile.js
@@ -18,6 +18,11 @@
  *   before persisting.
  * - Profiles that were never touched (no data after the action) are not
  *   persisted, so casual users don't accumulate empty documents.
+ * - A save only writes the systems the flow actually marked. `prof.data` is
+ *   replaced wholesale, so writing an untouched system would push a snapshot read
+ *   at load time back over anything that changed in between — which is how a
+ *   /mine raid's material transfer could be undone by an unrelated /fish cast
+ *   that merely had the mining profile attached for a cross-system read.
  */
 
 const GrindProfile = require('../models/GrindProfile');
@@ -47,6 +52,8 @@ async function attachGrind(user, systems = SYSTEMS) {
                 ?? new GrindProfile({ guildId: user.guildId, userId: user.userId, system });
             user._grindProfiles[system] = prof;
             user[system] = prof.data;
+            user._grindSnapshots ??= {};
+            user._grindSnapshots[system] = snapshot(prof.data);
         }
     }
 
@@ -54,10 +61,44 @@ async function attachGrind(user, systems = SYSTEMS) {
     return user;
 }
 
-/** Persists the attached profiles for `user` (subset via `systems`). */
-async function saveGrind(user, systems = SYSTEMS) {
+/**
+ * Snapshot of a profile's data as loaded, used to tell a flow that changed a system
+ * from one that merely had it attached for a cross-system read.
+ */
+function snapshot(data) {
+    try {
+        return JSON.stringify(data ?? null);
+    } catch {
+        // Anything uncomparable is treated as changed — a redundant write is safe,
+        // a skipped one is not.
+        return null;
+    }
+}
+
+function grindChanged(user, system) {
+    const before = user._grindSnapshots?.[system];
+    if (before === undefined) return true;
+    const after = snapshot(user[system]);
+    return after === null || after !== before;
+}
+
+/**
+ * Persists the attached profiles for `user`.
+ *
+ * With no `systems` argument this writes only the profiles whose data actually
+ * differs from what was loaded. `prof.data` is replaced wholesale, so writing back
+ * an untouched system would push a load-time snapshot over anything that changed in
+ * the meantime — which is how a /mine raid's material transfer could be undone by
+ * an unrelated /fish cast that had the mining profile attached only to read it.
+ *
+ * Comparison is by content rather than by markModified: a mutation site that forgot
+ * to mark would otherwise stop persisting silently, which is a worse failure than a
+ * redundant write. Pass `systems` explicitly to force a write regardless.
+ */
+async function saveGrind(user, systems = null) {
     if (!user?._grindProfiles) return;
-    for (const system of systems) {
+    const targets = systems ?? SYSTEMS.filter(system => grindChanged(user, system));
+    for (const system of targets) {
         const prof = user._grindProfiles[system];
         if (!prof) continue;
         prof.data = user[system];
@@ -66,6 +107,7 @@ async function saveGrind(user, systems = SYSTEMS) {
         if (prof.data == null || (prof.isNew && Object.keys(prof.data).length === 0)) continue;
         prof.markModified('data');
         await prof.save();
+        if (user._grindSnapshots) user._grindSnapshots[system] = snapshot(prof.data);
     }
 }
 
@@ -83,6 +125,7 @@ async function persistGrindIfNew(user, system) {
 function wrapSave(user) {
     if (user._grindSaveWrapped || typeof user.save !== 'function') return;
     user._grindSaveWrapped = true;
+
     const origSave = user.save.bind(user);
     user.save = async function (...args) {
         const res = await origSave(...args);

--- a/tests/craftMiningLock.test.js
+++ b/tests/craftMiningLock.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+// Crafting spends mining materials, and a grind profile is persisted by replacing
+// its whole `data` document. So the mining action lock has to cover the *read* as
+// well as the write: holding it only around user.save() left the window that
+// matters open — a /mine raid landing between attachGrind and the save was simply
+// overwritten by the snapshot the craft had already loaded, and the raider kept
+// their credit while the defender kept their materials.
+
+jest.mock('../src/utils/activeGameLock', () => ({
+    tryAcquire: jest.fn(),
+    release:    jest.fn().mockResolvedValue(true),
+    DEFAULT_TTL_MS: 120_000,
+}));
+
+jest.mock('../src/models/Guild', () => ({ findOne: jest.fn() }));
+jest.mock('../src/models/User', () => ({ findOneAndUpdate: jest.fn() }));
+
+const lock  = require('../src/utils/activeGameLock');
+const Guild = require('../src/models/Guild');
+const craft = require('../src/commands/economy/craft');
+
+/** Records the order of lock and data operations so their nesting can be asserted. */
+let trace;
+
+function interaction(sub) {
+    return {
+        guild: { id: 'g1' },
+        user:  { id: 'u1' },
+        options: { getSubcommand: () => sub, getString: () => null, getInteger: () => 1 },
+        reply: jest.fn(async () => { trace.push('reply'); }),
+    };
+}
+
+beforeEach(() => {
+    trace = [];
+    lock.tryAcquire.mockReset().mockImplementation(async () => { trace.push('acquire'); return 'tok'; });
+    lock.release.mockReset().mockImplementation(async () => { trace.push('release'); return true; });
+    // Economy disabled makes the inner handler return before any profile is read,
+    // which is enough to observe the wrapper without standing up a database.
+    Guild.findOne.mockReset().mockResolvedValue({ economy: { enabled: false } });
+});
+
+describe('/craft make runs under the mining lock', () => {
+    test('takes the lock before the handler runs and releases it after', async () => {
+        await craft.execute(interaction('make'));
+        expect(trace).toEqual(['acquire', 'reply', 'release']);
+    });
+
+    test('uses the same key /mine holds, so the two serialise against each other', async () => {
+        await craft.execute(interaction('make'));
+        expect(lock.tryAcquire).toHaveBeenCalledWith('grind:mine:g1:u1', expect.any(Number));
+    });
+
+    test('a busy miner is turned away without touching their data', async () => {
+        lock.tryAcquire.mockImplementation(async () => { trace.push('acquire'); return null; });
+        const i = interaction('make');
+
+        await craft.execute(i);
+
+        expect(i.reply).toHaveBeenCalledWith(expect.objectContaining({
+            content: expect.stringContaining('mining action in progress'),
+        }));
+        expect(Guild.findOne).not.toHaveBeenCalled();   // never read anything
+        expect(lock.release).not.toHaveBeenCalled();    // nothing to release
+    });
+
+    test('the lock is released even when the handler throws', async () => {
+        Guild.findOne.mockRejectedValue(new Error('db down'));
+        await expect(craft.execute(interaction('make'))).rejects.toThrow('db down');
+        expect(trace).toEqual(['acquire', 'release']);
+    });
+});
+
+describe('/craft list is read-only and never blocks a raid', () => {
+    test('browsing recipes takes no lock at all', async () => {
+        await craft.execute(interaction('list'));
+        expect(lock.tryAcquire).not.toHaveBeenCalled();
+        expect(lock.release).not.toHaveBeenCalled();
+    });
+});

--- a/tests/grindProfile.test.js
+++ b/tests/grindProfile.test.js
@@ -126,3 +126,77 @@ describe('saveGrind', () => {
         expect(prof.saved).toBe(1);
     });
 });
+
+describe('a save only writes what the flow changed', () => {
+    // Profiles are persisted by replacing the whole `data` document. Writing back a
+    // system the flow merely attached for a cross-system read would push a load-time
+    // snapshot over anything that changed in between — which is how an unrelated
+    // /fish cast could undo a /mine raid's material transfer.
+    function existing(system, data) {
+        const prof = new GrindProfile({ userId: 'u1', guildId: 'g1', system });
+        prof.data = data;
+        prof.isNew = false;
+        return prof;
+    }
+
+    test('an attached but untouched system is left alone', async () => {
+        GrindProfile.find.mockResolvedValue([
+            existing('fishing', { xp: 1 }),
+            existing('mining', { materials: { gold_nugget: 10 } }),
+        ]);
+        const user = makeUser();
+        await attachGrind(user);
+
+        user.fishing.xp = 2;
+        await user.save();
+
+        expect(user._grindProfiles.fishing.saved).toBe(1);
+        expect(user._grindProfiles.mining.saved).toBe(0);
+        expect(user._grindProfiles.mining.data.materials.gold_nugget).toBe(10);
+    });
+
+    test('a system the flow did change is written', async () => {
+        GrindProfile.find.mockResolvedValue([existing('mining', { materials: { gold_nugget: 10 } })]);
+        const user = makeUser();
+        await attachGrind(user);
+
+        user.mining.materials.gold_nugget = 7;
+        await user.save();
+
+        expect(user._grindProfiles.mining.saved).toBe(1);
+        expect(user._grindProfiles.mining.data.materials.gold_nugget).toBe(7);
+    });
+
+    test('replacing the property wholesale still counts as a change', async () => {
+        GrindProfile.find.mockResolvedValue([existing('mining', { xp: 1 })]);
+        const user = makeUser();
+        await attachGrind(user);
+
+        user.mining = { xp: 1, level: 2 };   // what an ensure*Data rebuild looks like
+        await user.save();
+
+        expect(user._grindProfiles.mining.saved).toBe(1);
+    });
+
+    test('an explicit system list still forces the write', async () => {
+        GrindProfile.find.mockResolvedValue([existing('mining', { xp: 1 })]);
+        const user = makeUser();
+        await attachGrind(user);
+
+        await saveGrind(user, ['mining']);
+        expect(user._grindProfiles.mining.saved).toBe(1);
+    });
+
+    test('a repeat save does not rewrite a profile that has not moved since', async () => {
+        GrindProfile.find.mockResolvedValue([existing('mining', { xp: 1 })]);
+        const user = makeUser();
+        await attachGrind(user);
+
+        user.mining.xp = 2;
+        await user.save();
+        expect(user._grindProfiles.mining.saved).toBe(1);
+
+        await user.save();
+        expect(user._grindProfiles.mining.saved).toBe(1);
+    });
+});

--- a/tests/mineDepthTiers.test.js
+++ b/tests/mineDepthTiers.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const { rollTier, rollOre, hasOreAtDepth } = require('../src/services/mineService');
+const { DEPTHS, DEPTH_LIST, ORES_BY_TIER, MINE_QUEST_TEMPLATES } = require('../src/data/mineData');
+
+const TIERS = ['common', 'uncommon', 'rare', 'epic', 'legendary', 'event'];
+
+/** A miner carrying every rarity boost the game can stack onto a tier roll. */
+function maxBoostUser() {
+    return {
+        mining: {
+            activeMagnet: 'premium_magnet',
+            prestige: 5,
+            pickaxes: [{ tier: 5, upgrade: 'gem_lens' }],
+            equippedPickaxeIndex: 0,
+        },
+        accountPrestige: { rank: 10 },
+    };
+}
+
+describe('depth tier weights', () => {
+    test('no depth carries weight on a tier it has no ore for', () => {
+        for (const depth of DEPTH_LIST) {
+            for (const tier of TIERS) {
+                const weight = depth.tierWeights[tier] ?? 0;
+                if (weight > 0) {
+                    expect([depth.id, tier, hasOreAtDepth(tier, depth.id)]).toEqual([depth.id, tier, true]);
+                }
+            }
+        }
+    });
+
+    test('rare-or-better odds rise monotonically with depth', () => {
+        const rarePlus = depth => {
+            const w = depth.tierWeights;
+            const total = TIERS.reduce((s, t) => s + (w[t] ?? 0), 0);
+            return (w.rare + w.epic + w.legendary + w.event) / total;
+        };
+        const ordered = DEPTH_LIST.map(rarePlus);
+        for (let i = 1; i < ordered.length; i++) {
+            expect(ordered[i]).toBeGreaterThan(ordered[i - 1]);
+        }
+    });
+
+    test('epic and legendary ore first appear at the depths their quests gate on', () => {
+        const questLevel = id => MINE_QUEST_TEMPLATES.find(t => t.id === id).minLevel;
+        const firstDepthWith = tier => DEPTH_LIST.find(d => (d.tierWeights[tier] ?? 0) > 0);
+
+        expect(firstDepthWith('epic').unlockLevel).toBe(questLevel('mq_epic_1'));
+        expect(firstDepthWith('legendary').unlockLevel).toBe(questLevel('mq_legendary_1'));
+    });
+});
+
+describe('rollOre stays inside the depth', () => {
+    test('a tier the depth cannot produce steps down instead of reaching outside it', () => {
+        // The starter quarry has no epic or legendary ore at all.
+        for (const tier of ['epic', 'legendary']) {
+            const ore = rollOre(tier, 'surface_quarry');
+            expect(ore.depths.includes('all') || ore.depths.includes('surface_quarry')).toBe(true);
+            expect(TIERS.indexOf(ore.tier)).toBeLessThan(TIERS.indexOf(tier));
+        }
+    });
+
+    test('a legal tier is still honoured', () => {
+        const ore = rollOre('legendary', 'the_abyss');
+        expect(ore.tier).toBe('legendary');
+    });
+
+    test('every ore the abyss can roll is reachable there', () => {
+        const seen = new Set();
+        for (let i = 0; i < 5_000; i++) seen.add(rollOre('legendary', 'the_abyss').id);
+        const expected = ORES_BY_TIER.legendary
+            .filter(o => o.depths.includes('all') || o.depths.includes('the_abyss'))
+            .map(o => o.id);
+        expect([...seen].sort()).toEqual(expected.sort());
+    });
+});
+
+describe('rarity boosts cannot resurrect an impossible tier', () => {
+    // Every boost in rollTier adds to w.rare/w.epic/w.legendary unconditionally, so
+    // without the depth guard a Void Pickaxe would hand out Abyss ore in the quarry.
+    test.each(DEPTH_LIST.map(d => [d.id]))('%s never yields out-of-depth ore under max boosts', depthId => {
+        const user = maxBoostUser();
+        const depth = DEPTHS[depthId];
+
+        for (let i = 0; i < 8_000; i++) {
+            const tier = rollTier(user, depth);
+            expect(hasOreAtDepth(tier, depthId)).toBe(true);
+
+            const ore = rollOre(tier, depthId);
+            expect(ore.depths.includes('all') || ore.depths.includes(depthId)).toBe(true);
+        }
+    });
+
+    test('the starter quarry never rolls legendary, however boosted', () => {
+        const user = maxBoostUser();
+        for (let i = 0; i < 20_000; i++) {
+            expect(rollTier(user, DEPTHS.surface_quarry)).not.toBe('legendary');
+        }
+    });
+});

--- a/tests/mineDepthTiers.test.js
+++ b/tests/mineDepthTiers.test.js
@@ -99,3 +99,55 @@ describe('rarity boosts cannot resurrect an impossible tier', () => {
         }
     });
 });
+
+describe('tier quests are only handed out where they can be completed', () => {
+    const { assignDailyMineQuests, ensureMineData } = require('../src/services/mineService');
+
+    /** Every quest id that can be rolled for a miner at this level and these depths. */
+    function offerable(level, unlockedDepths) {
+        const user = { mining: {}, quests: [], markModified() {} };
+        ensureMineData(user);
+        Object.assign(user.mining, { level, unlockedDepths });
+
+        const seen = new Set();
+        for (let i = 0; i < 300; i++) {
+            user.quests = [];
+            assignDailyMineQuests(user);
+            for (const q of user.quests) seen.add(q.questId);
+        }
+        return seen;
+    }
+
+    test('an epic quest waits for a depth with epic ore, not just the level', () => {
+        // mq_epic_1 unlocks at miner level 20; epic ore starts at the Iron Mines,
+        // which costs 12,000 coins on top of that level.
+        expect(offerable(20, ['surface_quarry', 'coal_tunnels'])).not.toContain('mq_epic_1');
+        expect(offerable(20, ['surface_quarry', 'coal_tunnels', 'iron_mines'])).toContain('mq_epic_1');
+    });
+
+    test('a legendary quest waits for the Crystal Caves', () => {
+        const shallow = ['surface_quarry', 'coal_tunnels', 'iron_mines'];
+        expect(offerable(30, shallow)).not.toContain('mq_legendary_1');
+        expect(offerable(30, [...shallow, 'crystal_caves'])).toContain('mq_legendary_1');
+    });
+
+    test('the starter quarry still offers the rare quest it can complete', () => {
+        expect(offerable(1, ['surface_quarry'])).toContain('mq_rare_1');
+    });
+
+    test('every offerable tier quest has a depth that can actually produce its tier', () => {
+        const REQUIRED = {
+            mq_rare_1: 'rare', mq_rare_2: 'rare', mq_epic_1: 'epic', mq_legendary_1: 'legendary',
+        };
+        const depths = ['surface_quarry', 'coal_tunnels', 'iron_mines', 'crystal_caves', 'the_abyss'];
+
+        for (let owned = 1; owned <= depths.length; owned++) {
+            const unlocked = depths.slice(0, owned);
+            for (const questId of offerable(50, unlocked)) {
+                const tier = REQUIRED[questId];
+                if (!tier) continue;
+                expect(unlocked.some(d => (DEPTHS[d].tierWeights[tier] ?? 0) > 0)).toBe(true);
+            }
+        }
+    });
+});

--- a/tests/mineIntensity.test.js
+++ b/tests/mineIntensity.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const { promoteIntensity, executeMine, ensureMineData } = require('../src/services/mineService');
+const {
+    INTENSITY_LEVELS, CHOOSABLE_INTENSITY, DEFAULT_INTENSITY_LEVEL,
+} = require('../src/data/mineData');
+
+const byLevel = n => INTENSITY_LEVELS.find(l => l.level === n);
+
+describe('the intensity ladder', () => {
+    test('rises in payout and in risk together', () => {
+        for (let i = 1; i < INTENSITY_LEVELS.length; i++) {
+            expect(INTENSITY_LEVELS[i].multiplier).toBeGreaterThan(INTENSITY_LEVELS[i - 1].multiplier);
+            expect(INTENSITY_LEVELS[i].caveInRisk).toBeGreaterThanOrEqual(INTENSITY_LEVELS[i - 1].caveInRisk);
+            expect(INTENSITY_LEVELS[i].durLoss).toBeGreaterThanOrEqual(INTENSITY_LEVELS[i - 1].durLoss);
+        }
+    });
+
+    test('the Abyss cannot be selected — it is what a good read pays at Deep', () => {
+        expect(CHOOSABLE_INTENSITY.map(l => l.level)).toEqual([1, 2, 3, 4]);
+        expect(promoteIntensity(byLevel(4)).multiplier).toBe(byLevel(5).multiplier);
+    });
+
+    test('the safe rung really is free of cave-ins', () => {
+        expect(byLevel(1).caveInRisk).toBe(0);
+    });
+
+    test('the default rung is one a miner can actually pick', () => {
+        expect(CHOOSABLE_INTENSITY.some(l => l.level === DEFAULT_INTENSITY_LEVEL)).toBe(true);
+    });
+});
+
+describe('a correct vein read pays more without adding danger', () => {
+    test.each(CHOOSABLE_INTENSITY.map(l => [l.name, l.level]))(
+        'from %s the promotion raises payout and leaves risk alone', (_name, level) => {
+            const chosen   = byLevel(level);
+            const promoted = promoteIntensity(chosen);
+
+            expect(promoted.multiplier).toBe(byLevel(level + 1).multiplier);
+            expect(promoted.multiplier).toBeGreaterThan(chosen.multiplier);
+            // The whole point: the miner chose this risk, and reading the seam does
+            // not silently raise it on them.
+            expect(promoted.caveInRisk).toBe(chosen.caveInRisk);
+            expect(promoted.durLoss).toBe(chosen.durLoss);
+            expect(promoted.name).toBe(chosen.name);
+        });
+
+    test('the top rung has nothing above it to promote into', () => {
+        const top = INTENSITY_LEVELS[INTENSITY_LEVELS.length - 1];
+        expect(promoteIntensity(top)).toEqual(top);
+    });
+
+    test('promotion does not mutate the shared ladder', () => {
+        const before = JSON.parse(JSON.stringify(INTENSITY_LEVELS));
+        CHOOSABLE_INTENSITY.forEach(promoteIntensity);
+        expect(INTENSITY_LEVELS).toEqual(before);
+    });
+});
+
+describe('the chosen intensity is what the dig actually uses', () => {
+    function miner() {
+        const user = { balance: 0, mining: {}, quests: [], markModified() {} };
+        ensureMineData(user);
+        Object.assign(user.mining, {
+            level: 20,
+            pickaxes: [{
+                name: 'Steel Pickaxe', tier: 3, slug: 'steel_pickaxe',
+                currentDurability: 160, maxDurability: 160, baseDurability: 160,
+                repairCount: 0, upgrade: null, status: 'good',
+            }],
+            equippedPickaxeIndex: 0,
+        });
+        return user;
+    }
+
+    afterEach(() => { if (jest.isMockFunction(Math.random)) Math.random.mockRestore(); });
+
+    test('a safe dig can never cave in, however unlucky the roll', () => {
+        jest.spyOn(Math, 'random').mockReturnValue(0);   // worst case for every roll
+        const result = executeMine(miner(), 'surface_quarry', { intensity: byLevel(1) });
+        expect(result.caveIn).toBeUndefined();
+    });
+
+    test('a promoted dig pays the higher multiplier at the risk that was chosen', () => {
+        jest.spyOn(Math, 'random').mockReturnValue(0);
+        const deep     = byLevel(4);
+        const promoted = promoteIntensity(deep);
+
+        const plain = executeMine(miner(), 'surface_quarry', { intensity: { ...deep, caveInRisk: 0 } });
+        const read  = executeMine(miner(), 'surface_quarry', { intensity: { ...promoted, caveInRisk: 0 } });
+
+        expect(read.finalPayout).toBeGreaterThan(plain.finalPayout);
+        expect(read.intensityLevel.caveInRisk).toBe(plain.intensityLevel.caveInRisk);
+    });
+
+    test('a new miner starts on a sane default rung', () => {
+        expect(miner().mining.preferredIntensity).toBe(DEFAULT_INTENSITY_LEVEL);
+    });
+});

--- a/tests/minePrestige.test.js
+++ b/tests/minePrestige.test.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const {
+    ensureMineData,
+    getMaxStamina,
+    calculateCritChance,
+    applyPayoutModifiers,
+    rollTier,
+    levelFromXp,
+} = require('../src/services/mineService');
+const {
+    MINER_LEVELS, PRESTIGE_BONUSES, DEPTHS, LIMITS,
+} = require('../src/data/mineData');
+
+const MAX_MINER_LEVEL   = MINER_LEVELS.length;
+const MAX_MINE_PRESTIGE = PRESTIGE_BONUSES.length - 1;
+
+function miner({ level = 1, prestige = 0, xp = 0 } = {}) {
+    const user = { mining: {}, markModified() {} };
+    ensureMineData(user);
+    Object.assign(user.mining, { level, prestige, xp });
+    return user;
+}
+
+/** What /mine prestige does to the profile when a miner ascends. */
+function ascend(user) {
+    user.mining.prestige += 1;
+    user.mining.level = 1;
+    user.mining.xp = 0;
+    return user;
+}
+
+describe('the prestige ladder is reachable', () => {
+    test('Miner Level tops out where the level table ends', () => {
+        expect(levelFromXp(MINER_LEVELS[MAX_MINER_LEVEL - 1].xpRequired)).toBe(MAX_MINER_LEVEL);
+        expect(levelFromXp(Number.MAX_SAFE_INTEGER)).toBe(MAX_MINER_LEVEL);
+    });
+
+    test('every rank in the bonus table can be climbed to', () => {
+        const user = miner({ level: MAX_MINER_LEVEL });
+        for (let rank = 1; rank <= MAX_MINE_PRESTIGE; rank++) {
+            user.mining.level = MAX_MINER_LEVEL;
+            ascend(user);
+            expect(user.mining.prestige).toBe(rank);
+            expect(user.mining.level).toBe(1);
+            expect(user.mining.xp).toBe(0);
+        }
+        expect(user.mining.prestige).toBe(MAX_MINE_PRESTIGE);
+    });
+});
+
+describe('prestige bonuses actually apply', () => {
+    test('max stamina grows at the rank the table says it does', () => {
+        for (let rank = 0; rank <= MAX_MINE_PRESTIGE; rank++) {
+            const expected = LIMITS.MAX_STAMINA_BASE + PRESTIGE_BONUSES[rank].staminaBonus;
+            expect(getMaxStamina(miner({ prestige: rank }))).toBe(expected);
+        }
+    });
+
+    test('crit chance rises with rank', () => {
+        const p0 = calculateCritChance(miner({ prestige: 0 }));
+        const p1 = calculateCritChance(miner({ prestige: 1 }));
+        expect(p1).toBeGreaterThan(p0);
+        expect(p1 - p0).toBeCloseTo(PRESTIGE_BONUSES[1].critBonus, 5);
+    });
+
+    test('payouts rise at the rank that grants a payout bonus', () => {
+        const depth = DEPTHS.surface_quarry;
+        const plain  = applyPayoutModifiers(miner({ prestige: 2 }), 1000, depth).adjustedPayout;
+        const bonused = applyPayoutModifiers(miner({ prestige: 3 }), 1000, depth).adjustedPayout;
+        expect(bonused).toBe(Math.round(1000 * (1 + PRESTIGE_BONUSES[3].payoutBonus)));
+        expect(bonused).toBeGreaterThan(plain);
+    });
+
+    test('the rarity bonus shifts weight toward rare ore', () => {
+        const depth = DEPTHS.the_abyss;
+        const rareRate = prestige => {
+            const user = miner({ prestige });
+            let rare = 0;
+            for (let i = 0; i < 40_000; i++) {
+                if (['rare', 'epic', 'legendary', 'event'].includes(rollTier(user, depth))) rare++;
+            }
+            return rare / 40_000;
+        };
+        expect(rareRate(4)).toBeGreaterThan(rareRate(3));
+    });
+
+    test('rank is clamped so a rank past the table cannot crash the lookups', () => {
+        const beyond = miner({ prestige: MAX_MINE_PRESTIGE + 10 });
+        expect(getMaxStamina(beyond)).toBe(LIMITS.MAX_STAMINA_BASE + PRESTIGE_BONUSES[MAX_MINE_PRESTIGE].staminaBonus);
+        expect(() => calculateCritChance(beyond)).not.toThrow();
+        expect(() => rollTier(beyond, DEPTHS.the_abyss)).not.toThrow();
+    });
+});
+
+describe('a prestiged miner keeps what they bought', () => {
+    test('unlocked depths survive the level reset', () => {
+        const user = miner({ level: MAX_MINER_LEVEL });
+        user.mining.unlockedDepths = ['surface_quarry', 'coal_tunnels', 'iron_mines', 'crystal_caves', 'the_abyss'];
+        user.mining.pickaxes = [{ tier: 5, name: 'Void Pickaxe' }];
+        user.mining.materials = { mythril_dust: 7 };
+
+        ascend(user);
+
+        expect(user.mining.unlockedDepths).toContain('the_abyss');
+        expect(user.mining.pickaxes).toHaveLength(1);
+        expect(user.mining.materials.mythril_dust).toBe(7);
+    });
+
+    test('access is decided by the unlock list, not the reset level', () => {
+        // The dig handler gates on unlockedDepths alone; the level requirement is
+        // enforced once at purchase. Otherwise a P1 miner at Level 1 would be locked
+        // out of an Abyss they had already paid 75,000 coins for.
+        const user = ascend(miner({ level: MAX_MINER_LEVEL }));
+        user.mining.unlockedDepths = ['surface_quarry', 'the_abyss'];
+
+        expect(user.mining.level).toBeLessThan(DEPTHS.the_abyss.unlockLevel);
+        expect(user.mining.unlockedDepths.includes('the_abyss')).toBe(true);
+    });
+});

--- a/tests/minePrestige.test.js
+++ b/tests/minePrestige.test.js
@@ -72,17 +72,30 @@ describe('prestige bonuses actually apply', () => {
         expect(bonused).toBeGreaterThan(plain);
     });
 
-    test('the rarity bonus shifts weight toward rare ore', () => {
-        const depth = DEPTHS.the_abyss;
-        const rareRate = prestige => {
+    test('the rarity bonus shifts weight off common', () => {
+        // P4 adds a 2% rarity bonus, which moves 2% of the depth's *common* weight
+        // into rare. On the Abyss that is a third of a percentage point — far too
+        // small to separate by sampling — so probe the boundary instead. rollTier
+        // consumes exactly one Math.random(), and weightedRoll walks the tiers in
+        // ascending rarity, so the largest random value that still returns 'common'
+        // is that tier's share of the roll.
+        const commonShare = prestige => {
             const user = miner({ prestige });
-            let rare = 0;
-            for (let i = 0; i < 40_000; i++) {
-                if (['rare', 'epic', 'legendary', 'event'].includes(rollTier(user, depth))) rare++;
+            const spy = jest.spyOn(Math, 'random');
+            let lo = 0;
+            let hi = 1;
+            for (let i = 0; i < 50; i++) {
+                const mid = (lo + hi) / 2;
+                spy.mockReturnValue(mid);
+                if (rollTier(user, DEPTHS.surface_quarry) === 'common') lo = mid;
+                else hi = mid;
             }
-            return rare / 40_000;
+            spy.mockRestore();
+            return lo;
         };
-        expect(rareRate(4)).toBeGreaterThan(rareRate(3));
+
+        expect(commonShare(4)).toBeLessThan(commonShare(3));
+        expect(commonShare(3)).toEqual(commonShare(0));   // no rarity bonus below P4
     });
 
     test('rank is clamped so a rank past the table cannot crash the lookups', () => {

--- a/tests/mineRaidMaterials.test.js
+++ b/tests/mineRaidMaterials.test.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const {
+    getRaidableMaterials,
+    hasRaidableMaterials,
+    planRaidHaul,
+    ensureMineData,
+    updateMineMap,
+    RAID_MAX_MATERIAL_TYPES,
+    RAID_MAX_PER_MATERIAL,
+    RAID_MIN_HOLDING,
+} = require('../src/services/mineService');
+const { RAID_STEAL_MIN, RAID_STEAL_MAX } = require('../src/data/mineData');
+
+function makeUser(materials = {}) {
+    const user = { mining: { materials }, markModified() {} };
+    return user;
+}
+
+describe('raidable materials', () => {
+    test('ignores anything the miner holds only one of', () => {
+        const user = makeUser({ gold_nugget: 1, iron_filing: 4 });
+        expect(getRaidableMaterials(user).map(([id]) => id)).toEqual(['iron_filing']);
+    });
+
+    test('exposes only the largest piles, largest first', () => {
+        const user = makeUser({
+            a: 2, b: 9, c: 4, d: 7, e: 3, f: 5, g: 8,
+        });
+        const exposed = getRaidableMaterials(user);
+        expect(exposed).toHaveLength(RAID_MAX_MATERIAL_TYPES);
+        expect(exposed.map(([id]) => id)).toEqual(['b', 'g', 'd', 'f', 'c']);
+    });
+
+    test('a miner with nothing stacked has nothing to raid', () => {
+        expect(hasRaidableMaterials(makeUser({}))).toBe(false);
+        expect(hasRaidableMaterials(makeUser({ gold_nugget: 1 }))).toBe(false);
+        expect(hasRaidableMaterials(makeUser({ gold_nugget: RAID_MIN_HOLDING }))).toBe(true);
+    });
+});
+
+describe('raid haul', () => {
+    test('never takes more than the per-material cap, however large the hoard', () => {
+        const user = makeUser({ gold_nugget: 10_000 });
+        const haul = planRaidHaul(user, RAID_STEAL_MAX);
+        expect(haul).toEqual([{ matId: 'gold_nugget', take: RAID_MAX_PER_MATERIAL }]);
+    });
+
+    test('always takes at least one from an exposed pile', () => {
+        // floor(2 * 0.05) is 0 — a raid that reached the pile must still take something.
+        const haul = planRaidHaul(makeUser({ gold_nugget: 2 }), RAID_STEAL_MIN);
+        expect(haul).toEqual([{ matId: 'gold_nugget', take: 1 }]);
+    });
+
+    test('never takes a miner down below what they held', () => {
+        const materials = { a: 2, b: 3, c: 12, d: 40, e: 5 };
+        for (const fraction of [RAID_STEAL_MIN, 0.12, RAID_STEAL_MAX]) {
+            for (const { matId, take } of planRaidHaul(makeUser(materials), fraction)) {
+                expect(take).toBeLessThanOrEqual(materials[matId]);
+                expect(take).toBeGreaterThan(0);
+            }
+        }
+    });
+
+    test('a raid conserves materials — what the defender loses, the raider gains', () => {
+        // The bug this replaces credited the raider from a parallel `oreStash` map
+        // while leaving the defender's real pile untouched, minting materials.
+        const defender = makeUser({ gold_nugget: 20, iron_filing: 6 });
+        const raider = makeUser({ gold_nugget: 1 });
+
+        const before = total(defender) + total(raider);
+        for (const { matId, take } of planRaidHaul(defender, RAID_STEAL_MAX)) {
+            defender.mining.materials[matId] -= take;
+            raider.mining.materials[matId] = (raider.mining.materials[matId] ?? 0) + take;
+        }
+
+        expect(total(defender) + total(raider)).toBe(before);
+        expect(defender.mining.materials.gold_nugget).toBe(20 - RAID_MAX_PER_MATERIAL);
+        expect(raider.mining.materials.gold_nugget).toBe(1 + RAID_MAX_PER_MATERIAL);
+    });
+});
+
+function total(user) {
+    return Object.values(user.mining.materials).reduce((s, q) => s + q, 0);
+}
+
+describe('the mine map no longer shadows the material pile', () => {
+    test('a material drop is booked once, not once per store', () => {
+        const user = { mining: {}, markModified() {} };
+        ensureMineData(user);
+        user.mining.materials.gold_nugget = 1;
+
+        updateMineMap(user, {
+            success: true,
+            ore: { id: 'gold', emoji: '🟡' },
+            specialDrop: { itemId: 'gold_nugget', name: 'Gold Nugget' },
+        });
+
+        expect(user.mining.materials.gold_nugget).toBe(1);
+        expect(user.mining.oreStash).toBeUndefined();
+    });
+
+    test('the map still records where the miner dug', () => {
+        const user = { mining: {}, markModified() {} };
+        ensureMineData(user);
+        // updateMineMap marks the cell the miner is standing on, then walks them to
+        // the next one — so the cell to assert on is the position from before the call.
+        const oreCell = user.mining.mineMapRow * 10 + user.mining.mineMapCol;
+        updateMineMap(user, { success: true, ore: { id: 'gold' } });
+        expect(user.mining.mineMap[oreCell]).toBe(2); // CELL.ORE
+
+        const dugCell = user.mining.mineMapRow * 10 + user.mining.mineMapCol;
+        updateMineMap(user, { success: false });
+        expect(user.mining.mineMap[dugCell]).toBe(1); // CELL.DUG
+
+        const caveCell = user.mining.mineMapRow * 10 + user.mining.mineMapCol;
+        updateMineMap(user, { success: true, caveIn: true, ore: { id: 'gold' } });
+        expect(user.mining.mineMap[caveCell]).toBe(3); // CELL.CAVE_IN
+    });
+});

--- a/tests/mineThrottleAndCaveIn.test.js
+++ b/tests/mineThrottleAndCaveIn.test.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const {
+    ensureMineData,
+    applyPayoutModifiers,
+    msUntilDailyReset,
+    executeMine,
+} = require('../src/services/mineService');
+const { DEPTHS, LIMITS } = require('../src/data/mineData');
+
+function miner({ dailyCoins = 0, dailyMines = 0, windowAgeMs = 0, level = 20 } = {}) {
+    const user = { balance: 0, mining: {}, quests: [], markModified() {} };
+    ensureMineData(user);
+    Object.assign(user.mining, {
+        level, dailyCoins, dailyMines,
+        dailyWindowStart: new Date(Date.now() - windowAgeMs),
+        pickaxes: [{
+            name: 'Steel Pickaxe', tier: 3, slug: 'steel_pickaxe',
+            currentDurability: 160, maxDurability: 160, baseDurability: 160,
+            repairCount: 0, upgrade: null, status: 'good',
+        }],
+        equippedPickaxeIndex: 0,
+    });
+    return user;
+}
+
+describe('daily throttles are reported, not just applied', () => {
+    const depth = DEPTHS.surface_quarry;
+
+    test('an untouched day throttles nothing', () => {
+        const r = applyPayoutModifiers(miner(), 1000, depth);
+        expect(r).toMatchObject({ adjustedPayout: 1000, forfeited: 0, softCapped: false, fatigueMult: 1, cappedByHard: false });
+    });
+
+    test('fatigue is reported at each threshold', () => {
+        const rateAt = dailyMines => applyPayoutModifiers(miner({ dailyMines }), 1000, depth).fatigueMult;
+        expect(rateAt(LIMITS.DIM_RETURNS_THRESHOLD_1 - 1)).toBe(1);
+        expect(rateAt(LIMITS.DIM_RETURNS_THRESHOLD_1)).toBe(0.85);
+        expect(rateAt(LIMITS.DIM_RETURNS_THRESHOLD_2)).toBe(0.70);
+        expect(rateAt(LIMITS.DIM_RETURNS_THRESHOLD_3)).toBe(0.55);
+    });
+
+    test('the soft cap flags itself and names what it took', () => {
+        const r = applyPayoutModifiers(miner({ dailyCoins: LIMITS.DAILY_SOFT_CAP + 5_000 }), 1000, depth);
+        expect(r.softCapped).toBe(true);
+        expect(r.adjustedPayout).toBe(500);
+        expect(r.forfeited).toBe(500);
+    });
+
+    test('the hard cap reports the whole haul as forfeited rather than a struck-out zero', () => {
+        const r = applyPayoutModifiers(miner({ dailyCoins: LIMITS.DAILY_HARD_CAP }), 1000, depth);
+        expect(r.cappedByHard).toBe(true);
+        expect(r.adjustedPayout).toBe(0);
+        // The number the embed strikes through has to be what was lost, not the zero
+        // that was paid.
+        expect(r.forfeited).toBe(1000);
+    });
+
+    test('forfeited always accounts for the gap between earned and paid', () => {
+        for (const dailyCoins of [0, 40_000, LIMITS.DAILY_SOFT_CAP, 149_500, LIMITS.DAILY_HARD_CAP]) {
+            const r = applyPayoutModifiers(miner({ dailyCoins }), 1000, depth);
+            const earned = Math.round(1000 * r.fatigueMult);
+            expect(r.adjustedPayout + r.forfeited).toBe(earned);
+        }
+    });
+
+    test('the reset countdown tracks the daily window', () => {
+        expect(msUntilDailyReset(miner({ windowAgeMs: 6 * 3_600_000 }))).toBeCloseTo(18 * 3_600_000, -4);
+        expect(msUntilDailyReset(miner({ windowAgeMs: LIMITS.DAILY_WINDOW_MS + 1000 }))).toBe(0);
+
+        const fresh = { mining: {}, markModified() {} };
+        ensureMineData(fresh);
+        expect(msUntilDailyReset(fresh)).toBeNull();
+    });
+});
+
+describe('a cave-in holds the earned multiplier in escrow', () => {
+    // Math.random() === 0 makes the dig succeed, the tier roll land on the first
+    // eligible tier, and the cave-in roll fire whenever its risk is above zero.
+    const always = value => jest.spyOn(Math, 'random').mockReturnValue(value);
+    afterEach(() => { if (jest.isMockFunction(Math.random)) Math.random.mockRestore(); });
+
+    const deep = { level: 4, name: 'Deep', emoji: '💎', multiplier: 2.0, caveInRisk: 1.0, durLoss: 3 };
+    const safe = { ...deep, caveInRisk: 0.0 };
+
+    test('the multiplier is escrowed rather than destroyed', () => {
+        always(0);
+        const user = miner();
+        const result = executeMine(user, 'surface_quarry', { intensity: deep });
+
+        expect(result.caveIn).toBe(true);
+        expect(result.caveInEscrow).toBe(Math.round(result.caveInPayout * (deep.multiplier - 1)));
+        expect(result.caveInEscrow).toBeGreaterThan(0);
+    });
+
+    test('escaping is worth the same as never caving in', () => {
+        always(0);
+        const escaped = executeMine(miner(), 'surface_quarry', { intensity: deep });
+        const clean   = executeMine(miner(), 'surface_quarry', { intensity: safe });
+
+        // What /mine dig credits on a blast-charge escape: the base haul plus escrow.
+        expect(escaped.caveInPayout + escaped.caveInEscrow).toBe(clean.finalPayout);
+    });
+
+    test('a level with no multiplier escrows nothing', () => {
+        always(0);
+        const flat = { ...deep, multiplier: 1.0 };
+        const result = executeMine(miner(), 'surface_quarry', { intensity: flat });
+        expect(result.caveIn).toBe(true);
+        expect(result.caveInEscrow).toBe(0);
+    });
+
+    test('the uninterrupted path still pays the multiplier outright', () => {
+        always(0);
+        const user = miner();
+        const result = executeMine(user, 'surface_quarry', { intensity: safe });
+        expect(result.caveIn).toBeUndefined();
+        expect(result.caveInEscrow).toBeUndefined();
+        expect(result.finalPayout).toBeGreaterThan(0);
+    });
+});

--- a/tests/rarityLadder.test.js
+++ b/tests/rarityLadder.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const {
+    TIER_NUM, TIER_RIBBON, TIER_LABELS, TIER_STARS, TIER_COLORS,
+} = require('../src/data/materialRarity');
+const { ORES_BY_TIER, TIER_COLORS: MINE_TIER_COLORS } = require('../src/data/mineData');
+
+// hunt, fish and mine all roll an `event` tier above legendary. It was missing from
+// TIER_NUM, so every presentation path that keys off the ladder — the rarity ribbon,
+// the staged loot reveal, the rare-drop announcement — fell through to its `?? 0` or
+// `?? 1` default and rendered the rarest drops in the game as common.
+const LADDER = ['common', 'uncommon', 'rare', 'epic', 'legendary', 'event'];
+
+describe('rarity ladder', () => {
+    test('covers every tier the grind systems can roll', () => {
+        expect(Object.keys(TIER_NUM).sort()).toEqual([...LADDER].sort());
+    });
+
+    test('numbers the tiers in ascending rarity with no gaps', () => {
+        expect(LADDER.map(t => TIER_NUM[t])).toEqual([1, 2, 3, 4, 5, 6]);
+    });
+
+    test('event outranks legendary', () => {
+        expect(TIER_NUM.event).toBeGreaterThan(TIER_NUM.legendary);
+    });
+
+    test('every rung has a label, stars and a colour', () => {
+        for (const tier of LADDER) {
+            const n = TIER_NUM[tier];
+            expect(TIER_LABELS[n]).toBeTruthy();
+            expect(TIER_STARS[n]).toBeTruthy();
+            expect(TIER_COLORS[n]).toMatch(/^#[0-9a-f]{6}$/i);
+        }
+    });
+
+    test('the ribbon marks the tier it was given and shows the whole ladder', () => {
+        for (const tier of LADDER) {
+            const ribbon = TIER_RIBBON(TIER_NUM[tier]);
+            expect(ribbon.split(' ─ ')).toHaveLength(LADDER.length);
+            expect(ribbon).toMatch(/\[.+\]/);
+        }
+    });
+
+    test('an event drop is not rendered as a common one', () => {
+        expect(TIER_RIBBON(TIER_NUM.event)).not.toEqual(TIER_RIBBON(TIER_NUM.common));
+    });
+
+    // The two colour tables are independently tuned and have never matched rung for
+    // rung; only the event rung added here is pinned to the mine palette.
+    test('the event rung uses the same colour the mine embeds already use', () => {
+        expect(TIER_COLORS[TIER_NUM.event].toLowerCase())
+            .toBe(MINE_TIER_COLORS.event.toLowerCase());
+    });
+
+    test('every mine ore sits on a rung of the ladder', () => {
+        for (const tier of Object.keys(ORES_BY_TIER)) {
+            expect(TIER_NUM[tier]).toBeDefined();
+        }
+    });
+});

--- a/tests/rewardReveal.test.js
+++ b/tests/rewardReveal.test.js
@@ -26,22 +26,26 @@ const { rarityRibbon, stackBar, rewardReveal } = require('../src/utils/rewardRev
 
 // ─── rarityRibbon ─────────────────────────────────────────────────────────────
 
+// The ladder runs to 6: hunt, fish and mine all roll an `event` tier above legendary.
+const LADDER_RUNGS = 6;
+
 describe('rarityRibbon', () => {
     test('highlights the correct tier and leaves others plain', () => {
-        expect(rarityRibbon(1)).toBe('[🟢] ─ 🔵 ─ 🟣 ─ 🟡 ─ 🌌');
-        expect(rarityRibbon(3)).toBe('🟢 ─ 🔵 ─ [🟣] ─ 🟡 ─ 🌌');
-        expect(rarityRibbon(5)).toBe('🟢 ─ 🔵 ─ 🟣 ─ 🟡 ─ [🌌]');
+        expect(rarityRibbon(1)).toBe('[🟢] ─ 🔵 ─ 🟣 ─ 🟡 ─ 🌌 ─ ☄️');
+        expect(rarityRibbon(3)).toBe('🟢 ─ 🔵 ─ [🟣] ─ 🟡 ─ 🌌 ─ ☄️');
+        expect(rarityRibbon(5)).toBe('🟢 ─ 🔵 ─ 🟣 ─ 🟡 ─ [🌌] ─ ☄️');
+        expect(rarityRibbon(6)).toBe('🟢 ─ 🔵 ─ 🟣 ─ 🟡 ─ 🌌 ─ [☄️]');
     });
 
-    test('contains exactly 5 segments separated by " ─ "', () => {
-        for (let tier = 1; tier <= 5; tier++) {
+    test(`contains exactly ${LADDER_RUNGS} segments separated by " ─ "`, () => {
+        for (let tier = 1; tier <= LADDER_RUNGS; tier++) {
             const segments = rarityRibbon(tier).split(' ─ ');
-            expect(segments).toHaveLength(5);
+            expect(segments).toHaveLength(LADDER_RUNGS);
         }
     });
 
     test('exactly one segment is wrapped in brackets per tier', () => {
-        for (let tier = 1; tier <= 5; tier++) {
+        for (let tier = 1; tier <= LADDER_RUNGS; tier++) {
             const bracketed = rarityRibbon(tier).match(/\[.*?\]/g);
             expect(bracketed).toHaveLength(1);
         }

--- a/tests/synergyEffects.test.js
+++ b/tests/synergyEffects.test.js
@@ -1,0 +1,106 @@
+'use strict';
+
+// Every synergy in crossSystemData is advertised by /synergies, /mine profile and
+// FEATURES.md. Several of them had a helper in synergyService and no call site at
+// all, so a player could see "Artificer — +5% ore yield, +1 max mining stamina"
+// listed as active and get neither. These tests pin each advertised bonus to the
+// code path that pays it out.
+
+const { getMaxStamina: mineMaxStamina } = require('../src/services/mineService');
+const { getMaxStamina: fishMaxStamina } = require('../src/services/fishService');
+const {
+    getActiveSynergies,
+    getArtificerMineYieldBonus,
+    getMerchantCoinBonus,
+} = require('../src/services/synergyService');
+const { SYNERGIES, SYNERGY_LIST } = require('../src/data/crossSystemData');
+const { LIMITS } = require('../src/data/mineData');
+
+/** A player at the given grind levels, with nothing else going on. */
+function player({ hunt = 0, fishing = 0, mining = 0, inventory = [] } = {}) {
+    return {
+        hunt:    { level: hunt,    prestige: 0 },
+        fishing: { level: fishing, prestige: 0 },
+        mining:  { level: mining,  prestige: 0 },
+        inventory,
+    };
+}
+
+describe('mining stamina synergies', () => {
+    test('a miner below the thresholds gets the base pool', () => {
+        expect(mineMaxStamina(player({ mining: 29, fishing: 29 }))).toBe(LIMITS.MAX_STAMINA_BASE);
+    });
+
+    test('Deep Prospector adds its advertised +1', () => {
+        const p = player({ mining: 30, fishing: 30 });
+        expect(getActiveSynergies(p).map(s => s.id)).toContain('deep_prospector');
+        expect(mineMaxStamina(p)).toBe(LIMITS.MAX_STAMINA_BASE + SYNERGIES.deep_prospector.bonuses.miningStamina);
+    });
+
+    test('Artificer adds its advertised +1', () => {
+        const p = player({ mining: 50 });
+        expect(getActiveSynergies(p).map(s => s.id)).toContain('artificer');
+        expect(mineMaxStamina(p)).toBe(LIMITS.MAX_STAMINA_BASE + SYNERGIES.artificer.bonuses.miningStamina);
+    });
+
+    test('both stack for a miner who has earned both', () => {
+        const expected = LIMITS.MAX_STAMINA_BASE
+            + SYNERGIES.deep_prospector.bonuses.miningStamina
+            + SYNERGIES.artificer.bonuses.miningStamina;
+        expect(mineMaxStamina(player({ mining: 50, fishing: 30 }))).toBe(expected);
+    });
+});
+
+describe('fishing stamina synergies', () => {
+    test('Outdoorsman and Deep Prospector both apply, and stack', () => {
+        const outdoorsmanOnly = player({ fishing: 30, hunt: 30 });
+        const both            = player({ fishing: 30, hunt: 30, mining: 30 });
+
+        expect(fishMaxStamina(outdoorsmanOnly))
+            .toBe(LIMITS.MAX_STAMINA_BASE + SYNERGIES.outdoorsman.bonuses.fishingStamina);
+        expect(fishMaxStamina(both)).toBe(
+            LIMITS.MAX_STAMINA_BASE
+            + SYNERGIES.outdoorsman.bonuses.fishingStamina
+            + SYNERGIES.deep_prospector.bonuses.fishingStamina,
+        );
+    });
+});
+
+describe('Artificer ore yield', () => {
+    test('pays nothing below Mining 50 and the advertised rate at 50', () => {
+        expect(getArtificerMineYieldBonus(player({ mining: 49 }))).toBe(0);
+        expect(getArtificerMineYieldBonus(player({ mining: 50 }))).toBe(SYNERGIES.artificer.bonuses.mineYieldPct);
+    });
+});
+
+describe('Merchant coin bonus', () => {
+    const qualified = extra => player({ hunt: 20, fishing: 20, mining: 20, ...extra });
+
+    test('needs the levels and something in the bag', () => {
+        expect(getMerchantCoinBonus(qualified({ inventory: [] }))).toBe(0);
+        expect(getMerchantCoinBonus(qualified({ inventory: [{ quantity: 0 }] }))).toBe(0);
+        expect(getMerchantCoinBonus(qualified({ inventory: [{ quantity: 1 }] })))
+            .toBe(SYNERGIES.merchant.bonuses.workCrimeCoinPct);
+    });
+
+    test('does not pay below the level requirement', () => {
+        const under = player({ hunt: 20, fishing: 20, mining: 19, inventory: [{ quantity: 5 }] });
+        expect(getMerchantCoinBonus(under)).toBe(0);
+    });
+});
+
+describe('no advertised synergy is left unwired', () => {
+    // A synergy whose bonuses nothing reads is a promise the game cannot keep. If a
+    // new one is added, wire it up (and assert it here) rather than relaxing this.
+    const WIRED = {
+        outdoorsman:     ['huntStamina', 'fishingStamina'],
+        iron_will:       ['mineIronWill'],
+        deep_prospector: ['fishingStamina', 'miningStamina'],
+        artificer:       ['mineYieldPct', 'miningStamina'],
+        merchant:        ['workCrimeCoinPct'],
+    };
+
+    test.each(SYNERGY_LIST.map(s => [s.id]))('%s has every bonus key accounted for', id => {
+        expect(Object.keys(SYNERGIES[id].bonuses).sort()).toEqual(WIRED[id].sort());
+    });
+});


### PR DESCRIPTION
## Summary

This PR overhauls the mining dig system from a three-round puzzle to a simpler risk-choice model, adds a prestige/ascension system for miners, and fixes several rarity ladder issues affecting loot presentation across all grind systems.

## Key Changes

**Mining Dig Mechanics**
- Replaced the three-round vein-following puzzle with a single intensity choice followed by one vein read
- Added five intensity levels (Surface through Abyss) with configurable risk/reward tradeoffs
- A correct vein read promotes the payout one rung without increasing the chosen risk level
- Intensity choice can be passed via command option to skip the interactive prompt
- Miner's last chosen intensity is remembered and used as the timeout default

**Prestige/Ascension System**
- Added `/mine prestige` subcommand to reset Miner Level to 1 in exchange for permanent bonuses
- Prestige rank grants cumulative bonuses: stamina, crit chance, and payout multipliers
- Max prestige rank is 10 with corresponding bonus table entries
- Prestige resets level but keeps all unlocked depths (purchase is permanent)

**Rarity Ladder Fixes**
- Added missing `event` tier (tier 6) to `TIER_NUM`, `TIER_LABELS`, `TIER_STARS`, and `TIER_COLORS`
- Event tier now properly displays in loot reveals, rarity ribbons, and rare-drop announcements
- Updated hunt, fish, and mine staged loot reveals to handle event tier presentation
- Event tier is the rarest drop in the game, appearing above legendary

**Mining Depth & Ore System**
- Enforced invariant: depths only carry weight on tiers they actually have ore for
- `rollOre()` now steps down the rarity ladder instead of reaching outside the depth's pool
- Prevents starter quarry from handing out Abyss-only legendaries
- Added `oresAtDepth()` and `hasOreAtDepth()` helpers for tier availability checks

**Raid System Refactor**
- Changed raid target from "unprocessed ore" to "crafting materials"
- Added `getRaidableMaterials()`, `hasRaidableMaterials()`, and `planRaidHaul()` functions
- Raid exposes only the largest material piles (up to 5 types) to prevent griefing
- Materials below minimum holding threshold are not raidable

**Throttle & Payout Reporting**
- `applyPayoutModifiers()` now returns detailed throttle state: `forfeited`, `softCapped`, `fatigueMult`, `cappedByHard`
- Daily soft cap and hard cap are now reported to the user before the dig
- Fatigue multiplier is explicitly tracked and displayed
- Pre-dig warning shows when daily cap is reached or soft cap is exceeded

**Pickaxe Management**
- Added `/mine inv discard` subcommand for broken/condemned pickaxes
- Equip subcommand now requires explicit slot selection

**Profile & Map**
- Added `msUntilDailyReset()` helper for displaying reset timing
- Removed `oreStash` from mining profile (replaced by materials system)
- Updated mine map rendering and related utilities

## Implementation Details

- Intensity levels are defined in `mineData.js` with `CHOOSABLE_INTENSITY` (4 selectable levels) and `INTENSITY_LEVELS` (5 total including Abyss)
- Vein read now uses a 1.4s flash window followed by a 10s answer window instead of three 15s rounds
- Prestige bonuses are cumulative and stored in `PRESTIGE_BONUSES` table
- Grind profile saves now only write systems that were actually modified, preventing cross-system interference (e.g., a fish cast undoing a mine raid)
- Added comprehensive test suites for intensity mechanics, prestige progression, throttling, raid materials, and rarity ladder coverage

## Testing

Added 6 new test files:
- `mineIntensity.test.js` - Intensity ladder and vein read promotion
- `minePrestige.test.js` - Prestige progression and bonus

https://claude.ai/code/session_01522P48ZEDt53BgW6ikWWVC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mining intensity choices, vein-reading bonuses, cave-in recovery, pickaxe management, Miner Prestige, and material raids.
  * Added event-tier rarity support across mining, fishing, hunting, rewards, announcements, and displays.
  * Improved depth-based ore availability, quest offers, payout details, inventory limits, and daily throttle information.
  * Added permanent depth progression, intensity shortcuts, and expanded mining guidance.
* **Bug Fixes**
  * Corrected ore rarity limits by mine depth and quest availability.
  * Prevented duplicate actions and protected crafting and raid updates from conflicting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->