### PR TITLE
Show ammo on hunt results and warn before it runs dry

### DIFF
--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -13,7 +13,8 @@ const {
     RELIC_LIST, RELIC_RARITY_ORDER, TOTAL_CORE_RELICS,
     FOOTER_LINES, INJURY_LINES,
 } = require('../../data/exploreData');
-const { fitDescription, EMBED_LIMITS } = require('../../utils/embedFields');
+const { fitDescription, chunkByLength, EMBED_LIMITS } = require('../../utils/embedFields');
+const { paginate } = require('../../utils/paginator');
 const {
     ensureExploreData,
     getMaxStamina,
@@ -65,6 +66,16 @@ const EVENT_TYPE_EMOJI = {
     trap: '🪤', encounter: '👁️', quiet: '🌫️',
 };
 
+const EVENT_TYPE_CHOICES = Object.entries(EVENT_TYPE_EMOJI).map(([id, emoji]) => ({
+    name: `${emoji} ${id.charAt(0).toUpperCase()}${id.slice(1)}`,
+    value: id,
+}));
+
+// Entries per journal page. Ten timestamped lines sit far under the 4096
+// description budget even when every summary runs long; chunkByLength backstops
+// the pathological case regardless.
+const JOURNAL_PAGE_SIZE = 10;
+
 module.exports = {
     cooldown: 5,
 
@@ -95,7 +106,17 @@ module.exports = {
                 .setDescription('Browse every known region — requirements, season windows, and your progress.'))
         .addSubcommand(sub =>
             sub.setName('journal')
-                .setDescription('Reread your expedition journal — your most recent finds, in order.'))
+                .setDescription('Reread your expedition journal — your most recent finds, in order.')
+                .addStringOption(o =>
+                    o.setName('region')
+                        .setDescription('Only show entries written in this region')
+                        .setRequired(false)
+                        .addChoices(...REGION_CHOICES))
+                .addStringOption(o =>
+                    o.setName('type')
+                        .setDescription('Only show one kind of find')
+                        .setRequired(false)
+                        .addChoices(...EVENT_TYPE_CHOICES)))
         .addSubcommand(sub =>
             sub.setName('relics')
                 .setDescription('Open your relic case — everything the wilds let you keep, and what it earns you.')
@@ -1051,20 +1072,50 @@ async function handleJournal(interaction) {
         });
     }
 
-    const lines = journal.slice(0, LIMITS.JOURNAL_CAP).map(entry => {
+    // Both filters run on data every entry already carries — the type each find
+    // was tagged with at write time, and the region it was written in.
+    const regionFilter = interaction.options.getString('region');
+    const typeFilter   = interaction.options.getString('type');
+    const entries = journal.slice(0, LIMITS.JOURNAL_CAP).filter(entry =>
+        (!regionFilter || entry.regionId === regionFilter)
+        && (!typeFilter || entry.eventType === typeFilter));
+
+    if (!entries.length) {
+        const filterRegion = REGIONS[regionFilter];
+        const wanted = [
+            typeFilter ? `${EVENT_TYPE_EMOJI[typeFilter]} ${typeFilter}` : 'matching',
+            filterRegion ? `entries from ${filterRegion.emoji} **${filterRegion.name}**` : 'entries',
+        ].join(' ');
+        return interaction.reply({
+            content: `No ${wanted} in the last ${journal.length} pages of your journal. The wilds keep their own schedule.`,
+            flags: MessageFlags.Ephemeral,
+        });
+    }
+
+    const lines = entries.map(entry => {
         const region = REGIONS[entry.regionId];
         const stamp = `<t:${Math.floor(new Date(entry.at).getTime() / 1000)}:R>`;
         return `${EVENT_TYPE_EMOJI[entry.eventType] ?? '🥾'} ${region?.emoji ?? ''} **${region?.name ?? entry.regionId}** — ${entry.summary} *(${stamp})*`;
     });
 
-    const embed = new EmbedBuilder()
-        .setColor('#8d6e63')
-        .setTitle(`📔 Expedition Journal — ${interaction.user.username}`)
-        .setDescription(lines.join('\n'))
-        .setFooter({ text: `The last ${LIMITS.JOURNAL_CAP} entries are kept. The rest live in the retelling.` })
-        .setTimestamp();
+    const filterNote = [
+        typeFilter ? `${typeFilter} only` : null,
+        REGIONS[regionFilter] ? `${REGIONS[regionFilter].name} only` : null,
+    ].filter(Boolean).join(' · ');
+    const footer = `${filterNote ? `${filterNote} • ` : ''}The last ${LIMITS.JOURNAL_CAP} entries are kept. The rest live in the retelling.`;
 
-    return interaction.reply({ embeds: [embed] });
+    // chunkByLength keeps each page inside the description budget even if a run
+    // of long relic and secret summaries stacks up — discord.js throws rather
+    // than truncating, so this used to be a latent way to lose the whole command.
+    const pages = chunkByLength(lines, { maxPerChunk: JOURNAL_PAGE_SIZE }).map(pageLines =>
+        new EmbedBuilder()
+            .setColor('#8d6e63')
+            .setTitle(`📔 Expedition Journal — ${interaction.user.username}`)
+            .setDescription(pageLines.join('\n'))
+            .setFooter({ text: footer })
+            .setTimestamp());
+
+    return paginate(interaction, pages);
 }
 
 // ─── RELICS ───────────────────────────────────────────────────────────────────

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -1087,7 +1087,7 @@ async function handleJournal(interaction) {
             filterRegion ? `entries from ${filterRegion.emoji} **${filterRegion.name}**` : 'entries',
         ].join(' ');
         return interaction.reply({
-            content: `No ${wanted} in the last ${journal.length} pages of your journal. The wilds keep their own schedule.`,
+            content: `No ${wanted} in the last ${journal.length} journal entries. The wilds keep their own schedule.`,
             flags: MessageFlags.Ephemeral,
         });
     }

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -1421,6 +1421,9 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
                 { name: 'Stamina',  value: buildStaminaLine(user),                inline: true }
             );
 
+        const ammoField = buildAmmoField(user, weapon);
+        if (ammoField) embed.addFields(ammoField);
+
         const huntMultEntries = [];
         if ((result.streakMult ?? 1) > 1.0) huntMultEntries.push({ emoji: '🔥', label: `${(result.streakMult).toFixed(2)}x` });
         if (isCrit)                          huntMultEntries.push({ emoji: '⚡', label: `${critMultiplier.toFixed(2)}x crit` });
@@ -1468,6 +1471,9 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
             embed.addFields({ name: '⚠️ Low Durability', value: `Your **${weapon.name}** is nearly worn out (${weapon.currentDurability}/${weapon.maxDurability}). Repair soon!`, inline: false });
         }
 
+        const lowAmmoField = buildLowAmmoField(user, weapon);
+        if (lowAmmoField) embed.addFields(lowAmmoField);
+
         const balanceLine = `${currency}${user.balance.toLocaleString()}`;
         const xpLine = buildXpLine(user);
         embed.addFields({ name: 'Balance', value: balanceLine, inline: true }, { name: 'Hunter XP', value: xpLine, inline: true });
@@ -1498,6 +1504,9 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
                 inline: true
             }
         );
+
+    const failAmmoField = buildAmmoField(user, weapon);
+    if (failAmmoField) embed.addFields(failAmmoField);
 
     if ((user.hunt.consecutiveFails ?? 0) > 0) {
         embed.addFields(buildPityStreakField(user.hunt.consecutiveFails, LIMITS, PITY_COPY.hunt));
@@ -1544,6 +1553,9 @@ function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
     if (weapon.status === 'broken' && !result.deathEvent) {
         embed.addFields({ name: '❌ Weapon Broke!', value: buildBrokenWeaponNote(weapon), inline: false });
     }
+
+    const failLowAmmoField = buildLowAmmoField(user, weapon);
+    if (failLowAmmoField) embed.addFields(failLowAmmoField);
 
     const sinceRareNow = user.hunt.sinceRare ?? 0;
     if (sinceRareNow >= 5) embed.addFields(buildPityField(user, zone));
@@ -1664,6 +1676,41 @@ function buildStaminaLine(user) {
     const h   = user.hunt;
     const max = getMaxStamina(user);
     return `${h.stamina}/${max} ⚡`;
+}
+
+// A hunt spends three consumables: durability, stamina, and — from T2 up — a
+// round of ammo. The first two have always been on the result embed; ammo was
+// only ever surfaced as the ephemeral refusal on the *next* hunt, after the
+// cooldown had already been claimed. These two fields give it the same
+// treatment durability gets: a running count on every result, and a warning
+// naming the pack to buy before the well runs dry mid-session.
+const AMMO_LOW_THRESHOLD = 5;
+
+function ammoContext(user, weapon) {
+    const weaponData = WEAPON_BY_TIER[weapon.tier];
+    if (!weaponData?.requiresAmmo) return null;
+    const pack = AMMO_PACKS.find(p => p.ammoType === weaponData.ammoType);
+    return {
+        remaining: user.hunt.ammo?.[weaponData.ammoType] ?? 0,
+        label: weaponData.ammoType.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase()),
+        emoji: pack?.emoji ?? '🔶',
+        packName: pack?.name ?? weaponData.ammoType.replace(/_/g, ' '),
+    };
+}
+
+function buildAmmoField(user, weapon) {
+    const ammo = ammoContext(user, weapon);
+    if (!ammo) return null;
+    return { name: 'Ammo', value: `${ammo.emoji} ${ammo.label} ×${ammo.remaining}`, inline: true };
+}
+
+function buildLowAmmoField(user, weapon) {
+    const ammo = ammoContext(user, weapon);
+    if (!ammo || ammo.remaining > AMMO_LOW_THRESHOLD) return null;
+    const value = ammo.remaining <= 0
+        ? `That was your last **${ammo.label}** round! Buy **${ammo.packName}** with \`/hunt shop buy\` before your next hunt.`
+        : `Only **${ammo.remaining}** ${ammo.label} round${ammo.remaining === 1 ? '' : 's'} left. Stock up on **${ammo.packName}** with \`/hunt shop buy\`.`;
+    return { name: '⚠️ Low Ammo', value, inline: false };
 }
 
 function buildXpLine(user) {
@@ -3519,7 +3566,7 @@ async function checkGrandPrestige(client, user, guild, guildId) {
 
 // Test hooks. The command loader only looks for `data` and `execute`
 // (src/index.js), so extra exports are inert at runtime.
-module.exports.__test__ = { buildHuntEmbed, buildBonusLines, buildTrophyField, buildFieldTrophyField, buildDailyTollField, buildTodayField, buildWeaponPages, WEAPON_SEPARATOR, gradeShot, runAimPhase, AIM_WINDOW_MS, AIM_LATE_MS, isCrossEconomyWeapon, huntingDaysFor, huntingDaysLabel, fullRepairCost, CROSS_ECONOMY_DAYS, APPROACH_PROFILES, TRAIT_PROFILE_ORDER, GENERIC_PROFILE_IDS, pickApproachProfile };
+module.exports.__test__ = { buildHuntEmbed, buildBonusLines, buildAmmoField, buildLowAmmoField, AMMO_LOW_THRESHOLD, buildTrophyField, buildFieldTrophyField, buildDailyTollField, buildTodayField, buildWeaponPages, WEAPON_SEPARATOR, gradeShot, runAimPhase, AIM_WINDOW_MS, AIM_LATE_MS, isCrossEconomyWeapon, huntingDaysFor, huntingDaysLabel, fullRepairCost, CROSS_ECONOMY_DAYS, APPROACH_PROFILES, TRAIT_PROFILE_ORDER, GENERIC_PROFILE_IDS, pickApproachProfile };
 
 // ── Per-user economy lock ─────────────────────────────────────────────────────
 // Hunting mutates the user document with read-modify-write saves, so concurrent

--- a/src/data/exploreData.js
+++ b/src/data/exploreData.js
@@ -23,7 +23,11 @@ const LIMITS = {
     DAILY_SOFT_CAP:       100_000,
     DAILY_SOFT_CAP_RATE:  0.5,
     DAILY_HARD_CAP:       150_000,
-    JOURNAL_CAP:          20,
+    // The journal lives in the exploration GrindProfile blob and is rewritten
+    // whole on every save, so the cap is a storage judgement, not a maximum to
+    // chase: 100 entries is roughly 15KB and covers a long session of finds,
+    // where 20 covered barely an hour and a half of steady exploring.
+    JOURNAL_CAP:          100,
     // Secret pity: each expedition without a secret adds bonus weight to the
     // secret slot, so long droughts self-correct. Only expeditions into a
     // region that still HAS an unfound secret count toward it.

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -15,6 +15,7 @@ const { applyXpGain, announceLevelUp } = require('../utils/applyXpGain');
 const BASE_BAD_WORDS = require('../data/profanityList');
 const { getGuildSettings } = require('../utils/guildSettingsCache');
 const { saveWithBalanceDelta } = require('../utils/balanceDelta');
+const { BoundedRateLimiter } = require('../utils/boundedRateLimiter');
 
 // Pre-compile base word regexes once at module load — avoids per-message regex construction
 const BASE_BAD_WORD_REGEXES = BASE_BAD_WORDS.map(word => {
@@ -690,7 +691,12 @@ function resolveAbsoluteTime(hour, min, ampm, tomorrow) {
 const NL_REMINDER_MAX_TEXT = 200;
 const NL_REMINDER_MAX_PENDING = 10;
 const NL_REMINDER_COOLDOWN_MS = 30_000; // 30 seconds between NL-created reminders per user
-const nlReminderLastUsed = new Map(); // userId → timestamp
+// One key per user who recently tripped the cooldown. A plain Map here grew an
+// entry per user forever; the bounded limiter FIFO-evicts at the cap, and the
+// sweep drops keys whose window has fully aged out (same shape as aiService's).
+const NL_REMINDER_MAX_KEYS = 10_000;
+const nlReminderLimiter = new BoundedRateLimiter(NL_REMINDER_MAX_KEYS);
+setInterval(() => nlReminderLimiter.cleanup(NL_REMINDER_COOLDOWN_MS), 15 * 60 * 1000).unref();
 
 function sanitizeReminderText(text) {
     // Normalize first to prevent Unicode normalization attacks / length bypass tricks.
@@ -731,9 +737,10 @@ async function handleNLReminder(message, contentOverride) {
         const reminderText = sanitizeReminderText(parsed.text);
         if (!reminderText) continue;
 
-        // Per-user cooldown
-        const lastUsed = nlReminderLastUsed.get(message.author.id) || 0;
-        if (Date.now() - lastUsed < NL_REMINDER_COOLDOWN_MS) return false;
+        // Per-user cooldown. The limiter records the attempt as it checks it, so
+        // a create that fails downstream still counts — the cooldown paces how
+        // often a user can *trigger* the path, not how often they succeed.
+        if (!nlReminderLimiter.check(message.author.id, NL_REMINDER_COOLDOWN_MS, 1)) return false;
 
         // Cap pending reminders per user
         const pending = await Reminder.countDocuments({ userId: message.author.id, completed: false }).catch(() => NL_REMINDER_MAX_PENDING);
@@ -747,8 +754,6 @@ async function handleNLReminder(message, contentOverride) {
                 message:   reminderText,
                 remindAt
             });
-
-            nlReminderLastUsed.set(message.author.id, Date.now());
 
             const unixTs = Math.floor(remindAt.getTime() / 1000);
             await message.reply({ content: `✅ Got it! I'll remind you <t:${unixTs}:R> about: **${reminderText}**`, allowedMentions: { parse: [] } }).catch(() => {});

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -116,20 +116,30 @@ module.exports = {
                 if (blocked) return await flushPendingUser(sharedUser);
             }
 
-            await handleSuggestions(message, guildSettings);
-
-            if (guildSettings?.bibleVerse?.autoRespond) {
-                await handleBibleVerseDetection(message, guildSettings);
+            // Automod was the only handler with a say over the ones below — past
+            // that gate they touch different data and issue unrelated writes, so
+            // they run concurrently instead of queueing behind whichever happens
+            // to be slowest.
+            const settled = await Promise.allSettled([
+                // Streak + quests — reuses the document handleLeveling already loaded
+                // and saves it once. It reports whether that write landed; when it
+                // bailed out early or threw before saving, the XP still has to be
+                // persisted. The flush stays inside this chain so it can never race
+                // the fire-and-forget saves that follow a landed write.
+                (async () => {
+                    const persisted = await handleStreakAndQuests(message, guildSettings, sharedUser);
+                    if (!persisted) await flushPendingUser(sharedUser);
+                })(),
+                handleSuggestions(message, guildSettings),
+                guildSettings?.bibleVerse?.autoRespond
+                    ? handleBibleVerseDetection(message, guildSettings)
+                    : null,
+                // Natural language reminders — available to everyone, any channel
+                handleNLReminder(message),
+            ]);
+            for (const outcome of settled) {
+                if (outcome.status === 'rejected') console.error('Error in messageCreate:', outcome.reason);
             }
-
-            // Natural language reminders — available to everyone, any channel
-            await handleNLReminder(message);
-
-            // Streak + quests — reuses the document handleLeveling already loaded and
-            // saves it once. It reports whether that write landed; when it bailed out
-            // early or threw before saving, the XP still has to be persisted.
-            const persisted = await handleStreakAndQuests(message, guildSettings, sharedUser);
-            if (!persisted) await flushPendingUser(sharedUser);
 
             // Ambient chat events (airdrops, crates, trivia) — fire-and-forget
             maybeTriggerChatEvent(message, guildSettings).catch(() => {});

--- a/tests/huntEmbedFields.test.js
+++ b/tests/huntEmbedFields.test.js
@@ -29,6 +29,9 @@ function maximalUser() {
             trophies: [], activeBait: 'premium_bait', activeBaitHuntsLeft: 1,
             activeCharm: 'luck_charm', activeCharmHuntsLeft: 1,
             activeFocus: true, activeXpScroll: true,
+            // Low enough that the "Low Ammo" warning fires alongside the Ammo
+            // count — both new fields must fit inside the budget at once.
+            ammo: { steel_shot: 3 },
         },
     };
 }
@@ -107,7 +110,7 @@ describe('hunt success embed field budget', () => {
 
     test('the maximal case really did populate the optional fields', () => {
         const names = fieldsOf(embed).map(f => f.name).join(' | ');
-        for (const expected of ['Multipliers', 'Traits', 'Trait Effects', 'Special Drop', 'Level Up', 'Buffs Expired', 'Weapon Broke', 'Rare Pity']) {
+        for (const expected of ['Multipliers', 'Traits', 'Trait Effects', 'Special Drop', 'Level Up', 'Buffs Expired', 'Weapon Broke', 'Rare Pity', 'Ammo', 'Low Ammo']) {
             expect(names).toContain(expected);
         }
     });
@@ -151,6 +154,65 @@ describe('buildBonusLines', () => {
         const many = { gatheringYield: { label: 'X', emoji: '🪙', chargesLeft: 2 } };
         expect(buildBonusLines(one, 0, 0)[0]).toContain('1 charge left');
         expect(buildBonusLines(many, 0, 0)[0]).toContain('2 charges left');
+    });
+});
+
+describe('ammo visibility', () => {
+    const { buildAmmoField, buildLowAmmoField, AMMO_LOW_THRESHOLD } = __test__;
+    const t1Weapon = { name: 'Wooden Slingshot', tier: 1, currentDurability: 50, maxDurability: 50, status: 'good' };
+
+    function userWithAmmo(count) {
+        const user = maximalUser();
+        user.hunt.ammo = { steel_shot: count };
+        return user;
+    }
+
+    test('shows the remaining round count for an ammo-fed weapon', () => {
+        const field = buildAmmoField(userWithAmmo(47), brokenWeapon);
+        expect(field).toEqual({ name: 'Ammo', value: '⚫ Steel Shot ×47', inline: true });
+    });
+
+    test('omits the field entirely for a T1 weapon', () => {
+        expect(buildAmmoField(userWithAmmo(47), t1Weapon)).toBeNull();
+        expect(buildLowAmmoField(userWithAmmo(0), t1Weapon)).toBeNull();
+    });
+
+    test('treats missing ammo state as zero rounds', () => {
+        const user = maximalUser();
+        delete user.hunt.ammo;
+        expect(buildAmmoField(user, brokenWeapon).value).toContain('×0');
+    });
+
+    test('warns at the threshold and stays quiet above it', () => {
+        expect(buildLowAmmoField(userWithAmmo(AMMO_LOW_THRESHOLD), brokenWeapon)).not.toBeNull();
+        expect(buildLowAmmoField(userWithAmmo(AMMO_LOW_THRESHOLD + 1), brokenWeapon)).toBeNull();
+    });
+
+    test('the warning names the pack the shop actually sells', () => {
+        const field = buildLowAmmoField(userWithAmmo(3), brokenWeapon);
+        expect(field.value).toContain('Steel Shot (20)');
+        expect(field.value).toContain('/hunt shop buy');
+    });
+
+    test('says so plainly when the hunt spent the last round', () => {
+        const field = buildLowAmmoField(userWithAmmo(0), brokenWeapon);
+        expect(field.value).toContain('last');
+        expect(field.value).toContain('Steel Shot (20)');
+    });
+
+    test('both embeds carry the count on an ammo-fed weapon', () => {
+        const success = buildHuntEmbed(maximalSuccessResult(), userWithAmmo(3), ZONES.legendary_peaks, brokenWeapon, '💰', discordUser);
+        const failure = buildHuntEmbed({
+            success: false,
+            failure: { severity: { id: 'clean_miss', injuryMs: 0 }, message: 'Nothing stirred.' },
+            xpEarned: 0,
+        }, userWithAmmo(3), ZONES.murky_swamp, brokenWeapon, '💰', discordUser);
+
+        for (const embed of [success, failure]) {
+            const names = fieldsOf(embed).map(f => f.name);
+            expect(names).toContain('Ammo');
+            expect(names).toContain('⚠️ Low Ammo');
+        }
     });
 });
 


### PR DESCRIPTION
A hunt spends three consumables — durability, stamina, and (from T2 up) a
round of ammo — but only the first two were ever on the result embed. The
first a player heard about an empty pouch was the ephemeral refusal on the
next hunt, mid-session, after the cooldown claim.

Mirror what durability already does: an Ammo count field on both the
success and failure embeds for ammo-fed weapons (omitted for T1), and a
low-ammo warning at 5 or fewer rounds that names the exact shop pack to
buy. The field-budget fixture now runs with low ammo so both new fields
are counted against the 25-field cap, and the maximal success embed stays
at the guarded five-field headroom.

Closes #743

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added journal filters for region and event type, with clearer empty states and paginated results.
  * Increased journal capacity from 20 to 100 entries.
  * Hunt results now display remaining ammunition and low-ammo warnings.

* **Bug Fixes**
  * Improved reminder cooldown handling and reliability.
  * Improved background event processing to help prevent missed progress updates.

* **Tests**
  * Added coverage for ammunition displays, low-ammo warnings, and hunt outcome embeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->