### PR TITLE
Add the Wayfinder synergy — exploration's first seat at the cross-system table

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -341,6 +341,7 @@ gathering tracks. `/synergies` shows progress toward each:
 | ⚒️ Artificer | Mining 50 | +5% ore yield, +1 max mining stamina |
 | ⚙️ Iron Will | Mining 50, Hunt 50 | Blocks cave-ins below 50% pickaxe durability |
 | 💼 Merchant | Hunt/Fishing/Mining 20 each | +5% coins from `/work` and `/crime` while carrying items |
+| 🧭 Wayfinder | Hunt 30, Exploration 20 | +1 max stamina in Exploration and Hunting |
 
 **Pets** are passive-bonus companions with their own hunger, mood, level, and
 evolution track.

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -16,6 +16,7 @@ const {
 const { fitDescription, EMBED_LIMITS } = require('../../utils/embedFields');
 const {
     ensureExploreData,
+    getMaxStamina,
     applyStaminaRegen,
     applyDailyReset,
     msUntilNextStamina,
@@ -811,7 +812,7 @@ function buildResultEmbed(result, region, user, currency, eventDrop, mainXp, fir
     const leaderNote = hourlyLeader
         ? `🏆 Richest this hour: ${hourlyLeader.username} — ${hourlyLeader.details ?? `${currency}${hourlyLeader.value.toLocaleString()}`}`
         : randomFrom(FOOTER_LINES);
-    embed.setFooter({ text: `⚡ ${e.stamina}/${LIMITS.MAX_STAMINA} stamina${staminaNote} · ${nextExpeditionNote(user)} · ${leaderNote}` });
+    embed.setFooter({ text: `⚡ ${e.stamina}/${getMaxStamina(user)} stamina${staminaNote} · ${nextExpeditionNote(user)} · ${leaderNote}` });
     return embed;
 }
 
@@ -1227,7 +1228,8 @@ async function handleProfile(interaction) {
     const activeRegion = REGIONS[e.activeRegion];
     const nextThreshold = EXPLORER_LEVELS.find(l => l.level === e.level + 1)?.xpRequired;
 
-    const stamBar = '⚡'.repeat(e.stamina) + '▪️'.repeat(Math.max(0, LIMITS.MAX_STAMINA - e.stamina));
+    const maxStam = getMaxStamina(userData);
+    const stamBar = '⚡'.repeat(e.stamina) + '▪️'.repeat(Math.max(0, maxStam - e.stamina));
     const regenMs = msUntilNextStamina(userData);
 
     const embed = new EmbedBuilder()
@@ -1254,7 +1256,7 @@ async function handleProfile(interaction) {
             },
             {
                 name: '⚡ Stamina',
-                value: `${stamBar}\n${e.stamina}/${LIMITS.MAX_STAMINA}${e.stamina < LIMITS.MAX_STAMINA ? `\nNext regen: ${formatMs(regenMs)}` : '\nFull!'}`,
+                value: `${stamBar}\n${e.stamina}/${maxStam}${e.stamina < maxStam ? `\nNext regen: ${formatMs(regenMs)}` : '\nFull!'}`,
                 inline: true,
             },
             {

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -321,7 +321,11 @@ module.exports = {
                     o.setName('zone')
                         .setDescription('Zone to hunt in (defaults to your active zone)')
                         .setRequired(false)
-                        .addChoices(...ZONE_CHOICES)))
+                        .addChoices(...ZONE_CHOICES))
+                .addBooleanOption(o =>
+                    o.setName('quick')
+                        .setDescription('Skip the stealth & aim phases (no phase bonuses). Remembered for future hunts.')
+                        .setRequired(false)))
         .addSubcommand(sub =>
             sub.setName('profile')
                 .setDescription("View your or another player's hunter profile")
@@ -561,6 +565,17 @@ async function executeStart(interaction) {
     applyDailyReset(user);
     assignDailyHuntQuests(user);
 
+    // Quick-hunt preference: passing the option flips the stored setting, so it
+    // never has to be retyped; omitting it uses whatever was chosen last. Set
+    // before the pre-check save so the choice sticks even when this hunt then
+    // bounces off a cooldown or stamina gate.
+    const quickOpt = interaction.options.getBoolean('quick');
+    if (quickOpt !== null && quickOpt !== (user.hunt.quickHunt ?? false)) {
+        user.hunt.quickHunt = quickOpt;
+        user.markModified('hunt');
+    }
+    const quick = quickOpt ?? user.hunt.quickHunt ?? false;
+
     if (user.isModified()) {
         await user.save().catch(e => console.error('[hunt] pre-check save error:', e));
     }
@@ -749,7 +764,10 @@ async function executeStart(interaction) {
         const approachData = ZONE_APPROACHES[zoneId];
         const delay = ms => new Promise(r => setTimeout(r, ms));
 
-        if (approachData) {
+        // A quick hunt trades both phase bonuses for the ~6-10 seconds of
+        // prompts and forced waits the interactive path costs — a real trade
+        // the player opts into, so it needs no rebalancing.
+        if (!quick && approachData) {
             // Shuffle the 3 options
             const shuffled = [...approachData.options].sort(() => Math.random() - 0.5);
 
@@ -997,6 +1015,7 @@ async function executeStart(interaction) {
             if (aimBonus >= 0.18) lines.push(`> 🎯 *Perfect shot — +18% crit chance*`);
             else if (aimBonus > 0) lines.push(`> ✅ *Clean shot — +8% crit chance*`);
             else if (aimBonus < 0) lines.push(`> 💨 *Rushed shot — −5% crit chance*`);
+            if (quick) lines.push(`> ⚡ *Quick hunt — stealth & aim skipped · turn off with \`/hunt start quick:false\`*`);
             if (lines.length) embed.setDescription(desc + '\n' + lines.join('\n'));
         }
         // One consolidated field rather than one per bonus: Discord caps an embed at
@@ -1054,8 +1073,10 @@ async function executeStart(interaction) {
             embed.data.fields.length = 25;
         }
 
-        // Staged loot reveal for rare+ drops
-        await stagedLootReveal(interaction, result.success ? result.tier : null, embed);
+        // Staged loot reveal for rare+ drops. A quick hunt skips the ceremony
+        // here too — the fog-and-fanfare build-up is the same forced wait the
+        // player opted out of, and the tier is still announced on the embed.
+        await stagedLootReveal(interaction, !quick && result.success ? result.tier : null, embed);
 
         if (result.success && ['epic', 'legendary', 'event'].includes(result.tier) && guildSettings?.economy?.announceRareDrops !== false) {
             const announceChannelId = guildSettings?.economy?.announcementChannelId;

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -2084,17 +2084,23 @@ async function executePrestige(interaction) {
 
 const RECORD_MEDALS = ['🥇', '🥈', '🥉'];
 
+// A board query that cannot use its index or hits a degenerate plan should
+// fail fast rather than hold the deferred reply open.
+const RECORDS_QUERY_TIMEOUT_MS = 5_000;
+
 /**
  * Top hunters for one stat, rendered as medal lines. `line` maps a lean
  * GrindProfile to the text after the mention; sorting happens in the query so
- * the whole guild is never loaded.
+ * the whole guild is never loaded, and `fields` projects only the data
+ * subpaths the line actually reads — `data` holds the full hunt blob
+ * (weapons, materials, trophies), which no board needs.
  */
-async function topHuntersBy(guildId, sort, filter, line, limit = 3) {
-    const profs = await GrindProfile.find(
-        { guildId, system: 'hunt', ...filter },
-        { userId: 1, data: 1 },
-    ).sort(sort).limit(limit).lean();
-    return profs.map((p, i) => `${RECORD_MEDALS[i] ?? `**${i + 1}.**`} <@${p.userId}> — ${line(p.data)}`).join('\n');
+async function topHuntersBy(guildId, sort, filter, fields, line, limit = 3) {
+    const projection = { userId: 1 };
+    for (const f of fields) projection[f] = 1;
+    const profs = await GrindProfile.find({ guildId, system: 'hunt', ...filter }, projection)
+        .sort(sort).limit(limit).maxTimeMS(RECORDS_QUERY_TIMEOUT_MS).lean();
+    return profs.map((p, i) => `${RECORD_MEDALS[i] ?? `**${i + 1}.**`} <@${p.userId}> — ${line(p.data ?? {})}`).join('\n');
 }
 
 async function executeRecords(interaction) {
@@ -2118,13 +2124,19 @@ async function executeRecords(interaction) {
     };
 
     const [bestPayout, legendary, mythical, veterans, volume, earned] = await Promise.all([
-        topHuntersBy(guildId, { 'data.bestPayout': -1 },     { 'data.bestPayout':     { $gt: 0 } }, describeBest),
-        topHuntersBy(guildId, { 'data.legendaryKills': -1 }, { 'data.legendaryKills': { $gt: 0 } }, d => `**${d.legendaryKills.toLocaleString()}** legendary kills`),
-        topHuntersBy(guildId, { 'data.eventKills': -1 },     { 'data.eventKills':     { $gt: 0 } }, d => `**${d.eventKills.toLocaleString()}** mythical kills`),
+        topHuntersBy(guildId, { 'data.bestPayout': -1 },     { 'data.bestPayout':     { $gt: 0 } },
+            ['data.bestPayout', 'data.bestPayoutMeta'], describeBest),
+        topHuntersBy(guildId, { 'data.legendaryKills': -1 }, { 'data.legendaryKills': { $gt: 0 } },
+            ['data.legendaryKills'], d => `**${d.legendaryKills.toLocaleString()}** legendary kills`),
+        topHuntersBy(guildId, { 'data.eventKills': -1 },     { 'data.eventKills':     { $gt: 0 } },
+            ['data.eventKills'], d => `**${d.eventKills.toLocaleString()}** mythical kills`),
         topHuntersBy(guildId, { 'data.prestige': -1, 'data.level': -1 }, { 'data.totalHunts': { $gt: 0 } },
+            ['data.prestige', 'data.level'],
             d => `${(d.prestige ?? 0) > 0 ? `${PRESTIGE_BADGES[Math.min(d.prestige, PRESTIGE_BADGES.length - 1)]} P${d.prestige} · ` : ''}Level **${d.level ?? 1}**`),
-        topHuntersBy(guildId, { 'data.totalHunts': -1 },  { 'data.totalHunts':  { $gt: 0 } }, d => `**${d.totalHunts.toLocaleString()}** hunts`),
-        topHuntersBy(guildId, { 'data.totalEarned': -1 }, { 'data.totalEarned': { $gt: 0 } }, d => `**${currency}${d.totalEarned.toLocaleString()}** earned`),
+        topHuntersBy(guildId, { 'data.totalHunts': -1 },  { 'data.totalHunts':  { $gt: 0 } },
+            ['data.totalHunts'], d => `**${d.totalHunts.toLocaleString()}** hunts`),
+        topHuntersBy(guildId, { 'data.totalEarned': -1 }, { 'data.totalEarned': { $gt: 0 } },
+            ['data.totalEarned'], d => `**${currency}${d.totalEarned.toLocaleString()}** earned`),
     ]);
 
     if (!bestPayout && !volume) {

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -53,6 +53,7 @@ const {
     apexNerveMax,
     getRarePityThreshold,
     getDiminishingReturns,
+    recordBestPayout,
     applyPayoutModifiers
 } = require('../../services/huntService');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
@@ -331,6 +332,9 @@ module.exports = {
         .addSubcommand(sub =>
             sub.setName('prestige')
                 .setDescription('Reset your hunter level for permanent prestige bonuses (requires Level 50)'))
+        .addSubcommand(sub =>
+            sub.setName('records')
+                .setDescription("View the server's all-time hunting records"))
         .addSubcommandGroup(group =>
             group.setName('inv')
                 .setDescription('View and manage your hunt inventory')
@@ -479,6 +483,7 @@ module.exports = {
             if (sub === 'start')    return executeStart(interaction);
             if (sub === 'profile')  return executeProfile(interaction);
             if (sub === 'prestige') return executePrestige(interaction);
+            if (sub === 'records')  return executeRecords(interaction);
         }
         if (group === 'inv')    return executeInv(interaction, sub);
         if (group === 'quests') return executeQuests(interaction, sub);
@@ -907,7 +912,9 @@ async function executeStart(interaction) {
                 result.wildernessBonus  = bonus;
             }
         }
-        if (result.success && result.finalPayout > user.hunt.bestPayout) user.hunt.bestPayout = result.finalPayout;
+        if (result.success) {
+            recordBestPayout(user.hunt, result.finalPayout, { animal: result.animal, tier: result.tier, zoneId });
+        }
 
         updateHuntQuestProgress(user, result, zoneId);
         await ensureQuests(user, guildSettings);
@@ -1194,7 +1201,11 @@ async function executeStart(interaction) {
                 freshUser.balance          += adjustedPayout;
                 freshUser.hunt.totalEarned += adjustedPayout;
                 freshUser.hunt.dailyCoins  += adjustedPayout;
-                if (adjustedPayout > freshUser.hunt.bestPayout) freshUser.hunt.bestPayout = adjustedPayout;
+                recordBestPayout(freshUser.hunt, adjustedPayout, {
+                    animal: result.apexEncounter.animal,
+                    tier:   result.apexEncounter.tier,
+                    zoneId: freshUser.hunt.activeZone,
+                });
 
                 await ensureQuests(freshUser, guildSettings);
                 const earn = await onEconomyEarn(freshUser, guildSettings, adjustedPayout);
@@ -1972,6 +1983,82 @@ async function executePrestige(interaction) {
                 .catch(() => {});
         }
     });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RECORDS — server-wide all-time hunting records
+// ═══════════════════════════════════════════════════════════════════════════════
+
+const RECORD_MEDALS = ['🥇', '🥈', '🥉'];
+
+/**
+ * Top hunters for one stat, rendered as medal lines. `line` maps a lean
+ * GrindProfile to the text after the mention; sorting happens in the query so
+ * the whole guild is never loaded.
+ */
+async function topHuntersBy(guildId, sort, filter, line, limit = 3) {
+    const profs = await GrindProfile.find(
+        { guildId, system: 'hunt', ...filter },
+        { userId: 1, data: 1 },
+    ).sort(sort).limit(limit).lean();
+    return profs.map((p, i) => `${RECORD_MEDALS[i] ?? `**${i + 1}.**`} <@${p.userId}> — ${line(p.data)}`).join('\n');
+}
+
+async function executeRecords(interaction) {
+    await interaction.deferReply();
+    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id }, 'economy').lean().catch(() => null);
+    const currency = guildSettings?.economy?.currency ?? '💰';
+    const guildId  = interaction.guild.id;
+
+    const describeBest = d => {
+        const meta  = d.bestPayoutMeta;
+        const base  = `**${currency}${(d.bestPayout ?? 0).toLocaleString()}**`;
+        if (!meta?.animalName) return base;
+        const zone     = ZONES[meta.zoneId];
+        const tierName = meta.tier ? meta.tier.charAt(0).toUpperCase() + meta.tier.slice(1) : null;
+        const parts = [
+            `${meta.animalEmoji ?? ''} ${tierName ? `${tierName} ` : ''}${meta.animalName}`.trim(),
+            zone ? `${zone.emoji} ${zone.name}` : null,
+            meta.at ? `<t:${Math.floor(new Date(meta.at).getTime() / 1000)}:d>` : null,
+        ].filter(Boolean);
+        return `${base} · ${parts.join(' · ')}`;
+    };
+
+    const [bestPayout, legendary, mythical, veterans, volume, earned] = await Promise.all([
+        topHuntersBy(guildId, { 'data.bestPayout': -1 },     { 'data.bestPayout':     { $gt: 0 } }, describeBest),
+        topHuntersBy(guildId, { 'data.legendaryKills': -1 }, { 'data.legendaryKills': { $gt: 0 } }, d => `**${d.legendaryKills.toLocaleString()}** legendary kills`),
+        topHuntersBy(guildId, { 'data.eventKills': -1 },     { 'data.eventKills':     { $gt: 0 } }, d => `**${d.eventKills.toLocaleString()}** mythical kills`),
+        topHuntersBy(guildId, { 'data.prestige': -1, 'data.level': -1 }, { 'data.totalHunts': { $gt: 0 } },
+            d => `${(d.prestige ?? 0) > 0 ? `${PRESTIGE_BADGES[Math.min(d.prestige, PRESTIGE_BADGES.length - 1)]} P${d.prestige} · ` : ''}Level **${d.level ?? 1}**`),
+        topHuntersBy(guildId, { 'data.totalHunts': -1 },  { 'data.totalHunts':  { $gt: 0 } }, d => `**${d.totalHunts.toLocaleString()}** hunts`),
+        topHuntersBy(guildId, { 'data.totalEarned': -1 }, { 'data.totalEarned': { $gt: 0 } }, d => `**${currency}${d.totalEarned.toLocaleString()}** earned`),
+    ]);
+
+    if (!bestPayout && !volume) {
+        return interaction.editReply({
+            embeds: [new EmbedBuilder()
+                .setColor('#3b1f04')
+                .setTitle('🏹 Server Hunting Records')
+                .setDescription('No records yet — head out with `/hunt start` and claim the top spot!')
+                .setTimestamp()],
+        });
+    }
+
+    const embed = new EmbedBuilder()
+        .setColor('#c0392b')
+        .setTitle('🏹 Server Hunting Records')
+        .setDescription('The all-time boards. The hourly leader resets every hour — these never do.')
+        .setFooter({ text: 'Records never reset · Your own numbers live in /hunt profile' })
+        .setTimestamp();
+
+    if (bestPayout) embed.addFields({ name: '💰 Biggest Single Hunt',  value: bestPayout, inline: false });
+    if (legendary)  embed.addFields({ name: '⚡ Legendary Hunters',    value: legendary,  inline: false });
+    if (mythical)   embed.addFields({ name: '☄️ Mythical Hunters',     value: mythical,   inline: false });
+    if (veterans)   embed.addFields({ name: '🎖️ Highest Rank',        value: veterans,   inline: false });
+    if (volume)     embed.addFields({ name: '🏹 Most Hunts',           value: volume,     inline: false });
+    if (earned)     embed.addFields({ name: '💵 Career Earnings',      value: earned,     inline: false });
+
+    return interaction.editReply({ embeds: [embed] });
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -3339,7 +3426,7 @@ const { withEconomyLock, exceptReadOnly } = require('../../utils/economyLock');
 // exceptReadOnly. Everything else, including /hunt inv equip and discard,
 // still locks.
 const HUNT_READ_ONLY = [
-    'profile',
+    'profile', 'records',
     'inv weapons', 'inv ammo', 'inv consumables', 'inv materials',
     'shop list',
     'zone list',

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -1719,7 +1719,7 @@ async function executeProfile(interaction) {
     } else if (h.level >= 25) {
         embed.addFields({
             name: '🔗 Synergies',
-            value: 'Reach combined level milestones across Hunt, Fish & Mine to unlock cross-system bonuses!',
+            value: 'Reach combined level milestones across Hunt, Fish, Mine & Explore to unlock cross-system bonuses!',
             inline: false
         });
     }

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -54,7 +54,9 @@ const {
     getRarePityThreshold,
     getDiminishingReturns,
     recordBestPayout,
-    applyPayoutModifiers
+    applyPayoutModifiers,
+    rollHuntEncounter,
+    rollAnimal
 } = require('../../services/huntService');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
 const { stackBar } = require('../../utils/rewardReveal');
@@ -232,57 +234,114 @@ const walletOf = interaction => ({ userId: interaction.user.id, guildId: interac
 const chargeBalance = (interaction, cost) => chargeExact(User, walletOf(interaction), cost);
 const refundBalance = (interaction, cost) => refundCharge(User, walletOf(interaction), cost, 'huntshop');
 
-// ─── STEALTH APPROACH OPTIONS (per zone) ─────────────────────────────────────
-// Each zone has a hint about the animal's behaviour + 3 approach strategies.
-// One approach is correct; correct = stealthBonus, wrong = noise penalty.
+// ─── STEALTH APPROACH PROFILES (per animal) ──────────────────────────────────
+// The prey is rolled before the prompt (rollHuntEncounter), so the hint
+// describes the animal that is actually there and the correct answer follows
+// from how *that* animal behaves. Trait prey keys on its traits — elusive
+// rewards patience, aggressive rewards cover, giant/armored/venomous reward
+// distance, spectral rewards stillness — and trait-less prey rolls one of
+// three behaviours per hunt. Either way the right answer changes hunt to
+// hunt, so the prompt is a read, not a memorised zone fact (issue #739).
+//
+// Each profile: one correct option (+0.25), one safe-but-suboptimal (+0.05),
+// one wrong (−0.10). The probabilistic outcome layer on top is unchanged.
 
-const ZONE_APPROACHES = {
-    beginner_forest: {
-        hint: 'A deer is grazing peacefully in a sun-dappled clearing, ears flicking at every sound.',
+const APPROACH_PROFILES = {
+    stillness: {
+        id: 'stillness',
+        hint: a => `${a.emoji} A **${a.name}** drifts at the edge of sight, half there and half not. It doesn't listen for you — it *feels* movement.`,
         options: [
-            { id: 'undergrowth', label: '🌿 Creep through the undergrowth', stealthBonus: 0.25 },
-            { id: 'sprint',      label: '🏃 Sprint straight in to close the gap', stealthBonus: -0.10 },
-            { id: 'call',        label: '📢 Mimic a bird call to distract it', stealthBonus: 0.05 },
+            { id: 'freeze',    label: '🗿 Freeze and let it drift closer',    stealthBonus: 0.25 },
+            { id: 'ease_back', label: '🌿 Ease back and wait it out',         stealthBonus: 0.05 },
+            { id: 'circle',    label: '🏃 Circle around for a better angle',  stealthBonus: -0.10 },
+        ],
+        correctId: 'freeze',
+    },
+    patience: {
+        id: 'patience',
+        hint: a => `${a.emoji} A **${a.name}** flickers between cover, never still for more than a breath — one hasty move and it's gone.`,
+        options: [
+            { id: 'read_pattern', label: '⏳ Study its pattern and wait for the pause', stealthBonus: 0.25 },
+            { id: 'shadow',       label: '🌿 Shadow it from a distance',                stealthBonus: 0.05 },
+            { id: 'rush',         label: '🏃 Rush it before it slips away',             stealthBonus: -0.10 },
+        ],
+        correctId: 'read_pattern',
+    },
+    cover: {
+        id: 'cover',
+        hint: a => `${a.emoji} A **${a.name}** prowls the clearing, head snapping up at every sound — whatever it sees, it charges.`,
+        options: [
+            { id: 'hard_cover', label: '🌳 Keep hard cover between you and it', stealthBonus: 0.25 },
+            { id: 'downwind',   label: '💨 Circle downwind in the open',        stealthBonus: 0.05 },
+            { id: 'direct',     label: '⚔️ Advance on it directly',             stealthBonus: -0.10 },
+        ],
+        correctId: 'hard_cover',
+    },
+    distance: {
+        id: 'distance',
+        hint: a => `${a.emoji} A **${a.name}** dominates the ground ahead — up close it's the one holding every advantage. Take it from range.`,
+        options: [
+            { id: 'high_ground', label: '🎯 Line up a long shot from high ground', stealthBonus: 0.25 },
+            { id: 'treeline',    label: '🌿 Skirt the treeline at range',          stealthBonus: 0.05 },
+            { id: 'close_in',    label: '🏃 Slip in close for a sure shot',        stealthBonus: -0.10 },
+        ],
+        correctId: 'high_ground',
+    },
+    // Behaviours for trait-less prey, rolled per hunt.
+    grazing: {
+        id: 'grazing',
+        hint: a => `${a.emoji} A **${a.name}** feeds in the open, ears flicking at every sound — it hasn't noticed you yet.`,
+        options: [
+            { id: 'undergrowth', label: '🌿 Creep through the undergrowth',   stealthBonus: 0.25 },
+            { id: 'call',        label: '📢 Mimic a call to distract it',     stealthBonus: 0.05 },
+            { id: 'sprint',      label: '🏃 Sprint in to close the gap',      stealthBonus: -0.10 },
         ],
         correctId: 'undergrowth',
     },
-    desert_wastes: {
-        hint: 'A desert serpent basks motionless on a sun-warmed rock — utterly still, eyes open.',
+    alert: {
+        id: 'alert',
+        hint: a => `${a.emoji} A **${a.name}** stands rigid, nose working the air — it's caught wind of something.`,
         options: [
-            { id: 'rock_crawl', label: '🪨 Crawl low between boulders', stealthBonus: 0.25 },
-            { id: 'open_run',   label: '💨 Sprint across the open sand', stealthBonus: -0.10 },
-            { id: 'shade_wait', label: '☁️ Wait for a cloud to pass over', stealthBonus: 0.05 },
+            { id: 'go_downwind', label: '💨 Circle downwind before closing in',  stealthBonus: 0.25 },
+            { id: 'hold',        label: '⏳ Hold position until it settles',     stealthBonus: 0.05 },
+            { id: 'upwind',      label: '🌬️ Push straight in from upwind',      stealthBonus: -0.10 },
         ],
-        correctId: 'rock_crawl',
+        correctId: 'go_downwind',
     },
-    arctic_tundra: {
-        hint: 'A white wolf moves in tight circles — it\'s caught a scent. One wrong step and it bolts.',
+    moving: {
+        id: 'moving',
+        hint: a => `${a.emoji} A **${a.name}** is on the move, weaving through cover with somewhere to be.`,
         options: [
-            { id: 'downwind',   label: '💨 Circle downwind before closing in', stealthBonus: 0.25 },
-            { id: 'upwind',     label: '🌬️ Walk directly into the wind toward it', stealthBonus: -0.10 },
-            { id: 'white_out',  label: '🌨️ Use a snow squall as cover', stealthBonus: 0.05 },
+            { id: 'ambush', label: '🪤 Cut ahead and set an ambush',        stealthBonus: 0.25 },
+            { id: 'trail',  label: '🐾 Trail it and wait for it to stop',   stealthBonus: 0.05 },
+            { id: 'chase',  label: '🏃 Run it down',                        stealthBonus: -0.10 },
         ],
-        correctId: 'downwind',
-    },
-    murky_swamp: {
-        hint: 'A large reptile floats just below the surface — only its eyes are visible.',
-        options: [
-            { id: 'wade_slow',  label: '🌊 Wade in slowly without splashing', stealthBonus: 0.25 },
-            { id: 'throw_rock', label: '🪨 Throw a rock to distract it first', stealthBonus: -0.10 },
-            { id: 'reed_hide',  label: '🌾 Hide in the reeds and wait for it to surface', stealthBonus: 0.05 },
-        ],
-        correctId: 'wade_slow',
-    },
-    legendary_peaks: {
-        hint: 'An ancient creature roosts on a cliff ledge — its senses are preternatural.',
-        options: [
-            { id: 'cliff_path', label: '🧗 Climb the cliff path at dusk, shadow-side', stealthBonus: 0.25 },
-            { id: 'direct',     label: '⚔️ Charge straight up the ridge', stealthBonus: -0.10 },
-            { id: 'below',      label: '🎯 Position below and let it come to you', stealthBonus: 0.05 },
-        ],
-        correctId: 'cliff_path',
+        correctId: 'ambush',
     },
 };
+
+// First matching trait wins; the order puts the most read-defining trait
+// first. Traits with no behavioural read of their own (enraged) fall through
+// to the rolled behaviours.
+const TRAIT_PROFILE_ORDER = [
+    ['spectral',    'stillness'],
+    ['elusive',     'patience'],
+    ['aggressive',  'cover'],
+    ['pack_hunter', 'cover'],
+    ['giant',       'distance'],
+    ['armored',     'distance'],
+    ['venomous',    'distance'],
+];
+
+const GENERIC_PROFILE_IDS = ['grazing', 'alert', 'moving'];
+
+function pickApproachProfile(animal) {
+    const traits = animal?.traits ?? [];
+    for (const [trait, profileId] of TRAIT_PROFILE_ORDER) {
+        if (traits.includes(trait)) return APPROACH_PROFILES[profileId];
+    }
+    return APPROACH_PROFILES[GENERIC_PROFILE_IDS[Math.floor(Math.random() * GENERIC_PROFILE_IDS.length)]];
+}
 
 // ─── SHARED CHOICE LISTS ──────────────────────────────────────────────────────
 
@@ -747,7 +806,8 @@ async function executeStart(interaction) {
         }
 
         // ── Stealth Approach + Precision Aim ─────────────────────────────────────
-        // Phase 1 — Stealth: player reads a behaviour hint and picks the right approach.
+        // Phase 1 — Stealth: the prey is rolled first, and the player reads a
+        // behaviour hint about *that animal* and picks the matching approach.
         //   Correct  → stealthBonus = +0.25 success chance, common→uncommon upgrade ~30%
         //   Partial  → stealthBonus = +0.05 (safe but suboptimal)
         //   Wrong    → stealthBonus = −0.10 (spooked the animal)
@@ -761,13 +821,17 @@ async function executeStart(interaction) {
         let stealthBonus = 0;
         let aimBonus     = 0;
 
-        const approachData = ZONE_APPROACHES[zoneId];
+        // Rolled before the prompt so the hint can be truthful and the correct
+        // answer can follow the animal rather than the zone.
+        let encounter = rollHuntEncounter(user, zoneId);
+
         const delay = ms => new Promise(r => setTimeout(r, ms));
 
         // A quick hunt trades both phase bonuses for the ~6-10 seconds of
         // prompts and forced waits the interactive path costs — a real trade
         // the player opts into, so it needs no rebalancing.
-        if (!quick && approachData) {
+        if (!quick) {
+            const approachData = pickApproachProfile(encounter.animal);
             // Shuffle the 3 options
             const shuffled = [...approachData.options].sort(() => Math.random() - 0.5);
 
@@ -775,7 +839,7 @@ async function executeStart(interaction) {
                 .setColor('#556B2F')
                 .setTitle(`🌿 Approaching ${zone.emoji} ${zone.name}…`)
                 .setDescription(
-                    `*${approachData.hint}*\n\n` +
+                    `*${approachData.hint(encounter.animal)}*\n\n` +
                     `**How do you close in on your prey?**\n` +
                     `Choose wisely — the animal will react to your approach.`
                 )
@@ -851,6 +915,14 @@ async function executeStart(interaction) {
             await interaction.editReply({ embeds: [stealthResultEmbed], components: [] });
             await delay(800);
 
+            // A patient, correct approach can turn common prey into something
+            // better — the "chance of better prey" the result copy promises.
+            // Applied here, once the stealth outcome is known, because the
+            // encounter itself is rolled before the prompt now.
+            if (stealthBonus > 0 && encounter.tier === 'common' && Math.random() < 0.30) {
+                encounter = { tier: 'uncommon', animal: rollAnimal('uncommon', zoneId) };
+            }
+
             aimBonus = (await runAimPhase(interaction, huntMsg)).bonus;
 
         } else {
@@ -866,7 +938,7 @@ async function executeStart(interaction) {
         const isFeaturedZone = zoneId === featured.huntZone.id;
 
         const marketplaceActive = isDistrictActive(guildSettings, 'marketplace');
-        const result = executeHunt(user, zoneId, { stealthBonus, aimBonus, marketplaceActive });
+        const result = executeHunt(user, zoneId, { stealthBonus, aimBonus, marketplaceActive, encounter });
 
         // Pity counter: reset on rare+ success, increment otherwise
         if (result.success && ['rare', 'epic', 'legendary', 'event'].includes(result.tier)) {
@@ -3435,7 +3507,7 @@ async function checkGrandPrestige(client, user, guild, guildId) {
 
 // Test hooks. The command loader only looks for `data` and `execute`
 // (src/index.js), so extra exports are inert at runtime.
-module.exports.__test__ = { buildHuntEmbed, buildBonusLines, buildTrophyField, buildFieldTrophyField, buildDailyTollField, buildTodayField, buildWeaponPages, WEAPON_SEPARATOR, gradeShot, runAimPhase, AIM_WINDOW_MS, AIM_LATE_MS, isCrossEconomyWeapon, huntingDaysFor, huntingDaysLabel, fullRepairCost, CROSS_ECONOMY_DAYS };
+module.exports.__test__ = { buildHuntEmbed, buildBonusLines, buildTrophyField, buildFieldTrophyField, buildDailyTollField, buildTodayField, buildWeaponPages, WEAPON_SEPARATOR, gradeShot, runAimPhase, AIM_WINDOW_MS, AIM_LATE_MS, isCrossEconomyWeapon, huntingDaysFor, huntingDaysLabel, fullRepairCost, CROSS_ECONOMY_DAYS, APPROACH_PROFILES, TRAIT_PROFILE_ORDER, GENERIC_PROFILE_IDS, pickApproachProfile };
 
 // ── Per-user economy lock ─────────────────────────────────────────────────────
 // Hunting mutates the user document with read-modify-write saves, so concurrent

--- a/src/commands/economy/synergies.js
+++ b/src/commands/economy/synergies.js
@@ -8,6 +8,7 @@ const { SYNERGY_LIST } = require('../../data/crossSystemData');
 const { ensureHuntData }    = require('../../services/huntService');
 const { ensureFishingData } = require('../../services/fishService');
 const { ensureMineData }    = require('../../services/mineService');
+const { ensureExploreData } = require('../../services/exploreService');
 
 module.exports = {
     cooldown: 5,
@@ -31,17 +32,20 @@ module.exports = {
         ensureHuntData(user);
         ensureFishingData(user);
         ensureMineData(user);
+        ensureExploreData(user);
 
-        const huntLevel  = user.hunt?.level    ?? 0;
-        const fishLevel  = user.fishing?.level ?? 0;
-        const mineLevel  = user.mining?.level  ?? 0;
+        const huntLevel    = user.hunt?.level        ?? 0;
+        const fishLevel    = user.fishing?.level     ?? 0;
+        const mineLevel    = user.mining?.level      ?? 0;
+        const exploreLevel = user.exploration?.level ?? 0;
 
         const lines = SYNERGY_LIST.map(syn => {
             const req = syn.requirements;
             const checks = [];
-            if (req.hunt)    checks.push({ label: `Hunt Lv.${req.hunt}`,   have: huntLevel,  need: req.hunt  });
-            if (req.fishing) checks.push({ label: `Fish Lv.${req.fishing}`, have: fishLevel,  need: req.fishing });
-            if (req.mining)  checks.push({ label: `Mine Lv.${req.mining}`,  have: mineLevel,  need: req.mining  });
+            if (req.hunt)        checks.push({ label: `Hunt Lv.${req.hunt}`,          have: huntLevel,    need: req.hunt        });
+            if (req.fishing)     checks.push({ label: `Fish Lv.${req.fishing}`,       have: fishLevel,    need: req.fishing     });
+            if (req.mining)      checks.push({ label: `Mine Lv.${req.mining}`,        have: mineLevel,    need: req.mining      });
+            if (req.exploration) checks.push({ label: `Explore Lv.${req.exploration}`, have: exploreLevel, need: req.exploration });
 
             const unlocked = checks.every(c => c.have >= c.need);
 
@@ -65,8 +69,8 @@ module.exports = {
             .setColor('#1abc9c')
             .setTitle('🔗 Cross-System Synergies')
             .setDescription(
-                'Reach level milestones across **Hunt**, **Fish**, and **Mine** to unlock ' +
-                'permanent passive bonuses that work across all three systems.\n​'
+                'Reach level milestones across **Hunt**, **Fish**, **Mine**, and **Explore** to unlock ' +
+                'permanent passive bonuses that work across systems.\n​'
             )
             .addFields({ name: '​', value: lines.join('\n\n'), inline: false })
             .addFields({
@@ -75,6 +79,7 @@ module.exports = {
                     `🏹 Hunt: **${huntLevel}**`,
                     `🎣 Fish: **${fishLevel}**`,
                     `⛏️ Mine: **${mineLevel}**`,
+                    `🧭 Explore: **${exploreLevel}**`,
                 ].join('  ·  '),
                 inline: false,
             })

--- a/src/data/crossSystemData.js
+++ b/src/data/crossSystemData.js
@@ -118,6 +118,17 @@ const SYNERGIES = {
         flavor: 'A full bag and a sharp eye — the mark of someone who knows value.',
         requirements: { hunt: 20, fishing: 20, mining: 20 },
         bonuses: { workCrimeCoinPct: 0.05 }
+    },
+    wayfinder: {
+        id: 'wayfinder',
+        name: 'Wayfinder',
+        emoji: '🧭',
+        description: '+1 max stamina in both Exploration and Hunting',
+        flavor: 'Reading the land and reading the prey are the same craft.',
+        // Exploration's track tops out at 30, so 20 here is the same mid-track
+        // commitment the 50-level systems ask for at 30.
+        requirements: { hunt: 30, exploration: 20 },
+        bonuses: { explorationStamina: 1, huntStamina: 1 }
     }
 };
 

--- a/src/data/huntData.js
+++ b/src/data/huntData.js
@@ -1305,36 +1305,63 @@ const TROPHY_QUALITIES = [
 // strategy players learn over time: match its moves, hold your ground, or
 // wait it out. 'safe' choices never cost nerve but only the correct choice
 // counts toward the reward.
+// Each apex carries a pool of phases; a duel draws three of them in a random
+// order (huntService.rollApexType). Every phase has its own correct answer,
+// and the tell for it lives in the hint — a feint carries no weight behind it
+// (mirror it), a committed attack does (plant against it). The old shape had
+// one `strategy` repeated across all three phases, so knowing the apex's name
+// made the 1.5x bonus free and the hints were flavour dressed as information
+// (issue #740). `safe` stays the always-available hedge: never correct, never
+// costs nerve — the choice you make when you can't read the tell.
 const APEX_TYPES = {
     dire_alpha: {
         name: 'Dire Alpha',
         emoji: '🐺',
-        strategy: 'match', // mirror its feints
-        phases: [
+        // The read: does the attack carry its weight? A probe wants you to
+        // flinch — move with it. A committed strike must be met standing.
+        phasePool: [
             {
-                hint: '**THE DIRE ALPHA** feints LEFT, hackles raised!',
+                hint: '**THE DIRE ALPHA** feints LEFT — its paws never leave the ground. It wants you to flinch first.',
                 choices: {
-                    match: { label: '🎯 Mirror it — sidestep LEFT', risk: 'high' },
-                    hold:  { label: '🛑 Stand your ground',          risk: 'high' },
-                    safe:  { label: '🌿 Back away slowly',           risk: 'none' }
+                    match: { label: '🎯 Mirror the feint — step LEFT', risk: 'high' },
+                    hold:  { label: '🛑 Stand your ground',            risk: 'high' },
+                    safe:  { label: '🌿 Back away slowly',             risk: 'none' }
                 },
                 correct: 'match'
             },
             {
-                hint: 'It lunges RIGHT, snapping at your flank!',
+                hint: 'It darts RIGHT, snapping at air — a probe, not a strike. Its weight is still centred.',
                 choices: {
-                    match: { label: '🎯 Pivot RIGHT with it',  risk: 'high' },
-                    hold:  { label: '🛑 Brace for the hit',    risk: 'high' },
-                    safe:  { label: '🌿 Give ground',          risk: 'none' }
+                    match: { label: '🎯 Pivot RIGHT with it', risk: 'high' },
+                    hold:  { label: '🛑 Brace for the hit',   risk: 'high' },
+                    safe:  { label: '🌿 Give ground',         risk: 'none' }
                 },
                 correct: 'match'
             },
             {
-                hint: '**It rears for a final pounce** — read the angle.',
+                hint: 'It charges dead-on — ears pinned, weight low. **This one is real.**',
                 choices: {
-                    match: { label: '💪 Strike as it commits',     risk: 'high' },
-                    hold:  { label: '🛑 Plant and counter',        risk: 'high' },
-                    safe:  { label: '🌿 Wait for an opening',      risk: 'none' }
+                    match: { label: '🎯 Sidestep and swing',   risk: 'high' },
+                    hold:  { label: '🛑 Plant and meet it',    risk: 'high' },
+                    safe:  { label: '🌿 Dive clear',           risk: 'none' }
+                },
+                correct: 'hold'
+            },
+            {
+                hint: 'It circles you slowly, hackles up, testing whether you\'ll turn your back.',
+                choices: {
+                    match: { label: '🎯 Turn with it, blade out',        risk: 'high' },
+                    hold:  { label: '🛑 Hold your ground, eyes on it',   risk: 'high' },
+                    safe:  { label: '🌿 Back toward a tree',             risk: 'none' }
+                },
+                correct: 'hold'
+            },
+            {
+                hint: 'It rears for a pounce — but its hips swing LEFT. The leap is a feint into a flank strike.',
+                choices: {
+                    match: { label: '🎯 Slide LEFT to meet the flank', risk: 'high' },
+                    hold:  { label: '🛑 Set your stance',              risk: 'high' },
+                    safe:  { label: '🌿 Wait for an opening',          risk: 'none' }
                 },
                 correct: 'match'
             }
@@ -1343,66 +1370,106 @@ const APEX_TYPES = {
     phantom_stag: {
         name: 'Phantom Stag',
         emoji: '🦌',
-        strategy: 'safe', // it cannot be forced — patience wins
-        phases: [
+        // The read: which image is flesh? Shadows, tracks and breath betray
+        // the real stag — hold on the true one, swing when the truth is
+        // elsewhere.
+        phasePool: [
             {
-                hint: 'The **Phantom Stag** flickers between the trees — your eyes can\'t track it!',
+                hint: 'The **Phantom Stag** steps into a moonbeam — breath misting, hooves pressing real tracks into the moss. **This one is flesh.**',
                 choices: {
-                    match: { label: '🎯 Chase the afterimage',  risk: 'high' },
-                    hold:  { label: '🛑 Take the shot anyway',  risk: 'high' },
-                    safe:  { label: '🌿 Stay still and watch',  risk: 'none' }
+                    match: { label: '🎯 Swing to the flicker beside it', risk: 'high' },
+                    hold:  { label: '🛑 Hold your aim on it',            risk: 'high' },
+                    safe:  { label: '🌿 Lower your weapon',              risk: 'none' }
                 },
-                correct: 'safe'
+                correct: 'hold'
             },
             {
-                hint: 'It freezes… antlers shimmering… then it\'s somewhere else entirely.',
+                hint: 'It flickers ahead of you — but the bright shape casts no shadow. The true stag is the dim one at your flank.',
                 choices: {
-                    match: { label: '🎯 Swing to the new spot', risk: 'high' },
-                    hold:  { label: '🛑 Hold your aim',         risk: 'high' },
-                    safe:  { label: '🌿 Lower your weapon',     risk: 'none' }
+                    match: { label: '🎯 Turn on the shadowed shape',   risk: 'high' },
+                    hold:  { label: '🛑 Keep aim on the bright one',   risk: 'high' },
+                    safe:  { label: '🌿 Stay still and watch',         risk: 'none' }
                 },
-                correct: 'safe'
+                correct: 'match'
             },
             {
-                hint: 'The stag steps into a moonbeam and **looks straight at you**.',
+                hint: 'Three stags shimmer between the trees — only the middle one\'s antlers scrape off bark that actually falls.',
                 choices: {
-                    match: { label: '🎯 Take the shot NOW',      risk: 'high' },
-                    hold:  { label: '🛑 Steady... steady...',    risk: 'high' },
-                    safe:  { label: '🌿 Let it come closer',     risk: 'none' }
+                    match: { label: '🎯 Track the nearest image',        risk: 'high' },
+                    hold:  { label: '🛑 Stay locked on the middle one',  risk: 'high' },
+                    safe:  { label: '🌿 Let them drift past',            risk: 'none' }
                 },
-                correct: 'safe'
+                correct: 'hold'
+            },
+            {
+                hint: 'It freezes before you… but its reflection in the pool is looking somewhere else. The body in front of you is the echo.',
+                choices: {
+                    match: { label: '🎯 Follow the reflection\'s gaze', risk: 'high' },
+                    hold:  { label: '🛑 Trust your eyes and hold',      risk: 'high' },
+                    safe:  { label: '🌿 Lower your weapon',             risk: 'none' }
+                },
+                correct: 'match'
+            },
+            {
+                hint: 'The air folds, and the stag blinks ten paces LEFT — mist still curling where it is about to land.',
+                choices: {
+                    match: { label: '🎯 Lead it — swing LEFT now',   risk: 'high' },
+                    hold:  { label: '🛑 Hold on where it stood',     risk: 'high' },
+                    safe:  { label: '🌿 Wait for it to settle',      risk: 'none' }
+                },
+                correct: 'match'
             }
         ]
     },
     ironhide_boar: {
         name: 'Ironhide Boar',
         emoji: '🐗',
-        strategy: 'hold', // it only respects an unmoving hunter
-        phases: [
+        // The read: which way do the tusks come? A straight ram is met
+        // planted; a hooking or scything attack is beaten by stepping around
+        // it.
+        phasePool: [
             {
-                hint: '**THE IRONHIDE BOAR** charges head-on, tusks down!',
+                hint: '**THE IRONHIDE BOAR** charges dead straight, tusks low — a battering ram with exactly one line.',
                 choices: {
-                    match: { label: '🎯 Dodge and strike',     risk: 'high' },
-                    hold:  { label: '🛑 Plant your feet',      risk: 'high' },
-                    safe:  { label: '🌿 Dive clear',           risk: 'none' }
+                    match: { label: '🎯 Dodge and strike',            risk: 'high' },
+                    hold:  { label: '🛑 Plant your feet and meet it', risk: 'high' },
+                    safe:  { label: '🌿 Dive clear',                  risk: 'none' }
                 },
                 correct: 'hold'
             },
             {
-                hint: 'It wheels around, pawing the dirt for another charge!',
+                hint: 'It wheels mid-run, hooking WIDE to catch you on the turn — its cracked flank swings into reach.',
                 choices: {
-                    match: { label: '🎯 Flank it',             risk: 'high' },
-                    hold:  { label: '🛑 Hold the line',        risk: 'high' },
-                    safe:  { label: '🌿 Put a tree between you', risk: 'none' }
+                    match: { label: '🎯 Sidestep and hit the flank', risk: 'high' },
+                    hold:  { label: '🛑 Hold the line',              risk: 'high' },
+                    safe:  { label: '🌿 Put a tree between you',     risk: 'none' }
+                },
+                correct: 'match'
+            },
+            {
+                hint: 'It paws the dirt, drops its head, and commits — dead-on. It only respects an unmoving hunter.',
+                choices: {
+                    match: { label: '🎯 Flank it',           risk: 'high' },
+                    hold:  { label: '🛑 Hold your ground',   risk: 'high' },
+                    safe:  { label: '🌿 Stand aside',        risk: 'none' }
                 },
                 correct: 'hold'
             },
             {
-                hint: '**Its armored hide is cracked** — it charges one last time.',
+                hint: 'It stops short and swings its head in a scything arc — the tusks come sideways, not forward.',
                 choices: {
-                    match: { label: '🎯 Sidestep and slash',   risk: 'high' },
-                    hold:  { label: '🛑 Meet it head-on',      risk: 'high' },
-                    safe:  { label: '🌿 Stand aside',          risk: 'none' }
+                    match: { label: '🎯 Step inside the arc and strike', risk: 'high' },
+                    hold:  { label: '🛑 Brace against the swing',        risk: 'high' },
+                    safe:  { label: '🌿 Jump back',                      risk: 'none' }
+                },
+                correct: 'match'
+            },
+            {
+                hint: 'One last charge — straight, ragged, hide heaving. Everything it has left, on a single line.',
+                choices: {
+                    match: { label: '🎯 Sidestep and slash', risk: 'high' },
+                    hold:  { label: '🛑 Meet it head-on',    risk: 'high' },
+                    safe:  { label: '🌿 Stand aside',        risk: 'none' }
                 },
                 correct: 'hold'
             }

--- a/src/models/GrindProfile.js
+++ b/src/models/GrindProfile.js
@@ -25,5 +25,13 @@ grindProfileSchema.index({ guildId: 1, userId: 1, system: 1 }, { unique: true })
 // Leaderboard / "top grinder" lookups
 grindProfileSchema.index({ guildId: 1, system: 1, 'data.xp': -1 });
 grindProfileSchema.index({ guildId: 1, system: 1, 'data.totalEarned': -1 });
+// /hunt records boards — one index per sort path, matching the reads in
+// executeRecords (hunt.js). prestige and level share one compound index
+// because they are always sorted together.
+grindProfileSchema.index({ guildId: 1, system: 1, 'data.bestPayout': -1 });
+grindProfileSchema.index({ guildId: 1, system: 1, 'data.legendaryKills': -1 });
+grindProfileSchema.index({ guildId: 1, system: 1, 'data.eventKills': -1 });
+grindProfileSchema.index({ guildId: 1, system: 1, 'data.prestige': -1, 'data.level': -1 });
+grindProfileSchema.index({ guildId: 1, system: 1, 'data.totalHunts': -1 });
 
 module.exports = model('GrindProfile', grindProfileSchema);

--- a/src/services/exploreService.js
+++ b/src/services/exploreService.js
@@ -10,6 +10,7 @@ const {
     RELIC_INDEX,
     QUIET_LINES,
 } = require('../data/exploreData');
+const { getExploreWayfinderStaminaBonus } = require('./synergyService');
 
 // ─── INIT ────────────────────────────────────────────────────────────────────
 
@@ -83,10 +84,21 @@ function getRegionProgress(user, regionId, { create = false } = {}) {
 
 // ─── STAMINA / DAILY WINDOW ──────────────────────────────────────────────────
 
+/**
+ * Max exploration stamina for a user. The other three grind systems each grew a
+ * per-user getter when synergies started lifting their caps; exploration's was
+ * still the flat constant, which is why no synergy could pay out into it.
+ * The Permanent Stamina +1 shop item stays out of this on purpose — it is sold
+ * as hunt/fish/mine only.
+ */
+function getMaxStamina(user) {
+    return LIMITS.MAX_STAMINA + getExploreWayfinderStaminaBonus(user);
+}
+
 /** @returns {boolean} true if anything was written */
 function applyStaminaRegen(user) {
     const e = user.exploration;
-    const max = LIMITS.MAX_STAMINA;
+    const max = getMaxStamina(user);
 
     if (e.stamina >= max) {
         // Sitting at full: keep the regen anchor fresh so the clock starts from
@@ -118,7 +130,7 @@ function applyStaminaRegen(user) {
 
 function msUntilNextStamina(user) {
     const e = user.exploration;
-    if (e.stamina >= LIMITS.MAX_STAMINA) return 0;
+    if (e.stamina >= getMaxStamina(user)) return 0;
     if (!e.staminaLastRegen) return LIMITS.STAMINA_REGEN_MS;
     const elapsed = Date.now() - e.staminaLastRegen.getTime();
     return Math.max(0, LIMITS.STAMINA_REGEN_MS - (elapsed % LIMITS.STAMINA_REGEN_MS));
@@ -502,7 +514,7 @@ function executeExplore(user, region, guildSettings, opts = {}) {
             result.type = 'quiet';
             result.quietLine = randomFrom(QUIET_LINES);
             result.xp = grantXp(user, EVENT_XP.quiet, result);
-            e.stamina = Math.min(LIMITS.MAX_STAMINA, e.stamina + 1);
+            e.stamina = Math.min(getMaxStamina(user), e.stamina + 1);
             result.staminaSpared = true;
             break;
         }
@@ -877,6 +889,7 @@ function formatMs(ms) {
 module.exports = {
     ensureExploreData,
     getRegionProgress,
+    getMaxStamina,
     applyStaminaRegen,
     msUntilNextStamina,
     applyDailyReset,

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -451,6 +451,10 @@ function rollTier(user, zone) {
 function rollHuntEncounter(user, zoneId) {
     const resolvedZoneId = zoneId ?? user.hunt.activeZone;
     const zone = ZONES[resolvedZoneId];
+    // Same contract as quoteRepair's unknown tier: callers validate the zone
+    // first, so an unknown one here is a programming error — fail loudly
+    // rather than dereferencing undefined inside rollTier.
+    if (!zone) throw new Error(`Unknown hunt zone: ${resolvedZoneId}`);
     const tier = rollTier(user, zone);
     return { tier, animal: rollAnimal(tier, resolvedZoneId) };
 }

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -66,6 +66,7 @@ function ensureHuntData(user) {
     if (h.activeCharmHuntsLeft == null) h.activeCharmHuntsLeft = 0;
     if (h.activeFocus          == null) h.activeFocus          = false;
     if (h.activeXpScroll       == null) h.activeXpScroll       = false;
+    if (h.quickHunt            == null) h.quickHunt            = false;
     if (h.luckyPaw             == null) h.luckyPaw             = false;
     if (h.precisionScope       == null) h.precisionScope       = false;
     // Field Trophies — one permanent per zone, crafted from that zone's materials.

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -440,6 +440,22 @@ function rollTier(user, zone) {
 // ─── ANIMAL ROLL ─────────────────────────────────────────────────────────────
 
 /**
+ * Rolls the prey for a hunt — tier first, then a specific animal — *before*
+ * the approach prompt, so the prompt can describe the animal that is actually
+ * there and key its correct answer on that animal's traits. The roll used to
+ * live inside executeHunt, which runs after the prompt was answered: the hint
+ * described a deer while the player shot a squirrel, a crow, or a Golden Fox.
+ *
+ * Pass the result to executeHunt as options.encounter.
+ */
+function rollHuntEncounter(user, zoneId) {
+    const resolvedZoneId = zoneId ?? user.hunt.activeZone;
+    const zone = ZONES[resolvedZoneId];
+    const tier = rollTier(user, zone);
+    return { tier, animal: rollAnimal(tier, resolvedZoneId) };
+}
+
+/**
  * Picks a specific animal from the resolved tier that can spawn in this zone.
  */
 function rollAnimal(tier, zoneId) {
@@ -886,11 +902,20 @@ function executeHunt(user, zoneId, options = {}) {
         };
     }
 
-    // Roll the animal upfront so traits can influence the success check
-    let tier = rollTier(user, zone);
-    // Stealth bonus: patient approach upgrades common prey to uncommon ~30% of the time
-    if (options.stealthBonus > 0 && tier === 'common' && Math.random() < 0.30) tier = 'uncommon';
-    const animal = rollAnimal(tier, zoneId ?? h.activeZone);
+    // The encounter is normally pre-rolled by the caller (rollHuntEncounter)
+    // before the approach prompt, so the prompt describes the real animal. The
+    // internal roll remains for callers that skip the prompt entirely.
+    let tier, animal;
+    if (options.encounter?.animal) {
+        ({ tier, animal } = options.encounter);
+    } else {
+        tier = rollTier(user, zone);
+        // Stealth bonus: patient approach upgrades common prey to uncommon ~30% of
+        // the time. Pre-rolled encounters apply this upgrade caller-side, after the
+        // stealth outcome is known.
+        if (options.stealthBonus > 0 && tier === 'common' && Math.random() < 0.30) tier = 'uncommon';
+        animal = rollAnimal(tier, zoneId ?? h.activeZone);
+    }
     const traits = animal.traits ?? [];
 
     // Base success chance + trait adjustments
@@ -1338,6 +1363,7 @@ module.exports = {
     applyAimBonus,
     rollTier,
     rollAnimal,
+    rollHuntEncounter,
     getRarePityThreshold,
     rollFailureSeverity,
     applyPayoutModifiers,

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -18,7 +18,7 @@ const {
 const { hasEffect, consumeEffect, getEffect, getGatheringYieldEffect, EFFECT_CONFIGS } = require('./effectsService');
 const { getStreakMultiplier } = require('../utils/streakMultiplier');
 const { getPityBonus } = require('../utils/pityBonus');
-const { getHuntSynergyStaminaBonus } = require('./synergyService');
+const { getHuntSynergyStaminaBonus, getHuntWayfinderStaminaBonus } = require('./synergyService');
 const { MAX_STAMINA_UPGRADES } = require('../data/crossSystemData');
 const { getBonusMultipliers } = require('../utils/prestige');
 
@@ -96,7 +96,9 @@ function ensureHuntData(user) {
 function getMaxStamina(user) {
     const prestige = user.hunt?.prestige ?? 0;
     const bonus = PRESTIGE_BONUSES[Math.min(prestige, PRESTIGE_BONUSES.length - 1)]?.staminaBonus ?? 0;
-    const synergyBonus = getHuntSynergyStaminaBonus(user);
+    // Outdoorsman and Wayfinder both advertise +1 max hunt stamina; they stack,
+    // exactly as Deep Prospector and Artificer do on mining.
+    const synergyBonus = getHuntSynergyStaminaBonus(user) + getHuntWayfinderStaminaBonus(user);
     const trophyBonus  = user.hunt?.woodlandInstinct ? 1 : 0;
     // Permanent Stamina +1 from the shop, applied through /use.
     const purchased = Math.min(Math.max(0, user?.staminaUpgrades ?? 0), MAX_STAMINA_UPGRADES);

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -1264,9 +1264,27 @@ function durabilityBar(current, max, length = 10) {
 
 // ─── APEX ENCOUNTER RESOLUTION ───────────────────────────────────────────────
 
+const APEX_PHASES_PER_DUEL = 3;
+
+/**
+ * One duel's worth of phases: a random draw of APEX_PHASES_PER_DUEL from the
+ * apex's phase pool, in a random order. Every phase carries its own correct
+ * answer with the tell in its hint, so recognising the apex no longer hands
+ * over the whole duel — the sequence isn't memorisable either, because it
+ * differs encounter to encounter.
+ */
+function buildApexEncounter(base) {
+    const pool = [...base.phasePool];
+    for (let i = pool.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [pool[i], pool[j]] = [pool[j], pool[i]];
+    }
+    return { ...base, phases: pool.slice(0, APEX_PHASES_PER_DUEL) };
+}
+
 function rollApexType() {
     const keys = Object.keys(APEX_TYPES);
-    return APEX_TYPES[keys[Math.floor(Math.random() * keys.length)]];
+    return buildApexEncounter(APEX_TYPES[keys[Math.floor(Math.random() * keys.length)]]);
 }
 
 // Nerve: the duel's second axis. A wrong aggressive read costs two, so two bad
@@ -1383,6 +1401,8 @@ module.exports = {
     rollTrophyQuality,
     executeHunt,
     rollApexType,
+    buildApexEncounter,
+    APEX_PHASES_PER_DUEL,
     resolveApexEncounter,
     apexNerveAfter,
     apexNerveMax,

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -823,6 +823,27 @@ function tickConsumables(user) {
     user.markModified('hunt');
 }
 
+// ─── BEST PAYOUT ─────────────────────────────────────────────────────────────
+
+/**
+ * Raises h.bestPayout when beaten, and remembers what the record hunt actually
+ * was. The number alone has always been kept; the context (which animal, what
+ * tier, where) is what /hunt records needs to make the board worth reading.
+ * Older records that predate this carry no meta and render as the bare amount.
+ */
+function recordBestPayout(h, amount, { animal, tier, zoneId } = {}) {
+    if (!(amount > (h.bestPayout ?? 0))) return false;
+    h.bestPayout = amount;
+    h.bestPayoutMeta = {
+        animalName:  animal?.name  ?? null,
+        animalEmoji: animal?.emoji ?? null,
+        tier:        tier          ?? null,
+        zoneId:      zoneId        ?? null,
+        at:          new Date(),
+    };
+    return true;
+}
+
 // ─── FULL HUNT EXECUTION ─────────────────────────────────────────────────────
 
 /**
@@ -974,7 +995,7 @@ function executeHunt(user, zoneId, options = {}) {
         user.balance         += adjustedPayout;
         h.totalEarned        += adjustedPayout;
         h.dailyCoins         += adjustedPayout;
-        if (adjustedPayout > h.bestPayout) h.bestPayout = adjustedPayout;
+        recordBestPayout(h, adjustedPayout, { animal, tier, zoneId: zone.id });
 
         // Statistics
         h.successfulHunts    += 1;
@@ -1320,6 +1341,7 @@ module.exports = {
     rollFailureSeverity,
     applyPayoutModifiers,
     getDiminishingReturns,
+    recordBestPayout,
     applyDurabilityLoss,
     updateWeaponStatus,
     isCondemned,

--- a/src/services/synergyService.js
+++ b/src/services/synergyService.js
@@ -3,15 +3,17 @@
 const { SYNERGIES, SYNERGY_LIST } = require('../data/crossSystemData');
 
 function getActiveSynergies(user) {
-    const huntLevel  = user.hunt?.level    ?? 0;
-    const fishLevel  = user.fishing?.level ?? 0;
-    const mineLevel  = user.mining?.level  ?? 0;
+    const huntLevel    = user.hunt?.level        ?? 0;
+    const fishLevel    = user.fishing?.level     ?? 0;
+    const mineLevel    = user.mining?.level      ?? 0;
+    const exploreLevel = user.exploration?.level ?? 0;
 
     return SYNERGY_LIST.filter(syn => {
         const req = syn.requirements;
-        if (req.hunt    && huntLevel  < req.hunt)    return false;
-        if (req.fishing && fishLevel  < req.fishing) return false;
-        if (req.mining  && mineLevel  < req.mining)  return false;
+        if (req.hunt        && huntLevel    < req.hunt)        return false;
+        if (req.fishing     && fishLevel    < req.fishing)     return false;
+        if (req.mining      && mineLevel    < req.mining)      return false;
+        if (req.exploration && exploreLevel < req.exploration) return false;
         return true;
     });
 }
@@ -60,6 +62,18 @@ function getArtificerMineStaminaBonus(user) {
         : 0;
 }
 
+function getExploreWayfinderStaminaBonus(user) {
+    return hasSynergy(user, 'wayfinder')
+        ? (SYNERGIES.wayfinder?.bonuses?.explorationStamina ?? 0)
+        : 0;
+}
+
+function getHuntWayfinderStaminaBonus(user) {
+    return hasSynergy(user, 'wayfinder')
+        ? (SYNERGIES.wayfinder?.bonuses?.huntStamina ?? 0)
+        : 0;
+}
+
 function getMerchantCoinBonus(user) {
     if (!hasSynergy(user, 'merchant')) return 0;
     const hasItems = (user.inventory ?? []).some(e => e.quantity > 0);
@@ -76,5 +90,7 @@ module.exports = {
     getMineDeepProspectorStaminaBonus,
     getArtificerMineYieldBonus,
     getArtificerMineStaminaBonus,
+    getExploreWayfinderStaminaBonus,
+    getHuntWayfinderStaminaBonus,
     getMerchantCoinBonus,
 };

--- a/tests/huntApexNerve.test.js
+++ b/tests/huntApexNerve.test.js
@@ -4,25 +4,41 @@ const {
     resolveApexEncounter,
     apexNerveAfter,
     APEX_NERVE_MAX,
+    APEX_PHASES_PER_DUEL,
+    buildApexEncounter,
+    rollApexType,
     getRarePityThreshold,
     msUntilDailyReset,
     applyPayoutModifiers,
 } = require('../src/services/huntService');
 const { APEX_TYPES, ZONES, ZONE_LIST, LIMITS } = require('../src/data/huntData');
 
-const APEX = APEX_TYPES.dire_alpha;   // strategy: 'match'
+// A concrete duel: three phases drawn from the pool, each with its own
+// correct answer. Patterns spell one choice per phase: C = the phase's
+// correct read, W = the wrong aggressive read (the other of match/hold),
+// S = the safe hedge.
+const APEX = buildApexEncounter(APEX_TYPES.dire_alpha);
 const ANIMAL = { payoutMin: 100, payoutMax: 100 };
 
-function duel(choices) {
+function choicesFor(pattern) {
+    return APEX.phases.map((phase, i) => {
+        const c = pattern[i];
+        if (c === 'C') return phase.correct;
+        if (c === 'W') return phase.correct === 'match' ? 'hold' : 'match';
+        return 'safe';
+    });
+}
+
+function duel(pattern) {
     const user = { hunt: { equippedWeaponIndex: -1, weapons: [] }, markModified() {} };
-    return resolveApexEncounter(user, ANIMAL, 'legendary', choices, APEX, -1);
+    return resolveApexEncounter(user, ANIMAL, 'legendary', choicesFor(pattern), APEX, -1);
 }
 
 describe('apex nerve', () => {
     it('busts the duel on two misreads even when a phase landed', () => {
         // One correct read, two wrong aggressive reads: nerve is spent, so the
         // apex escapes despite the hit. This is the case that used to pay out.
-        const result = duel(['match', 'hold', 'hold']);
+        const result = duel('CWW');
         expect(result.correctCount).toBe(1);
         expect(result.outcome).toBe('escaped');
         expect(result.bonusPayout).toBe(0);
@@ -31,7 +47,7 @@ describe('apex nerve', () => {
     it('lets backing off preserve a partial reward', () => {
         // Same single correct read, but the hunter hedged instead of guessing
         // wrong a second time.
-        const result = duel(['match', 'hold', 'safe']);
+        const result = duel('CWS');
         expect(result.correctCount).toBe(1);
         expect(result.outcome).toBe('survived');
         expect(result.bonusPayout).toBeGreaterThan(0);
@@ -47,16 +63,67 @@ describe('apex nerve', () => {
     });
 
     it('still rewards a flawless read', () => {
-        const result = duel(['match', 'match', 'match']);
+        const result = duel('CCC');
         expect(result.outcome).toBe('perfect');
         expect(apexNerveAfter(result.phaseResults)).toBe(APEX_NERVE_MAX);
     });
 
     it('reports zero nerve exactly when the duel was lost to misreads', () => {
-        for (const choices of [['match', 'hold', 'hold'], ['hold', 'hold', 'match']]) {
-            const result = duel(choices);
+        for (const pattern of ['CWW', 'WWC']) {
+            const result = duel(pattern);
             expect(apexNerveAfter(result.phaseResults)).toBe(0);
             expect(result.outcome).toBe('escaped');
+        }
+    });
+});
+
+describe('apex phases carry a real read', () => {
+    it('gives every apex a pool with both aggressive answers represented', () => {
+        // A pool where every phase shares one correct answer is the old
+        // one-fact-per-apex problem again with extra steps.
+        for (const apex of Object.values(APEX_TYPES)) {
+            const corrects = new Set(apex.phasePool.map(p => p.correct));
+            expect(apex.phasePool.length).toBeGreaterThan(APEX_PHASES_PER_DUEL);
+            expect(corrects.has('match')).toBe(true);
+            expect(corrects.has('hold')).toBe(true);
+        }
+    });
+
+    it('never makes the safe hedge the correct answer', () => {
+        for (const apex of Object.values(APEX_TYPES)) {
+            for (const phase of apex.phasePool) {
+                expect(['match', 'hold']).toContain(phase.correct);
+                expect(phase.choices.match).toBeDefined();
+                expect(phase.choices.hold).toBeDefined();
+                expect(phase.choices.safe).toBeDefined();
+            }
+        }
+    });
+
+    it('deals each duel a fresh hand of phases from the pool', () => {
+        const base = APEX_TYPES.dire_alpha;
+        const sequences = new Set();
+        for (let i = 0; i < 100; i++) {
+            const enc = buildApexEncounter(base);
+            expect(enc.phases).toHaveLength(APEX_PHASES_PER_DUEL);
+            for (const phase of enc.phases) expect(base.phasePool).toContain(phase);
+            expect(new Set(enc.phases).size).toBe(APEX_PHASES_PER_DUEL);
+            sequences.add(enc.phases.map(p => base.phasePool.indexOf(p)).join('-'));
+        }
+        // 5 phases drawn 3 at a time in order = 60 sequences; 100 duels
+        // landing on one would mean the shuffle is not shuffling.
+        expect(sequences.size).toBeGreaterThan(5);
+    });
+
+    it('rolls a playable encounter, not the shared base table', () => {
+        const enc = rollApexType();
+        expect(Array.isArray(enc.phases)).toBe(true);
+        expect(enc.phases).toHaveLength(APEX_PHASES_PER_DUEL);
+        // The instance must not alias the base object, or one duel's draw
+        // would leak into every later duel of the same apex.
+        for (const base of Object.values(APEX_TYPES)) {
+            expect(enc).not.toBe(base);
+            expect(base.phases).toBeUndefined();
         }
     });
 });

--- a/tests/huntApexNerve.test.js
+++ b/tests/huntApexNerve.test.js
@@ -21,6 +21,9 @@ const APEX = buildApexEncounter(APEX_TYPES.dire_alpha);
 const ANIMAL = { payoutMin: 100, payoutMax: 100 };
 
 function choicesFor(pattern) {
+    // A pattern shorter than the duel would silently default the extra
+    // phases to 'safe'; fail loudly if the phase count ever changes.
+    expect(pattern).toHaveLength(APEX_PHASES_PER_DUEL);
     return APEX.phases.map((phase, i) => {
         const c = pattern[i];
         if (c === 'C') return phase.correct;

--- a/tests/huntApproach.test.js
+++ b/tests/huntApproach.test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+// The stealth approach used to be a knowledge check: ZONE_APPROACHES hardcoded
+// one permanently-correct answer per zone, and the hint described a deer the
+// player would never actually meet because the animal was rolled after the
+// prompt. Now the encounter is rolled first, the hint names the real animal,
+// and the correct approach follows that animal's traits (#739).
+
+const {
+    APPROACH_PROFILES,
+    TRAIT_PROFILE_ORDER,
+    GENERIC_PROFILE_IDS,
+    pickApproachProfile,
+} = require('../src/commands/economy/hunt').__test__;
+const { rollHuntEncounter, executeHunt, ensureHuntData } = require('../src/services/huntService');
+const { ANIMALS } = require('../src/data/huntData');
+
+describe('approach profiles', () => {
+    const profiles = Object.values(APPROACH_PROFILES);
+
+    test('every profile has exactly one correct option, one neutral, one wrong', () => {
+        for (const p of profiles) {
+            const bonuses = p.options.map(o => o.stealthBonus).sort((a, b) => b - a);
+            expect(bonuses).toEqual([0.25, 0.05, -0.10]);
+            const correct = p.options.find(o => o.id === p.correctId);
+            expect(correct).toBeDefined();
+            expect(correct.stealthBonus).toBe(0.25);
+        }
+    });
+
+    test('every hint names the animal it describes', () => {
+        const animal = { name: 'Golden Fox', emoji: '🦊', traits: [] };
+        for (const p of profiles) {
+            expect(p.hint(animal)).toContain('Golden Fox');
+        }
+    });
+
+    test('trait prey keys its profile on the trait, not the zone', () => {
+        expect(pickApproachProfile({ traits: ['spectral'] }).id).toBe('stillness');
+        expect(pickApproachProfile({ traits: ['elusive'] }).id).toBe('patience');
+        expect(pickApproachProfile({ traits: ['aggressive'] }).id).toBe('cover');
+        expect(pickApproachProfile({ traits: ['giant'] }).id).toBe('distance');
+        // Multi-trait prey: the most read-defining trait wins.
+        expect(pickApproachProfile({ traits: ['giant', 'armored'] }).id).toBe('distance');
+        expect(pickApproachProfile({ traits: ['spectral', 'elusive'] }).id).toBe('stillness');
+    });
+
+    test('every trait mapping points at a real profile', () => {
+        for (const [, profileId] of TRAIT_PROFILE_ORDER) {
+            expect(APPROACH_PROFILES[profileId]).toBeDefined();
+        }
+        for (const id of GENERIC_PROFILE_IDS) {
+            expect(APPROACH_PROFILES[id]).toBeDefined();
+        }
+    });
+
+    test('trait-less prey rolls a behaviour rather than repeating one answer', () => {
+        const seen = new Set();
+        for (let i = 0; i < 200; i++) {
+            seen.add(pickApproachProfile({ traits: [] }).id);
+        }
+        expect([...seen].sort()).toEqual([...GENERIC_PROFILE_IDS].sort());
+        for (const id of seen) expect(GENERIC_PROFILE_IDS).toContain(id);
+    });
+
+    test('the correct answer varies across the animal roster', () => {
+        // The old system had one answer per zone. Across the animals of a
+        // single zone the profile-driven answer must not collapse back to one.
+        const answers = new Set();
+        for (const animal of Object.values(ANIMALS)) {
+            if (!animal.zones.includes('legendary_peaks') && !animal.zones.includes('all')) continue;
+            answers.add(pickApproachProfile(animal).correctId);
+        }
+        expect(answers.size).toBeGreaterThan(1);
+    });
+});
+
+describe('pre-rolled encounters', () => {
+    function makeHunter() {
+        const user = {
+            balance: 0,
+            streak: { current: 0 },
+            markModified() {},
+            hunt: null,
+        };
+        ensureHuntData(user);
+        user.hunt.weapons = [{
+            tier: 1, name: 'Training Bow', status: 'good',
+            currentDurability: 100, maxDurability: 100, baseDurability: 100,
+            repairCount: 0, upgrade: null,
+        }];
+        user.hunt.equippedWeaponIndex = 0;
+        user.quests = [];
+        return user;
+    }
+
+    test('rollHuntEncounter returns an animal that can spawn in the zone', () => {
+        const user = makeHunter();
+        for (let i = 0; i < 50; i++) {
+            const { tier, animal } = rollHuntEncounter(user, 'beginner_forest');
+            expect(animal.tier).toBe(tier);
+            expect(
+                animal.zones.includes('all') || animal.zones.includes('beginner_forest')
+            ).toBe(true);
+        }
+    });
+
+    test('executeHunt hunts the pre-rolled animal instead of rolling its own', () => {
+        const user = makeHunter();
+        const encounter = rollHuntEncounter(user, 'beginner_forest');
+        const result = executeHunt(user, 'beginner_forest', { encounter });
+        expect(result.animal).toBe(encounter.animal);
+        expect(result.tier).toBe(encounter.tier);
+    });
+
+    test('executeHunt still rolls internally when no encounter is passed', () => {
+        const user = makeHunter();
+        const result = executeHunt(user, 'beginner_forest');
+        expect(result.animal).toBeDefined();
+        expect(result.tier).toBeDefined();
+    });
+});

--- a/tests/huntMaterialSinks.test.js
+++ b/tests/huntMaterialSinks.test.js
@@ -211,11 +211,18 @@ describe('field trophies', () => {
             expect(plain.length).toBeGreaterThan(0);
             expect(charmed.length).toBeGreaterThan(0);
 
-            // The pack adds 3 durability damage on top of the failure severity,
-            // whose worst case is 5.
-            expect(plain.some(m => m.durability > 5)).toBe(true);
+            // The pack adds 3 durability damage on top of the failure severity.
+            // Asserted as invariants of every observed failure rather than as a
+            // some() over the severity roll: the old check needed at least one
+            // severity ≥ 3 among a handful of pack failures, which flaked when
+            // the sample ran unlucky (CI run 127). Uncharmed, every pack
+            // failure pays at least the minimum severity (1) plus the pack's 3;
+            // charmed, the pack never piles on, so the loss stays within the
+            // plain severity table (worst case 5).
+            expect(plain.every(m => m.durability >= 4)).toBe(true);
+            expect(plain.every(m => m.effects.some(msg => msg.includes('pack descended')))).toBe(true);
             expect(charmed.every(m => m.durability <= 5)).toBe(true);
-            expect(charmed.some(m => m.effects.some(msg => msg.includes('Swampwalker')))).toBe(true);
+            expect(charmed.every(m => m.effects.some(msg => msg.includes('Swampwalker')))).toBe(true);
         });
 
         it('halves how often aggressive prey injures a successful hunter', () => {

--- a/tests/synergyDelivery.test.js
+++ b/tests/synergyDelivery.test.js
@@ -11,16 +11,18 @@ const fs = require('fs');
 const path = require('path');
 
 const { SYNERGIES, SYNERGY_LIST, MAX_STAMINA_UPGRADES } = require('../src/data/crossSystemData');
-const huntService = require('../src/services/huntService');
-const fishService = require('../src/services/fishService');
-const mineService = require('../src/services/mineService');
+const huntService    = require('../src/services/huntService');
+const fishService    = require('../src/services/fishService');
+const mineService    = require('../src/services/mineService');
+const exploreService = require('../src/services/exploreService');
 
 // A user whose grind levels are high enough to hold every synergy at once.
 function makeUser(overrides = {}) {
     return {
-        hunt:    { level: 60, prestige: 0 },
-        fishing: { level: 60, prestige: 0 },
-        mining:  { level: 60, prestige: 0 },
+        hunt:        { level: 60, prestige: 0 },
+        fishing:     { level: 60, prestige: 0 },
+        mining:      { level: 60, prestige: 0 },
+        exploration: { level: 30 },
         inventory: [],
         pets: [],
         ...overrides,
@@ -30,9 +32,10 @@ function makeUser(overrides = {}) {
 // A user below every synergy requirement.
 function makeNovice(overrides = {}) {
     return {
-        hunt:    { level: 1, prestige: 0 },
-        fishing: { level: 1, prestige: 0 },
-        mining:  { level: 1, prestige: 0 },
+        hunt:        { level: 1, prestige: 0 },
+        fishing:     { level: 1, prestige: 0 },
+        mining:      { level: 1, prestige: 0 },
+        exploration: { level: 1 },
         inventory: [],
         pets: [],
         ...overrides,
@@ -98,6 +101,29 @@ describe('stamina synergies actually raise max stamina', () => {
         const user = makeNovice({ mining: { level: 50, prestige: 0 } });
         expect(mineService.getMaxStamina(user))
             .toBe(mineService.getMaxStamina(novice) + SYNERGIES.artificer.bonuses.miningStamina);
+    });
+
+    test('Wayfinder lifts exploration and hunting', () => {
+        const novice = makeNovice();
+        const user = makeNovice({ hunt: { level: 30, prestige: 0 }, exploration: { level: 20 } });
+        expect(exploreService.getMaxStamina(user))
+            .toBe(exploreService.getMaxStamina(novice) + SYNERGIES.wayfinder.bonuses.explorationStamina);
+        expect(huntService.getMaxStamina(user))
+            .toBe(huntService.getMaxStamina(novice) + SYNERGIES.wayfinder.bonuses.huntStamina);
+    });
+
+    test('Outdoorsman and Wayfinder stack on hunting', () => {
+        const novice = makeNovice();
+        const user = makeUser();
+        const expected = SYNERGIES.outdoorsman.bonuses.huntStamina
+                       + SYNERGIES.wayfinder.bonuses.huntStamina;
+        expect(huntService.getMaxStamina(user)).toBe(huntService.getMaxStamina(novice) + expected);
+    });
+
+    test('exploration ignores the hunt/fish/mine-only shop stamina item', () => {
+        const base = makeNovice();
+        const bought = makeNovice({ staminaUpgrades: MAX_STAMINA_UPGRADES });
+        expect(exploreService.getMaxStamina(bought)).toBe(exploreService.getMaxStamina(base));
     });
 
     test('Deep Prospector and Artificer stack on mining', () => {

--- a/tests/synergyEffects.test.js
+++ b/tests/synergyEffects.test.js
@@ -6,8 +6,11 @@
 // listed as active and get neither. These tests pin each advertised bonus to the
 // code path that pays it out.
 
-const { getMaxStamina: mineMaxStamina } = require('../src/services/mineService');
-const { getMaxStamina: fishMaxStamina } = require('../src/services/fishService');
+const { getMaxStamina: mineMaxStamina }    = require('../src/services/mineService');
+const { getMaxStamina: fishMaxStamina }    = require('../src/services/fishService');
+const { getMaxStamina: huntMaxStamina }    = require('../src/services/huntService');
+const { getMaxStamina: exploreMaxStamina } = require('../src/services/exploreService');
+const { LIMITS: EXPLORE_LIMITS } = require('../src/data/exploreData');
 const {
     getActiveSynergies,
     getArtificerMineYieldBonus,
@@ -17,11 +20,12 @@ const { SYNERGIES, SYNERGY_LIST } = require('../src/data/crossSystemData');
 const { LIMITS } = require('../src/data/mineData');
 
 /** A player at the given grind levels, with nothing else going on. */
-function player({ hunt = 0, fishing = 0, mining = 0, inventory = [] } = {}) {
+function player({ hunt = 0, fishing = 0, mining = 0, exploration = 0, inventory = [] } = {}) {
     return {
-        hunt:    { level: hunt,    prestige: 0 },
-        fishing: { level: fishing, prestige: 0 },
-        mining:  { level: mining,  prestige: 0 },
+        hunt:        { level: hunt,    prestige: 0 },
+        fishing:     { level: fishing, prestige: 0 },
+        mining:      { level: mining,  prestige: 0 },
+        exploration: { level: exploration },
         inventory,
     };
 }
@@ -66,6 +70,26 @@ describe('fishing stamina synergies', () => {
     });
 });
 
+describe('Wayfinder stamina', () => {
+    test('pays both sides at the thresholds and neither below them', () => {
+        const under = player({ hunt: 30, exploration: 19 });
+        const at    = player({ hunt: 30, exploration: 20 });
+
+        expect(getActiveSynergies(under).map(s => s.id)).not.toContain('wayfinder');
+        expect(exploreMaxStamina(under)).toBe(EXPLORE_LIMITS.MAX_STAMINA);
+
+        expect(getActiveSynergies(at).map(s => s.id)).toContain('wayfinder');
+        expect(exploreMaxStamina(at))
+            .toBe(EXPLORE_LIMITS.MAX_STAMINA + SYNERGIES.wayfinder.bonuses.explorationStamina);
+        expect(huntMaxStamina(at)).toBe(
+            huntMaxStamina(player({ hunt: 29 }))
+            + SYNERGIES.wayfinder.bonuses.huntStamina
+            // hunt 30 alone doesn't reach Outdoorsman (needs fishing 30 too),
+            // so the whole lift here is Wayfinder's.
+        );
+    });
+});
+
 describe('Artificer ore yield', () => {
     test('pays nothing below Mining 50 and the advertised rate at 50', () => {
         expect(getArtificerMineYieldBonus(player({ mining: 49 }))).toBe(0);
@@ -98,6 +122,7 @@ describe('no advertised synergy is left unwired', () => {
         deep_prospector: ['fishingStamina', 'miningStamina'],
         artificer:       ['mineYieldPct', 'miningStamina'],
         merchant:        ['workCrimeCoinPct'],
+        wayfinder:       ['explorationStamina', 'huntStamina'],
     };
 
     test.each(SYNERGY_LIST.map(s => [s.id]))('%s has every bonus key accounted for', id => {


### PR DESCRIPTION
Every synergy spanned only hunt, fish and mine, and getActiveSynergies never
read exploration's level, so exploring could neither contribute to nor gain
from any synergy (#751).

Wayfinder (hunt 30 + exploration 20) grants +1 max stamina in both systems.
Exploration gets the per-user getMaxStamina() the other three systems already
had — its cap was a flat constant, which is why nothing could lift it — and
every stamina read (regen, quiet-walk refund, profile and footer displays)
now goes through it. The hunt side stacks with Outdoorsman the same way Deep
Prospector and Artificer stack on mining. /synergies now shows exploration
requirements and levels.

The Permanent Stamina +1 shop item deliberately stays hunt/fish/mine-only,
matching its advertised description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Wayfinder synergy, granting additional maximum stamina for Exploration and Hunting.
  * Added quick hunts with animal-specific approaches and streamlined interactions.
  * Added `/hunt records` leaderboards with encounter details.
  * Apex hunts now feature varied, randomized phases and choices.
  * Synergy displays now include Exploration requirements and progress.

* **Improvements**
  * Exploration and Hunting stamina limits, regeneration, and refunds now reflect active bonuses.
  * Hunt results provide more detailed encounter and payout information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->