### PR TITLE
Bind the OAuth login to the session that started it

### DIFF
--- a/src/commands/admin/raidmode.js
+++ b/src/commands/admin/raidmode.js
@@ -62,6 +62,9 @@ module.exports = {
                 .addIntegerOption(o => o.setName('weekly_coins').setDescription('Coin reward per weekly quest (default 150)').setMinValue(0).setRequired(false)))
         .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild),
 
+    // Re-checked inside the gate in events/interactionCreate — the builder line
+    // above is only Discord's default, which a guild admin can reassign.
+    requiredPermissions: [PermissionFlagsBits.ManageGuild],
     async execute(interaction) {
         const sub = interaction.options.getSubcommand();
 

--- a/src/commands/economy/boost.js
+++ b/src/commands/economy/boost.js
@@ -42,6 +42,9 @@ module.exports = {
             sub.setName('status')
                 .setDescription('Check the current server boost status')),
 
+    // Re-checked inside the gate in events/interactionCreate — the builder line
+    // above is only Discord's default, which a guild admin can reassign.
+    requiredPermissions: [PermissionFlagsBits.Administrator],
     async execute(interaction) {
         const sub = interaction.options.getSubcommand();
 

--- a/src/commands/leveling/setlevel.js
+++ b/src/commands/leveling/setlevel.js
@@ -12,6 +12,9 @@ module.exports = {
             o.setName('level').setDescription('Level to assign').setRequired(true).setMinValue(0).setMaxValue(500))
         .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild),
 
+    // Re-checked inside the gate in events/interactionCreate — the builder line
+    // above is only Discord's default, which a guild admin can reassign.
+    requiredPermissions: [PermissionFlagsBits.ManageGuild],
     async execute(interaction) {
         await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 

--- a/src/commands/moderation/ban.js
+++ b/src/commands/moderation/ban.js
@@ -68,7 +68,16 @@ module.exports = {
             return interaction.reply({ content: 'I cannot ban myself.', flags: MessageFlags.Ephemeral });
         }
 
-        const member = await resolveMember(interaction.guild, user.id);
+        const { member, indeterminate } = await resolveMember(interaction.guild, user.id);
+        // Not the same as "not in the guild": we could not find out. Proceeding
+        // would skip both checks below on a target who may well outrank you.
+        if (indeterminate) {
+            return interaction.reply({
+                content: 'I could not look this user up just now, so I have not banned them. Try again in a moment.',
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
         if (member && !member.bannable) {
             return interaction.reply({ content: 'I cannot ban this user — they may have higher permissions.', flags: MessageFlags.Ephemeral });
         }

--- a/src/commands/moderation/ban.js
+++ b/src/commands/moderation/ban.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, MessageFlags } = require('discord.js');
 const { logModeration } = require('../../utils/logger');
+const { hierarchyDenial, resolveMember } = require('../../utils/moderationHierarchy');
 const TempBan = require('../../models/TempBan');
 
 const DURATION_RE = /^(\d+)(m|h|d)$/i;
@@ -51,6 +52,9 @@ module.exports = {
                 .setRequired(false))
         .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers),
 
+    // Re-checked inside the gate in events/interactionCreate — the builder line
+    // above is only Discord's default, which a guild admin can reassign.
+    requiredPermissions: [PermissionFlagsBits.BanMembers],
     async execute(interaction) {
         const user        = interaction.options.getUser('user');
         const reason      = interaction.options.getString('reason') || 'No reason provided';
@@ -64,9 +68,16 @@ module.exports = {
             return interaction.reply({ content: 'I cannot ban myself.', flags: MessageFlags.Ephemeral });
         }
 
-        const member = interaction.guild.members.cache.get(user.id);
+        const member = await resolveMember(interaction.guild, user.id);
         if (member && !member.bannable) {
             return interaction.reply({ content: 'I cannot ban this user — they may have higher permissions.', flags: MessageFlags.Ephemeral });
+        }
+
+        // `bannable` above answered whether the bot outranks the target. This
+        // answers whether the moderator does.
+        const denial = hierarchyDenial(interaction.member, member, 'ban');
+        if (denial) {
+            return interaction.reply({ content: denial, flags: MessageFlags.Ephemeral });
         }
 
         let durationMs = null;

--- a/src/commands/moderation/case.js
+++ b/src/commands/moderation/case.js
@@ -20,6 +20,9 @@ module.exports = {
             o.setName('id').setDescription('Case ID number').setRequired(true).setMinValue(1))
         .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
 
+    // Re-checked inside the gate in events/interactionCreate — the builder line
+    // above is only Discord's default, which a guild admin can reassign.
+    requiredPermissions: [PermissionFlagsBits.ModerateMembers],
     async execute(interaction) {
         const caseId = interaction.options.getInteger('id');
         const modCase = await getCase(interaction.guild.id, caseId);

--- a/src/commands/moderation/cases.js
+++ b/src/commands/moderation/cases.js
@@ -17,6 +17,9 @@ module.exports = {
                 .setMinValue(1).setMaxValue(25).setRequired(false))
         .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
 
+    // Re-checked inside the gate in events/interactionCreate — the builder line
+    // above is only Discord's default, which a guild admin can reassign.
+    requiredPermissions: [PermissionFlagsBits.ModerateMembers],
     async execute(interaction) {
         const user = interaction.options.getUser('user');
         const limit = interaction.options.getInteger('limit') ?? 10;

--- a/src/commands/moderation/clear.js
+++ b/src/commands/moderation/clear.js
@@ -11,6 +11,9 @@ module.exports = {
                 .setMinValue(1)
                 .setMaxValue(100))
         .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages),
+    // Re-checked inside the gate in events/interactionCreate — the builder line
+    // above is only Discord's default, which a guild admin can reassign.
+    requiredPermissions: [PermissionFlagsBits.ManageMessages],
     async execute(interaction) {
         const amount = interaction.options.getInteger('amount');
 

--- a/src/commands/moderation/closecase.js
+++ b/src/commands/moderation/closecase.js
@@ -11,6 +11,9 @@ module.exports = {
             o.setName('resolution').setDescription('Resolution / closing note').setRequired(false))
         .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
 
+    // Re-checked inside the gate in events/interactionCreate — the builder line
+    // above is only Discord's default, which a guild admin can reassign.
+    requiredPermissions: [PermissionFlagsBits.ModerateMembers],
     async execute(interaction) {
         const caseId = interaction.options.getInteger('case_id');
         const resolution = interaction.options.getString('resolution') ?? 'Closed by moderator.';

--- a/src/commands/moderation/kick.js
+++ b/src/commands/moderation/kick.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, MessageFlags } = require('discord.js');
 const { logModeration } = require('../../utils/logger');
+const { hierarchyDenial } = require('../../utils/moderationHierarchy');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -14,6 +15,9 @@ module.exports = {
                 .setDescription('Reason for the kick')
                 .setRequired(false))
         .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers),
+    // Re-checked inside the gate in events/interactionCreate — the builder line
+    // above is only Discord's default, which a guild admin can reassign.
+    requiredPermissions: [PermissionFlagsBits.KickMembers],
     async execute(interaction) {
         const user = interaction.options.getUser('user');
         const reason = interaction.options.getString('reason') || 'No reason provided';
@@ -29,6 +33,13 @@ module.exports = {
 
         if (!member.kickable) {
             return interaction.reply({ content: 'I cannot kick this user! They may have higher permissions.', flags: MessageFlags.Ephemeral });
+        }
+
+        // `kickable` above answered whether the bot outranks the target. This
+        // answers whether the moderator does.
+        const denial = hierarchyDenial(interaction.member, member, 'kick');
+        if (denial) {
+            return interaction.reply({ content: denial, flags: MessageFlags.Ephemeral });
         }
 
         try {

--- a/src/commands/moderation/lockdown.js
+++ b/src/commands/moderation/lockdown.js
@@ -12,6 +12,9 @@ module.exports = {
             .setDescription('Lift the active lockdown'))
         .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild),
 
+    // Re-checked inside the gate in events/interactionCreate — the builder line
+    // above is only Discord's default, which a guild admin can reassign.
+    requiredPermissions: [PermissionFlagsBits.ManageGuild],
     async execute(interaction) {
         const sub = interaction.options.getSubcommand();
         await interaction.deferReply({ flags: MessageFlags.Ephemeral });

--- a/src/commands/moderation/massban.js
+++ b/src/commands/moderation/massban.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder } = require('discord.js');
 const { logModeration } = require('../../utils/logger');
+const { hierarchyDenial, resolveMembers } = require('../../utils/moderationHierarchy');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -22,6 +23,9 @@ module.exports = {
                 .setRequired(false))
         .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers | PermissionFlagsBits.ManageGuild),
 
+    // Re-checked inside the gate in events/interactionCreate — the builder line
+    // above is only Discord's default, which a guild admin can reassign.
+    requiredPermissions: [PermissionFlagsBits.BanMembers, PermissionFlagsBits.ManageGuild],
     async execute(interaction) {
         await interaction.deferReply();
 
@@ -38,14 +42,36 @@ module.exports = {
             return interaction.editReply('Maximum 50 users per mass ban. Split into multiple calls if needed.');
         }
 
+        // One resolution pass for the whole batch: the member cache holds at most
+        // 200 per guild, so reading it alone would leave most of these ids
+        // looking like non-members and skip both checks below.
+        const members = await resolveMembers(interaction.guild, ids);
+
         const succeeded = [];
         const failed    = [];
+        const refused   = [];
 
         for (const userId of ids) {
             if (userId === interaction.user.id || userId === interaction.client.user.id) {
                 failed.push(userId);
                 continue;
             }
+
+            // The single-target commands run these two checks; this one looped
+            // guild.members.ban() over raw IDs with neither, which made it the
+            // way around the hierarchy rule the others enforce. IDs belonging to
+            // nobody in the guild — the raid cleanup this command exists for —
+            // have no member to check and fall straight through.
+            const member = members.get(userId);
+            if (member && !member.bannable) {
+                refused.push(userId);
+                continue;
+            }
+            if (hierarchyDenial(interaction.member, member, 'ban')) {
+                refused.push(userId);
+                continue;
+            }
+
             try {
                 await interaction.guild.members.ban(userId, {
                     deleteMessageSeconds: deleteDays * 86400,
@@ -61,7 +87,7 @@ module.exports = {
         }
 
         const embed = new EmbedBuilder()
-            .setColor(failed.length === 0 ? '#ff0000' : '#ff9900')
+            .setColor(failed.length === 0 && refused.length === 0 ? '#ff0000' : '#ff9900')
             .setTitle('Mass Ban Complete')
             .addFields(
                 { name: 'Banned', value: `${succeeded.length} user(s)`, inline: true },
@@ -72,6 +98,15 @@ module.exports = {
 
         if (failed.length > 0) {
             embed.addFields({ name: 'Failed IDs', value: failed.slice(0, 20).join(', ') });
+        }
+
+        // Reported apart from failures: these did not error, they were declined,
+        // and a moderator who cannot tell the two apart will just retry them.
+        if (refused.length > 0) {
+            embed.addFields({
+                name: 'Skipped — outranks you or the bot',
+                value: refused.slice(0, 20).join(', ')
+            });
         }
 
         await interaction.editReply({ embeds: [embed] });

--- a/src/commands/moderation/massban.js
+++ b/src/commands/moderation/massban.js
@@ -45,11 +45,12 @@ module.exports = {
         // One resolution pass for the whole batch: the member cache holds at most
         // 200 per guild, so reading it alone would leave most of these ids
         // looking like non-members and skip both checks below.
-        const members = await resolveMembers(interaction.guild, ids);
+        const { members, indeterminate } = await resolveMembers(interaction.guild, ids);
 
-        const succeeded = [];
-        const failed    = [];
-        const refused   = [];
+        const succeeded  = [];
+        const failed     = [];
+        const refused    = [];
+        const unverified = [];
 
         for (const userId of ids) {
             if (userId === interaction.user.id || userId === interaction.client.user.id) {
@@ -62,6 +63,13 @@ module.exports = {
             // way around the hierarchy rule the others enforce. IDs belonging to
             // nobody in the guild — the raid cleanup this command exists for —
             // have no member to check and fall straight through.
+            // Unsettled, not confirmed absent — banning here would skip both
+            // checks below on someone who may outrank the moderator.
+            if (indeterminate.has(userId)) {
+                unverified.push(userId);
+                continue;
+            }
+
             const member = members.get(userId);
             if (member && !member.bannable) {
                 refused.push(userId);
@@ -87,7 +95,7 @@ module.exports = {
         }
 
         const embed = new EmbedBuilder()
-            .setColor(failed.length === 0 && refused.length === 0 ? '#ff0000' : '#ff9900')
+            .setColor(failed.length === 0 && refused.length === 0 && unverified.length === 0 ? '#ff0000' : '#ff9900')
             .setTitle('Mass Ban Complete')
             .addFields(
                 { name: 'Banned', value: `${succeeded.length} user(s)`, inline: true },
@@ -106,6 +114,14 @@ module.exports = {
             embed.addFields({
                 name: 'Skipped — outranks you or the bot',
                 value: refused.slice(0, 20).join(', ')
+            });
+        }
+
+        // These are the ones worth retrying: nothing was decided about them.
+        if (unverified.length > 0) {
+            embed.addFields({
+                name: 'Skipped — could not be looked up, try again',
+                value: unverified.slice(0, 20).join(', ')
             });
         }
 

--- a/src/commands/moderation/mute.js
+++ b/src/commands/moderation/mute.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, MessageFlags } = require('discord.js');
 const { logModeration } = require('../../utils/logger');
+const { hierarchyDenial } = require('../../utils/moderationHierarchy');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -20,6 +21,9 @@ module.exports = {
                 .setDescription('Reason for the timeout')
                 .setRequired(false))
         .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
+    // Re-checked inside the gate in events/interactionCreate — the builder line
+    // above is only Discord's default, which a guild admin can reassign.
+    requiredPermissions: [PermissionFlagsBits.ModerateMembers],
     async execute(interaction) {
         const user = interaction.options.getUser('user');
         const duration = interaction.options.getInteger('duration');
@@ -32,6 +36,13 @@ module.exports = {
 
         if (!member.moderatable) {
             return interaction.reply({ content: 'I cannot mute this user!', flags: MessageFlags.Ephemeral });
+        }
+
+        // `moderatable` above answered whether the bot outranks the target. This
+        // answers whether the moderator does.
+        const denial = hierarchyDenial(interaction.member, member, 'mute');
+        if (denial) {
+            return interaction.reply({ content: denial, flags: MessageFlags.Ephemeral });
         }
 
         try {

--- a/src/commands/moderation/note.js
+++ b/src/commands/moderation/note.js
@@ -16,6 +16,9 @@ module.exports = {
             o.setName('assign').setDescription('Assign this case to a moderator').setRequired(false))
         .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
 
+    // Re-checked inside the gate in events/interactionCreate — the builder line
+    // above is only Discord's default, which a guild admin can reassign.
+    requiredPermissions: [PermissionFlagsBits.ModerateMembers],
     async execute(interaction) {
         const caseId = interaction.options.getInteger('case_id');
         const text = interaction.options.getString('text');

--- a/src/commands/moderation/slowmode.js
+++ b/src/commands/moderation/slowmode.js
@@ -16,6 +16,9 @@ module.exports = {
                 .setRequired(false))
         .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels),
 
+    // Re-checked inside the gate in events/interactionCreate — the builder line
+    // above is only Discord's default, which a guild admin can reassign.
+    requiredPermissions: [PermissionFlagsBits.ManageChannels],
     async execute(interaction) {
         const seconds = interaction.options.getInteger('seconds');
         const channel = interaction.options.getChannel('channel') ?? interaction.channel;

--- a/src/commands/moderation/softban.js
+++ b/src/commands/moderation/softban.js
@@ -37,7 +37,16 @@ module.exports = {
             return interaction.reply({ content: 'I cannot softban myself.', flags: MessageFlags.Ephemeral });
         }
 
-        const member = await resolveMember(interaction.guild, user.id);
+        const { member, indeterminate } = await resolveMember(interaction.guild, user.id);
+        // Not the same as "not in the guild": we could not find out. Proceeding
+        // would skip both checks below on a target who may well outrank you.
+        if (indeterminate) {
+            return interaction.reply({
+                content: 'I could not look this user up just now, so I have not softbanned them. Try again in a moment.',
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
         if (member && !member.bannable) {
             return interaction.reply({ content: 'I cannot ban this user — they may have higher permissions.', flags: MessageFlags.Ephemeral });
         }

--- a/src/commands/moderation/softban.js
+++ b/src/commands/moderation/softban.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, MessageFlags } = require('discord.js');
 const { logModeration } = require('../../utils/logger');
+const { hierarchyDenial, resolveMember } = require('../../utils/moderationHierarchy');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -21,6 +22,9 @@ module.exports = {
                 .setRequired(false))
         .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers),
 
+    // Re-checked inside the gate in events/interactionCreate — the builder line
+    // above is only Discord's default, which a guild admin can reassign.
+    requiredPermissions: [PermissionFlagsBits.BanMembers],
     async execute(interaction) {
         const user       = interaction.options.getUser('user');
         const reason     = interaction.options.getString('reason') || 'No reason provided';
@@ -33,9 +37,16 @@ module.exports = {
             return interaction.reply({ content: 'I cannot softban myself.', flags: MessageFlags.Ephemeral });
         }
 
-        const member = interaction.guild.members.cache.get(user.id);
+        const member = await resolveMember(interaction.guild, user.id);
         if (member && !member.bannable) {
             return interaction.reply({ content: 'I cannot ban this user — they may have higher permissions.', flags: MessageFlags.Ephemeral });
+        }
+
+        // `bannable` above answered whether the bot outranks the target. This
+        // answers whether the moderator does.
+        const denial = hierarchyDenial(interaction.member, member, 'softban');
+        if (denial) {
+            return interaction.reply({ content: denial, flags: MessageFlags.Ephemeral });
         }
 
         try {

--- a/src/commands/moderation/unban.js
+++ b/src/commands/moderation/unban.js
@@ -16,6 +16,9 @@ module.exports = {
                 .setRequired(false))
         .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers),
 
+    // Re-checked inside the gate in events/interactionCreate — the builder line
+    // above is only Discord's default, which a guild admin can reassign.
+    requiredPermissions: [PermissionFlagsBits.BanMembers],
     async execute(interaction) {
         const userId = interaction.options.getString('user_id').trim();
         const reason = interaction.options.getString('reason') || 'No reason provided';

--- a/src/commands/moderation/unmute.js
+++ b/src/commands/moderation/unmute.js
@@ -9,6 +9,9 @@ module.exports = {
                 .setDescription('The user to unmute')
                 .setRequired(true))
         .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
+    // Re-checked inside the gate in events/interactionCreate — the builder line
+    // above is only Discord's default, which a guild admin can reassign.
+    requiredPermissions: [PermissionFlagsBits.ModerateMembers],
     async execute(interaction) {
         const user = interaction.options.getUser('user');
         const member = interaction.guild.members.cache.get(user.id);

--- a/src/commands/moderation/warn.js
+++ b/src/commands/moderation/warn.js
@@ -25,6 +25,9 @@ module.exports = {
                 .addIntegerOption(o => o.setName('case_id').setDescription('The case ID of the warning to remove').setRequired(true).setMinValue(1)))
         .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
 
+    // Re-checked inside the gate in events/interactionCreate — the builder line
+    // above is only Discord's default, which a guild admin can reassign.
+    requiredPermissions: [PermissionFlagsBits.ModerateMembers],
     async execute(interaction) {
         const sub = interaction.options.getSubcommand();
 

--- a/src/commands/utility/giveaway.js
+++ b/src/commands/utility/giveaway.js
@@ -23,6 +23,9 @@ module.exports = {
                 .addStringOption(o => o.setName('message_id').setDescription('Message ID of the giveaway').setRequired(true)))
         .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild),
 
+    // Re-checked inside the gate in events/interactionCreate — the builder line
+    // above is only Discord's default, which a guild admin can reassign.
+    requiredPermissions: [PermissionFlagsBits.ManageGuild],
     async execute(interaction) {
         const sub = interaction.options.getSubcommand();
 

--- a/src/dashboard/routes/api/rss.js
+++ b/src/dashboard/routes/api/rss.js
@@ -8,7 +8,10 @@ const { isValidDiscordId } = require('../../lib/apiHelpers');
 const { rescheduleDailyNews, sendDailyNews } = require('../../../services/rssService');
 
 
-router.post('/guild/:guildId/validate-feed', checkAuth, checkGuildAccess, async (req, res) => {
+// The one write on the router that had no rate limit, and the one that reaches
+// out to a caller-supplied URL — an admin looping it turns the bot into an
+// outbound fetcher on someone else's behalf.
+router.post('/guild/:guildId/validate-feed', checkAuth, checkGuildAccess, checkWriteRateLimit, async (req, res) => {
     const { url } = req.body;
     if (!url || typeof url !== 'string') {
         return res.status(400).json({ valid: false, error: 'No URL provided.' });

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -39,18 +39,40 @@ function resolveDashboardUrl() {
     return `${parsed.protocol}//${parsed.host}`;
 }
 
+// Options for the Discord OAuth2 strategy, split out from the passport.use()
+// call so the login CSRF defence below is assertable without booting the app.
+//
+// `state: true` is the load-bearing line. Without it passport-oauth2 falls back
+// to its NullStore (lib/strategy.js), which issues no state parameter and
+// verifies none on the way back — so /auth/callback accepts any `code` from
+// anyone, with nothing tying it to the session that started the login. An
+// attacker who begins a login, captures their own code and gets an operator to
+// open /auth/callback?code=... silently signs that operator into the attacker's
+// Discord identity, where anything they then configure or paste lands in the
+// attacker's guild. With `state: true` the strategy uses the session-backed
+// NonceStore: the callback only completes for a state value this session
+// generated moments earlier.
+//
+// PKCE (`pkce: true`) would layer on protection for the code itself; it is left
+// off deliberately, since the client secret already covers the confidential-client
+// case this dashboard is and enabling it changes the token request.
+function discordStrategyOptions(callbackURL) {
+    return {
+        clientID: process.env.CLIENT_ID,
+        clientSecret: process.env.CLIENT_SECRET,
+        callbackURL,
+        scope: [DiscordScope.Identify, DiscordScope.Guilds],
+        state: true
+    };
+}
+
 function setupPassport() {
     const baseUrl = resolveDashboardUrl();
     const callbackURL = `${baseUrl}/auth/callback`;
     console.log(`[DASHBOARD] OAuth callback URL: ${callbackURL}`);
     console.log('[DASHBOARD] This EXACT URL must be added under "OAuth2 → Redirects" in the Discord Developer Portal.');
 
-    passport.use(new DiscordStrategy({
-        clientID: process.env.CLIENT_ID,
-        clientSecret: process.env.CLIENT_SECRET,
-        callbackURL,
-        scope: [DiscordScope.Identify, DiscordScope.Guilds]
-    }, async (accessToken, refreshToken, profile, done, consumable) => {
+    passport.use(new DiscordStrategy(discordStrategyOptions(callbackURL), async (accessToken, refreshToken, profile, done, consumable) => {
         try {
             if (!profile || !profile.id || !profile.username) {
                 return done(new Error('Invalid Discord profile returned from OAuth'));
@@ -203,4 +225,4 @@ function start(client) {
     });
 }
 
-module.exports = { start };
+module.exports = { start, discordStrategyOptions };

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -132,6 +132,31 @@ function isWithinRuleWindow(rule, now) {
     return hour >= rule.startHourUtc || hour <= rule.endHourUtc;
 }
 
+// `setDefaultMemberPermissions` on a command builder is a *default*, not a rule.
+// A guild admin can reassign any command to @everyone under Server Settings →
+// Integrations, and Discord will then deliver it as an ordinary interaction with
+// nothing to say the gate was moved. Fifteen moderation commands took Discord's
+// word for it and re-checked nothing, so the only thing standing between a
+// reassigned /ban and an ordinary member was a setting an attacker's own admin
+// could change.
+//
+// Commands opt in by declaring `requiredPermissions`, and the check lands here
+// once rather than in fifteen handlers where the sixteenth is the one that
+// forgets. Administrators and the guild owner satisfy any bit — Discord already
+// folds that into the permissions it sends, and PermissionsBitField#missing
+// honours it.
+function missingRequiredPermissions(interaction, command) {
+    const required = command.requiredPermissions;
+    if (!required || (Array.isArray(required) && required.length === 0)) return null;
+
+    // A guild chat-input interaction always carries this. Absent means we cannot
+    // establish what the caller holds, and "cannot establish" is not "allowed".
+    if (!interaction.memberPermissions) return ['Unknown'];
+
+    const missing = interaction.memberPermissions.missing(required);
+    return missing.length ? missing : null;
+}
+
 function getPolicyDecision(interaction, guildSettings) {
     const policies = guildSettings?.commandPolicies;
     if (!policies?.enabled) return { allowed: true };
@@ -289,6 +314,15 @@ module.exports = {
             return;
         }
 
+        const missingPerms = missingRequiredPermissions(interaction, command);
+        if (missingPerms) {
+            await logCommandMetric(interaction, false, 'missing_permissions');
+            return interaction.reply({
+                content: `You need the following permission(s) to use \`/${command.data.name}\`: **${missingPerms.join(', ')}**.`,
+                flags: MessageFlags.Ephemeral
+            });
+        }
+
         const policy = getPolicyDecision(interaction, guildSettings);
         if (!policy.allowed) {
             await logCommandMetric(interaction, false, 'policy_denied');
@@ -352,3 +386,7 @@ module.exports = {
         }
     }
 };
+
+// Exposed for the permission-gate tests, which drive the check directly rather
+// than booting the whole interaction handler and its model imports.
+module.exports.missingRequiredPermissions = missingRequiredPermissions;

--- a/src/utils/moderationHierarchy.js
+++ b/src/utils/moderationHierarchy.js
@@ -65,8 +65,13 @@ function hierarchyDenial(invoker, target, action = 'moderate') {
     return null;
 }
 
+// Discord's "this user is not in the guild" answers. Anything else a fetch
+// throws — 429, 5xx, a timeout — says nothing about membership.
+const UNKNOWN_MEMBER = 10007;
+const UNKNOWN_USER   = 10013;
+
 /**
- * The member behind a user id, or null if they are not in this guild.
+ * Resolve a user id to a member of this guild.
  *
  * The commands used to read `guild.members.cache.get(id)` and treat a miss as
  * "not a member". That is not what a miss means here: GuildMemberManager is
@@ -76,44 +81,59 @@ function hierarchyDenial(invoker, target, action = 'moderate') {
  * attacker skips by picking a target who has been quiet — which is most of the
  * senior staff this guard exists to protect.
  *
- * A genuine non-member (banning a raider by id, the case massban is for) still
- * comes back null; the fetch just makes that answer true rather than assumed.
+ * Three outcomes, and the third is the one that matters:
+ *
+ *   { member }                    — found, so the rank comparison can run
+ *   { member: null }              — confirmed not in the guild; there is no rank
+ *                                   to compare, which is the ban-by-id case
+ *   { member: null, indeterminate: true }
+ *                                 — we could not find out
+ *
+ * Collapsing the third into the second is a fail-open. The ban-shaped commands
+ * proceed when no member is found, so "the fetch failed" would read as "nobody
+ * to outrank" and wave the action through with neither the hierarchy check nor
+ * the bot's own bannable check — and since a rate limit produces exactly that
+ * failure, it is a state a caller can provoke. Callers must refuse on
+ * `indeterminate` instead.
  */
 async function resolveMember(guild, userId) {
     const cached = guild?.members?.cache?.get(userId);
-    if (cached) return cached;
+    if (cached) return { member: cached, indeterminate: false };
+
     try {
-        return await guild.members.fetch(userId);
-    } catch {
-        // Unknown Member, or the fetch failed. Either way there is no member to
-        // compare against; the caller's own permission checks still apply.
-        return null;
+        const fetched = await guild.members.fetch(userId);
+        return { member: fetched ?? null, indeterminate: !fetched };
+    } catch (error) {
+        const absent = error?.code === UNKNOWN_MEMBER || error?.code === UNKNOWN_USER;
+        return { member: null, indeterminate: !absent };
     }
 }
 
 /**
  * The same resolution for a batch of ids, in one round trip rather than fifty.
- * Returns a Map of id -> member, holding only the ids that are members.
+ *
+ * Returns `{ members, indeterminate }`: a Map of id -> member for the ids that
+ * are members, and a Set of the ids we could not settle. The batch fetch omits
+ * non-members rather than erroring on them, so a throw here tells us nothing
+ * about any of the ids it covered — all of them land in `indeterminate`.
  */
 async function resolveMembers(guild, userIds) {
-    const resolved = new Map();
+    const members = new Map();
     for (const id of userIds) {
         const cached = guild?.members?.cache?.get(id);
-        if (cached) resolved.set(id, cached);
+        if (cached) members.set(id, cached);
     }
 
-    const unresolved = userIds.filter(id => !resolved.has(id));
-    if (unresolved.length === 0) return resolved;
+    const unresolved = userIds.filter(id => !members.has(id));
+    if (unresolved.length === 0) return { members, indeterminate: new Set() };
 
     try {
         const fetched = await guild.members.fetch({ user: unresolved });
-        for (const [id, member] of fetched) resolved.set(id, member);
+        for (const [id, member] of fetched) members.set(id, member);
+        return { members, indeterminate: new Set() };
     } catch {
-        // A failed batch fetch leaves the ids unresolved, which reads as "not a
-        // member" — the same answer the cache-only code always gave, and the
-        // bot's own bannable check still stands behind it.
+        return { members, indeterminate: new Set(unresolved) };
     }
-    return resolved;
 }
 
 module.exports = { hierarchyDenial, resolveMember, resolveMembers };

--- a/src/utils/moderationHierarchy.js
+++ b/src/utils/moderationHierarchy.js
@@ -1,0 +1,119 @@
+'use strict';
+
+/**
+ * Does the moderator running this command actually outrank the member they are
+ * aiming at?
+ *
+ * Every moderation command used to answer a different question. `member.bannable`,
+ * `member.kickable` and `member.moderatable` all describe the *bot's* power over
+ * the target — whether the bot's highest role sits above theirs and whether it
+ * holds the permission. None of them look at the invoker at all. So a trial
+ * moderator holding only Ban Members could ban the head moderator, or an admin,
+ * as long as the bot outranked them: an action Discord's own right-click menu
+ * would refuse, waved through because the check asked about the wrong actor.
+ *
+ * This is the missing half. It compares the invoker's highest role against the
+ * target's, the way Discord does, and is deliberately the only place that
+ * comparison lives — the repo previously had exactly one `roles.highest` call
+ * site in the whole tree, in antiNukeService.
+ *
+ * Returns a ready-to-send refusal string, or `null` when the action may proceed.
+ * Callers read as:
+ *
+ *     const denial = hierarchyDenial(interaction.member, member, 'ban');
+ *     if (denial) return interaction.reply({ content: denial, ... });
+ */
+
+/**
+ * @param {import('discord.js').GuildMember|null|undefined} invoker  the moderator
+ * @param {import('discord.js').GuildMember|null|undefined} target   the member being acted on
+ * @param {string} action  verb for the refusal message, e.g. 'ban'
+ * @returns {string|null} refusal text, or null if allowed
+ */
+function hierarchyDenial(invoker, target, action = 'moderate') {
+    // Not a member of this guild — a banned-by-ID user, someone who already left.
+    // There is no role to outrank, so hierarchy has nothing to say; the caller's
+    // own permission and bannable checks still apply.
+    if (!target) return null;
+
+    // Should not happen for a guild interaction, but an absent invoker means we
+    // cannot establish rank, and an unestablished rank is not a passing one.
+    if (!invoker) return `Could not verify your role position, so this ${action} was not performed.`;
+
+    const ownerId = invoker.guild?.ownerId ?? target.guild?.ownerId ?? null;
+
+    // The owner sits above the role list entirely — outside it, in fact, since
+    // their highest role can be anything. Check both ends against ownership
+    // before touching positions.
+    if (ownerId && invoker.id === ownerId) return null;
+    if (ownerId && target.id === ownerId) {
+        return `You cannot ${action} the server owner.`;
+    }
+
+    let outranks;
+    try {
+        outranks = invoker.roles.highest.comparePositionTo(target.roles.highest) > 0;
+    } catch {
+        // Malformed member objects, or roles from different guilds — fail closed.
+        return `Could not compare your role position with theirs, so this ${action} was not performed.`;
+    }
+
+    if (!outranks) {
+        return `You cannot ${action} someone whose highest role is above or equal to yours.`;
+    }
+
+    return null;
+}
+
+/**
+ * The member behind a user id, or null if they are not in this guild.
+ *
+ * The commands used to read `guild.members.cache.get(id)` and treat a miss as
+ * "not a member". That is not what a miss means here: GuildMemberManager is
+ * capped at 200 per guild with an hourly sweep (utils/cacheOptions), so in any
+ * guild worth moderating the cache is a small recently-seen sample, not a
+ * roster. A hierarchy check that only runs on cache hits is a hierarchy check an
+ * attacker skips by picking a target who has been quiet — which is most of the
+ * senior staff this guard exists to protect.
+ *
+ * A genuine non-member (banning a raider by id, the case massban is for) still
+ * comes back null; the fetch just makes that answer true rather than assumed.
+ */
+async function resolveMember(guild, userId) {
+    const cached = guild?.members?.cache?.get(userId);
+    if (cached) return cached;
+    try {
+        return await guild.members.fetch(userId);
+    } catch {
+        // Unknown Member, or the fetch failed. Either way there is no member to
+        // compare against; the caller's own permission checks still apply.
+        return null;
+    }
+}
+
+/**
+ * The same resolution for a batch of ids, in one round trip rather than fifty.
+ * Returns a Map of id -> member, holding only the ids that are members.
+ */
+async function resolveMembers(guild, userIds) {
+    const resolved = new Map();
+    for (const id of userIds) {
+        const cached = guild?.members?.cache?.get(id);
+        if (cached) resolved.set(id, cached);
+    }
+
+    const unresolved = userIds.filter(id => !resolved.has(id));
+    if (unresolved.length === 0) return resolved;
+
+    try {
+        const fetched = await guild.members.fetch({ user: unresolved });
+        for (const [id, member] of fetched) resolved.set(id, member);
+    } catch {
+        // A failed batch fetch leaves the ids unresolved, which reads as "not a
+        // member" — the same answer the cache-only code always gave, and the
+        // bot's own bannable check still stands behind it.
+    }
+    return resolved;
+}
+
+module.exports = { hierarchyDenial, resolveMember, resolveMembers };

--- a/tests/commandPermissionGate.test.js
+++ b/tests/commandPermissionGate.test.js
@@ -1,0 +1,155 @@
+'use strict';
+
+// `setDefaultMemberPermissions` is a default, not a rule. Under Server Settings →
+// Integrations a guild admin can hand any command to @everyone, and Discord will
+// then deliver it as an ordinary interaction with nothing to say the gate moved.
+// Fifteen moderation commands trusted that default and re-checked nothing, so the
+// only thing between a reassigned /ban and an ordinary member was a setting an
+// attacker's own admin could change.
+//
+// Two things need proving. That the gate refuses; and that every command which
+// declares a default also opts into it — the gate is central precisely so no
+// individual handler can forget, but a command can still forget to declare.
+
+const fs   = require('fs');
+const path = require('path');
+const { PermissionFlagsBits, PermissionsBitField } = require('discord.js');
+const { missingRequiredPermissions } = require('../src/events/interactionCreate');
+
+const held = (...bits) => new PermissionsBitField(bits);
+
+describe('missingRequiredPermissions', () => {
+    test('names the permission a caller is missing', () => {
+        const missing = missingRequiredPermissions(
+            { memberPermissions: held(PermissionFlagsBits.SendMessages) },
+            { requiredPermissions: [PermissionFlagsBits.BanMembers] },
+        );
+        expect(missing).toEqual(['BanMembers']);
+    });
+
+    test('passes a caller who holds it', () => {
+        const missing = missingRequiredPermissions(
+            { memberPermissions: held(PermissionFlagsBits.BanMembers) },
+            { requiredPermissions: [PermissionFlagsBits.BanMembers] },
+        );
+        expect(missing).toBeNull();
+    });
+
+    // massban wants both bits. Holding one is not holding the pair.
+    test('rejects a caller holding only part of what a command requires', () => {
+        const missing = missingRequiredPermissions(
+            { memberPermissions: held(PermissionFlagsBits.BanMembers) },
+            { requiredPermissions: [PermissionFlagsBits.BanMembers, PermissionFlagsBits.ManageGuild] },
+        );
+        expect(missing).toEqual(['ManageGuild']);
+    });
+
+    test('reports every missing bit, not just the first', () => {
+        const missing = missingRequiredPermissions(
+            { memberPermissions: held(PermissionFlagsBits.SendMessages) },
+            { requiredPermissions: [PermissionFlagsBits.BanMembers, PermissionFlagsBits.ManageGuild] },
+        );
+        expect(missing.sort()).toEqual(['BanMembers', 'ManageGuild']);
+    });
+
+    // Discord folds Administrator (and ownership) into the permissions it sends,
+    // and PermissionsBitField#missing honours it — so an admin is not locked out
+    // of a command whose specific bit they were never granted.
+    test('an Administrator satisfies any requirement', () => {
+        const missing = missingRequiredPermissions(
+            { memberPermissions: held(PermissionFlagsBits.Administrator) },
+            { requiredPermissions: [PermissionFlagsBits.BanMembers, PermissionFlagsBits.ManageGuild] },
+        );
+        expect(missing).toBeNull();
+    });
+
+    test('leaves commands that declare nothing alone', () => {
+        const open = { memberPermissions: held() };
+        expect(missingRequiredPermissions(open, {})).toBeNull();
+        expect(missingRequiredPermissions(open, { requiredPermissions: [] })).toBeNull();
+        expect(missingRequiredPermissions(open, { requiredPermissions: null })).toBeNull();
+    });
+
+    // A DM or a malformed payload leaves memberPermissions null. "Cannot tell"
+    // is not "allowed".
+    test('fails closed when the interaction carries no permissions', () => {
+        for (const memberPermissions of [null, undefined]) {
+            expect(missingRequiredPermissions(
+                { memberPermissions },
+                { requiredPermissions: [PermissionFlagsBits.BanMembers] },
+            )).toEqual(['Unknown']);
+        }
+    });
+});
+
+// Walk the real command tree. A command that declares a Discord-side default is
+// declaring "this needs the bit"; if it does not also declare it to the gate, the
+// bit is enforced only by a setting a guild admin can move.
+describe('every command with a Discord-side default re-declares it to the gate', () => {
+    const commandsDir = path.join(__dirname, '..', 'src', 'commands');
+
+    const commands = fs.readdirSync(commandsDir)
+        .filter(d => fs.statSync(path.join(commandsDir, d)).isDirectory())
+        .flatMap(dir => fs.readdirSync(path.join(commandsDir, dir))
+            .filter(f => f.endsWith('.js'))
+            .map(file => {
+                const mod = require(path.join(commandsDir, dir, file));
+                return { file: `${dir}/${file}`, mod };
+            }))
+        .filter(c => typeof c.mod?.data?.toJSON === 'function')
+        .map(c => ({ ...c, json: c.mod.data.toJSON() }));
+
+    const gated = commands.filter(c => c.json.default_member_permissions != null);
+
+    test('the sweep found the command tree', () => {
+        expect(commands.length).toBeGreaterThan(50);
+        expect(gated.length).toBeGreaterThan(15);
+    });
+
+    test.each(gated.map(c => [c.file, c]))('%s', (_file, command) => {
+        expect(command.mod.requiredPermissions).toBeDefined();
+        // Same bits on both sides: a mismatch means the gate enforces something
+        // other than what the command told Discord it needs.
+        expect(new PermissionsBitField(command.mod.requiredPermissions).bitfield)
+            .toBe(BigInt(command.json.default_member_permissions));
+    });
+
+    test('the commands the issue named are all in the gated set', () => {
+        const named = [
+            'ban', 'kick', 'mute', 'softban', 'clear', 'lockdown', 'massban', 'unban',
+            'warn', 'note', 'case', 'cases', 'closecase', 'slowmode', 'raidmode',
+        ];
+        const gatedNames = new Set(gated.map(c => c.json.name));
+        for (const name of named) expect(gatedNames).toContain(name);
+    });
+
+    test('a command that sets no default declares no requirement either', () => {
+        // /shop passes null deliberately — it is a player command. The gate must
+        // not acquire a requirement the command never asked for.
+        for (const command of commands.filter(c => c.json.default_member_permissions == null)) {
+            expect(`${command.file}: ${command.mod.requiredPermissions ?? 'none'}`)
+                .toBe(`${command.file}: none`);
+        }
+    });
+});
+
+describe('the gate is wired into the dispatch', () => {
+    const source = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'events', 'interactionCreate.js'), 'utf8',
+    );
+
+    test('runs before the command executes', () => {
+        const gate = source.indexOf('missingRequiredPermissions(interaction, command)');
+        const run  = source.indexOf('await command.execute(interaction, client)');
+        expect(gate).toBeGreaterThan(-1);
+        expect(run).toBeGreaterThan(gate);
+    });
+
+    test('refuses rather than falling through', () => {
+        expect(source).toMatch(/if \(missingPerms\) \{[\s\S]*?return interaction\.reply\(/);
+    });
+
+    test('records the refusal, so a reassigned command is visible in metrics', () => {
+        expect(source).toContain("'missing_permissions'");
+    });
+});

--- a/tests/dashboardAuthEnforcement.test.js
+++ b/tests/dashboardAuthEnforcement.test.js
@@ -1,0 +1,354 @@
+'use strict';
+
+// The authorization *rule* — `hasManagePermission` — was already at 100% coverage.
+// The middleware that enforces it was at 17.9%, and not one test asserted that a
+// non-admin request gets turned away. A rule nothing proves is applied is a rule
+// that can quietly stop being applied.
+//
+// So this suite is about the deny paths, and only the deny paths: no session,
+// wrong guild, a guild the bot is not in, a cross-origin write, an admin of
+// nothing. Plus a structural pass over every API sub-router, because the second
+// way this protection disappears is not a broken check — it is a new route added
+// next month that forgets to list the guard at all.
+
+const fs   = require('fs');
+const path = require('path');
+
+const {
+    checkAuth,
+    checkGuildAccess,
+    checkCsrfOrigin,
+    checkAnyGuildAdmin,
+} = require('../src/dashboard/lib/middleware');
+
+const MANAGE_GUILD = (0x20n).toString();
+const NO_PERMS     = '0';
+
+function makeRes() {
+    return {
+        statusCode: null,
+        body: null,
+        status(code) { this.statusCode = code; return this; },
+        json(payload) { this.body = payload; return this; },
+    };
+}
+
+// `guilds` is what Discord's /users/@me/guilds returned for this session;
+// `botGuilds` is what the bot is actually in. Both matter: dashboard access needs
+// the user to administer the guild *and* the bot to be present in it.
+function makeReq({ authenticated = true, guilds = [], botGuilds = [], params = {}, headers = {} } = {}) {
+    return {
+        isAuthenticated: () => authenticated,
+        user: authenticated ? { id: 'user-1', guilds } : undefined,
+        client: { guilds: { cache: { has: id => botGuilds.includes(id) } } },
+        params,
+        headers,
+    };
+}
+
+const adminOf   = id => ({ id, name: `guild ${id}`, permissions: MANAGE_GUILD });
+const memberOf  = id => ({ id, name: `guild ${id}`, permissions: NO_PERMS });
+
+describe('checkAuth', () => {
+    test('rejects an unauthenticated request with 401 and does not call next', () => {
+        const res = makeRes();
+        const next = jest.fn();
+
+        checkAuth(makeReq({ authenticated: false }), res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(401);
+        expect(res.body).toEqual({ error: 'Unauthorized' });
+    });
+
+    test('lets an authenticated request through', () => {
+        const res = makeRes();
+        const next = jest.fn();
+
+        checkAuth(makeReq(), res, next);
+
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(res.statusCode).toBeNull();
+    });
+});
+
+describe('checkGuildAccess', () => {
+    test('rejects a guild the user only belongs to, with no manage permission', () => {
+        const res = makeRes();
+        const next = jest.fn();
+        const req = makeReq({
+            guilds: [memberOf('g1')],
+            botGuilds: ['g1'],
+            params: { guildId: 'g1' },
+        });
+
+        checkGuildAccess(req, res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(403);
+        expect(res.body).toEqual({ error: 'Forbidden' });
+    });
+
+    // The IDOR shape: authenticated, genuinely an admin — just not of this guild.
+    test('rejects an admin of one guild reaching for another', () => {
+        const res = makeRes();
+        const next = jest.fn();
+        const req = makeReq({
+            guilds: [adminOf('g1'), memberOf('g2')],
+            botGuilds: ['g1', 'g2'],
+            params: { guildId: 'g2' },
+        });
+
+        checkGuildAccess(req, res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(403);
+    });
+
+    test('rejects a guild the user administers but the bot is not in', () => {
+        const res = makeRes();
+        const next = jest.fn();
+        const req = makeReq({
+            guilds: [adminOf('g1')],
+            botGuilds: [],
+            params: { guildId: 'g1' },
+        });
+
+        checkGuildAccess(req, res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(403);
+    });
+
+    test('rejects a guild id the session has never heard of', () => {
+        const res = makeRes();
+        const next = jest.fn();
+        const req = makeReq({
+            guilds: [adminOf('g1')],
+            botGuilds: ['g1', 'g9'],
+            params: { guildId: 'g9' },
+        });
+
+        checkGuildAccess(req, res, next);
+
+        expect(res.statusCode).toBe(403);
+    });
+
+    test('admits an admin of a guild the bot shares', () => {
+        const res = makeRes();
+        const next = jest.fn();
+        const req = makeReq({
+            guilds: [adminOf('g1')],
+            botGuilds: ['g1'],
+            params: { guildId: 'g1' },
+        });
+
+        checkGuildAccess(req, res, next);
+
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(res.statusCode).toBeNull();
+    });
+});
+
+describe('checkAnyGuildAdmin', () => {
+    test('rejects an unauthenticated caller with 401', () => {
+        const res = makeRes();
+        const next = jest.fn();
+
+        checkAnyGuildAdmin(makeReq({ authenticated: false }), res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(401);
+    });
+
+    test('rejects a signed-in user who administers nothing', () => {
+        const res = makeRes();
+        const next = jest.fn();
+
+        checkAnyGuildAdmin(makeReq({ guilds: [memberOf('g1')], botGuilds: ['g1'] }), res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(403);
+        expect(res.body).toEqual({ error: 'Forbidden' });
+    });
+
+    test('rejects an admin whose only guilds are ones the bot is absent from', () => {
+        const res = makeRes();
+        const next = jest.fn();
+
+        checkAnyGuildAdmin(makeReq({ guilds: [adminOf('g1')], botGuilds: [] }), res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(403);
+    });
+
+    test('admits an admin of at least one shared guild', () => {
+        const res = makeRes();
+        const next = jest.fn();
+
+        checkAnyGuildAdmin(makeReq({ guilds: [adminOf('g1')], botGuilds: ['g1'] }), res, next);
+
+        expect(next).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('checkCsrfOrigin', () => {
+    const DASHBOARD = 'https://dash.example.com';
+    let saved;
+
+    beforeAll(() => { saved = process.env.DASHBOARD_URL; process.env.DASHBOARD_URL = DASHBOARD; });
+    afterAll(() => {
+        if (saved === undefined) delete process.env.DASHBOARD_URL;
+        else process.env.DASHBOARD_URL = saved;
+    });
+
+    test('rejects a write carrying a foreign Origin', () => {
+        const res = makeRes();
+        const next = jest.fn();
+
+        checkCsrfOrigin(makeReq({ headers: { origin: 'https://evil.example.com' } }), res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(403);
+        expect(res.body).toEqual({ error: 'Forbidden: cross-origin request rejected' });
+    });
+
+    // Prefix matching is the classic way this check is written wrong:
+    // dash.example.com.evil.test starts with the dashboard host.
+    test('rejects a host that merely starts with the dashboard host', () => {
+        const res = makeRes();
+        const next = jest.fn();
+
+        checkCsrfOrigin(makeReq({ headers: { origin: 'https://dash.example.com.evil.test' } }), res, next);
+
+        expect(res.statusCode).toBe(403);
+    });
+
+    test('rejects the same host on another scheme or port', () => {
+        for (const origin of ['http://dash.example.com', 'https://dash.example.com:8443']) {
+            const res = makeRes();
+            checkCsrfOrigin(makeReq({ headers: { origin } }), res, jest.fn());
+            expect(res.statusCode).toBe(403);
+        }
+    });
+
+    test('rejects an unparseable Origin rather than falling through', () => {
+        const res = makeRes();
+        const next = jest.fn();
+
+        checkCsrfOrigin(makeReq({ headers: { origin: 'not a url' } }), res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(403);
+    });
+
+    test('admits a matching Origin, and a request that sends none', () => {
+        for (const headers of [{ origin: DASHBOARD }, {}]) {
+            const res = makeRes();
+            const next = jest.fn();
+            checkCsrfOrigin(makeReq({ headers }), res, next);
+            expect(next).toHaveBeenCalledTimes(1);
+            expect(res.statusCode).toBeNull();
+        }
+    });
+});
+
+// The middleware above can be perfect and still protect nothing if a route never
+// lists it. Rather than trusting 33 route declarations to stay right, this walks
+// the routers Express actually built and reads the guard off each layer.
+describe('every API route mounts its guards', () => {
+    const apiDir = path.join(__dirname, '..', 'src', 'dashboard', 'routes', 'api');
+    const files = fs.readdirSync(apiDir).filter(f => f.endsWith('.js'));
+
+    // Each entry: { file, method, routePath, handlers: [middleware names] }
+    const routes = files.flatMap(file => {
+        const router = require(path.join(apiDir, file));
+        return router.stack
+            .filter(layer => layer.route)
+            .flatMap(layer => Object.keys(layer.route.methods).map(method => ({
+                file,
+                method: method.toUpperCase(),
+                routePath: layer.route.path,
+                handlers: layer.route.stack.map(s => s.handle.name),
+            })));
+    });
+
+    const label = r => `${r.file} ${r.method} ${r.routePath}`;
+
+    // The two routes that serve image bytes to <img> tags. A shop or activity
+    // image is decoration, not guild data, and a browser rendering one cannot be
+    // asked to present a session — so these are public by design, GET-only, and
+    // still counted by the router-wide read limiter. Listed here rather than
+    // skipped by pattern: adding a public route should mean editing this line and
+    // saying why, not slipping past a wildcard.
+    const PUBLIC_ROUTES = new Set([
+        'itemImages.js GET /item-image/shop/:guildId/:itemId',
+        'itemImages.js GET /item-image/activity/:itemId',
+    ]);
+
+    const guarded = routes.filter(r => !PUBLIC_ROUTES.has(label(r)));
+
+    test('the public-route allowlist still describes routes that exist', () => {
+        const all = new Set(routes.map(label));
+        for (const entry of PUBLIC_ROUTES) expect(all).toContain(entry);
+    });
+
+    test('nothing on the allowlist is a write', () => {
+        for (const route of routes.filter(r => PUBLIC_ROUTES.has(label(r)))) {
+            expect(`${label(route)} is ${route.method}`).toBe(`${label(route)} is GET`);
+        }
+    });
+
+    test('there are routes to check, so an empty sweep cannot pass silently', () => {
+        expect(files.length).toBeGreaterThan(10);
+        expect(routes.length).toBeGreaterThan(25);
+    });
+
+    test.each(files)('%s guards every route with checkAuth', file => {
+        const own = guarded.filter(r => r.file === file);
+        expect(own.length).toBeGreaterThan(0);
+        for (const route of own) {
+            expect(`${label(route)}: ${route.handlers.join(' | ')}`)
+                .toContain('checkAuth');
+        }
+    });
+
+    test('every guild-scoped route also checks access to that guild', () => {
+        const scoped = guarded.filter(r => r.routePath.includes(':guildId'));
+        expect(scoped.length).toBeGreaterThan(20);
+        for (const route of scoped) {
+            expect(`${label(route)}: ${route.handlers.join(' | ')}`)
+                .toContain('checkGuildAccess');
+        }
+    });
+
+    // checkGuildAccess dereferences req.user.guilds with no null check of its
+    // own, so ordering here is not style — reversed, an anonymous request would
+    // throw a 500 out of the guard instead of returning 401.
+    test('checkAuth runs before checkGuildAccess, which reads req.user unguarded', () => {
+        for (const route of routes.filter(r => r.handlers.includes('checkGuildAccess'))) {
+            const auth   = route.handlers.indexOf('checkAuth');
+            const access = route.handlers.indexOf('checkGuildAccess');
+            expect(`${label(route)}: auth=${auth} access=${access}`)
+                .toBe(`${label(route)}: auth=${auth} access=${access}`);
+            expect(auth).toBeGreaterThanOrEqual(0);
+            expect(access).toBeGreaterThan(auth);
+        }
+    });
+
+    test('every state-changing route is rate limited', () => {
+        const writes = guarded.filter(r => ['POST', 'PUT', 'PATCH', 'DELETE'].includes(r.method));
+        expect(writes.length).toBeGreaterThan(15);
+        for (const route of writes) {
+            expect(`${label(route)}: ${route.handlers.join(' | ')}`)
+                .toContain('checkWriteRateLimit');
+        }
+    });
+
+    test('no guarded route reaches its own handler before checkAuth', () => {
+        for (const route of guarded) {
+            expect(`${label(route)} runs ${route.handlers[0] || '(its handler)'} first`)
+                .toBe(`${label(route)} runs checkAuth first`);
+        }
+    });
+});

--- a/tests/moderationHierarchy.test.js
+++ b/tests/moderationHierarchy.test.js
@@ -1,0 +1,236 @@
+'use strict';
+
+// Every moderation command asked `member.bannable` / `.kickable` / `.moderatable`
+// and stopped there. All three describe the *bot's* power over the target. None
+// of them look at the moderator, so a trial mod holding only Ban Members could
+// ban the head moderator — Discord's own UI refuses that, the bot did not.
+//
+// A repo-wide grep for `roles.highest` returned exactly one hit before this, in
+// antiNukeService. These tests pin the rule and the call sites, since a guard
+// nothing exercises is a guard that gets deleted in a refactor.
+
+const fs   = require('fs');
+const path = require('path');
+const { hierarchyDenial, resolveMember, resolveMembers } = require('../src/utils/moderationHierarchy');
+
+const OWNER_ID = 'owner-1';
+
+// Enough of a GuildMember for the comparison: an id, a highest role with a
+// position, and the guild's ownerId. comparePositionTo is what discord.js
+// exposes and what the guard calls, so the fake implements it rather than
+// letting the guard reach for `.position` directly.
+function member(id, position, { ownerId = OWNER_ID } = {}) {
+    return {
+        id,
+        guild: { ownerId },
+        roles: {
+            highest: {
+                position,
+                comparePositionTo: other => position - other.position,
+            },
+        },
+    };
+}
+
+describe('hierarchyDenial', () => {
+    test('lets a moderator act on someone strictly below them', () => {
+        expect(hierarchyDenial(member('mod', 5), member('target', 3), 'ban')).toBeNull();
+    });
+
+    test('refuses a moderator acting on someone above them', () => {
+        const denial = hierarchyDenial(member('trial-mod', 2), member('head-mod', 9), 'ban');
+        expect(denial).toMatch(/cannot ban/i);
+    });
+
+    // The realistic case: two moderators handed the same role. Discord treats
+    // equal as "no", and so does this.
+    test('refuses a moderator acting on an equal', () => {
+        expect(hierarchyDenial(member('mod-a', 5), member('mod-b', 5), 'kick')).not.toBeNull();
+    });
+
+    test('names the action it refused, so the message fits the command', () => {
+        expect(hierarchyDenial(member('a', 1), member('b', 4), 'softban')).toContain('softban');
+        expect(hierarchyDenial(member('a', 1), member('b', 4), 'mute')).toContain('mute');
+    });
+
+    test('the owner outranks everyone, including a member holding a higher role', () => {
+        // Ownership is not a role position — an owner can sit at the bottom of
+        // the list and still outrank the whole server.
+        expect(hierarchyDenial(member(OWNER_ID, 0), member('admin', 50), 'ban')).toBeNull();
+    });
+
+    test('nobody may act on the owner, however high their own role', () => {
+        const denial = hierarchyDenial(member('admin', 50), member(OWNER_ID, 1), 'ban');
+        expect(denial).toMatch(/server owner/i);
+    });
+
+    test('a target who is not in the guild has no rank to outrank', () => {
+        // massban's whole reason to exist: IDs of people who were never here.
+        for (const absent of [null, undefined]) {
+            expect(hierarchyDenial(member('mod', 5), absent, 'ban')).toBeNull();
+        }
+    });
+
+    test('fails closed when the invoker is missing', () => {
+        expect(hierarchyDenial(null, member('target', 1), 'ban')).not.toBeNull();
+        expect(hierarchyDenial(undefined, member('target', 1), 'ban')).not.toBeNull();
+    });
+
+    test('fails closed when the comparison throws', () => {
+        const broken = {
+            id: 'mod',
+            guild: { ownerId: OWNER_ID },
+            roles: { highest: { comparePositionTo() { throw new Error('different guild'); } } },
+        };
+        expect(hierarchyDenial(broken, member('target', 1), 'ban')).not.toBeNull();
+    });
+
+    test('fails closed on a member with no roles at all rather than throwing', () => {
+        const shapeless = { id: 'mod', guild: { ownerId: OWNER_ID } };
+        expect(() => hierarchyDenial(shapeless, member('target', 1), 'ban')).not.toThrow();
+        expect(hierarchyDenial(shapeless, member('target', 1), 'ban')).not.toBeNull();
+    });
+
+    test('still compares when only the target knows the ownerId', () => {
+        // interaction.member is built from the interaction payload and its
+        // .guild is the same object in practice, but the guard reads either end.
+        const invoker = { id: 'mod', roles: { highest: { position: 9, comparePositionTo: o => 9 - o.position } } };
+        expect(hierarchyDenial(invoker, member('target', 2), 'ban')).toBeNull();
+        expect(hierarchyDenial(invoker, member(OWNER_ID, 2), 'ban')).toMatch(/server owner/i);
+    });
+});
+
+// A hierarchy check that only runs on cache hits is one an attacker skips by
+// picking a quiet target. GuildMemberManager is capped at 200 per guild and swept
+// hourly (utils/cacheOptions), so the cache is a recently-seen sample, not a
+// roster — these cover the resolution that turns a miss into a real answer.
+describe('resolveMember', () => {
+    const fakeGuild = ({ cached = {}, fetched = {} } = {}) => ({
+        members: {
+            cache: { get: id => cached[id] },
+            fetch: jest.fn(async arg => {
+                if (typeof arg === 'string') {
+                    if (!fetched[arg]) throw new Error('Unknown Member');
+                    return fetched[arg];
+                }
+                const wanted = arg.user;
+                return new Map(wanted.filter(id => fetched[id]).map(id => [id, fetched[id]]));
+            }),
+        },
+    });
+
+    test('uses the cache when it has the member, without a round trip', async () => {
+        const guild = fakeGuild({ cached: { u1: { id: 'u1' } } });
+        await expect(resolveMember(guild, 'u1')).resolves.toEqual({ id: 'u1' });
+        expect(guild.members.fetch).not.toHaveBeenCalled();
+    });
+
+    test('fetches on a cache miss rather than calling them a non-member', async () => {
+        const guild = fakeGuild({ fetched: { u2: { id: 'u2' } } });
+        await expect(resolveMember(guild, 'u2')).resolves.toEqual({ id: 'u2' });
+        expect(guild.members.fetch).toHaveBeenCalledWith('u2');
+    });
+
+    test('returns null for someone who really is not in the guild', async () => {
+        await expect(resolveMember(fakeGuild(), 'stranger')).resolves.toBeNull();
+    });
+
+    test('a failed fetch resolves to null rather than throwing at the command', async () => {
+        const guild = { members: { cache: { get: () => undefined }, fetch: async () => { throw new Error('5xx'); } } };
+        await expect(resolveMember(guild, 'u3')).resolves.toBeNull();
+    });
+
+    describe('resolveMembers', () => {
+        test('asks for the uncached ids only, in one call', async () => {
+            const guild = fakeGuild({ cached: { a: { id: 'a' } }, fetched: { b: { id: 'b' }, c: { id: 'c' } } });
+            const out = await resolveMembers(guild, ['a', 'b', 'c']);
+
+            expect(guild.members.fetch).toHaveBeenCalledTimes(1);
+            expect(guild.members.fetch).toHaveBeenCalledWith({ user: ['b', 'c'] });
+            expect([...out.keys()].sort()).toEqual(['a', 'b', 'c']);
+        });
+
+        test('omits ids that belong to nobody in the guild', async () => {
+            const guild = fakeGuild({ fetched: { b: { id: 'b' } } });
+            const out = await resolveMembers(guild, ['b', 'ghost']);
+
+            expect(out.has('b')).toBe(true);
+            expect(out.has('ghost')).toBe(false);
+        });
+
+        test('skips the round trip entirely when everything is cached', async () => {
+            const guild = fakeGuild({ cached: { a: { id: 'a' }, b: { id: 'b' } } });
+            await resolveMembers(guild, ['a', 'b']);
+            expect(guild.members.fetch).not.toHaveBeenCalled();
+        });
+
+        test('a failed batch leaves the cached half intact', async () => {
+            const guild = {
+                members: {
+                    cache: { get: id => (id === 'a' ? { id: 'a' } : undefined) },
+                    fetch: async () => { throw new Error('gateway timeout'); },
+                },
+            };
+            const out = await resolveMembers(guild, ['a', 'b']);
+            expect([...out.keys()]).toEqual(['a']);
+        });
+    });
+});
+
+// The guard only helps where it is called. These read the commands the issue
+// named, so removing a call site fails here rather than in production.
+describe('the commands that take a target call the guard', () => {
+    const cases = [
+        ['ban.js', 'moderation'],
+        ['kick.js', 'moderation'],
+        ['mute.js', 'moderation'],
+        ['softban.js', 'moderation'],
+        ['massban.js', 'moderation'],
+    ];
+
+    test.each(cases)('%s', (file, dir) => {
+        const source = fs.readFileSync(
+            path.join(__dirname, '..', 'src', 'commands', dir, file), 'utf8',
+        );
+        expect(source).toContain("require('../../utils/moderationHierarchy')");
+        expect(source).toMatch(/hierarchyDenial\(interaction\.member,/);
+    });
+
+    test('massban checks each target rather than once for the batch', () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, '..', 'src', 'commands', 'moderation', 'massban.js'), 'utf8',
+        );
+        const loopStart = source.indexOf('for (const userId of ids)');
+        const banCall   = source.indexOf('guild.members.ban(userId');
+        expect(loopStart).toBeGreaterThan(-1);
+        expect(banCall).toBeGreaterThan(loopStart);
+
+        // The call that matters is the one between the loop opening and the ban,
+        // not the require at the top of the file.
+        const callInLoop = source.indexOf('hierarchyDenial(interaction.member', loopStart);
+        expect(callInLoop).toBeGreaterThan(loopStart);
+        expect(callInLoop).toBeLessThan(banCall);
+    });
+
+    test('massban also checks bannable, which it never did', () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, '..', 'src', 'commands', 'moderation', 'massban.js'), 'utf8',
+        );
+        expect(source).toContain('bannable');
+    });
+
+    // The ban-shaped commands proceed when no member is found, so a cache-only
+    // lookup would let the guard be skipped by targeting anyone not recently
+    // seen. kick and mute refuse outright on a miss, so they fail closed either
+    // way and are left alone here.
+    test.each([['ban.js'], ['softban.js'], ['massban.js']])(
+        '%s resolves the target rather than reading the capped member cache',
+        file => {
+            const source = fs.readFileSync(
+                path.join(__dirname, '..', 'src', 'commands', 'moderation', file), 'utf8',
+            );
+            expect(source).toMatch(/resolveMembers?\(/);
+            expect(source).not.toContain('members.cache.get');
+        },
+    );
+});

--- a/tests/moderationHierarchy.test.js
+++ b/tests/moderationHierarchy.test.js
@@ -105,12 +105,18 @@ describe('hierarchyDenial', () => {
 // hourly (utils/cacheOptions), so the cache is a recently-seen sample, not a
 // roster — these cover the resolution that turns a miss into a real answer.
 describe('resolveMember', () => {
+    // Discord answers "not in this guild" with error code 10007; anything else it
+    // throws is a transport failure that says nothing about membership. The fake
+    // keeps that distinction because the whole point of these tests is that the
+    // code does too.
+    const unknownMember = () => Object.assign(new Error('Unknown Member'), { code: 10007 });
+
     const fakeGuild = ({ cached = {}, fetched = {} } = {}) => ({
         members: {
             cache: { get: id => cached[id] },
             fetch: jest.fn(async arg => {
                 if (typeof arg === 'string') {
-                    if (!fetched[arg]) throw new Error('Unknown Member');
+                    if (!fetched[arg]) throw unknownMember();
                     return fetched[arg];
                 }
                 const wanted = arg.user;
@@ -121,58 +127,82 @@ describe('resolveMember', () => {
 
     test('uses the cache when it has the member, without a round trip', async () => {
         const guild = fakeGuild({ cached: { u1: { id: 'u1' } } });
-        await expect(resolveMember(guild, 'u1')).resolves.toEqual({ id: 'u1' });
+        await expect(resolveMember(guild, 'u1'))
+            .resolves.toEqual({ member: { id: 'u1' }, indeterminate: false });
         expect(guild.members.fetch).not.toHaveBeenCalled();
     });
 
     test('fetches on a cache miss rather than calling them a non-member', async () => {
         const guild = fakeGuild({ fetched: { u2: { id: 'u2' } } });
-        await expect(resolveMember(guild, 'u2')).resolves.toEqual({ id: 'u2' });
+        await expect(resolveMember(guild, 'u2'))
+            .resolves.toEqual({ member: { id: 'u2' }, indeterminate: false });
         expect(guild.members.fetch).toHaveBeenCalledWith('u2');
     });
 
-    test('returns null for someone who really is not in the guild', async () => {
-        await expect(resolveMember(fakeGuild(), 'stranger')).resolves.toBeNull();
+    test('reports a confirmed non-member as absent, not as unsettled', async () => {
+        // The ban-by-id case: Discord said 10007, so there really is no member
+        // and no rank to compare. The commands may proceed.
+        await expect(resolveMember(fakeGuild(), 'stranger'))
+            .resolves.toEqual({ member: null, indeterminate: false });
     });
 
-    test('a failed fetch resolves to null rather than throwing at the command', async () => {
-        const guild = { members: { cache: { get: () => undefined }, fetch: async () => { throw new Error('5xx'); } } };
-        await expect(resolveMember(guild, 'u3')).resolves.toBeNull();
+    // The fail-open this distinction exists to prevent: a 429 or 5xx used to
+    // return the same null as a confirmed non-member, and the ban-shaped commands
+    // proceed when no member is found — so a failed lookup skipped both the
+    // hierarchy check and the bot's own bannable check, on a target who might
+    // well outrank the moderator. A rate limit is a state a caller can provoke.
+    test.each([
+        ['a rate limit', Object.assign(new Error('rate limited'), { code: 0, status: 429 })],
+        ['a server error', Object.assign(new Error('server error'), { status: 500 })],
+        ['a timeout', new Error('ETIMEDOUT')],
+    ])('reports %s as indeterminate, never as absent', async (_label, error) => {
+        const guild = { members: { cache: { get: () => undefined }, fetch: async () => { throw error; } } };
+        await expect(resolveMember(guild, 'u3'))
+            .resolves.toEqual({ member: null, indeterminate: true });
     });
 
     describe('resolveMembers', () => {
         test('asks for the uncached ids only, in one call', async () => {
             const guild = fakeGuild({ cached: { a: { id: 'a' } }, fetched: { b: { id: 'b' }, c: { id: 'c' } } });
-            const out = await resolveMembers(guild, ['a', 'b', 'c']);
+            const { members, indeterminate } = await resolveMembers(guild, ['a', 'b', 'c']);
 
             expect(guild.members.fetch).toHaveBeenCalledTimes(1);
             expect(guild.members.fetch).toHaveBeenCalledWith({ user: ['b', 'c'] });
-            expect([...out.keys()].sort()).toEqual(['a', 'b', 'c']);
+            expect([...members.keys()].sort()).toEqual(['a', 'b', 'c']);
+            expect(indeterminate.size).toBe(0);
         });
 
-        test('omits ids that belong to nobody in the guild', async () => {
+        test('omits ids that belong to nobody in the guild, and settles them', async () => {
+            // The batch fetch drops non-members rather than erroring, so a
+            // successful call is a real answer for every id it covered.
             const guild = fakeGuild({ fetched: { b: { id: 'b' } } });
-            const out = await resolveMembers(guild, ['b', 'ghost']);
+            const { members, indeterminate } = await resolveMembers(guild, ['b', 'ghost']);
 
-            expect(out.has('b')).toBe(true);
-            expect(out.has('ghost')).toBe(false);
+            expect(members.has('b')).toBe(true);
+            expect(members.has('ghost')).toBe(false);
+            expect(indeterminate.size).toBe(0);
         });
 
         test('skips the round trip entirely when everything is cached', async () => {
             const guild = fakeGuild({ cached: { a: { id: 'a' }, b: { id: 'b' } } });
-            await resolveMembers(guild, ['a', 'b']);
+            const { indeterminate } = await resolveMembers(guild, ['a', 'b']);
             expect(guild.members.fetch).not.toHaveBeenCalled();
+            expect(indeterminate.size).toBe(0);
         });
 
-        test('a failed batch leaves the cached half intact', async () => {
+        // Same fail-open as above, with a wider blast radius: massban would have
+        // banned every uncached id in the batch with no check at all.
+        test('a failed batch marks its ids unsettled rather than absent', async () => {
             const guild = {
                 members: {
                     cache: { get: id => (id === 'a' ? { id: 'a' } : undefined) },
                     fetch: async () => { throw new Error('gateway timeout'); },
                 },
             };
-            const out = await resolveMembers(guild, ['a', 'b']);
-            expect([...out.keys()]).toEqual(['a']);
+            const { members, indeterminate } = await resolveMembers(guild, ['a', 'b', 'c']);
+
+            expect([...members.keys()]).toEqual(['a']);
+            expect([...indeterminate].sort()).toEqual(['b', 'c']);
         });
     });
 });
@@ -217,6 +247,28 @@ describe('the commands that take a target call the guard', () => {
             path.join(__dirname, '..', 'src', 'commands', 'moderation', 'massban.js'), 'utf8',
         );
         expect(source).toContain('bannable');
+    });
+
+    // Resolving the target is only half of it: the commands have to refuse when
+    // the lookup came back unsettled. Returning `indeterminate` and then banning
+    // anyway is the same fail-open with an extra field.
+    test.each([
+        ['ban.js', /guild\.members\.ban\(|\.ban\(user/],
+        ['softban.js', /guild\.members\.ban\(/],
+        ['massban.js', /guild\.members\.ban\(userId/],
+    ])('%s refuses before banning when the lookup is unsettled', (file, banPattern) => {
+        const source = fs.readFileSync(
+            path.join(__dirname, '..', 'src', 'commands', 'moderation', file), 'utf8',
+        );
+
+        const check = source.search(/indeterminate/);
+        const ban   = source.search(banPattern);
+        expect(check).toBeGreaterThan(-1);
+        expect(ban).toBeGreaterThan(-1);
+        expect(check).toBeLessThan(ban);
+
+        // And it stops there rather than falling through to the ban.
+        expect(source).toMatch(/indeterminate[\s\S]{0,400}?(return interaction\.reply|continue;)/);
     });
 
     // The ban-shaped commands proceed when no member is found, so a cache-only

--- a/tests/oauthLoginCsrf.test.js
+++ b/tests/oauthLoginCsrf.test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+// Without `state: true`, passport-oauth2 installs its NullStore: no state
+// parameter goes out on the authorize redirect and none is checked on the way
+// back, so /auth/callback accepts any `code` from anyone with nothing tying it to
+// the session that began the login. That is login CSRF — an attacker starts a
+// login, grabs their own code, and gets an operator to open
+// /auth/callback?code=..., which silently signs that operator into the attacker's
+// Discord identity. Whatever they configure next lands in the attacker's guild.
+//
+// The fix is one option. This asserts it, and asserts what passport actually
+// builds from it, because "we passed state: true" and "a state store is installed"
+// are different claims and only the second one defends anything.
+
+const { Strategy: DiscordStrategy } = require('discord-strategy');
+const { discordStrategyOptions } = require('../src/dashboard/server');
+
+const CALLBACK = 'https://dash.example.com/auth/callback';
+
+// The options read the app's Discord credentials from the environment; passport
+// refuses to build a strategy without them, and these tests build real ones.
+const savedEnv = {};
+beforeAll(() => {
+    for (const key of ['CLIENT_ID', 'CLIENT_SECRET']) {
+        savedEnv[key] = process.env[key];
+        process.env[key] = `test-${key.toLowerCase()}`;
+    }
+});
+afterAll(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+    }
+});
+
+describe('discordStrategyOptions', () => {
+    test('asks for a state parameter', () => {
+        expect(discordStrategyOptions(CALLBACK).state).toBe(true);
+    });
+
+    test('still carries the credentials, callback and scopes the dashboard needs', () => {
+        const { scope, callbackURL, clientID, clientSecret } = discordStrategyOptions(CALLBACK);
+        expect(callbackURL).toBe(CALLBACK);
+        expect(clientID).toBe(process.env.CLIENT_ID);
+        expect(clientSecret).toBe(process.env.CLIENT_SECRET);
+        expect(scope).toEqual(expect.arrayContaining(['identify', 'guilds']));
+    });
+});
+
+describe('the strategy passport actually builds', () => {
+    const build = options => new DiscordStrategy(options, () => {});
+
+    test('installs a session-backed state store, not the null one', () => {
+        const strategy = build(discordStrategyOptions(CALLBACK));
+
+        // Named SessionStore in passport-oauth2's lib/state/store.js — it
+        // generates a nonce into req.session and verifies it on the callback.
+        expect(strategy._stateStore.constructor.name).not.toBe('NullStore');
+        expect(typeof strategy._stateStore.store).toBe('function');
+        expect(typeof strategy._stateStore.verify).toBe('function');
+    });
+
+    // The control: this is precisely the shape the dashboard shipped with, and it
+    // is what the assertion above would silently become if the option were dropped.
+    test('and would install NullStore without the option', () => {
+        const { state, ...withoutState } = discordStrategyOptions(CALLBACK);
+        expect(state).toBe(true);
+        expect(build(withoutState)._stateStore.constructor.name).toBe('NullStore');
+    });
+
+    test('the store round-trips a state value it issued', done => {
+        const strategy = build(discordStrategyOptions(CALLBACK));
+        const req = { session: {} };
+
+        strategy._stateStore.store(req, (err, issued) => {
+            expect(err).toBeNull();
+            expect(typeof issued).toBe('string');
+            expect(issued.length).toBeGreaterThan(0);
+
+            strategy._stateStore.verify(req, issued, (verifyErr, ok) => {
+                expect(verifyErr).toBeNull();
+                expect(ok).toBe(true);
+                done();
+            });
+        });
+    });
+
+    test('the store rejects a state value it never issued — the attack itself', done => {
+        const strategy = build(discordStrategyOptions(CALLBACK));
+        const victimSession = { session: {} };
+
+        strategy._stateStore.store(victimSession, () => {
+            strategy._stateStore.verify(victimSession, 'state-from-the-attackers-login', (err, ok) => {
+                expect(err).toBeNull();
+                expect(ok).toBe(false);
+                done();
+            });
+        });
+    });
+
+    test('a callback with no login in progress does not verify', done => {
+        const strategy = build(discordStrategyOptions(CALLBACK));
+
+        strategy._stateStore.verify({ session: {} }, 'anything', (err, ok) => {
+            expect(err).toBeNull();
+            expect(ok).toBe(false);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Without `state: true` passport-oauth2 installs its NullStore: no state
parameter goes out on the authorize redirect and none is checked coming
back, so /auth/callback accepted any `code` with nothing tying it to the
session that began the login. An attacker starts a login, captures their
own code, and gets an operator to open /auth/callback?code=... — the
operator is silently signed into the attacker's Discord identity, and
whatever they configure next lands in the attacker's guild.

The strategy options move out of the passport.use() call so the defence
is assertable without booting the app. The tests check both halves:
that the option is passed, and that passport builds a session-backed
store from it — those are different claims, and only the second one
defends anything. A control case pins that dropping the option really
does fall back to NullStore.

PKCE is deliberately left off: the client secret already covers the
confidential-client case this dashboard is.

Closes #557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Added centralized permission checks for administrative and moderation commands.
  - Prevented moderation actions against members with equal or higher roles.
  - Improved handling of uncached moderation targets.
  - Strengthened dashboard authorization, CSRF protection, and OAuth login state validation.
  - Added rate limiting for RSS feed validation requests.

- **Bug Fixes**
  - Commands now consistently reject unauthorized interactions with clear, private responses.
  - Bulk bans distinguish skipped targets from failed bans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->