### PR TITLE
Land every inventory credit as an atomic upsert, and market debits as compare-and-sets

### DIFF
--- a/src/commands/economy/eventshop.js
+++ b/src/commands/economy/eventshop.js
@@ -8,6 +8,7 @@ const {
     getEventCurrencyBalance,
 } = require('../../services/seasonalEventService');
 const { addEffect, resolveEffectType } = require('../../services/effectsService');
+const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const { paginate, chunkArray } = require('../../utils/paginator');
 
 // Items that grant effects when purchased (grant via effectsService)
@@ -182,36 +183,44 @@ async function handleBuy(interaction, ev, def, currency, currencyId) {
 
     // Step 3: Grant item or effect (currency already secured above)
     const user = charged;
-    if (EFFECT_ITEMS.has(shopItem.itemId)) {
-        const effectType = resolveEffectType(shopItem.name) ?? shopItem.itemId;
-        for (let i = 0; i < qty; i++) addEffect(user, effectType);
-    } else {
-        if (!user.inventory) user.inventory = [];
-        const slot = user.inventory.find(i => i.itemId === shopItem.itemId);
-        if (slot) {
-            slot.quantity += qty;
-        } else {
-            user.inventory.push({ itemId: shopItem.itemId, quantity: qty });
-        }
-    }
 
-    try {
-        await user.save();
-    } catch (err) {
-        console.error('[eventshop] item grant save failed:', err.message);
-        // Revert currency deduction
+    // Hand the currency and any stock back when the grant cannot land.
+    const revertPurchase = async () => {
         await User.findOneAndUpdate(
             { userId: interaction.user.id, guildId: interaction.guild.id, 'eventCurrency.currencyId': currencyId },
             { $inc: { 'eventCurrency.$.amount': totalCost } }
         ).catch(() => {});
-        // Revert stock decrement
         if (stockLimited) {
             await Guild.findOneAndUpdate(
                 { guildId: interaction.guild.id, 'activeEvent.eventShop': { $elemMatch: { itemId: shopItem.itemId } } },
                 { $inc: { 'activeEvent.eventShop.$.stock': qty } }
             ).catch(() => {});
         }
-        return interaction.editReply({ content: '❌ Purchase failed due to a server error. Please try again.' });
+    };
+
+    if (EFFECT_ITEMS.has(shopItem.itemId)) {
+        const effectType = resolveEffectType(shopItem.name) ?? shopItem.itemId;
+        for (let i = 0; i < qty; i++) addEffect(user, effectType);
+        try {
+            await user.save();
+        } catch (err) {
+            console.error('[eventshop] effect grant save failed:', err.message);
+            await revertPurchase();
+            return interaction.editReply({ content: '❌ Purchase failed due to a server error. Please try again.' });
+        }
+    } else {
+        // One atomic upsert rather than mutate-then-save: the save would write
+        // the whole inventory array as read a moment ago, flattening any credit
+        // that landed in between, and two concurrent credits of the same item
+        // could each push their own slot (src/utils/inventoryGrant.js).
+        try {
+            const granted = await grantInventoryItem(interaction.user.id, interaction.guild.id, shopItem.itemId, qty);
+            if (!granted) throw new Error('user document not found');
+        } catch (err) {
+            console.error('[eventshop] item grant failed:', err.message);
+            await revertPurchase();
+            return interaction.editReply({ content: '❌ Purchase failed due to a server error. Please try again.' });
+        }
     }
 
     const newBalance = getEventCurrencyBalance(user, currencyId);

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -5,6 +5,7 @@ const User  = require('../../models/User');
 const { attachGrind, persistGrindIfNew } = require('../../utils/grindProfile');
 const { isVersionError } = require('../../utils/versionRetry');
 const { detachBalanceDelta, commitBalanceDelta } = require('../../utils/balanceDelta');
+const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const GrindProfile = require('../../models/GrindProfile');
 const Guild = require('../../models/Guild');
 const {
@@ -343,9 +344,22 @@ async function handleGo(interaction) {
         // encounter prompt below. Once this lands the expedition is real, so the
         // cooldown slot is earned and must not be handed back on a later failure.
         const findDelta = detachBalanceDelta(user, balanceBaseline);
+        // A recovered relic stays in the in-memory inventory — the encounter
+        // stakes and the reply both read it — but must not ride the save:
+        // `save()` writes the whole array as read at load, flattening any credit
+        // that landed in between, so the relic is re-applied as an atomic upsert
+        // right after (src/utils/inventoryGrant.js). A brand-new document
+        // inserts its whole inventory in one piece, so there is nothing to
+        // detach or re-apply there.
+        const relicDetached = Boolean(result.relic) && !user.isNew;
+        if (relicDetached) user.unmarkModified('inventory');
         try {
             await user.save();
             exploreCommitted = true;
+            if (relicDetached) {
+                await grantInventoryItem(user.userId, user.guildId, result.relic.itemId, 1)
+                    .catch(err => console.error(`[explore] relic ${result.relic.itemId} owed to ${user.userId} — grant failed:`, err));
+            }
             const paid = await commitBalanceDelta(User, balanceFilter, user, findDelta, {
                 service: 'explore',
                 jobName: 'findPayout',

--- a/src/commands/economy/forge.js
+++ b/src/commands/economy/forge.js
@@ -5,6 +5,7 @@ const User    = require('../../models/User');
 const Guild   = require('../../models/Guild');
 const AiItem  = require('../../models/AiItem');
 const { resolveProviderConfig, getCompletion } = require('../../services/aiService');
+const { grantInventoryItem } = require('../../utils/inventoryGrant');
 
 const RARITY_CONFIG = {
     common:    { label: 'Common',    emoji: '⚪', color: 0xAAAAAA, cost: 500,   xpReward: 25  },
@@ -177,10 +178,15 @@ Respond with ONLY the JSON object. No markdown, no extra text.`;
                 createdBy: interaction.user.id, guildId: interaction.guild.id,
             });
 
-            chargedUser.inventory = chargedUser.inventory || [];
-            chargedUser.inventory.push({ itemId, quantity: 1 });
-            chargedUser.xp = (chargedUser.xp || 0) + cfg.xpReward;
-            await chargedUser.save();
+            // One atomic update for the item and the XP: a mutate-then-save here
+            // would write inventory and xp as absolute values read before the
+            // (multi-second) AI call, flattening anything credited in between.
+            // The itemId is freshly minted so no slot can exist yet, but the
+            // shared upsert keeps every credit site the same shape.
+            const granted = await grantInventoryItem(interaction.user.id, interaction.guild.id, itemId, 1, {
+                extraSet: { xp: { $add: [{ $ifNull: ['$xp', 0] }, cfg.xpReward] } },
+            });
+            if (!granted) throw new Error('user document not found');
         } catch (err) {
             console.error('[FORGE] Persistence failed:', err?.message || err);
             await User.updateOne(

--- a/src/commands/economy/lovenote.js
+++ b/src/commands/economy/lovenote.js
@@ -3,6 +3,7 @@ const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { logTransaction } = require('../../utils/logTransaction');
 const { saveWithBalanceDelta } = require('../../utils/balanceDelta');
+const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const {
     hasActiveEvent,
     getEventCurrencyId,
@@ -139,15 +140,6 @@ module.exports = {
 
             user.balance = (user.balance ?? 0) + reply.coins;
 
-            // Add a chocolate box to inventory
-            const invSlot = user.inventory?.find(i => i.itemId === 'chocolate_box');
-            if (invSlot) {
-                invSlot.quantity += 1;
-            } else {
-                if (!user.inventory) user.inventory = [];
-                user.inventory.push({ itemId: 'chocolate_box', quantity: 1 });
-            }
-
             logPayload = {
                 userId:   interaction.user.id,
                 guildId:  interaction.guild.id,
@@ -175,6 +167,14 @@ module.exports = {
             jobName: 'notePayout',
             guildId: interaction.guild.id,
         });
+        if (!isRejected) {
+            // The chocolate box lands as its own atomic upsert rather than riding
+            // the save: a slot pushed in memory can duplicate one a concurrent
+            // credit is creating (src/utils/inventoryGrant.js). The save above
+            // inserted the document for a first-time player, so the grant always
+            // has a doc to hit.
+            await grantInventoryItem(interaction.user.id, interaction.guild.id, 'chocolate_box', 1);
+        }
         logTransaction(logPayload);
         return interaction.editReply({ embeds: [embed] });
     }

--- a/src/commands/economy/market.js
+++ b/src/commands/economy/market.js
@@ -10,6 +10,7 @@ const Transaction    = require('../../models/Transaction');
 const { DEFAULT_SHOP_ITEMS, getItemLore, getItemRarity, RARITY_ORDER } = require('../../data/defaultShopItems');
 const { EFFECT_CONFIGS } = require('../../services/effectsService');
 const { logTransaction } = require('../../utils/logTransaction');
+const { grantInventoryItem } = require('../../utils/inventoryGrant');
 
 const ITEM_META = Object.fromEntries(DEFAULT_SHOP_ITEMS.map(i => [i.itemId, i]));
 
@@ -100,10 +101,29 @@ async function handleList(interaction, currency) {
         return interaction.reply({ content: `You can only have ${MAX_LISTINGS_PER_USER} active listings at a time.`, flags: MessageFlags.Ephemeral });
     }
 
-    slot.quantity -= qty;
-    if (slot.quantity <= 0) seller.inventory = seller.inventory.filter(i => i.itemId !== itemId);
-    seller.markModified('inventory');
-    await seller.save();
+    // The stock leaves as a compare-and-set, not `slot.quantity -= qty` followed
+    // by a save: the quantity read above is history by now, and two concurrent
+    // `/market list` calls for the same stack would each see the full count and
+    // both take it — one stack backing two listings. The `$elemMatch` filter
+    // makes the check and the debit the same write (same shape as use.js).
+    const debited = await User.findOneAndUpdate(
+        {
+            userId:    interaction.user.id,
+            guildId:   interaction.guild.id,
+            inventory: { $elemMatch: { itemId, quantity: { $gte: qty } } },
+        },
+        { $inc: { 'inventory.$.quantity': -qty } },
+        { new: true },
+    );
+    if (!debited) {
+        return interaction.reply({ content: `You don't have ${qty}x \`${itemId}\` in your inventory.`, flags: MessageFlags.Ephemeral });
+    }
+    // Drop slots the decrement above emptied. Advisory: a failure leaves an
+    // empty slot, not wrong quantities.
+    await User.updateOne(
+        { userId: interaction.user.id, guildId: interaction.guild.id },
+        { $pull: { inventory: { quantity: { $lte: 0 } } } },
+    ).catch(err => console.error('[market list] inventory cleanup failed:', err));
 
     let listing;
     try {
@@ -116,14 +136,13 @@ async function handleList(interaction, currency) {
             expiresAt:    new Date(Date.now() + LISTING_TTL_MS),
         });
     } catch (err) {
-        const restored = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
-        if (restored) {
-            const s = restored.inventory.find(i => i.itemId === itemId);
-            if (s) { s.quantity += qty; }
-            else   { restored.inventory.push({ itemId, quantity: qty }); }
-            restored.markModified('inventory');
-            await restored.save().catch(console.error);
-        }
+        // Hand the stock back the same way every other credit lands — one atomic
+        // upsert, so the return can't duplicate a slot a concurrent credit is
+        // creating (src/utils/inventoryGrant.js).
+        await grantInventoryItem(interaction.user.id, interaction.guild.id, itemId, qty)
+            .catch(restoreErr => console.error(
+                `[market list] returning ${qty}x ${itemId} to ${interaction.user.id} failed — items owed:`, restoreErr,
+            ));
         console.error('[market list] MarketListing.create failed:', err);
         return interaction.reply({ content: 'Failed to create listing. Your item has been returned.', flags: MessageFlags.Ephemeral });
     }
@@ -322,14 +341,13 @@ async function handleBuy(interaction, currency) {
             return editReply({ content: 'This listing was just sold. Your coins have been refunded.', embeds: [], components: [] });
         }
 
-        // Update buyer inventory first; roll back the buyer deduction if it fails
+        // Update buyer inventory first; roll back the buyer deduction if it fails.
+        // One atomic upsert rather than read-modify-save: a save computed from a
+        // read here would flatten any credit that landed in between, and two
+        // concurrent credits of the same item could each push their own slot.
         try {
-            const buyerDoc = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
-            const slot = buyerDoc.inventory.find(i => i.itemId === listing.itemId);
-            if (slot) { slot.quantity += listing.quantity; }
-            else       { buyerDoc.inventory.push({ itemId: listing.itemId, quantity: listing.quantity }); }
-            buyerDoc.markModified('inventory');
-            await buyerDoc.save();
+            const credited = await grantInventoryItem(interaction.user.id, interaction.guild.id, listing.itemId, listing.quantity);
+            if (!credited) throw new Error('buyer document not found');
         } catch (inventoryErr) {
             console.error('[market buy] inventory update failed, refunding buyer:', inventoryErr);
             await User.updateOne({ userId: interaction.user.id, guildId: interaction.guild.id }, { $inc: { balance: totalCost } }).catch(console.error);
@@ -428,12 +446,21 @@ async function handleCancel(interaction, currency) {
         return interaction.reply({ content: 'Listing not found, already sold, or not yours.', flags: MessageFlags.Ephemeral });
     }
 
-    const seller = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
-    const slot = seller.inventory.find(i => i.itemId === listing.itemId);
-    if (slot) { slot.quantity += listing.quantity; }
-    else       { seller.inventory.push({ itemId: listing.itemId, quantity: listing.quantity }); }
-    seller.markModified('inventory');
-    await seller.save();
+    // The listing is already deleted, so this credit is the only copy of the
+    // stock — return it atomically and say so if the return fails, rather than
+    // saving a stale in-memory inventory over concurrent credits.
+    try {
+        await grantInventoryItem(interaction.user.id, interaction.guild.id, listing.itemId, listing.quantity, { upsert: true });
+    } catch (creditErr) {
+        console.error(
+            `[market cancel] listing ${listing._id} was removed but returning ` +
+            `${listing.quantity}x ${listing.itemId} to ${interaction.user.id} failed — items owed:`, creditErr,
+        );
+        return interaction.reply({
+            content: 'The listing was cancelled, but returning your items hit an error. Tell an admin — it is recoverable.',
+            flags: MessageFlags.Ephemeral,
+        });
+    }
 
     const embed = new EmbedBuilder()
         .setColor('#e67e22')

--- a/src/commands/economy/sandcastle.js
+++ b/src/commands/economy/sandcastle.js
@@ -3,6 +3,7 @@ const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { logTransaction } = require('../../utils/logTransaction');
 const { saveWithBalanceDelta } = require('../../utils/balanceDelta');
+const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const {
     hasActiveEvent,
     getEventCurrencyId,
@@ -139,15 +140,6 @@ module.exports = {
 
             user.balance = (user.balance ?? 0) + prize.coins;
 
-            // Add a seashell to inventory
-            const invSlot = user.inventory?.find(i => i.itemId === 'seashell');
-            if (invSlot) {
-                invSlot.quantity += 1;
-            } else {
-                if (!user.inventory) user.inventory = [];
-                user.inventory.push({ itemId: 'seashell', quantity: 1 });
-            }
-
             logPayload = {
                 userId:   interaction.user.id,
                 guildId:  interaction.guild.id,
@@ -175,6 +167,14 @@ module.exports = {
             jobName: 'buildPayout',
             guildId: interaction.guild.id,
         });
+        if (!isWave) {
+            // The seashell lands as its own atomic upsert rather than riding the
+            // save: a slot pushed in memory can duplicate one a concurrent credit
+            // is creating (src/utils/inventoryGrant.js). The save above inserted
+            // the document for a first-time player, so the grant always has a doc
+            // to hit.
+            await grantInventoryItem(interaction.user.id, interaction.guild.id, 'seashell', 1);
+        }
         logTransaction(logPayload);
         return interaction.editReply({ embeds: [embed] });
     }

--- a/src/commands/economy/season.js
+++ b/src/commands/economy/season.js
@@ -11,6 +11,7 @@ const { rewardReveal } = require('../../utils/rewardReveal');
 const { logTransaction } = require('../../utils/logTransaction');
 const { awardSeasonXp } = require('../../services/questService');
 const { saveWithBalanceDelta } = require('../../utils/balanceDelta');
+const { grantInventoryItem, inventoryAddStages } = require('../../utils/inventoryGrant');
 
 // Reset a user's season sub-document to the fresh shape when their stored
 // seasonId is stale (a new season started). Prevents carrying old xp / claimed
@@ -192,10 +193,8 @@ async function executeClaim(interaction) {
     const balanceAtLoad = user.balance ?? 0;
 
     if (reward.coins > 0) user.balance += reward.coins;
-    if (reward.itemId) user.inventory.push({ itemId: reward.itemId, quantity: 1 });
     (wantsPremium ? user.season.claimedPremiumTiers : user.season.claimedTiers).push(tier);
     user.markModified('season');
-    if (reward.itemId) user.markModified('inventory');
 
     let coinsOwed = 0;
     try {
@@ -210,6 +209,22 @@ async function executeClaim(interaction) {
     } catch (err) {
         if (isVersionError(err)) return interaction.reply({ content: 'Edit conflict — try again.', flags: MessageFlags.Ephemeral });
         throw err;
+    }
+
+    // The claim is recorded; the item now lands as its own atomic upsert rather
+    // than riding the save — an inventory array written through `save()` would
+    // flatten any credit that landed since the read, and a slot pushed in memory
+    // can duplicate one a concurrent credit is creating
+    // (src/utils/inventoryGrant.js). A grant that fails is owed and logged, not
+    // lost silently — same posture as the coins above.
+    let itemOwed = false;
+    if (reward.itemId) {
+        try {
+            await grantInventoryItem(interaction.user.id, interaction.guild.id, reward.itemId, 1);
+        } catch (err) {
+            console.error(`[season] tier ${tier} item ${reward.itemId} owed to ${interaction.user.id} — grant failed:`, err);
+            itemOwed = true;
+        }
     }
 
     // Social proof: how many users in this guild have claimed this tier (this track)
@@ -236,6 +251,9 @@ async function executeClaim(interaction) {
                 ? (coinsOwed > 0
                     ? `\n⚠️ **${reward.coins.toLocaleString()} ${currency}** could not be credited just now and has been recorded as owed — your wallet does not include it yet.`
                     : `\n+**${reward.coins.toLocaleString()} ${currency}** added to your wallet`)
+                : '') +
+            (itemOwed
+                ? `\n⚠️ **${reward.label}** could not be added to your inventory just now — it has been logged and an admin can restore it.`
                 : '')
         );
 
@@ -481,6 +499,7 @@ async function executeClaimAll(interaction) {
     const balanceAtLoad = user.balance ?? 0;
     let totalCoins = 0;
     const itemsClaimed = [];
+    const itemsToGrant = [];
 
     for (const tierDef of claimable) {
         const reward = rewardFor(tierDef.tier, wantsPremium);
@@ -491,14 +510,8 @@ async function executeClaimAll(interaction) {
             totalCoins += reward.coins;
         }
         if (reward.itemId) {
-            const existing = user.inventory.find(e => e.itemId === reward.itemId);
-            if (existing) {
-                existing.quantity += 1;
-            } else {
-                user.inventory.push({ itemId: reward.itemId, quantity: 1 });
-            }
             itemsClaimed.push(reward.label);
-            user.markModified('inventory');
+            itemsToGrant.push(reward.itemId);
         }
 
         if (wantsPremium) {
@@ -526,6 +539,26 @@ async function executeClaimAll(interaction) {
         throw err;
     }
 
+    // The claims are recorded; the reward items now land in one atomic pipeline
+    // update rather than riding the save — an inventory array written through
+    // `save()` would flatten any credit that landed since the read, and slots
+    // pushed in memory can duplicate ones a concurrent credit is creating
+    // (src/utils/inventoryGrant.js). A grant that fails is owed and logged, not
+    // lost silently — same posture as the coins above.
+    let itemsOwed = false;
+    if (itemsToGrant.length > 0) {
+        try {
+            const granted = await User.findOneAndUpdate(
+                { userId: interaction.user.id, guildId: interaction.guild.id },
+                inventoryAddStages(itemsToGrant.map(itemId => ({ itemId }))),
+            );
+            if (!granted) throw new Error('user document not found');
+        } catch (err) {
+            console.error(`[season] claim-all items [${itemsToGrant.join(', ')}] owed to ${interaction.user.id} — grant failed:`, err);
+            itemsOwed = true;
+        }
+    }
+
     const track = wantsPremium ? '✨ Premium' : '🆓 Free';
     const tierNums = claimable.map(t => t.tier);
     const tierRange = tierNums.length === 1
@@ -538,7 +571,11 @@ async function executeClaimAll(interaction) {
             ? `⚠️ **${totalCoins.toLocaleString()} ${currency}** could not be credited just now and has been recorded as owed — your wallet does not include it yet.`
             : `💰 +**${totalCoins.toLocaleString()} ${currency}**`);
     }
-    if (itemsClaimed.length > 0) lines.push(`🎁 Items: ${itemsClaimed.join(', ')}`);
+    if (itemsClaimed.length > 0) {
+        lines.push(itemsOwed
+            ? `⚠️ Items (${itemsClaimed.join(', ')}) could not be added to your inventory just now — they have been logged and an admin can restore them.`
+            : `🎁 Items: ${itemsClaimed.join(', ')}`);
+    }
 
     const embed = new EmbedBuilder()
         .setColor(wantsPremium ? '#ffd700' : '#5865f2')

--- a/src/commands/economy/trackhunt.js
+++ b/src/commands/economy/trackhunt.js
@@ -3,6 +3,7 @@ const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { logTransaction } = require('../../utils/logTransaction');
 const { saveWithBalanceDelta } = require('../../utils/balanceDelta');
+const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const {
     hasActiveEvent,
     getEventCurrencyId,
@@ -139,15 +140,6 @@ module.exports = {
 
             user.balance = (user.balance ?? 0) + find.coins;
 
-            // Add a snowflake lure to inventory
-            const invSlot = user.inventory?.find(i => i.itemId === 'snowflake_lure');
-            if (invSlot) {
-                invSlot.quantity += 1;
-            } else {
-                if (!user.inventory) user.inventory = [];
-                user.inventory.push({ itemId: 'snowflake_lure', quantity: 1 });
-            }
-
             logPayload = {
                 userId:   interaction.user.id,
                 guildId:  interaction.guild.id,
@@ -175,6 +167,14 @@ module.exports = {
             jobName: 'trackPayout',
             guildId: interaction.guild.id,
         });
+        if (!isLost) {
+            // The snowflake lure lands as its own atomic upsert rather than riding
+            // the save: a slot pushed in memory can duplicate one a concurrent
+            // credit is creating (src/utils/inventoryGrant.js). The save above
+            // inserted the document for a first-time player, so the grant always
+            // has a doc to hit.
+            await grantInventoryItem(interaction.user.id, interaction.guild.id, 'snowflake_lure', 1);
+        }
         logTransaction(logPayload);
         return interaction.editReply({ embeds: [embed] });
     }

--- a/src/commands/economy/trickortreat.js
+++ b/src/commands/economy/trickortreat.js
@@ -3,6 +3,7 @@ const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { logTransaction } = require('../../utils/logTransaction');
 const { saveWithBalanceDelta } = require('../../utils/balanceDelta');
+const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const {
     hasActiveEvent,
     getEventCurrencyId,
@@ -138,15 +139,6 @@ module.exports = {
 
             user.balance = (user.balance ?? 0) + treat.coins;
 
-            // Add candy item to inventory
-            const invSlot = user.inventory?.find(i => i.itemId === 'candy_bag');
-            if (invSlot) {
-                invSlot.quantity += 1;
-            } else {
-                if (!user.inventory) user.inventory = [];
-                user.inventory.push({ itemId: 'candy_bag', quantity: 1 });
-            }
-
             logTransaction({
                 userId:   interaction.user.id,
                 guildId:  interaction.guild.id,
@@ -174,6 +166,14 @@ module.exports = {
             jobName: 'knockPayout',
             guildId: interaction.guild.id,
         });
+        if (!isTrick) {
+            // The candy bag lands as its own atomic upsert rather than riding the
+            // save: a slot pushed in memory can duplicate one a concurrent credit
+            // is creating (src/utils/inventoryGrant.js). The save above inserted
+            // the document for a first-time player, so the grant always has a doc
+            // to hit.
+            await grantInventoryItem(interaction.user.id, interaction.guild.id, 'candy_bag', 1);
+        }
         return interaction.editReply({ embeds: [embed] });
     }
 };

--- a/tests/inventorySaveGuard.test.js
+++ b/tests/inventorySaveGuard.test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+// Inventory credits land through the aggregation-pipeline upsert in
+// src/utils/inventoryGrant.js, never through `save()`. The dangerous shape is a
+// find-then-push (or `slot.quantity += n`) on an in-memory document that a
+// later `save()` writes back: the whole array goes out as an absolute `$set`
+// when the path is marked modified, flattening any credit that landed since the
+// read — and two concurrent credits that both miss the slot each push their
+// own, stranding the second slot's quantity behind every `find()`-first reader
+// (issue #573).
+//
+// This scan pins the sweep that removed those sites. It is spelling-based
+// rather than AST-based on purpose: the two spellings below are exactly the
+// ones the unsafe shape needs, they have no legitimate new use, and a scan that
+// flags a rare false positive is cheaper than one that misses a real credit.
+//
+//   - `.inventory.push(`            the miss half of check-then-push
+//   - `markModified('inventory')`   forces the whole array into the next save
+//
+// (`unmarkModified('inventory')` is the *fix* — use.js and explore.js detach
+// the array from a save — so the match requires the un-prefix to be absent.)
+
+const fs   = require('fs');
+const path = require('path');
+
+const SRC = path.join(__dirname, '..', 'src');
+
+// Verified by hand, and only these.
+const REVIEWED = new Map([
+    // The relic mutation keeps the in-memory inventory current for the
+    // encounter-stakes math and the reply, but explore.js detaches it from the
+    // pre-encounter save (`unmarkModified('inventory')`) and re-applies it as a
+    // grantInventoryItem upsert right after.
+    ['services/exploreService.js', 'relic mutation is detached from the save by explore.js and re-applied atomically'],
+    // decrementMaterial spends a grind material when feeding a pet — a debit,
+    // not a credit, cascading across hunt/fishing/mining stores that all live
+    // in the same save. Concurrency here can strand a unit of pet food, not
+    // mint one. Reworking it means reshaping the material stores; tracked as
+    // its own problem rather than waved through silently.
+    ['commands/economy/pet.js', 'decrementMaterial is a clamped debit of grind materials, not a credit'],
+]);
+
+const PATTERN = /\.inventory\.push\(|(?<!un)markModified\(['"]inventory['"]\)/;
+
+function walk(dir, out = []) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(full, out);
+        else if (entry.name.endsWith('.js')) out.push(full);
+    }
+    return out;
+}
+
+function findHits() {
+    const hits = [];
+    for (const file of walk(SRC)) {
+        const rel = path.relative(SRC, file).split(path.sep).join('/');
+        const lines = fs.readFileSync(file, 'utf8').split('\n');
+        lines.forEach((line, i) => {
+            if (PATTERN.test(line)) hits.push({ rel, line: i + 1, text: line.trim() });
+        });
+    }
+    return hits;
+}
+
+describe('inventory credits never ride a save()', () => {
+    const hits = findHits();
+
+    test('every in-memory inventory mutation is a reviewed exception', () => {
+        // Route new sites through src/utils/inventoryGrant.js, or detach them
+        // from the save the way explore.js does.
+        const unreviewed = hits
+            .filter(h => !REVIEWED.has(h.rel))
+            .map(h => `${h.rel}:${h.line}  ${h.text}`);
+        expect(unreviewed).toEqual([]);
+    });
+
+    test('no stale exemptions: every reviewed file still contains the pattern', () => {
+        const present = new Set(hits.map(h => h.rel));
+        const stale = [...REVIEWED.keys()].filter(rel => !present.has(rel));
+        expect(stale).toEqual([]);
+    });
+
+    // The scan is only as good as its spellings; prove each one still matches.
+    test('the pattern recognises both unsafe spellings and skips the fix', () => {
+        expect(PATTERN.test("user.inventory.push({ itemId: 'x', quantity: 1 });")).toBe(true);
+        expect(PATTERN.test("user.markModified('inventory');")).toBe(true);
+        expect(PATTERN.test('user.markModified("inventory");')).toBe(true);
+        expect(PATTERN.test("user.unmarkModified('inventory');")).toBe(false);
+        expect(PATTERN.test("user.markModified('exploration');")).toBe(false);
+    });
+});


### PR DESCRIPTION
Finishes the sweep #573 called for. That issue's four cited sites were fixed by #733, which extracted the shop.js pipeline into `utils/inventoryGrant` — but eleven sites still mutated `user.inventory` in memory and let `save()` write it back. Where `markModified('inventory')` was involved, the save writes the whole array as an absolute `$set` over whatever landed since the read, erasing concurrent atomic credits; even without it, a find-then-push pair can duplicate a slot, stranding the second slot's quantity behind every `find()`-first reader.

Converted to the shared atomic upsert:

- **market.js** — list-failure restore, buy credit, and cancel return. The listing **debit** also stops spending stock it read seconds ago: it is now the same `$elemMatch` compare-and-set that use.js established, so two concurrent `/market list` calls for one stack can no longer both take it — one stack backing two listings was a real duplication exploit.
- **eventshop.js** — item purchases; the effect branch keeps its save, and both branches keep the currency/stock revert on failure.
- **forge.js** — the forged item and its XP land in one pipeline update instead of a mutate-then-save computed before the multi-second AI call.
- **lovenote / sandcastle / trackhunt / trickortreat** — the souvenir item lands as its own upsert after `saveWithBalanceDelta`.
- **season.js** — tier-claim and claim-all reward items granted atomically after the claim is recorded, with "owed and logged" reporting when a grant cannot land, mirroring the existing coins-owed posture.
- **explore.js** — the relic stays in the in-memory inventory (the encounter stakes and the reply read it) but is detached from the pre-encounter save (`unmarkModified`) and re-applied atomically.

`tests/inventorySaveGuard.test.js` pins the rule the way `balanceSaveGuard` pins balance: the two unsafe spellings are scanned for across `src/`, with two reviewed exceptions (exploreService's detached relic mutation; pet.js's `decrementMaterial`, which is a clamped debit of grind materials, not a credit) checked for staleness so an exemption cannot outlive its justification.

Full suite: 101 suites, 1,488 tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoLbExCh2reyHNNQW69BgF

---
_Generated by [Claude Code](https://claude.ai/code/session_01QoLbExCh2reyHNNQW69BgF)_