### PR TITLE
Price the apex duel off the kill that spawned it

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,17 @@ AUDIT_LOG_RETENTION_DAYS=90
 # own (005 does), in which case the larger of the two applies.
 # MIGRATION_TIMEOUT_MS=30000
 
+# ── Sharding (optional) ──────────────────────────────────────────────────────
+# `npm start` runs one process and one gateway connection, which is right for
+# every deployment below roughly 2,000 guilds and is the default. Above that,
+# `npm run start:sharded` spawns one process per shard under a ShardingManager.
+#
+# Leave SHARD_COUNT unset to take Discord's recommended count; set it to pin a
+# number. Only shard 0 runs the dashboard, the schema migrations and the cron
+# scheduler — see src/utils/sharding.js for why, and for the guild-to-shard
+# affinity rule the live multiplayer rounds depend on.
+# SHARD_COUNT=2
+
 # Paired with the http://localhost DASHBOARD_URL above so this file works as-is
 # for local development. Switch BOTH to production values together: set this to
 # "production" and DASHBOARD_URL to your https:// address, or the bot refuses to

--- a/.env.example
+++ b/.env.example
@@ -61,9 +61,11 @@ AUDIT_LOG_RETENTION_DAYS=90
 # MIGRATION_TIMEOUT_MS=30000
 
 # ── Sharding (optional) ──────────────────────────────────────────────────────
-# `npm start` runs one process and one gateway connection, which is right for
-# every deployment below roughly 2,000 guilds and is the default. Above that,
-# `npm run start:sharded` spawns one process per shard under a ShardingManager.
+# `npm start` runs one process and one gateway connection, and is the default.
+# Discord suggests preparing for sharding as you approach 2,000 guilds, and
+# requires it at 2,500 or more — the gateway refuses an unsharded IDENTIFY past
+# that point. `npm run start:sharded` spawns one process per shard under a
+# ShardingManager.
 #
 # Leave SHARD_COUNT unset to take Discord's recommended count; set it to pin a
 # number. Only shard 0 runs the dashboard, the schema migrations and the cron

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -497,6 +497,7 @@ Narrated expeditions in Clawdia's voice. Players set out into distinct regions, 
 /explore relics        - Open your relic case and see what it earns you
 /explore profile       - Explorer level, stamina, and field record
 /explore map - Unroll your persistent Explorer's Map
+/explore prestige      - Reset Explorer Level for a permanent bonus (Lv 30, to P5)
 ```
 
 **Regions:**
@@ -507,7 +508,7 @@ Narrated expeditions in Clawdia's voice. Players set out into distinct regions, 
 **Progression:**
 - **Secret pity** — every expedition into a region that still hides a secret lifts the odds of finding one, shown as a live chance on the result embed. Regions you have fully uncovered stop building pity instead of promising a secret they can't deliver
 - **Fully surveyed** — chart every landmark, lore fragment and secret in a region and everything it pays you afterwards carries a standing +15%
-- **Relic case** — each distinct relic is worth +1% on exploration coins, up to +10%. Treasure prefers relics you don't own yet, so the case fills instead of stacking duplicates
+- **Relic case** — each distinct relic is worth +1% on exploration coins, up to the width of your case. Treasure prefers relics you don't own yet, so the case fills instead of stacking duplicates. The case starts at 10 of the 25 known relics and is widened by explorer prestige
 - **Encounters are a real bet** — the prompt quotes the win chance and both coin bands in the money *you* would see, and losing is priced off what was on the table rather than a flat fee, so the long-odds encounters with the biggest prizes are worth taking instead of worth dodging
 - **Quiet expeditions** cost the cooldown but refund the stamina point — a blank walk isn't charged for
 - **Level-ups are announced** on the result embed, and name any region the new Explorer Level just brought within reach
@@ -523,6 +524,27 @@ Narrated expeditions in Clawdia's voice. Players set out into distinct regions, 
 - Expeditions grant Explorer XP and mirror guild leveling XP, and Explorer Level shows on `/profile`
 - Rare finds unlock exploration achievements (including secret ones)
 - The Explorer's Map persists per player: landmarks, lore, and secrets charted per region
+
+**Explorer prestige** (`/explore prestige`) opens at Explorer Level 30 and runs to
+P5. Each rank resets Explorer Level and XP and keeps everything else — charted
+regions, completed surveys, the relic case, the journal and every lifetime stat.
+An ascended explorer carries a prestige title rather than dropping back to
+"Doorstep Wanderer", but region unlocks are level-gated, so the deeper regions sit
+behind the ladder again until it is re-climbed:
+
+| Rank | Grants (cumulative) |
+|---|---|
+| 🧭 P1 | Relic case holds 13 of 25 |
+| 🧭🧭 P2 | +5% all payouts |
+| 🗺️ P3 | +1 max stamina · relic case holds 16 |
+| 🗺️✨ P4 | +25% weight on the secret slot |
+| 🌌 P5 | +10% all payouts · relic case holds all 25 |
+
+The relic cap is the point of the ladder as much as the payout is: at P0 the case
+pays for 10 of the 25 known relics, so the back half of a completed collection was
+worth only its trade value. Region surveys stay a one-off — a charted map is
+knowledge, and taking it back on every ascension would be a punishment rather than
+a reset.
 
 **Dashboard Settings:**
 - Enable/disable exploration, per-region toggles

--- a/README.md
+++ b/README.md
@@ -86,6 +86,24 @@ npm run deploy  # Deploy slash commands globally
 npm start
 ```
 
+### Sharding
+
+`npm start` runs one process with one gateway connection — right for every
+deployment below roughly 2,000 guilds, and the default. Past that, Discord
+requires sharding:
+
+```bash
+npm run start:sharded          # Discord's recommended shard count
+SHARD_COUNT=2 npm run start:sharded
+```
+
+Each shard is its own process. Discord routes a guild's events to exactly one of
+them, which is what keeps the live multiplayer rounds — crash lobbies, heists,
+the raid join window — correct without persisting them. Work that must happen
+once per deployment rather than once per shard runs on shard 0 only: the
+dashboard, schema migrations, and the cron scheduler. `src/utils/sharding.js`
+has the full reasoning.
+
 ## Configuration
 
 1. Invite the bot to your server

--- a/README.md
+++ b/README.md
@@ -88,9 +88,10 @@ npm start
 
 ### Sharding
 
-`npm start` runs one process with one gateway connection — right for every
-deployment below roughly 2,000 guilds, and the default. Past that, Discord
-requires sharding:
+`npm start` runs one process with one gateway connection, and is the default.
+Discord suggests preparing for sharding as you approach 2,000 guilds, and
+**requires** it at 2,500 or more — past that the gateway refuses an unsharded
+IDENTIFY outright:
 
 ```bash
 npm run start:sharded          # Discord's recommended shard count

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "clawdia",
   "version": "1.0.0",
-  "description": "Clawdia — a chill, self-hosted Discord bot with a full-featured admin dashboard",
+  "description": "Clawdia \u2014 a chill, self-hosted Discord bot with a full-featured admin dashboard",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",
+    "start:sharded": "node src/shard.js",
     "dev": "nodemon src/index.js",
     "deploy": "node src/deploy-commands.js",
     "migrate:rollback": "node scripts/rollback-migration.js",

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -12,6 +12,7 @@ const {
     LIMITS, EXPLORER_LEVELS, TIER_COLORS, REGIONS, REGION_LIST,
     RELIC_LIST, RELIC_RARITY_ORDER, TOTAL_CORE_RELICS,
     FOOTER_LINES, INJURY_LINES,
+    EXPLORER_PRESTIGE, PRESTIGE_BADGES, MAX_EXPLORER_LEVEL, MAX_EXPLORER_PRESTIGE,
 } = require('../../data/exploreData');
 const { fitDescription, chunkByLength, EMBED_LIMITS } = require('../../utils/embedFields');
 const { paginate } = require('../../utils/paginator');
@@ -21,7 +22,6 @@ const {
     applyStaminaRegen,
     applyDailyReset,
     msUntilNextStamina,
-    getLevelData,
     xpToNextLevel,
     getRegionProgress,
     isRegionInSeason,
@@ -30,6 +30,12 @@ const {
     resolveActiveRegion,
     getRelicCollection,
     getRelicBonus,
+    getRelicBonusCap,
+    getRelicCapacity,
+    relicCapacityForBonus,
+    getExplorerPrestige,
+    getExplorerTitle,
+    canPrestige,
     getSecretOdds,
     executeExplore,
     resolveEncounter,
@@ -130,7 +136,10 @@ module.exports = {
                 .addUserOption(o =>
                     o.setName('user')
                         .setDescription('Explorer to inspect')
-                        .setRequired(false))),
+                        .setRequired(false)))
+        .addSubcommand(sub =>
+            sub.setName('prestige')
+                .setDescription('Walk off the edge of your own map: reset Explorer Level for a permanent bonus.')),
 
     async execute(interaction) {
         const sub = interaction.options.getSubcommand();
@@ -141,6 +150,7 @@ module.exports = {
         if (sub === 'journal') return handleJournal(interaction);
         if (sub === 'relics')  return handleRelics(interaction);
         if (sub === 'profile') return handleProfile(interaction);
+        if (sub === 'prestige') return handlePrestige(interaction);
     },
 
     // Exposed so sibling commands can render the same Explorer's Map
@@ -875,7 +885,8 @@ async function handleMap(interaction) {
     ensureExploreData(userData);
     const e = userData.exploration;
     const lines = renderMap(userData, guildSettings);
-    const levelData = getLevelData(e.level);
+    const mapRank = Math.max(0, Number(e.prestige) || 0);
+    const mapBadge = mapRank > 0 ? `${PRESTIGE_BADGES[Math.min(mapRank, PRESTIGE_BADGES.length - 1)]} P${mapRank} · ` : '';
 
     const embed = new EmbedBuilder()
         .setColor('#2e7d32')
@@ -887,7 +898,7 @@ async function handleMap(interaction) {
         .addFields({
             name: '🧭 The Tally',
             value: [
-                `**${levelData.title}** — Explorer Lv ${e.level}`,
+                `${mapBadge}**${getExplorerTitle(userData)}** — Explorer Lv ${e.level}`,
                 `🗿 ${e.landmarksDiscovered} landmarks · 📜 ${e.loreCollected} lore · ✨ ${e.secretsFound} secrets · 🏺 ${e.relicsRecovered} relics`,
                 `${e.totalExpeditions.toLocaleString()} expeditions logged · 🏅 ${surveyedCount(userData, guildSettings)} regions fully surveyed`,
             ].join('\n'),
@@ -1172,8 +1183,10 @@ async function handleRelics(interaction) {
 
     const distinct = collection.length;
     const missingField = buildMissingRelicsField(collection, isSelf, target.username);
-    const bonus = getRelicBonus(userData);
-    const atCap = bonus >= LIMITS.RELIC_BONUS_MAX;
+    const bonus    = getRelicBonus(userData);
+    const bonusCap = getRelicBonusCap(userData);
+    const capacity = getRelicCapacity(userData);
+    const atCap    = bonus >= bonusCap;
     const caseValue = collection.reduce((sum, r) => sum + r.value * r.quantity, 0);
 
     const embed = new EmbedBuilder()
@@ -1193,8 +1206,10 @@ async function handleRelics(interaction) {
                 name: '📈 What It Earns You',
                 value: `**+${Math.round(bonus * 100)}%** on every coin exploration pays you`
                      + (atCap
-                         ? ' — *the case is as persuasive as it gets.*'
-                         : `\n*+${Math.round(LIMITS.RELIC_BONUS_PER * 100)}% per distinct relic, up to +${Math.round(LIMITS.RELIC_BONUS_MAX * 100)}%. Duplicates are for trading, not for stacking.*`),
+                         ? (capacity >= RELIC_LIST.length
+                             ? ' — *every relic there is, and the case counts all of them.*'
+                             : `\n*The case holds **${capacity}** of ${RELIC_LIST.length} at this rank — \`/explore prestige\` widens it.*`)
+                         : `\n*+${Math.round(LIMITS.RELIC_BONUS_PER * 100)}% per distinct relic, up to +${Math.round(bonusCap * 100)}% (**${capacity}** relics at your rank). Duplicates are for trading, not for stacking.*`),
                 inline: false,
             },
         )
@@ -1202,6 +1217,202 @@ async function handleRelics(interaction) {
         .setTimestamp();
 
     return interaction.reply({ embeds: [embed] });
+}
+
+// ─── PRESTIGE ─────────────────────────────────────────────────────────────────
+//
+// Exploration was the only grind system with nothing behind its ceiling (#750).
+// Explorer Level stopped at 30 and kept banking XP into a counter nothing read;
+// the relic case capped at ten of twenty-five relics, so the back half of a
+// completed collection was worth nothing but trade value. Ascending resets the
+// level for a permanent bonus stack, and each rank widens the case — so the
+// reason to prestige and the reason to finish the collection are the same one.
+
+/** Formats one row of EXPLORER_PRESTIGE as the lines a player sees. */
+function prestigeBonusLines(bonus, previous = null) {
+    const lines = [];
+    if (bonus.payoutBonus > 0)   lines.push(`💰 +${Math.round(bonus.payoutBonus * 100)}% on every coin the wilds pay you`);
+    if (bonus.staminaBonus > 0)  lines.push(`⚡ +${bonus.staminaBonus} max stamina`);
+    if (bonus.secretBonus > 0)   lines.push(`✨ +${Math.round(bonus.secretBonus * 100)}% weight on the secret slot`);
+    if (bonus.relicCapBonus > 0) lines.push(`🏺 Relic case holds **${relicCapacityForBonus(bonus.relicCapBonus)}** of ${RELIC_LIST.length}`);
+    // With a previous row to compare against, a rank that adds nothing new says
+    // so rather than re-listing the bonuses the player already has.
+    if (previous) {
+        const keys = ['payoutBonus', 'staminaBonus', 'secretBonus', 'relicCapBonus'];
+        const gained = keys.filter(k => (bonus[k] ?? 0) > (previous[k] ?? 0));
+        if (!gained.length) lines.push('*(nothing new at this rank — the one after it is the step)*');
+    }
+    return lines;
+}
+
+async function handlePrestige(interaction) {
+    const ctx = await loadContext(interaction);
+    if (!ctx) return;
+    const { user } = ctx;
+
+    const e     = user.exploration;
+    const state = canPrestige(user);
+    const rank  = state.rank;
+    const badge = PRESTIGE_BADGES[Math.min(rank, PRESTIGE_BADGES.length - 1)] ?? '';
+
+    if (state.reason === 'max_rank') {
+        return interaction.reply({
+            embeds: [new EmbedBuilder()
+                .setColor('#6a1b9a')
+                .setTitle(`${badge} There Is No Further Edge`)
+                .setDescription(
+                    `You are a **P${rank}** explorer — the last rank the map has a name for.\n` +
+                    `Whatever lies past this, I haven't charted it either.`
+                )
+                .addFields({ name: 'Your Standing Bonuses', value: prestigeBonusLines(EXPLORER_PRESTIGE[rank]).join('\n') || 'None' })
+                .setTimestamp()],
+        });
+    }
+
+    const nextRow   = EXPLORER_PRESTIGE[rank + 1];
+    const nextBadge = PRESTIGE_BADGES[rank + 1] ?? '';
+
+    if (state.reason === 'level_too_low') {
+        const finalXp = EXPLORER_LEVELS[MAX_EXPLORER_LEVEL - 1].xpRequired;
+        return interaction.reply({
+            embeds: [new EmbedBuilder()
+                .setColor('#2e7d32')
+                .setTitle(`${badge} Explorer Prestige — P${rank}`)
+                .setDescription(
+                    `Reach **Explorer Level ${MAX_EXPLORER_LEVEL}** to ascend to ${nextBadge} **P${rank + 1}**.\n` +
+                    `You're Level **${e.level}**.`
+                )
+                .addFields(
+                    { name: `${nextBadge} P${rank + 1} would grant`, value: prestigeBonusLines(nextRow, EXPLORER_PRESTIGE[rank]).join('\n') || 'Nothing new', inline: true },
+                    { name: 'Progress', value: `${e.xp.toLocaleString()} / ${finalXp.toLocaleString()} XP\n${progressBar(e.xp, finalXp, 12)}`, inline: true },
+                )
+                .setFooter({ text: 'Prestige keeps your map, your surveys, your relics, your journal and every lifetime stat — only Explorer Level and XP reset.' })
+                .setTimestamp()],
+            flags: MessageFlags.Ephemeral,
+        });
+    }
+
+    const confirmEmbed = new EmbedBuilder()
+        .setColor('#6a1b9a')
+        .setTitle(`${nextBadge} Walk Off The Edge — Ascend to P${rank + 1}?`)
+        .setDescription(
+            `You've reached **Explorer Level ${MAX_EXPLORER_LEVEL}**. Ascending is permanent and cannot be undone.\n\n` +
+            `**Resets:** Explorer Level → 1, Explorer XP → 0\n` +
+            `**Keeps:** every charted region, every survey, your relic case, your journal and every lifetime stat`
+        )
+        .addFields({ name: `${nextBadge} P${rank + 1} bonuses`, value: prestigeBonusLines(nextRow, EXPLORER_PRESTIGE[rank]).join('\n') || 'Nothing new', inline: false });
+
+    // Region access is gated on explorer level, so an ascension puts the deeper
+    // regions back behind the ladder. Say so before the button, not after it.
+    const relocked = REGION_LIST
+        .filter(r => !r.seasonalEventId
+            && e.unlockedRegions.includes(r.id)
+            && r.unlockLevel > 1)
+        .map(r => `${r.emoji} ${r.name} *(Lv.${r.unlockLevel})*`);
+    if (relocked.length) {
+        confirmEmbed.addFields({
+            name: '⚠️ Behind the level gate again until you re-climb',
+            value: relocked.join('\n'),
+            inline: false,
+        });
+    }
+    confirmEmbed.setFooter({ text: 'Confirmation expires in 30 seconds' });
+
+    const row = new ActionRowBuilder().addComponents(
+        new ButtonBuilder().setCustomId('exploreprestige_confirm').setLabel('Ascend').setStyle(ButtonStyle.Success).setEmoji('🧭'),
+        new ButtonBuilder().setCustomId('exploreprestige_cancel').setLabel('Cancel').setStyle(ButtonStyle.Secondary).setEmoji('❌')
+    );
+
+    const response  = await interaction.reply({ embeds: [confirmEmbed], components: [row], withResponse: true });
+    const reply     = response.resource.message;
+    const collector = reply.createMessageComponentCollector({ time: 30_000 });
+
+    let actionPromise = null;
+    collector.on('collect', btn => {
+        if (btn.user.id !== interaction.user.id) {
+            return btn.reply({ content: 'This is not your confirmation.', flags: MessageFlags.Ephemeral });
+        }
+
+        if (btn.customId === 'exploreprestige_cancel') {
+            collector.stop();
+            return btn.update({ content: 'You stay on the map. For now.', embeds: [], components: [] });
+        }
+
+        // Assigned before collector.stop(): stop() emits 'end' synchronously, so an
+        // assignment after it would leave the handler below awaiting a null.
+        actionPromise = (async () => {
+            try {
+                await btn.deferUpdate();
+
+                // Nothing is written from the in-memory snapshot. It was read before
+                // a 30-second window during which an expedition may have moved this
+                // profile, and a save() would put all of that back. The ascension is
+                // the conditional update alone.
+                //
+                // `data.prestige` is absent on profiles written before the field
+                // existed, so a first ascension has to match that shape too —
+                // ensureExploreData only defaults it in memory.
+                const rankMatches = rank === 0
+                    ? [{ 'data.prestige': 0 }, { 'data.prestige': { $exists: false } }, { 'data.prestige': null }]
+                    : [{ 'data.prestige': rank }];
+
+                // Conditional so a second confirmation cannot ascend twice: the level
+                // requirement and the rank both have to still hold.
+                const ascended = await GrindProfile.findOneAndUpdate(
+                    {
+                        userId: user.userId, guildId: user.guildId, system: 'exploration',
+                        'data.level': { $gte: MAX_EXPLORER_LEVEL },
+                        $or: rankMatches,
+                    },
+                    { $set: { 'data.prestige': rank + 1, 'data.level': 1, 'data.xp': 0 } },
+                    { new: true }
+                ).catch(err => { console.error('[explore prestige] ascend error:', err); return null; });
+
+                if (!ascended) {
+                    return interaction.editReply({
+                        content: 'Your explorer changed while that confirmation was open — run `/explore prestige` again.',
+                        embeds: [], components: [],
+                    });
+                }
+
+                e.prestige = rank + 1;
+                e.level    = 1;
+                e.xp       = 0;
+
+                const embed = new EmbedBuilder()
+                    .setColor('#6a1b9a')
+                    .setTitle(`${nextBadge} Prestige ${rank + 1} — ${getExplorerTitle(user)}`)
+                    .setDescription(
+                        `You walk back out through the doorstep you started at, and it doesn't look any smaller.\n` +
+                        `The map kept everything. The ladder starts again, and you start it as a **P${rank + 1}**.`
+                    )
+                    .addFields(
+                        { name: 'Permanent Bonuses', value: prestigeBonusLines(EXPLORER_PRESTIGE[rank + 1]).join('\n') || 'None', inline: false },
+                        { name: 'Explorer Level',   value: `**${MAX_EXPLORER_LEVEL}** → **1**`, inline: true },
+                        { name: 'Relic Case',       value: `holds **${relicCapacityForBonus(nextRow.relicCapBonus)}** of ${RELIC_LIST.length}`, inline: true },
+                        { name: 'Kept',             value: `${e.regions.length} region record(s) · ${getRelicCollection(user).length} distinct relic(s)`, inline: true },
+                    )
+                    .setFooter({ text: rank + 1 >= MAX_EXPLORER_PRESTIGE
+                        ? 'That is the last rank the map has a name for.'
+                        : `Reach Explorer Level ${MAX_EXPLORER_LEVEL} again to ascend to P${rank + 2}.` })
+                    .setTimestamp();
+
+                await interaction.editReply({ embeds: [embed], components: [] });
+            } catch (err) {
+                console.error('[explore prestige] error:', err);
+                interaction.editReply({ content: 'Something went wrong. Please try again.', embeds: [], components: [] }).catch(() => {});
+            }
+        })();
+
+        collector.stop();
+    });
+
+    return new Promise(resolve => {
+        collector.on('end', async () => {
+            if (actionPromise) await actionPromise.catch(() => {});
+            resolve();
+        });
+    });
 }
 
 /**
@@ -1274,8 +1485,9 @@ async function handleProfile(interaction) {
     applyDailyReset(userData);
 
     const e = userData.exploration;
-    const levelData = getLevelData(e.level);
     const toNext = xpToNextLevel(e.level, e.xp);
+    const prestigeRank  = Math.max(0, Number(e.prestige) || 0);
+    const prestigeBadge = PRESTIGE_BADGES[Math.min(prestigeRank, PRESTIGE_BADGES.length - 1)] ?? '';
     const activeRegion = REGIONS[e.activeRegion];
     const nextThreshold = EXPLORER_LEVELS.find(l => l.level === e.level + 1)?.xpRequired;
 
@@ -1290,14 +1502,20 @@ async function handleProfile(interaction) {
         .addFields(
             {
                 name: '🥾 Rank',
-                value: `**${levelData.title}** (Level ${e.level})`,
+                value: `**${getExplorerTitle(userData)}** (Level ${e.level})`
+                     + (prestigeRank > 0 ? `\n${prestigeBadge} **Prestige ${prestigeRank}**` : ''),
                 inline: true,
             },
             {
                 name: '⭐ Explorer XP',
                 value: toNext !== null
                     ? `${e.xp.toLocaleString()} / ${nextThreshold.toLocaleString()} XP\n${progressBar(e.xp, nextThreshold, 12)}\n${toNext.toLocaleString()} to Level ${e.level + 1}`
-                    : `${e.xp.toLocaleString()} XP — **MAX LEVEL**`,
+                    // Level 30 is no longer the end of the road, so the profile
+                    // points at the road rather than declaring a dead end (#750).
+                    : `${e.xp.toLocaleString()} XP — **MAX LEVEL**`
+                        + (prestigeRank < MAX_EXPLORER_PRESTIGE
+                            ? `\n${isSelf ? '`/explore prestige` to ascend' : 'ready to ascend'}`
+                            : '\n*the last rank there is*'),
                 inline: true,
             },
             {
@@ -1333,10 +1551,15 @@ async function handleProfile(interaction) {
 
     const relicBonus = getRelicBonus(userData);
     const surveyed = surveyedCount(userData, guildSettings);
-    if (relicBonus > 0 || surveyed > 0) {
+    const prestigeRow = getExplorerPrestige(userData);
+    if (relicBonus > 0 || surveyed > 0 || prestigeRank > 0) {
         const boosts = [];
         if (surveyed > 0)   boosts.push(`🏅 **+${Math.round(LIMITS.SURVEY_BONUS * 100)}%** in ${surveyed} fully surveyed region${surveyed === 1 ? '' : 's'}`);
-        if (relicBonus > 0) boosts.push(`🏺 **+${Math.round(relicBonus * 100)}%** everywhere, from the relic case`);
+        if (relicBonus > 0) {
+            const capacity = getRelicCapacity(userData);
+            boosts.push(`🏺 **+${Math.round(relicBonus * 100)}%** everywhere, from the relic case *(holds ${capacity} of ${RELIC_LIST.length})*`);
+        }
+        if (prestigeRank > 0) boosts.push(...prestigeBonusLines(prestigeRow).map(l => `${prestigeBadge} ${l}`));
         embed.addFields({ name: '📈 Standing Bonuses', value: boosts.join('\n'), inline: false });
     }
 

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -1329,13 +1329,19 @@ async function handlePrestige(interaction) {
 
     let actionPromise = null;
     collector.on('collect', btn => {
+        // An emitter discards whatever a listener returns, so these replies are
+        // floating promises: a failed one (an expired interaction token, a
+        // deleted message) becomes an unhandled rejection rather than a logged
+        // miss, and enough of those trip the process-level rejection guard.
         if (btn.user.id !== interaction.user.id) {
-            return btn.reply({ content: 'This is not your confirmation.', flags: MessageFlags.Ephemeral });
+            return btn.reply({ content: 'This is not your confirmation.', flags: MessageFlags.Ephemeral })
+                .catch(err => console.error('[explore prestige] foreign-user reply failed:', err));
         }
 
         if (btn.customId === 'exploreprestige_cancel') {
             collector.stop();
-            return btn.update({ content: 'You stay on the map. For now.', embeds: [], components: [] });
+            return btn.update({ content: 'You stay on the map. For now.', embeds: [], components: [] })
+                .catch(err => console.error('[explore prestige] cancel update failed:', err));
         }
 
         // Assigned before collector.stop(): stop() emits 'end' synchronously, so an

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -1069,7 +1069,14 @@ async function executeStart(interaction) {
             }
             await attachGrind(freshUser);
             ensureHuntData(freshUser);
-            const apexResult = resolveApexEncounter(freshUser, result.apexEncounter.animal, result.apexEncounter.tier, choicesMade, apexType, apexWeaponIndex);
+            // The duel is priced off the kill that spawned it — crit, trophy
+            // quality, streak and traits included — rather than a fresh roll of
+            // the animal's base range (#744). Caps are still applied below.
+            const apexResult = resolveApexEncounter(
+                freshUser, result.apexEncounter.animal, result.apexEncounter.tier,
+                choicesMade, apexType, apexWeaponIndex,
+                { killPayout: result.apexEncounter.killPayout },
+            );
 
             // The reload above is already seconds old by the time the fight
             // resolves, and `save()` writes `balance` as an absolute `$set` — so

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -44,6 +44,8 @@ const {
     applyRepair,
     updateWeaponStatus,
     isCondemned,
+    repairsRemaining,
+    projectWeaponLifetime,
     quoteRepair,
     applyXp,
     rollApexType,
@@ -2125,10 +2127,15 @@ function buildWeaponPages(h) {
         const bar        = durabilityBar(w.currentDurability, w.maxDurability, 12);
         const upgrade    = w.upgrade ? `[${w.upgrade.replace(/_/g, ' ')}]` : '';
         const equipped   = index === h.equippedWeaponIndex ? ' **[EQUIPPED]**' : '';
+        // Repairs spent is the number the profile stores; repairs LEFT is the
+        // number that decides whether this weapon is worth putting money into,
+        // and it is the one a player cannot work out from the durability bar.
+        const left = repairsRemaining(w);
+        const repairNote = left > 0 ? `${w.repairCount} used, ${left} left` : `${w.repairCount} used, condemned`;
         return [
             `**#${index + 1} — ${wd?.emoji ?? '🔫'} ${w.name}**${equipped}`,
             `> ${statusIcon} ${w.status.toUpperCase()} · ${bar} ${w.currentDurability}/${w.maxDurability} dur`,
-            `> Repairs: ${w.repairCount} · Max: ${w.maxDurability}/${w.baseDurability} · ${upgrade || 'No upgrade'}`
+            `> Repairs: ${repairNote} · Max: ${w.maxDurability}/${w.baseDurability} · ${upgrade || 'No upgrade'}`
         ].join('\n');
     });
 
@@ -2716,12 +2723,13 @@ async function handleBuyWeapon(interaction, user, currency) {
     // again several times over before they are condemned — and at the top of
     // the ladder none of it is fundable from hunting alone.
     if (isCrossEconomyWeapon(weaponData)) {
-        const repair = fullRepairCost(weaponData);
+        const { repairs, maintenance, lifetimeCost, firstRepairCost } = projectWeaponLifetime(weaponData);
         confirmEmbed.addFields({
             name: '🌐 A whole-economy purchase',
             value: [
-                `Hunting is capped at ${currency}${LIMITS.DAILY_SOFT_CAP.toLocaleString()} a day before payouts halve, so this is about **${huntingDaysLabel(weaponData.cost)} days** of hunting on its own.`,
-                `A full repair runs ${currency}${repair.toLocaleString()} — another **${huntingDaysLabel(repair)} days** — and it has roughly eight before the wear condemns it.`,
+                `Hunting is capped at ${currency}${LIMITS.DAILY_SOFT_CAP.toLocaleString()} a day before payouts halve, so the sticker price alone is about **${huntingDaysLabel(weaponData.cost)} days** of hunting.`,
+                `The sticker price is the down payment. A full repair runs ${currency}${firstRepairCost.toLocaleString()}, it has **${repairs}** of them before the wear condemns it, and keeping it in the field costs ${currency}${maintenance.toLocaleString()} over that life.`,
+                `**Total cost of ownership: ${currency}${lifetimeCost.toLocaleString()}** — about **${huntingDaysLabel(lifetimeCost)} days** of hunting.`,
                 `It is priced for a wallet fed by everything you do: casino, work, crime, heists and the rest all pay into the same balance.`,
             ].join('\n'),
             inline: false,
@@ -3202,6 +3210,13 @@ async function handleRepair(interaction, user, currency) {
     }
 
     const statusIcon = weaponStatusEmoji(result.newStatus);
+    // How many repairs are left is the number that decides whether to keep
+    // paying into this weapon or replace it, and it was never shown — the embed
+    // only counted the ones already spent (#747).
+    const repairsLeft = repairsRemaining(weapon);
+    const repairCountValue = result.condemned
+        ? `${weapon.repairCount} — no repairs left`
+        : `${weapon.repairCount} used · **${repairsLeft}** left (max dur -10% each)`;
     const embed = new EmbedBuilder()
         .setColor(result.condemned ? '#e74c3c' : '#2ecc71')
         .setTitle('🔧 Weapon Repaired')
@@ -3212,7 +3227,7 @@ async function handleRepair(interaction, user, currency) {
             { name: 'Weapon Status',        value: `${statusIcon} ${result.newStatus}`,                     inline: true },
             { name: 'Repair Cost',          value: `${currency}${result.cost.toLocaleString()}`,            inline: true },
             { name: 'New Balance',          value: `${currency}${user.balance.toLocaleString()}`,           inline: true },
-            { name: 'Repair Count',         value: `${weapon.repairCount} (max dur -10% per repair)`,      inline: true },
+            { name: 'Repair Count',         value: repairCountValue,                                       inline: true },
             { name: 'Durability Bar',       value: `${durabilityBar(weapon.currentDurability, weapon.maxDurability)} ${weapon.currentDurability}/${weapon.maxDurability}` }
         );
 

--- a/src/data/exploreData.js
+++ b/src/data/exploreData.js
@@ -51,6 +51,9 @@ const LIMITS = {
     SURVEY_BONUS:         0.15,
     // Each DISTINCT relic in your collection is worth a small standing payout
     // bonus, capped so a full set is a nice edge and not a second economy.
+    // The cap is the FLOOR of the case's capacity, not its ceiling: explorer
+    // prestige widens it (see EXPLORER_PRESTIGE), which is what gives relics
+    // 11-25 a reason to exist beyond the trade window.
     RELIC_BONUS_PER:      0.01,
     RELIC_BONUS_MAX:      0.10,
 };
@@ -89,6 +92,48 @@ const EXPLORER_LEVELS = [
     { level: 28, xpRequired: 75_300, title: 'Legend of the Blank Spaces' },
     { level: 29, xpRequired: 84_700, title: 'Legend of the Blank Spaces' },
     { level: 30, xpRequired: 95_000, title: 'Legend of the Blank Spaces' },
+];
+
+// ─── EXPLORER PRESTIGE ───────────────────────────────────────────────────────
+//
+// Exploration used to be the only grind system with nothing behind its ceiling
+// (#750). Hunting, fishing and mining each reset a maxed level for a permanent
+// bonus stack; an explorer who reached Level 30 was simply finished, and kept
+// earning Explorer XP into a counter nothing read.
+//
+// The ladder mirrors those three in shape — six ranks, bonuses that accumulate
+// — but pulls exploration's own levers rather than copying hunting's. The one
+// that matters most is `relicCapBonus`: the relic case caps at
+// LIMITS.RELIC_BONUS_MAX (0.10, so ten distinct relics) while RELIC_LIST holds
+// twenty-five, which made relics 11-25 mechanically worthless. Each rank widens
+// the case, and P5 opens it far enough that all twenty-five pay. That deals
+// with two of the three dead ends at once, and ties them to each other: the
+// reason to prestige is the reason to finish the collection.
+//
+// Region surveys stay a one-off — a charted map is knowledge, and taking it
+// back on every ascension would be a punishment rather than a reset.
+
+const EXPLORER_PRESTIGE = [
+    { prestige: 0, payoutBonus: 0,    staminaBonus: 0, secretBonus: 0,    relicCapBonus: 0    },
+    { prestige: 1, payoutBonus: 0,    staminaBonus: 0, secretBonus: 0,    relicCapBonus: 0.03 },
+    { prestige: 2, payoutBonus: 0.05, staminaBonus: 0, secretBonus: 0,    relicCapBonus: 0.03 },
+    { prestige: 3, payoutBonus: 0.05, staminaBonus: 1, secretBonus: 0,    relicCapBonus: 0.06 },
+    { prestige: 4, payoutBonus: 0.05, staminaBonus: 1, secretBonus: 0.25, relicCapBonus: 0.06 },
+    { prestige: 5, payoutBonus: 0.10, staminaBonus: 1, secretBonus: 0.25, relicCapBonus: 0.15 },
+];
+
+// Rank badges, indexed by prestige.
+const PRESTIGE_BADGES = ['', '🧭', '🧭🧭', '🗺️', '🗺️✨', '🌌'];
+
+// The titles a returning explorer carries instead of the level-1 one, so an
+// ascended wanderer never reads as a beginner on someone else's profile.
+const PRESTIGE_TITLES = [
+    null,
+    'Wanderer Returned',
+    'Twice-Lost',
+    'Keeper of Old Roads',
+    'The Map Cannot Hold You',
+    'Walked Off Every Edge',
 ];
 
 // Explorer XP awarded per event type
@@ -1030,6 +1075,11 @@ const INJURY_LINES = [
 module.exports = {
     LIMITS,
     EXPLORER_LEVELS,
+    EXPLORER_PRESTIGE,
+    PRESTIGE_BADGES,
+    PRESTIGE_TITLES,
+    MAX_EXPLORER_LEVEL:    EXPLORER_LEVELS.length,
+    MAX_EXPLORER_PRESTIGE: EXPLORER_PRESTIGE.length - 1,
     EVENT_XP,
     TREASURE_TIERS,
     TIER_COLORS,

--- a/src/games/casino/crash.js
+++ b/src/games/casino/crash.js
@@ -288,7 +288,7 @@ async function openLobby(interaction, bet, hostAutoCashout, releaseLock, onWager
         return interaction.editReply({ content: 'A crash lobby is already open in this channel.', components: [] });
     }
 
-    const lobby = createLobby(channelId, interaction.user.id, bet);
+    const lobby = createLobby(channelId, interaction.user.id, bet, interaction.guild.id);
     if (!lobby) {
         releaseLock?.();
         return interaction.editReply({ content: 'A crash lobby is already open in this channel.', components: [] });

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ require('dotenv').config();
 
 const health = require('./health');
 const { makeCache, sweepers } = require('./utils/cacheOptions');
+const { isPrimaryShard, shardTag, shardCount } = require('./utils/sharding');
 
 // Validate required environment variables before doing anything else.
 // Fail loudly at startup rather than silently misbehaving at runtime.
@@ -119,6 +120,14 @@ async function connectDatabase() {
 }
 
 async function startDashboard() {
+    // The dashboard binds a TCP port, so it is singleton work: under sharding
+    // every shard is its own process and N of them would fight over one port.
+    // Shard 0 runs it; the rest skip it. Unsharded, `isPrimaryShard` is true and
+    // nothing changes. See src/utils/sharding.js (#732).
+    if (!isPrimaryShard(client)) {
+        console.log(`${shardTag(client)}[DASHBOARD] Not the primary shard — dashboard not started.`);
+        return;
+    }
     const dashboard = require('./dashboard/server');
     dashboard.start(client);
 }
@@ -141,9 +150,22 @@ async function shutdown(signal) {
 async function startBot() {
     await connectDatabase();
 
-    // Run pending schema migrations before the bot starts accepting traffic
-    const { runMigrations } = require('./migrations/runner');
-    await runMigrations();
+    // Migrations are singleton work too: N shards racing the same schema change
+    // is a different failure every time. Shard 0 runs them before it logs in;
+    // the others wait for the flag it sets rather than running their own.
+    const { runMigrations, waitForMigrations } = require('./migrations/runner');
+    if (isPrimaryShard(client)) {
+        await runMigrations();
+    } else {
+        // Not "skip and carry on": serving traffic against a half-migrated
+        // database is the failure this ordering exists to prevent.
+        console.log(`${shardTag(client)}[MIGRATIONS] Shard 0 owns migrations — waiting for them.`);
+        const ready = await waitForMigrations();
+        if (!ready) {
+            console.error(`${shardTag(client)}[STARTUP] Migrations did not complete — refusing to start.`);
+            process.exit(1);
+        }
+    }
 
     await loadCommands();
     await loadEvents();

--- a/src/migrations/runner.js
+++ b/src/migrations/runner.js
@@ -317,4 +317,63 @@ async function rollbackMigration(name, { dir = __dirname } = {}) {
     );
 }
 
-module.exports = { runMigrations, rollbackMigration };
+/**
+ * Migration names that are discovered on disk but not yet recorded as applied.
+ *
+ * Split out of runMigrations so a process that must NOT run migrations can
+ * still tell whether they have finished — which is what every shard but the
+ * primary one needs (#732).
+ */
+async function pendingMigrationNames({ dir = __dirname } = {}) {
+    const declared = loadMigrations(dir)
+        .map(({ migration }) => migration?.name)
+        .filter(name => typeof name === 'string' && name.length > 0);
+    if (declared.length === 0) return [];
+
+    const applied = new Set(
+        (await MigrationRecord.find({ name: { $in: declared } }, 'name').lean()).map(r => r.name)
+    );
+    return declared.filter(name => !applied.has(name));
+}
+
+/**
+ * Blocks until every discovered migration is recorded as applied.
+ *
+ * Only shard 0 runs migrations; the others must not start serving traffic
+ * against a half-migrated database, and they cannot simply run their own —
+ * concurrent runs of the same migration is a different failure every time. So
+ * they wait for the records shard 0 writes.
+ *
+ * Gives up after `timeoutMs` and says so rather than blocking a boot forever: a
+ * migration that never completes is an operator problem, and a shard stuck
+ * silently in a poll loop is a worse way to find out about it.
+ *
+ * @returns {Promise<boolean>} true if everything applied, false on timeout.
+ */
+async function waitForMigrations({ dir = __dirname, timeoutMs = 300_000, pollMs = 2_000 } = {}) {
+    const deadline = Date.now() + timeoutMs;
+    let announced = false;
+
+    for (;;) {
+        let pending;
+        try {
+            pending = await pendingMigrationNames({ dir });
+        } catch (err) {
+            console.error('[MIGRATIONS] Could not check migration state while waiting:', err.message);
+            return false;
+        }
+        if (pending.length === 0) return true;
+
+        if (!announced) {
+            console.log(`[MIGRATIONS] Waiting for ${pending.length} migration(s) to be applied elsewhere: ${pending.join(', ')}`);
+            announced = true;
+        }
+        if (Date.now() >= deadline) {
+            console.error(`[MIGRATIONS] Gave up after ${Math.round(timeoutMs / 1000)}s waiting for: ${pending.join(', ')}`);
+            return false;
+        }
+        await new Promise(resolve => setTimeout(resolve, pollMs).unref());
+    }
+}
+
+module.exports = { runMigrations, rollbackMigration, pendingMigrationNames, waitForMigrations };

--- a/src/migrations/runner.js
+++ b/src/migrations/runner.js
@@ -318,6 +318,29 @@ async function rollbackMigration(name, { dir = __dirname } = {}) {
 }
 
 /**
+ * True for a migration `runMigrations` will actually apply *and record*.
+ *
+ * This has to agree with runMigrations' own filtering exactly, because
+ * waitForMigrations blocks on the answer. Two shapes run and leave no record,
+ * and counting either as pending strands every non-primary shard on a
+ * successful boot until it times out and refuses to start:
+ *
+ *   - A file that does not export both a name and an `up` function is skipped
+ *     with a warning and never recorded.
+ *   - An `optional` migration that fails is deliberately not recorded, so the
+ *     next boot retries it. The bot is merely faster with one applied, which is
+ *     the whole reason it is allowed to fail — so it is not something another
+ *     shard should refuse to start over.
+ */
+function isRecordableMigration(migration) {
+    const name = migration?.name;
+    if (typeof name !== 'string' || name.length === 0) return false;
+    if (typeof migration.up !== 'function') return false;
+    if (migration.optional) return false;
+    return true;
+}
+
+/**
  * Migration names that are discovered on disk but not yet recorded as applied.
  *
  * Split out of runMigrations so a process that must NOT run migrations can
@@ -326,8 +349,8 @@ async function rollbackMigration(name, { dir = __dirname } = {}) {
  */
 async function pendingMigrationNames({ dir = __dirname } = {}) {
     const declared = loadMigrations(dir)
-        .map(({ migration }) => migration?.name)
-        .filter(name => typeof name === 'string' && name.length > 0);
+        .filter(({ migration }) => isRecordableMigration(migration))
+        .map(({ migration }) => migration.name);
     if (declared.length === 0) return [];
 
     const applied = new Set(
@@ -376,4 +399,10 @@ async function waitForMigrations({ dir = __dirname, timeoutMs = 300_000, pollMs 
     }
 }
 
-module.exports = { runMigrations, rollbackMigration, pendingMigrationNames, waitForMigrations };
+module.exports = {
+    runMigrations,
+    rollbackMigration,
+    pendingMigrationNames,
+    waitForMigrations,
+    isRecordableMigration,
+};

--- a/src/services/exploreService.js
+++ b/src/services/exploreService.js
@@ -3,6 +3,10 @@
 const {
     LIMITS,
     EXPLORER_LEVELS,
+    EXPLORER_PRESTIGE,
+    MAX_EXPLORER_LEVEL,
+    MAX_EXPLORER_PRESTIGE,
+    PRESTIGE_TITLES,
     EVENT_XP,
     TREASURE_TIERS,
     REGIONS,
@@ -45,6 +49,7 @@ function ensureExploreData(user) {
 
     seed('stamina', LIMITS.MAX_STAMINA);
     seed('level', 1);
+    seed('prestige', 0);
     seed('activeRegion', 'whispering_forest');
     for (const key of EXPLORE_COUNTERS) seed(key, 0);
     for (const key of EXPLORE_TIMESTAMPS) {
@@ -92,7 +97,9 @@ function getRegionProgress(user, regionId, { create = false } = {}) {
  * as hunt/fish/mine only.
  */
 function getMaxStamina(user) {
-    return LIMITS.MAX_STAMINA + getExploreWayfinderStaminaBonus(user);
+    return LIMITS.MAX_STAMINA
+        + getExploreWayfinderStaminaBonus(user)
+        + getExplorerPrestige(user).staminaBonus;
 }
 
 /** @returns {boolean} true if anything was written */
@@ -154,6 +161,46 @@ function applyDailyReset(user) {
 
 function getLevelData(level) {
     return EXPLORER_LEVELS[Math.min(level, EXPLORER_LEVELS.length) - 1] ?? EXPLORER_LEVELS[0];
+}
+
+// ─── EXPLORER PRESTIGE ───────────────────────────────────────────────────────
+
+/**
+ * The bonus row for a user's prestige rank, clamped to the table (#750).
+ * Reads a missing rank as 0, so profiles written before the field existed
+ * behave exactly as they did.
+ */
+function getExplorerPrestige(user) {
+    const rank = Math.max(0, Number(user?.exploration?.prestige) || 0);
+    return EXPLORER_PRESTIGE[Math.min(rank, MAX_EXPLORER_PRESTIGE)];
+}
+
+/** Whether this explorer has anything left to ascend into, and what blocks it. */
+function canPrestige(user) {
+    const e    = user?.exploration ?? {};
+    const rank = Math.max(0, Number(e.prestige) || 0);
+    if (rank >= MAX_EXPLORER_PRESTIGE) return { ok: false, reason: 'max_rank', rank };
+    if ((e.level ?? 1) < MAX_EXPLORER_LEVEL) {
+        return { ok: false, reason: 'level_too_low', rank, level: e.level ?? 1 };
+    }
+    return { ok: true, rank, nextRank: rank + 1 };
+}
+
+/**
+ * The title an explorer carries. A prestiged wanderer keeps their rank title
+ * rather than dropping back to 'Doorstep Wanderer' — resetting the level is the
+ * cost of ascending, reading as a beginner afterwards is not.
+ */
+function getExplorerTitle(user) {
+    const rank = Math.max(0, Number(user?.exploration?.prestige) || 0);
+    const level = user?.exploration?.level ?? 1;
+    // Once the level ladder has been climbed back past its own titles, the
+    // level title is the more specific one and wins.
+    if (rank > 0 && level < MAX_EXPLORER_LEVEL) {
+        return PRESTIGE_TITLES[Math.min(rank, PRESTIGE_TITLES.length - 1)]
+            ?? getLevelData(level).title;
+    }
+    return getLevelData(level).title;
 }
 
 function xpToNextLevel(level, xp) {
@@ -303,7 +350,27 @@ function getRelicCollection(user) {
  */
 function getRelicBonus(user) {
     const distinct = getRelicCollection(user).length;
-    return Math.min(LIMITS.RELIC_BONUS_MAX, distinct * LIMITS.RELIC_BONUS_PER);
+    return Math.min(getRelicBonusCap(user), distinct * LIMITS.RELIC_BONUS_PER);
+}
+
+/**
+ * How wide this explorer's display case is. The base cap pays for ten distinct
+ * relics out of twenty-five, which is what made the back half of the collection
+ * worth nothing but trade value; each prestige rank widens it, and the top rank
+ * opens it far enough that a complete set pays in full (#750).
+ */
+function getRelicBonusCap(user) {
+    return LIMITS.RELIC_BONUS_MAX + getExplorerPrestige(user).relicCapBonus;
+}
+
+/** How many distinct relics a case of the given width actually pays for. */
+function relicCapacityForBonus(relicCapBonus = 0) {
+    return Math.round((LIMITS.RELIC_BONUS_MAX + relicCapBonus) / LIMITS.RELIC_BONUS_PER);
+}
+
+/** How many distinct relics this explorer's case has room to pay for. */
+function getRelicCapacity(user) {
+    return relicCapacityForBonus(getExplorerPrestige(user).relicCapBonus);
 }
 
 // ─── EVENT ROLL ──────────────────────────────────────────────────────────────
@@ -335,11 +402,24 @@ function buildEventWeights(region, guildSettings) {
     return w;
 }
 
+/**
+ * The prestige rank's share of the secret slot, applied as a multiplier on the
+ * slot's own weight rather than a flat addition — a flat one would swamp the
+ * starter region's table and barely register in a deep one.
+ *
+ * Applied in both the roll and the odds display, so a prestiged explorer is
+ * quoted the chance they actually play against.
+ */
+function applySecretPrestige(weight, user) {
+    return weight * (1 + getExplorerPrestige(user).secretBonus);
+}
+
 function rollEventType(user, region, guildSettings, progress) {
     const w = buildEventWeights(region, guildSettings);
     const secretsLeft = hasUnfoundSecrets(region, progress);
 
     if (secretsLeft) {
+        w.secret = applySecretPrestige(w.secret, user);
         // Secret pity: long droughts self-correct
         w.secret += getSecretPity(user);
     } else {
@@ -375,6 +455,9 @@ function getSecretOdds(user, region, progress, guildSettings = null) {
     // Same table the roll uses, so a server running rareEventBonus is quoted
     // the odds it actually plays against.
     const w = buildEventWeights(region, guildSettings);
+    // Same widening the roll applies, before the total is taken — quoting the
+    // unprestiged slot against a prestiged roll is the one thing this must not do.
+    w.secret = applySecretPrestige(w.secret, user);
     const total = Object.values(w).reduce((s, n) => s + n, 0);
     const pity = getSecretPity(user);
     return {
@@ -680,7 +763,8 @@ function getPayoutMultiplier(user, region, guildSettings, eventCoinMultiplier = 
     const dropRate = clamp(guildSettings?.exploration?.dropRateMultiplier ?? 1, 0.1, 5);
     const survey   = isRegionFullyCharted(region, progress) ? 1 + LIMITS.SURVEY_BONUS : 1;
     const relics   = 1 + getRelicBonus(user);
-    return eventCoinMultiplier * dropRate * region.payoutMultiplier * survey * relics;
+    const prestige = 1 + getExplorerPrestige(user).payoutBonus;
+    return eventCoinMultiplier * dropRate * region.payoutMultiplier * survey * relics * prestige;
 }
 
 /**
@@ -895,6 +979,12 @@ module.exports = {
     applyDailyReset,
     getLevelData,
     xpToNextLevel,
+    getExplorerPrestige,
+    getExplorerTitle,
+    canPrestige,
+    getRelicBonusCap,
+    getRelicCapacity,
+    relicCapacityForBonus,
     applyExplorerXp,
     weightedRoll,
     randomFrom,

--- a/src/services/heistService.js
+++ b/src/services/heistService.js
@@ -9,6 +9,8 @@
 // duplicates anyone's coins. The per-user action lock, which is the thing that
 // actually gates money, is in Mongo; see src/utils/activeGameLock.js.
 
+const { assertGuildAffinity } = require('../utils/sharding');
+
 const activeHeists = new Map();
 
 const ROLES = {
@@ -52,6 +54,9 @@ function createLobby({ guildId, channelId, initiatorId, target, lobbyDurationSec
         skillResults: {},
         skillTimers: {},
     };
+    // One heist per guild only holds while one shard handles that guild; see
+    // src/utils/sharding.js (#732).
+    assertGuildAffinity(guildId, 'heist lobby');
     activeHeists.set(guildId, state);
     return state;
 }

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -714,6 +714,81 @@ function applyRepair(weapon, requestedAmount) {
     return { cost, restoredAmount: amount, newStatus: weapon.status, condemned: isCondemned(weapon) };
 }
 
+/**
+ * How many more shop repairs a weapon has in it before the wear condemns it.
+ *
+ * Simulated against the real `applyRepair` rather than derived algebraically, so
+ * it cannot drift from the mechanic: the degradation step, its floor and the
+ * condemnation threshold are all read from the same code the shop runs.
+ * `weapon` is not touched — the walk happens on a copy.
+ */
+function repairsRemaining(weapon) {
+    if (!weapon?.baseDurability || !WEAPON_BY_TIER[weapon.tier]) return 0;
+    if (isCondemned(weapon)) return 0;
+
+    const sim = {
+        tier:             weapon.tier,
+        baseDurability:   weapon.baseDurability,
+        maxDurability:    weapon.maxDurability,
+        currentDurability: 0,
+        repairCount:      weapon.repairCount ?? 0,
+        status:           'broken',
+    };
+
+    let count = 0;
+    // The loop is bounded by the degradation step, but a weapon whose base
+    // durability is small enough to floor that step to zero would never
+    // condemn; cap it rather than spin.
+    while (count < 100) {
+        const result = applyRepair(sim, sim.maxDurability);
+        if (result.error) break;
+        count += 1;
+        if (result.condemned) break;
+        sim.currentDurability = 0;
+    }
+    return count;
+}
+
+/**
+ * The whole service life of a fresh weapon of this tier, in coins (#747).
+ *
+ * A weapon is a consumable: every shop repair permanently drops maxDurability
+ * by 10% of base, so the sticker price is only the down payment. Running the
+ * full cycle out gives the number that actually decides whether a tier is worth
+ * buying — a T12 Altair Rifle costs 20M and then another 35M to keep in the
+ * field, which is the part the shop used to leave unsaid.
+ *
+ * Returns { repairs, maintenance, lifetimeCost, firstRepairCost }.
+ */
+function projectWeaponLifetime(weaponData) {
+    const sim = {
+        tier:             weaponData.tier,
+        baseDurability:   weaponData.baseDurability,
+        maxDurability:    weaponData.baseDurability,
+        currentDurability: 0,
+        repairCount:      0,
+        status:           'broken',
+    };
+
+    let repairs = 0, maintenance = 0, firstRepairCost = 0;
+    while (repairs < 100) {
+        const result = applyRepair(sim, sim.maxDurability);
+        if (result.error) break;
+        repairs     += 1;
+        maintenance += result.cost;
+        if (repairs === 1) firstRepairCost = result.cost;
+        if (result.condemned) break;
+        sim.currentDurability = 0;
+    }
+
+    return {
+        repairs,
+        maintenance,
+        lifetimeCost: weaponData.cost + maintenance,
+        firstRepairCost,
+    };
+}
+
 // ─── LEVEL / XP ──────────────────────────────────────────────────────────────
 
 /**
@@ -1660,6 +1735,8 @@ module.exports = {
     applyDurabilityLoss,
     updateWeaponStatus,
     isCondemned,
+    repairsRemaining,
+    projectWeaponLifetime,
     quoteRepair,
     applyRepair,
     levelFromXp,

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -877,6 +877,7 @@ function recordBestPayout(h, amount, { animal, tier, zoneId } = {}) {
  *   animal?: Animal,
  *   tier?: string,
  *   rawPayout?: number,
+ *   payoutBeforeMods?: number,
  *   finalPayout?: number,
  *   isCrit?: boolean,
  *   critMultiplier?: number,
@@ -1046,7 +1047,7 @@ function executeHunt(user, zoneId, options = {}) {
         const lvResult = applyXp(user, xpGain);
 
         Object.assign(result, {
-            rawPayout, finalPayout: adjustedPayout,
+            rawPayout, payoutBeforeMods, finalPayout: adjustedPayout,
             isCrit, critMultiplier: parseFloat(critMultiplier.toFixed(2)),
             trophyQuality,
             specialDrop, xpEarned: xpGain,
@@ -1064,7 +1065,9 @@ function executeHunt(user, zoneId, options = {}) {
         // 12% chance for legendary, 8% for epic, 3% for rare, skipped for others
         const apexTierChance = tier === 'legendary' ? 0.12 : tier === 'epic' ? 0.08 : tier === 'rare' ? 0.03 : 0;
         if (apexTierChance > 0 && Math.random() < apexTierChance) {
-            result.apexEncounter = { animal, tier };
+            // The kill's own earned payout rides along so the duel can price
+            // itself off the kill rather than re-rolling the base range (#744).
+            result.apexEncounter = { animal, tier, killPayout: payoutBeforeMods };
             // Bonus payout handled when the player responds to the encounter
         }
 
@@ -1330,11 +1333,39 @@ function resolveApexPhases(apexType, choicesMade, user) {
     return { phaseResults, nerve: apexNerveAfter(phaseResults, user) };
 }
 
+/** What each apex outcome is worth, as a share of the kill it grew out of. */
+const APEX_OUTCOME_RATE = { escaped: 0, survived: 0.4, win: 1.0, perfect: 1.5 };
+
+/**
+ * The number an apex bonus is a share of (#744).
+ *
+ * The duel is the climax of a specific kill, so it prices off that kill's own
+ * earned payout — crit, trophy quality, streak and the enraged trait included —
+ * rather than re-rolling the animal's base range and throwing every multiplier
+ * away. Re-rolling also made two identical duels on identical kills pay
+ * differently for no reason a player could see.
+ *
+ * `killPayout` is `payoutBeforeMods` from the hunt that spawned the encounter:
+ * post-multiplier but pre-cap, because the apex path runs the payout through
+ * `applyPayoutModifiers` itself. Callers that have no kill to point at (the
+ * duel primitive under test, a future standalone encounter) fall back to the
+ * base range so the function stays callable on its own.
+ */
+function apexBasePayout(animal, killPayout) {
+    const fromKill = Number(killPayout);
+    if (Number.isFinite(fromKill) && fromKill > 0) return fromKill;
+    return randInt(animal.payoutMin, animal.payoutMax);
+}
+
 /**
  * Resolve the final apex outcome after all phases.
+ *
+ * `options.killPayout` scales the bonus off the kill that spawned the duel; see
+ * apexBasePayout.
+ *
  * Returns { outcome, bonusPayout, durabilityLost, correctCount, phaseResults, apexType, message }
  */
-function resolveApexEncounter(user, animal, tier, choicesMade, apexType, weaponIndex) {
+function resolveApexEncounter(user, animal, tier, choicesMade, apexType, weaponIndex, options = {}) {
     const idx    = weaponIndex ?? user.hunt.equippedWeaponIndex;
     const weapon = user.hunt?.weapons[idx];
     const at     = apexType ?? rollApexType();
@@ -1343,6 +1374,10 @@ function resolveApexEncounter(user, animal, tier, choicesMade, apexType, weaponI
     const correctCount = phaseResults.filter(p => p.correct).length;
     const broken       = nerve <= 0;
 
+    // One roll for the whole duel: the outcome tier picks a share of it, so the
+    // four outcomes stay ordered against each other on any single encounter.
+    const basePayout = apexBasePayout(animal, options.killPayout);
+
     let bonusPayout = 0, durabilityLost = 0, outcome = '';
 
     if (broken || correctCount === 0) {
@@ -1350,15 +1385,15 @@ function resolveApexEncounter(user, animal, tier, choicesMade, apexType, weaponI
         if (weapon) { applyDurabilityLoss(weapon, 4); durabilityLost = 4; }
     } else if (correctCount === 1) {
         outcome = 'survived';
-        bonusPayout = Math.round(randInt(animal.payoutMin, animal.payoutMax) * 0.4);
+        bonusPayout = Math.round(basePayout * APEX_OUTCOME_RATE.survived);
         if (weapon) { applyDurabilityLoss(weapon, 3); durabilityLost = 3; }
     } else if (correctCount === 2) {
         outcome = 'win';
-        bonusPayout = Math.round(randInt(animal.payoutMin, animal.payoutMax) * 1.0);
+        bonusPayout = Math.round(basePayout * APEX_OUTCOME_RATE.win);
         if (weapon) { applyDurabilityLoss(weapon, 2); durabilityLost = 2; }
     } else {
         outcome = 'perfect';
-        bonusPayout = Math.round(randInt(animal.payoutMin, animal.payoutMax) * 1.5);
+        bonusPayout = Math.round(basePayout * APEX_OUTCOME_RATE.perfect);
         if (weapon) { applyDurabilityLoss(weapon, 1); durabilityLost = 1; }
     }
 
@@ -1639,6 +1674,8 @@ module.exports = {
     buildApexEncounter,
     APEX_PHASES_PER_DUEL,
     resolveApexEncounter,
+    apexBasePayout,
+    APEX_OUTCOME_RATE,
     apexNerveAfter,
     apexNerveMax,
     APEX_NERVE_MAX,

--- a/src/services/raidService.js
+++ b/src/services/raidService.js
@@ -1,5 +1,6 @@
 const { EmbedBuilder } = require('discord.js');
 const Guild = require('../models/Guild');
+const { assertGuildAffinity } = require('../utils/sharding');
 
 // guildId -> [{timestamp, userId, accountAgeDays}]
 //
@@ -61,6 +62,11 @@ async function handleMemberJoin(member, client) {
 
     const accountAgeDays = (Date.now() - member.user.createdTimestamp) / 86400000;
 
+    // The window is a per-guild sliding count, so it is only a true count while
+    // one shard sees all of that guild's joins — which Discord's routing
+    // guarantees. See src/utils/sharding.js (#732); two shards each seeing half
+    // the joins is precisely a detector that needs double the real rate to trip.
+    assertGuildAffinity(guildId, 'raid join window');
     const entries = pruneLog(guildId, windowMs);
     entries.push({ timestamp: Date.now(), userId: member.id, accountAgeDays });
     joinLog.set(guildId, entries);

--- a/src/services/scheduler/index.js
+++ b/src/services/scheduler/index.js
@@ -1,6 +1,7 @@
 const cron = require('node-cron');
 const { ActivityType } = require('discord.js');
 const { runJob } = require('../../utils/jobRunner');
+const { isPrimaryShard, shardTag } = require('../../utils/sharding');
 
 // Single owner of all recurring background work. Every scheduled job goes
 // through runJob (overlap protection, DLQ, health tracking), and every
@@ -163,7 +164,43 @@ function startScheduler(client) {
         console.warn('[SCHEDULER] startScheduler called twice — ignoring second call.');
         return;
     }
+
     started = true;
+
+    // Presence is a property of a gateway connection, so it is set per shard
+    // rather than per deployment — a shard that skipped this would show no
+    // activity to every guild it serves. It runs before the primary-shard gate
+    // for exactly that reason.
+    setPresence(client);
+    presenceInterval = setInterval(() => setPresence(client), PRESENCE_ROTATE_MS);
+
+    // ── The scheduler is singleton work, and runs on shard 0 only (#732) ─────
+    //
+    // Under sharding each shard is its own process, so an ungated scheduler
+    // fires every job once per shard. jobRunner's overlap guard would not
+    // notice: `inFlight` is a process-local Set, so N processes each see an
+    // empty one. applyBankInterest paying every account N times is the shape of
+    // that mistake, and it is the expensive shape.
+    //
+    // The trade-off this makes, stated plainly rather than discovered later:
+    // most of these jobs reach a guild through the client, and shard 0's client
+    // only has the guilds Discord routed to shard 0. So gating here means a job
+    // that announces into a guild on another shard cannot reach it. That is a
+    // missed announcement; the alternative is duplicated money. Money wins.
+    //
+    // Step 2 is to classify each job as deployment-wide (bank interest, market
+    // listing returns — pure database work that must happen once) or per-guild
+    // (the announcements, which should run on every shard filtered to the
+    // guilds that shard owns, since `ownsGuild` makes that partition exact).
+    // That classification needs each job read against a live multi-shard
+    // deployment, which is why it is not guessed at here.
+    //
+    // Unsharded — every deployment today — `isPrimaryShard` is true and none of
+    // this changes anything.
+    if (!isPrimaryShard(client)) {
+        console.log(`${shardTag(client)}[SCHEDULER] Presence only — scheduled jobs and services run on shard 0.`);
+        return;
+    }
 
     for (const job of JOBS) {
         const run = () => runJob(job.service, job.name, () => job.fn(client));
@@ -183,10 +220,7 @@ function startScheduler(client) {
         }
     }
 
-    setPresence(client);
-    presenceInterval = setInterval(() => setPresence(client), PRESENCE_ROTATE_MS);
-
-    console.log(`[SCHEDULER] Started ${JOBS.length} scheduled jobs and ${STARTERS.length} services`);
+    console.log(`${shardTag(client)}[SCHEDULER] Started ${JOBS.length} scheduled jobs and ${STARTERS.length} services`);
 }
 
 /** Stop presence rotation and all cron tasks (used on graceful shutdown). */

--- a/src/services/syndicateService.js
+++ b/src/services/syndicateService.js
@@ -7,6 +7,8 @@
 // an `$inc` per participant at the end, so neither pays anyone twice. Money is
 // gated by the Mongo-backed per-user lock in src/utils/activeGameLock.js.
 
+const { assertGuildAffinity } = require('../utils/sharding');
+
 const activeSyndicateHeists = new Map();
 
 const SYNDICATE_TARGETS = {
@@ -90,6 +92,8 @@ function createSyndicateLobby({ guildId, channelId, syndicateId, leaderId, targe
         resolving: false,
         _skillChecks: {},
     };
+    // Same affinity assumption as the plain heist; see src/utils/sharding.js.
+    assertGuildAffinity(guildId, 'syndicate heist lobby');
     activeSyndicateHeists.set(guildId, state);
     return state;
 }

--- a/src/shard.js
+++ b/src/shard.js
@@ -1,0 +1,69 @@
+'use strict';
+
+// Sharding entry point (#732).
+//
+// `npm start` runs src/index.js directly — one process, one gateway connection,
+// which is correct for every deployment below roughly 2,000 guilds and is what
+// Clawdia has always done. This file is the other way in: `npm run start:sharded`
+// spawns one src/index.js per shard under a ShardingManager.
+//
+// It is deliberately thin. The interesting part of sharding this bot is not
+// spawning processes, it is what stops being true once there is more than one —
+// and that is written down in src/utils/sharding.js, which both entry points
+// share. In particular:
+//
+//   - Guild-scoped session state (crash lobbies, heists, syndicate heists, the
+//     raid join window) is safe, because Discord routes a guild's events to
+//     exactly one shard. That is the affinity guarantee #732 asked about.
+//   - Singleton work is NOT safe and is gated on `isPrimaryShard()` at its
+//     bootstrap site: the dashboard would otherwise have N processes fighting
+//     for one port, and every cron job would fire once per shard.
+//
+// Set SHARD_COUNT to pin a number; leave it unset for Discord's recommendation.
+
+require('dotenv').config();
+
+const path = require('path');
+const { ShardingManager } = require('discord.js');
+
+const REQUIRED_ENV = ['DISCORD_TOKEN', 'CLIENT_ID', 'MONGODB_URI', 'SESSION_SECRET', 'CLIENT_SECRET'];
+const missingEnv = REQUIRED_ENV.filter(k => !process.env[k]);
+if (missingEnv.length) {
+    console.error(`[SHARD] Missing required environment variables: ${missingEnv.join(', ')}`);
+    process.exit(1);
+}
+
+function resolveShardCount() {
+    const pinned = Number(process.env.SHARD_COUNT);
+    if (Number.isInteger(pinned) && pinned > 0) return pinned;
+    // 'auto' asks the gateway what it wants. Anything else and the manager would
+    // read the string as a number and spawn NaN shards.
+    return 'auto';
+}
+
+const manager = new ShardingManager(path.join(__dirname, 'index.js'), {
+    token: process.env.DISCORD_TOKEN,
+    totalShards: resolveShardCount(),
+    // The child reads its own identity from `client.shard`, but the singleton
+    // gate runs before login — so the count is passed down as an env var too,
+    // and `shardCount()` falls back to it.
+    respawn: true,
+});
+
+manager.on('shardCreate', shard => {
+    console.log(`[SHARD] Launched shard ${shard.id}`);
+    shard.on('death', () => console.error(`[SHARD] Shard ${shard.id} died`));
+    shard.on('error', err => console.error(`[SHARD] Shard ${shard.id} error:`, err.message));
+});
+
+manager.spawn()
+    .then(shards => {
+        console.log(`[SHARD] ${shards.size} shard(s) spawned.`);
+        // Only shard 0 runs the dashboard and the cron scheduler; see
+        // src/utils/sharding.js for why, and index.js/ready.js for the gates.
+        console.log('[SHARD] Dashboard and scheduled jobs run on shard 0 only.');
+    })
+    .catch(err => {
+        console.error('[SHARD] Failed to spawn shards:', err);
+        process.exit(1);
+    });

--- a/src/utils/crashLobby.js
+++ b/src/utils/crashLobby.js
@@ -16,6 +16,8 @@
 // from the `pendingCrashRefund` field the debit writes, which is in Mongo
 // precisely so a lost lobby cannot strand a stake.
 
+const { assertGuildAffinity } = require('./sharding');
+
 const lobbies = new Map();
 
 const LOBBY_JOIN_WINDOW_MS = 30_000;
@@ -23,11 +25,18 @@ const MAX_PLAYERS          = 10;
 
 /**
  * Creates a new lobby. Returns the lobby object or null if one already exists.
+ *
+ * `guildId` is only used to check shard affinity — a channel belongs to exactly
+ * one guild, and Discord routes that guild's events to exactly one shard, which
+ * is what makes one lobby per channel a safe thing to hold in a Map. The check
+ * makes that assumption loud if it ever stops holding (#732).
  */
-function createLobby(channelId, hostId, bet) {
+function createLobby(channelId, hostId, bet, guildId = null) {
     if (lobbies.has(channelId)) return null;
+    if (guildId) assertGuildAffinity(guildId, 'crash lobby');
     const lobby = {
         channelId,
+        guildId,
         hostId,
         bet,
         players: new Map(), // userId -> { cashedOutAt: number|null }

--- a/src/utils/sharding.js
+++ b/src/utils/sharding.js
@@ -1,0 +1,157 @@
+'use strict';
+
+// Shard identity, and the guild-to-shard affinity rule the session stores rely
+// on (#732).
+//
+// ── The decision this module records ─────────────────────────────────────────
+//
+// #609 moved every piece of money-adjacent state out of process-local Maps and
+// into Mongo. Four things were left behind, all of them live multiplayer rounds:
+// crash lobbies (src/utils/crashLobby.js), heist and syndicate heist sessions,
+// and the raid-mode join window. They stayed because a lobby is not a value — it
+// is an object graph holding setInterval handles and component collectors bound
+// to a specific message, none of which serialises.
+//
+// #732 asked whether that is safe under sharding, and the answer turns on one
+// question: is a guild guaranteed to be handled by exactly one shard?
+//
+// It is, and not by convention — by Discord's gateway. Every guild's events are
+// delivered to the shard `(guildId >> 22) % shardCount` and to no other, which
+// is the same formula `shardIdForGuild` implements below. So:
+//
+//   - heist, syndicate heist and the raid join window are keyed by guildId, and
+//     one guild's events only ever reach one shard;
+//   - crash lobbies are keyed by channelId, and a channel belongs to exactly one
+//     guild, so they inherit the same affinity.
+//
+// A second process therefore cannot produce a duplicate lobby for the same
+// guild the way #609's framing suggested. What remains is narrower and was
+// always true of a single process too: a restart mid-round abandons that round.
+// Crash already answers that with `pendingCrashRefund`, reconciled at startup in
+// src/events/ready.js.
+//
+// So this module is deliberately not a session-persistence layer. It is the
+// scaffolding that makes affinity real: the identity a process has, the formula
+// stated once, and an assertion the session stores call so a violation is loud
+// rather than a silently duplicated round.
+//
+// ── What is NOT shard-safe, and is gated instead ─────────────────────────────
+//
+// Affinity solves guild-scoped state. It does nothing for singleton work, which
+// must run in exactly one process no matter how many shards there are:
+//
+//   - the dashboard binds a TCP port, and N processes would fight over it;
+//   - every cron job in src/services/scheduler would fire once per shard, and
+//     jobRunner's overlap guard is process-local so it would not notice.
+//
+// Both are gated on `isPrimaryShard()` at their bootstrap site.
+
+/** Discord's gateway routing rule. The one place it is written down. */
+const GUILD_SHARD_SHIFT = 22n;
+
+/**
+ * The shard a guild's events are delivered to.
+ *
+ * `(guildId >> 22) % shardCount`, in BigInt because a snowflake does not fit in
+ * a double — computing this in Number arithmetic silently rounds the low bits
+ * away and lands on the wrong shard for a fraction of guilds.
+ */
+function shardIdForGuild(guildId, shardCount) {
+    const count = Number(shardCount);
+    if (!Number.isInteger(count) || count < 1) {
+        throw new TypeError(`shardIdForGuild: shardCount must be a positive integer, got ${shardCount}`);
+    }
+    if (count === 1) return 0;
+    let id;
+    try {
+        id = BigInt(guildId);
+    } catch {
+        throw new TypeError(`shardIdForGuild: guildId must be a snowflake, got ${guildId}`);
+    }
+    return Number((id >> GUILD_SHARD_SHIFT) % BigInt(count));
+}
+
+/**
+ * How many shards this deployment runs. One when unsharded, which is the
+ * default and makes every rule here a no-op rather than a special case.
+ */
+function shardCount(client = null) {
+    if (client?.shard?.count) return client.shard.count;
+    const fromEnv = Number(process.env.SHARD_COUNT);
+    return Number.isInteger(fromEnv) && fromEnv > 0 ? fromEnv : 1;
+}
+
+/**
+ * Which shard this process is. Null when the client has no shard assignment
+ * yet; 0 when unsharded.
+ */
+function shardId(client = null) {
+    const ids = client?.shard?.ids;
+    if (Array.isArray(ids) && ids.length) return ids[0];
+    const fromEnv = Number(process.env.SHARD_ID);
+    if (Number.isInteger(fromEnv) && fromEnv >= 0) return fromEnv;
+    return 0;
+}
+
+/**
+ * True in the one process that owns singleton work — the dashboard, the cron
+ * scheduler, anything that must happen once per deployment rather than once per
+ * shard. Shard 0, or the only process when unsharded.
+ */
+function isPrimaryShard(client = null) {
+    return shardId(client) === 0;
+}
+
+/** True when this process is the shard Discord routes that guild to. */
+function ownsGuild(guildId, client = null) {
+    const count = shardCount(client);
+    if (count === 1) return true;
+    try {
+        return shardIdForGuild(guildId, count) === shardId(client);
+    } catch {
+        // An unparseable id is not this shard's to claim, but it is also not a
+        // reason to take the process down — the caller's assertion decides.
+        return false;
+    }
+}
+
+/**
+ * Guard for process-local session state keyed by guild.
+ *
+ * The four multiplayer stores hold a round for one guild in memory, which is
+ * only correct while that guild's events reach one process. This says so out
+ * loud at the point the assumption is used, so a routing change shows up as a
+ * logged violation on the round that broke it rather than as two lobbies.
+ *
+ * Warns rather than throws on purpose: a mid-round throw would strand players
+ * in a lobby whose stakes are already debited, which is a worse outcome than
+ * the duplicate this is warning about.
+ *
+ * @returns {boolean} true when the guild belongs to this shard.
+ */
+function assertGuildAffinity(guildId, label, client = null) {
+    if (ownsGuild(guildId, client)) return true;
+    console.warn(
+        `[sharding] ${label}: guild ${guildId} is handled in shard ${shardId(client)} but routes to ` +
+        `shard ${shardIdForGuild(guildId, shardCount(client))}. Guild-scoped session state assumes ` +
+        `one shard per guild — see src/utils/sharding.js.`
+    );
+    return false;
+}
+
+/** Prefix for log lines, so a multi-process tail can be read. */
+function shardTag(client = null) {
+    const count = shardCount(client);
+    return count === 1 ? '' : `[shard ${shardId(client)}/${count}] `;
+}
+
+module.exports = {
+    GUILD_SHARD_SHIFT,
+    shardIdForGuild,
+    shardCount,
+    shardId,
+    isPrimaryShard,
+    ownsGuild,
+    assertGuildAffinity,
+    shardTag,
+};

--- a/src/utils/sharding.js
+++ b/src/utils/sharding.js
@@ -131,10 +131,23 @@ function ownsGuild(guildId, client = null) {
  */
 function assertGuildAffinity(guildId, label, client = null) {
     if (ownsGuild(guildId, client)) return true;
+
+    // `ownsGuild` returns false for an id it cannot route as well as for one
+    // that belongs elsewhere, so the destination has to be resolved separately —
+    // and resolving it is exactly what throws on an unroutable id. Working it
+    // out before the warning is built keeps the "warns, never throws" contract
+    // true for both cases.
+    let routesTo;
+    try {
+        routesTo = `shard ${shardIdForGuild(guildId, shardCount(client))}`;
+    } catch {
+        routesTo = 'no shard — it is not a snowflake';
+    }
+
     console.warn(
         `[sharding] ${label}: guild ${guildId} is handled in shard ${shardId(client)} but routes to ` +
-        `shard ${shardIdForGuild(guildId, shardCount(client))}. Guild-scoped session state assumes ` +
-        `one shard per guild — see src/utils/sharding.js.`
+        `${routesTo}. Guild-scoped session state assumes one shard per guild — ` +
+        `see src/utils/sharding.js.`
     );
     return false;
 }

--- a/tests/casinoBetGuard.test.js
+++ b/tests/casinoBetGuard.test.js
@@ -163,7 +163,8 @@ describe('/crash leaves nothing behind when the host cannot pay', () => {
         await load('crash').execute(interaction, { releaseLock: jest.fn() });
 
         // Opened for this channel, then gone again — not merely never opened.
-        expect(createLobby).toHaveBeenCalledWith(CHANNEL_ID, USER_ID, BET);
+        // The guild id rides along so the lobby can check shard affinity (#732).
+        expect(createLobby).toHaveBeenCalledWith(CHANNEL_ID, USER_ID, BET, GUILD_ID);
         expect(getLobby(CHANNEL_ID)).toBeFalsy();
         errorSpy.mockRestore();
     });

--- a/tests/explorePrestige.test.js
+++ b/tests/explorePrestige.test.js
@@ -1,0 +1,228 @@
+'use strict';
+
+// #750 — exploration was the only grind system whose progression simply stopped.
+// Explorer Level ended at 30 and kept banking XP into a counter nothing read;
+// the relic case paid for ten distinct relics out of twenty-five, so the back
+// half of a completed collection was worth nothing but trade value; and unlike
+// hunting, fishing and mining there was no prestige of any kind to reset into.
+//
+// These cover the ladder that answers it, and — as much as anything — that the
+// ladder is actually reachable and its bonuses actually apply.
+
+const {
+    ensureExploreData,
+    getMaxStamina,
+    getExplorerPrestige,
+    getExplorerTitle,
+    canPrestige,
+    getRelicBonus,
+    getRelicBonusCap,
+    getRelicCapacity,
+    relicCapacityForBonus,
+    getPayoutMultiplier,
+    getSecretOdds,
+    applyExplorerXp,
+    xpToNextLevel,
+} = require('../src/services/exploreService');
+const {
+    EXPLORER_LEVELS, EXPLORER_PRESTIGE, PRESTIGE_TITLES, LIMITS,
+    RELIC_LIST, RELIC_INDEX, REGIONS,
+    MAX_EXPLORER_LEVEL, MAX_EXPLORER_PRESTIGE,
+} = require('../src/data/exploreData');
+
+function explorer({ level = 1, prestige = 0, xp = 0, relics = 0 } = {}) {
+    const user = { exploration: {}, inventory: [], balance: 0, markModified() {} };
+    ensureExploreData(user);
+    Object.assign(user.exploration, { level, prestige, xp });
+    // Distinct relics, taken off the front of the real index.
+    user.inventory = RELIC_LIST.slice(0, relics).map(r => ({ itemId: r.itemId, quantity: 1 }));
+    return user;
+}
+
+/** What /explore prestige does to the profile when a wanderer ascends. */
+function ascend(user) {
+    user.exploration.prestige += 1;
+    user.exploration.level = 1;
+    user.exploration.xp = 0;
+    return user;
+}
+
+describe('the ladder is reachable', () => {
+    test('explorer level still tops out where the level table ends', () => {
+        const user = explorer({ level: MAX_EXPLORER_LEVEL });
+        expect(xpToNextLevel(MAX_EXPLORER_LEVEL, EXPLORER_LEVELS.at(-1).xpRequired)).toBeNull();
+        expect(canPrestige(user).ok).toBe(true);
+    });
+
+    test('every rank in the bonus table can be climbed to', () => {
+        const user = explorer({ level: MAX_EXPLORER_LEVEL });
+        for (let rank = 1; rank <= MAX_EXPLORER_PRESTIGE; rank++) {
+            user.exploration.level = MAX_EXPLORER_LEVEL;
+            ascend(user);
+            expect(user.exploration.prestige).toBe(rank);
+            expect(user.exploration.level).toBe(1);
+            expect(user.exploration.xp).toBe(0);
+        }
+        expect(canPrestige(user)).toMatchObject({ ok: false, reason: 'max_rank' });
+    });
+
+    test('an unmaxed explorer is told what blocks them, not just refused', () => {
+        const state = canPrestige(explorer({ level: 12 }));
+        expect(state).toMatchObject({ ok: false, reason: 'level_too_low', rank: 0, level: 12 });
+    });
+
+    test('a profile written before the field existed reads as rank 0', () => {
+        const legacy = { exploration: { level: 30 }, inventory: [], markModified() {} };
+        expect(getExplorerPrestige(legacy)).toBe(EXPLORER_PRESTIGE[0]);
+        expect(canPrestige(legacy).ok).toBe(true);
+    });
+
+    test('a rank past the end of the table clamps rather than throwing', () => {
+        const user = explorer({ prestige: 99 });
+        expect(getExplorerPrestige(user)).toBe(EXPLORER_PRESTIGE[MAX_EXPLORER_PRESTIGE]);
+    });
+});
+
+describe('the bonuses actually apply', () => {
+    test('max stamina grows at the rank the table says it does', () => {
+        for (let rank = 0; rank <= MAX_EXPLORER_PRESTIGE; rank++) {
+            const expected = LIMITS.MAX_STAMINA + EXPLORER_PRESTIGE[rank].staminaBonus;
+            expect(getMaxStamina(explorer({ prestige: rank }))).toBe(expected);
+        }
+    });
+
+    test('payouts rise at the rank that grants a payout bonus', () => {
+        const region = REGIONS.whispering_forest;
+        const plain   = getPayoutMultiplier(explorer({ prestige: 1 }), region, {}, 1, null);
+        const bonused = getPayoutMultiplier(explorer({ prestige: 2 }), region, {}, 1, null);
+        expect(bonused / plain).toBeCloseTo(1 + EXPLORER_PRESTIGE[2].payoutBonus, 10);
+    });
+
+    test('the payout bonus never shrinks as the rank climbs', () => {
+        const region = REGIONS.whispering_forest;
+        let previous = 0;
+        for (let rank = 0; rank <= MAX_EXPLORER_PRESTIGE; rank++) {
+            const mult = getPayoutMultiplier(explorer({ prestige: rank }), region, {}, 1, null);
+            expect(mult).toBeGreaterThanOrEqual(previous);
+            previous = mult;
+        }
+    });
+
+    test('the secret slot widens at the rank that grants it', () => {
+        const region = REGIONS.whispering_forest;
+        const progress = { landmarksFound: [], loreFound: [], secretsFound: [], expeditions: 0 };
+        const plain   = getSecretOdds(explorer({ prestige: 3 }), region, progress);
+        const bonused = getSecretOdds(explorer({ prestige: 4 }), region, progress);
+        expect(bonused.baseChance).toBeGreaterThan(plain.baseChance);
+    });
+
+    test('the quoted secret odds are the odds the roll plays against', () => {
+        // Quoting an unprestiged slot while rolling a prestiged one is the exact
+        // bug the shared buildEventWeights helper exists to prevent.
+        const region = REGIONS.whispering_forest;
+        const progress = { landmarksFound: [], loreFound: [], secretsFound: [], expeditions: 0 };
+        const odds = getSecretOdds(explorer({ prestige: MAX_EXPLORER_PRESTIGE }), region, progress);
+        const expected = region.eventWeights.secret * (1 + EXPLORER_PRESTIGE[MAX_EXPLORER_PRESTIGE].secretBonus);
+        const total = Object.entries(region.eventWeights)
+            .reduce((sum, [type, w]) => sum + (type === 'secret' ? expected : w), 0);
+        expect(odds.baseChance).toBeCloseTo(expected / total, 10);
+    });
+
+    test('a maxed rank does not exhaust a region that still has secrets', () => {
+        const region = REGIONS.whispering_forest;
+        const odds = getSecretOdds(explorer({ prestige: MAX_EXPLORER_PRESTIGE }), region,
+            { landmarksFound: [], loreFound: [], secretsFound: [], expeditions: 0 });
+        expect(odds.exhausted).toBe(false);
+        expect(odds.chance).toBeGreaterThan(0);
+        expect(odds.chance).toBeLessThan(1);
+    });
+});
+
+describe('the relic case is what the ladder is for', () => {
+    test('the base case pays for well under half the known relics', () => {
+        // This is the dead end the ladder exists to open: 25 relics, 10 of them
+        // worth anything mechanically.
+        expect(relicCapacityForBonus(0)).toBe(10);
+        expect(RELIC_LIST.length).toBe(25);
+    });
+
+    test('each rank widens the case, and the top rank opens it completely', () => {
+        let previous = 0;
+        for (let rank = 0; rank <= MAX_EXPLORER_PRESTIGE; rank++) {
+            const capacity = getRelicCapacity(explorer({ prestige: rank }));
+            expect(capacity).toBeGreaterThanOrEqual(previous);
+            previous = capacity;
+        }
+        expect(getRelicCapacity(explorer({ prestige: MAX_EXPLORER_PRESTIGE }))).toBe(RELIC_LIST.length);
+    });
+
+    test('a full collection pays in full only at the top rank', () => {
+        const full = RELIC_LIST.length;
+        const p0 = getRelicBonus(explorer({ prestige: 0, relics: full }));
+        const p5 = getRelicBonus(explorer({ prestige: MAX_EXPLORER_PRESTIGE, relics: full }));
+        expect(p0).toBeCloseTo(LIMITS.RELIC_BONUS_MAX, 10);
+        expect(p5).toBeCloseTo(full * LIMITS.RELIC_BONUS_PER, 10);
+        expect(p5).toBeGreaterThan(p0);
+    });
+
+    test('the eleventh relic is worth nothing at rank 0 and something above it', () => {
+        // The precise complaint in the issue: relics 11-25 were shelf decoration.
+        const at10 = explorer({ prestige: 0, relics: 10 });
+        const at11 = explorer({ prestige: 0, relics: 11 });
+        expect(getRelicBonus(at11)).toBe(getRelicBonus(at10));
+
+        const p1at10 = explorer({ prestige: 1, relics: 10 });
+        const p1at11 = explorer({ prestige: 1, relics: 11 });
+        expect(getRelicBonus(p1at11)).toBeGreaterThan(getRelicBonus(p1at10));
+    });
+
+    test('the bonus never exceeds the case it is capped by', () => {
+        for (let rank = 0; rank <= MAX_EXPLORER_PRESTIGE; rank++) {
+            const user = explorer({ prestige: rank, relics: RELIC_LIST.length });
+            expect(getRelicBonus(user)).toBeLessThanOrEqual(getRelicBonusCap(user) + 1e-9);
+        }
+    });
+
+    test('duplicates still do not stack', () => {
+        const user = explorer({ prestige: MAX_EXPLORER_PRESTIGE });
+        const [first] = RELIC_LIST;
+        user.inventory = [{ itemId: first.itemId, quantity: 40 }];
+        expect(getRelicBonus(user)).toBeCloseTo(LIMITS.RELIC_BONUS_PER, 10);
+    });
+
+    test('every relic in the list is one the case can recognise', () => {
+        for (const relic of RELIC_LIST) expect(RELIC_INDEX[relic.itemId]).toBeTruthy();
+    });
+});
+
+describe('an ascended explorer does not read as a beginner', () => {
+    test('a reset explorer carries their prestige title, not "Doorstep Wanderer"', () => {
+        const fresh  = explorer({ level: 1, prestige: 0 });
+        const reborn = explorer({ level: 1, prestige: 2 });
+        expect(getExplorerTitle(fresh)).toBe(EXPLORER_LEVELS[0].title);
+        expect(getExplorerTitle(reborn)).toBe(PRESTIGE_TITLES[2]);
+    });
+
+    test('the level title takes back over once the ladder is re-climbed', () => {
+        const maxed = explorer({ level: MAX_EXPLORER_LEVEL, prestige: 3 });
+        expect(getExplorerTitle(maxed)).toBe(EXPLORER_LEVELS.at(-1).title);
+    });
+
+    test('rank 0 is unaffected at every level', () => {
+        for (const row of EXPLORER_LEVELS) {
+            expect(getExplorerTitle(explorer({ level: row.level, prestige: 0 }))).toBe(row.title);
+        }
+    });
+});
+
+describe('the XP that used to be discarded now goes somewhere', () => {
+    test('a reset explorer climbs the same ladder again from zero', () => {
+        const user = explorer({ level: MAX_EXPLORER_LEVEL, xp: EXPLORER_LEVELS.at(-1).xpRequired });
+        ascend(user);
+        expect(xpToNextLevel(user.exploration.level, user.exploration.xp))
+            .toBe(EXPLORER_LEVELS[1].xpRequired);
+        applyExplorerXp(user, EXPLORER_LEVELS.at(-1).xpRequired);
+        expect(user.exploration.level).toBe(MAX_EXPLORER_LEVEL);
+        expect(canPrestige(user).ok).toBe(true);
+    });
+});

--- a/tests/huntApexPayoutScaling.test.js
+++ b/tests/huntApexPayoutScaling.test.js
@@ -1,0 +1,172 @@
+'use strict';
+
+// #744 — the apex duel used to price itself from a fresh roll of the animal's
+// base payout range, so every multiplier the kill had earned (crit, trophy
+// quality, streak, the enraged trait) was thrown away, and the climax of a
+// mythic crit paid like a consolation. It now scales off the kill it belongs to.
+
+const {
+    resolveApexEncounter,
+    apexBasePayout,
+    APEX_OUTCOME_RATE,
+    buildApexEncounter,
+    executeHunt,
+    ensureHuntData,
+    APEX_PHASES_PER_DUEL,
+} = require('../src/services/huntService');
+const { APEX_TYPES, ANIMALS_BY_TIER } = require('../src/data/huntData');
+
+// A real legendary from the tables — the apex slot only opens on rare or better.
+// Snow Leopard carries no 'armored' trait, so a pinned-low random still crits.
+const LEGENDARY_ANIMAL = ANIMALS_BY_TIER.legendary.find(a => !a.traits?.includes('armored'));
+
+const APEX = buildApexEncounter(APEX_TYPES.dire_alpha);
+// A wide base range, so a re-roll would land on the pinned number essentially
+// never — that is the whole point of the assertions below.
+const ANIMAL = { payoutMin: 100, payoutMax: 2_000, name: 'Deer', emoji: '🦌' };
+
+function choicesFor(pattern) {
+    expect(pattern).toHaveLength(APEX_PHASES_PER_DUEL);
+    return APEX.phases.map((phase, i) => {
+        const c = pattern[i];
+        if (c === 'C') return phase.correct;
+        if (c === 'W') return phase.correct === 'match' ? 'hold' : 'match';
+        return 'safe';
+    });
+}
+
+function duel(pattern, options) {
+    const user = { hunt: { equippedWeaponIndex: -1, weapons: [] }, markModified() {} };
+    return resolveApexEncounter(user, ANIMAL, 'legendary', choicesFor(pattern), APEX, -1, options);
+}
+
+describe('apexBasePayout', () => {
+    test('uses the kill payout when the duel has one to point at', () => {
+        expect(apexBasePayout(ANIMAL, 12_345)).toBe(12_345);
+    });
+
+    test('falls back to the animal range for a duel with no kill behind it', () => {
+        for (let i = 0; i < 50; i++) {
+            const base = apexBasePayout(ANIMAL, undefined);
+            expect(base).toBeGreaterThanOrEqual(ANIMAL.payoutMin);
+            expect(base).toBeLessThanOrEqual(ANIMAL.payoutMax);
+        }
+    });
+
+    test('ignores a kill payout that is not a usable number', () => {
+        // A zero or missing payout is a kill that paid nothing (hard-capped, say);
+        // pricing the duel at zero off it would silently delete the reward.
+        for (const bad of [0, -50, null, NaN, 'lots']) {
+            const base = apexBasePayout(ANIMAL, bad);
+            expect(base).toBeGreaterThanOrEqual(ANIMAL.payoutMin);
+            expect(base).toBeLessThanOrEqual(ANIMAL.payoutMax);
+        }
+    });
+});
+
+describe('the apex bonus scales off the kill', () => {
+    test('each outcome pays its share of the kill payout, not a fresh roll', () => {
+        const killPayout = 8_000; // far above the animal's own 100–2,000 band
+        expect(duel('CCC', { killPayout }).bonusPayout)
+            .toBe(Math.round(killPayout * APEX_OUTCOME_RATE.perfect));
+        expect(duel('CCS', { killPayout }).bonusPayout)
+            .toBe(Math.round(killPayout * APEX_OUTCOME_RATE.win));
+        expect(duel('CSS', { killPayout }).bonusPayout)
+            .toBe(Math.round(killPayout * APEX_OUTCOME_RATE.survived));
+        expect(duel('SSS', { killPayout }).bonusPayout)
+            .toBe(0); // no correct read at all — the apex escapes
+    });
+
+    test('a flawless duel out-earns the kill it grew out of', () => {
+        // The framing is "the climax". A perfect three-phase duel that risks the
+        // weapon must not pay less than the shot that preceded it.
+        const killPayout = 4_000;
+        expect(duel('CCC', { killPayout }).bonusPayout).toBeGreaterThan(killPayout);
+    });
+
+    test('two identical duels on identical kills pay identically', () => {
+        // The old re-roll made the same duel pay differently run to run for no
+        // reason a player could see.
+        const payouts = new Set();
+        for (let i = 0; i < 25; i++) {
+            payouts.add(duel('CCC', { killPayout: 3_333 }).bonusPayout);
+        }
+        expect(payouts.size).toBe(1);
+    });
+
+    test('a better kill produces a better apex bonus', () => {
+        const modest = duel('CCC', { killPayout: 1_000 }).bonusPayout;
+        const mythic = duel('CCC', { killPayout: 10_000 }).bonusPayout;
+        expect(mythic).toBeGreaterThan(modest * 9);
+    });
+
+    test('outcome tiers stay ordered against each other on one encounter', () => {
+        const killPayout = 5_000;
+        const perfect  = duel('CCC', { killPayout });
+        const win      = duel('CCS', { killPayout });
+        const survived = duel('CSS', { killPayout });
+        expect([perfect.outcome, win.outcome, survived.outcome])
+            .toEqual(['perfect', 'win', 'survived']);
+        expect(perfect.bonusPayout).toBeGreaterThan(win.bonusPayout);
+        expect(win.bonusPayout).toBeGreaterThan(survived.bonusPayout);
+    });
+});
+
+describe('the hunt hands the duel its kill payout', () => {
+    function hunter() {
+        const user = {
+            balance: 0,
+            streak: { current: 0 },
+            inventory: [],
+            markModified() {},
+        };
+        ensureHuntData(user);
+        Object.assign(user.hunt, {
+            level: 50,
+            stamina: 10,
+            unlockedZones: ['beginner_forest'],
+            activeZone: 'beginner_forest',
+            weapons: [{ tier: 5, currentDurability: 500, maxDurability: 500, baseDurability: 500, upgrade: null }],
+            equippedWeaponIndex: 0,
+        });
+        return user;
+    }
+
+    test('an apex encounter carries the kill payout the duel needs to price itself', () => {
+        // Force a success, and force the apex roll, by pinning Math.random low.
+        const realRandom = Math.random;
+        Math.random = () => 0.001;
+        try {
+            // Pin the encounter to a legendary so the apex slot is even in play;
+            // its 12% roll then always trips against a pinned-low random.
+            const encounter = { tier: 'legendary', animal: LEGENDARY_ANIMAL };
+            let found = null;
+            for (let i = 0; i < 40 && !found; i++) {
+                const user = hunter();
+                const result = executeHunt(user, 'beginner_forest', { encounter });
+                if (result.apexEncounter) found = result;
+            }
+            expect(found).not.toBeNull();
+            expect(found.apexEncounter.killPayout).toBe(found.payoutBeforeMods);
+            expect(found.apexEncounter.killPayout).toBeGreaterThan(0);
+        } finally {
+            Math.random = realRandom;
+        }
+    });
+
+    test('payoutBeforeMods carries the kill multipliers, not just the base roll', () => {
+        const user = hunter();
+        user.streak.current = 30; // a streak multiplier the apex used to ignore
+        const realRandom = Math.random;
+        Math.random = () => 0.001; // success, and a crit
+        try {
+            const result = executeHunt(user, 'beginner_forest', {
+                encounter: { tier: 'legendary', animal: LEGENDARY_ANIMAL },
+            });
+            expect(result.success).toBe(true);
+            expect(result.payoutBeforeMods).toBeGreaterThan(result.rawPayout);
+        } finally {
+            Math.random = realRandom;
+        }
+    });
+});

--- a/tests/huntWeaponLifetime.test.js
+++ b/tests/huntWeaponLifetime.test.js
@@ -1,0 +1,132 @@
+'use strict';
+
+// #747 — the shop told a hunter what a top-tier rifle costs at the till, and
+// what one repair costs, but never what owning one costs. A weapon is a
+// consumable: every shop repair permanently drops maxDurability by 10% of base,
+// so the sticker price is a down payment. These cover the projection that puts
+// the real number in front of the player, and the repairs-left count that says
+// when to stop paying into a worn weapon.
+
+const {
+    projectWeaponLifetime,
+    repairsRemaining,
+    applyRepair,
+    isCondemned,
+} = require('../src/services/huntService');
+const { WEAPON_TIERS, WEAPON_BY_TIER, LIMITS } = require('../src/data/huntData');
+
+const byTier = tier => WEAPON_TIERS.find(w => w.tier === tier);
+
+function freshWeapon(tier) {
+    const wd = WEAPON_BY_TIER[tier];
+    return {
+        tier,
+        baseDurability:    wd.baseDurability,
+        maxDurability:     wd.baseDurability,
+        currentDurability: wd.baseDurability,
+        repairCount:       0,
+        status:            'good',
+    };
+}
+
+describe('projectWeaponLifetime', () => {
+    it('walks a weapon out to condemnation and totals what it cost', () => {
+        const t12 = byTier(12);
+        const life = projectWeaponLifetime(t12);
+
+        // Nine repairs, not the "roughly eight" the shop copy used to assert:
+        // max durability falls by floor(base * 0.10) each time and condemnation
+        // trips below 20% of base, so the ninth repair is the one that ends it.
+        expect(life.repairs).toBe(9);
+        expect(life.maintenance).toBe(35_000_000);
+        expect(life.lifetimeCost).toBe(t12.cost + life.maintenance);
+        expect(life.lifetimeCost).toBe(55_000_000);
+    });
+
+    it('quotes a first repair that matches what the shop would actually charge', () => {
+        const t12 = byTier(12);
+        const { firstRepairCost } = projectWeaponLifetime(t12);
+        expect(firstRepairCost).toBe(Math.ceil(t12.baseDurability / 20) * t12.repairCostPer20);
+    });
+
+    it('makes maintenance the larger half of the bill at the top of the ladder', () => {
+        // This is the fact the issue is about: the 20M rifle is the cheap part.
+        const life = projectWeaponLifetime(byTier(12));
+        expect(life.maintenance).toBeGreaterThan(byTier(12).cost);
+    });
+
+    it('agrees with the repair mechanic rather than restating it', () => {
+        // Drive the real applyRepair the way the shop does and check the
+        // projection landed on the same totals. If the degradation rule, its
+        // floor or the condemnation threshold moves, both sides move together.
+        for (const wd of WEAPON_TIERS) {
+            const sim = freshWeapon(wd.tier);
+            sim.currentDurability = 0;
+            let repairs = 0, maintenance = 0;
+            while (repairs < 100) {
+                const r = applyRepair(sim, sim.maxDurability);
+                if (r.error) break;
+                repairs += 1;
+                maintenance += r.cost;
+                if (r.condemned) break;
+                sim.currentDurability = 0;
+            }
+            const life = projectWeaponLifetime(wd);
+            expect(life.repairs).toBe(repairs);
+            expect(life.maintenance).toBe(maintenance);
+            expect(isCondemned(sim)).toBe(true);
+        }
+    });
+
+    it('measures the real commitment in days of hunting, not the sticker price', () => {
+        // 250 days was the number the shop quoted. The honest one is closer to
+        // 700, and only the second one tells a hunter not to grind toward it.
+        const life = projectWeaponLifetime(byTier(12));
+        const stickerDays  = byTier(12).cost / LIMITS.DAILY_SOFT_CAP;
+        const lifetimeDays = life.lifetimeCost / LIMITS.DAILY_SOFT_CAP;
+        expect(Math.round(stickerDays)).toBe(250);
+        expect(lifetimeDays).toBeGreaterThan(2 * stickerDays);
+    });
+});
+
+describe('repairsRemaining', () => {
+    it('gives a fresh weapon its whole repair budget', () => {
+        for (const wd of WEAPON_TIERS) {
+            expect(repairsRemaining(freshWeapon(wd.tier))).toBe(projectWeaponLifetime(wd).repairs);
+        }
+    });
+
+    it('counts down as the weapon is worn', () => {
+        const weapon = freshWeapon(12);
+        let previous = repairsRemaining(weapon);
+        for (let i = 0; i < 9; i++) {
+            weapon.currentDurability = 0;
+            const result = applyRepair(weapon, weapon.maxDurability);
+            expect(result.error).toBeUndefined();
+            const left = repairsRemaining(weapon);
+            expect(left).toBe(previous - 1);
+            previous = left;
+            if (result.condemned) break;
+        }
+        expect(previous).toBe(0);
+    });
+
+    it('reports nothing left for a condemned weapon', () => {
+        const weapon = freshWeapon(12);
+        weapon.maxDurability = Math.floor(weapon.baseDurability * 0.10);
+        expect(isCondemned(weapon)).toBe(true);
+        expect(repairsRemaining(weapon)).toBe(0);
+    });
+
+    it('does not mutate the weapon it is asked about', () => {
+        const weapon = freshWeapon(12);
+        const before = { ...weapon };
+        repairsRemaining(weapon);
+        expect(weapon).toEqual(before);
+    });
+
+    it('returns zero for a weapon whose tier is not in the table', () => {
+        expect(repairsRemaining({ tier: 99, baseDurability: 100, maxDurability: 100 })).toBe(0);
+        expect(repairsRemaining(null)).toBe(0);
+    });
+});

--- a/tests/inventoryGrantCallSites.test.js
+++ b/tests/inventoryGrantCallSites.test.js
@@ -102,6 +102,74 @@ function collectCalls() {
     return calls;
 }
 
+/**
+ * How each file that uses the credit helpers brings them in.
+ *
+ * The sweep matches calls by name, which is only sound while a name in a source
+ * file means the imported helper and nothing else. Two shapes would break that
+ * silently — an aliased import (`const { grantInventoryItem: grant } = ...`,
+ * whose calls the sweep never sees) and a namespace import
+ * (`const inv = require(...); inv.grantInventoryItem(...)`, likewise) — and a
+ * third would make it lie the other way, a local function that happens to share
+ * a helper's name.
+ *
+ * Resolving bindings properly means a scope analyser in a test file. Refusing
+ * the shapes that would need one is the same guarantee for a fraction of the
+ * machinery: if someone writes an alias, this fails and says the sweep cannot
+ * see it, rather than the sweep quietly covering less than it claims.
+ */
+function importShapeProblems() {
+    const problems = [];
+    const IMPORT_PATH = /inventoryGrant/;
+
+    for (const file of sourceFiles(SRC)) {
+        if (file === PRIMITIVE) continue;
+        const code = fs.readFileSync(file, 'utf8');
+        if (!HELPERS.some(h => code.includes(h))) continue;
+        const rel = path.relative(SRC, file);
+        const ast = parse(code, { sourceType: 'unambiguous', plugins: ['classProperties'] });
+
+        walk(ast, node => {
+            // A local declaration shadowing a helper name would make the sweep
+            // report a call site that is not one.
+            if ((node.type === 'FunctionDeclaration' || node.type === 'ClassDeclaration')
+                && HELPERS.includes(node.id?.name)) {
+                problems.push(`${rel}:${node.loc?.start.line} declares its own ${node.id.name}`);
+            }
+
+            if (node.type !== 'VariableDeclarator') return;
+            const init = node.init;
+            const isHelperRequire = init?.type === 'CallExpression'
+                && init.callee.type === 'Identifier' && init.callee.name === 'require'
+                && init.arguments[0]?.type === 'StringLiteral'
+                && IMPORT_PATH.test(init.arguments[0].value);
+            if (!isHelperRequire) return;
+
+            if (node.id.type === 'Identifier') {
+                problems.push(`${rel}:${node.loc?.start.line} imports the module as a namespace (${node.id.name}); the sweep matches bare calls only`);
+                return;
+            }
+            if (node.id.type !== 'ObjectPattern') {
+                problems.push(`${rel}:${node.loc?.start.line} uses an import shape the sweep cannot follow`);
+                return;
+            }
+            for (const property of node.id.properties) {
+                if (property.type !== 'ObjectProperty') {
+                    problems.push(`${rel}:${node.loc?.start.line} uses a rest element in the import; the sweep matches bare calls only`);
+                    continue;
+                }
+                const imported = property.key.name;
+                const local    = property.value.type === 'Identifier' ? property.value.name : null;
+                if (!HELPERS.includes(imported)) continue;
+                if (local !== imported) {
+                    problems.push(`${rel}:${node.loc?.start.line} imports ${imported} as ${local ?? '<pattern>'}; the sweep would not see its calls`);
+                }
+            }
+        });
+    }
+    return problems;
+}
+
 const CALLS  = collectCalls();
 const GRANTS = CALLS.filter(c => c.name === 'grantInventoryItem');
 const where  = c => `${c.file}:${c.line}`;
@@ -174,13 +242,22 @@ function unguardedAccumulator(grants) {
     }).map(where);
 }
 
+// Parents that genuinely observe the promise. `VariableDeclarator` is NOT one:
+// `const p = grantInventoryItem(...)` with nothing downstream is as floating as
+// a bare call, and reads more like it was handled. A binding that IS handled is
+// written `const x = await grant(...)` or `const x = grant(...).catch(...)`,
+// both of which put an Await or a MemberExpression between the call and the
+// declarator — so dropping it costs nothing and keeps the check honest.
+const OBSERVING_PARENTS = [
+    'AwaitExpression',        // await grant(...)
+    'ReturnStatement',        // return grant(...)
+    'ArrowFunctionExpression', // const f = () => grant(...)
+    'MemberExpression',       // grant(...).catch(...) / .then(...)
+];
+
 /** A grant whose promise nobody awaits, returns or handles. */
 function floatingGrants(grants) {
-    return grants.filter(call => {
-        const parentType = call.parent?.type;
-        return !['AwaitExpression', 'ReturnStatement', 'ArrowFunctionExpression',
-                 'VariableDeclarator', 'MemberExpression'].includes(parentType);
-    }).map(where);
+    return grants.filter(call => !OBSERVING_PARENTS.includes(call.parent?.type)).map(where);
 }
 
 /** inventoryAddStages spread into an update *object* rather than a pipeline array. */
@@ -216,6 +293,14 @@ describe('the sweep is actually sweeping', () => {
         const areas = new Set(GRANTS.map(c => c.file.split(path.sep)[0]));
         expect(areas).toContain('commands');
         expect(areas).toContain('services');
+    });
+
+    it('sees every use, because nothing imports the helpers under another name', () => {
+        // The sweep matches calls by name. An alias or a namespace import would
+        // hide a call site from it entirely, and a local function of the same
+        // name would invent one. Refusing those shapes is what makes matching by
+        // name sound.
+        expect(importShapeProblems()).toEqual([]);
     });
 });
 
@@ -355,15 +440,21 @@ describe('each check can still fail', () => {
     });
 
     it('catches a grant nobody waits for', () => {
-        expect(floatingGrants(bad(
-            `async function f() { grantInventoryItem(u, g, 'x', 1); }`
-        ))).toHaveLength(1);
+        for (const floating of [
+            `async function f() { grantInventoryItem(u, g, 'x', 1); }`,
+            // Bound to a name and then dropped. This reads as handled and is not:
+            // the rejection is still unobserved.
+            `const p = grantInventoryItem(u, g, 'x', 1);`,
+        ]) {
+            expect(floatingGrants(bad(floating))).toHaveLength(1);
+        }
         for (const handled of [
             `async function f() { await grantInventoryItem(u, g, 'x', 1); }`,
             `async function f() { return grantInventoryItem(u, g, 'x', 1); }`,
             `const f = () => grantInventoryItem(u, g, 'x', 1);`,
-            `const p = grantInventoryItem(u, g, 'x', 1);`,
+            `async function f() { const x = await grantInventoryItem(u, g, 'x', 1); }`,
             `grantInventoryItem(u, g, 'x', 1).catch(() => null);`,
+            `const p = grantInventoryItem(u, g, 'x', 1).catch(() => null);`,
         ]) {
             expect(floatingGrants(bad(handled))).toEqual([]);
         }

--- a/tests/inventoryGrantCallSites.test.js
+++ b/tests/inventoryGrantCallSites.test.js
@@ -1,0 +1,380 @@
+'use strict';
+
+// Every caller of the inventory credit primitive, checked at the call site.
+//
+// tests/inventoryGrant.test.js covers `grantInventoryItem` and
+// `inventoryAddExpr` themselves — the fold, the duplicate-slot handling, the
+// `$ifNull` on a legacy quantity. It imports the util and nothing else, so no
+// call site is loaded by it, and a caller that spells the contract wrong is
+// invisible to it. That is the gap #736 is about, and the primitive is subtle
+// enough that a bug once survived in it *and* in its own test.
+//
+// The contract is "every caller must spell this correctly", the branches are
+// hard to drive (most of these are seasonal commands, boss drops and market
+// flows), and there are 18 of them across 15 files — so this is a static sweep
+// rather than a behavioural test, the same shape as
+// tests/balanceDebitGuard.test.js.
+//
+// What a call-site bug costs, in order of how quietly it does it:
+//
+//   - Swapped userId/guildId credits nobody's inventory and returns null; the
+//     item is simply gone, and only a caller that checks the return value
+//     notices.
+//   - A negative or zero quantity turns a credit into an unguarded debit. This
+//     primitive has no `$gte` guard — it cannot have one, since the slot may
+//     not exist — so a negative quantity drives the count below zero.
+//   - An update operator inside `extraSet` is the silent one. `extraSet` fields
+//     are *aggregation* expressions spliced into a pipeline `$set`, so
+//     `{ $addToSet: ... }` there is not the update operator of the same name;
+//     it is read as an accumulator and writes something else entirely.
+//   - A floating promise loses the item on a failed write and can take the
+//     process down with an unhandled rejection.
+
+const fs   = require('fs');
+const path = require('path');
+// Ships with jest (jest → babel-jest → @babel/core → @babel/parser).
+const { parse } = require('@babel/parser');
+
+const SRC = path.join(__dirname, '..', 'src');
+const PRIMITIVE = path.join(SRC, 'utils', 'inventoryGrant.js');
+
+function sourceFiles(dir) {
+    return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) return sourceFiles(full);
+        return entry.name.endsWith('.js') ? [full] : [];
+    });
+}
+
+function walk(node, visit, parent = null) {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) return node.forEach(n => walk(n, visit, parent));
+    if (typeof node.type === 'string') visit(node, parent);
+    for (const key of Object.keys(node)) {
+        if (key === 'loc' || key === 'leadingComments' || key === 'trailingComments') continue;
+        walk(node[key], visit, typeof node.type === 'string' ? node : parent);
+    }
+}
+
+function isKey(node, name) {
+    return node.type === 'ObjectProperty' &&
+        ((node.key.type === 'Identifier' && !node.computed && node.key.name === name) ||
+         (node.key.type === 'StringLiteral' && node.key.value === name));
+}
+
+function prop(objectNode, name) {
+    if (objectNode?.type !== 'ObjectExpression') return null;
+    return objectNode.properties.find(p => isKey(p, name)) ?? null;
+}
+
+const HELPERS = ['grantInventoryItem', 'inventoryAddExpr', 'inventoryAddStages'];
+
+/**
+ * Every call to one of the credit helpers in one source, with its arguments,
+ * the source text and the parent node — the last so a floating promise can be
+ * told from an awaited or returned one.
+ *
+ * Takes the code rather than reading it, so the same extraction runs against
+ * the synthetic call sites the negative controls at the bottom of this file
+ * use to prove each check can actually fail.
+ */
+function callsInCode(code, file) {
+    const calls = [];
+    const ast = parse(code, { sourceType: 'unambiguous', plugins: ['classProperties'] });
+    walk(ast, (node, parent) => {
+        if (node.type !== 'CallExpression') return;
+        const callee = node.callee;
+        const name = callee.type === 'Identifier' ? callee.name : null;
+        if (!HELPERS.includes(name)) return;
+        calls.push({ name, file, line: node.loc?.start.line, args: node.arguments, node, parent, code });
+    });
+    return calls;
+}
+
+function collectCalls() {
+    const calls = [];
+    for (const file of sourceFiles(SRC)) {
+        if (file === PRIMITIVE) continue; // the primitive's own internal use
+        const code = fs.readFileSync(file, 'utf8');
+        if (!HELPERS.some(h => code.includes(h))) continue;
+        calls.push(...callsInCode(code, path.relative(SRC, file)));
+    }
+    return calls;
+}
+
+const CALLS  = collectCalls();
+const GRANTS = CALLS.filter(c => c.name === 'grantInventoryItem');
+const where  = c => `${c.file}:${c.line}`;
+const text   = (c, node) => c.code.slice(node.start, node.end);
+
+// ─── The checks ──────────────────────────────────────────────────────────────
+//
+// Each returns the offending call sites. Named and exported to the tests below
+// so the same predicate runs against the real tree and against the synthetic
+// bad call sites at the bottom — a static sweep that cannot be shown to fail is
+// indistinguishable from one that isn't running.
+
+const UPDATE_OPERATORS = ['$addToSet', '$push', '$inc', '$pull', '$pop', '$unset', '$pullAll', '$setOnInsert'];
+const ACCUMULATORS = /\$add|\$concatArrays|\$setUnion|\$subtract|\$max|\$min/;
+
+/** (userId, guildId, ...) passed the other way round. */
+function swappedIds(grants) {
+    return grants.filter(c => {
+        if (c.args.length < 2) return false;
+        const first  = text(c, c.args[0]);
+        const second = text(c, c.args[1]);
+        return /guild/i.test(first) && /user|seller|buyer|member/i.test(second);
+    }).map(where);
+}
+
+/** Fewer than the user, guild and item the primitive needs. */
+function tooFewArgs(grants) {
+    return grants.filter(c => c.args.length < 3).map(where);
+}
+
+/** A spread in the positional ids defeats every other check here. */
+function spreadArgs(grants) {
+    return grants.filter(c => c.args.some(a => a.type === 'SpreadElement')).map(where);
+}
+
+/** A quantity that is not a positive whole count. */
+function badQuantity(grants) {
+    return grants.filter(c => {
+        const qty = c.args[3];
+        if (!qty) return false; // defaults to 1
+        if (qty.type === 'NumericLiteral') return qty.value <= 0 || !Number.isInteger(qty.value);
+        if (qty.type === 'UnaryExpression' && qty.operator === '-') return true;
+        return false;
+    }).map(where);
+}
+
+/** An update operator where an aggregation expression belongs. */
+function updateOperatorInExtraSet(grants) {
+    const offenders = [];
+    for (const call of grants) {
+        const extra = prop(call.args[4], 'extraSet');
+        if (!extra) continue;
+        walk(extra.value, node => {
+            for (const op of UPDATE_OPERATORS) {
+                if (isKey(node, op)) offenders.push(`${where(call)} → ${op}`);
+            }
+        });
+    }
+    return offenders;
+}
+
+/** An accumulating extraSet expression that reads a field without $ifNull. */
+function unguardedAccumulator(grants) {
+    return grants.filter(call => {
+        const extra = prop(call.args[4], 'extraSet');
+        if (!extra) return false;
+        const src = text(call, extra.value);
+        if (!ACCUMULATORS.test(src)) return false;
+        return !src.includes('$ifNull');
+    }).map(where);
+}
+
+/** A grant whose promise nobody awaits, returns or handles. */
+function floatingGrants(grants) {
+    return grants.filter(call => {
+        const parentType = call.parent?.type;
+        return !['AwaitExpression', 'ReturnStatement', 'ArrowFunctionExpression',
+                 'VariableDeclarator', 'MemberExpression'].includes(parentType);
+    }).map(where);
+}
+
+/** inventoryAddStages spread into an update *object* rather than a pipeline array. */
+function stagesSpreadIntoObject(code, file) {
+    const found = [];
+    const ast = parse(code, { sourceType: 'unambiguous', plugins: ['classProperties'] });
+    walk(ast, node => {
+        if (node.type !== 'ObjectExpression') return;
+        for (const property of node.properties) {
+            if (property.type !== 'SpreadElement') continue;
+            const arg = property.argument;
+            if (arg?.type === 'CallExpression'
+                && arg.callee.type === 'Identifier'
+                && arg.callee.name === 'inventoryAddStages') {
+                found.push(`${file}:${property.loc?.start.line}`);
+            }
+        }
+    });
+    return found;
+}
+
+// ─── The real tree ───────────────────────────────────────────────────────────
+
+describe('the sweep is actually sweeping', () => {
+    it('finds the call sites it claims to check', () => {
+        // A refactor that renames the helper, or a parse that silently returns
+        // nothing, must fail here rather than pass by finding zero problems.
+        expect(GRANTS.length).toBeGreaterThanOrEqual(15);
+        expect(new Set(GRANTS.map(c => c.file)).size).toBeGreaterThanOrEqual(12);
+    });
+
+    it('covers services and commands alike, not just one folder', () => {
+        const areas = new Set(GRANTS.map(c => c.file.split(path.sep)[0]));
+        expect(areas).toContain('commands');
+        expect(areas).toContain('services');
+    });
+});
+
+describe('every credit names the right user in the right order', () => {
+    it('passes userId then guildId then itemId', () => {
+        // The signature is (userId, guildId, itemId, quantity). Swapping the
+        // first two matches no document, credits nobody, and returns null —
+        // which most call sites do not check.
+        expect(swappedIds(GRANTS)).toEqual([]);
+    });
+
+    it('gives every credit a user, a guild and an item', () => {
+        expect(tooFewArgs(GRANTS)).toEqual([]);
+    });
+
+    it('never passes a spread where the primitive expects positional ids', () => {
+        expect(spreadArgs(GRANTS)).toEqual([]);
+    });
+});
+
+describe('a credit is a credit', () => {
+    it('never passes a quantity that is not a positive count', () => {
+        // The primitive has no `$gte` guard and cannot have one — the slot may
+        // not exist yet — so a negative quantity drives the count below zero
+        // with nothing to stop it. Item removals go through their own guarded
+        // update, not through here.
+        expect(badQuantity(GRANTS)).toEqual([]);
+    });
+});
+
+describe('extraSet carries aggregation expressions, not update operators', () => {
+    it('uses no update operator inside an extraSet value', () => {
+        // The one that fails silently. `extraSet` is spliced into a pipeline
+        // `$set`, where `$addToSet`, `$inc` and `$push` are not the update
+        // operators of the same name. The primitive's docstring spells the
+        // correct form out (`{ $setUnion: [{ $ifNull: ['$path', []] }, [v]] }`).
+        expect(updateOperatorInExtraSet(GRANTS)).toEqual([]);
+    });
+
+    it('reads the field it accumulates onto with $ifNull', () => {
+        // A pipeline expression that reads `$xp` on a document without one gets
+        // null, and `$add` on null is null — which writes the field away rather
+        // than leaving it alone.
+        expect(unguardedAccumulator(GRANTS)).toEqual([]);
+    });
+});
+
+describe('no credit is left floating', () => {
+    it('awaits, returns, or explicitly handles every grant', () => {
+        // An unhandled rejection here loses the item silently and can take the
+        // process with it.
+        expect(floatingGrants(GRANTS)).toEqual([]);
+    });
+});
+
+describe('inventoryAddStages is used as a pipeline', () => {
+    it('is passed as an update argument, never spread into an operator object', () => {
+        // Spread into a pipeline array (`[...inventoryAddStages(items), { $set }]`)
+        // is exactly right — src/utils/starterKit.js does it to fold the kit's
+        // coins into the same atomic write. Spread into an ordinary *update
+        // object* it produces `{ 0: {...}, 1: {...} }`, which is not an update.
+        const misused = [];
+        for (const file of new Set(CALLS.filter(c => c.name === 'inventoryAddStages').map(c => c.file))) {
+            misused.push(...stagesSpreadIntoObject(fs.readFileSync(path.join(SRC, file), 'utf8'), file));
+        }
+        expect(misused).toEqual([]);
+    });
+
+    it('is given one object per item, each carrying an itemId', () => {
+        const bad = CALLS
+            .filter(c => c.name === 'inventoryAddStages')
+            .filter(c => {
+                const arg = c.args[0];
+                if (arg?.type !== 'ArrayExpression') return false; // computed elsewhere
+                return arg.elements.some(el => el?.type === 'ObjectExpression' && !prop(el, 'itemId'));
+            })
+            .map(where);
+        expect(bad).toEqual([]);
+    });
+});
+
+// ─── Negative controls ───────────────────────────────────────────────────────
+//
+// Every check above passes today, which is only reassuring if each one can
+// still fail. These run the same predicates against call sites written the
+// wrong way: a check that stops detecting its own bug goes green here first.
+
+describe('each check can still fail', () => {
+    const bad = code => callsInCode(code, 'synthetic.js').filter(c => c.name === 'grantInventoryItem');
+
+    it('catches swapped ids', () => {
+        expect(swappedIds(bad(
+            `await grantInventoryItem(interaction.guild.id, interaction.user.id, 'relic', 1);`
+        ))).toHaveLength(1);
+    });
+
+    it('catches a call that forgot the item', () => {
+        expect(tooFewArgs(bad(
+            `await grantInventoryItem(userId, guildId);`
+        ))).toHaveLength(1);
+    });
+
+    it('catches a spread that hides the arguments', () => {
+        expect(spreadArgs(bad(
+            `await grantInventoryItem(...args);`
+        ))).toHaveLength(1);
+    });
+
+    it('catches a negative, zero and fractional quantity', () => {
+        expect(badQuantity(bad(`await grantInventoryItem(u, g, 'x', -1);`))).toHaveLength(1);
+        expect(badQuantity(bad(`await grantInventoryItem(u, g, 'x', 0);`))).toHaveLength(1);
+        expect(badQuantity(bad(`await grantInventoryItem(u, g, 'x', 1.5);`))).toHaveLength(1);
+        expect(badQuantity(bad(`await grantInventoryItem(u, g, 'x', qty);`))).toEqual([]);
+        expect(badQuantity(bad(`await grantInventoryItem(u, g, 'x');`))).toEqual([]);
+    });
+
+    it('catches an update operator smuggled into extraSet', () => {
+        expect(updateOperatorInExtraSet(bad(
+            `await grantInventoryItem(u, g, 'x', 1, { extraSet: { tags: { $addToSet: 'a' } } });`
+        ))).toHaveLength(1);
+        expect(updateOperatorInExtraSet(bad(
+            `await grantInventoryItem(u, g, 'x', 1, { extraSet: { tags: { $setUnion: [{ $ifNull: ['$tags', []] }, ['a']] } } });`
+        ))).toEqual([]);
+    });
+
+    it('catches an accumulator that would null out the field it reads', () => {
+        expect(unguardedAccumulator(bad(
+            `await grantInventoryItem(u, g, 'x', 1, { extraSet: { xp: { $add: ['$xp', 5] } } });`
+        ))).toHaveLength(1);
+        expect(unguardedAccumulator(bad(
+            `await grantInventoryItem(u, g, 'x', 1, { extraSet: { xp: { $add: [{ $ifNull: ['$xp', 0] }, 5] } } });`
+        ))).toEqual([]);
+        // A plain literal assignment reads nothing and needs no guard.
+        expect(unguardedAccumulator(bad(
+            `await grantInventoryItem(u, g, 'x', 1, { extraSet: { claimed: true } });`
+        ))).toEqual([]);
+    });
+
+    it('catches a grant nobody waits for', () => {
+        expect(floatingGrants(bad(
+            `async function f() { grantInventoryItem(u, g, 'x', 1); }`
+        ))).toHaveLength(1);
+        for (const handled of [
+            `async function f() { await grantInventoryItem(u, g, 'x', 1); }`,
+            `async function f() { return grantInventoryItem(u, g, 'x', 1); }`,
+            `const f = () => grantInventoryItem(u, g, 'x', 1);`,
+            `const p = grantInventoryItem(u, g, 'x', 1);`,
+            `grantInventoryItem(u, g, 'x', 1).catch(() => null);`,
+        ]) {
+            expect(floatingGrants(bad(handled))).toEqual([]);
+        }
+    });
+
+    it('catches stages spread into an update object but not into a pipeline', () => {
+        expect(stagesSpreadIntoObject(
+            `User.updateOne(f, { ...inventoryAddStages(items), $set: { a: 1 } });`, 'synthetic.js'
+        )).toHaveLength(1);
+        expect(stagesSpreadIntoObject(
+            `User.updateOne(f, [...inventoryAddStages(items), { $set: { a: 1 } }]);`, 'synthetic.js'
+        )).toEqual([]);
+    });
+});

--- a/tests/migrationShardWait.test.js
+++ b/tests/migrationShardWait.test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+// Under sharding only shard 0 runs migrations (#732). The other shards must not
+// run their own — concurrent runs of the same migration is a different failure
+// every time — and must not start serving traffic against a half-migrated
+// database either. So they wait for the records shard 0 writes, and these cover
+// the waiting.
+
+const fs   = require('fs');
+const os   = require('os');
+const path = require('path');
+
+const records = [];
+jest.mock('../src/models/MigrationRecord', () => ({
+    find: (filter = {}) => ({
+        lean: async () => {
+            const wanted = filter?.name?.$in;
+            return records
+                .filter(r => !wanted || wanted.includes(r.name))
+                .map(r => ({ name: r.name }));
+        },
+    }),
+    create: async doc => { records.push(doc); return doc; },
+}));
+
+const { pendingMigrationNames, waitForMigrations } = require('../src/migrations/runner');
+
+let dir;
+
+function writeMigration(file, name) {
+    fs.writeFileSync(path.join(dir, file), `module.exports = { name: ${JSON.stringify(name)}, up: async () => {}, down: async () => {} };\n`);
+}
+
+beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'migration-wait-'));
+    records.length = 0;
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+    fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('pendingMigrationNames', () => {
+    it('reports what is on disk but not yet recorded', async () => {
+        writeMigration('001_a.js', '001_a');
+        writeMigration('002_b.js', '002_b');
+        expect(await pendingMigrationNames({ dir })).toEqual(['001_a', '002_b']);
+
+        records.push({ name: '001_a' });
+        expect(await pendingMigrationNames({ dir })).toEqual(['002_b']);
+
+        records.push({ name: '002_b' });
+        expect(await pendingMigrationNames({ dir })).toEqual([]);
+    });
+
+    it('reports nothing when there are no migrations to run', async () => {
+        expect(await pendingMigrationNames({ dir })).toEqual([]);
+    });
+
+    it('ignores a record for a migration that is not on this disk', async () => {
+        // A rolled-back deploy can leave records for files this build does not
+        // carry; that is not something to wait for.
+        writeMigration('001_a.js', '001_a');
+        records.push({ name: '001_a' }, { name: '999_from_the_future' });
+        expect(await pendingMigrationNames({ dir })).toEqual([]);
+    });
+});
+
+describe('waitForMigrations', () => {
+    it('returns immediately when everything is already applied', async () => {
+        writeMigration('001_a.js', '001_a');
+        records.push({ name: '001_a' });
+        await expect(waitForMigrations({ dir, timeoutMs: 50, pollMs: 5 })).resolves.toBe(true);
+    });
+
+    it('waits, and returns true once the primary shard records the migration', async () => {
+        writeMigration('001_a.js', '001_a');
+        // Stands in for shard 0 finishing partway through the wait.
+        setTimeout(() => records.push({ name: '001_a' }), 20);
+        await expect(waitForMigrations({ dir, timeoutMs: 2_000, pollMs: 5 })).resolves.toBe(true);
+    });
+
+    it('gives up rather than blocking a boot forever', async () => {
+        // A migration that never lands is an operator problem, and a shard stuck
+        // silently in a poll loop is a worse way to find out about it.
+        writeMigration('001_a.js', '001_a');
+        await expect(waitForMigrations({ dir, timeoutMs: 40, pollMs: 5 })).resolves.toBe(false);
+        expect(console.error).toHaveBeenCalled();
+    });
+
+    it('reports failure rather than looping when the database cannot be read', async () => {
+        writeMigration('001_a.js', '001_a');
+        const MigrationRecord = require('../src/models/MigrationRecord');
+        const original = MigrationRecord.find;
+        MigrationRecord.find = () => ({ lean: async () => { throw new Error('no connection'); } });
+        try {
+            await expect(waitForMigrations({ dir, timeoutMs: 5_000, pollMs: 5 })).resolves.toBe(false);
+        } finally {
+            MigrationRecord.find = original;
+        }
+    });
+});

--- a/tests/migrationShardWait.test.js
+++ b/tests/migrationShardWait.test.js
@@ -23,12 +23,20 @@ jest.mock('../src/models/MigrationRecord', () => ({
     create: async doc => { records.push(doc); return doc; },
 }));
 
-const { pendingMigrationNames, waitForMigrations } = require('../src/migrations/runner');
+const { pendingMigrationNames, waitForMigrations, isRecordableMigration } = require('../src/migrations/runner');
 
 let dir;
 
-function writeMigration(file, name) {
-    fs.writeFileSync(path.join(dir, file), `module.exports = { name: ${JSON.stringify(name)}, up: async () => {}, down: async () => {} };\n`);
+function writeMigration(file, name, extra = '') {
+    fs.writeFileSync(
+        path.join(dir, file),
+        `module.exports = { name: ${JSON.stringify(name)}, up: async () => {}, down: async () => {}${extra} };\n`
+    );
+}
+
+/** A file the runner skips outright: it never runs, so it is never recorded. */
+function writeMalformedMigration(file, body) {
+    fs.writeFileSync(path.join(dir, file), `module.exports = ${body};\n`);
 }
 
 beforeEach(() => {
@@ -57,6 +65,33 @@ describe('pendingMigrationNames', () => {
     });
 
     it('reports nothing when there are no migrations to run', async () => {
+        expect(await pendingMigrationNames({ dir })).toEqual([]);
+    });
+
+    // ── What runMigrations will never record ─────────────────────────────────
+    //
+    // Both of these strand a non-primary shard: shard 0 boots fine, every other
+    // shard waits the full timeout for a record that is never coming and then
+    // refuses to start. The filter here has to agree with runMigrations' own.
+
+    it('does not wait on a file that does not export a name and an up()', async () => {
+        writeMigration('001_a.js', '001_a');
+        writeMalformedMigration('002_no_up.js', '{ name: "002_no_up" }');
+        writeMalformedMigration('003_no_name.js', '{ up: async () => {} }');
+        records.push({ name: '001_a' });
+
+        // runMigrations skips both with a warning and records neither.
+        expect(await pendingMigrationNames({ dir })).toEqual([]);
+    });
+
+    it('does not wait on an optional migration', async () => {
+        // An optional migration that fails is deliberately left unrecorded so
+        // the next boot retries it. The bot is merely faster with one applied —
+        // not a thing another shard should refuse to start over.
+        writeMigration('001_a.js', '001_a');
+        writeMigration('002_index.js', '002_index', ', optional: true');
+        records.push({ name: '001_a' });
+
         expect(await pendingMigrationNames({ dir })).toEqual([]);
     });
 
@@ -91,6 +126,19 @@ describe('waitForMigrations', () => {
         expect(console.error).toHaveBeenCalled();
     });
 
+    it('does not strand a shard behind a migration that will never be recorded', async () => {
+        // The end-to-end shape of the two cases above: shard 0 boots
+        // successfully, and every other shard must boot too rather than sitting
+        // out its timeout and exiting.
+        writeMigration('001_a.js', '001_a');
+        writeMalformedMigration('002_no_up.js', '{ name: "002_no_up" }');
+        writeMigration('003_index.js', '003_index', ', optional: true');
+        records.push({ name: '001_a' });
+
+        await expect(waitForMigrations({ dir, timeoutMs: 40, pollMs: 5 })).resolves.toBe(true);
+        expect(console.error).not.toHaveBeenCalled();
+    });
+
     it('reports failure rather than looping when the database cannot be read', async () => {
         writeMigration('001_a.js', '001_a');
         const MigrationRecord = require('../src/models/MigrationRecord');
@@ -101,5 +149,20 @@ describe('waitForMigrations', () => {
         } finally {
             MigrationRecord.find = original;
         }
+    });
+});
+
+describe('isRecordableMigration agrees with what runMigrations records', () => {
+    it('accepts a migration that will run and be recorded', () => {
+        expect(isRecordableMigration({ name: 'a', up: async () => {} })).toBe(true);
+    });
+
+    it('rejects the shapes runMigrations runs without recording', () => {
+        expect(isRecordableMigration({ name: 'a' })).toBe(false);                                  // no up()
+        expect(isRecordableMigration({ up: async () => {} })).toBe(false);                          // no name
+        expect(isRecordableMigration({ name: '', up: async () => {} })).toBe(false);                // empty name
+        expect(isRecordableMigration({ name: 'a', up: async () => {}, optional: true })).toBe(false);
+        expect(isRecordableMigration(null)).toBe(false);
+        expect(isRecordableMigration(undefined)).toBe(false);
     });
 });

--- a/tests/sharding.test.js
+++ b/tests/sharding.test.js
@@ -1,0 +1,281 @@
+'use strict';
+
+// Guild-to-shard affinity, and the singleton gate (#732).
+//
+// #609 moved every piece of money-adjacent state into Mongo and left four live
+// multiplayer rounds behind — crash lobbies, heist and syndicate heist
+// sessions, and the raid join window — because a lobby is an object graph of
+// timers and collectors, not a value. #732 asked whether that is safe under
+// sharding, and the answer turns entirely on whether a guild is guaranteed to
+// be handled by exactly one shard.
+//
+// It is, by Discord's own gateway routing. These tests hold that claim to the
+// formula, hold the four stores to being keyed by something a guild determines,
+// and hold the singleton gate to shard 0 — because the failure mode on the
+// other side of that gate is every cron job firing once per shard, which for
+// applyBankInterest means paying every account N times.
+
+const fs   = require('fs');
+const path = require('path');
+
+const {
+    shardIdForGuild,
+    shardCount,
+    shardId,
+    isPrimaryShard,
+    ownsGuild,
+    assertGuildAffinity,
+    shardTag,
+} = require('../src/utils/sharding');
+
+// Real-shaped snowflakes: a Discord id is a 64-bit integer whose top 42 bits are
+// a millisecond timestamp, which is exactly the part the routing formula reads.
+const SNOWFLAKES = [
+    '81384788765712384',
+    '222078108977594368',
+    '613425648685547541',
+    '1234567890123456789',
+    '900000000000000000',
+    '1099511627776',
+];
+
+const fakeClient = (id, count) => ({ shard: { ids: [id], count } });
+
+afterEach(() => {
+    delete process.env.SHARD_COUNT;
+    delete process.env.SHARD_ID;
+});
+
+describe('the routing formula', () => {
+    it('is Discord\'s own: (guildId >> 22) % shardCount', () => {
+        for (const guildId of SNOWFLAKES) {
+            for (const count of [1, 2, 3, 4, 8, 16]) {
+                const expected = Number((BigInt(guildId) >> 22n) % BigInt(count));
+                expect(shardIdForGuild(guildId, count)).toBe(expected);
+            }
+        }
+    });
+
+    it('computes in BigInt, because a snowflake does not fit in a double', () => {
+        // The bug this exists to prevent: routing through a float rounds the low
+        // bits away and lands on the wrong shard for a fraction of guilds —
+        // rarely enough to ship, and impossible to reproduce from a bug report.
+        // These two ids are ones where the float form really does diverge.
+        for (const guildId of ['1000000000190578654', '1000000001067188197']) {
+            expect(Number.isSafeInteger(Number(guildId))).toBe(false);
+            const naive = Math.floor(Number(guildId) / 2 ** 22) % 4;
+            const correct = shardIdForGuild(guildId, 4);
+            expect(correct).toBe(Number((BigInt(guildId) >> 22n) % 4n));
+            expect(naive).not.toBe(correct);
+        }
+    });
+
+    it('always lands inside the shard range', () => {
+        for (const guildId of SNOWFLAKES) {
+            for (const count of [1, 2, 3, 5, 7, 16, 64]) {
+                const id = shardIdForGuild(guildId, count);
+                expect(Number.isInteger(id)).toBe(true);
+                expect(id).toBeGreaterThanOrEqual(0);
+                expect(id).toBeLessThan(count);
+            }
+        }
+    });
+
+    it('is stable: the same guild always routes to the same shard', () => {
+        for (const guildId of SNOWFLAKES) {
+            const first = shardIdForGuild(guildId, 8);
+            for (let i = 0; i < 20; i++) expect(shardIdForGuild(guildId, 8)).toBe(first);
+        }
+    });
+
+    it('puts everything on shard 0 when there is one shard', () => {
+        for (const guildId of SNOWFLAKES) expect(shardIdForGuild(guildId, 1)).toBe(0);
+    });
+
+    it('refuses a shard count or a guild id it cannot route with', () => {
+        expect(() => shardIdForGuild(SNOWFLAKES[0], 0)).toThrow(TypeError);
+        expect(() => shardIdForGuild(SNOWFLAKES[0], -1)).toThrow(TypeError);
+        expect(() => shardIdForGuild(SNOWFLAKES[0], 2.5)).toThrow(TypeError);
+        expect(() => shardIdForGuild('not-a-snowflake', 4)).toThrow(TypeError);
+    });
+});
+
+describe('shard identity', () => {
+    it('reads the client first, then the environment, then falls back to unsharded', () => {
+        expect(shardCount(fakeClient(2, 8))).toBe(8);
+        expect(shardId(fakeClient(2, 8))).toBe(2);
+
+        process.env.SHARD_COUNT = '4';
+        process.env.SHARD_ID = '3';
+        expect(shardCount()).toBe(4);
+        expect(shardId()).toBe(3);
+
+        delete process.env.SHARD_COUNT;
+        delete process.env.SHARD_ID;
+        expect(shardCount()).toBe(1);
+        expect(shardId()).toBe(0);
+    });
+
+    it('ignores a malformed environment rather than spawning NaN shards', () => {
+        for (const bad of ['', 'auto', '0', '-2', '1.5']) {
+            process.env.SHARD_COUNT = bad;
+            expect(shardCount()).toBe(1);
+        }
+    });
+});
+
+describe('the singleton gate', () => {
+    it('is true unsharded, so nothing changes for a single-process deployment', () => {
+        expect(isPrimaryShard()).toBe(true);
+        expect(shardTag()).toBe('');
+    });
+
+    it('is true on exactly one shard when sharded', () => {
+        const primaries = [0, 1, 2, 3, 4, 5, 6, 7].filter(id => isPrimaryShard(fakeClient(id, 8)));
+        expect(primaries).toEqual([0]);
+    });
+
+    it('tags log lines only when there is more than one process to tell apart', () => {
+        expect(shardTag(fakeClient(0, 1))).toBe('');
+        expect(shardTag(fakeClient(3, 8))).toBe('[shard 3/8] ');
+    });
+});
+
+describe('ownership partitions every guild exactly once', () => {
+    it('assigns each guild to one shard and no other', () => {
+        const count = 8;
+        for (const guildId of SNOWFLAKES) {
+            const owners = [];
+            for (let id = 0; id < count; id++) {
+                if (ownsGuild(guildId, fakeClient(id, count))) owners.push(id);
+            }
+            expect(owners).toHaveLength(1);
+        }
+    });
+
+    it('claims everything when unsharded', () => {
+        for (const guildId of SNOWFLAKES) expect(ownsGuild(guildId)).toBe(true);
+    });
+
+    it('does not claim a guild it cannot route, and does not throw doing it', () => {
+        expect(ownsGuild('not-a-snowflake', fakeClient(1, 4))).toBe(false);
+    });
+});
+
+describe('the affinity assertion', () => {
+    it('passes silently for a guild this shard owns', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const guildId = SNOWFLAKES[0];
+        const owner = shardIdForGuild(guildId, 4);
+        expect(assertGuildAffinity(guildId, 'test', fakeClient(owner, 4))).toBe(true);
+        expect(warn).not.toHaveBeenCalled();
+        warn.mockRestore();
+    });
+
+    it('warns rather than throws when affinity is violated', () => {
+        // A mid-round throw would strand players in a lobby whose stakes are
+        // already debited, which is worse than the duplicate being warned about.
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const guildId = SNOWFLAKES[0];
+        const owner = shardIdForGuild(guildId, 4);
+        const wrong = (owner + 1) % 4;
+        expect(() => assertGuildAffinity(guildId, 'crash lobby', fakeClient(wrong, 4))).not.toThrow();
+        expect(assertGuildAffinity(guildId, 'crash lobby', fakeClient(wrong, 4))).toBe(false);
+        expect(warn).toHaveBeenCalled();
+        expect(String(warn.mock.calls[0][0])).toContain('crash lobby');
+        warn.mockRestore();
+    });
+
+    it('never fires unsharded', () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        for (const guildId of SNOWFLAKES) expect(assertGuildAffinity(guildId, 'test')).toBe(true);
+        expect(warn).not.toHaveBeenCalled();
+        warn.mockRestore();
+    });
+});
+
+describe('the four process-bound session stores are covered by affinity', () => {
+    const read = rel => fs.readFileSync(path.join(__dirname, '..', 'src', rel), 'utf8');
+
+    // Each of these holds a live round in a Map. That is only correct while one
+    // process sees all of one guild's events, so each one says so at the point
+    // it makes the assumption.
+    const STORES = [
+        ['utils/crashLobby.js',          'crash lobby'],
+        ['services/heistService.js',     'heist lobby'],
+        ['services/syndicateService.js', 'syndicate heist lobby'],
+        ['services/raidService.js',      'raid join window'],
+    ];
+
+    it.each(STORES)('%s asserts affinity when it opens a round', (rel, label) => {
+        const code = read(rel);
+        expect(code).toContain('assertGuildAffinity');
+        expect(code).toContain(label);
+    });
+
+    it('keys every store by something one guild determines', () => {
+        // heist, syndicate and raid are keyed by guildId outright; crash is
+        // keyed by channelId, and a channel belongs to exactly one guild — which
+        // is why it carries the guild id along purely for this check.
+        expect(read('services/heistService.js')).toContain('activeHeists.set(guildId,');
+        expect(read('services/syndicateService.js')).toContain('activeSyndicateHeists.set(guildId,');
+        expect(read('services/raidService.js')).toContain('joinLog.set(guildId,');
+        expect(read('utils/crashLobby.js')).toContain('lobbies.set(channelId,');
+    });
+});
+
+describe('singleton work is gated, not merely documented', () => {
+    const read = rel => fs.readFileSync(path.join(__dirname, '..', 'src', rel), 'utf8');
+
+    it('starts the dashboard only on the primary shard', () => {
+        // N processes binding one TCP port is the first thing that breaks.
+        const code = read('index.js');
+        expect(code).toMatch(/isPrimaryShard\(client\)[\s\S]{0,400}dashboard/i);
+    });
+
+    it('runs migrations on the primary shard and makes the others wait', () => {
+        // Not "skip and carry on": serving traffic against a half-migrated
+        // database is what the ordering exists to prevent.
+        const code = read('index.js');
+        expect(code).toContain('waitForMigrations');
+        expect(code).toMatch(/isPrimaryShard\(client\)[\s\S]{0,200}runMigrations\(\)/);
+    });
+
+    it('schedules cron jobs on the primary shard only', () => {
+        // jobRunner's overlap guard is a process-local Set, so it cannot see a
+        // second process running the same job — applyBankInterest paying every
+        // account twice is the shape of getting this wrong.
+        const code = read('services/scheduler/index.js');
+        expect(code).toContain('isPrimaryShard');
+        const gateIndex = code.indexOf('if (!isPrimaryShard(client))');
+        expect(gateIndex).toBeGreaterThan(-1);
+        expect(code.indexOf('for (const job of JOBS)')).toBeGreaterThan(gateIndex);
+        expect(code.indexOf('for (const starter of STARTERS)')).toBeGreaterThan(gateIndex);
+    });
+
+    it('still sets presence on every shard', () => {
+        // Presence belongs to a gateway connection, not to the deployment: a
+        // shard that skipped it would show no activity to the guilds it serves.
+        const code = read('services/scheduler/index.js');
+        const presenceIndex = code.indexOf('setPresence(client);');
+        const gateIndex = code.indexOf('if (!isPrimaryShard(client))');
+        expect(presenceIndex).toBeGreaterThan(-1);
+        expect(presenceIndex).toBeLessThan(gateIndex);
+    });
+});
+
+describe('the sharded entry point', () => {
+    it('exists and spawns index.js under a ShardingManager', () => {
+        const code = fs.readFileSync(path.join(__dirname, '..', 'src', 'shard.js'), 'utf8');
+        expect(code).toContain('ShardingManager');
+        expect(code).toContain("path.join(__dirname, 'index.js')");
+    });
+
+    it('is wired to an npm script, so it is reachable without knowing the path', () => {
+        const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
+        expect(pkg.scripts['start:sharded']).toBe('node src/shard.js');
+        // The unsharded path stays the default: nothing about this turns
+        // sharding on for an existing deployment.
+        expect(pkg.scripts.start).toBe('node src/index.js');
+    });
+});

--- a/tests/sharding.test.js
+++ b/tests/sharding.test.js
@@ -186,6 +186,18 @@ describe('the affinity assertion', () => {
         warn.mockRestore();
     });
 
+    it('warns without throwing for an id it cannot route at all', () => {
+        // `ownsGuild` returns false for an unroutable id as well as for one that
+        // belongs elsewhere, and resolving the destination for the warning is
+        // exactly what throws on an unroutable one. The "warns, never throws"
+        // contract has to hold for both.
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        expect(() => assertGuildAffinity('not-a-snowflake', 'crash lobby', fakeClient(1, 4))).not.toThrow();
+        expect(assertGuildAffinity('not-a-snowflake', 'crash lobby', fakeClient(1, 4))).toBe(false);
+        expect(warn).toHaveBeenCalled();
+        warn.mockRestore();
+    });
+
     it('never fires unsharded', () => {
         const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
         for (const guildId of SNOWFLAKES) expect(assertGuildAffinity(guildId, 'test')).toBe(true);

--- a/tests/versionRetryCallSites.test.js
+++ b/tests/versionRetryCallSites.test.js
@@ -1,0 +1,285 @@
+'use strict';
+
+// The replay contract of withVersionRetry, checked at the callers.
+//
+// tests/versionRetry.test.js covers the primitive: how many attempts it makes,
+// the backoff, that a `false` from mutate aborts, that a non-version error
+// propagates. It imports the util and nothing else. But the primitive was never
+// the risk — retrying is exactly what it is supposed to do. The risk is a
+// caller that hands it a block which cannot survive being run twice, and the
+// primitive has no way to tell.
+//
+// The rule is in the primitive's own docstring:
+//
+//   Only use this where the mutation is a pure function of the freshly loaded
+//   document. A handler that has already rolled dice, awarded a reward, or sent
+//   a message cannot be replayed — its mutation is not derivable from the
+//   document alone, and re-running it would roll or award twice.
+//
+// Nothing enforced it. A `mutate` that credits coins double-credits the moment
+// a version race happens, which is both rare enough to survive review and
+// expensive enough to matter — and the losing attempt is the one that retries,
+// so it only ever misfires under the concurrency nobody tests by hand.
+//
+// This is the "every caller must spell this correctly" shape, so it is a static
+// sweep like tests/balanceDebitGuard.test.js, with negative controls at the
+// bottom proving each check can still fail.
+//
+// tests/petRenameRetry.test.js is the behavioural half: it drives /pet rename
+// and /pet release through a model whose save() loses a version race.
+
+const fs   = require('fs');
+const path = require('path');
+const { parse } = require('@babel/parser');
+
+const SRC = path.join(__dirname, '..', 'src');
+const PRIMITIVE = path.join(SRC, 'utils', 'versionRetry.js');
+
+function sourceFiles(dir) {
+    return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) return sourceFiles(full);
+        return entry.name.endsWith('.js') ? [full] : [];
+    });
+}
+
+function walk(node, visit) {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) return node.forEach(n => walk(n, visit));
+    if (typeof node.type === 'string') visit(node);
+    for (const key of Object.keys(node)) {
+        if (key === 'loc' || key === 'leadingComments' || key === 'trailingComments') continue;
+        walk(node[key], visit);
+    }
+}
+
+/** Every `withVersionRetry(load, mutate, opts)` call in one source. */
+function retriesInCode(code, file) {
+    const found = [];
+    const ast = parse(code, { sourceType: 'unambiguous', plugins: ['classProperties'] });
+    walk(ast, node => {
+        if (node.type !== 'CallExpression') return;
+        if (node.callee.type !== 'Identifier' || node.callee.name !== 'withVersionRetry') return;
+        found.push({
+            file,
+            line: node.loc?.start.line,
+            load:   node.arguments[0],
+            mutate: node.arguments[1],
+            opts:   node.arguments[2],
+            args:   node.arguments,
+            code,
+        });
+    });
+    return found;
+}
+
+function collect() {
+    const found = [];
+    for (const file of sourceFiles(SRC)) {
+        if (file === PRIMITIVE) continue;
+        const code = fs.readFileSync(file, 'utf8');
+        if (!code.includes('withVersionRetry')) continue;
+        found.push(...retriesInCode(code, path.relative(SRC, file)));
+    }
+    return found;
+}
+
+const RETRIES = collect();
+const where = r => `${r.file}:${r.line}`;
+const text  = (r, node) => r.code.slice(node.start, node.end);
+
+// ─── The checks ──────────────────────────────────────────────────────────────
+
+/** Calls inside a subtree, as `object.property` / `name` strings. */
+function callNames(node) {
+    const names = [];
+    walk(node, n => {
+        if (n.type !== 'CallExpression') return;
+        const c = n.callee;
+        if (c.type === 'Identifier') names.push(c.name);
+        else if (c.type === 'MemberExpression' && c.property.type === 'Identifier') {
+            const object = c.object.type === 'Identifier' ? c.object.name : '';
+            names.push(object ? `${object}.${c.property.name}` : c.property.name);
+        }
+    });
+    return names;
+}
+
+// Anything whose second run would produce a different world than its first.
+const NON_REPLAYABLE = {
+    'Math.random':        'rolls dice again on every retry',
+    randInt:              'rolls dice again on every retry',
+    randomFrom:           'rolls dice again on every retry',
+    weightedRoll:         'rolls dice again on every retry',
+    grantInventoryItem:   'awards the item again on every retry',
+    logTransaction:       'writes a second ledger entry on every retry',
+    logBigWin:            'announces the win again on every retry',
+    saveWithBalanceDelta: 'commits a second write inside a block the primitive will save itself',
+};
+
+const REPLIES = /\.(reply|editReply|followUp|update|send|deferUpdate|deferReply)$/;
+
+/** A mutate callback that cannot survive being run twice. */
+function nonReplayableMutations(retries) {
+    const offenders = [];
+    for (const retry of retries) {
+        if (!retry.mutate) continue;
+        for (const name of callNames(retry.mutate)) {
+            if (NON_REPLAYABLE[name]) offenders.push(`${where(retry)} → ${name} (${NON_REPLAYABLE[name]})`);
+            if (REPLIES.test(name))   offenders.push(`${where(retry)} → ${name} (messages the player again on every retry)`);
+        }
+    }
+    return offenders;
+}
+
+/** A mutate callback that moves coins — the double-credit the issue names. */
+function coinMutations(retries) {
+    const offenders = [];
+    for (const retry of retries) {
+        if (!retry.mutate) continue;
+        walk(retry.mutate, node => {
+            // `doc.balance += x`, `doc.balance = ...`, `doc.bank -= x`
+            if (node.type !== 'AssignmentExpression') return;
+            const left = node.left;
+            if (left.type !== 'MemberExpression' || left.property.type !== 'Identifier') return;
+            if (['balance', 'bank'].includes(left.property.name)) {
+                offenders.push(`${where(retry)} → ${text(retry, node)}`);
+            }
+        });
+    }
+    return offenders;
+}
+
+/**
+ * A load callback that does not actually re-read.
+ *
+ * `withVersionRetry(() => user, ...)` closes over the document that already
+ * lost the race and hands it back on every attempt, so the retry loop burns all
+ * three attempts against the same stale version and then throws — the exact
+ * failure the retry existed to avoid, dressed up as an unavoidable conflict.
+ */
+function staleLoaders(retries) {
+    return retries.filter(retry => {
+        const load = retry.load;
+        if (!load) return true;
+        if (load.type !== 'ArrowFunctionExpression' && load.type !== 'FunctionExpression') {
+            // A bare identifier (`load`) or a member expression is a function
+            // reference; it is re-invoked per attempt, which is the point.
+            return false;
+        }
+        return callNames(load).length === 0;
+    }).map(where);
+}
+
+/** A call that does not give the primitive both halves it needs. */
+function malformedCalls(retries) {
+    return retries.filter(r => r.args.length < 2 || !r.load || !r.mutate).map(where);
+}
+
+/** A retry with no label — the give-up warning would name nothing. */
+function unlabelled(retries) {
+    return retries.filter(retry => {
+        if (!retry.opts || retry.opts.type !== 'ObjectExpression') return true;
+        return !retry.opts.properties.some(p =>
+            p.type === 'ObjectProperty' && p.key.type === 'Identifier' && p.key.name === 'label');
+    }).map(where);
+}
+
+// ─── The real tree ───────────────────────────────────────────────────────────
+
+describe('the sweep is actually sweeping', () => {
+    it('finds the retry call sites it claims to check', () => {
+        expect(RETRIES.length).toBeGreaterThanOrEqual(2);
+    });
+});
+
+describe('every retried block can survive being run twice', () => {
+    it('rolls no dice, awards nothing and messages nobody inside a mutate', () => {
+        // The primitive replays `mutate` verbatim on each attempt. Anything in
+        // there with an effect the document does not describe happens again.
+        expect(nonReplayableMutations(RETRIES)).toEqual([]);
+    });
+
+    it('moves no coins inside a mutate', () => {
+        // The double-credit. A retried `doc.balance += reward` pays twice, and
+        // only ever under the concurrency that makes it hard to notice.
+        expect(coinMutations(RETRIES)).toEqual([]);
+    });
+});
+
+describe('every retry re-reads what it is retrying against', () => {
+    it('loads the document afresh on each attempt', () => {
+        expect(staleLoaders(RETRIES)).toEqual([]);
+    });
+
+    it('passes both a loader and a mutation', () => {
+        expect(malformedCalls(RETRIES)).toEqual([]);
+    });
+
+    it('labels itself, so a give-up warning names the flow', () => {
+        expect(unlabelled(RETRIES)).toEqual([]);
+    });
+});
+
+// ─── Negative controls ───────────────────────────────────────────────────────
+
+describe('each check can still fail', () => {
+    const bad = code => retriesInCode(code, 'synthetic.js');
+
+    it('catches a mutate that rolls dice', () => {
+        expect(nonReplayableMutations(bad(
+            `withVersionRetry(() => load(), doc => { doc.roll = Math.random(); }, { label: 'x' });`
+        ))).toHaveLength(1);
+    });
+
+    it('catches a mutate that awards an item', () => {
+        expect(nonReplayableMutations(bad(
+            `withVersionRetry(() => load(), async doc => { await grantInventoryItem(u, g, 'x', 1); }, { label: 'x' });`
+        ))).toHaveLength(1);
+    });
+
+    it('catches a mutate that talks to the player', () => {
+        expect(nonReplayableMutations(bad(
+            `withVersionRetry(() => load(), async doc => { await interaction.followUp('done'); }, { label: 'x' });`
+        ))).toHaveLength(1);
+    });
+
+    it('catches a mutate that credits coins', () => {
+        expect(coinMutations(bad(
+            `withVersionRetry(() => load(), doc => { doc.balance += reward; }, { label: 'x' });`
+        ))).toHaveLength(1);
+        expect(coinMutations(bad(
+            `withVersionRetry(() => load(), doc => { doc.hunt.dailyCoins += n; }, { label: 'x' });`
+        ))).toEqual([]);
+    });
+
+    it('catches a loader that hands back the same stale document', () => {
+        expect(staleLoaders(bad(
+            `withVersionRetry(() => user, doc => { doc.name = n; }, { label: 'x' });`
+        ))).toHaveLength(1);
+        expect(staleLoaders(bad(
+            `withVersionRetry(() => resolveUser(interaction), doc => { doc.name = n; }, { label: 'x' });`
+        ))).toEqual([]);
+    });
+
+    it('catches a call missing a half, and an unlabelled one', () => {
+        expect(malformedCalls(bad(`withVersionRetry(() => load());`))).toHaveLength(1);
+        expect(unlabelled(bad(`withVersionRetry(() => load(), d => { d.a = 1; });`))).toHaveLength(1);
+        expect(unlabelled(bad(`withVersionRetry(() => load(), d => { d.a = 1; }, { label: 'x' });`))).toEqual([]);
+    });
+
+    it('accepts the shape the primitive documents', () => {
+        const good = bad(
+            `withVersionRetry(
+                 () => resolveUser(interaction),
+                 fresh => { const t = find(fresh.pets, id); if (!t) return false; fresh.pets.splice(t.index, 1); fresh.markModified('pets'); },
+                 { label: 'pet release' },
+             );`
+        );
+        expect(nonReplayableMutations(good)).toEqual([]);
+        expect(coinMutations(good)).toEqual([]);
+        expect(staleLoaders(good)).toEqual([]);
+        expect(malformedCalls(good)).toEqual([]);
+        expect(unlabelled(good)).toEqual([]);
+    });
+});

--- a/tests/versionRetryCallSites.test.js
+++ b/tests/versionRetryCallSites.test.js
@@ -127,6 +127,13 @@ function nonReplayableMutations(retries) {
         for (const name of callNames(retry.mutate)) {
             if (NON_REPLAYABLE[name]) offenders.push(`${where(retry)} → ${name} (${NON_REPLAYABLE[name]})`);
             if (REPLIES.test(name))   offenders.push(`${where(retry)} → ${name} (messages the player again on every retry)`);
+            // The primitive saves the document itself once mutate returns. A
+            // mutate that also saves writes twice per attempt, and the second
+            // write is the one whose VersionError the retry loop then catches —
+            // so the block retries against a document it has already committed.
+            if (name === 'save' || name.endsWith('.save')) {
+                offenders.push(`${where(retry)} → ${name} (the primitive saves after mutate returns; this saves again)`);
+            }
         }
     }
     return offenders;
@@ -150,6 +157,24 @@ function coinMutations(retries) {
     return offenders;
 }
 
+// Calls that hand back whatever they were given. A loader whose returned
+// expression is one of these is doing no re-reading, however call-shaped it
+// looks: `() => Promise.resolve(user)` re-wraps the stale document every time.
+const PASS_THROUGH = ['Promise.resolve', 'Promise.reject', 'Promise.all', 'Promise.race'];
+
+/** The expression a loader hands back, or null if it never returns one. */
+function returnedExpression(fn) {
+    if (fn.body.type !== 'BlockStatement') return fn.body; // () => expr
+    let returned = null;
+    walk(fn.body, node => {
+        // The first return wins; a loader with several is unusual enough that
+        // treating the first as representative is fine, and a loader with none
+        // returns undefined, which the caller reads as "found nothing".
+        if (!returned && node.type === 'ReturnStatement' && node.argument) returned = node.argument;
+    });
+    return returned;
+}
+
 /**
  * A load callback that does not actually re-read.
  *
@@ -157,6 +182,10 @@ function coinMutations(retries) {
  * lost the race and hands it back on every attempt, so the retry loop burns all
  * three attempts against the same stale version and then throws — the exact
  * failure the retry existed to avoid, dressed up as an unavoidable conflict.
+ *
+ * Judged on what the loader *returns*, not on whether its body contains a call
+ * anywhere: a body can log, count attempts or build a filter and still hand
+ * back the same document it was closed over.
  */
 function staleLoaders(retries) {
     return retries.filter(retry => {
@@ -167,21 +196,91 @@ function staleLoaders(retries) {
             // reference; it is re-invoked per attempt, which is the point.
             return false;
         }
-        return callNames(load).length === 0;
+
+        const returned = returnedExpression(load);
+        if (!returned) return true;
+        return !isReload(returned, load);
     }).map(where);
 }
 
-/** A call that does not give the primitive both halves it needs. */
-function malformedCalls(retries) {
-    return retries.filter(r => r.args.length < 2 || !r.load || !r.mutate).map(where);
+/**
+ * Whether `node` is the expression that re-reads the document.
+ *
+ * Handles the shapes a loader is actually written in: the call itself, an await
+ * of it, a member access off it, and — the common one — a local binding that
+ * the body awaited into and then returns. A returned identifier with no such
+ * binding in the body is something the loader closed over, which is the stale
+ * case this exists to catch.
+ */
+function isReload(node, fn) {
+    let current = node;
+    if (current?.type === 'AwaitExpression') current = current.argument;
+    // `(await load()).doc` and `load().then(...)` both re-read; walk down to the
+    // call that does it.
+    while (current?.type === 'MemberExpression') current = current.object;
+
+    if (current?.type === 'Identifier') {
+        // `const u = await User.findOne(f); return u;` — resolve the binding
+        // inside this loader. Anything not bound here was closed over.
+        let bound = null;
+        walk(fn.body, n => {
+            if (!bound && n.type === 'VariableDeclarator'
+                && n.id.type === 'Identifier' && n.id.name === current.name && n.init) {
+                bound = n.init;
+            }
+        });
+        return bound ? isReload(bound, fn) : false;
+    }
+
+    if (current?.type !== 'CallExpression') return false;
+
+    const callee = current.callee;
+    const name = callee.type === 'Identifier'
+        ? callee.name
+        : (callee.type === 'MemberExpression' && callee.property.type === 'Identifier'
+            ? `${callee.object.type === 'Identifier' ? `${callee.object.name}.` : ''}${callee.property.name}`
+            : '');
+    return !PASS_THROUGH.includes(name);
 }
 
-/** A retry with no label — the give-up warning would name nothing. */
+// Node types that are definitely not a function. A call the primitive will
+// invoke has to be one, and `!node` only catches the argument being absent.
+const NOT_CALLABLE = ['NullLiteral', 'StringLiteral', 'NumericLiteral', 'BooleanLiteral',
+                      'ObjectExpression', 'ArrayExpression', 'TemplateLiteral'];
+
+const isUndefinedLiteral = node =>
+    node?.type === 'Identifier' && node.name === 'undefined';
+
+/** A call that does not give the primitive both halves it needs, as callables. */
+function malformedCalls(retries) {
+    return retries.filter(r => {
+        if (r.args.length < 2) return true;
+        for (const arg of [r.load, r.mutate]) {
+            if (!arg) return true;
+            if (isUndefinedLiteral(arg)) return true;
+            if (NOT_CALLABLE.includes(arg.type)) return true;
+        }
+        return false;
+    }).map(where);
+}
+
+/** A retry with no usable label — the give-up warning would name nothing. */
 function unlabelled(retries) {
     return retries.filter(retry => {
         if (!retry.opts || retry.opts.type !== 'ObjectExpression') return true;
-        return !retry.opts.properties.some(p =>
+        const label = retry.opts.properties.find(p =>
             p.type === 'ObjectProperty' && p.key.type === 'Identifier' && p.key.name === 'label');
+        if (!label) return true;
+        // Present but empty is the same as absent once it reaches the log line,
+        // and worse to read in review — it looks answered.
+        const value = label.value;
+        if (isUndefinedLiteral(value)) return true;
+        if (value.type === 'NullLiteral') return true;
+        if (value.type === 'StringLiteral' && value.value.trim() === '') return true;
+        if (value.type === 'TemplateLiteral'
+            && value.expressions.length === 0
+            && value.quasis.every(q => q.value.cooked.trim() === '')) return true;
+        return false;
     }).map(where);
 }
 
@@ -244,6 +343,19 @@ describe('each check can still fail', () => {
         ))).toHaveLength(1);
     });
 
+    it('catches a mutate that saves the document itself', () => {
+        // The primitive saves once mutate returns. Saving inside it writes twice
+        // per attempt, and it is the second write whose VersionError the loop
+        // catches — so the retry replays a block that already committed.
+        expect(nonReplayableMutations(bad(
+            `withVersionRetry(() => load(), async doc => { doc.a = 1; await doc.save(); }, { label: 'x' });`
+        ))).toHaveLength(1);
+        // markModified is the correct way to tell mongoose about the change.
+        expect(nonReplayableMutations(bad(
+            `withVersionRetry(() => load(), doc => { doc.a = 1; doc.markModified('a'); }, { label: 'x' });`
+        ))).toEqual([]);
+    });
+
     it('catches a mutate that credits coins', () => {
         expect(coinMutations(bad(
             `withVersionRetry(() => load(), doc => { doc.balance += reward; }, { label: 'x' });`
@@ -254,21 +366,58 @@ describe('each check can still fail', () => {
     });
 
     it('catches a loader that hands back the same stale document', () => {
-        expect(staleLoaders(bad(
-            `withVersionRetry(() => user, doc => { doc.name = n; }, { label: 'x' });`
-        ))).toHaveLength(1);
-        expect(staleLoaders(bad(
-            `withVersionRetry(() => resolveUser(interaction), doc => { doc.name = n; }, { label: 'x' });`
-        ))).toEqual([]);
+        for (const stale of [
+            // Closed over outright.
+            `withVersionRetry(() => user, doc => { doc.name = n; }, { label: 'x' });`,
+            // Call-shaped, but the call only re-wraps the same stale document —
+            // the case a body-wide "does it contain a call" check waves through.
+            `withVersionRetry(() => Promise.resolve(user), doc => { doc.name = n; }, { label: 'x' });`,
+            // A body that does work and still hands back what it closed over.
+            `withVersionRetry(() => { attempts++; return user; }, doc => { doc.a = 1; }, { label: 'x' });`,
+            // Never returns anything at all.
+            `withVersionRetry(() => { load(); }, doc => { doc.a = 1; }, { label: 'x' });`,
+        ]) {
+            expect(staleLoaders(bad(stale))).toHaveLength(1);
+        }
+        for (const fresh of [
+            `withVersionRetry(() => resolveUser(interaction), doc => { doc.name = n; }, { label: 'x' });`,
+            `withVersionRetry(async () => { const u = await User.findOne(f); return u; }, d => { d.a = 1; }, { label: 'x' });`,
+            `withVersionRetry(() => User.findOne(f).exec(), d => { d.a = 1; }, { label: 'x' });`,
+            // A function reference is re-invoked per attempt, which is the point.
+            `withVersionRetry(loadUser, d => { d.a = 1; }, { label: 'x' });`,
+            `withVersionRetry(deps.loadUser, d => { d.a = 1; }, { label: 'x' });`,
+        ]) {
+            expect(staleLoaders(bad(fresh))).toEqual([]);
+        }
     });
 
-    it('catches a call missing a half, and an unlabelled one', () => {
+    it('catches a call whose halves are not callable', () => {
+        // Presence is not enough: the primitive invokes both, so a null or a
+        // literal in either slot is a TypeError on the first attempt.
         expect(malformedCalls(bad(`withVersionRetry(() => load());`))).toHaveLength(1);
+        expect(malformedCalls(bad(`withVersionRetry(null, d => { d.a = 1; }, { label: 'x' });`))).toHaveLength(1);
+        expect(malformedCalls(bad(`withVersionRetry(() => load(), null, { label: 'x' });`))).toHaveLength(1);
+        expect(malformedCalls(bad(`withVersionRetry(() => load(), undefined, { label: 'x' });`))).toHaveLength(1);
+        expect(malformedCalls(bad(`withVersionRetry(() => load(), {}, { label: 'x' });`))).toHaveLength(1);
+        expect(malformedCalls(bad(`withVersionRetry(loadUser, mutateUser, { label: 'x' });`))).toEqual([]);
+    });
+
+    it('catches a label that is present but says nothing', () => {
+        // A label that reaches the give-up warning as an empty string names the
+        // flow no better than a missing one, and reads in review as answered.
         expect(unlabelled(bad(`withVersionRetry(() => load(), d => { d.a = 1; });`))).toHaveLength(1);
-        expect(unlabelled(bad(`withVersionRetry(() => load(), d => { d.a = 1; }, { label: 'x' });`))).toEqual([]);
+        expect(unlabelled(bad(`withVersionRetry(() => load(), d => { d.a = 1; }, { label: undefined });`))).toHaveLength(1);
+        expect(unlabelled(bad(`withVersionRetry(() => load(), d => { d.a = 1; }, { label: null });`))).toHaveLength(1);
+        expect(unlabelled(bad(`withVersionRetry(() => load(), d => { d.a = 1; }, { label: '' });`))).toHaveLength(1);
+        expect(unlabelled(bad(`withVersionRetry(() => load(), d => { d.a = 1; }, { label: '   ' });`))).toHaveLength(1);
+        expect(unlabelled(bad(`withVersionRetry(() => load(), d => { d.a = 1; }, { label: 'pet release' });`))).toEqual([]);
+        expect(unlabelled(bad("withVersionRetry(() => load(), d => { d.a = 1; }, { label: `pet ${verb}` });"))).toEqual([]);
     });
 
     it('accepts the shape the primitive documents', () => {
+        // Lifted from src/commands/economy/pet.js: a re-read, a mutation that is
+        // a pure function of what came back, an abort when the precondition no
+        // longer holds, and a label. No check here may reject this.
         const good = bad(
             `withVersionRetry(
                  () => resolveUser(interaction),


### PR DESCRIPTION
The apex bonus was computed from a fresh roll of the animal's base payout
range, so none of the multipliers the kill had actually earned reached it —
not the crit, not the trophy quality, not the streak, not the enraged trait.
The better the kill, the worse the apex paid relative to it: a mythic crit on
a Snow Leopard could pay ~4,000 and the three-phase duel that risked the
weapon on top of it added ~1,600. Re-rolling also made two identical duels on
identical kills pay differently for no reason a player could see.

executeHunt now reports payoutBeforeMods and hands it to the encounter as
killPayout; resolveApexEncounter applies the existing 1.5 / 1.0 / 0.4 / 0
outcome tiers to that number instead of re-rolling. Callers with no kill
behind them still fall back to the base range, so the duel stays callable on
its own. The apex path's applyPayoutModifiers call is unchanged, so zone,
prestige and the daily caps still apply as before.

Closes #744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional Discord sharding for larger deployments, with automatic or configured shard counts.
  - Added `/explore prestige`, allowing eligible explorers to reset progression while retaining records and collectibles and gaining lasting bonuses.
  - Explorer views now display prestige ranks, titles, badges, and expanded relic capacity.

- **Bug Fixes**
  - Improved hunt payout scaling for apex encounters.
  - Added clearer weapon repair, condemnation, and ownership-cost information.
  - Improved guild-specific routing for multiplayer activities.

- **Documentation**
  - Documented sharding setup and exploration prestige progression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->