### PR TITLE
Exclude giveaway entrant lists from the guild settings cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
     "deploy": "node src/deploy-commands.js",
+    "migrate:rollback": "node scripts/rollback-migration.js",
     "test": "jest --forceExit"
   },
   "keywords": [

--- a/scripts/rollback-migration.js
+++ b/scripts/rollback-migration.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+'use strict';
+
+// Rolls back one applied migration by name:
+//
+//   npm run migrate:rollback -- 013_split_guild_analytics
+//
+// Runs the migration's down() and deletes its MigrationRecord, so the next
+// boot re-applies it — pair a rollback with deploying the code being rolled
+// back to (or removing the migration file). Only the most recently applied
+// migration can be rolled back; unwind further one invocation at a time.
+// Irreversible migrations refuse here — restore the pre-migration backup
+// instead (scripts/restore.sh).
+
+require('dotenv').config();
+
+const mongoose = require('mongoose');
+const { rollbackMigration } = require('../src/migrations/runner');
+
+async function main() {
+    const name = process.argv[2];
+    if (!name) {
+        console.error('Usage: npm run migrate:rollback -- <migration-name>');
+        console.error('   or: node scripts/rollback-migration.js <migration-name>');
+        process.exit(1);
+    }
+
+    if (!process.env.MONGODB_URI) {
+        console.error('MONGODB_URI is not set (put it in .env or the environment).');
+        process.exit(1);
+    }
+
+    await mongoose.connect(process.env.MONGODB_URI);
+    try {
+        await rollbackMigration(name);
+    } finally {
+        await mongoose.disconnect();
+    }
+}
+
+main().catch(err => {
+    console.error(err.message || err);
+    process.exitCode = 1;
+});

--- a/src/migrations/001_add_indexes.js
+++ b/src/migrations/001_add_indexes.js
@@ -92,4 +92,24 @@ module.exports = {
             { name: 'idx_failedjobs_status_service' }
         );
     },
+
+    async down() {
+        const db = mongoose.connection.db;
+
+        const built = [
+            ['reminders',   'idx_remind_due'],
+            ['guilds',      'idx_giveaways_active'],
+            ['cases',       'idx_cases_sla'],
+            ['summaryjobs', 'idx_summaryjobs_schedule'],
+            ['guilds',      'idx_guilds_rssfeeds'],
+            ['failedjobs',  'idx_failedjobs_status_service'],
+        ];
+
+        for (const [collection, name] of built) {
+            await db.collection(collection).dropIndex(name).catch(err => {
+                // Already gone, or the collection was never created.
+                if (err?.codeName !== 'IndexNotFound' && err?.code !== 26) throw err;
+            });
+        }
+    },
 };

--- a/src/migrations/004_seasonal_events.js
+++ b/src/migrations/004_seasonal_events.js
@@ -32,4 +32,17 @@ module.exports = {
             );
         }
     },
+
+    async down() {
+        const db = mongoose.connection.db;
+
+        for (const [collection, name] of [
+            ['guilds', 'idx_guilds_active_event'],
+            ['users',  'idx_users_event_currency'],
+        ]) {
+            await db.collection(collection).dropIndex(name).catch(err => {
+                if (err?.codeName !== 'IndexNotFound' && err?.code !== 26) throw err;
+            });
+        }
+    },
 };

--- a/src/migrations/005_grind_profiles.js
+++ b/src/migrations/005_grind_profiles.js
@@ -14,6 +14,12 @@ const mongoose = require('mongoose');
 module.exports = {
     name: '005_grind_profiles',
 
+    // The $unset half discards the User-document copy of the grind state, and
+    // writing a faithful inverse (merging profiles back into user documents
+    // that may have changed since) would be a migration as risky as this one.
+    // Rolling back means restoring the pre-migration backup.
+    irreversible: true,
+
     // Eight full passes over the users collection — four $merge aggregations
     // and four updateMany $unsets. The runner's 30 s default is a development
     // figure; on a real install this is the migration that outgrows it, and

--- a/src/migrations/006_drop_wheel_fields.js
+++ b/src/migrations/006_drop_wheel_fields.js
@@ -3,6 +3,11 @@ const mongoose = require('mongoose');
 module.exports = {
     name: '006_drop_wheel_fields',
 
+    // $unset discards the values; nothing keeps a copy to put back. The way
+    // back is the pre-migration backup the runner takes before anything
+    // irreversible runs (scripts/restore.sh).
+    irreversible: true,
+
     async up() {
         const db = mongoose.connection.db;
 

--- a/src/migrations/008_pet_decay_cursor.js
+++ b/src/migrations/008_pet_decay_cursor.js
@@ -13,6 +13,10 @@ const mongoose = require('mongoose');
 module.exports = {
     name: '008_pet_decay_cursor',
 
+    // Overwrites every pet's starvation clock without keeping the old values;
+    // rolling back means restoring the pre-migration backup.
+    irreversible: true,
+
     async up() {
         const db = mongoose.connection.db;
 

--- a/src/migrations/009_drop_stale_grind_indexes.js
+++ b/src/migrations/009_drop_stale_grind_indexes.js
@@ -51,4 +51,11 @@ module.exports = {
             });
         }
     },
+
+    // The exact inverse is re-running the migrations whose indexes this one
+    // dropped — their specs live in one place instead of being copied here.
+    async down() {
+        await require('./002_hunt_indexes').up();
+        await require('./003_fishing_indexes').up();
+    },
 };

--- a/src/migrations/010_merge_duplicate_inventory_slots.js
+++ b/src/migrations/010_merge_duplicate_inventory_slots.js
@@ -19,6 +19,10 @@ const mongoose = require('mongoose');
 module.exports = {
     name: '010_merge_duplicate_inventory_slots',
 
+    // The merge folds duplicate slots together without remembering how the
+    // quantities were split; only the pre-migration backup can restore that.
+    irreversible: true,
+
     // A `$expr` scan of the whole users collection, then a batched rewrite of
     // every document it matches. Like 005, that is more than the runner's 30 s
     // default is meant to cover on a grown install, and running out of budget

--- a/src/migrations/011_clamp_negative_balances.js
+++ b/src/migrations/011_clamp_negative_balances.js
@@ -17,6 +17,10 @@ const mongoose = require('mongoose');
 module.exports = {
     name: '011_clamp_negative_balances',
 
+    // The negative values are overwritten with zero, not recorded; the
+    // pre-migration backup is the only place they survive.
+    irreversible: true,
+
     async up() {
         const users = mongoose.connection.db.collection('users');
 

--- a/src/migrations/012_active_lock_unique_key.js
+++ b/src/migrations/012_active_lock_unique_key.js
@@ -39,4 +39,14 @@ module.exports = {
             );
         }
     },
+
+    // Rolling this back re-opens the concurrent-acquire hole described above;
+    // it exists for unwinding to a build that predates the conditional-upsert
+    // lock, not for running current code without the index.
+    async down() {
+        const locks = mongoose.connection.db.collection('activelocks');
+        await locks.dropIndex('idx_activelock_key').catch(err => {
+            if (err?.codeName !== 'IndexNotFound' && err?.code !== 26) throw err;
+        });
+    },
 };

--- a/src/migrations/013_split_guild_analytics.js
+++ b/src/migrations/013_split_guild_analytics.js
@@ -71,4 +71,42 @@ module.exports = {
             `removed the field from ${unsetResult.modifiedCount} document(s)`
         );
     },
+
+    /**
+     * Moves every GuildAnalytics document's arrays back onto its Guild
+     * document and deletes the moved document — the shape the pre-013 code
+     * reads. Only meaningful alongside deploying that older code: current
+     * writers upsert GuildAnalytics again on the next command, so rolling
+     * back under current code just splits the data anew.
+     */
+    async down({ timeoutMs } = {}) {
+        const guilds = mongoose.connection.db.collection('guilds');
+        const analyticsCollection = require('../models/GuildAnalytics').collection;
+
+        const bounded = timeoutMs > 0 ? { maxTimeMS: timeoutMs } : {};
+
+        const cursor = analyticsCollection.find({}, bounded);
+        let restored = 0;
+        for await (const doc of cursor) {
+            if (doc.guildId) {
+                await guilds.updateOne(
+                    { guildId: doc.guildId },
+                    {
+                        $set: {
+                            analytics: {
+                                memberEvents: doc.memberEvents || [],
+                                commandUsage: doc.commandUsage || [],
+                            },
+                        },
+                    },
+                );
+            }
+            // Deleted either way: a document whose guild is gone has nowhere
+            // to go back to.
+            await analyticsCollection.deleteOne({ _id: doc._id });
+            restored++;
+        }
+
+        console.log(`[MIGRATIONS] 013 down: moved analytics back for ${restored} guild(s)`);
+    },
 };

--- a/src/migrations/runner.js
+++ b/src/migrations/runner.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { spawnSync } = require('child_process');
 const MigrationRecord = require('../models/MigrationRecord');
 
 // Wall-clock budget for a single migration. A migration that hangs holds the
@@ -59,12 +60,97 @@ function withTimeout(promise, ms, label) {
     ]);
 }
 
+// Discovers migration files and requires them, in apply order.
+function loadMigrations(dir) {
+    return fs.readdirSync(dir)
+        .filter(f => f.endsWith('.js') && f !== 'runner.js')
+        .sort()
+        .map(file => ({ file, migration: require(path.join(dir, file)) }));
+}
+
+/**
+ * A mongodump taken immediately before irreversible migrations run, because
+ * afterwards it is the only way back: the runner rolls migrations back through
+ * their `down()`, and an irreversible migration by definition has none.
+ *
+ * Controlled by MIGRATION_BACKUP:
+ *   'skip'     don't attempt one
+ *   'require'  a failed or impossible backup aborts startup rather than
+ *              letting the destructive step run unprotected
+ *   unset      attempt it; if mongodump is missing or fails, warn loudly and
+ *              carry on, because a bot that cannot boot without a tool its
+ *              container may not ship is a worse default than no backup —
+ *              operators who want the guarantee set 'require'.
+ *
+ * The archive lands in MIGRATION_BACKUP_DIR (default ./backups, same place as
+ * scripts/backup.sh) and is restored with scripts/restore.sh.
+ */
+function preMigrationBackup(irreversibleNames) {
+    const mode = String(process.env.MIGRATION_BACKUP || '').toLowerCase();
+    if (mode === 'skip') {
+        console.warn('[MIGRATIONS] MIGRATION_BACKUP=skip — applying irreversible migrations without a backup.');
+        return;
+    }
+
+    const fail = message => {
+        if (mode === 'require') {
+            throw new Error(`[MIGRATIONS] ${message} (MIGRATION_BACKUP=require, so refusing to run: ${irreversibleNames.join(', ')})`);
+        }
+        console.warn(
+            `[MIGRATIONS] ${message} — continuing WITHOUT a backup before irreversible ` +
+            `migration(s): ${irreversibleNames.join(', ')}. Run scripts/backup.sh first, ` +
+            'or set MIGRATION_BACKUP=require to make this abort instead.'
+        );
+    };
+
+    const uri = process.env.MONGODB_URI;
+    if (!uri) return fail('MONGODB_URI is not set, cannot take a pre-migration backup');
+
+    const backupDir = process.env.MIGRATION_BACKUP_DIR || path.join(process.cwd(), 'backups');
+    const stamp = new Date().toISOString().replace(/[:.]/g, '').replace(/-/g, '');
+    const archive = path.join(backupDir, `pre-migration-${stamp}.gz`);
+
+    try {
+        fs.mkdirSync(backupDir, { recursive: true });
+    } catch (err) {
+        return fail(`could not create backup directory ${backupDir}: ${err.message}`);
+    }
+
+    console.log(`[MIGRATIONS] Taking pre-migration backup → ${archive}`);
+    // Synchronous on purpose: this runs at boot before anything is served, and
+    // the destructive migration must not start until the dump has finished.
+    const result = spawnSync('mongodump', [`--uri=${uri}`, '--gzip', `--archive=${archive}`], {
+        stdio: ['ignore', 'inherit', 'inherit'],
+    });
+
+    if (result.error) {
+        return fail(`mongodump could not be run (${result.error.code === 'ENOENT' ? 'not on PATH' : result.error.message})`);
+    }
+    if (result.status !== 0) {
+        return fail(`mongodump exited with status ${result.status}`);
+    }
+    console.log('[MIGRATIONS] Pre-migration backup complete.');
+}
+
 /**
  * Discovers and applies any pending migrations in this directory.
  * Migrations are .js files (excluding runner.js itself) sorted by filename.
  *
- * Each migration file must export `{ name: string, up: async function }`, and
- * may export:
+ * Each migration file must export `{ name: string, up: async function }`, plus
+ * a rollback story — one of:
+ *
+ *   down          async function that undoes `up`. Invoked only by
+ *                 rollbackMigration (a boot never rolls back on its own),
+ *                 under the same timeout machinery as `up`.
+ *   irreversible  `true` for a migration whose effect cannot be computed back
+ *                 (dropped fields, merged data). Declaring it is what triggers
+ *                 the pre-migration backup, which is then the only way back.
+ *
+ * tests/migrationRollback.test.js enforces that every shipped migration
+ * declares one of the two; the runner itself only warns, so a boot is never
+ * blocked over a missing annotation.
+ *
+ * A migration may also export:
  *
  *   timeoutMs  Wall-clock budget for this migration, when the default is too
  *              tight for the work it does. `up({ timeoutMs })` receives the
@@ -78,11 +164,9 @@ function withTimeout(promise, ms, label) {
  * Already-applied migrations are skipped (tracked in the MigrationRecord collection).
  */
 async function runMigrations({ dir = __dirname } = {}) {
-    const files = fs.readdirSync(dir)
-        .filter(f => f.endsWith('.js') && f !== 'runner.js')
-        .sort();
+    const loaded = loadMigrations(dir);
 
-    if (files.length === 0) {
+    if (loaded.length === 0) {
         console.log('[MIGRATIONS] No migration files found.');
         return;
     }
@@ -93,10 +177,8 @@ async function runMigrations({ dir = __dirname } = {}) {
 
     const baseTimeoutMs = envTimeoutMs() ?? DEFAULT_TIMEOUT_MS;
 
-    let count = 0;
-    const deferred = [];
-    for (const file of files) {
-        const migration = require(path.join(dir, file));
+    const pending = [];
+    for (const { file, migration } of loaded) {
         const { name, up } = migration;
 
         if (!name || typeof up !== 'function') {
@@ -109,6 +191,27 @@ async function runMigrations({ dir = __dirname } = {}) {
             continue;
         }
 
+        if (typeof migration.down !== 'function' && migration.irreversible !== true) {
+            console.warn(
+                `[MIGRATIONS] ${name} declares no rollback story: export down() or ` +
+                'irreversible: true. Treating it as irreversible.'
+            );
+        }
+
+        pending.push(migration);
+    }
+
+    // Anything without a down() cannot be unwound once it runs, so this is the
+    // last moment a copy of the data can be taken.
+    const irreversible = pending.filter(m => typeof m.down !== 'function').map(m => m.name);
+    if (irreversible.length > 0) {
+        preMigrationBackup(irreversible);
+    }
+
+    let count = 0;
+    const deferred = [];
+    for (const migration of pending) {
+        const { name, up } = migration;
         const timeoutMs = resolveTimeoutMs(migration.timeoutMs, baseTimeoutMs);
 
         console.log(`[MIGRATIONS] Applying: ${name} (budget ${timeoutMs}ms)`);
@@ -147,4 +250,71 @@ async function runMigrations({ dir = __dirname } = {}) {
     }
 }
 
-module.exports = { runMigrations };
+/**
+ * Rolls back one applied migration by running its `down()` and deleting its
+ * MigrationRecord — after which the next boot re-applies it, so pair a
+ * rollback with deploying the code you are rolling back to (or removing the
+ * migration file).
+ *
+ * Never called at boot; the entry point is `npm run migrate:rollback -- <name>`
+ * (scripts/rollback-migration.js). Only the most recently applied migration
+ * can be rolled back: later migrations may build on what an earlier one wrote,
+ * so the chain unwinds in reverse order, one step per invocation.
+ *
+ * A migration marked `irreversible` (or missing `down()`) refuses here by
+ * design — the way back from those is the pre-migration backup, via
+ * scripts/restore.sh.
+ */
+async function rollbackMigration(name, { dir = __dirname } = {}) {
+    if (!name) {
+        throw new Error('[MIGRATIONS] rollbackMigration needs a migration name.');
+    }
+
+    const loaded = loadMigrations(dir).filter(({ migration }) =>
+        migration.name && typeof migration.up === 'function');
+
+    const target = loaded.find(({ migration }) => migration.name === name);
+    if (!target) {
+        throw new Error(`[MIGRATIONS] No migration named "${name}" found in ${dir}.`);
+    }
+
+    const applied = new Set(
+        (await MigrationRecord.find({}, 'name').lean()).map(r => r.name)
+    );
+    if (!applied.has(name)) {
+        throw new Error(`[MIGRATIONS] ${name} is not recorded as applied — nothing to roll back.`);
+    }
+
+    const appliedInOrder = loaded
+        .map(({ migration }) => migration.name)
+        .filter(n => applied.has(n));
+    const latest = appliedInOrder[appliedInOrder.length - 1];
+    if (name !== latest) {
+        throw new Error(
+            `[MIGRATIONS] ${name} is not the most recently applied migration — ` +
+            `roll back ${latest} first. Migrations unwind in reverse order.`
+        );
+    }
+
+    const { migration } = target;
+    if (typeof migration.down !== 'function') {
+        throw new Error(
+            `[MIGRATIONS] ${name} is irreversible: it defines no down(). ` +
+            'Restore the pre-migration backup instead — see scripts/restore.sh.'
+        );
+    }
+
+    const timeoutMs = resolveTimeoutMs(migration.timeoutMs, envTimeoutMs() ?? DEFAULT_TIMEOUT_MS);
+
+    console.log(`[MIGRATIONS] Rolling back: ${name} (budget ${timeoutMs}ms)`);
+    const start = Date.now();
+    await withTimeout(migration.down({ timeoutMs }), timeoutMs, `${name} (down)`);
+    await MigrationRecord.deleteOne({ name });
+    console.log(
+        `[MIGRATIONS] Rolled back ${name} in ${Date.now() - start}ms. ` +
+        'It is no longer recorded as applied, so the next boot will re-apply it ' +
+        'unless the file is removed with the code being rolled back to.'
+    );
+}
+
+module.exports = { runMigrations, rollbackMigration };

--- a/src/services/rivalryService.js
+++ b/src/services/rivalryService.js
@@ -1,10 +1,18 @@
 const User = require('../models/User');
 
-// guildId -> { entries: [{userId, level, xp}], index: Map(userId -> position), updatedAt }
+// guildId -> { entries: [{userId, level, xp}], index: Map(userId -> position), updatedAt, truncated }
 const rankCache = new Map();
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 const MAX_RANK = 100;             // only notify users within top 100
 const MAX_RANK_DIFF = 10;         // only notify when rival is within 10 ranks
+
+// Both bounds exist so the cache has a memory ceiling instead of growing with
+// every guild and member the bot ever sees. Rivalry only cares about the top
+// MAX_RANK, so a window of double that loses nothing the feature reads; a
+// guild beyond MAX_GUILDS evicts the oldest cached guild FIFO (same pattern as
+// utils/boundedRateLimiter), which merely costs that guild one re-read.
+const MAX_GUILDS = 500;
+const MAX_ENTRIES_PER_GUILD = 200;
 const NOTIFY_COOLDOWN = 60 * 60 * 1000; // 1 notification per user per hour
 
 // Significant rank thresholds that trigger the optional "climbed" DM
@@ -28,9 +36,20 @@ async function getLeaderboard(guildId) {
     }
     const users = await User.find({ guildId })
         .sort({ level: -1, xp: -1 })
+        .limit(MAX_ENTRIES_PER_GUILD)
         .select('userId level xp')
         .lean();
-    const entry = { entries: users, index: buildIndex(users), updatedAt: Date.now() };
+    const entry = {
+        entries: users,
+        index: buildIndex(users),
+        updatedAt: Date.now(),
+        // A full window means the guild (probably) has more members than the
+        // cache holds, so anyone not in the index has an unknown rank below it.
+        truncated: users.length === MAX_ENTRIES_PER_GUILD,
+    };
+    if (!rankCache.has(guildId) && rankCache.size >= MAX_GUILDS) {
+        rankCache.delete(rankCache.keys().next().value);
+    }
     rankCache.set(guildId, entry);
     return entry;
 }
@@ -79,11 +98,29 @@ function reposition(entries, index, from) {
  * from before its own await.
  *
  * Returns `{ oldRank, newRank, overtaken }`, where `overtaken` lists the players
- * this user passed together with the rank each of them now holds.
+ * this user passed together with the rank each of them now holds — or null when
+ * the board is a truncated window and this user falls outside it, in which case
+ * nothing changed and the caller has nothing to notify about.
+ *
+ * Deliberately does NOT touch board.updatedAt: bumping it on every write-through
+ * turned the TTL into "5 minutes since the last message", which on any active
+ * guild is never — the entry could not expire, so a board that drifted (or a
+ * guild that shrank) was never re-read. The write-through keeps the board
+ * current between refreshes; the TTL now actually fires and replaces it.
  */
 function applyStanding(board, savedUser) {
     const { entries, index } = board;
     const oldIdx = index.get(savedUser.userId) ?? -1;
+
+    // On a truncated board an unknown user's real rank is somewhere below the
+    // window. If they still sort at-or-below the current last entry, placing
+    // them would invent a rank; they are also nowhere near MAX_RANK, so skip.
+    // A user who now sorts above the last entry has climbed into the window
+    // and is inserted (the entry that falls off the end is trimmed below).
+    if (oldIdx === -1 && board.truncated) {
+        const last = entries[entries.length - 1];
+        if (last && compare(savedUser, last) >= 0) return null;
+    }
 
     let from;
     if (oldIdx === -1) {
@@ -97,13 +134,18 @@ function applyStanding(board, savedUser) {
     }
 
     const newIdx = reposition(entries, index, from);
-    board.updatedAt = Date.now();
 
     // Everyone between the new and old positions was shifted down by exactly
     // one, so their ranks are known without searching for them again.
     const overtaken = [];
     for (let i = newIdx + 1; i <= from; i++) {
         overtaken.push({ userId: entries[i].userId, rank: i + 1 });
+    }
+
+    // An insertion into a truncated window pushed one entry past the cap.
+    if (board.truncated && entries.length > MAX_ENTRIES_PER_GUILD) {
+        const dropped = entries.pop();
+        index.delete(dropped.userId);
     }
 
     return {
@@ -124,7 +166,9 @@ function applyStanding(board, savedUser) {
 async function checkRivalry(client, guild, savedUser) {
     try {
         const board = await getLeaderboard(guild.id);
-        const { oldRank, newRank, overtaken } = applyStanding(board, savedUser);
+        const standing = applyStanding(board, savedUser);
+        if (!standing) return; // outside a truncated board's window — nothing to report
+        const { oldRank, newRank, overtaken } = standing;
 
         if (newRank > MAX_RANK) return;
         if (!oldRank || newRank >= oldRank) return;
@@ -192,4 +236,10 @@ async function checkRivalry(client, guild, savedUser) {
     }
 }
 
-module.exports = { checkRivalry, __test__: { applyStanding, reposition, compare, buildIndex, rankCache } };
+module.exports = {
+    checkRivalry,
+    __test__: {
+        applyStanding, reposition, compare, buildIndex, rankCache, getLeaderboard,
+        CACHE_TTL, MAX_GUILDS, MAX_ENTRIES_PER_GUILD,
+    },
+};

--- a/src/services/rssService.js
+++ b/src/services/rssService.js
@@ -22,10 +22,48 @@ const runtimeTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
 // Consecutive failure counts per feed URL. Feeds are skipped after DEAD_FEED_THRESHOLD failures,
 // but a retry is allowed once DEAD_FEED_COOLDOWN_MS has elapsed since the last failure.
+// Shared between the 5-minute sweep and the daily digests: a feed that is down
+// is down for both.
 const feedFailCounts = new Map();
 const feedLastFailTime = new Map();
 const DEAD_FEED_THRESHOLD = 3;
 const DEAD_FEED_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
+
+// How many feed URLs checkRssFeeds fetches at once. Each fetch can take up to
+// ~40s worst case (8s/hop × 5 redirects through safeFetchFeed), so strictly
+// serial fetching could not finish a few dozen slow feeds inside the 5-minute
+// schedule; unbounded parallelism would burst-open one socket per configured
+// feed. Five keeps the sweep short without being a thundering herd.
+const RSS_FETCH_CONCURRENCY = 5;
+
+function shouldSkipDeadFeed(feedUrl) {
+    const failCount = feedFailCounts.get(feedUrl) || 0;
+    if (failCount < DEAD_FEED_THRESHOLD) return false;
+
+    const lastFail = feedLastFailTime.get(feedUrl) || 0;
+    if (Date.now() - lastFail < DEAD_FEED_COOLDOWN_MS) {
+        console.warn(`Skipping dead feed (${failCount} consecutive failures): ${feedUrl}`);
+        return true;
+    }
+    console.log(`Retrying previously dead feed after cooldown: ${feedUrl}`);
+    return false;
+}
+
+function recordFeedSuccess(feedUrl) {
+    feedFailCounts.delete(feedUrl);
+    feedLastFailTime.delete(feedUrl);
+}
+
+function recordFeedFailure(feedUrl, error) {
+    const newCount = (feedFailCounts.get(feedUrl) || 0) + 1;
+    feedFailCounts.set(feedUrl, newCount);
+    feedLastFailTime.set(feedUrl, Date.now());
+    if (newCount >= DEAD_FEED_THRESHOLD) {
+        console.error(`Feed marked as dead after ${newCount} consecutive failures: ${feedUrl}`);
+    } else {
+        console.error(`Error parsing feed (failure ${newCount}/${DEAD_FEED_THRESHOLD}) ${feedUrl}:`, error.message);
+    }
+}
 
 const SENT_LINKS_RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
@@ -115,54 +153,102 @@ async function fetchSendableChannel(client, channelId) {
 
     return channel;
 }
+/**
+ * Delivers a freshly-parsed feed to one guild's subscription: sends the embed
+ * if the latest item is new for that guild, and advances its lastPublished
+ * cursor. Per-subscription failures are contained here so one guild's deleted
+ * channel does not stop the fan-out to the others.
+ */
+async function deliverFeedUpdate(client, guild, feed, parsedFeed, latestItem, itemDate) {
+    try {
+        // Not `itemDate <= lastPublished`: an unparseable pubDate gives an
+        // invalid Date, which compares false both ways, and it must skip (as
+        // it always has) rather than post with a timestamp that cannot render.
+        if (feed.lastPublished && !(itemDate > feed.lastPublished)) return;
+
+        const channel = await fetchSendableChannel(client, feed.channelId);
+
+        if (channel) {
+            const embed = new EmbedBuilder()
+                .setColor('#00ff00')
+                .setTitle(latestItem.title || 'New Post')
+                .setURL(latestItem.link)
+                .setDescription(latestItem.contentSnippet?.substring(0, 200) || 'No description available')
+                .setTimestamp(itemDate);
+
+            if (parsedFeed.image?.url) {
+                embed.setThumbnail(parsedFeed.image.url);
+            }
+
+            await channel.send({ embeds: [embed] });
+        }
+
+        // Targets the one subdocument rather than rewriting the whole
+        // rssFeeds array, which is also what `guild.save()` on a
+        // projected document could not do.
+        await Guild.updateOne(
+            { guildId: guild.guildId, 'rssFeeds._id': feed._id },
+            { $set: { 'rssFeeds.$.lastPublished': itemDate } }
+        );
+    } catch (error) {
+        console.error(`Error delivering RSS update for ${feed.url} to guild ${guild.guildId}:`, error);
+    }
+}
+
+// Overlap protection lives in the scheduler: this runs through runJob, which
+// drops a tick while the previous sweep is still in flight.
 async function checkRssFeeds(client) {
     try {
-        // Projected and lean: a full Guild document carries the 3000-entry
-        // analytics.commandUsage array and every shop item's image Buffer, none of
-        // which this job reads.
+        // Projected and lean: a full Guild document carries every shop item's
+        // image Buffer and each giveaway's entrant list, none of which this
+        // job reads.
         const guilds = await Guild.find({ 'rssFeeds.0': { $exists: true } }, 'guildId rssFeeds').lean();
 
+        // Popular feeds are configured by many guilds; fetch each URL once per
+        // sweep and fan the parsed result out to every subscription.
+        const subscriptionsByUrl = new Map(); // url -> [{ guild, feed }]
         for (const guild of guilds) {
             for (const feed of guild.rssFeeds) {
-                try {
-                    const parsedFeed = await parseFeedUrl(feed.url);
-                    
-                    if (parsedFeed.items.length === 0) continue;
-
-                    const latestItem = parsedFeed.items[0];
-                    const itemDate = new Date(latestItem.pubDate || latestItem.isoDate);
-
-                    if (!feed.lastPublished || itemDate > feed.lastPublished) {
-                        const channel = await fetchSendableChannel(client, feed.channelId);
-                        
-                        if (channel) {
-                            const embed = new EmbedBuilder()
-                                .setColor('#00ff00')
-                                .setTitle(latestItem.title || 'New Post')
-                                .setURL(latestItem.link)
-                                .setDescription(latestItem.contentSnippet?.substring(0, 200) || 'No description available')
-                                .setTimestamp(itemDate);
-
-                            if (parsedFeed.image?.url) {
-                                embed.setThumbnail(parsedFeed.image.url);
-                            }
-
-                            await channel.send({ embeds: [embed] });
-                        }
-
-                        // Targets the one subdocument rather than rewriting the whole
-                        // rssFeeds array, which is also what `guild.save()` on a
-                        // projected document could not do.
-                        await Guild.updateOne(
-                            { guildId: guild.guildId, 'rssFeeds._id': feed._id },
-                            { $set: { 'rssFeeds.$.lastPublished': itemDate } }
-                        );
-                    }
-                } catch (error) {
-                    console.error(`Error parsing RSS feed ${feed.url}:`, error);
-                }
+                if (!feed?.url) continue;
+                let subs = subscriptionsByUrl.get(feed.url);
+                if (!subs) subscriptionsByUrl.set(feed.url, subs = []);
+                subs.push({ guild, feed });
             }
         }
+
+        // A shared cursor over the URL list, drained by a small pool of
+        // workers — bounded parallelism without chunking (no worker idles
+        // while a slow feed holds up its chunk).
+        const urls = [...subscriptionsByUrl.keys()];
+        let next = 0;
+        const worker = async () => {
+            while (next < urls.length) {
+                const url = urls[next++];
+                if (shouldSkipDeadFeed(url)) continue;
+
+                let parsedFeed;
+                try {
+                    parsedFeed = await parseFeedUrl(url);
+                    recordFeedSuccess(url);
+                } catch (error) {
+                    recordFeedFailure(url, error);
+                    continue;
+                }
+
+                if (parsedFeed.items.length === 0) continue;
+
+                const latestItem = parsedFeed.items[0];
+                const itemDate = new Date(latestItem.pubDate || latestItem.isoDate);
+
+                for (const { guild, feed } of subscriptionsByUrl.get(url)) {
+                    await deliverFeedUpdate(client, guild, feed, parsedFeed, latestItem, itemDate);
+                }
+            }
+        };
+
+        await Promise.all(
+            Array.from({ length: Math.min(RSS_FETCH_CONCURRENCY, urls.length) }, worker)
+        );
     } catch (error) {
         console.error('Error checking RSS feeds:', error);
     }
@@ -179,20 +265,11 @@ async function sendDailyNewsForProfile(client, guild, profile) {
     const cutoffMs = Date.now() - (24 * 60 * 60 * 1000);
 
     for (const feedUrl of profile.feeds) {
-        const failCount = feedFailCounts.get(feedUrl) || 0;
-        if (failCount >= DEAD_FEED_THRESHOLD) {
-            const lastFail = feedLastFailTime.get(feedUrl) || 0;
-            if (Date.now() - lastFail < DEAD_FEED_COOLDOWN_MS) {
-                console.warn(`Skipping dead feed (${failCount} consecutive failures): ${feedUrl}`);
-                continue;
-            }
-            console.log(`Retrying previously dead feed after cooldown: ${feedUrl}`);
-        }
+        if (shouldSkipDeadFeed(feedUrl)) continue;
 
         try {
             const parsedFeed = await parseFeedUrl(feedUrl);
-            feedFailCounts.delete(feedUrl);
-            feedLastFailTime.delete(feedUrl);
+            recordFeedSuccess(feedUrl);
             const feedItems = parsedFeed.items
                 .map(item => ({
                     title: item.title,
@@ -208,14 +285,7 @@ async function sendDailyNewsForProfile(client, guild, profile) {
 
             allItems.push(...feedItems);
         } catch (error) {
-            const newCount = (feedFailCounts.get(feedUrl) || 0) + 1;
-            feedFailCounts.set(feedUrl, newCount);
-            feedLastFailTime.set(feedUrl, Date.now());
-            if (newCount >= DEAD_FEED_THRESHOLD) {
-                console.error(`Feed marked as dead after ${newCount} consecutive failures: ${feedUrl}`);
-            } else {
-                console.error(`Error parsing daily news feed (failure ${newCount}/${DEAD_FEED_THRESHOLD}) ${feedUrl}:`, error.message);
-            }
+            recordFeedFailure(feedUrl, error);
         }
     }
 
@@ -346,4 +416,10 @@ function rescheduleDailyNews(client, guildId) {
     });
 }
 
-module.exports = { checkRssFeeds, scheduleDailyNews, rescheduleDailyNews, sendDailyNews };
+module.exports = {
+    checkRssFeeds, scheduleDailyNews, rescheduleDailyNews, sendDailyNews,
+    __test__: {
+        feedFailCounts, feedLastFailTime, shouldSkipDeadFeed,
+        DEAD_FEED_THRESHOLD, DEAD_FEED_COOLDOWN_MS, RSS_FETCH_CONCURRENCY,
+    },
+};

--- a/src/utils/guildSettingsCache.js
+++ b/src/utils/guildSettingsCache.js
@@ -54,10 +54,12 @@ let misses = 0;
 
 // Heavy payloads nothing on the cached read paths (messageCreate,
 // interactionCreate) ever looks at. Excluded so a guild with a fully
-// illustrated shop does not pin megabytes of image Buffers in this cache.
-// Exclusion projection on a hydrated read still applies schema defaults to
-// every other field.
-const HEAVY_FIELDS_PROJECTION = '-shop.imageData';
+// illustrated shop (up to 35 items × 512 KB image Buffers) or a giveaway with
+// thousands of entrants does not pin megabytes in this cache. Every giveaway
+// reader/writer (the entry button, /giveaway, giveawayService) goes through
+// the model directly, never through here. Exclusion projection on a hydrated
+// read still applies schema defaults to every other field.
+const HEAVY_FIELDS_PROJECTION = '-shop.imageData -giveaways.entrantIds';
 
 // Required lazily: models/Guild.js registers invalidation hooks that reach back
 // into this module, and a top-level require in both directions would leave one

--- a/tests/guildSettingsCache.test.js
+++ b/tests/guildSettingsCache.test.js
@@ -39,6 +39,18 @@ describe('getGuildSettings', () => {
         expect(third).toBe(first);
     });
 
+    it('excludes the heavy payloads nothing on the cached paths reads', async () => {
+        // Shop image Buffers (up to 35 × 512 KB per guild) and giveaway
+        // entrant lists would otherwise be pinned for every cached guild.
+        Guild.findOne.mockResolvedValue(makeDoc('g1'));
+
+        await getGuildSettings('g1');
+
+        const projection = Guild.findOne.mock.calls[0][1];
+        expect(projection).toContain('-shop.imageData');
+        expect(projection).toContain('-giveaways.entrantIds');
+    });
+
     it('returns a plain object with no save(), so a caller cannot persist a shared view', async () => {
         Guild.findOne.mockResolvedValue(makeDoc('g1'));
         const settings = await getGuildSettings('g1');

--- a/tests/migrationRollback.test.js
+++ b/tests/migrationRollback.test.js
@@ -1,0 +1,193 @@
+'use strict';
+
+const fs   = require('fs');
+const os   = require('os');
+const path = require('path');
+
+// Migrations used to be forward-only: the runner read {name, up} and nothing
+// ever called a down(), while destructive $unset/dropIndex steps ran with no
+// backup. These tests pin the rollback contract that replaced that:
+// rollbackMigration unwinds the latest applied migration through its down(),
+// every shipped migration declares down() or irreversible: true, and a
+// mongodump is attempted before anything irreversible runs.
+
+const records = [];
+jest.mock('../src/models/MigrationRecord', () => ({
+    find: () => ({ lean: async () => records.map(r => ({ name: r.name })) }),
+    create: async doc => { records.push(doc); return doc; },
+    deleteOne: async ({ name }) => {
+        const i = records.findIndex(r => r.name === name);
+        if (i !== -1) records.splice(i, 1);
+        return { deletedCount: i === -1 ? 0 : 1 };
+    },
+}));
+
+jest.mock('child_process', () => ({ spawnSync: jest.fn() }));
+
+const { spawnSync } = require('child_process');
+const { runMigrations, rollbackMigration } = require('../src/migrations/runner');
+
+let dir;
+
+function writeMigration(file, body) {
+    fs.writeFileSync(path.join(dir, file), body);
+}
+
+const logPath = () => path.join(dir, 'calls.log');
+const calls = () => (fs.existsSync(logPath()) ? fs.readFileSync(logPath(), 'utf8').trim().split('\n').filter(Boolean) : []);
+const record = expr => `require('fs').appendFileSync(${JSON.stringify(logPath())}, ${expr} + '\\n');`;
+
+beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'migrations-rollback-'));
+    records.length = 0;
+    spawnSync.mockReset().mockReturnValue({ status: 0 });
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+    delete process.env.MIGRATION_BACKUP;
+    delete process.env.MIGRATION_BACKUP_DIR;
+    delete process.env.MONGODB_URI;
+    fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('rollbackMigration', () => {
+    test('runs down() on the latest applied migration and deletes its record', async () => {
+        writeMigration('001_a.js', `module.exports = { name: 'a', async up() {}, async down() { ${record("'down-a'")} } };`);
+        writeMigration('002_b.js', `module.exports = { name: 'b', async up() {}, async down() { ${record("'down-b'")} } };`);
+        records.push({ name: 'a' }, { name: 'b' });
+
+        await rollbackMigration('b', { dir });
+
+        expect(calls()).toEqual(['down-b']);
+        expect(records.map(r => r.name)).toEqual(['a']);
+    });
+
+    test('after a rollback the migration is pending again on the next run', async () => {
+        writeMigration('001_a.js', `module.exports = { name: 'a', async up() { ${record("'up-a'")} }, async down() {} };`);
+
+        await runMigrations({ dir });
+        await rollbackMigration('a', { dir });
+        await runMigrations({ dir });
+
+        expect(calls()).toEqual(['up-a', 'up-a']);
+        expect(records.map(r => r.name)).toEqual(['a']);
+    });
+
+    test('refuses a migration that is not the most recently applied', async () => {
+        writeMigration('001_a.js', "module.exports = { name: 'a', async up() {}, async down() {} };");
+        writeMigration('002_b.js', "module.exports = { name: 'b', async up() {}, async down() {} };");
+        records.push({ name: 'a' }, { name: 'b' });
+
+        await expect(rollbackMigration('a', { dir })).rejects.toThrow(/roll back b first/);
+        expect(records.map(r => r.name)).toEqual(['a', 'b']);
+    });
+
+    test('refuses a migration that was never applied', async () => {
+        writeMigration('001_a.js', "module.exports = { name: 'a', async up() {}, async down() {} };");
+
+        await expect(rollbackMigration('a', { dir })).rejects.toThrow(/not recorded as applied/);
+    });
+
+    test('refuses an irreversible migration and points at the backup', async () => {
+        writeMigration('001_a.js', "module.exports = { name: 'a', irreversible: true, async up() {} };");
+        records.push({ name: 'a' });
+
+        await expect(rollbackMigration('a', { dir })).rejects.toThrow(/irreversible.*restore/is);
+        expect(records.map(r => r.name)).toEqual(['a']);
+    });
+
+    test('refuses a name that matches no migration file', async () => {
+        await expect(rollbackMigration('ghost', { dir })).rejects.toThrow(/No migration named "ghost"/);
+    });
+
+    test('a down() that hangs runs out of the same budget up() gets', async () => {
+        process.env.MIGRATION_TIMEOUT_MS = '60';
+        writeMigration('001_a.js', "module.exports = { name: 'a', async up() {}, down: () => new Promise(() => {}) };");
+        records.push({ name: 'a' });
+
+        await expect(rollbackMigration('a', { dir })).rejects.toThrow(/Timed out after 60ms: a \(down\)/);
+        // The record stays: the rollback did not complete.
+        expect(records.map(r => r.name)).toEqual(['a']);
+        delete process.env.MIGRATION_TIMEOUT_MS;
+    });
+});
+
+describe('pre-migration backup', () => {
+    const backupEnv = () => {
+        process.env.MONGODB_URI = 'mongodb://localhost/test';
+        process.env.MIGRATION_BACKUP_DIR = path.join(dir, 'backups');
+    };
+
+    test('a pending migration without down() triggers a mongodump first', async () => {
+        backupEnv();
+        writeMigration('001_a.js', "module.exports = { name: 'a', irreversible: true, async up() {} };");
+
+        await runMigrations({ dir });
+
+        expect(spawnSync).toHaveBeenCalledTimes(1);
+        const [cmd, args] = spawnSync.mock.calls[0];
+        expect(cmd).toBe('mongodump');
+        expect(args).toEqual(expect.arrayContaining([
+            '--uri=mongodb://localhost/test',
+            '--gzip',
+            expect.stringContaining('pre-migration-'),
+        ]));
+        expect(records.map(r => r.name)).toEqual(['a']);
+    });
+
+    test('a pending migration with down() does not need one', async () => {
+        backupEnv();
+        writeMigration('001_a.js', "module.exports = { name: 'a', async up() {}, async down() {} };");
+
+        await runMigrations({ dir });
+
+        expect(spawnSync).not.toHaveBeenCalled();
+        expect(records.map(r => r.name)).toEqual(['a']);
+    });
+
+    test('by default a missing mongodump warns but does not block the boot', async () => {
+        backupEnv();
+        spawnSync.mockReturnValue({ error: Object.assign(new Error('spawn mongodump ENOENT'), { code: 'ENOENT' }) });
+        writeMigration('001_a.js', "module.exports = { name: 'a', irreversible: true, async up() {} };");
+
+        await expect(runMigrations({ dir })).resolves.toBeUndefined();
+        expect(records.map(r => r.name)).toEqual(['a']);
+        expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('WITHOUT a backup'));
+    });
+
+    test('MIGRATION_BACKUP=require turns a failed backup into an aborted boot', async () => {
+        backupEnv();
+        process.env.MIGRATION_BACKUP = 'require';
+        spawnSync.mockReturnValue({ status: 1 });
+        writeMigration('001_a.js', "module.exports = { name: 'a', irreversible: true, async up() {} };");
+
+        await expect(runMigrations({ dir })).rejects.toThrow(/mongodump exited with status 1/);
+        expect(records).toEqual([]);
+    });
+
+    test('MIGRATION_BACKUP=skip skips the dump entirely', async () => {
+        backupEnv();
+        process.env.MIGRATION_BACKUP = 'skip';
+        writeMigration('001_a.js', "module.exports = { name: 'a', irreversible: true, async up() {} };");
+
+        await runMigrations({ dir });
+
+        expect(spawnSync).not.toHaveBeenCalled();
+        expect(records.map(r => r.name)).toEqual(['a']);
+    });
+});
+
+describe('every shipped migration declares its rollback story', () => {
+    const shippedDir = path.join(__dirname, '..', 'src', 'migrations');
+    const files = fs.readdirSync(shippedDir).filter(f => f.endsWith('.js') && f !== 'runner.js');
+
+    test.each(files)('%s exports down() or irreversible: true', file => {
+        const migration = require(path.join(shippedDir, file));
+        const hasStory = typeof migration.down === 'function' || migration.irreversible === true;
+        expect(hasStory).toBe(true);
+    });
+});

--- a/tests/migrationRunner.test.js
+++ b/tests/migrationRunner.test.js
@@ -30,6 +30,9 @@ const record = expr => `require('fs').appendFileSync(${JSON.stringify(logPath())
 beforeEach(() => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'migrations-'));
     records.length = 0;
+    // The inline fixtures declare no down(), which would otherwise trigger the
+    // pre-migration backup attempt; that path has its own tests.
+    process.env.MIGRATION_BACKUP = 'skip';
     jest.spyOn(console, 'log').mockImplementation(() => {});
     jest.spyOn(console, 'warn').mockImplementation(() => {});
     jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -38,6 +41,7 @@ beforeEach(() => {
 afterEach(() => {
     jest.restoreAllMocks();
     delete process.env.MIGRATION_TIMEOUT_MS;
+    delete process.env.MIGRATION_BACKUP;
     fs.rmSync(dir, { recursive: true, force: true });
 });
 

--- a/tests/rivalryCacheBounds.test.js
+++ b/tests/rivalryCacheBounds.test.js
@@ -1,0 +1,154 @@
+'use strict';
+
+// rankCache used to hold every user of every guild the bot ever saw, and the
+// write-through bumped updatedAt on every XP-earning message — so on any
+// active guild the 5-minute TTL never fired and nothing was ever evicted or
+// refreshed. These tests pin the bounds that replaced that: a per-guild entry
+// cap, a FIFO cap on cached guilds, and a TTL that actually expires.
+
+// getLeaderboard queries the User model; replace it with a stand-in whose
+// result the tests control.
+let mockFindResult = [];
+jest.mock('../src/models/User', () => ({
+    find: jest.fn(() => ({
+        sort: () => ({
+            limit: limit => ({
+                select: () => ({
+                    lean: async () => mockFindResult.slice(0, limit),
+                }),
+            }),
+        }),
+    })),
+}));
+
+const User = require('../src/models/User');
+const { __test__ } = require('../src/services/rivalryService');
+const {
+    applyStanding, buildIndex, compare, rankCache, getLeaderboard,
+    CACHE_TTL, MAX_GUILDS, MAX_ENTRIES_PER_GUILD,
+} = __test__;
+
+function population(size) {
+    return Array.from({ length: size }, (_, i) => ({
+        userId: `u${i}`,
+        level:  size - i, // already in leaderboard order
+        xp:     0,
+    }));
+}
+
+function makeBoard(entries, { truncated = false } = {}) {
+    const sorted = entries.slice().sort(compare);
+    return { entries: sorted, index: buildIndex(sorted), updatedAt: Date.now(), truncated };
+}
+
+beforeEach(() => {
+    rankCache.clear();
+    mockFindResult = [];
+    User.find.mockClear();
+});
+
+describe('getLeaderboard bounds what it caches', () => {
+    test('caps a guild at MAX_ENTRIES_PER_GUILD and marks the board truncated', async () => {
+        mockFindResult = population(MAX_ENTRIES_PER_GUILD + 500);
+        const board = await getLeaderboard('g1');
+
+        expect(board.entries).toHaveLength(MAX_ENTRIES_PER_GUILD);
+        expect(board.truncated).toBe(true);
+    });
+
+    test('a guild smaller than the cap is complete and not truncated', async () => {
+        mockFindResult = population(30);
+        const board = await getLeaderboard('g1');
+
+        expect(board.entries).toHaveLength(30);
+        expect(board.truncated).toBe(false);
+    });
+
+    test('evicts the oldest guild FIFO once MAX_GUILDS are cached', async () => {
+        mockFindResult = population(1);
+        for (let i = 0; i < MAX_GUILDS; i++) await getLeaderboard(`g${i}`);
+        expect(rankCache.size).toBe(MAX_GUILDS);
+
+        await getLeaderboard('one-more');
+        expect(rankCache.size).toBe(MAX_GUILDS);
+        expect(rankCache.has('g0')).toBe(false);
+        expect(rankCache.has('one-more')).toBe(true);
+    });
+
+    test('a refresh of an already-cached guild does not evict anyone', async () => {
+        mockFindResult = population(1);
+        for (let i = 0; i < MAX_GUILDS; i++) await getLeaderboard(`g${i}`);
+
+        rankCache.get('g0').updatedAt = 0; // expire it
+        await getLeaderboard('g0');
+
+        expect(rankCache.size).toBe(MAX_GUILDS);
+        expect(rankCache.has('g0')).toBe(true);
+    });
+
+    test('an expired entry is re-read from the database', async () => {
+        mockFindResult = population(5);
+        const first = await getLeaderboard('g1');
+        expect(User.find).toHaveBeenCalledTimes(1);
+
+        // Fresh: served from cache.
+        expect(await getLeaderboard('g1')).toBe(first);
+        expect(User.find).toHaveBeenCalledTimes(1);
+
+        first.updatedAt = Date.now() - CACHE_TTL - 1;
+        const second = await getLeaderboard('g1');
+        expect(second).not.toBe(first);
+        expect(User.find).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('applyStanding leaves the TTL alone', () => {
+    test('a write-through no longer refreshes updatedAt', () => {
+        const board = makeBoard(population(10));
+        board.updatedAt = 12345;
+
+        applyStanding(board, { userId: 'u9', level: 100, xp: 0 });
+
+        expect(board.updatedAt).toBe(12345);
+    });
+});
+
+describe('applyStanding on a truncated board', () => {
+    test('a user below the window is reported as out of scope, not inserted', () => {
+        const board = makeBoard(population(MAX_ENTRIES_PER_GUILD), { truncated: true });
+
+        const result = applyStanding(board, { userId: 'outsider', level: 0, xp: 0 });
+
+        expect(result).toBeNull();
+        expect(board.entries).toHaveLength(MAX_ENTRIES_PER_GUILD);
+        expect(board.index.has('outsider')).toBe(false);
+    });
+
+    test('a user climbing into the window is inserted and the last entry falls out', () => {
+        const board = makeBoard(population(MAX_ENTRIES_PER_GUILD), { truncated: true });
+        const lastBefore = board.entries[board.entries.length - 1];
+
+        const result = applyStanding(board, { userId: 'climber', level: 50, xp: 1 });
+
+        expect(result.oldRank).toBeNull();
+        expect(board.entries).toHaveLength(MAX_ENTRIES_PER_GUILD);
+        expect(board.index.has('climber')).toBe(true);
+        expect(board.index.has(lastBefore.userId)).toBe(false);
+        // The index still maps every entry to its position.
+        for (let i = 0; i < board.entries.length; i++) {
+            expect(board.index.get(board.entries[i].userId)).toBe(i);
+        }
+    });
+
+    test('an update to a user already inside the window behaves as before', () => {
+        const board = makeBoard(population(MAX_ENTRIES_PER_GUILD), { truncated: true });
+
+        const result = applyStanding(board, { userId: 'u150', level: 90, xp: 0 });
+
+        expect(result.oldRank).toBe(151);
+        // Passes everyone below level 90; the incumbent at exactly 90 keeps
+        // the tie, as elsewhere.
+        expect(result.newRank).toBe(112);
+        expect(board.entries).toHaveLength(MAX_ENTRIES_PER_GUILD);
+    });
+});

--- a/tests/rssCheckFeeds.test.js
+++ b/tests/rssCheckFeeds.test.js
@@ -1,0 +1,171 @@
+'use strict';
+
+// checkRssFeeds used to fetch every feed of every guild strictly serially —
+// worst case ~40s per feed through safeFetchFeed's redirect budget — with no
+// dedup when many guilds subscribe to the same URL and no skip for feeds that
+// were already known dead. These tests pin the sweep that replaced it: one
+// fetch per unique URL fanned out to every subscription, a bounded worker
+// pool, and the shared dead-feed bookkeeping.
+
+const mockFetches = []; // urls handed to safeFetchFeed, in call order
+let mockConcurrent = 0;
+let mockMaxConcurrent = 0;
+let mockFeedBodies = new Map(); // url -> xml string or Error
+
+jest.mock('../src/utils/safeFeedFetch', () => ({
+    safeFetchFeed: jest.fn(async url => {
+        mockFetches.push(url);
+        mockConcurrent++;
+        mockMaxConcurrent = Math.max(mockMaxConcurrent, mockConcurrent);
+        // Yield so other workers can start before this fetch resolves —
+        // otherwise every fetch completes synchronously and concurrency
+        // never rises above 1 no matter what the pool does.
+        await new Promise(resolve => setImmediate(resolve));
+        mockConcurrent--;
+        const body = mockFeedBodies.get(url);
+        if (body instanceof Error) throw body;
+        if (body === undefined) throw new Error(`no fixture for ${url}`);
+        return body;
+    }),
+}));
+
+let mockGuilds = [];
+jest.mock('../src/models/Guild', () => ({
+    find: jest.fn(() => ({ lean: async () => mockGuilds })),
+    updateOne: jest.fn(async () => ({})),
+    findOne: jest.fn(),
+}));
+
+const Guild = require('../src/models/Guild');
+const { checkRssFeeds, __test__ } = require('../src/services/rssService');
+const { feedFailCounts, feedLastFailTime, DEAD_FEED_THRESHOLD, RSS_FETCH_CONCURRENCY } = __test__;
+
+function rssXml({ title = 'Feed', itemTitle = 'Post', link = 'https://example.com/post', pubDate = 'Wed, 20 Aug 2025 12:00:00 GMT' } = {}) {
+    return `<?xml version="1.0"?>
+<rss version="2.0"><channel><title>${title}</title>
+<item><title>${itemTitle}</title><link>${link}</link><pubDate>${pubDate}</pubDate></item>
+</channel></rss>`;
+}
+
+function makeClient() {
+    const send = jest.fn(async () => ({}));
+    const channel = { send, isTextBased: () => true };
+    return {
+        channels: { fetch: jest.fn(async () => channel), cache: new Map() },
+        send,
+    };
+}
+
+beforeEach(() => {
+    mockFetches.length = 0;
+    mockConcurrent = 0;
+    mockMaxConcurrent = 0;
+    mockFeedBodies = new Map();
+    mockGuilds = [];
+    feedFailCounts.clear();
+    feedLastFailTime.clear();
+    Guild.updateOne.mockClear();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+test('a URL shared by many guilds is fetched once and delivered to each', async () => {
+    const url = 'https://example.com/rss';
+    mockFeedBodies.set(url, rssXml());
+    mockGuilds = [
+        { guildId: 'g1', rssFeeds: [{ _id: 'f1', url, channelId: 'c1', lastPublished: null }] },
+        { guildId: 'g2', rssFeeds: [{ _id: 'f2', url, channelId: 'c2', lastPublished: null }] },
+        { guildId: 'g3', rssFeeds: [{ _id: 'f3', url, channelId: 'c3', lastPublished: null }] },
+    ];
+    const client = makeClient();
+
+    await checkRssFeeds(client);
+
+    expect(mockFetches).toEqual([url]);
+    expect(client.send).toHaveBeenCalledTimes(3);
+    expect(Guild.updateOne).toHaveBeenCalledTimes(3);
+    expect(Guild.updateOne).toHaveBeenCalledWith(
+        { guildId: 'g2', 'rssFeeds._id': 'f2' },
+        { $set: { 'rssFeeds.$.lastPublished': expect.any(Date) } }
+    );
+});
+
+test('fetches run in parallel but never more than the pool size at once', async () => {
+    mockGuilds = Array.from({ length: 20 }, (_, i) => {
+        const url = `https://example.com/rss${i}`;
+        mockFeedBodies.set(url, rssXml({ link: `https://example.com/p${i}` }));
+        return { guildId: `g${i}`, rssFeeds: [{ _id: `f${i}`, url, channelId: `c${i}`, lastPublished: null }] };
+    });
+
+    await checkRssFeeds(makeClient());
+
+    expect(mockFetches).toHaveLength(20);
+    expect(mockMaxConcurrent).toBeGreaterThan(1);
+    expect(mockMaxConcurrent).toBeLessThanOrEqual(RSS_FETCH_CONCURRENCY);
+});
+
+test('an item no newer than lastPublished sends and writes nothing', async () => {
+    const url = 'https://example.com/rss';
+    mockFeedBodies.set(url, rssXml({ pubDate: 'Wed, 20 Aug 2025 12:00:00 GMT' }));
+    mockGuilds = [{
+        guildId: 'g1',
+        rssFeeds: [{ _id: 'f1', url, channelId: 'c1', lastPublished: new Date('2025-08-21T00:00:00Z') }],
+    }];
+    const client = makeClient();
+
+    await checkRssFeeds(client);
+
+    expect(client.send).not.toHaveBeenCalled();
+    expect(Guild.updateOne).not.toHaveBeenCalled();
+});
+
+test('an unparseable pubDate on a cursored feed skips rather than posting', async () => {
+    const url = 'https://example.com/rss';
+    mockFeedBodies.set(url, rssXml({ pubDate: 'not a date' }));
+    mockGuilds = [{
+        guildId: 'g1',
+        rssFeeds: [{ _id: 'f1', url, channelId: 'c1', lastPublished: new Date('2025-08-01T00:00:00Z') }],
+    }];
+    const client = makeClient();
+
+    await checkRssFeeds(client);
+
+    expect(client.send).not.toHaveBeenCalled();
+    expect(Guild.updateOne).not.toHaveBeenCalled();
+});
+
+test('a feed that keeps failing is marked dead and skipped on the next sweep', async () => {
+    const url = 'https://dead.example.com/rss';
+    mockFeedBodies.set(url, new Error('connection refused'));
+    mockGuilds = [{ guildId: 'g1', rssFeeds: [{ _id: 'f1', url, channelId: 'c1', lastPublished: null }] }];
+    const client = makeClient();
+
+    for (let i = 0; i < DEAD_FEED_THRESHOLD; i++) await checkRssFeeds(client);
+    expect(mockFetches).toHaveLength(DEAD_FEED_THRESHOLD);
+
+    await checkRssFeeds(client);
+    expect(mockFetches).toHaveLength(DEAD_FEED_THRESHOLD); // not fetched again
+});
+
+test('one guild whose delivery blows up does not stop the fan-out to the rest', async () => {
+    const url = 'https://example.com/rss';
+    mockFeedBodies.set(url, rssXml());
+    mockGuilds = [
+        { guildId: 'g1', rssFeeds: [{ _id: 'f1', url, channelId: 'c1', lastPublished: null }] },
+        { guildId: 'g2', rssFeeds: [{ _id: 'f2', url, channelId: 'c2', lastPublished: null }] },
+    ];
+    const client = makeClient();
+    client.send.mockRejectedValueOnce(new Error('Missing Access'));
+
+    await checkRssFeeds(client);
+
+    // g1's send failed, but g2 was still delivered and cursored.
+    expect(Guild.updateOne).toHaveBeenCalledTimes(1);
+    expect(Guild.updateOne).toHaveBeenCalledWith(
+        { guildId: 'g2', 'rssFeeds._id': 'f2' },
+        { $set: { 'rssFeeds.$.lastPublished': expect.any(Date) } }
+    );
+});


### PR DESCRIPTION
The cached read already projected out shop.imageData, but each giveaway's
entrantIds array (unbounded, one string per entrant) still rode along on
every cached guild document. Nothing on the cached read paths touches
giveaways — the entry button, /giveaway and giveawayService all go through
the model directly — so exclude it too.

Fixes #596