### PR TITLE
One lock per player, not one per subsystem

### DIFF
--- a/src/commands/economy/casino.js
+++ b/src/commands/economy/casino.js
@@ -4,6 +4,7 @@ const User  = require('../../models/User');
 const { processJackpotBet, getJackpotDisplay } = require('../../services/casinoJackpotService');
 const { advanceMissions } = require('../../services/seasonMissionService');
 const { tryAcquire, release } = require('../../utils/activeGameLock');
+const { economyLockKey, busyMessage } = require('../../utils/economyLock');
 
 const games = [
     require('../../games/casino/blackjack'),
@@ -98,13 +99,18 @@ module.exports = {
             return interaction.reply({ content: 'Unknown casino game.', flags: MessageFlags.Ephemeral });
         }
 
-        // One active casino game per user — prevents concurrent sessions from racing
-        // each other's debits, effects, and jackpot snapshots.
-        const lockKey   = `casino:${interaction.guild.id}:${interaction.user.id}`;
-        const lockToken = await tryAcquire(lockKey);
+        // One economy action per user — prevents concurrent sessions from racing
+        // each other's debits, effects, and jackpot snapshots. The key is shared
+        // with /fish, /hunt, /mine, /explore and /craft (utils/economyLock.js),
+        // so a hand cannot interleave with a cast over the same user document
+        // either. The TTL is the primitive's ten-minute default rather than the
+        // grind commands' two minutes, because a hand outlives `execute` by as
+        // long as the player takes to play it.
+        const lockKey   = economyLockKey(interaction.guild.id, interaction.user.id);
+        const lockToken = await tryAcquire(lockKey, undefined, 'casino');
         if (!lockToken) {
             return interaction.reply({
-                content: '🎰 You already have a casino game in progress — finish it first.',
+                content: await busyMessage(lockKey),
                 flags: MessageFlags.Ephemeral,
             });
         }
@@ -120,7 +126,7 @@ module.exports = {
         //
         // If a game throws, or forgets to call releaseLock on some exotic
         // early-return path, the lock's own TTL (10 min) frees the slot —
-        // worst case the player is blocked from a second casino game for
+        // worst case the player is blocked from every economy command for
         // that long, never permanently.
         // Fire-and-forget: the games call this from collector callbacks that
         // cannot await, and a release that loses its round trip is covered by

--- a/src/commands/economy/casino.js
+++ b/src/commands/economy/casino.js
@@ -138,30 +138,42 @@ module.exports = {
             release(lockKey, lockToken).catch(err => console.error('[casino] lock release failed:', err));
         };
 
-        try {
-            // Progressive jackpot: contribute a share of each bet to the pool and check for a win.
+        // What a bet *is*, for everything that wants to know one happened.
+        //
+        // This used to read the bet straight off the command options and fire on
+        // `bet > 0` — before game.execute had validated anything. A bet larger
+        // than the wallet, or over the guild's casinoMaxBet, or refused for any
+        // other game-level reason still contributed to the jackpot pool and
+        // still ticked "Play 5 casino games", for a hand that never happened.
+        //
+        // Now the games report it: utils/placeWager calls this once the coins
+        // have actually moved, and only for the wager that opens a hand — a
+        // double-down or a poker raise is more money on a hand already counted,
+        // not another game played. `user` and `source` are the player and the
+        // interaction to announce through, which differ from the invoker for a
+        // crash lobby: joiners stake their own coins on someone else's command.
+        const onWager = ({ amount, user = null, source = null }) => {
+            const better = user ?? interaction.user;
+
             // Fire-and-forget — the service handles pool reset, user credit, and logging.
-            const bet = interaction.options.getInteger(game.betOptionName ?? 'bet') ?? 0;
-            if (bet > 0) {
-                processJackpotBet({
-                    guildId:  interaction.guild.id,
-                    userId:   interaction.user.id,
-                    username: interaction.user.username,
-                    bet,
-                    interaction,
-                }).catch(err => console.error('[CasinoJackpot] error:', err));
+            processJackpotBet({
+                guildId:  interaction.guild.id,
+                userId:   better.id,
+                username: better.username,
+                bet:      amount,
+                interaction: source ?? interaction,
+            }).catch(err => console.error('[CasinoJackpot] error:', err));
 
-                // Season pass: "Play 5 casino games". Counted here rather than at
-                // subcommand dispatch so a hand that never got a bet down — bad
-                // amount, empty wallet — isn't scored as a game played.
-                advanceMissions(
-                    User,
-                    { userId: interaction.user.id, guildId: interaction.guild.id },
-                    'casino', 1, guildSettings,
-                ).catch(err => console.error('[casino] season mission error:', err));
-            }
+            // Season pass: "Play 5 casino games".
+            advanceMissions(
+                User,
+                { userId: better.id, guildId: interaction.guild.id },
+                'casino', 1, guildSettings,
+            ).catch(err => console.error('[casino] season mission error:', err));
+        };
 
-            return await game.execute(interaction, { releaseLock });
+        try {
+            return await game.execute(interaction, { releaseLock, onWager });
         } catch (err) {
             releaseLock();
             throw err;

--- a/src/commands/economy/craft.js
+++ b/src/commands/economy/craft.js
@@ -339,32 +339,19 @@ module.exports = {
 };
 
 
-// ── Per-user mining lock for the craft flow ───────────────────────────────────
+// ── Per-user economy lock for the craft flow ──────────────────────────────────
 // Crafting spends mining materials, and a grind profile is persisted by replacing
 // its whole `data` document — so the lock has to cover the *read* as well as the
 // write. Taking it only around user.save() left the window that matters open: a
 // /mine raid landing between attachGrind and the save was simply overwritten by
 // the snapshot this flow had already loaded, and the raider kept their credit.
 //
-// So the whole `make` flow runs under the same key /mine holds, from before the
+// So the whole `make` flow runs under the shared economy lock, from before the
 // profiles are attached until after they are saved. `list` is read-only and is
 // left alone, so browsing recipes never blocks a raid.
-const { tryAcquire: _craftLockAcquire, release: _craftLockRelease } = require('../../utils/activeGameLock');
-const _craftExecute = module.exports.execute;
-module.exports.execute = async function (interaction) {
-    if (interaction.options.getSubcommand() !== 'make') return _craftExecute(interaction);
-
-    const lockKey   = `grind:mine:${interaction.guild?.id}:${interaction.user.id}`;
-    const lockToken = await _craftLockAcquire(lockKey, 60_000);
-    if (!lockToken) {
-        return interaction.reply({
-            content: '⛏️ You have a mining action in progress — finish it before crafting.',
-            flags: MessageFlags.Ephemeral,
-        }).catch(() => {});
-    }
-    try {
-        return await _craftExecute(interaction);
-    } finally {
-        await _craftLockRelease(lockKey, lockToken);
-    }
-};
+const { withEconomyLock } = require('../../utils/economyLock');
+module.exports.execute = withEconomyLock(module.exports.execute, {
+    activity: 'craft',
+    ttlMs:    60_000,
+    only:     interaction => interaction.options.getSubcommand() === 'make',
+});

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -1310,5 +1310,11 @@ async function handleProfile(interaction) {
 // expedition can sit for 20s waiting on the encounter prompt. The lock key is
 // the player rather than this command, so every other money-moving command
 // contends for it too — see utils/economyLock.js.
-const { withEconomyLock } = require('../../utils/economyLock');
-module.exports.execute = withEconomyLock(module.exports.execute, { activity: 'explore' });
+const { withEconomyLock, exceptReadOnly } = require('../../utils/economyLock');
+// Reads that persist nothing, so they never wait on a lease — see
+// exceptReadOnly. `go` and `travel` still lock.
+const EXPLORE_READ_ONLY = ['map', 'regions', 'journal', 'relics', 'profile'];
+module.exports.execute = withEconomyLock(module.exports.execute, {
+    activity: 'explore',
+    only:     exceptReadOnly(EXPLORE_READ_ONLY),
+});

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -1305,24 +1305,10 @@ async function handleProfile(interaction) {
     return interaction.reply({ embeds: [embed] });
 }
 
-// ── Per-user action lock ──────────────────────────────────────────────────────
+// ── Per-user economy lock ─────────────────────────────────────────────────────
 // Exploration mutates the user document with read-modify-write saves, and an
-// expedition can sit for 20s waiting on the encounter prompt. Serialize them:
-// one exploration action at a time per user, matching /fish, /hunt and /mine.
-const { tryAcquire: _lockAcquire, release: _lockRelease } = require('../../utils/activeGameLock');
-const _exploreExecute = module.exports.execute;
-module.exports.execute = async function (interaction) {
-    const lockKey   = `grind:explore:${interaction.guild?.id}:${interaction.user.id}`;
-    const lockToken = await _lockAcquire(lockKey, 120_000);
-    if (!lockToken) {
-        return interaction.reply({
-            content: '🥾 You already have an exploration action in progress — finish it first.',
-            flags: MessageFlags.Ephemeral,
-        }).catch(() => {});
-    }
-    try {
-        return await _exploreExecute(interaction);
-    } finally {
-        await _lockRelease(lockKey, lockToken);
-    }
-};
+// expedition can sit for 20s waiting on the encounter prompt. The lock key is
+// the player rather than this command, so every other money-moving command
+// contends for it too — see utils/economyLock.js.
+const { withEconomyLock } = require('../../utils/economyLock');
+module.exports.execute = withEconomyLock(module.exports.execute, { activity: 'explore' });

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -3323,5 +3323,17 @@ async function checkGrandPrestige(client, user, guild, guildId) {
 // /fish invocations from the same user can race stamina, daily caps, and drops.
 // The lock key is the player rather than this command, so a hand of blackjack
 // races the same document and contends for it too — see utils/economyLock.js.
-const { withEconomyLock } = require('../../utils/economyLock');
-module.exports.execute = withEconomyLock(module.exports.execute, { activity: 'fish' });
+const { withEconomyLock, exceptReadOnly } = require('../../utils/economyLock');
+// Reads that persist nothing, so they never wait on a lease — see
+// exceptReadOnly. Everything else, including /fish inv equip, still locks.
+const FISH_READ_ONLY = [
+    'profile', 'records',
+    'inv rods', 'inv bait', 'inv materials',
+    'shop list',
+    'craft list',
+    'location list',
+];
+module.exports.execute = withEconomyLock(module.exports.execute, {
+    activity: 'fish',
+    only:     exceptReadOnly(FISH_READ_ONLY),
+});

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -63,6 +63,8 @@ const { getDailyFeatured, FEATURED_PAYOUT_BONUS, FEATURED_RARE_BONUS } = require
 const { getTimeBand } = require('../../utils/timeBand');
 const { logBigWin } = require('../../utils/bigWinLogger');
 const { tryUpdateHourlyWinner, getCurrentHourlyLeader } = require('../../utils/hourlyWinner');
+const { chunkByLength } = require('../../utils/embedFields');
+const { paginate } = require('../../utils/paginator');
 const { isDistrictActive } = require('../../services/districtService');
 const { ensureQuests, onFish, onEconomyEarn, notifyQuestComplete, notifyQuestNearComplete } = require('../../services/questService');
 const { recordMissionProgress } = require('../../services/seasonMissionService');
@@ -1801,22 +1803,36 @@ async function showRods(interaction, user) {
         return interaction.reply({ content: `You don't own any rods yet. Buy one with \`/fish shop rod\`.`, flags: MessageFlags.Ephemeral });
     }
 
-    const lines = f.rods.map((rod, i) => {
-        const equipped   = i === f.equippedRodIndex ? ' **[EQUIPPED]**' : '';
+    // Paged for the same reason /hunt inv weapons is: rods accumulate without
+    // limit — nothing forces a working spare out of the inventory — and one
+    // joined description overflows the 4096-character embed cap somewhere past
+    // thirty rods, which fails the whole command rather than truncating it.
+    // The number in each heading is what /fish inv equip takes, so trimming the
+    // tail would put those rods permanently out of reach.
+    const ordered = f.rods
+        .map((rod, index) => ({ rod, index }))
+        .sort((a, b) => {
+            if (a.index === f.equippedRodIndex) return -1;
+            if (b.index === f.equippedRodIndex) return 1;
+            return (b.rod.tier ?? 0) - (a.rod.tier ?? 0);
+        });
+
+    const lines = ordered.map(({ rod, index }) => {
+        const equipped    = index === f.equippedRodIndex ? ' **[EQUIPPED]**' : '';
         const statusEmoji = rodStatusEmoji(rod.status);
         const bar         = durabilityBar(rod.currentDurability, rod.maxDurability, 8);
         const upgradeStr  = rod.upgrade ? ` | ${ROD_UPGRADES[rod.upgrade]?.emoji ?? ''} ${rod.upgrade.replace(/_/g, ' ')}` : '';
-        return `**${i + 1}.** ${rod.name}${equipped}\n   ${statusEmoji} ${bar} ${rod.currentDurability}/${rod.maxDurability}${upgradeStr}`;
+        return `**${index + 1}.** ${rod.name}${equipped}\n   ${statusEmoji} ${bar} ${rod.currentDurability}/${rod.maxDurability}${upgradeStr}`;
     });
 
-    const embed = new EmbedBuilder()
+    const pages = chunkByLength(lines, { separator: '\n\n', maxPerChunk: 8 }).map((chunk, _i, all) => new EmbedBuilder()
         .setColor('#3498db')
-        .setTitle(`🎣 ${interaction.user.username}'s Rods`)
-        .setDescription(lines.join('\n\n'))
+        .setTitle(all.length > 1 ? `🎣 ${interaction.user.username}'s Rods (${f.rods.length})` : `🎣 ${interaction.user.username}'s Rods`)
+        .setDescription(chunk.join('\n\n'))
         .setFooter({ text: 'Use /fish inv equip <number> to equip a rod • /fish shop repair to repair' })
-        .setTimestamp();
+        .setTimestamp());
 
-    return interaction.reply({ embeds: [embed] });
+    return paginate(interaction, pages);
 }
 
 async function equipRod(interaction, user) {

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -3302,24 +3302,10 @@ async function checkGrandPrestige(client, user, guild, guildId) {
     }
 }
 
-// ── Per-user action lock ──────────────────────────────────────────────────────
+// ── Per-user economy lock ─────────────────────────────────────────────────────
 // Fishing mutates the user document with read-modify-write saves, so concurrent
 // /fish invocations from the same user can race stamina, daily caps, and drops.
-// Serialize them: one fishing action at a time per user.
-const { tryAcquire: _lockAcquire, release: _lockRelease } = require('../../utils/activeGameLock');
-const _fishExecute = module.exports.execute;
-module.exports.execute = async function (interaction) {
-    const lockKey   = `grind:fish:${interaction.guild?.id}:${interaction.user.id}`;
-    const lockToken = await _lockAcquire(lockKey, 120_000);
-    if (!lockToken) {
-        return interaction.reply({
-            content: '🎣 You already have a fishing action in progress — finish it first.',
-            flags: MessageFlags.Ephemeral,
-        }).catch(() => {});
-    }
-    try {
-        return await _fishExecute(interaction);
-    } finally {
-        await _lockRelease(lockKey, lockToken);
-    }
-};
+// The lock key is the player rather than this command, so a hand of blackjack
+// races the same document and contends for it too — see utils/economyLock.js.
+const { withEconomyLock } = require('../../utils/economyLock');
+module.exports.execute = withEconomyLock(module.exports.execute, { activity: 'fish' });

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -71,6 +71,67 @@ const { paginate } = require('../../utils/paginator');
 
 const WEAPON_SEPARATOR = '\n\n';
 
+// ── Aim phase timing ─────────────────────────────────────────────────────────
+// How long the shot stays perfect once the window opens, and how long after
+// that the trigger stays live at all.
+//
+// The window is wide on purpose, and timed from when the call reaches the
+// screen rather than from when the wait elapsed. It has to be comfortably
+// longer than the spread in players' round-trip times, or the grade goes back
+// to measuring connection quality: a hunter on a 400ms connection spends about
+// 650ms of the 900 on the wire and their own reaction, leaving a quarter of a
+// second in hand. What separates a perfect shot from a late one is whether the
+// player waited for the call, which is the same for everybody.
+const AIM_WINDOW_MS = 900;
+const AIM_LATE_MS   = 2500;
+
+/**
+ * Grades a shot by *when* it was fired relative to the window, and returns both
+ * the crit bonus and the embed that reports it.
+ *
+ * @param {number|null} shotMs  ms from the sights appearing to the trigger,
+ *                              or null if the trigger was never pulled
+ * @param {number} openAtMs     ms from the sights appearing to the call landing
+ *                              on screen — the moment the window opened
+ */
+function gradeShot(shotMs, openAtMs) {
+    const grade =
+        shotMs === null                    ? 'timeout' :
+        shotMs < openAtMs                  ? 'early'   :
+        shotMs <= openAtMs + AIM_WINDOW_MS ? 'perfect' :
+                                             'late';
+
+    const GRADES = {
+        perfect: {
+            bonus: 0.18, color: '#FFD700', title: '🎯 Perfect Shot!',
+            body: 'You held it until the moment came. **+18% crit chance** this hunt.',
+        },
+        late: {
+            bonus: 0.08, color: '#00CC66', title: '✅ Clean Shot!',
+            body: 'A beat behind the call, but the shot landed. **+8% crit chance** this hunt.',
+        },
+        // A rushed shot costs rather than merely failing to pay: an early
+        // trigger used to be impossible, so "don't fire too early" warned about
+        // nothing. It is a real decision now, so it has a real price.
+        early: {
+            bonus: -0.05, color: '#FF6B6B', title: '💨 You rushed it!',
+            body: 'You pulled before the shot lined up and the animal bolted at the noise. **−5% crit chance** this hunt.',
+        },
+        timeout: {
+            bonus: 0, color: '#888888', title: '⏰ Never took the shot',
+            body: 'The window closed with your finger still off the trigger. No aim bonus this hunt.',
+        },
+    };
+
+    const { bonus, color, title, body } = GRADES[grade];
+    return {
+        grade,
+        bonus,
+        embed: () => new EmbedBuilder().setColor(color).setTitle(title).setDescription(body),
+    };
+}
+
+
 const WILDERNESS_YIELD_BONUS = 0.10;
 
 const walletOf = interaction => ({ userId: interaction.user.id, guildId: interaction.guild.id });
@@ -583,10 +644,11 @@ async function executeStart(interaction) {
         //   Partial  → stealthBonus = +0.05 (safe but suboptimal)
         //   Wrong    → stealthBonus = −0.10 (spooked the animal)
         //   Timeout  → stealthBonus = 0
-        // Phase 2 — Aim: a single quick timing window for the shot.
-        //   Perfect (<0.8s) → aimBonus = +0.18 crit chance
-        //   Good    (<2.5s) → aimBonus = +0.08 crit chance
-        //   Timeout         → aimBonus = 0
+        // Phase 2 — Aim: hold the shot until the target lines up, then fire.
+        //   In the window  → aimBonus = +0.18 crit chance
+        //   Late           → aimBonus = +0.08 crit chance
+        //   Early          → aimBonus = −0.05 crit chance (rushed the shot)
+        //   Timeout        → aimBonus = 0
 
         let stealthBonus = 0;
         let aimBonus     = 0;
@@ -679,52 +741,71 @@ async function executeStart(interaction) {
             await delay(800);
 
             // ── Aim Phase ──────────────────────────────────────────────────────────
-            // Show "target in sights" then after a short wait show the FIRE! button.
+            // The Fire button is attached with the "sights" embed, not after it,
+            // so the shot can genuinely be taken early — which is what the
+            // footer has always warned about. The button used to arrive only
+            // once the wait had elapsed, so firing early was impossible and the
+            // grade was decided purely by how fast the click came back: under
+            // 800ms of round trip paid +18% crit, anything slower +8%. That
+            // scored the player's connection, not their play, and paid at least
+            // +8% for any click at all.
+            //
+            // Now the wait is the mechanic. The window opens at a random moment
+            // the player cannot anticipate and stays open long enough that a
+            // slow connection still comfortably clears it — so what separates
+            // the outcomes is *when* you fire, not how fast the wire is.
             const aimWaitMs = 1000 + Math.floor(Math.random() * 1001);
-            const aimSightsEmbed = new EmbedBuilder()
-                .setColor('#8B0000')
-                .setTitle('🎯 Target in Sights…')
-                .setDescription('*Hold your breath… wait for the right moment…*')
-                .setFooter({ text: 'Ready your shot — don\'t fire too early.' });
-            await interaction.editReply({ embeds: [aimSightsEmbed], components: [] });
-            await delay(aimWaitMs);
 
             const fireId  = `hunt_fire_${interaction.id}`;
-            const aimEmbed = new EmbedBuilder()
-                .setColor('#FF0000')
-                .setTitle('💥 FIRE!')
-                .setDescription('**Take the shot — NOW!**');
             const aimRow = new ActionRowBuilder().addComponents(
                 new ButtonBuilder().setCustomId(fireId).setLabel('🔫 Fire!').setStyle(ButtonStyle.Danger)
             );
-            await interaction.editReply({ embeds: [aimEmbed], components: [aimRow] });
+            const aimSightsEmbed = new EmbedBuilder()
+                .setColor('#8B0000')
+                .setTitle('🎯 Target in Sights…')
+                .setDescription('*Hold your breath… wait for the shot to line up.*')
+                .setFooter({ text: 'Fire when the shot is called — rush it and you spoil the shot.' });
+
+            await interaction.editReply({ embeds: [aimSightsEmbed], components: [aimRow] });
             const aimTime = Date.now();
 
-            const shotMs = await new Promise(resolve => {
+            let shotTaken = false;
+            const shot = new Promise(resolve => {
                 const col = huntMsg.createMessageComponentCollector({
                     filter: i => i.user.id === interaction.user.id && i.customId === fireId,
-                    time: 2500,
+                    time: aimWaitMs + AIM_LATE_MS,
                     max: 1,
                 });
                 col.on('collect', async i => { await i.deferUpdate(); resolve(Date.now() - aimTime); });
                 col.on('end',     (_, reason) => { if (reason !== 'limit') resolve(null); });
-            });
+            }).then(ms => { shotTaken = ms !== null; return ms; });
 
-            if (shotMs !== null && shotMs < 800) {
-                aimBonus = 0.18;
-            } else if (shotMs !== null) {
-                aimBonus = 0.08;
+            // Call the shot when the window opens — unless it has already been
+            // taken, in which case editing to "FIRE!" would tell a player who
+            // jumped the gun that they were right on time.
+            //
+            // The window is timed from when the call is actually on screen, not
+            // from when the wait elapsed: the edit is a round trip of its own,
+            // and charging it to the player would put the latency straight back
+            // into the grade this phase exists to take it out of.
+            let windowOpensAt = aimWaitMs;
+            await Promise.race([shot, delay(aimWaitMs)]);
+            if (!shotTaken) {
+                await interaction.editReply({
+                    embeds: [new EmbedBuilder()
+                        .setColor('#FF0000')
+                        .setTitle('💥 FIRE!')
+                        .setDescription('**Take the shot — NOW!**')],
+                    components: [aimRow],
+                });
+                windowOpensAt = Date.now() - aimTime;
             }
 
-            const aimResultEmbed = new EmbedBuilder()
-                .setColor(aimBonus >= 0.18 ? '#FFD700' : aimBonus > 0 ? '#00CC66' : '#888888')
-                .setTitle(aimBonus >= 0.18 ? '🎯 Perfect Shot!' : aimBonus > 0 ? '✅ Clean Shot!' : '⏰ Shot rushed…')
-                .setDescription(
-                    aimBonus >= 0.18 ? `Textbook precision. **+18% crit chance** this hunt.` :
-                    aimBonus > 0     ? `Solid hit. **+8% crit chance** this hunt.` :
-                                       `You hesitated on the trigger. No aim bonus this hunt.`
-                );
-            await interaction.editReply({ embeds: [aimResultEmbed], components: [] });
+            const shotMs = await shot;
+            const aim    = gradeShot(shotMs, windowOpensAt);
+            aimBonus     = aim.bonus;
+
+            await interaction.editReply({ embeds: [aim.embed()], components: [] });
             await delay(600);
 
         } else {
@@ -886,6 +967,7 @@ async function executeStart(interaction) {
             else if (stealthBonus < 0) lines.push(`> 🔊 *Spooked the animal — −10% success*`);
             if (aimBonus >= 0.18) lines.push(`> 🎯 *Perfect shot — +18% crit chance*`);
             else if (aimBonus > 0) lines.push(`> ✅ *Clean shot — +8% crit chance*`);
+            else if (aimBonus < 0) lines.push(`> 💨 *Rushed shot — −5% crit chance*`);
             if (lines.length) embed.setDescription(desc + '\n' + lines.join('\n'));
         }
         // One consolidated field rather than one per bonus: Discord caps an embed at
@@ -3152,7 +3234,7 @@ async function checkGrandPrestige(client, user, guild, guildId) {
 
 // Test hooks. The command loader only looks for `data` and `execute`
 // (src/index.js), so extra exports are inert at runtime.
-module.exports.__test__ = { buildHuntEmbed, buildBonusLines, buildTrophyField, buildFieldTrophyField, buildDailyTollField, buildTodayField, buildWeaponPages, WEAPON_SEPARATOR };
+module.exports.__test__ = { buildHuntEmbed, buildBonusLines, buildTrophyField, buildFieldTrophyField, buildDailyTollField, buildTodayField, buildWeaponPages, WEAPON_SEPARATOR, gradeShot, AIM_WINDOW_MS, AIM_LATE_MS };
 
 // ── Per-user economy lock ─────────────────────────────────────────────────────
 // Hunting mutates the user document with read-modify-write saves, so concurrent

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -3110,24 +3110,10 @@ async function checkGrandPrestige(client, user, guild, guildId) {
 // (src/index.js), so extra exports are inert at runtime.
 module.exports.__test__ = { buildHuntEmbed, buildBonusLines, buildTrophyField, buildFieldTrophyField, buildDailyTollField, buildTodayField };
 
-// ── Per-user action lock ──────────────────────────────────────────────────────
+// ── Per-user economy lock ─────────────────────────────────────────────────────
 // Hunting mutates the user document with read-modify-write saves, so concurrent
 // /hunt invocations from the same user can race stamina, daily caps, and drops.
-// Serialize them: one hunting action at a time per user.
-const { tryAcquire: _lockAcquire, release: _lockRelease } = require('../../utils/activeGameLock');
-const _huntExecute = module.exports.execute;
-module.exports.execute = async function (interaction) {
-    const lockKey   = `grind:hunt:${interaction.guild?.id}:${interaction.user.id}`;
-    const lockToken = await _lockAcquire(lockKey, 120_000);
-    if (!lockToken) {
-        return interaction.reply({
-            content: '🏹 You already have a hunting action in progress — finish it first.',
-            flags: MessageFlags.Ephemeral,
-        }).catch(() => {});
-    }
-    try {
-        return await _huntExecute(interaction);
-    } finally {
-        await _lockRelease(lockKey, lockToken);
-    }
-};
+// The lock key is the player rather than this command, so a hand of blackjack
+// races the same document and contends for it too — see utils/economyLock.js.
+const { withEconomyLock } = require('../../utils/economyLock');
+module.exports.execute = withEconomyLock(module.exports.execute, { activity: 'hunt' });

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -2411,6 +2411,48 @@ async function executeShop(interaction, sub) {
     }
 }
 
+/**
+ * How the top of the weapon ladder is priced, and why it says so out loud.
+ *
+ * Hunt income has a ceiling: payouts halve above `DAILY_SOFT_CAP` (80,000) and
+ * stop entirely at `DAILY_HARD_CAP`. Measured against that ceiling, the last
+ * few tiers cost more than hunting can plausibly produce — a T12 Altair Rifle
+ * is 250 days of hunting at the soft cap, and a full repair on one is another
+ * 80, of which it has about eight before the shop wears it out for good.
+ *
+ * The numbers are not wrong. Hunting is not the only thing that feeds a wallet
+ * — casino, work, crime, heist and the rest all pay into the same balance, and
+ * the daily caps are hunt-specific — so the top tiers are whole-economy
+ * purchases by design. What was wrong is that nothing said so: a hunter looking
+ * at the shop had no way to tell the ladder stops being hunt-funded partway up,
+ * and could grind toward a number hunting cannot reach.
+ *
+ * Derived from the caps rather than hardcoded to a tier, so it stays true if
+ * either the prices or the caps move.
+ */
+const CROSS_ECONOMY_DAYS = 30;
+
+/** Days of hunting at the soft cap that `cost` represents. */
+function huntingDaysFor(cost) {
+    return cost / LIMITS.DAILY_SOFT_CAP;
+}
+
+/** Cost of taking a fresh weapon of this tier from empty back to full. */
+function fullRepairCost(weapon) {
+    return Math.ceil(weapon.baseDurability / 20) * weapon.repairCostPer20;
+}
+
+/** True for a weapon hunting alone cannot realistically pay for. */
+function isCrossEconomyWeapon(weapon) {
+    return huntingDaysFor(weapon.cost) > CROSS_ECONOMY_DAYS;
+}
+
+/** Rounded day count for display — "~250 days", never "249.9". */
+function huntingDaysLabel(cost) {
+    const days = huntingDaysFor(cost);
+    return days >= 10 ? Math.round(days) : Math.round(days * 10) / 10;
+}
+
 async function showShopList(interaction, user, currency) {
     const h = user.hunt;
 
@@ -2421,10 +2463,19 @@ async function showShopList(interaction, user, currency) {
         emoji:   w.emoji,
         badge:   `T${w.tier}`,
         subline: `${Math.round(w.successRate * 100)}% • +${Math.round(w.rarityBoost * 100)}% rare`
+            + (isCrossEconomyWeapon(w) ? ` • 🌐 ~${huntingDaysLabel(w.cost)}d of hunting` : '')
     }));
-    const weaponList = WEAPON_TIERS.map(w =>
-        `${w.emoji} **${w.name}** — ${currency}${w.cost.toLocaleString()} · \`/hunt shop weapon type:${w.slug}\``
-    ).join('\n');
+    const weaponLines = WEAPON_TIERS.map(w =>
+        `${w.emoji} **${w.name}** — ${currency}${w.cost.toLocaleString()}`
+        + (isCrossEconomyWeapon(w) ? ` 🌐` : '')
+        + ` · \`/hunt shop weapon type:${w.slug}\``
+    );
+    // The legend goes in the embed description rather than the banner subtitle:
+    // the banner is drawn with fillText on a canvas, which has no line breaks.
+    if (WEAPON_TIERS.some(isCrossEconomyWeapon)) {
+        weaponLines.push('', '🌐 *Costs more than hunting alone can fund — casino, work, crime and the rest all pay into the same wallet.*');
+    }
+    const weaponList = weaponLines.join('\n');
 
     const upgradeItems = Object.values(WEAPON_UPGRADES).map(u => ({
         imageId: `hunt:${u.id}`,
@@ -2523,6 +2574,24 @@ async function handleBuyWeapon(interaction, user, currency) {
             { name: 'Your Balance', value: `${currency}${user.balance.toLocaleString()}`,                             inline: true }
         )
         .setFooter({ text: 'Confirmation expires in 30 seconds' });
+
+    // The one place a hunter commits to the number, so it is the place to say
+    // what the number means. A weapon is a consumable — every shop repair drops
+    // maxDurability by 10% of base, so the top tiers cost their purchase price
+    // again several times over before they are condemned — and at the top of
+    // the ladder none of it is fundable from hunting alone.
+    if (isCrossEconomyWeapon(weaponData)) {
+        const repair = fullRepairCost(weaponData);
+        confirmEmbed.addFields({
+            name: '🌐 A whole-economy purchase',
+            value: [
+                `Hunting is capped at ${currency}${LIMITS.DAILY_SOFT_CAP.toLocaleString()} a day before payouts halve, so this is about **${huntingDaysLabel(weaponData.cost)} days** of hunting on its own.`,
+                `A full repair runs ${currency}${repair.toLocaleString()} — another **${huntingDaysLabel(repair)} days** — and it has roughly eight before the wear condemns it.`,
+                `It is priced for a wallet fed by everything you do: casino, work, crime, heists and the rest all pay into the same balance.`,
+            ].join('\n'),
+            inline: false,
+        });
+    }
 
     const weaponImg = await getItemImageAttachment(`hunt:${weaponData.slug || weaponData.id}`).catch(() => null);
     if (weaponImg) confirmEmbed.setThumbnail(weaponImg.url);
@@ -3234,7 +3303,7 @@ async function checkGrandPrestige(client, user, guild, guildId) {
 
 // Test hooks. The command loader only looks for `data` and `execute`
 // (src/index.js), so extra exports are inert at runtime.
-module.exports.__test__ = { buildHuntEmbed, buildBonusLines, buildTrophyField, buildFieldTrophyField, buildDailyTollField, buildTodayField, buildWeaponPages, WEAPON_SEPARATOR, gradeShot, AIM_WINDOW_MS, AIM_LATE_MS };
+module.exports.__test__ = { buildHuntEmbed, buildBonusLines, buildTrophyField, buildFieldTrophyField, buildDailyTollField, buildTodayField, buildWeaponPages, WEAPON_SEPARATOR, gradeShot, AIM_WINDOW_MS, AIM_LATE_MS, isCrossEconomyWeapon, huntingDaysFor, huntingDaysLabel, fullRepairCost, CROSS_ECONOMY_DAYS };
 
 // ── Per-user economy lock ─────────────────────────────────────────────────────
 // Hunting mutates the user document with read-modify-write saves, so concurrent

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -66,6 +66,10 @@ const { ensureQuests, onHunt, onEconomyEarn, notifyQuestComplete, notifyQuestNea
 const { recordMissionProgress } = require('../../services/seasonMissionService');
 const { getActiveSynergies } = require('../../services/synergyService');
 const { buildPityStreakField, PITY_COPY } = require('../../utils/pityBonus');
+const { chunkByLength } = require('../../utils/embedFields');
+const { paginate } = require('../../utils/paginator');
+
+const WEAPON_SEPARATOR = '\n\n';
 
 const WILDERNESS_YIELD_BONUS = 0.10;
 
@@ -1870,6 +1874,52 @@ async function executePrestige(interaction) {
 // INV (was /huntinv)
 // ═══════════════════════════════════════════════════════════════════════════════
 
+/**
+ * The weapon list, split into pages that each fit an embed description.
+ *
+ * This used to be one `lines.join('\n\n')` straight into `setDescription`. At
+ * roughly 180 characters an entry that overflows Discord's 4096-character cap
+ * at about 22 weapons, and the API rejects the whole embed — so the command
+ * stopped working entirely for the player who owned the most. The same defect
+ * broke `/hunt profile` at 56 trophies.
+ *
+ * Paged rather than trimmed, because the number in each heading is what
+ * `/hunt inv equip <#>` and `/hunt inv discard <#>` take: a weapon cut off the
+ * end of a `+N more` tail could never be equipped or thrown away again, and
+ * `/hunt inv discard` only accepts broken or condemned weapons — so the pile a
+ * trimmed list would hide is exactly the pile you cannot clear.
+ *
+ * Ordered equipped-first, then by tier descending, so page one is the one
+ * worth reading. The displayed number stays the weapon's index in `h.weapons`,
+ * which is what the other subcommands address it by.
+ */
+function buildWeaponPages(h) {
+    const ordered = h.weapons
+        .map((w, index) => ({ w, index }))
+        .sort((a, b) => {
+            if (a.index === h.equippedWeaponIndex) return -1;
+            if (b.index === h.equippedWeaponIndex) return 1;
+            return (b.w.tier ?? 0) - (a.w.tier ?? 0);
+        });
+
+    const lines = ordered.map(({ w, index }) => {
+        const wd         = WEAPON_BY_TIER[w.tier];
+        const statusIcon = weaponStatusEmoji(w.status);
+        const bar        = durabilityBar(w.currentDurability, w.maxDurability, 12);
+        const upgrade    = w.upgrade ? `[${w.upgrade.replace(/_/g, ' ')}]` : '';
+        const equipped   = index === h.equippedWeaponIndex ? ' **[EQUIPPED]**' : '';
+        return [
+            `**#${index + 1} — ${wd?.emoji ?? '🔫'} ${w.name}**${equipped}`,
+            `> ${statusIcon} ${w.status.toUpperCase()} · ${bar} ${w.currentDurability}/${w.maxDurability} dur`,
+            `> Repairs: ${w.repairCount} · Max: ${w.maxDurability}/${w.baseDurability} · ${upgrade || 'No upgrade'}`
+        ].join('\n');
+    });
+
+    // A page cap as well as a character budget: eight entries is a screenful,
+    // and a list that fills 4096 characters before it pages is one nobody reads.
+    return chunkByLength(lines, { separator: WEAPON_SEPARATOR, maxPerChunk: 8 });
+}
+
 async function executeInv(interaction, sub) {
     const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
     if (guildSettings?.economy?.enabled === false) {
@@ -1893,27 +1943,13 @@ async function executeInv(interaction, sub) {
             });
         }
 
-        const lines = h.weapons.map((w, i) => {
-            const isEquipped = i === h.equippedWeaponIndex;
-            const wd         = WEAPON_BY_TIER[w.tier];
-            const statusIcon = weaponStatusEmoji(w.status);
-            const bar        = durabilityBar(w.currentDurability, w.maxDurability, 12);
-            const upgrade    = w.upgrade ? `[${w.upgrade.replace(/_/g, ' ')}]` : '';
-            const equipped   = isEquipped ? ' **[EQUIPPED]**' : '';
-            return [
-                `**#${i + 1} — ${wd?.emoji ?? '🔫'} ${w.name}**${equipped}`,
-                `> ${statusIcon} ${w.status.toUpperCase()} · ${bar} ${w.currentDurability}/${w.maxDurability} dur`,
-                `> Repairs: ${w.repairCount} · Max: ${w.maxDurability}/${w.baseDurability} · ${upgrade || 'No upgrade'}`
-            ].join('\n');
-        });
-
-        const embed = new EmbedBuilder()
+        const pages = buildWeaponPages(h).map((lines, page, all) => new EmbedBuilder()
             .setColor('#3498db')
-            .setTitle('🔫 Your Weapons')
-            .setDescription(lines.join('\n\n'))
-            .setFooter({ text: 'Use /hunt inv equip <#> to change weapon • /hunt shop repair to restore durability • /hunt shop upgrade for modules' });
+            .setTitle(all.length > 1 ? `🔫 Your Weapons (${h.weapons.length})` : '🔫 Your Weapons')
+            .setDescription(lines.join(WEAPON_SEPARATOR))
+            .setFooter({ text: 'Use /hunt inv equip <#> to change weapon • /hunt shop repair to restore durability • /hunt shop upgrade for modules' }));
 
-        return interaction.reply({ embeds: [embed] });
+        return paginate(interaction, pages);
     }
 
     if (sub === 'equip') {
@@ -2010,18 +2046,26 @@ async function executeInv(interaction, sub) {
             .filter(([, qty]) => qty > 0)
             .map(([id, qty]) => `• **${MATERIAL_NAMES[id] ?? id}** ×${qty}`);
 
-        const embed = new EmbedBuilder()
-            .setColor('#1abc9c')
-            .setTitle('🪨 Crafting Materials')
-            .setDescription(entries.length ? entries.join('\n') : 'No materials yet. Hunt rare+ animals to find special drops!');
+        const footer = entries.length
+            ? 'Every material feeds a recipe — see /craft list. Each zone ends in a permanent Field Trophy.'
+            : 'Tip: Use bait from /hunt shop to boost rare animal chances';
 
-        embed.setFooter({
-            text: entries.length
-                ? 'Every material feeds a recipe — see /craft list. Each zone ends in a permanent Field Trophy.'
-                : 'Tip: Use bait from /hunt shop to boost rare animal chances',
-        });
+        // Bounded by the 58 material ids to about 1,700 characters, so this
+        // fits today — but it is the same join-and-hope shape the weapon list
+        // broke on, and the material table only ever grows.
+        const pages = entries.length
+            ? chunkByLength(entries).map(lines => new EmbedBuilder()
+                .setColor('#1abc9c')
+                .setTitle('🪨 Crafting Materials')
+                .setDescription(lines.join('\n'))
+                .setFooter({ text: footer }))
+            : [new EmbedBuilder()
+                .setColor('#1abc9c')
+                .setTitle('🪨 Crafting Materials')
+                .setDescription('No materials yet. Hunt rare+ animals to find special drops!')
+                .setFooter({ text: footer })];
 
-        return interaction.reply({ embeds: [embed] });
+        return paginate(interaction, pages);
     }
 
     if (sub === 'discard') {
@@ -3108,7 +3152,7 @@ async function checkGrandPrestige(client, user, guild, guildId) {
 
 // Test hooks. The command loader only looks for `data` and `execute`
 // (src/index.js), so extra exports are inert at runtime.
-module.exports.__test__ = { buildHuntEmbed, buildBonusLines, buildTrophyField, buildFieldTrophyField, buildDailyTollField, buildTodayField };
+module.exports.__test__ = { buildHuntEmbed, buildBonusLines, buildTrophyField, buildFieldTrophyField, buildDailyTollField, buildTodayField, buildWeaponPages, WEAPON_SEPARATOR };
 
 // ── Per-user economy lock ─────────────────────────────────────────────────────
 // Hunting mutates the user document with read-modify-write saves, so concurrent

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -130,6 +130,96 @@ function gradeShot(shotMs, openAtMs) {
 }
 
 
+/**
+ * The aim phase: hold the shot, take it when the target lines up.
+ *
+ * The Fire button is attached with the "sights" embed, not after it, so the
+ * shot can genuinely be taken early — which is what the footer has always
+ * warned about. The button used to arrive only once the wait had elapsed, so
+ * firing early was impossible and the grade was decided purely by how fast the
+ * click came back: under 800ms of round trip paid +18% crit, anything slower
+ * +8%. That scored the player's connection, not their play, and paid at least
+ * +8% for any click at all.
+ *
+ * Now the wait is the mechanic. The window opens at a random moment the player
+ * cannot anticipate and stays open long enough that a slow connection still
+ * comfortably clears it — so what separates the outcomes is *when* you fire,
+ * not how fast the wire is.
+ *
+ * Lives out here rather than inline in executeStart so the timing can be driven
+ * by a test: it is the one part of a hunt whose result depends on when things
+ * happen rather than on what they are.
+ *
+ * @returns the grade from `gradeShot`.
+ */
+async function runAimPhase(interaction, huntMsg) {
+    const delay = ms => new Promise(r => setTimeout(r, ms));
+
+    const aimWaitMs = 1000 + Math.floor(Math.random() * 1001);
+
+    const fireId = `hunt_fire_${interaction.id}`;
+    const aimRow = new ActionRowBuilder().addComponents(
+        new ButtonBuilder().setCustomId(fireId).setLabel('🔫 Fire!').setStyle(ButtonStyle.Danger)
+    );
+    const aimSightsEmbed = new EmbedBuilder()
+        .setColor('#8B0000')
+        .setTitle('🎯 Target in Sights…')
+        .setDescription('*Hold your breath… wait for the shot to line up.*')
+        .setFooter({ text: 'Fire when the shot is called — rush it and you spoil the shot.' });
+
+    await interaction.editReply({ embeds: [aimSightsEmbed], components: [aimRow] });
+    const aimTime = Date.now();
+
+    const collector = huntMsg.createMessageComponentCollector({
+        filter: i => i.user.id === interaction.user.id && i.customId === fireId,
+        time: aimWaitMs + AIM_LATE_MS,
+        max: 1,
+    });
+
+    let shotTaken = false;
+    const shot = new Promise(resolve => {
+        collector.on('collect', async i => { await i.deferUpdate(); resolve(Date.now() - aimTime); });
+        collector.on('end',     (_, reason) => { if (reason !== 'limit') resolve(null); });
+    }).then(ms => { shotTaken = ms !== null; return ms; });
+
+    // Call the shot when the window opens — unless it has already been taken,
+    // in which case editing to "FIRE!" would tell a player who jumped the gun
+    // that they were right on time.
+    //
+    // The window is timed from when the call is actually on screen, not from
+    // when the wait elapsed: the edit is a round trip of its own, and charging
+    // it to the player would put the latency straight back into the grade this
+    // phase exists to take it out of.
+    let windowOpensAt = aimWaitMs;
+    await Promise.race([shot, delay(aimWaitMs)]);
+    if (!shotTaken) {
+        await interaction.editReply({
+            embeds: [new EmbedBuilder()
+                .setColor('#FF0000')
+                .setTitle('💥 FIRE!')
+                .setDescription('**Take the shot — NOW!**')],
+            components: [aimRow],
+        });
+        windowOpensAt = Date.now() - aimTime;
+
+        // Re-arm for the same reason the window is timed from here. The
+        // collector was armed before the edit went out, so its deadline counts
+        // the edit's round trip against the player's grace period — a slow
+        // connection got less time to take a late shot than a fast one, which
+        // is the latency-decides-the-grade problem again at the other end of
+        // the window. AIM_LATE_MS is a promise about time after the call.
+        if (!shotTaken) collector.resetTimer({ time: AIM_LATE_MS });
+    }
+
+    const shotMs = await shot;
+    const aim    = gradeShot(shotMs, windowOpensAt);
+
+    await interaction.editReply({ embeds: [aim.embed()], components: [] });
+    await delay(600);
+
+    return aim;
+}
+
 const WILDERNESS_YIELD_BONUS = 0.10;
 
 const walletOf = interaction => ({ userId: interaction.user.id, guildId: interaction.guild.id });
@@ -738,73 +828,7 @@ async function executeStart(interaction) {
             await interaction.editReply({ embeds: [stealthResultEmbed], components: [] });
             await delay(800);
 
-            // ── Aim Phase ──────────────────────────────────────────────────────────
-            // The Fire button is attached with the "sights" embed, not after it,
-            // so the shot can genuinely be taken early — which is what the
-            // footer has always warned about. The button used to arrive only
-            // once the wait had elapsed, so firing early was impossible and the
-            // grade was decided purely by how fast the click came back: under
-            // 800ms of round trip paid +18% crit, anything slower +8%. That
-            // scored the player's connection, not their play, and paid at least
-            // +8% for any click at all.
-            //
-            // Now the wait is the mechanic. The window opens at a random moment
-            // the player cannot anticipate and stays open long enough that a
-            // slow connection still comfortably clears it — so what separates
-            // the outcomes is *when* you fire, not how fast the wire is.
-            const aimWaitMs = 1000 + Math.floor(Math.random() * 1001);
-
-            const fireId  = `hunt_fire_${interaction.id}`;
-            const aimRow = new ActionRowBuilder().addComponents(
-                new ButtonBuilder().setCustomId(fireId).setLabel('🔫 Fire!').setStyle(ButtonStyle.Danger)
-            );
-            const aimSightsEmbed = new EmbedBuilder()
-                .setColor('#8B0000')
-                .setTitle('🎯 Target in Sights…')
-                .setDescription('*Hold your breath… wait for the shot to line up.*')
-                .setFooter({ text: 'Fire when the shot is called — rush it and you spoil the shot.' });
-
-            await interaction.editReply({ embeds: [aimSightsEmbed], components: [aimRow] });
-            const aimTime = Date.now();
-
-            let shotTaken = false;
-            const shot = new Promise(resolve => {
-                const col = huntMsg.createMessageComponentCollector({
-                    filter: i => i.user.id === interaction.user.id && i.customId === fireId,
-                    time: aimWaitMs + AIM_LATE_MS,
-                    max: 1,
-                });
-                col.on('collect', async i => { await i.deferUpdate(); resolve(Date.now() - aimTime); });
-                col.on('end',     (_, reason) => { if (reason !== 'limit') resolve(null); });
-            }).then(ms => { shotTaken = ms !== null; return ms; });
-
-            // Call the shot when the window opens — unless it has already been
-            // taken, in which case editing to "FIRE!" would tell a player who
-            // jumped the gun that they were right on time.
-            //
-            // The window is timed from when the call is actually on screen, not
-            // from when the wait elapsed: the edit is a round trip of its own,
-            // and charging it to the player would put the latency straight back
-            // into the grade this phase exists to take it out of.
-            let windowOpensAt = aimWaitMs;
-            await Promise.race([shot, delay(aimWaitMs)]);
-            if (!shotTaken) {
-                await interaction.editReply({
-                    embeds: [new EmbedBuilder()
-                        .setColor('#FF0000')
-                        .setTitle('💥 FIRE!')
-                        .setDescription('**Take the shot — NOW!**')],
-                    components: [aimRow],
-                });
-                windowOpensAt = Date.now() - aimTime;
-            }
-
-            const shotMs = await shot;
-            const aim    = gradeShot(shotMs, windowOpensAt);
-            aimBonus     = aim.bonus;
-
-            await interaction.editReply({ embeds: [aim.embed()], components: [] });
-            await delay(600);
+            aimBonus = (await runAimPhase(interaction, huntMsg)).bonus;
 
         } else {
             await interaction.deferReply();
@@ -3303,7 +3327,7 @@ async function checkGrandPrestige(client, user, guild, guildId) {
 
 // Test hooks. The command loader only looks for `data` and `execute`
 // (src/index.js), so extra exports are inert at runtime.
-module.exports.__test__ = { buildHuntEmbed, buildBonusLines, buildTrophyField, buildFieldTrophyField, buildDailyTollField, buildTodayField, buildWeaponPages, WEAPON_SEPARATOR, gradeShot, AIM_WINDOW_MS, AIM_LATE_MS, isCrossEconomyWeapon, huntingDaysFor, huntingDaysLabel, fullRepairCost, CROSS_ECONOMY_DAYS };
+module.exports.__test__ = { buildHuntEmbed, buildBonusLines, buildTrophyField, buildFieldTrophyField, buildDailyTollField, buildTodayField, buildWeaponPages, WEAPON_SEPARATOR, gradeShot, runAimPhase, AIM_WINDOW_MS, AIM_LATE_MS, isCrossEconomyWeapon, huntingDaysFor, huntingDaysLabel, fullRepairCost, CROSS_ECONOMY_DAYS };
 
 // ── Per-user economy lock ─────────────────────────────────────────────────────
 // Hunting mutates the user document with read-modify-write saves, so concurrent

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -69,8 +69,6 @@ const { buildPityStreakField, PITY_COPY } = require('../../utils/pityBonus');
 const { chunkByLength } = require('../../utils/embedFields');
 const { paginate } = require('../../utils/paginator');
 
-const WEAPON_SEPARATOR = '\n\n';
-
 // ── Aim phase timing ─────────────────────────────────────────────────────────
 // How long the shot stays perfect once the window opens, and how long after
 // that the trigger stays live at all.
@@ -1955,6 +1953,8 @@ async function executePrestige(interaction) {
 // ═══════════════════════════════════════════════════════════════════════════════
 // INV (was /huntinv)
 // ═══════════════════════════════════════════════════════════════════════════════
+
+const WEAPON_SEPARATOR = '\n\n';
 
 /**
  * The weapon list, split into pages that each fit an embed description.

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -3310,5 +3310,17 @@ module.exports.__test__ = { buildHuntEmbed, buildBonusLines, buildTrophyField, b
 // /hunt invocations from the same user can race stamina, daily caps, and drops.
 // The lock key is the player rather than this command, so a hand of blackjack
 // races the same document and contends for it too — see utils/economyLock.js.
-const { withEconomyLock } = require('../../utils/economyLock');
-module.exports.execute = withEconomyLock(module.exports.execute, { activity: 'hunt' });
+const { withEconomyLock, exceptReadOnly } = require('../../utils/economyLock');
+// Reads that persist nothing, so they never wait on a lease — see
+// exceptReadOnly. Everything else, including /hunt inv equip and discard,
+// still locks.
+const HUNT_READ_ONLY = [
+    'profile',
+    'inv weapons', 'inv ammo', 'inv consumables', 'inv materials',
+    'shop list',
+    'zone list',
+];
+module.exports.execute = withEconomyLock(module.exports.execute, {
+    activity: 'hunt',
+    only:     exceptReadOnly(HUNT_READ_ONLY),
+});

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -2775,9 +2775,10 @@ async function handleRaid(interaction) {
     // defender's lock for the transfer rather than racing it.
     //
     // tryAcquire never blocks, so two miners raiding each other simultaneously cannot
-    // deadlock — one or both are simply turned away.
-    const defenderLockKey = `grind:mine:${interaction.guild.id}:${defender.userId}`;
-    const defenderLock    = await _lockAcquire(defenderLockKey, 30_000);
+    // deadlock — one or both are simply turned away. The raider's own lease is a
+    // different key (theirs, taken by the wrapper below), so this cannot self-block.
+    const defenderLockKey = economyLockKey(interaction.guild.id, defender.userId);
+    const defenderLock    = await _lockAcquire(defenderLockKey, 30_000, 'raid');
     if (!defenderLock) {
         return interaction.reply({
             content: `**${targetUser.username}** is down in the mine right now — you can't get in behind them. Try again in a moment.`,
@@ -2905,24 +2906,11 @@ async function handleRaid(interaction) {
 }
 
 
-// ── Per-user action lock ──────────────────────────────────────────────────────
+// ── Per-user economy lock ─────────────────────────────────────────────────────
 // Mining mutates the user document with read-modify-write saves, so concurrent
 // /mine invocations from the same user can race stamina, daily caps, and drops.
-// Serialize them: one mining action at a time per user.
+// The lock key is the player rather than this command, so a hand of blackjack
+// races the same document and contends for it too — see utils/economyLock.js.
 const { tryAcquire: _lockAcquire, release: _lockRelease } = require('../../utils/activeGameLock');
-const _mineExecute = module.exports.execute;
-module.exports.execute = async function (interaction) {
-    const lockKey   = `grind:mine:${interaction.guild?.id}:${interaction.user.id}`;
-    const lockToken = await _lockAcquire(lockKey, 120_000);
-    if (!lockToken) {
-        return interaction.reply({
-            content: '⛏️ You already have a mining action in progress — finish it first.',
-            flags: MessageFlags.Ephemeral,
-        }).catch(() => {});
-    }
-    try {
-        return await _mineExecute(interaction);
-    } finally {
-        await _lockRelease(lockKey, lockToken);
-    }
-};
+const { withEconomyLock, economyLockKey } = require('../../utils/economyLock');
+module.exports.execute = withEconomyLock(module.exports.execute, { activity: 'mine' });

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -2780,8 +2780,12 @@ async function handleRaid(interaction) {
     const defenderLockKey = economyLockKey(interaction.guild.id, defender.userId);
     const defenderLock    = await _lockAcquire(defenderLockKey, 30_000, 'raid');
     if (!defenderLock) {
+        // Deliberately vague about *what* they are doing: the lease is the
+        // shared economy one, so it is just as likely to be a hand of blackjack
+        // as a dig, and naming the wrong activity would be worse than naming
+        // none. It is also somebody else's business.
         return interaction.reply({
-            content: `**${targetUser.username}** is down in the mine right now — you can't get in behind them. Try again in a moment.`,
+            content: `**${targetUser.username}** is busy right now — you can't get in behind them. Try again in a moment.`,
             flags: MessageFlags.Ephemeral
         });
     }
@@ -2912,5 +2916,15 @@ async function handleRaid(interaction) {
 // The lock key is the player rather than this command, so a hand of blackjack
 // races the same document and contends for it too — see utils/economyLock.js.
 const { tryAcquire: _lockAcquire, release: _lockRelease } = require('../../utils/activeGameLock');
-const { withEconomyLock, economyLockKey } = require('../../utils/economyLock');
-module.exports.execute = withEconomyLock(module.exports.execute, { activity: 'mine' });
+const { withEconomyLock, exceptReadOnly, economyLockKey } = require('../../utils/economyLock');
+// Reads that persist nothing, so they never wait on a lease — see
+// exceptReadOnly. Everything else, including /mine raid, still locks.
+const MINE_READ_ONLY = [
+    'profile', 'map',
+    'inv view',
+    'shop list',
+];
+module.exports.execute = withEconomyLock(module.exports.execute, {
+    activity: 'mine',
+    only:     exceptReadOnly(MINE_READ_ONLY),
+});

--- a/src/games/casino/blackjack.js
+++ b/src/games/casino/blackjack.js
@@ -6,6 +6,7 @@ const {
     MessageFlags,
 } = require('discord.js');
 const User  = require('../../models/User');
+const { placeWager } = require('../../utils/placeWager');
 const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier, luckySaveEligible } = require('../../services/effectsService');
@@ -200,7 +201,7 @@ module.exports = {
                 .setMinValue(MIN_BET)
                 .setMaxValue(1_000_000_000)),
 
-    async execute(interaction, { releaseLock } = {}) {
+    async execute(interaction, { releaseLock, onWager } = {}) {
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
         if (guildSettings?.economy?.enabled === false || guildSettings?.economy?.gamesEnabled === false || guildSettings?.economy?.blackjackEnabled === false) {
             releaseLock?.();
@@ -227,11 +228,13 @@ module.exports = {
         if (!shouldProceed) { releaseLock?.(); return; }
         const sendInitial = (payload) => alreadyReplied ? interaction.editReply(payload) : interaction.reply(payload);
 
-        // Atomic debit — re-validates balance at write time to prevent race conditions
-        const debited = await User.findOneAndUpdate(
-            { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: bet } },
-            { $inc: { balance: -bet, lifetimeGambled: bet } },
-            { new: true },
+        // The opening wager, and the only debit of this hand that reports one:
+        // insurance, a split and a double down below are all further money on
+        // the same hand, not another game played.
+        const debited = await placeWager(
+            { userId: interaction.user.id, guildId: interaction.guild.id },
+            bet,
+            { extraInc: { lifetimeGambled: bet }, onWager },
         );
         if (!debited) {
             releaseLock?.();
@@ -314,10 +317,10 @@ module.exports = {
                         time: 15_000,
                     });
                     await insI.deferUpdate();
-                    const peekUpdated = await User.findOneAndUpdate(
-                        { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: insuranceCost } },
-                        { $inc: { balance: -insuranceCost, lifetimeGambled: insuranceCost } },
-                        { new: true },
+                    const peekUpdated = await placeWager(
+                        { userId: interaction.user.id, guildId: interaction.guild.id },
+                        insuranceCost,
+                        { extraInc: { lifetimeGambled: insuranceCost } },
                     );
                     if (peekUpdated) peekInsuranceBet = insuranceCost;
                 } catch {
@@ -383,10 +386,10 @@ module.exports = {
             // ── Insurance ──────────────────────────────────────────────────────────
             if (i.customId === `bj_insurance_${gameId}`) {
                 insuranceAvailable = false;
-                const updated = await User.findOneAndUpdate(
-                    { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: insuranceCost } },
-                    { $inc: { balance: -insuranceCost, lifetimeGambled: insuranceCost } },
-                    { new: true },
+                const updated = await placeWager(
+                    { userId: interaction.user.id, guildId: interaction.guild.id },
+                    insuranceCost,
+                    { extraInc: { lifetimeGambled: insuranceCost } },
                 );
                 if (updated) insuranceBet = insuranceCost;
                 const statusMsg = updated
@@ -400,10 +403,10 @@ module.exports = {
             if (i.customId === `bj_double_${gameId}`) {
                 doubleAvailable = false;
                 splitAvailable  = false;
-                const updated = await User.findOneAndUpdate(
-                    { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: bet } },
-                    { $inc: { balance: -bet, lifetimeGambled: bet } },
-                    { new: true },
+                const updated = await placeWager(
+                    { userId: interaction.user.id, guildId: interaction.guild.id },
+                    bet,
+                    { extraInc: { lifetimeGambled: bet } },
                 );
                 if (!updated) {
                     const embed = buildEmbed(interaction, playerHand, dealerHand, activeBet, currency, `⚠️ Not enough balance for double down · Your turn`, '#5865F2', true);
@@ -430,10 +433,10 @@ module.exports = {
             if (i.customId === `bj_split_${gameId}`) {
                 doubleAvailable = false;
                 splitAvailable  = false;
-                const updated = await User.findOneAndUpdate(
-                    { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: bet } },
-                    { $inc: { balance: -bet, lifetimeGambled: bet } },
-                    { new: true },
+                const updated = await placeWager(
+                    { userId: interaction.user.id, guildId: interaction.guild.id },
+                    bet,
+                    { extraInc: { lifetimeGambled: bet } },
                 );
                 if (!updated) {
                     const embed = buildEmbed(interaction, playerHand, dealerHand, activeBet, currency, `⚠️ Not enough balance for split · Your turn`, '#5865F2', true);

--- a/src/games/casino/crash.js
+++ b/src/games/casino/crash.js
@@ -355,12 +355,19 @@ async function openLobby(interaction, bet, hostAutoCashout, releaseLock, onWager
 
         // A joiner stakes their own coins on somebody else's command, so the
         // wager is reported against them — the jackpot is credited to whoever
-        // wins it and the mission ticks for the player who actually bet. Their
-        // button interaction carries the channel a jackpot would announce in.
+        // wins it and the mission ticks for the player who actually bet.
+        //
+        // The debit is not the last thing that can go wrong here, though: the
+        // seat is claimed after it, and a lobby that filled in between refunds
+        // the stake. Reporting from inside placeWager would contribute to the
+        // jackpot and tick the mission for a bet that was then handed straight
+        // back — the same "counted a hand that never happened" this signal
+        // exists to stop. So the debit stays silent and the wager is reported
+        // once the seat is actually theirs.
         const deducted = await placeWager(
             { userId: i.user.id, guildId: interaction.guild.id },
             bet,
-            { extraInc: { pendingCrashRefund: bet }, onWager, user: i.user, source: i },
+            { extraInc: { pendingCrashRefund: bet } },
         );
         if (!deducted) {
             return i.reply({ content: `You need **${bet.toLocaleString()}** coins to join.`, flags: MessageFlags.Ephemeral });
@@ -374,6 +381,9 @@ async function openLobby(interaction, bet, hostAutoCashout, releaseLock, onWager
             ).catch(err => console.error('[crash] join refund failed:', err));
             return i.reply({ content: 'Could not join the lobby (it may have just filled up). Your coins have been refunded.', flags: MessageFlags.Ephemeral });
         }
+
+        // Their button interaction carries the channel a jackpot would announce in.
+        onWager?.({ amount: bet, user: i.user, source: i });
         await i.deferUpdate().catch(() => {});
         await updateLobbyEmbed();
     });

--- a/src/games/casino/crash.js
+++ b/src/games/casino/crash.js
@@ -6,6 +6,7 @@ const {
     MessageFlags,
 } = require('discord.js');
 const User  = require('../../models/User');
+const { placeWager } = require('../../utils/placeWager');
 const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, luckySaveEligible } = require('../../services/effectsService');
@@ -257,7 +258,7 @@ module.exports = {
                 .setMaxValue(99.99)
                 .setRequired(false)),
 
-    async execute(interaction, { releaseLock } = {}) {
+    async execute(interaction, { releaseLock, onWager } = {}) {
         const bet         = interaction.options.getInteger('bet');
         const autoCashout = interaction.options.getNumber('auto_cashout') ?? null;
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
@@ -270,7 +271,7 @@ module.exports = {
         const { shouldProceed, alreadyReplied } = await confirmBet(interaction, bet, user?.balance ?? 0, 'Crash', guildSettings);
         if (!shouldProceed) { releaseLock?.(); return; }
         if (!alreadyReplied) await interaction.deferReply();
-        await openLobby(interaction, bet, autoCashout, releaseLock);
+        await openLobby(interaction, bet, autoCashout, releaseLock, onWager);
     },
 };
 
@@ -278,7 +279,7 @@ module.exports = {
 // is created and the host's debit succeeds) — the host's casino lock isn't
 // held through the lobby wait + the multiplayer game itself, since their
 // stake is already atomically deducted and can't be double-spent.
-async function openLobby(interaction, bet, hostAutoCashout, releaseLock) {
+async function openLobby(interaction, bet, hostAutoCashout, releaseLock, onWager) {
     const channelId = interaction.channel.id;
     const lobbyId   = `${channelId}_${Date.now()}`;
 
@@ -293,10 +294,10 @@ async function openLobby(interaction, bet, hostAutoCashout, releaseLock) {
         return interaction.editReply({ content: 'A crash lobby is already open in this channel.', components: [] });
     }
 
-    const deducted = await User.findOneAndUpdate(
-        { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: bet } },
-        { $inc: { balance: -bet, pendingCrashRefund: bet } },
-        { new: true }
+    const deducted = await placeWager(
+        { userId: interaction.user.id, guildId: interaction.guild.id },
+        bet,
+        { extraInc: { pendingCrashRefund: bet }, onWager },
     );
     if (!deducted) {
         deleteLobby(channelId);
@@ -352,10 +353,14 @@ async function openLobby(interaction, bet, hostAutoCashout, releaseLock) {
             return i.reply({ content: 'Lobby is full.', flags: MessageFlags.Ephemeral });
         }
 
-        const deducted = await User.findOneAndUpdate(
-            { userId: i.user.id, guildId: interaction.guild.id, balance: { $gte: bet } },
-            { $inc: { balance: -bet, pendingCrashRefund: bet } },
-            { new: true }
+        // A joiner stakes their own coins on somebody else's command, so the
+        // wager is reported against them — the jackpot is credited to whoever
+        // wins it and the mission ticks for the player who actually bet. Their
+        // button interaction carries the channel a jackpot would announce in.
+        const deducted = await placeWager(
+            { userId: i.user.id, guildId: interaction.guild.id },
+            bet,
+            { extraInc: { pendingCrashRefund: bet }, onWager, user: i.user, source: i },
         );
         if (!deducted) {
             return i.reply({ content: `You need **${bet.toLocaleString()}** coins to join.`, flags: MessageFlags.Ephemeral });

--- a/src/games/casino/cupgame.js
+++ b/src/games/casino/cupgame.js
@@ -6,6 +6,7 @@ const {
     MessageFlags,
 } = require('discord.js');
 const User  = require('../../models/User');
+const { placeWager } = require('../../utils/placeWager');
 const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier, luckySaveEligible } = require('../../services/effectsService');
@@ -49,7 +50,7 @@ function buildReveal(queenPos) {
 // hand) and called once the hand truly settles — final loss/win or a cash-out
 // — but not held through "Play Again", since a replay re-debits atomically
 // just like any fresh bet.
-async function playMonte(interaction, bet, round = 1, releaseLock) {
+async function playMonte(interaction, bet, round = 1, releaseLock, onWager) {
     const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
     let debited = null;
     let settled = false;
@@ -58,11 +59,7 @@ async function playMonte(interaction, bet, round = 1, releaseLock) {
     if (round === 1) {
         try {
             const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
-            debited = await User.findOneAndUpdate(
-                { ...userFilter, balance: { $gte: bet } },
-                { $inc: { balance: -bet } },
-                { new: true }
-            );
+            debited = await placeWager(userFilter, bet, { onWager });
 
             if (!debited) {
                 releaseLock?.();
@@ -298,7 +295,7 @@ async function playMonte(interaction, bet, round = 1, releaseLock) {
                 time: 60_000,
             }).on('collect', async i => {
                 await i.deferUpdate();
-                await playMonte(interaction, bet);
+                await playMonte(interaction, bet, 1, null, onWager);
             }).on('end', (_, reason) => {
                 if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
             });
@@ -381,7 +378,7 @@ async function playMonte(interaction, bet, round = 1, releaseLock) {
                         max: 1, time: 60_000,
                     }).on('collect', async i => {
                         await i.deferUpdate();
-                        await playMonte(interaction, bet);
+                        await playMonte(interaction, bet, 1, null, onWager);
                     }).on('end', (_, reason) => {
                         if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
                     });
@@ -389,7 +386,7 @@ async function playMonte(interaction, bet, round = 1, releaseLock) {
 
                 } else {
                     // Double or Nothing — recurse with next round (no payout yet)
-                    await playMonte(interaction, bet, round + 1, releaseLock);
+                    await playMonte(interaction, bet, round + 1, releaseLock, onWager);
                 }
 
             } catch {
@@ -433,7 +430,7 @@ module.exports = {
                 .setMinValue(MIN_BET)
                 .setMaxValue(1_000_000_000)),
 
-    async execute(interaction, { releaseLock } = {}) {
+    async execute(interaction, { releaseLock, onWager } = {}) {
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
         if (guildSettings?.economy?.enabled === false || guildSettings?.economy?.gamesEnabled === false) {
             releaseLock?.();
@@ -461,6 +458,6 @@ module.exports = {
         const { shouldProceed, alreadyReplied } = await confirmBet(interaction, bet, user.balance, 'Three Card Monte', guildSettings);
         if (!shouldProceed) { releaseLock?.(); return; }
         if (!alreadyReplied) await interaction.deferReply();
-        await playMonte(interaction, bet, 1, releaseLock);
+        await playMonte(interaction, bet, 1, releaseLock, onWager);
     },
 };

--- a/src/games/casino/higherlower.js
+++ b/src/games/casino/higherlower.js
@@ -6,6 +6,7 @@ const {
     MessageFlags,
 } = require('discord.js');
 const User  = require('../../models/User');
+const { placeWager } = require('../../utils/placeWager');
 const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier, luckySaveEligible } = require('../../services/effectsService');
@@ -196,7 +197,7 @@ module.exports = {
                 .setMaxValue(1_000_000_000)
                 .setRequired(true)),
 
-    async execute(interaction, { releaseLock } = {}) {
+    async execute(interaction, { releaseLock, onWager } = {}) {
         const bet = interaction.options.getInteger('bet');
         const [user, guildSettings] = await Promise.all([
             User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }),
@@ -228,11 +229,7 @@ module.exports = {
                 { upsert: true, new: true, setDefaultsOnInsert: true }
             );
 
-            const debited = await User.findOneAndUpdate(
-                { ...userFilter, balance: { $gte: bet } },
-                { $inc: { balance: -bet } },
-                { new: true }
-            );
+            const debited = await placeWager(userFilter, bet, { onWager });
 
             if (!debited) {
                 releaseLock?.();
@@ -241,7 +238,7 @@ module.exports = {
                 });
             }
 
-            await playHigherLower(interaction, bet, userFilter, guildSettings, [], 0, releaseLock);
+            await playHigherLower(interaction, bet, userFilter, guildSettings, [], 0, releaseLock, onWager);
 
         } catch (err) {
             console.error('[HigherLower] error:', err);
@@ -257,7 +254,7 @@ module.exports = {
 // loss/cash-out/timeout) — NOT held through "Play Again", since a replay
 // re-runs the same atomic debit as any fresh bet and can't double-spend even
 // if another casino game starts in parallel once this hand has settled.
-async function playHigherLower(interaction, bet, userFilter, guildSettings, history, streak, releaseLock) {
+async function playHigherLower(interaction, bet, userFilter, guildSettings, history, streak, releaseLock, onWager) {
     const current = rollCard();
     const canHigh = probabilities(current.value).higher > 0;
     const canLow  = probabilities(current.value).lower  > 0;
@@ -308,7 +305,7 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
                 // Tie: push — refund this round and continue session without changing streak
                 const newHistory = [...history, current];
                 await i.deferUpdate();
-                await playHigherLower(interaction, bet, userFilter, guildSettings, newHistory.slice(-5), streak, releaseLock);
+                await playHigherLower(interaction, bet, userFilter, guildSettings, newHistory.slice(-5), streak, releaseLock, onWager);
                 return;
             }
 
@@ -329,7 +326,7 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
                         .setTimestamp()],
                     components: [playAgainRow(replayId)],
                 });
-                attachReplay(message, replayId, interaction, bet, userFilter, guildSettings);
+                attachReplay(message, replayId, interaction, bet, userFilter, guildSettings, onWager);
                 releaseLock?.();
                 return;
             }
@@ -349,7 +346,7 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
                         .setTimestamp()],
                     components: [playAgainRow(replayId)],
                 });
-                attachReplay(message, replayId, interaction, bet, userFilter, guildSettings);
+                attachReplay(message, replayId, interaction, bet, userFilter, guildSettings, onWager);
                 releaseLock?.();
                 return;
             }
@@ -362,7 +359,7 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
                     embeds:     [lossEmbed(interaction, current, next, pickedHigher, bet, updated?.balance ?? 0)],
                     components: [playAgainRow(replayId)],
                 });
-                attachReplay(message, replayId, interaction, bet, userFilter, guildSettings);
+                attachReplay(message, replayId, interaction, bet, userFilter, guildSettings, onWager);
                 releaseLock?.();
                 return;
             }
@@ -417,12 +414,12 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
                             embeds:     [cashOutEmbed(interaction, bet, rawPayout, updated?.balance ?? 0, newStreak)],
                             components: [playAgainRow(replayId)],
                         });
-                        attachReplay(riskMsg, replayId, interaction, bet, userFilter, guildSettings);
+                        attachReplay(riskMsg, replayId, interaction, bet, userFilter, guildSettings, onWager);
                         releaseLock?.();
                     } else {
                         // Risk another card — recurse without paying out
                         await r.deferUpdate();
-                        await playHigherLower(interaction, bet, userFilter, guildSettings, newHistory.slice(-5), newStreak, releaseLock);
+                        await playHigherLower(interaction, bet, userFilter, guildSettings, newHistory.slice(-5), newStreak, releaseLock, onWager);
                     }
                 } catch (riskErr) {
                     console.error('[HigherLower] risk collect error:', riskErr);
@@ -443,7 +440,7 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
                     embeds:     [cashOutEmbed(interaction, bet, rawPayout, updated?.balance ?? 0, newStreak)],
                     components: [playAgainRow(replayId)],
                 }).catch(() => {});
-                attachReplay(riskMsg, replayId, interaction, bet, userFilter, guildSettings);
+                attachReplay(riskMsg, replayId, interaction, bet, userFilter, guildSettings, onWager);
                 releaseLock?.();
             });
 
@@ -467,18 +464,17 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
     });
 }
 
-function attachReplay(message, replayId, interaction, bet, userFilter, guildSettings) {
+function attachReplay(message, replayId, interaction, bet, userFilter, guildSettings, onWager) {
     message.createMessageComponentCollector({
         filter: ri => ri.user.id === interaction.user.id && ri.customId === replayId,
         max: 1,
         time: 60_000,
     }).on('collect', async ri => {
         try {
-            const newDebited = await User.findOneAndUpdate(
-                { ...userFilter, balance: { $gte: bet } },
-                { $inc: { balance: -bet } },
-                { new: true }
-            );
+            // A replay is a fresh hand paid for with fresh coins, so it reports
+            // its own wager rather than riding on the one that opened the
+            // original — the jackpot and the season mission both count it.
+            const newDebited = await placeWager(userFilter, bet, { onWager });
             if (!newDebited) {
                 const fresh = await User.findOne(userFilter);
                 return ri.update({
@@ -487,7 +483,7 @@ function attachReplay(message, replayId, interaction, bet, userFilter, guildSett
                 });
             }
             await ri.deferUpdate();
-            await playHigherLower(interaction, bet, userFilter, guildSettings, [], 0);
+            await playHigherLower(interaction, bet, userFilter, guildSettings, [], 0, null, onWager);
         } catch (replayErr) {
             console.error('[HigherLower] replay error:', replayErr);
             await interaction.editReply({ content: 'Something went wrong on replay.', embeds: [], components: [] }).catch(() => {});

--- a/src/games/casino/keno.js
+++ b/src/games/casino/keno.js
@@ -6,6 +6,7 @@ const {
     MessageFlags,
 } = require('discord.js');
 const User  = require('../../models/User');
+const { placeWager } = require('../../utils/placeWager');
 const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier, luckySaveEligible } = require('../../services/effectsService');
@@ -83,7 +84,7 @@ function phaseTitle(hits, total) {
 // releaseLock is called once the draw settles into a result — replays/
 // rerolls don't need it re-held since they re-debit atomically like any
 // fresh bet.
-async function playKeno(interaction, bet, picked, alreadyDebited = false, releaseLock) {
+async function playKeno(interaction, bet, picked, alreadyDebited = false, releaseLock, onWager) {
     const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
     let debited = null;
     let settled = false;
@@ -94,11 +95,7 @@ async function playKeno(interaction, bet, picked, alreadyDebited = false, releas
         if (alreadyDebited) {
             debited = await User.findOne(userFilter);
         } else {
-            debited = await User.findOneAndUpdate(
-                { ...userFilter, balance: { $gte: bet } },
-                { $inc: { balance: -bet } },
-                { new: true }
-            );
+            debited = await placeWager(userFilter, bet, { onWager });
 
             if (!debited) {
                 releaseLock?.();
@@ -374,20 +371,18 @@ async function playKeno(interaction, bet, picked, alreadyDebited = false, releas
             time: 60_000,
         }).on('collect', async i => {
             if (i.customId === rerollId) {
-                // Quick reroll at 50% cost with same picks
-                const rerollDebited = await User.findOneAndUpdate(
-                    { ...userFilter, balance: { $gte: rerollCost } },
-                    { $inc: { balance: -rerollCost } },
-                    { new: true }
-                );
+                // Quick reroll at 50% cost with same picks. A discounted draw is
+                // still a fresh draw paid for with fresh coins, so it reports its
+                // own wager — at the reroll price, not the original bet.
+                const rerollDebited = await placeWager(userFilter, rerollCost, { onWager });
                 if (!rerollDebited) {
                     return i.update({ content: `❌ Not enough coins for the quick reroll (need **${rerollCost.toLocaleString()}** coins).`, embeds: [], components: [] });
                 }
                 await i.deferUpdate();
-                await playKeno(interaction, rerollCost, picked, true, null);
+                await playKeno(interaction, rerollCost, picked, true, null, onWager);
             } else {
                 await i.deferUpdate();
-                await playKeno(interaction, bet, picked, false, null);
+                await playKeno(interaction, bet, picked, false, null, onWager);
             }
         }).on('end', (_, reason) => {
             if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
@@ -420,7 +415,7 @@ module.exports = {
                 .setDescription('Your 5 numbers from 1–40, space-separated (e.g. 3 12 21 33 39)')
                 .setRequired(true)),
 
-    async execute(interaction, { releaseLock } = {}) {
+    async execute(interaction, { releaseLock, onWager } = {}) {
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
         if (guildSettings?.economy?.enabled === false || guildSettings?.economy?.gamesEnabled === false) {
             releaseLock?.();
@@ -465,6 +460,6 @@ module.exports = {
         const { shouldProceed: knProceed, alreadyReplied: knReplied } = await confirmBet(interaction, bet, user.balance, 'Keno', guildSettings);
         if (!knProceed) { releaseLock?.(); return; }
         if (!knReplied) await interaction.deferReply();
-        await playKeno(interaction, bet, uniquePicked.sort((a, b) => a - b), false, releaseLock);
+        await playKeno(interaction, bet, uniquePicked.sort((a, b) => a - b), false, releaseLock, onWager);
     },
 };

--- a/src/games/casino/poker.js
+++ b/src/games/casino/poker.js
@@ -6,6 +6,7 @@ const {
     MessageFlags,
 } = require('discord.js');
 const User  = require('../../models/User');
+const { placeWager } = require('../../utils/placeWager');
 const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier, luckySaveEligible } = require('../../services/effectsService');
@@ -154,7 +155,7 @@ function embedAuthor(interaction) {
 // releaseLock is called at every terminal point of a hand (dealer/player
 // fold at any street, showdown, or a timeout refund) — "Play Again" starts
 // a brand-new hand with its own atomic debit, so it isn't passed releaseLock.
-async function playPoker(interaction, bet, releaseLock) {
+async function playPoker(interaction, bet, releaseLock, onWager) {
     const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
     let debited = null;
     let settled = false;
@@ -162,11 +163,7 @@ async function playPoker(interaction, bet, releaseLock) {
     try {
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
 
-        debited = await User.findOneAndUpdate(
-            { ...userFilter, balance: { $gte: bet } },
-            { $inc: { balance: -bet } },
-            { new: true }
-        );
+        debited = await placeWager(userFilter, bet, { onWager });
 
         if (!debited) {
             releaseLock?.();
@@ -290,11 +287,9 @@ async function playPoker(interaction, bet, releaseLock) {
         } else if (preFlopAction === 'call' || preFlopAction === 'raise') {
             // Player calls dealer raise or makes their own raise
             const extraBet = bet;
-            const raised = await User.findOneAndUpdate(
-                { ...userFilter, balance: { $gte: extraBet } },
-                { $inc: { balance: -extraBet } },
-                { new: true }
-            );
+            // More money on a hand already counted — no onWager, or calling a
+            // dealer raise would score as another game played.
+            const raised = await placeWager(userFilter, extraBet);
             if (raised) {
                 debited = raised;
                 playerStake += extraBet;
@@ -419,11 +414,7 @@ async function playPoker(interaction, bet, releaseLock) {
         } else if (flopAction === 'call' || flopAction === 'raise') {
             const raiseAmt = Math.min(bet, debited.balance);
             if (raiseAmt > 0) {
-                const raised = await User.findOneAndUpdate(
-                    { ...userFilter, balance: { $gte: raiseAmt } },
-                    { $inc: { balance: -raiseAmt } },
-                    { new: true }
-                );
+                const raised = await placeWager(userFilter, raiseAmt);
                 if (raised) {
                     debited = raised;
                     playerStake += raiseAmt;
@@ -546,11 +537,7 @@ async function playPoker(interaction, bet, releaseLock) {
         } else if (turnAction === 'call' || turnAction === 'raise') {
             const raiseAmt = Math.min(bet, debited.balance);
             if (raiseAmt > 0) {
-                const raised = await User.findOneAndUpdate(
-                    { ...userFilter, balance: { $gte: raiseAmt } },
-                    { $inc: { balance: -raiseAmt } },
-                    { new: true }
-                );
+                const raised = await placeWager(userFilter, raiseAmt);
                 if (raised) {
                     debited = raised;
                     playerStake += raiseAmt;
@@ -671,11 +658,7 @@ async function playPoker(interaction, bet, releaseLock) {
         } else if (riverAction === 'call' || riverAction === 'raise') {
             const raiseAmt = Math.min(bet, debited.balance);
             if (raiseAmt > 0) {
-                const raised = await User.findOneAndUpdate(
-                    { ...userFilter, balance: { $gte: raiseAmt } },
-                    { $inc: { balance: -raiseAmt } },
-                    { new: true }
-                );
+                const raised = await placeWager(userFilter, raiseAmt);
                 if (raised) {
                     debited = raised;
                     playerStake += raiseAmt;
@@ -780,7 +763,7 @@ async function playPoker(interaction, bet, releaseLock) {
             time: 60_000,
         }).on('collect', async i => {
             await i.deferUpdate();
-            await playPoker(interaction, bet, null);
+            await playPoker(interaction, bet, null, onWager);
         }).on('end', (_, reason) => {
             if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});
         });
@@ -808,7 +791,7 @@ module.exports = {
                 .setMinValue(MIN_BET)
                 .setMaxValue(1_000_000_000)),
 
-    async execute(interaction, { releaseLock } = {}) {
+    async execute(interaction, { releaseLock, onWager } = {}) {
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
         if (guildSettings?.economy?.enabled === false || guildSettings?.economy?.gamesEnabled === false) {
             releaseLock?.();
@@ -835,6 +818,6 @@ module.exports = {
         const { shouldProceed: pkProceed, alreadyReplied: pkReplied } = await confirmBet(interaction, bet, user.balance, 'Poker', guildSettings);
         if (!pkProceed) { releaseLock?.(); return; }
         if (!pkReplied) await interaction.deferReply();
-        await playPoker(interaction, bet, releaseLock);
+        await playPoker(interaction, bet, releaseLock, onWager);
     },
 };

--- a/src/games/casino/roulette.js
+++ b/src/games/casino/roulette.js
@@ -6,6 +6,7 @@ const {
     MessageFlags,
 } = require('discord.js');
 const User  = require('../../models/User');
+const { placeWager } = require('../../utils/placeWager');
 const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, luckySaveEligible } = require('../../services/effectsService');
@@ -144,7 +145,6 @@ module.exports = {
     name: 'roulette',
     description: 'Bet on Red/Black, Odd/Even, dozens, columns, or a specific number.',
     cooldown: 5,
-    betOptionName: 'amount',
     configure: sub => sub
         .addStringOption(opt =>
             opt.setName('bet')
@@ -178,7 +178,7 @@ module.exports = {
                 .setMaxValue(36)
                 .setRequired(false)),
 
-    async execute(interaction, { releaseLock } = {}) {
+    async execute(interaction, { releaseLock, onWager } = {}) {
         if (!interaction.guild) {
             releaseLock?.();
             return interaction.reply({ content: 'This command can only be used in a server.', flags: MessageFlags.Ephemeral });
@@ -207,14 +207,14 @@ module.exports = {
         const { shouldProceed: rProceed, alreadyReplied: rReplied } = await confirmBet(interaction, bet, wallet, 'Roulette', guildSettings);
         if (!rProceed) { releaseLock?.(); return; }
         if (!rReplied) await interaction.deferReply();
-        await playRoulette(interaction, betKey, bet, target, releaseLock);
+        await playRoulette(interaction, betKey, bet, target, releaseLock, onWager);
     },
 };
 
 // releaseLock is called once the spin settles into a result — "Spin Again"
 // starts a brand-new hand with its own atomic debit, so it doesn't need the
 // lock re-held.
-async function playRoulette(interaction, betKey, bet, target, releaseLock) {
+async function playRoulette(interaction, betKey, bet, target, releaseLock, onWager) {
     const userFilter = { userId: interaction.user.id, guildId: interaction.guild.id };
     let debited = null;
     let settled = false;
@@ -232,11 +232,7 @@ async function playRoulette(interaction, betKey, bet, target, releaseLock) {
             { upsert: true, new: true, setDefaultsOnInsert: true },
         );
 
-        debited = await User.findOneAndUpdate(
-            { ...userFilter, balance: { $gte: bet } },
-            { $inc: { balance: -bet } },
-            { new: true },
-        );
+        debited = await placeWager(userFilter, bet, { onWager });
 
         if (!debited) {
             releaseLock?.();
@@ -326,7 +322,7 @@ async function playRoulette(interaction, betKey, bet, target, releaseLock) {
         const wallet = user?.balance ?? 0;
         if (!await confirmBet(interaction, bet, wallet, 'Roulette', guildSettings)) return;
 
-        await playRoulette(interaction, betKey, bet, target, null);
+        await playRoulette(interaction, betKey, bet, target, null, onWager);
         });
         collector.on('end', (_, reason) => {
             if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});

--- a/src/games/casino/roulette.js
+++ b/src/games/casino/roulette.js
@@ -318,11 +318,17 @@ async function playRoulette(interaction, betKey, bet, target, releaseLock, onWag
         });
         collector.on('collect', async i => {
             await i.deferUpdate();
-            const user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
-        const wallet = user?.balance ?? 0;
-        if (!await confirmBet(interaction, bet, wallet, 'Roulette', guildSettings)) return;
+            const user   = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+            const wallet = user?.balance ?? 0;
 
-        await playRoulette(interaction, betKey, bet, target, null, onWager);
+            // confirmBet answers `{ shouldProceed, alreadyReplied }`, which is
+            // always truthy — so testing the object itself never caught a
+            // cancellation, and a player who pressed Cancel on the large-bet
+            // prompt had the replay spun and their coins taken anyway.
+            const { shouldProceed } = await confirmBet(interaction, bet, wallet, 'Roulette', guildSettings);
+            if (!shouldProceed) return;
+
+            await playRoulette(interaction, betKey, bet, target, null, onWager);
         });
         collector.on('end', (_, reason) => {
             if (reason !== 'limit') interaction.editReply({ components: [] }).catch(() => {});

--- a/src/games/casino/roulette.js
+++ b/src/games/casino/roulette.js
@@ -317,17 +317,29 @@ async function playRoulette(interaction, betKey, bet, target, releaseLock, onWag
             time: 60_000,
         });
         collector.on('collect', async i => {
-            await i.deferUpdate();
             const user   = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
             const wallet = user?.balance ?? 0;
 
-            // confirmBet answers `{ shouldProceed, alreadyReplied }`, which is
-            // always truthy — so testing the object itself never caught a
-            // cancellation, and a player who pressed Cancel on the large-bet
-            // prompt had the replay spun and their coins taken anyway.
-            const { shouldProceed } = await confirmBet(interaction, bet, wallet, 'Roulette', guildSettings);
+            // Confirm against the button press, not the original command.
+            // confirmBet prompts with `interaction.reply`, and the original was
+            // deferred and edited several times before this collector was ever
+            // attached — so replaying a bet big enough to need confirming threw
+            // InteractionAlreadyReplied out of the collector callback and the
+            // replay silently did nothing. The button press is unacknowledged
+            // and can carry the prompt.
+            //
+            // It answers `{ shouldProceed, alreadyReplied }`, which is always
+            // truthy — so testing the object itself never caught a cancellation
+            // either, and a player who pressed Cancel had the replay spun and
+            // their coins taken anyway.
+            const { shouldProceed, alreadyReplied } = await confirmBet(i, bet, wallet, 'Roulette', guildSettings);
             if (!shouldProceed) return;
+            // Prompting already acknowledged the press; without one it still
+            // needs acknowledging, or the button sits spinning.
+            if (!alreadyReplied) await i.deferUpdate();
 
+            // The spin still renders on the original command's reply, which is
+            // the message the wheel has been drawn on all along.
             await playRoulette(interaction, betKey, bet, target, null, onWager);
         });
         collector.on('end', (_, reason) => {

--- a/src/games/casino/slots.js
+++ b/src/games/casino/slots.js
@@ -6,6 +6,7 @@ const {
     MessageFlags,
 } = require('discord.js');
 const User = require('../../models/User');
+const { placeWager } = require('../../utils/placeWager');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier, luckySaveEligible } = require('../../services/effectsService');
 const Guild = require('../../models/Guild');
@@ -205,7 +206,7 @@ module.exports = {
                 .setMinValue(10)
                 .setMaxValue(1_000_000_000)
                 .setRequired(true)),
-    async execute(interaction, { releaseLock } = {}) {
+    async execute(interaction, { releaseLock, onWager } = {}) {
         const bet           = interaction.options.getInteger('bet');
         const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
         const casinoMaxBet  = guildSettings?.economy?.casinoMaxBet ?? 0;
@@ -218,14 +219,14 @@ module.exports = {
         const { shouldProceed: slProceed, alreadyReplied: slReplied } = await confirmBet(interaction, bet, wallet, 'Slots', guildSettings);
         if (!slProceed) { releaseLock?.(); return; }
         if (!slReplied) await interaction.deferReply();
-        await playSlots(interaction, bet, releaseLock);
+        await playSlots(interaction, bet, releaseLock, onWager);
     },
 };
 
 // releaseLock is called once the spin settles into a result — "Spin Again"
 // starts a brand-new hand with its own atomic debit, so it doesn't need the
 // lock re-held.
-async function playSlots(interaction, bet, releaseLock) {
+async function playSlots(interaction, bet, releaseLock, onWager) {
     const userFilter  = { userId: interaction.user.id, guildId: interaction.guild.id };
     const guildFilter = { guildId: interaction.guild.id };
     try {
@@ -250,11 +251,7 @@ async function playSlots(interaction, bet, releaseLock) {
         const totalCoinMult    = coinMult * serverMult;
 
         // ── Debit the bet FIRST, before any pool mutations ─────────────────
-        const debited = await User.findOneAndUpdate(
-            { ...userFilter, balance: { $gte: bet } },
-            { $inc: { balance: -bet } },
-            { new: true }
-        );
+        const debited = await placeWager(userFilter, bet, { onWager });
         if (!debited) {
             releaseLock?.();
             const fresh = await User.findOne(userFilter);
@@ -467,7 +464,7 @@ async function playSlots(interaction, bet, releaseLock) {
             }
             collector.stop('replay');
             await i.deferUpdate();
-            await playSlots(interaction, bet, null);
+            await playSlots(interaction, bet, null, onWager);
         });
 
         collector.on('end', (_, reason) => {

--- a/src/models/ActiveLock.js
+++ b/src/models/ActiveLock.js
@@ -14,6 +14,11 @@ const activeLockSchema = new Schema({
     key:       { type: String, required: true, unique: true },
     token:     { type: String, required: true },
     expiresAt: { type: Date,   required: true },
+    // What the lease is being held for ('hunt', 'casino', …), so a user turned
+    // away from one economy command can be told which other one is holding
+    // them up. Optional: a lock with no activity still locks, it just gets
+    // generic wording.
+    activity:  { type: String, default: null },
 });
 
 // A garbage collector, not the expiry mechanism: Mongo's TTL monitor only runs

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -242,6 +242,21 @@ function calculateCritChance(user, traits = []) {
     return Math.min(LIMITS.MAX_CRIT_CHANCE, crit);
 }
 
+/**
+ * Folds the aim phase's grade into a crit chance.
+ *
+ * The aim bonus moves in both directions now: a shot taken inside the window
+ * adds to crit chance, one rushed before the window opened takes a little off.
+ * The old guard was `aimBonus > 0`, which silently discarded any penalty — fine
+ * while an early shot was impossible, wrong now that it is a decision the player
+ * makes. Clamped at both ends, so a hunter with almost no crit chance to lose
+ * cannot be pushed below zero and the cap still holds.
+ */
+function applyAimBonus(critChance, aimBonus = 0) {
+    if (!aimBonus) return critChance;
+    return Math.min(LIMITS.MAX_CRIT_CHANCE, Math.max(0, critChance + aimBonus));
+}
+
 // ─── TROPHY QUALITY ──────────────────────────────────────────────────────────
 
 /**
@@ -884,9 +899,8 @@ function executeHunt(user, zoneId, options = {}) {
     if (success) {
         const rawPayout = randInt(animal.payoutMin, animal.payoutMax);
 
-        // Crit — armored trait negates crits; aim bonus from precision shot boosts crit chance
-        let critChance = calculateCritChance(user, traits);
-        if (options.aimBonus > 0) critChance = Math.min(LIMITS.MAX_CRIT_CHANCE, critChance + options.aimBonus);
+        // Crit — armored trait negates crits; the aim phase moves crit chance.
+        const critChance = applyAimBonus(calculateCritChance(user, traits), options.aimBonus);
         const isCrit         = traits.includes('armored') ? false : Math.random() < critChance;
         const critMultiplier = isCrit ? (1.5 + Math.random() * 1.0) : 1.0;
 
@@ -1297,6 +1311,7 @@ module.exports = {
     msUntilDailyReset,
     calculateSuccessChance,
     calculateCritChance,
+    applyAimBonus,
     rollTier,
     rollAnimal,
     getRarePityThreshold,

--- a/src/utils/activeGameLock.js
+++ b/src/utils/activeGameLock.js
@@ -27,6 +27,11 @@
  * Acquisition returns a lease token; release requires the matching token, so a
  * holder whose lease expired — and whose key was then taken by a newer flow —
  * cannot release the new holder's lock.
+ *
+ * An acquire also records what the lease is being held *for*. One key now
+ * covers every money-moving command a user can run (see utils/economyLock.js),
+ * so "you already have something in progress" is only useful if it can say
+ * which something — `holderActivity` is how the turned-away call finds out.
  */
 
 const ActiveLock = require('../models/ActiveLock');
@@ -55,14 +60,14 @@ function isDuplicateKey(err) {
  * for something that gates money, and if Mongo is unreachable the action it
  * guards has nothing to write to anyway.
  */
-async function tryAcquire(key, ttlMs = DEFAULT_TTL_MS) {
+async function tryAcquire(key, ttlMs = DEFAULT_TTL_MS, activity = null) {
     const now   = Date.now();
     const token = mintToken(now);
 
     try {
         const lock = await ActiveLock.findOneAndUpdate(
             { key, expiresAt: { $lte: new Date(now) } },
-            { $set: { key, token, expiresAt: new Date(now + ttlMs) } },
+            { $set: { key, token, expiresAt: new Date(now + ttlMs), activity } },
             { new: true, upsert: true },
         );
         // Someone else's token coming back would mean a concurrent takeover won.
@@ -70,6 +75,25 @@ async function tryAcquire(key, ttlMs = DEFAULT_TTL_MS) {
     } catch (err) {
         if (isDuplicateKey(err)) return null;
         console.error('[activeGameLock] acquire failed:', err);
+        return null;
+    }
+}
+
+/**
+ * What the live lease on `key` is being held for, or null if nothing holds it,
+ * the holder recorded no activity, or the read failed.
+ *
+ * Only ever used to word a message, so every failure answers null and lets the
+ * caller fall back to generic phrasing — never to decide whether a lock is held,
+ * which is `tryAcquire`'s job and has to stay a single atomic operation.
+ */
+async function holderActivity(key) {
+    try {
+        const lock = await ActiveLock.findOne({ key }).lean();
+        if (!lock || lock.expiresAt <= new Date()) return null;
+        return lock.activity ?? null;
+    } catch (err) {
+        console.error('[activeGameLock] holder lookup failed:', err);
         return null;
     }
 }
@@ -92,4 +116,4 @@ async function release(key, token) {
     }
 }
 
-module.exports = { tryAcquire, release, DEFAULT_TTL_MS };
+module.exports = { tryAcquire, holderActivity, release, DEFAULT_TTL_MS };

--- a/src/utils/economyLock.js
+++ b/src/utils/economyLock.js
@@ -68,6 +68,34 @@ async function busyMessage(key) {
 }
 
 /**
+ * Builds an `only` predicate from an allowlist of subcommands that write nothing.
+ *
+ * A shared key makes exempting reads matter in a way a per-command key did not.
+ * `/hunt profile` has always taken its command's lock, which cost the player
+ * nothing when the only thing it could collide with was another `/hunt`. Now
+ * that one key covers every money-moving command, the same lock would refuse to
+ * show a player their own profile because they have a blackjack hand open — a
+ * lease that runs for as long as they take to play it. Reads have no
+ * read-modify-write to protect, so they should not be waiting on one.
+ *
+ * An allowlist rather than a denylist, so the failure mode is a read that locks
+ * needlessly rather than a write that races. Every entry here has been checked
+ * to persist nothing beyond the idempotent `$setOnInsert` upsert that makes sure
+ * the user document exists.
+ *
+ * Keys are `"sub"` for a bare subcommand and `"group sub"` for one inside a
+ * group.
+ */
+function exceptReadOnly(readOnly) {
+    const exempt = new Set(readOnly);
+    return (interaction) => {
+        const group = interaction.options.getSubcommandGroup?.(false) ?? null;
+        const sub   = interaction.options.getSubcommand?.(false) ?? null;
+        return !exempt.has(group ? `${group} ${sub}` : sub);
+    };
+}
+
+/**
  * Wraps a command's `execute` so it holds the shared economy lock for its whole
  * run and releases it on the way out — including when the body throws, where a
  * leaked lease would lock the player out of every economy command for the TTL
@@ -96,4 +124,4 @@ function withEconomyLock(execute, { activity, ttlMs = GRIND_TTL_MS, only = null 
     };
 }
 
-module.exports = { economyLockKey, busyMessage, withEconomyLock, GRIND_TTL_MS, ACTIVITIES, GENERIC };
+module.exports = { economyLockKey, busyMessage, withEconomyLock, exceptReadOnly, GRIND_TTL_MS, ACTIVITIES, GENERIC };

--- a/src/utils/economyLock.js
+++ b/src/utils/economyLock.js
@@ -1,0 +1,99 @@
+'use strict';
+
+/**
+ * One lock per user, across every command that moves their coins.
+ *
+ * The lock keys used to be namespaced per subsystem — `grind:fish:…`,
+ * `casino:…`, `grind:hunt:…` — which meant they only ever stopped a user
+ * running the *same* command twice. `/fish cast` and `/casino blackjack` from
+ * one user took different keys and ran side by side, over the same user
+ * document, which is exactly the interleaving the remaining read-modify-write
+ * sites lose money to.
+ *
+ * So the key is now the user: `economy:{guildId}:{userId}`. Any two
+ * balance-touching commands from the same player in the same guild contend for
+ * it, and the second one is turned away rather than queued.
+ *
+ * This is mitigation, not a fix. It narrows the window the surviving RMW sites
+ * are exposed through; it does not make them atomic, and it stops helping the
+ * moment a raid, a gift or a rob writes to a *second* user's document, which no
+ * per-user lock covers. The durable answer is still guarded updates at each
+ * write site.
+ *
+ * Because one key now covers many commands, the "already in progress" message
+ * has to name the activity actually holding the lease — being told you are
+ * already fishing when you are mid-blackjack is worse than not being told
+ * anything. `tryAcquire` records the activity and `holderActivity` reads it
+ * back; if the holder released in between, the wording falls back to generic.
+ */
+
+const { MessageFlags } = require('discord.js');
+const { tryAcquire, holderActivity, release } = require('./activeGameLock');
+
+/**
+ * Grind actions resolve within one command invocation, so two minutes is far
+ * more than they need and short enough that a leaked lease is a nuisance rather
+ * than an outage. Casino hands run on in button collectors long after
+ * `execute` returns and keep the primitive's ten-minute default.
+ */
+const GRIND_TTL_MS = 120_000;
+
+/**
+ * The full turned-away message per activity, rather than a noun slotted into a
+ * template: `raid` is held on behalf of *another* player and so cannot be
+ * phrased as something you are doing.
+ */
+const ACTIVITIES = {
+    hunt:    '🏹 You already have a hunting action in progress — finish it before starting another.',
+    mine:    '⛏️ You already have a mining action in progress — finish it before starting another.',
+    fish:    '🎣 You already have a fishing action in progress — finish it before starting another.',
+    explore: '🥾 You already have an exploration in progress — finish it before starting another.',
+    craft:   '🔨 You already have a craft in progress — finish it before starting another.',
+    casino:  '🎰 You already have a casino game in progress — finish it before starting another.',
+    raid:    '⚔️ Someone is raiding your mine right now — try again in a moment.',
+};
+
+const GENERIC = '⏳ You already have an economy action in progress — finish it before starting another.';
+
+function economyLockKey(guildId, userId) {
+    return `economy:${guildId}:${userId}`;
+}
+
+/**
+ * The message for a user turned away from `key`, worded around whatever is
+ * actually holding it.
+ */
+async function busyMessage(key) {
+    return ACTIVITIES[await holderActivity(key)] ?? GENERIC;
+}
+
+/**
+ * Wraps a command's `execute` so it holds the shared economy lock for its whole
+ * run and releases it on the way out — including when the body throws, where a
+ * leaked lease would lock the player out of every economy command for the TTL
+ * over a failure that already cost them the action.
+ *
+ * `only` narrows the wrapper to the subcommands that actually move coins;
+ * without it every subcommand is guarded.
+ */
+function withEconomyLock(execute, { activity, ttlMs = GRIND_TTL_MS, only = null } = {}) {
+    return async function wrappedExecute(interaction, ...rest) {
+        if (only && !only(interaction)) return execute.call(this, interaction, ...rest);
+
+        const lockKey   = economyLockKey(interaction.guild?.id, interaction.user.id);
+        const lockToken = await tryAcquire(lockKey, ttlMs, activity);
+        if (!lockToken) {
+            return interaction.reply({
+                content: await busyMessage(lockKey),
+                flags: MessageFlags.Ephemeral,
+            }).catch(() => {});
+        }
+        try {
+            return await execute.call(this, interaction, ...rest);
+        } finally {
+            await release(lockKey, lockToken);
+        }
+    };
+}
+
+module.exports = { economyLockKey, busyMessage, withEconomyLock, GRIND_TTL_MS, ACTIVITIES, GENERIC };

--- a/src/utils/embedFields.js
+++ b/src/utils/embedFields.js
@@ -80,10 +80,53 @@ function fitDescription(lines, { limit = EMBED_LIMITS.DESCRIPTION, separator = '
     return { text: kept.join(separator), omitted: lines.length - kept.length };
 }
 
+/**
+ * Split lines into groups, each of which joins to no more than `limit`
+ * characters — one group per embed the caller then pages through.
+ *
+ * `fitDescription` is the right answer when the tail genuinely doesn't matter
+ * (the lowest-ranked trophies of a hundred). It is the wrong one for a list the
+ * player *acts on* by position: a weapon dropped off the end can never be
+ * equipped or discarded, because its number is only ever shown by the embed
+ * that just hid it. Those lists get paged instead, so nothing becomes
+ * unreachable by owning too much.
+ *
+ * A single line longer than the limit is truncated into a group of its own
+ * rather than dropped.
+ *
+ * @returns {string[][]} groups of lines, in order; empty input gives [].
+ */
+function chunkByLength(lines, {
+    limit = EMBED_LIMITS.DESCRIPTION,
+    separator = '\n',
+    maxPerChunk = Infinity,
+} = {}) {
+    const chunks = [];
+    let current = [];
+    let length  = 0;
+
+    for (const line of lines) {
+        const piece = truncate(line, limit);
+        const cost  = current.length ? separator.length + piece.length : piece.length;
+
+        if (current.length && (length + cost > limit || current.length >= maxPerChunk)) {
+            chunks.push(current);
+            current = [];
+            length  = 0;
+        }
+
+        length += current.length ? separator.length + piece.length : piece.length;
+        current.push(piece);
+    }
+
+    if (current.length) chunks.push(current);
+    return chunks;
+}
+
 /** Hard-truncate a single string to `limit`, marking the cut with an ellipsis. */
 function truncate(text, limit) {
     if (text.length <= limit) return text;
     return `${text.slice(0, Math.max(0, limit - 1)).trimEnd()}…`;
 }
 
-module.exports = { EMBED_LIMITS, packFields, fitDescription, truncate };
+module.exports = { EMBED_LIMITS, packFields, fitDescription, chunkByLength, truncate };

--- a/src/utils/placeWager.js
+++ b/src/utils/placeWager.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const User = require('../models/User');
+
+/**
+ * Takes a wager off a player — and, for the wager that opens a hand, says so.
+ *
+ * Two things used to be true of casino bets and neither was good.
+ *
+ * The first is that every game wrote its own debit. All eight had the same
+ * compare-and-set — `balance: { $gte: bet }` in the filter, `$inc` in the update,
+ * null means the coins moved and the hand must not start — copied out by hand,
+ * some of them five times over for insurance, splits, raises and rerolls. That
+ * filter *is* the anti-duplication defence, so eight independent copies of it is
+ * eight chances to get it subtly wrong.
+ *
+ * The second is that nothing downstream could tell whether a bet had actually
+ * been placed. `casino.js` took "the player typed a number above zero" as its
+ * signal, and fired the progressive jackpot contribution and the "Play 5 casino
+ * games" season mission on it — before `game.execute` had validated anything. A
+ * bet larger than the wallet, or over the guild's `casinoMaxBet`, or refused for
+ * any other reason still grew the jackpot pool and still ticked the mission, for
+ * a hand that never happened.
+ *
+ * So the debit reports back. `onWager` fires only once the money has actually
+ * moved, and only for the wager that opens a hand: a double-down, an insurance
+ * side bet, a poker raise and a keno reroll all go through the same helper
+ * without it, because they are more money on a hand already counted — not
+ * another game played.
+ *
+ * @param {object} filter          the user's `{ userId, guildId }`
+ * @param {number} amount          coins to take
+ * @param {object} [opts]
+ * @param {object} [opts.extraInc] further `$inc` fields for the same write, so a
+ *                                 stake and its bookkeeping commit together
+ * @param {Function} [opts.onWager] called with `{ amount, user, source }` when
+ *                                 this debit opened a hand and landed
+ * @param {object} [opts.user]     who placed it, if not the command's invoker —
+ *                                 a crash lobby takes bets from joiners too
+ * @param {object} [opts.source]   the interaction to announce a jackpot through
+ * @returns {Promise<object|null>} the updated user document, or null if the
+ *                                 coins were gone by the time the write landed
+ */
+async function placeWager(filter, amount, { extraInc = {}, onWager = null, user = null, source = null } = {}) {
+    const wager = Math.floor(amount);
+    if (!(wager > 0)) return null;
+
+    const debited = await User.findOneAndUpdate(
+        { ...filter, balance: { $gte: wager } },
+        { $inc: { balance: -wager, ...extraInc } },
+        { new: true },
+    );
+
+    // Fire-and-forget by contract: the caller is mid-hand and the jackpot and
+    // mission writes are both best-effort, so a slow round trip must not hold
+    // up dealing the cards.
+    if (debited && onWager) onWager({ amount: wager, user, source });
+
+    return debited;
+}
+
+module.exports = { placeWager };

--- a/tests/activeGameLockWrappers.test.js
+++ b/tests/activeGameLockWrappers.test.js
@@ -137,14 +137,19 @@ beforeEach(() => {
 // per-command regression, not a shared-helper one, and only a per-command test
 // catches it.
 
+// One key for all four — that is the property under test now, not an incidental
+// duplication in the table.
+const KEY = 'economy:g1:u1';
+
 const GRIND = [
-    { name: 'hunt',    sub: 'start', busy: /hunting action in progress/,     key: 'grind:hunt:g1:u1' },
-    { name: 'mine',    sub: 'dig',   busy: /mining action in progress/,      key: 'grind:mine:g1:u1' },
-    { name: 'fish',    sub: 'cast',  busy: /fishing action in progress/,     key: 'grind:fish:g1:u1' },
-    { name: 'explore', sub: 'go',    busy: /exploration action in progress/, key: 'grind:explore:g1:u1' },
+    { name: 'hunt',    sub: 'start', busy: /hunting action in progress/ },
+    { name: 'mine',    sub: 'dig',   busy: /mining action in progress/ },
+    { name: 'fish',    sub: 'cast',  busy: /fishing action in progress/ },
+    { name: 'explore', sub: 'go',    busy: /exploration in progress/ },
 ];
 
-describe.each(GRIND)('/$name — the lock wrapper around execute', ({ name, sub, busy, key }) => {
+describe.each(GRIND)('/$name — the lock wrapper around execute', ({ name, sub, busy }) => {
+    const key = KEY;
     const command = require(`../src/commands/economy/${name}`);
     const interactionFor = overrides => makeInteraction({ sub, ...overrides });
 
@@ -259,7 +264,6 @@ describe.each(GRIND)('/$name — the lock wrapper around execute', ({ name, sub,
 
 describe('/casino — the lock around a game that outlives execute()', () => {
     const casino = require('../src/commands/economy/casino');
-    const KEY = 'casino:g1:u1';
     const BUSY = /casino game in progress/;
 
     const interactionFor = overrides => makeInteraction({ sub: 'slots', ...overrides });
@@ -351,5 +355,84 @@ describe('/casino — the lock around a game that outlives execute()', () => {
         // Turned away by the still-held lease rather than allowed to start a
         // second hand: the game ran once in total, for the first call.
         expect(slots.execute).toHaveBeenCalledTimes(1);
+    });
+});
+
+// ── One lock, every command ──────────────────────────────────────────────────
+//
+// The keys used to be namespaced per subsystem, so `/fish` and `/casino
+// blackjack` from one user took different leases and ran side by side over the
+// same user document — the interleaving the surviving read-modify-write sites
+// lose coins to. The whole point of the shared `economy:{guild}:{user}` key is
+// that these two contend, so a per-command test cannot see it: only a test that
+// runs *two different commands* can.
+//
+// The second property is the message. One key means the command that turns you
+// away is not the one holding the lease, so "you already have a fishing action
+// in progress" has to come from what is actually running, not from whichever
+// command you happened to type.
+
+describe('one economy lock across every money-moving command', () => {
+    const fish   = require('../src/commands/economy/fish');
+    const casino = require('../src/commands/economy/casino');
+    const KEY    = 'economy:g1:u1';
+
+    test('a cast in progress turns away a casino game, and says so', async () => {
+        const parked = gate();
+        Guild.findOne.mockReturnValueOnce(parked.promise);  // parks /fish inside its body
+        Guild.findOne.mockResolvedValue({});                // /casino reads its settings and falls through
+
+        const casting = fish.execute(makeInteraction({ sub: 'cast' }));
+        await until(() => Guild.findOne.mock.calls.length === 1, '/fish to reach its first read');
+
+        const blocked = makeInteraction({ sub: 'slots' });
+        await casino.execute(blocked);
+
+        expect(replyContent(blocked)).toMatch(/fishing action in progress/);
+        expect(slots.execute).not.toHaveBeenCalled();
+
+        parked.resolve(ECONOMY_OFF);
+        await casting;
+    });
+
+    test('a hand in progress turns away a cast, and says so', async () => {
+        Guild.findOne.mockResolvedValue({});
+        // A game that returns without releasing is a hand still being played in
+        // collectors — the lease is held for real, not leaked.
+        slots.execute.mockResolvedValueOnce(undefined);
+        await casino.execute(makeInteraction({ sub: 'slots' }));
+
+        const blocked = makeInteraction({ sub: 'cast' });
+        await fish.execute(blocked);
+
+        expect(replyContent(blocked)).toMatch(/casino game in progress/);
+        // Turned away before the body: /fish never got as far as its first read.
+        expect(Guild.findOne).toHaveBeenCalledTimes(1);
+    });
+
+    test('the lease is still per user — one player mid-hand does not stop another fishing', async () => {
+        Guild.findOne.mockResolvedValue({});
+        slots.execute.mockResolvedValueOnce(undefined);
+        await casino.execute(makeInteraction({ sub: 'slots', userId: 'u1' }));
+
+        Guild.findOne.mockResolvedValue(ECONOMY_OFF);
+        const other = makeInteraction({ sub: 'cast', userId: 'u2' });
+        await fish.execute(other);
+
+        expect(replyContent(other)).not.toMatch(/in progress/);
+    });
+
+    test('a lease with no recorded activity still blocks, with generic wording', async () => {
+        // Locks taken before this field existed, and any future caller that
+        // forgets to pass one: the message degrades, the lock does not.
+        const token = await tryAcquire(KEY, 60_000);
+        expect(token).toBeTruthy();
+
+        Guild.findOne.mockResolvedValue(ECONOMY_OFF);
+        const blocked = makeInteraction({ sub: 'cast' });
+        await fish.execute(blocked);
+
+        expect(replyContent(blocked)).toMatch(/economy action in progress/);
+        await release(KEY, token);
     });
 });

--- a/tests/activeGameLockWrappers.test.js
+++ b/tests/activeGameLockWrappers.test.js
@@ -142,14 +142,22 @@ beforeEach(() => {
 const KEY = 'economy:g1:u1';
 
 const GRIND = [
-    { name: 'hunt',    sub: 'start', busy: /hunting action in progress/ },
-    { name: 'mine',    sub: 'dig',   busy: /mining action in progress/ },
-    { name: 'fish',    sub: 'cast',  busy: /fishing action in progress/ },
-    { name: 'explore', sub: 'go',    busy: /exploration in progress/ },
+    // `read` is a subcommand from that command's read-only allowlist. hunt and
+    // fish use a grouped one, which also exercises the "group sub" key form.
+    { name: 'hunt',    sub: 'start', busy: /hunting action in progress/, read: { group: 'shop', sub: 'list' } },
+    { name: 'mine',    sub: 'dig',   busy: /mining action in progress/,  read: { sub: 'map' } },
+    { name: 'fish',    sub: 'cast',  busy: /fishing action in progress/, read: { group: 'shop', sub: 'list' } },
+    { name: 'explore', sub: 'go',    busy: /exploration in progress/,    read: { sub: 'journal' } },
 ];
 
-describe.each(GRIND)('/$name — the lock wrapper around execute', ({ name, sub, busy }) => {
+describe.each(GRIND)('/$name — the lock wrapper around execute', ({ name, sub, busy, read }) => {
     const key = KEY;
+    /** An interaction for a read-only subcommand, grouped or not. */
+    const readInteraction = ({ group = null, sub: readSub }) => {
+        const interaction = makeInteraction({ sub: readSub });
+        interaction.options.getSubcommandGroup = () => group;
+        return interaction;
+    };
     const command = require(`../src/commands/economy/${name}`);
     const interactionFor = overrides => makeInteraction({ sub, ...overrides });
 
@@ -233,6 +241,42 @@ describe.each(GRIND)('/$name — the lock wrapper around execute', ({ name, sub,
         await both;
 
         expect(replyContent(theirs)).not.toMatch(busy);
+    });
+
+    test('a read-only subcommand takes no lease at all', async () => {
+        // These write nothing, so they have no read-modify-write to protect —
+        // and one shared key means a lock here would refuse to show a player
+        // their own profile because they have a casino hand open.
+        await command.execute(readInteraction(read));
+
+        // Free, and takeable exactly once — so it was never taken, rather than
+        // taken and released.
+        const token = await tryAcquire(key);
+        expect(token).toBeTruthy();
+        await release(key, token);
+    });
+
+    test('a read-only subcommand runs while a lease is held', async () => {
+        // The property as the player meets it: mid-hand, they can still look.
+        const held = await tryAcquire(key, 60_000, 'casino');
+        expect(held).toBeTruthy();
+
+        const looking = readInteraction(read);
+        await command.execute(looking);
+
+        expect(replyContent(looking)).not.toMatch(/in progress/);
+        await release(key, held);
+    });
+
+    test('a mutating subcommand still waits on that same lease', async () => {
+        // The other half: exempting reads must not have exempted the action.
+        const held = await tryAcquire(key, 60_000, 'casino');
+
+        const acting = makeInteraction({ sub });
+        await command.execute(acting);
+
+        expect(replyContent(acting)).toMatch(/casino game in progress/);
+        await release(key, held);
     });
 
     test('the lock is per guild, not global', async () => {
@@ -434,5 +478,36 @@ describe('one economy lock across every money-moving command', () => {
 
         expect(replyContent(blocked)).toMatch(/economy action in progress/);
         await release(KEY, token);
+    });
+});
+
+describe('exceptReadOnly', () => {
+    const { exceptReadOnly } = require('../src/utils/economyLock');
+
+    /** The two shapes discord.js reports: a bare subcommand, and one in a group. */
+    const at = (group, sub) => ({
+        options: { getSubcommandGroup: () => group, getSubcommand: () => sub },
+    });
+
+    const only = exceptReadOnly(['profile', 'shop list']);
+
+    test('exempts a bare subcommand on the list', () => {
+        expect(only(at(null, 'profile'))).toBe(false);
+    });
+
+    test('exempts a grouped subcommand on the list', () => {
+        expect(only(at('shop', 'list'))).toBe(false);
+    });
+
+    test('locks anything not on it — an allowlist, so the miss is a needless lock', () => {
+        expect(only(at(null, 'start'))).toBe(true);
+        expect(only(at('shop', 'weapon'))).toBe(true);
+        expect(only(at('inv', 'discard'))).toBe(true);
+    });
+
+    test('does not confuse a grouped subcommand with a bare one of the same name', () => {
+        // `list` is read-only under `shop` and says nothing about `zone list`.
+        expect(only(at(null, 'list'))).toBe(true);
+        expect(only(at('zone', 'list'))).toBe(true);
     });
 });

--- a/tests/casinoBetGuard.test.js
+++ b/tests/casinoBetGuard.test.js
@@ -290,3 +290,46 @@ describe('a stake that is available is taken exactly once', () => {
         expect(debits).toEqual([{ $inc: { balance: -BET } }]);
     });
 });
+
+// ── The confirmation has to be able to say no ────────────────────────────────
+//
+// confirmBet answers `{ shouldProceed, alreadyReplied }`. An object is always
+// truthy, so testing the call itself — `if (!await confirmBet(...)) return;` —
+// reads like a cancellation check and is one that can never fire. Roulette's
+// replay path did exactly that: a player who pressed Cancel on the large-bet
+// prompt had the wheel spun and their coins taken anyway.
+//
+// One site is a bug; the shape is a trap, because the wrong version looks right.
+// So this checks every caller rather than the one that got it wrong.
+
+describe('every confirmBet caller reads shouldProceed', () => {
+    const fs   = require('fs');
+    const path = require('path');
+
+    const ROOTS = ['src/games/casino', 'src/commands/economy'];
+    const CALL  = /\bconfirmBet\s*\(/;
+
+    function jsFilesUnder(dir) {
+        return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+            const full = path.join(dir, entry.name);
+            if (entry.isDirectory()) return jsFilesUnder(full);
+            return entry.name.endsWith('.js') ? [full] : [];
+        });
+    }
+
+    test('no call site relies on the return value being truthy', () => {
+        const offenders = [];
+
+        for (const root of ROOTS) {
+            for (const file of jsFilesUnder(path.join(__dirname, '..', root))) {
+                fs.readFileSync(file, 'utf8').split('\n').forEach((line, i) => {
+                    if (CALL.test(line) && !line.includes('shouldProceed')) {
+                        offenders.push(`${root}/${path.basename(file)}:${i + 1} — ${line.trim()}`);
+                    }
+                });
+            }
+        }
+
+        expect(offenders).toEqual([]);
+    });
+});

--- a/tests/casinoBetGuard.test.js
+++ b/tests/casinoBetGuard.test.js
@@ -37,24 +37,9 @@ jest.mock('../src/utils/crashLobby', () => {
 
 const User  = require('../src/models/User');
 const Guild = require('../src/models/Guild');
-
-const GUILD_ID   = 'guild-1';
-const USER_ID    = 'user-1';
-const CHANNEL_ID = 'channel-1';
-const BET        = 100;
-// Comfortably above the bet: every game reads this first and decides the player
-// can afford the hand. That stale "yes" is the premise of the race.
-const WALLET     = 10_000;
-
-/** The stale read every game starts from. */
-const walletDoc = () => ({
-    userId: USER_ID,
-    guildId: GUILD_ID,
-    balance: WALLET,
-    activeEffects: [],
-    casinoStats: {},
-    save: jest.fn().mockResolvedValue(undefined),
-});
+const {
+    GUILD_ID, USER_ID, CHANNEL_ID, BET, WALLET, walletDoc, makeInteraction, GAMES, stakeFor,
+} = require('./helpers/casinoInteraction');
 
 /** True for the compare-and-set that takes a stake. */
 const isGuardedDebit = filter => filter?.balance?.$gte !== undefined;
@@ -65,59 +50,9 @@ function credits(update) {
     return typeof inc === 'number' && inc > 0;
 }
 
-function makeInteraction(options) {
-    const replies = [];
-    const record = payload => { replies.push(payload); return Promise.resolve(payload); };
-
-    const message = {
-        createMessageComponentCollector: () => ({ on() { return this; }, stop() {} }),
-        // Nobody presses anything in these tests. A rejection is what discord.js
-        // hands back when the window closes, and the games all treat it as "no
-        // response"; a promise that never settles would just hang them.
-        awaitMessageComponent: () => Promise.reject(new Error('no response')),
-        edit: record,
-    };
-
-    return {
-        replies,
-        id: 'interaction-1',
-        // discord.js validates author icons as real URLs, so this has to look like one.
-        user:    { id: USER_ID, username: 'player', displayAvatarURL: () => 'https://cdn.discordapp.com/avatar.png' },
-        member:  { displayName: 'player' },
-        guild:   { id: GUILD_ID, name: 'Guild' },
-        channel: { id: CHANNEL_ID, send: record },
-        client:  { users: { fetch: () => Promise.resolve(null) } },
-        options: {
-            getInteger: name => options[name] ?? null,
-            getString:  name => options[name] ?? null,
-            getNumber:  name => options[name] ?? null,
-        },
-        deferReply:  jest.fn().mockResolvedValue(undefined),
-        reply:       jest.fn(record),
-        editReply:   jest.fn(record),
-        followUp:    jest.fn(record),
-        fetchReply:  jest.fn().mockResolvedValue(message),
-    };
-}
-
 // Loaded once: `jest.mock` replaces the models for every module in this file, so
 // the games see the same mocks the assertions read.
 const load = name => require(`../src/games/casino/${name}`);
-
-// Every game's opening bet, with whatever options it reads to get there.
-const GAMES = [
-    { name: 'blackjack',   options: { bet: BET } },
-    { name: 'crash',       options: { bet: BET, auto_cashout: null } },
-    { name: 'cupgame',     options: { bet: BET } },
-    { name: 'higherlower', options: { bet: BET } },
-    { name: 'keno',        options: { bet: BET, numbers: '3 12 21 33 39' } },
-    { name: 'poker',       options: { bet: BET } },
-    { name: 'roulette',    options: { bet: 'red', amount: BET, number: null } },
-    { name: 'slots',       options: { bet: BET } },
-];
-
-/** The wager each game's guard must cover — roulette takes its amount elsewhere. */
-const stakeFor = game => (game.name === 'roulette' ? game.options.amount : game.options.bet);
 
 describe.each(GAMES)('/$name — the stake is taken with a compare-and-set', (game) => {
     const stake = stakeFor(game);

--- a/tests/casinoWagerSignal.test.js
+++ b/tests/casinoWagerSignal.test.js
@@ -49,6 +49,12 @@ jest.mock('../src/services/casinoJackpotService', () => ({
 jest.mock('../src/services/seasonMissionService', () => ({
     advanceMissions: jest.fn().mockResolvedValue([]),
 }));
+// The real lobby store, with the seat claim observable so a lobby that fills
+// between the debit and the claim can be forced.
+jest.mock('../src/utils/crashLobby', () => {
+    const actual = jest.requireActual('../src/utils/crashLobby');
+    return { ...actual, addPlayer: jest.fn(actual.addPlayer) };
+});
 
 const User  = require('../src/models/User');
 const Guild = require('../src/models/Guild');
@@ -252,5 +258,127 @@ describe.each(GAMES)('/$name reports the wager that opens a hand', (game) => {
         errorSpy.mockRestore();
         jest.dontMock('../src/utils/placeWager');
         jest.resetModules();
+    });
+});
+
+describe('/crash — a joiner is counted only once the seat is theirs', () => {
+    // The debit is not the last thing that can fail on a join: the seat is
+    // claimed after it, and a lobby that filled in between refunds the stake.
+    // Reporting the wager from inside the debit contributed to the jackpot and
+    // ticked the mission for a bet that was handed straight back — the same
+    // "counted a hand that never happened" the signal exists to stop.
+    const { deleteLobby, addPlayer } = require('../src/utils/crashLobby');
+    const { CHANNEL_ID } = require('./helpers/casinoInteraction');
+    const crash = require('../src/games/casino/crash');
+
+    let errorSpy;
+
+    /** An interaction whose editReply hands back a message that keeps its collectors. */
+    function hostInteraction() {
+        const interaction = makeInteraction({ bet: BET, auto_cashout: null });
+        const handlers = {};
+        const message = {
+            createMessageComponentCollector: () => ({
+                on(event, fn) { handlers[event] = fn; return this; },
+                stop() {},
+            }),
+        };
+        const record = interaction.editReply;
+        interaction.editReply = jest.fn(payload => { record(payload); return Promise.resolve(message); });
+        interaction.client = { users: { fetch: async () => ({ username: 'joiner' }) } };
+        interaction.handlers = handlers;
+        return interaction;
+    }
+
+    /** The button press of a second player hitting Join. */
+    const joinPress = () => ({
+        user:  { id: 'user-2', username: 'joiner' },
+        customId: 'crash_join_channel-1_0',
+        reply: jest.fn().mockResolvedValue(undefined),
+        deferUpdate: jest.fn().mockResolvedValue(undefined),
+    });
+
+    /** Opens a lobby and returns the join collector's collect handler. */
+    async function openLobby(onWager) {
+        Guild.findOne.mockReturnValue(Object.assign(
+            Promise.resolve({ guildId: GUILD_ID, economy: { enabled: true, gamesEnabled: true } }),
+            { lean: () => ({ catch: () => Promise.resolve(null) }) },
+        ));
+        User.findOne.mockResolvedValue(walletDoc());
+        User.findOneAndUpdate.mockResolvedValue(walletDoc());
+        User.updateOne.mockResolvedValue({});
+
+        const interaction = hostInteraction();
+        await crash.execute(interaction, { releaseLock: jest.fn(), onWager });
+        // The host's own stake is reported and their own seat claimed on the
+        // way in; this suite is about the joiner's, so start counting here.
+        onWager.mockClear();
+        addPlayer.mockClear();
+        return { collect: interaction.handlers.collect, interaction };
+    }
+
+    beforeEach(() => {
+        // openLobby arms a 30s join-window timeout that nothing in this test
+        // path ever fires; faked, it is never a real handle to leak.
+        jest.useFakeTimers({ doNotFake: ['queueMicrotask', 'nextTick'] });
+        jest.clearAllMocks();
+        errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        deleteLobby(CHANNEL_ID);
+    });
+
+    afterEach(() => {
+        deleteLobby(CHANNEL_ID);
+        errorSpy.mockRestore();
+        jest.useRealTimers();
+    });
+
+    test('a joiner who gets a seat is reported, and reported as themselves', async () => {
+        const onWager = jest.fn();
+        const { collect } = await openLobby(onWager);
+
+        await collect(joinPress());
+
+        expect(onWager).toHaveBeenCalledTimes(1);
+        expect(onWager).toHaveBeenCalledWith(expect.objectContaining({
+            amount: BET,
+            user: expect.objectContaining({ id: 'user-2' }),
+        }));
+    });
+
+    test('a joiner whose seat is gone is refunded and never counted', async () => {
+        const onWager = jest.fn();
+        const { collect } = await openLobby(onWager);
+
+        // The lobby filled between the debit landing and the seat being claimed.
+        // Once, so the real implementation survives for the next test.
+        addPlayer.mockImplementationOnce(() => false);
+        const press = joinPress();
+        await collect(press);
+
+        expect(onWager).not.toHaveBeenCalled();
+        // The stake really did come back, so counting it would have been
+        // counting a bet nobody ended up making.
+        expect(User.findOneAndUpdate).toHaveBeenCalledWith(
+            { userId: 'user-2', guildId: GUILD_ID },
+            { $inc: { balance: BET, pendingCrashRefund: -BET } },
+        );
+        expect(press.reply).toHaveBeenCalledWith(expect.objectContaining({
+            content: expect.stringMatching(/refunded/i),
+        }));
+    });
+
+    test('a joiner who cannot cover the bet is neither seated nor counted', async () => {
+        const onWager = jest.fn();
+        const { collect } = await openLobby(onWager);
+
+        User.findOneAndUpdate.mockResolvedValue(null); // guarded debit misses
+        const press = joinPress();
+        await collect(press);
+
+        expect(onWager).not.toHaveBeenCalled();
+        expect(addPlayer).not.toHaveBeenCalled();
+        expect(press.reply).toHaveBeenCalledWith(expect.objectContaining({
+            content: expect.stringMatching(/coins to join/i),
+        }));
     });
 });

--- a/tests/casinoWagerSignal.test.js
+++ b/tests/casinoWagerSignal.test.js
@@ -1,0 +1,256 @@
+'use strict';
+
+/**
+ * What counts as "a bet was placed", and who is told.
+ *
+ * `casino.js` used to answer that question by reading the bet straight off the
+ * command options:
+ *
+ *     const bet = interaction.options.getInteger(...) ?? 0;
+ *     if (bet > 0) { processJackpotBet(...); advanceMissions(..., 'casino', 1); }
+ *     return await game.execute(interaction, { releaseLock });
+ *
+ * Both calls fired *before* the game validated anything. A bet larger than the
+ * wallet, or over the guild's casinoMaxBet, or refused for any other game-level
+ * reason still contributed to the progressive jackpot pool and still ticked
+ * "Play 5 casino games" — for a hand that never happened.
+ *
+ * The fix is a signal the games raise once their debit actually lands. Three
+ * things have to hold for it to be worth anything, and each is a separate
+ * describe below:
+ *
+ *   1. utils/placeWager only raises it when the coins moved.
+ *   2. casino.js does nothing until it is raised, and then does both.
+ *   3. All eight games actually raise it for the wager that opens a hand — and
+ *      only for that one, so a double-down is not a second game played.
+ */
+
+jest.mock('../src/models/User', () => ({
+    findOne:          jest.fn(),
+    findOneAndUpdate: jest.fn(),
+    updateOne:        jest.fn(),
+    create:           jest.fn(),
+}));
+jest.mock('../src/models/Guild', () => ({
+    findOne:          jest.fn(),
+    findOneAndUpdate: jest.fn(),
+    updateOne:        jest.fn(),
+}));
+// /casino takes the shared economy lock before it dispatches; without this the
+// query buffers against a connection that never arrives and no game ever runs.
+jest.mock('../src/models/ActiveLock', () => require('./helpers/fakeActiveLock'));
+// casino.js destructures both of these at require time, so they have to be
+// replaced in the registry — a spy installed afterwards would not be the
+// function it calls.
+jest.mock('../src/services/casinoJackpotService', () => ({
+    processJackpotBet: jest.fn().mockResolvedValue({ triggered: false }),
+    getJackpotDisplay: jest.fn().mockResolvedValue({ pool: 0, hot: false, display: '0' }),
+}));
+jest.mock('../src/services/seasonMissionService', () => ({
+    advanceMissions: jest.fn().mockResolvedValue([]),
+}));
+
+const User  = require('../src/models/User');
+const Guild = require('../src/models/Guild');
+const { GUILD_ID, USER_ID, BET, walletDoc, makeInteraction, GAMES, stakeFor } = require('./helpers/casinoInteraction');
+
+const { placeWager } = require('../src/utils/placeWager');
+
+describe('placeWager — the debit is the signal', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    const filter = { userId: USER_ID, guildId: GUILD_ID };
+
+    test('takes the stake with the same compare-and-set the games hand-wrote', () => {
+        User.findOneAndUpdate.mockResolvedValue(walletDoc());
+        return placeWager(filter, BET).then(() => {
+            expect(User.findOneAndUpdate).toHaveBeenCalledWith(
+                { userId: USER_ID, guildId: GUILD_ID, balance: { $gte: BET } },
+                { $inc: { balance: -BET } },
+                { new: true },
+            );
+        });
+    });
+
+    test('commits a stake and its bookkeeping in one write', async () => {
+        User.findOneAndUpdate.mockResolvedValue(walletDoc());
+        await placeWager(filter, BET, { extraInc: { lifetimeGambled: BET } });
+
+        const [, update] = User.findOneAndUpdate.mock.calls[0];
+        expect(update).toEqual({ $inc: { balance: -BET, lifetimeGambled: BET } });
+    });
+
+    test('reports the wager once the coins have moved', async () => {
+        User.findOneAndUpdate.mockResolvedValue(walletDoc());
+        const onWager = jest.fn();
+
+        await placeWager(filter, BET, { onWager });
+
+        expect(onWager).toHaveBeenCalledTimes(1);
+        expect(onWager).toHaveBeenCalledWith({ amount: BET, user: null, source: null });
+    });
+
+    test('says nothing when the guard misses — the whole point', async () => {
+        // The player spent the coins between the pre-check and the write. No
+        // hand starts, so nothing may be told one did.
+        User.findOneAndUpdate.mockResolvedValue(null);
+        const onWager = jest.fn();
+
+        await expect(placeWager(filter, BET, { onWager })).resolves.toBeNull();
+        expect(onWager).not.toHaveBeenCalled();
+    });
+
+    test('carries the better and their interaction, for bets placed on someone else’s command', async () => {
+        // A crash lobby takes stakes from joiners: the jackpot has to be
+        // credited to whoever actually bet, not to the host who opened it.
+        User.findOneAndUpdate.mockResolvedValue(walletDoc());
+        const onWager = jest.fn();
+        const joiner  = { id: 'user-2', username: 'joiner' };
+        const source  = { id: 'button-1' };
+
+        await placeWager({ userId: joiner.id, guildId: GUILD_ID }, BET, { onWager, user: joiner, source });
+
+        expect(onWager).toHaveBeenCalledWith({ amount: BET, user: joiner, source });
+    });
+
+    test('refuses a non-positive stake without touching the database', async () => {
+        const onWager = jest.fn();
+
+        await expect(placeWager(filter, 0, { onWager })).resolves.toBeNull();
+        await expect(placeWager(filter, -50, { onWager })).resolves.toBeNull();
+
+        expect(User.findOneAndUpdate).not.toHaveBeenCalled();
+        expect(onWager).not.toHaveBeenCalled();
+    });
+});
+
+describe('/casino — the jackpot and the mission wait for the signal', () => {
+    const jackpot  = require('../src/services/casinoJackpotService');
+    const missions = require('../src/services/seasonMissionService');
+    const slots    = require('../src/games/casino/slots');
+    const casino   = require('../src/commands/economy/casino');
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        require('./helpers/fakeActiveLock').__locks.clear();
+        Guild.findOne.mockResolvedValue({ guildId: GUILD_ID, economy: {} });
+        jackpot.processJackpotBet.mockResolvedValue({ triggered: false });
+        missions.advanceMissions.mockResolvedValue([]);
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    /** Runs /casino slots with a game stubbed to behave as `play` describes. */
+    async function playSlots(play) {
+        jest.spyOn(slots, 'execute').mockImplementation(play);
+        const interaction = makeInteraction({ bet: BET });
+        interaction.options.getSubcommand = () => 'slots';
+        interaction.memberPermissions     = { has: () => true };
+        await casino.execute(interaction);
+        return interaction;
+    }
+
+    test('a hand that never gets a bet down contributes nothing and scores nothing', async () => {
+        // The bug, stated as a test: the player asked to bet, the game refused,
+        // and under the old code the jackpot pool and the season mission had
+        // both already moved.
+        await playSlots(async (interaction, { releaseLock }) => { releaseLock(); });
+
+        expect(jackpot.processJackpotBet).not.toHaveBeenCalled();
+        expect(missions.advanceMissions).not.toHaveBeenCalled();
+    });
+
+    test('a bet that lands contributes and scores, once', async () => {
+        await playSlots(async (interaction, { onWager }) => { onWager({ amount: BET }); });
+
+        expect(jackpot.processJackpotBet).toHaveBeenCalledTimes(1);
+        expect(jackpot.processJackpotBet).toHaveBeenCalledWith(expect.objectContaining({
+            guildId: GUILD_ID, userId: USER_ID, bet: BET,
+        }));
+        expect(missions.advanceMissions).toHaveBeenCalledTimes(1);
+        expect(missions.advanceMissions).toHaveBeenCalledWith(
+            expect.anything(), { userId: USER_ID, guildId: GUILD_ID }, 'casino', 1, expect.anything(),
+        );
+    });
+
+    test('the contribution is the stake that was actually taken', async () => {
+        // A reroll or a discounted replay reports its own price, not the number
+        // the player originally typed.
+        await playSlots(async (interaction, { onWager }) => { onWager({ amount: 37 }); });
+
+        expect(jackpot.processJackpotBet).toHaveBeenCalledWith(expect.objectContaining({ bet: 37 }));
+    });
+
+    test('a second hand on the same command reports again', async () => {
+        // "Play Again" re-debits, so it is another game played.
+        await playSlots(async (interaction, { onWager }) => {
+            onWager({ amount: BET });
+            onWager({ amount: BET });
+        });
+
+        expect(missions.advanceMissions).toHaveBeenCalledTimes(2);
+    });
+
+    test('a wager placed by someone other than the invoker is credited to them', async () => {
+        const joiner = { id: 'user-2', username: 'joiner' };
+        const source = { id: 'button-1' };
+
+        await playSlots(async (interaction, { onWager }) => { onWager({ amount: BET, user: joiner, source }); });
+
+        expect(jackpot.processJackpotBet).toHaveBeenCalledWith(expect.objectContaining({
+            userId: 'user-2', username: 'joiner', interaction: source,
+        }));
+        expect(missions.advanceMissions).toHaveBeenCalledWith(
+            expect.anything(), { userId: 'user-2', guildId: GUILD_ID }, 'casino', 1, expect.anything(),
+        );
+    });
+});
+
+describe.each(GAMES)('/$name reports the wager that opens a hand', (game) => {
+    // placeWager is stubbed to refuse, which aborts each game the same way the
+    // bet-guard suite does — the call itself is what is being inspected, and a
+    // refusal keeps eight full games from playing themselves out in a unit test.
+    //
+    // Every module is loaded fresh inside the test: the games destructure
+    // `placeWager` at require time, so a stub installed after they were first
+    // loaded would never be the function they call. Resetting the registry also
+    // hands back new model mocks, which is why those are configured here rather
+    // than from the file-level bindings.
+    const stake = stakeFor(game);
+
+    test('the opening stake is taken through the shared helper, carrying the signal', async () => {
+        jest.resetModules();
+        jest.doMock('../src/utils/placeWager', () => ({ placeWager: jest.fn().mockResolvedValue(null) }));
+
+        const errorSpy   = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const freshUser  = require('../src/models/User');
+        const freshGuild = require('../src/models/Guild');
+        const { placeWager: placeWagerMock } = require('../src/utils/placeWager');
+
+        freshGuild.findOne.mockReturnValue(Object.assign(
+            Promise.resolve({ guildId: GUILD_ID, economy: { enabled: true, gamesEnabled: true } }),
+            { lean: () => ({ catch: () => Promise.resolve(null) }) },
+        ));
+        freshGuild.findOneAndUpdate.mockResolvedValue(null);
+        freshGuild.updateOne.mockResolvedValue({});
+        freshUser.findOne.mockResolvedValue(walletDoc());
+        freshUser.create.mockResolvedValue(walletDoc());
+        freshUser.updateOne.mockResolvedValue({});
+        freshUser.findOneAndUpdate.mockResolvedValue(walletDoc());
+
+        const onWager = jest.fn();
+        await require(`../src/games/casino/${game.name}`)
+            .execute(makeInteraction(game.options), { releaseLock: jest.fn(), onWager });
+
+        const opening = placeWagerMock.mock.calls.find(([, amount]) => amount === stake);
+        expect(opening).toBeDefined();
+        expect(opening[0]).toMatchObject({ userId: USER_ID, guildId: GUILD_ID });
+        // A game that forgot to thread it through would still debit correctly
+        // and still never be counted — which is the failure this pins.
+        expect(opening[2]).toEqual(expect.objectContaining({ onWager }));
+
+        errorSpy.mockRestore();
+        jest.dontMock('../src/utils/placeWager');
+        jest.resetModules();
+    });
+});

--- a/tests/craftMiningLock.test.js
+++ b/tests/craftMiningLock.test.js
@@ -1,15 +1,16 @@
 'use strict';
 
 // Crafting spends mining materials, and a grind profile is persisted by replacing
-// its whole `data` document. So the mining action lock has to cover the *read* as
+// its whole `data` document. So the economy lock has to cover the *read* as
 // well as the write: holding it only around user.save() left the window that
 // matters open — a /mine raid landing between attachGrind and the save was simply
 // overwritten by the snapshot the craft had already loaded, and the raider kept
 // their credit while the defender kept their materials.
 
 jest.mock('../src/utils/activeGameLock', () => ({
-    tryAcquire: jest.fn(),
-    release:    jest.fn().mockResolvedValue(true),
+    tryAcquire:     jest.fn(),
+    holderActivity: jest.fn().mockResolvedValue('mine'),
+    release:        jest.fn().mockResolvedValue(true),
     DEFAULT_TTL_MS: 120_000,
 }));
 
@@ -41,19 +42,22 @@ beforeEach(() => {
     Guild.findOne.mockReset().mockResolvedValue({ economy: { enabled: false } });
 });
 
-describe('/craft make runs under the mining lock', () => {
+describe('/craft make runs under the economy lock', () => {
     test('takes the lock before the handler runs and releases it after', async () => {
         await craft.execute(interaction('make'));
         expect(trace).toEqual(['acquire', 'reply', 'release']);
     });
 
-    test('uses the same key /mine holds, so the two serialise against each other', async () => {
+    test('uses the shared per-user key, so every economy command serialises against it', async () => {
         await craft.execute(interaction('make'));
-        expect(lock.tryAcquire).toHaveBeenCalledWith('grind:mine:g1:u1', expect.any(Number));
+        expect(lock.tryAcquire).toHaveBeenCalledWith('economy:g1:u1', expect.any(Number), 'craft');
     });
 
-    test('a busy miner is turned away without touching their data', async () => {
+    test('a busy player is turned away without touching their data, and told what is holding them up', async () => {
         lock.tryAcquire.mockImplementation(async () => { trace.push('acquire'); return null; });
+        // The lease is held by a /mine dig, so the message names mining rather
+        // than the command the player just ran.
+        lock.holderActivity.mockResolvedValue('mine');
         const i = interaction('make');
 
         await craft.execute(i);

--- a/tests/embedFields.test.js
+++ b/tests/embedFields.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { EMBED_LIMITS, packFields, fitDescription, truncate } = require('../src/utils/embedFields');
+const { EMBED_LIMITS, packFields, fitDescription, chunkByLength, truncate } = require('../src/utils/embedFields');
 const { RELIC_LIST } = require('../src/data/exploreData');
 
 describe('truncate', () => {
@@ -95,5 +95,42 @@ describe('relic views stay inside Discord budgets', () => {
         const { text, omitted } = fitDescription(render(false));
         expect(text.length).toBeLessThanOrEqual(EMBED_LIMITS.DESCRIPTION);
         expect(omitted).toBe(0);
+    });
+});
+
+describe('chunkByLength', () => {
+    test('keeps a list that fits in a single chunk', () => {
+        expect(chunkByLength(['one', 'two'])).toEqual([['one', 'two']]);
+    });
+
+    test('gives nothing back for nothing', () => {
+        expect(chunkByLength([])).toEqual([]);
+    });
+
+    test('every chunk joins to within the limit', () => {
+        const lines  = Array.from({ length: 200 }, (_, i) => `${'x'.repeat(180)}${i}`);
+        const chunks = chunkByLength(lines, { separator: '\n\n' });
+
+        for (const chunk of chunks) {
+            expect(chunk.join('\n\n').length).toBeLessThanOrEqual(EMBED_LIMITS.DESCRIPTION);
+        }
+    });
+
+    test('loses no line while chunking — the point of paging over trimming', () => {
+        const lines = Array.from({ length: 200 }, (_, i) => `${'x'.repeat(180)}${i}`);
+        expect(chunkByLength(lines, { separator: '\n\n' }).flat()).toEqual(lines);
+    });
+
+    test('honours a per-chunk count as well as the character budget', () => {
+        expect(chunkByLength(['a', 'b', 'c', 'd', 'e'], { maxPerChunk: 2 }))
+            .toEqual([['a', 'b'], ['c', 'd'], ['e']]);
+    });
+
+    test('truncates an oversized line into its own chunk rather than dropping it', () => {
+        const chunks = chunkByLength(['short', 'y'.repeat(EMBED_LIMITS.DESCRIPTION + 500)]);
+
+        expect(chunks).toHaveLength(2);
+        expect(chunks[1][0]).toHaveLength(EMBED_LIMITS.DESCRIPTION);
+        expect(chunks[1][0].endsWith('…')).toBe(true);
     });
 });

--- a/tests/helpers/casinoInteraction.js
+++ b/tests/helpers/casinoInteraction.js
@@ -1,0 +1,85 @@
+'use strict';
+
+/**
+ * A stand-in ChatInputCommandInteraction for driving `src/games/casino/*`.
+ *
+ * The games reply, edit, fetch the reply and open collectors on it, and several
+ * of them read `interaction.user.displayAvatarURL()` into an embed author —
+ * which discord.js validates as a real URL, so it has to look like one. Every
+ * payload the game renders is pushed onto `replies`, which is what assertions
+ * about "what did the player actually see" read.
+ *
+ * Shared by the two suites that drive whole games: the bet guard
+ * (tests/casinoBetGuard.test.js) and the wager signal
+ * (tests/casinoWagerSignal.test.js).
+ */
+
+const GUILD_ID   = 'guild-1';
+const USER_ID    = 'user-1';
+const CHANNEL_ID = 'channel-1';
+const BET        = 100;
+// Comfortably above the bet: every game reads this first and decides the player
+// can afford the hand.
+const WALLET     = 10_000;
+
+/** The user document a game reads before it commits to anything. */
+const walletDoc = (overrides = {}) => ({
+    userId: USER_ID,
+    guildId: GUILD_ID,
+    balance: WALLET,
+    activeEffects: [],
+    casinoStats: {},
+    save: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+});
+
+function makeInteraction(options) {
+    const replies = [];
+    const record = payload => { replies.push(payload); return Promise.resolve(payload); };
+
+    const message = {
+        createMessageComponentCollector: () => ({ on() { return this; }, stop() {} }),
+        // Nobody presses anything in these tests. A rejection is what discord.js
+        // hands back when the window closes, and the games all treat it as "no
+        // response"; a promise that never settles would just hang them.
+        awaitMessageComponent: () => Promise.reject(new Error('no response')),
+        edit: record,
+    };
+
+    return {
+        replies,
+        id: 'interaction-1',
+        user:    { id: USER_ID, username: 'player', displayAvatarURL: () => 'https://cdn.discordapp.com/avatar.png' },
+        member:  { displayName: 'player' },
+        guild:   { id: GUILD_ID, name: 'Guild' },
+        channel: { id: CHANNEL_ID, send: record },
+        client:  { users: { fetch: () => Promise.resolve(null) } },
+        options: {
+            getInteger: name => options[name] ?? null,
+            getString:  name => options[name] ?? null,
+            getNumber:  name => options[name] ?? null,
+        },
+        deferReply:  jest.fn().mockResolvedValue(undefined),
+        reply:       jest.fn(record),
+        editReply:   jest.fn(record),
+        followUp:    jest.fn(record),
+        fetchReply:  jest.fn().mockResolvedValue(message),
+    };
+}
+
+/** Every game's opening bet, with whatever options it reads to get there. */
+const GAMES = [
+    { name: 'blackjack',   options: { bet: BET } },
+    { name: 'crash',       options: { bet: BET, auto_cashout: null } },
+    { name: 'cupgame',     options: { bet: BET } },
+    { name: 'higherlower', options: { bet: BET } },
+    { name: 'keno',        options: { bet: BET, numbers: '3 12 21 33 39' } },
+    { name: 'poker',       options: { bet: BET } },
+    { name: 'roulette',    options: { bet: 'red', amount: BET, number: null } },
+    { name: 'slots',       options: { bet: BET } },
+];
+
+/** The wager each game's guard must cover — roulette takes its amount elsewhere. */
+const stakeFor = game => (game.name === 'roulette' ? game.options.amount : game.options.bet);
+
+module.exports = { GUILD_ID, USER_ID, CHANNEL_ID, BET, WALLET, walletDoc, makeInteraction, GAMES, stakeFor };

--- a/tests/helpers/fakeActiveLock.js
+++ b/tests/helpers/fakeActiveLock.js
@@ -34,6 +34,12 @@ module.exports = {
         return options?.new ? doc : (existing ?? null);
     },
 
+    findOne(filter) {
+        const existing = locks.get(filter.key) ?? null;
+        // `.lean()` on a real query; here the stored object is already plain.
+        return { lean: async () => existing };
+    },
+
     async deleteOne(filter) {
         const existing = locks.get(filter.key);
         if (!existing || existing.token !== filter.token) return { deletedCount: 0 };

--- a/tests/huntAimPhase.test.js
+++ b/tests/huntAimPhase.test.js
@@ -1,0 +1,242 @@
+'use strict';
+
+/**
+ * The aim phase, driven by the clock.
+ *
+ * `gradeShot` is pure and unit-tested elsewhere. What it cannot see is the part
+ * that decides *what numbers it is handed*: a wait, an edit that goes out over
+ * the wire, and a collector armed against a deadline. Every bug this phase has
+ * had has been in that seam rather than in the grading — the old version armed
+ * the button only after the wait, which made an early shot impossible and left
+ * the grade to be decided by round-trip time.
+ *
+ * So the collector fake here honours its own deadline instead of standing in
+ * for one: `time` arms it, `resetTimer` re-arms it, expiry fires `end('time')`,
+ * and a press fires `collect` and ends it. Under fake timers that makes "the
+ * player fired 2.1 seconds after the call, over a connection that took 400ms to
+ * deliver it" a thing a test can actually say.
+ */
+
+jest.mock('../src/models/Guild', () => ({ findOne: jest.fn().mockResolvedValue(null) }));
+jest.mock('../src/models/User', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../src/models/GrindProfile', () => ({ find: jest.fn(), findOneAndUpdate: jest.fn() }));
+
+const { __test__ } = require('../src/commands/economy/hunt');
+const { runAimPhase, AIM_WINDOW_MS, AIM_LATE_MS } = __test__;
+
+const USER_ID = 'u1';
+/** Math.random stubbed to 0, so the wait is the bottom of its 1000–2000ms range. */
+const AIM_WAIT_MS = 1000;
+
+/** A collector that keeps its own deadline, the way the real one does. */
+function fakeCollector() {
+    const self = {
+        handlers: {},
+        ended:    false,
+        timer:    null,
+        options:  null,
+        resets:   [],
+
+        arm(ms) {
+            clearTimeout(self.timer);
+            self.timer = setTimeout(() => self.finish('time'), ms);
+        },
+        on(event, fn) { self.handlers[event] = fn; return self; },
+        resetTimer(opts) { self.resets.push(opts); self.arm(opts.time); },
+        stop() { self.finish('user'); },
+
+        finish(reason) {
+            if (self.ended) return;
+            self.ended = true;
+            clearTimeout(self.timer);
+            self.handlers.end?.(null, reason);
+        },
+
+        /** The player pressing Fire. Returns false if the window already closed. */
+        async press() {
+            if (self.ended) return false;
+            self.ended = true;
+            clearTimeout(self.timer);
+            await self.handlers.collect({ user: { id: USER_ID }, deferUpdate: async () => {} });
+            return true;
+        },
+    };
+    return self;
+}
+
+/**
+ * An interaction whose edits take `editMs` of wire time — the thing the phase
+ * must not charge to the player.
+ */
+function fakeInteraction(editMs = 0) {
+    return {
+        id:   'interaction-1',
+        user: { id: USER_ID },
+        edits: [],
+        editReply: jest.fn(function (payload) {
+            this.edits.push(payload);
+            return editMs ? new Promise(r => setTimeout(r, editMs)) : Promise.resolve();
+        }),
+    };
+}
+
+/** Title of the nth embed the phase rendered. */
+const titleAt = (interaction, n) => interaction.edits[n]?.embeds?.[0]?.data?.title ?? '';
+
+beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+});
+
+afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+});
+
+/** Starts the phase with the sights on screen and the button live. */
+async function startPhase(editMs) {
+    const interaction = fakeInteraction(editMs);
+    const collector   = fakeCollector();
+    const huntMsg     = { createMessageComponentCollector: opts => { collector.options = opts; collector.arm(opts.time); return collector; } };
+
+    const phase = runAimPhase(interaction, huntMsg);
+    await jest.advanceTimersByTimeAsync(editMs);   // the sights edit lands
+
+    // Settling costs the result edit plus the 600ms beat after it.
+    const settle = () => jest.advanceTimersByTimeAsync(editMs + 600).then(() => phase);
+
+    return { interaction, collector, phase, settle, editMs };
+}
+
+/**
+ * Runs the phase up to the moment the call is on screen, and reports when that
+ * was. Leaves the returned promise pending so the caller can decide when — or
+ * whether — to press.
+ */
+async function upToTheCall(editMs) {
+    const started = await startPhase(editMs);
+    const from    = Date.now();
+
+    await jest.advanceTimersByTimeAsync(AIM_WAIT_MS);   // the wait
+    await jest.advanceTimersByTimeAsync(editMs);        // the call going out
+
+    return { ...started, calledAt: Date.now() - from + editMs };
+}
+
+describe('the aim phase pays for a shot taken after the call', () => {
+    test('a shot inside the window is perfect', async () => {
+        const { collector, settle } = await upToTheCall(0);
+
+        await jest.advanceTimersByTimeAsync(300);
+        expect(await collector.press()).toBe(true);
+
+        expect((await settle()).grade).toBe('perfect');
+    });
+
+    test('a shot after the window closes is late, not nothing', async () => {
+        const { collector, settle } = await upToTheCall(0);
+
+        await jest.advanceTimersByTimeAsync(AIM_WINDOW_MS + 200);
+        expect(await collector.press()).toBe(true);
+
+        expect((await settle()).grade).toBe('late');
+    });
+
+    test('never firing scores nothing', async () => {
+        const { collector, settle } = await upToTheCall(0);
+
+        await jest.advanceTimersByTimeAsync(AIM_LATE_MS + 1);
+        expect(collector.ended).toBe(true);
+
+        expect((await settle()).grade).toBe('timeout');
+    });
+});
+
+describe('the call is what the clock starts from, not the wait', () => {
+    // 400ms is an ordinary mobile round trip. Before this, the collector was
+    // armed for aimWaitMs + AIM_LATE_MS from before the edit went out, so those
+    // 400ms came out of the player's grace: they had 2.1s to take a late shot
+    // where a player on a fast connection had 2.5s.
+    const SLOW_EDIT_MS = 400;
+
+    test('the grace period is re-armed once the call is actually on screen', async () => {
+        const { collector, settle, calledAt } = await upToTheCall(SLOW_EDIT_MS);
+
+        expect(collector.resets).toEqual([{ time: AIM_LATE_MS }]);
+        // Armed before the edit went out, the collector's original deadline was
+        // AIM_LATE_MS from the wait — which is SLOW_EDIT_MS before this.
+        expect(calledAt).toBe(AIM_WAIT_MS + 2 * SLOW_EDIT_MS);
+
+        await jest.advanceTimersByTimeAsync(AIM_LATE_MS + 1);
+        await settle();
+    });
+
+    test('a late shot near the end of the grace still counts on a slow connection', async () => {
+        const { collector, settle } = await upToTheCall(SLOW_EDIT_MS);
+
+        // Past where the deadline used to fall, inside the one the player was
+        // promised.
+        await jest.advanceTimersByTimeAsync(AIM_LATE_MS - 50);
+        expect(collector.ended).toBe(false);
+        expect(await collector.press()).toBe(true);
+
+        expect((await settle()).grade).toBe('late');
+    });
+
+    test('the grace still ends — a slow connection does not buy unlimited time', async () => {
+        const { collector, settle } = await upToTheCall(SLOW_EDIT_MS);
+
+        await jest.advanceTimersByTimeAsync(AIM_LATE_MS + 1);
+        expect(collector.ended).toBe(true);
+        expect(await collector.press()).toBe(false);
+
+        expect((await settle()).grade).toBe('timeout');
+    });
+
+    test('a slow connection does not shorten the perfect window either', async () => {
+        const { collector, settle } = await upToTheCall(SLOW_EDIT_MS);
+
+        await jest.advanceTimersByTimeAsync(AIM_WINDOW_MS);
+        expect(await collector.press()).toBe(true);
+
+        expect((await settle()).grade).toBe('perfect');
+    });
+});
+
+describe('firing before the call', () => {
+    test('is graded as rushed, and costs', async () => {
+        const { collector, settle } = await startPhase(0);
+
+        // Mashing the trigger the moment the button appears — which used to be
+        // the optimal play, because the button only appeared when it was time.
+        await jest.advanceTimersByTimeAsync(200);
+        expect(await collector.press()).toBe(true);
+
+        const aim = await settle();
+        expect(aim.grade).toBe('early');
+        expect(aim.bonus).toBeLessThan(0);
+    });
+
+    test('never shows the FIRE! call — a player who jumped the gun is not told they were on time', async () => {
+        const { interaction, collector, settle } = await startPhase(0);
+
+        await jest.advanceTimersByTimeAsync(200);
+        await collector.press();
+        await settle();
+
+        expect(titleAt(interaction, 0)).toMatch(/Target in Sights/);
+        expect(interaction.edits.map(e => e.embeds?.[0]?.data?.title ?? '')).not.toContain('💥 FIRE!');
+        expect(titleAt(interaction, 1)).toMatch(/rushed it/);
+    });
+
+    test('the button is on the message from the moment the sights are', async () => {
+        // The whole mechanic rests on this: an early shot has to be possible.
+        const { interaction, settle } = await startPhase(0);
+
+        expect(titleAt(interaction, 0)).toMatch(/Target in Sights/);
+        expect(interaction.edits[0].components).toHaveLength(1);
+
+        await jest.advanceTimersByTimeAsync(AIM_WAIT_MS + AIM_LATE_MS + 1);
+        await settle();
+    });
+});

--- a/tests/huntEmbedFields.test.js
+++ b/tests/huntEmbedFields.test.js
@@ -345,3 +345,40 @@ describe('aim phase grading', () => {
         expect(AIM_WINDOW_MS).toBeGreaterThanOrEqual(2 * 400);
     });
 });
+
+describe('weapon pricing legibility', () => {
+    const { isCrossEconomyWeapon, huntingDaysFor, huntingDaysLabel, fullRepairCost, CROSS_ECONOMY_DAYS } = __test__;
+    const byTier = tier => WEAPON_TIERS.find(w => w.tier === tier);
+
+    it('measures a price in days of hunting at the soft cap', () => {
+        // The cap is what makes the top of the ladder unreachable by hunting:
+        // payouts halve above it, so it is the honest ceiling to divide by.
+        expect(huntingDaysFor(LIMITS.DAILY_SOFT_CAP)).toBe(1);
+        expect(huntingDaysLabel(byTier(12).cost)).toBe(250);
+    });
+
+    it('prices a full repair the way the shop actually charges for one', () => {
+        // Repairs are sold in 20-durability units, rounded up — a rifle whose
+        // base durability is not a multiple of 20 pays for the part-unit.
+        const t12 = byTier(12);
+        expect(fullRepairCost(t12)).toBe(Math.ceil(t12.baseDurability / 20) * t12.repairCostPer20);
+        expect(fullRepairCost(t12)).toBe(6_440_000);
+    });
+
+    it('marks exactly the tiers hunting cannot fund', () => {
+        const marked = WEAPON_TIERS.filter(isCrossEconomyWeapon).map(w => w.tier);
+        expect(marked).toEqual([10, 11, 12]);
+    });
+
+    it('leaves T9 unmarked — fifteen days is a grind, not an impossibility', () => {
+        expect(huntingDaysFor(byTier(9).cost)).toBeLessThanOrEqual(CROSS_ECONOMY_DAYS);
+        expect(isCrossEconomyWeapon(byTier(9))).toBe(false);
+    });
+
+    it('derives the mark from the caps, not from a hardcoded tier', () => {
+        // Halve every price and nothing is out of reach any more. A rule pinned
+        // to "T10 and up" would still be marking the same three.
+        const cheap = WEAPON_TIERS.map(w => ({ ...w, cost: CROSS_ECONOMY_DAYS * LIMITS.DAILY_SOFT_CAP }));
+        expect(cheap.filter(isCrossEconomyWeapon)).toEqual([]);
+    });
+});

--- a/tests/huntEmbedFields.test.js
+++ b/tests/huntEmbedFields.test.js
@@ -299,3 +299,49 @@ describe('weapon inventory pages', () => {
         expect(buildWeaponPages(hoarder(9))).toHaveLength(2);
     });
 });
+
+describe('aim phase grading', () => {
+    const { gradeShot, AIM_WINDOW_MS, AIM_LATE_MS } = __test__;
+    const OPEN_AT = 1500; // the randomised moment the window opens
+
+    it('pays the top bonus for a shot inside the window', () => {
+        expect(gradeShot(OPEN_AT, OPEN_AT).bonus).toBe(0.18);
+        expect(gradeShot(OPEN_AT + AIM_WINDOW_MS, OPEN_AT).bonus).toBe(0.18);
+    });
+
+    it('pays less for a shot after the window has closed', () => {
+        expect(gradeShot(OPEN_AT + AIM_WINDOW_MS + 1, OPEN_AT).grade).toBe('late');
+        expect(gradeShot(OPEN_AT + AIM_LATE_MS, OPEN_AT).bonus).toBe(0.08);
+    });
+
+    it('charges for a shot fired before the window opened', () => {
+        // The mechanic the footer has always described. It used to be
+        // unreachable — the button did not exist yet — so mashing the trigger
+        // the instant it appeared was the *optimal* play and paid at least +8%.
+        expect(gradeShot(OPEN_AT - 1, OPEN_AT).grade).toBe('early');
+        expect(gradeShot(0, OPEN_AT).bonus).toBeLessThan(0);
+    });
+
+    it('pays nothing at all for never firing', () => {
+        expect(gradeShot(null, OPEN_AT).bonus).toBe(0);
+    });
+
+    it('grades on when the shot came, not how fast the wire is', () => {
+        // The old rule: under 800ms of round trip → +18%, otherwise +8%. The
+        // same play from a player 400ms further from Discord scored worse for
+        // no reason a hunter could act on. These two fire at the same moment
+        // relative to the call, 300ms apart in absolute terms, and grade the
+        // same.
+        const quick = gradeShot(OPEN_AT + 120, OPEN_AT);
+        const laggy = gradeShot(OPEN_AT + 420, OPEN_AT);
+
+        expect(quick.grade).toBe('perfect');
+        expect(laggy.grade).toBe('perfect');
+    });
+
+    it('leaves the window wide enough that a slow connection can still clear it', () => {
+        // Half a second of usable window at 400ms of round trip is twice a
+        // human reaction time; anything tighter grades the connection again.
+        expect(AIM_WINDOW_MS).toBeGreaterThanOrEqual(2 * 400);
+    });
+});

--- a/tests/huntEmbedFields.test.js
+++ b/tests/huntEmbedFields.test.js
@@ -6,12 +6,13 @@ jest.mock('../src/models/GrindProfile', () => ({ find: jest.fn(), findOneAndUpda
 
 const { __test__ } = require('../src/commands/economy/hunt');
 const { buildHuntEmbed, buildBonusLines } = __test__;
-const { ZONES, ANIMALS, TROPHY_QUALITIES, LIMITS } = require('../src/data/huntData');
+const { ZONES, ANIMALS, TROPHY_QUALITIES, LIMITS, WEAPON_TIERS, WEAPON_UPGRADES } = require('../src/data/huntData');
 
 // Discord's hard limits.
 const MAX_FIELDS      = 25;
 const MAX_FIELD_VALUE = 1024;
 const MAX_FIELD_NAME  = 256;
+const MAX_DESCRIPTION = 4096;
 
 // executeStart appends at most two further fields after buildHuntEmbed returns:
 // the consolidated "Bonuses" field and the rare-companion drop.
@@ -214,5 +215,87 @@ describe('trophy case', () => {
         const field = buildTrophyField(few);
         expect(field.value).toBe('🔷 Pristine Wolf, 🟢 Good Rabbit');
         expect(field.name).toBe('🏆 Trophies (2)');
+    });
+});
+
+describe('weapon inventory pages', () => {
+    const { buildWeaponPages, WEAPON_SEPARATOR } = __test__;
+
+    /**
+     * The longest entry the renderer can ever produce for a tier: the longest
+     * weapon name, the longest upgrade label, and the widest durability and
+     * repair-count numbers a real weapon reaches.
+     */
+    function weapon(tier, overrides = {}) {
+        const def = WEAPON_TIERS.find(w => w.tier === tier);
+        const longestUpgrade = Object.keys(WEAPON_UPGRADES)
+            .sort((a, b) => b.length - a.length)[0];
+        return {
+            tier,
+            name: def.name,
+            status: 'condemned',
+            currentDurability: def.baseDurability,
+            maxDurability: def.baseDurability,
+            baseDurability: def.baseDurability,
+            repairCount: 99,
+            upgrade: longestUpgrade,
+            ...overrides,
+        };
+    }
+
+    /**
+     * The worst inventory the game can produce. `/hunt inv discard` only accepts
+     * broken or condemned weapons and `/hunt shop weapon` caps nothing, so a
+     * player who replaces working weapons accumulates them permanently — there
+     * is no upper bound to test against, only "far past where it used to break".
+     */
+    function hoarder(count) {
+        return {
+            equippedWeaponIndex: count - 1,
+            weapons: Array.from({ length: count }, (_, i) =>
+                weapon(WEAPON_TIERS[i % WEAPON_TIERS.length].tier)),
+        };
+    }
+
+    it('keeps every page inside the description limit for a hoarded inventory', () => {
+        // 200 is an order of magnitude past the ~22 that used to fail the API
+        // call outright and take the whole command down with it.
+        for (const page of buildWeaponPages(hoarder(200))) {
+            expect(page.join(WEAPON_SEPARATOR).length).toBeLessThanOrEqual(MAX_DESCRIPTION);
+        }
+    });
+
+    it('loses no weapon to paging — every number is still reachable', () => {
+        const h = hoarder(200);
+        const shown = buildWeaponPages(h).flat()
+            .map(line => Number(line.match(/^\*\*#(\d+) /)[1]));
+
+        expect(shown.slice().sort((a, b) => a - b))
+            .toEqual(Array.from({ length: 200 }, (_, i) => i + 1));
+    });
+
+    it('numbers each weapon by its index in the inventory, not its position on the page', () => {
+        // /hunt inv equip and /hunt inv discard address weapons by that index,
+        // so a display order that renumbered them would equip the wrong rifle.
+        const h = hoarder(30);
+        const equipped = buildWeaponPages(h)[0][0];
+        expect(equipped).toContain(`#${h.equippedWeaponIndex + 1} `);
+        expect(equipped).toContain('[EQUIPPED]');
+    });
+
+    it('puts the equipped weapon first and the rest by tier descending', () => {
+        const h = {
+            equippedWeaponIndex: 2,
+            weapons: [weapon(12), weapon(1), weapon(5)],
+        };
+        const tiers = buildWeaponPages(h).flat()
+            .map(line => Number(line.match(/^\*\*#(\d+) /)[1]));
+
+        expect(tiers).toEqual([3, 1, 2]); // equipped (#3), then T12 (#1), then T1 (#2)
+    });
+
+    it('fits a normal inventory on one page', () => {
+        expect(buildWeaponPages(hoarder(8))).toHaveLength(1);
+        expect(buildWeaponPages(hoarder(9))).toHaveLength(2);
     });
 });

--- a/tests/huntService.test.js
+++ b/tests/huntService.test.js
@@ -6,6 +6,7 @@ const {
     activateConsumable,
     resolveApexEncounter,
     calculateSuccessChance,
+    applyAimBonus,
 } = require('../src/services/huntService');
 const { ZONES, LIMITS } = require('../src/data/huntData');
 
@@ -109,5 +110,30 @@ describe('resolveApexEncounter', () => {
 
         expect(user.hunt.weapons[0].currentDurability).toBeLessThan(80);
         expect(user.hunt.weapons[1].currentDurability).toBe(80);
+    });
+});
+
+describe('applyAimBonus', () => {
+    test('leaves crit chance alone when the aim phase did not run', () => {
+        expect(applyAimBonus(0.08)).toBe(0.08);
+        expect(applyAimBonus(0.08, 0)).toBe(0.08);
+    });
+
+    test('adds a shot taken inside the window', () => {
+        expect(applyAimBonus(0.05, 0.18)).toBeCloseTo(0.23);
+    });
+
+    test('takes the penalty off a rushed shot', () => {
+        // The old guard was `aimBonus > 0`, which threw the penalty away — so a
+        // player who fired early paid nothing for it.
+        expect(applyAimBonus(0.20, -0.05)).toBeCloseTo(0.15);
+    });
+
+    test('never pushes crit chance below zero', () => {
+        expect(applyAimBonus(0.03, -0.05)).toBe(0);
+    });
+
+    test('still respects the hard cap', () => {
+        expect(applyAimBonus(0.20, 0.18)).toBe(LIMITS.MAX_CRIT_CHANCE);
     });
 });


### PR DESCRIPTION
Lock keys were namespaced per command — grind:fish:, casino:, grind:hunt:,
grind:mine:, grind:explore: — so they only ever stopped a user running the
same command twice. /fish cast and /casino blackjack from one player took
different leases and ran side by side over the same user document, which is
exactly the interleaving the surviving read-modify-write sites lose coins to.

The key is now the player: economy:{guildId}:{userId}. Any two balance-
touching commands from the same user in the same guild contend for it, and
the second is turned away rather than queued. /craft make stops borrowing
/mine's key and takes the shared one; a /mine raid takes the *defender's*
shared lease, so a dig, a craft and a raid on the same player can no longer
overwrite each other's snapshot.

This is mitigation, not a fix. It narrows the window the remaining RMW sites
are exposed through; it does not make them atomic, and it stops helping the
moment the bot runs in more than one process — the locks are Mongo-backed,
so that part still holds, but a raid or a gift writes to a second user's
document that no per-user lock covers.

One key across many commands makes the "already in progress" message a
problem of its own: being told you are already fishing when you are mid-
blackjack is worse than being told nothing. So an acquire records what the
lease is for and the turned-away call reads it back, falling back to generic
wording when the holder released in between or recorded nothing.

The four grind wrappers were four copies of the same fifteen lines; they are
now one shared withEconomyLock.

Closes #575

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added shared protection against overlapping economy actions, with clearer activity-specific busy messages.
  - Casino wagers now update jackpot and mission progress only after valid bets.
  - Large fishing, hunting weapon, and material inventories are sorted and paginated.
  - Hunting aim timing supports early, late, perfect, and missed shots with visible penalties.
  - Hunting shop listings show funding, repair costs, and hunting-day estimates.

- **Bug Fixes**
  - Improved wager validation and atomic balance handling across casino games.
  - Prevented canceled bets and follow-up raises from being counted incorrectly.
  - Ensured aim bonuses cannot produce invalid critical-hit chances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->