### PR TITLE
Build the autorole chip from DOM nodes instead of markup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,16 @@
+# Every secret below can also be delivered as a file instead of a value: set
+# <NAME>_FILE to a path and the bot reads the value from it at startup. That is
+# what to use with docker secrets — a plain environment variable is readable via
+# `docker inspect` and in the Portainer UI, a path is not. See the commented
+# `secrets:` blocks in docker-compose.yml / portainer-stack.yml.
+#
+#   DISCORD_TOKEN_FILE=/run/secrets/discord_token
+#
+# Supported for: DISCORD_TOKEN, CLIENT_SECRET, SESSION_SECRET, MONGODB_URI,
+# OPENAI_API_KEY, GEMINI_API_KEY, ANTHROPIC_API_KEY, OPENROUTER_API_KEY,
+# IMGFLIP_USERNAME, IMGFLIP_PASSWORD. Setting both forms uses the plain value
+# and logs a warning; an unreadable or empty file aborts startup.
+
 # Discord Bot
 CLIENT_ID=your_client_id_here
 CLIENT_SECRET=your_client_secret_here

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ logs/
 dist/
 .DS_Store
 config/mcp-servers.json
+# Secret files mounted via the compose `secrets:` block (see docker-compose.yml).
+secrets/
 coverage/

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -485,10 +485,19 @@ docker exec clawdia-mongodb mongorestore /data/backup
   ```
 
   The container environment then holds only the path. `docker-compose.yml` and
-  `portainer-stack.yml` both carry a commented block ready to uncomment. Setting
-  both forms uses the plain value and logs a warning, so secrets can be migrated
-  one at a time; an unreadable or empty file aborts startup rather than leaving
-  the variable quietly unset.
+  `portainer-stack.yml` both carry a commented block covering every supported
+  secret; uncomment the entries you want on the service, the matching top-level
+  declarations, and nothing else — a declared secret whose file is missing fails
+  the deploy. Setting both forms uses the plain value and logs a warning, so
+  secrets can be migrated one at a time; an unreadable or empty file aborts
+  startup rather than leaving the variable quietly unset.
+
+  Two cases need more than uncommenting. In `portainer-stack.yml` the
+  `MONGODB_URI` mapping carries a `:-` default, so it is never empty and always
+  wins over `MONGODB_URI_FILE` — delete that line rather than blanking it. And
+  the optional `backup` service is a stock mongo image with no loader of its
+  own; it reads `MONGODB_URI_FILE` in its entrypoint, so mount the same secret
+  there if you move the database URI to a file.
 
 ### Performance
 

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -471,6 +471,24 @@ docker exec clawdia-mongodb mongorestore /data/backup
 - Use strong session secrets (32+ characters)
 - Limit bot permissions to only what's needed
 - Regularly update dependencies
+- In Docker, deliver secrets as files rather than environment variables. Anyone
+  who can reach the Docker API can read a container's environment in full —
+  `docker inspect clawdia` prints it, and the Portainer UI shows the same
+  values — without needing a shell in the container. Every secret variable also
+  accepts a `<NAME>_FILE` form naming a file to read the value from:
+
+  ```yaml
+  environment:
+    DISCORD_TOKEN_FILE: /run/secrets/discord_token
+  secrets:
+    - discord_token
+  ```
+
+  The container environment then holds only the path. `docker-compose.yml` and
+  `portainer-stack.yml` both carry a commented block ready to uncomment. Setting
+  both forms uses the plain value and logs a warning, so secrets can be migrated
+  one at a time; an unreadable or empty file aborts startup rather than leaving
+  the variable quietly unset.
 
 ### Performance
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,10 +46,8 @@ services:
     #   DISCORD_TOKEN_FILE: /run/secrets/discord_token
     #   CLIENT_SECRET_FILE: /run/secrets/client_secret
     #   SESSION_SECRET_FILE: /run/secrets/session_secret
-    #   # Note: the optional `backup` service below reads MONGODB_URI straight
-    #   # from .env — it is a stock mongo image with no loader — so moving that
-    #   # one to a file needs the same secret mounted there and the entrypoint
-    #   # taught to read it. Leave MONGODB_URI plain unless you use `backup`.
+    #   # The optional `backup` service reads MONGODB_URI too; uncomment the
+    #   # matching lines on it so both sides come from the same secret.
     #   MONGODB_URI_FILE: /run/secrets/mongodb_uri
     #   ANTHROPIC_API_KEY_FILE: /run/secrets/anthropic_api_key
     #   OPENAI_API_KEY_FILE: /run/secrets/openai_api_key
@@ -59,6 +57,11 @@ services:
     #   - discord_token
     #   - client_secret
     #   - session_secret
+    #   - mongodb_uri
+    #   - anthropic_api_key
+    #   - openai_api_key
+    #   - gemini_api_key
+    #   - openrouter_api_key
     # Bound to loopback only. DASHBOARD_URL is required to be HTTPS in
     # production, which means a TLS-terminating reverse proxy sits in front of
     # this; publishing on 0.0.0.0 would also expose the dashboard directly over
@@ -117,6 +120,12 @@ services:
     restart: unless-stopped
     env_file:
       - .env
+    # Mirrors the bot's MONGODB_URI_FILE. This is a stock mongo image with no
+    # loader of its own, so the entrypoint below reads the file itself.
+    # environment:
+    #   MONGODB_URI_FILE: /run/secrets/mongodb_uri
+    # secrets:
+    #   - mongodb_uri
     volumes:
       - ./backups:/backups
     networks:
@@ -126,6 +135,20 @@ services:
         condition: service_healthy
     entrypoint: >
       sh -c '
+        if [ -n "$$MONGODB_URI_FILE" ]; then
+          if [ ! -r "$$MONGODB_URI_FILE" ]; then
+            echo "[backup] MONGODB_URI_FILE=$$MONGODB_URI_FILE is not readable"; exit 1;
+          fi;
+          MONGODB_URI=$$(tr -d "\r\n" < "$$MONGODB_URI_FILE");
+          if [ -z "$$MONGODB_URI" ]; then
+            echo "[backup] MONGODB_URI_FILE=$$MONGODB_URI_FILE is empty"; exit 1;
+          fi;
+          export MONGODB_URI;
+          echo "[backup] Read MONGODB_URI from $$MONGODB_URI_FILE";
+        fi;
+        if [ -z "$$MONGODB_URI" ]; then
+          echo "[backup] Neither MONGODB_URI nor MONGODB_URI_FILE is set"; exit 1;
+        fi;
         NOW=$$(date -u +%s);
         MIDNIGHT=$$(( ($$NOW / 86400) * 86400 ));
         TARGET=$$(( $$MIDNIGHT + 10800 ));
@@ -148,6 +171,9 @@ services:
 # Host files mounted read-only at /run/secrets/<name> inside the container.
 # Keep ./secrets/ out of git (it already is, via .gitignore) and chmod 0400 the
 # files. Uncomment alongside the service block above.
+# Declare only the ones you actually create — compose fails the deploy for a
+# declared secret whose file is missing, and a service must not list one that
+# was never declared. Drop the lines for secrets you are not using.
 # secrets:
 #   discord_token:
 #     file: ./secrets/discord_token
@@ -155,6 +181,16 @@ services:
 #     file: ./secrets/client_secret
 #   session_secret:
 #     file: ./secrets/session_secret
+#   mongodb_uri:
+#     file: ./secrets/mongodb_uri
+#   anthropic_api_key:
+#     file: ./secrets/anthropic_api_key
+#   openai_api_key:
+#     file: ./secrets/openai_api_key
+#   gemini_api_key:
+#     file: ./secrets/gemini_api_key
+#   openrouter_api_key:
+#     file: ./secrets/openrouter_api_key
 
 volumes:
   mongodb_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,35 @@ services:
     restart: unless-stopped
     env_file:
       - .env
+    # Everything in .env arrives as a plain container environment variable, and
+    # those are readable by anyone who can reach the Docker API: `docker inspect
+    # clawdia` prints the bot token and every provider key in full, no shell in
+    # the container required. To keep them out of it, deliver each secret as a
+    # file instead — every secret variable also accepts a <NAME>_FILE form
+    # naming a file to read the value from (src/config/fileSecrets.js).
+    #
+    # To switch over: create ./secrets/discord_token (etc.), remove the plain
+    # variable from .env, and uncomment the matching lines here and the
+    # top-level `secrets:` block at the bottom of this file. If both forms are
+    # set the plain variable wins and the file is ignored, so the migration can
+    # be done one secret at a time.
+    # environment:
+    #   DISCORD_TOKEN_FILE: /run/secrets/discord_token
+    #   CLIENT_SECRET_FILE: /run/secrets/client_secret
+    #   SESSION_SECRET_FILE: /run/secrets/session_secret
+    #   # Note: the optional `backup` service below reads MONGODB_URI straight
+    #   # from .env — it is a stock mongo image with no loader — so moving that
+    #   # one to a file needs the same secret mounted there and the entrypoint
+    #   # taught to read it. Leave MONGODB_URI plain unless you use `backup`.
+    #   MONGODB_URI_FILE: /run/secrets/mongodb_uri
+    #   ANTHROPIC_API_KEY_FILE: /run/secrets/anthropic_api_key
+    #   OPENAI_API_KEY_FILE: /run/secrets/openai_api_key
+    #   GEMINI_API_KEY_FILE: /run/secrets/gemini_api_key
+    #   OPENROUTER_API_KEY_FILE: /run/secrets/openrouter_api_key
+    # secrets:
+    #   - discord_token
+    #   - client_secret
+    #   - session_secret
     # Bound to loopback only. DASHBOARD_URL is required to be HTTPS in
     # production, which means a TLS-terminating reverse proxy sits in front of
     # this; publishing on 0.0.0.0 would also expose the dashboard directly over
@@ -115,6 +144,17 @@ services:
           find /backups \( -name "clawdia-*.gz" -o -name "ultrabot-*.gz" \) -mtime +30 -delete;
           sleep 86400;
         done'
+
+# Host files mounted read-only at /run/secrets/<name> inside the container.
+# Keep ./secrets/ out of git (it already is, via .gitignore) and chmod 0400 the
+# files. Uncomment alongside the service block above.
+# secrets:
+#   discord_token:
+#     file: ./secrets/discord_token
+#   client_secret:
+#     file: ./secrets/client_secret
+#   session_secret:
+#     file: ./secrets/session_secret
 
 volumes:
   mongodb_data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,12 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.117.1",
-        "@google/generative-ai": "^0.24.1",
+        "@anthropic-ai/sdk": "^0.120.0",
+        "@google/genai": "^2.18.0",
         "axios": "^1.19.0",
         "canvas": "^3.2.3",
         "compression": "^1.8.1",
         "connect-mongo": "^5.1.0",
-        "discord-strategy": "^2.5.0",
         "discord.js": "^14.17.0",
         "dotenv": "^17.4.2",
         "ejs": "^6.0.1",
@@ -26,6 +25,7 @@
         "node-cron": "^4.6.0",
         "openai": "^7.4.0",
         "passport": "^0.7.0",
+        "passport-oauth2": "^1.8.0",
         "rss-parser": "^3.13.0"
       },
       "devDependencies": {
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.117.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.117.1.tgz",
-      "integrity": "sha512-Yn2QlXfyCiKJ5YGCOOay7ZE78ISvII2XY621WMCiflmG8IYgwx59IBwPExxki3Xk9jKUtnD/Sj6UvplWr0rZxg==",
+      "version": "0.120.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.120.0.tgz",
+      "integrity": "sha512-ZlvmNFT/iIF6JD13rxbbMWD8nvGR0RaUp6yMQnoc+4Af0YjVVe/bIdW1XSQQsoxXAtg1NaT6Vak0LKFlJ4d37Q==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",
@@ -886,13 +886,28 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@google/generative-ai": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
-      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+    "node_modules/@google/genai": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.18.0.tgz",
+      "integrity": "sha512-uy9gWVTAZXuA/2tld0QJl/QNiGEn4QOmfX4PiRgZQmeFQRQhojpD/Gf41SPnBJmjEnT83a+h4AdU1HHYaYvVDw==",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1426,6 +1441,63 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@sapphire/async-queue": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
@@ -1595,6 +1667,12 @@
       "dependencies": {
         "undici-types": "~7.19.0"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -2306,6 +2384,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2430,9 +2517,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2528,6 +2615,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -3037,6 +3130,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -3170,15 +3272,6 @@
         "scripts/actions/documentation"
       ]
     },
-    "node_modules/discord-strategy": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/discord-strategy/-/discord-strategy-2.5.0.tgz",
-      "integrity": "sha512-bPXOpR2rzClMx6HttfWnTY4ucaKM/uSzcFThg2MVpEUt9euWyfrBbNmoUGLO5h1UOgRqa/dE+iaJxo0oUC0HhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "passport-oauth2": "^1.8.0"
-      }
-    },
     "node_modules/discord.js": {
       "version": "14.27.0",
       "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.27.0.tgz",
@@ -3238,6 +3331,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -3642,6 +3744,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3669,6 +3777,29 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/fill-range": {
@@ -3772,6 +3903,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -3825,6 +3968,124 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gaxios/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
+      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
+      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/gcp-metadata/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/gcp-metadata/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/gensync": {
@@ -3946,6 +4207,46 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/gopd": {
@@ -4299,7 +4600,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5085,9 +5386,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5175,6 +5476,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -5206,6 +5516,27 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/kareem": {
@@ -5270,6 +5601,12 @@
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -5682,6 +6019,44 @@
         "node": ">=20"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5739,16 +6114,16 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/nodemon/node_modules/minimatch": {
@@ -5937,6 +6312,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -6224,6 +6612,29 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -6440,6 +6851,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/router": {
@@ -7133,9 +7553,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7512,6 +7932,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -20,13 +20,12 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.117.1",
-    "@google/generative-ai": "^0.24.1",
+    "@anthropic-ai/sdk": "^0.120.0",
+    "@google/genai": "^2.18.0",
     "axios": "^1.19.0",
     "canvas": "^3.2.3",
     "compression": "^1.8.1",
     "connect-mongo": "^5.1.0",
-    "discord-strategy": "^2.5.0",
     "discord.js": "^14.17.0",
     "dotenv": "^17.4.2",
     "ejs": "^6.0.1",
@@ -37,6 +36,7 @@
     "node-cron": "^4.6.0",
     "openai": "^7.4.0",
     "passport": "^0.7.0",
+    "passport-oauth2": "^1.8.0",
     "rss-parser": "^3.13.0"
   },
   "devDependencies": {

--- a/portainer-stack.yml
+++ b/portainer-stack.yml
@@ -25,7 +25,9 @@
 #      file wires that up; uncomment it and the matching lines in the service to
 #      switch over. Create the secrets first, in Portainer > Secrets (Swarm) or
 #      by mounting host files, and leave the plain variable unset — if both are
-#      set the plain one wins and the file is ignored.
+#      set the plain one wins and the file is ignored. MONGODB_URI is the one
+#      that needs its mapping deleted rather than merely left blank, because it
+#      has a default; see the note beside it below.
 #
 #      DASHBOARD_URL has no default on purpose. With NODE_ENV=production the bot
 #      refuses to start unless it is an https:// URL (see resolveDashboardUrl in
@@ -102,17 +104,27 @@ services:
       # - DISCORD_TOKEN_FILE=/run/secrets/discord_token
       # - CLIENT_SECRET_FILE=/run/secrets/client_secret
       # - SESSION_SECRET_FILE=/run/secrets/session_secret
+      # MONGODB_URI needs one extra step: unlike the others, its mapping above
+      # carries a `:-` default, so it is never empty and always wins over the
+      # file. DELETE the `- MONGODB_URI=...` line above before uncommenting
+      # this, or the secret is read and then ignored with a warning.
       # - MONGODB_URI_FILE=/run/secrets/mongodb_uri
       # - OPENAI_API_KEY_FILE=/run/secrets/openai_api_key
       # - GEMINI_API_KEY_FILE=/run/secrets/gemini_api_key
       # - ANTHROPIC_API_KEY_FILE=/run/secrets/anthropic_api_key
       # - OPENROUTER_API_KEY_FILE=/run/secrets/openrouter_api_key
     # The secrets this service should have mounted under /run/secrets. Only the
-    # ones you actually use — a declared-but-missing secret fails the deploy.
+    # ones you actually use — a declared-but-missing secret fails the deploy, so
+    # delete the lines for anything you are not mounting.
     # secrets:
     #   - discord_token
     #   - client_secret
     #   - session_secret
+    #   - mongodb_uri
+    #   - openai_api_key
+    #   - gemini_api_key
+    #   - anthropic_api_key
+    #   - openrouter_api_key
     # A Portainer stack has no repo checkout to mount, so put mcp-servers.json
     # somewhere on the Docker host and point MCP_SERVERS_CONFIG at it inside the
     # container. Mounted read-only: the file can hold OAuth tokens.
@@ -171,6 +183,16 @@ services:
 #   client_secret:
 #     external: true
 #   session_secret:
+#     external: true
+#   mongodb_uri:
+#     external: true
+#   openai_api_key:
+#     external: true
+#   gemini_api_key:
+#     external: true
+#   anthropic_api_key:
+#     external: true
+#   openrouter_api_key:
 #     external: true
 
 volumes:

--- a/portainer-stack.yml
+++ b/portainer-stack.yml
@@ -14,6 +14,19 @@
 #   3. Set all required variables in the Portainer Stack "Environment variables"
 #      section before clicking Deploy.
 #
+#      SECRETS: anything set here is a plain container environment variable, and
+#      those are readable by anyone who can reach the Docker API — `docker
+#      inspect clawdia` prints them in full, and Portainer shows the same values
+#      in the container detail view. To keep the bot token, the OAuth client
+#      secret, the session secret and the provider keys out of both, deliver
+#      them as files instead: every one of those variables also accepts a
+#      <NAME>_FILE form naming a file to read the value from (see
+#      src/config/fileSecrets.js). The `secrets:` block at the bottom of this
+#      file wires that up; uncomment it and the matching lines in the service to
+#      switch over. Create the secrets first, in Portainer > Secrets (Swarm) or
+#      by mounting host files, and leave the plain variable unset — if both are
+#      set the plain one wins and the file is ignored.
+#
 #      DASHBOARD_URL has no default on purpose. With NODE_ENV=production the bot
 #      refuses to start unless it is an https:// URL (see resolveDashboardUrl in
 #      src/dashboard/server.js), so a placeholder default would only produce a
@@ -53,6 +66,8 @@ services:
     restart: unless-stopped
     environment:
       # --- Required ---
+      # Every secret below is also readable as <NAME>_FILE; see the note at the
+      # top of this file and the commented block after this service.
       - DISCORD_TOKEN=${DISCORD_TOKEN}
       - CLIENT_ID=${CLIENT_ID}
       - CLIENT_SECRET=${CLIENT_SECRET}
@@ -78,6 +93,26 @@ services:
       - DASHBOARD_PORT=7001
       - AUDIT_LOG_RETENTION_DAYS=${AUDIT_LOG_RETENTION_DAYS:-90}
       - NODE_ENV=${NODE_ENV:-production}
+      #
+      # --- Secrets as files (recommended) ---------------------------------
+      # Uncomment these *and* the matching `secrets:` entries below, then leave
+      # the plain DISCORD_TOKEN / CLIENT_SECRET / SESSION_SECRET / *_API_KEY
+      # variables above unset. The container environment then holds only the
+      # paths, which `docker inspect` and the Portainer UI are welcome to show.
+      # - DISCORD_TOKEN_FILE=/run/secrets/discord_token
+      # - CLIENT_SECRET_FILE=/run/secrets/client_secret
+      # - SESSION_SECRET_FILE=/run/secrets/session_secret
+      # - MONGODB_URI_FILE=/run/secrets/mongodb_uri
+      # - OPENAI_API_KEY_FILE=/run/secrets/openai_api_key
+      # - GEMINI_API_KEY_FILE=/run/secrets/gemini_api_key
+      # - ANTHROPIC_API_KEY_FILE=/run/secrets/anthropic_api_key
+      # - OPENROUTER_API_KEY_FILE=/run/secrets/openrouter_api_key
+    # The secrets this service should have mounted under /run/secrets. Only the
+    # ones you actually use — a declared-but-missing secret fails the deploy.
+    # secrets:
+    #   - discord_token
+    #   - client_secret
+    #   - session_secret
     # A Portainer stack has no repo checkout to mount, so put mcp-servers.json
     # somewhere on the Docker host and point MCP_SERVERS_CONFIG at it inside the
     # container. Mounted read-only: the file can hold OAuth tokens.
@@ -124,6 +159,19 @@ services:
         reservations:
           memory: 256m
     stop_grace_period: 30s
+
+# Declare each secret once here, then list it under the service that needs it.
+# `external: true` means Portainer > Secrets (Swarm) already holds the value;
+# on a plain non-Swarm Docker host use the `file:` form instead, pointing at a
+# root-owned, 0400 file on the host.
+# secrets:
+#   discord_token:
+#     external: true
+#     # file: /opt/clawdia/secrets/discord_token
+#   client_secret:
+#     external: true
+#   session_secret:
+#     external: true
 
 volumes:
   mongodb_data:

--- a/scripts/rollback-migration.js
+++ b/scripts/rollback-migration.js
@@ -13,6 +13,11 @@
 // instead (scripts/restore.sh).
 
 require('dotenv').config();
+// Resolves any <NAME>_FILE variable into <NAME>, so secrets can be mounted as
+// files (docker secrets) instead of being readable via `docker inspect`. Runs
+// straight after dotenv so .env can set the *_FILE paths too, and before
+// anything reads process.env.
+require('../src/config/fileSecrets').loadFileSecrets();
 
 const mongoose = require('mongoose');
 const { rollbackMigration } = require('../src/migrations/runner');

--- a/src/commands/community/newspaper.js
+++ b/src/commands/community/newspaper.js
@@ -32,9 +32,16 @@ module.exports = {
         await interaction.deferReply();
 
         try {
-            const embed = await generateNewspaper(client, guildDoc);
+            const embed = await generateNewspaper(client, guildDoc, undefined, {
+                userId: interaction.user.id,
+                channelId: interaction.channelId,
+            });
             await interaction.editReply({ content: '📰 *Preview — this is how the newspaper will look when delivered:*', embeds: [embed] });
         } catch (err) {
+            if (err?.rateLimited) {
+                await interaction.editReply({ content: `This server's AI request limit has been reached (${err.limit} per ${err.windowMin}m). Please wait a few minutes.` });
+                return;
+            }
             console.error('[newspaper] preview failed:', err);
             await interaction.editReply({ content: 'Failed to generate the newspaper. Check that your AI provider is configured.' });
         }

--- a/src/commands/community/questgen.js
+++ b/src/commands/community/questgen.js
@@ -153,6 +153,11 @@ Create a legendary quest that feels fitting for their journey so far.`;
                 const raw = await getCompletion({
                     ...config,
                     guildId: interaction.guild.id,
+                    // Attribution for the guild's AI limits, which `config`
+                    // carries: without it this command spends provider tokens
+                    // bounded only by its own command cooldown.
+                    userId: interaction.user.id,
+                    channelId: interaction.channelId,
                     systemPrompt,
                     history: [],
                     prompt,
@@ -186,10 +191,15 @@ Create a legendary quest that feels fitting for their journey so far.`;
                 { userId: interaction.user.id, guildId: interaction.guild.id },
                 { $inc: { balance: COST } },
             ).catch(refundErr => { console.error('[QUESTGEN] Refund failed after AI failure:', refundErr); return null; });
+            // A refusal by the server's own AI limit is not a misfire — say so,
+            // or the user retries straight into the same wall.
+            const failure = err?.rateLimited
+                ? `This server's AI limit has been reached (${err.limit} per ${err.windowMin}m).`
+                : 'The quest forge misfired!';
             return interaction.editReply({
                 content: refunded
-                    ? 'The quest forge misfired! Your coins have been refunded. Try again in a moment.'
-                    : 'The quest forge misfired, and the refund failed to process. Please contact a server admin — your coins were not returned automatically.',
+                    ? `${failure} Your coins have been refunded. Try again in a moment.`
+                    : `${failure} The refund failed to process — please contact a server admin, your coins were not returned automatically.`,
             });
         }
 

--- a/src/commands/economy/forge.js
+++ b/src/commands/economy/forge.js
@@ -162,14 +162,23 @@ Respond with ONLY the JSON object. No markdown, no extra text.`;
             if (lastErr) throw lastErr;
         } catch (err) {
             console.error('[FORGE] AI generation failed:', err?.message || err);
-            await User.updateOne(
+            // The refund is what the message below promises, so its outcome
+            // decides what the message says. A swallowed write error used to
+            // leave the user told they had been refunded when they had not,
+            // with nothing but the log to say otherwise.
+            const refunded = await User.updateOne(
                 { userId: interaction.user.id, guildId: interaction.guild.id },
                 { $inc: { balance: cfg.cost } }
-            ).catch(() => {});
+            ).then(res => res.modifiedCount > 0)
+             .catch(refundErr => { console.error('[FORGE] Refund failed after AI failure:', refundErr); return false; });
             const failure = err?.rateLimited
                 ? `This server's AI limit has been reached (${err.limit} per ${err.windowMin}m).`
                 : 'The forge misfired!';
-            return interaction.editReply({ content: `${failure} Your coins have been refunded. Try again in a moment.` });
+            return interaction.editReply({
+                content: refunded
+                    ? `${failure} Your coins have been refunded. Try again in a moment.`
+                    : `${failure} The refund failed to process — please contact a server admin, your coins were not returned automatically.`,
+            });
         }
 
         // Sanitize

--- a/src/commands/economy/forge.js
+++ b/src/commands/economy/forge.js
@@ -130,6 +130,11 @@ Respond with ONLY the JSON object. No markdown, no extra text.`;
                 const raw = await getCompletion({
                     ...config,
                     guildId: interaction.guild.id,
+                    // Attribution for the guild's AI limits, which `config`
+                    // carries: without it this command spends provider tokens
+                    // bounded only by its own command cooldown.
+                    userId: interaction.user.id,
+                    channelId: interaction.channelId,
                     systemPrompt,
                     history: [],
                     prompt,
@@ -161,7 +166,10 @@ Respond with ONLY the JSON object. No markdown, no extra text.`;
                 { userId: interaction.user.id, guildId: interaction.guild.id },
                 { $inc: { balance: cfg.cost } }
             ).catch(() => {});
-            return interaction.editReply({ content: 'The forge misfired! Your coins have been refunded. Try again in a moment.' });
+            const failure = err?.rateLimited
+                ? `This server's AI limit has been reached (${err.limit} per ${err.windowMin}m).`
+                : 'The forge misfired!';
+            return interaction.editReply({ content: `${failure} Your coins have been refunded. Try again in a moment.` });
         }
 
         // Sanitize

--- a/src/config/fileSecrets.js
+++ b/src/config/fileSecrets.js
@@ -1,0 +1,102 @@
+const fs = require('fs');
+
+// Secrets delivered as plain environment variables are readable by anyone who
+// can reach the Docker API — `docker inspect clawdia` prints the bot token and
+// every provider key in full, and the Portainer UI shows the same values in the
+// container detail view to anyone with read access to the stack. Neither
+// requires a shell in the container.
+//
+// The fix is the convention Docker's own images use: put the secret in a file
+// (a docker secret is mounted at /run/secrets/<name>) and point the config at
+// the *path* instead of the value. `docker inspect` then shows the path, which
+// is not sensitive. This module is the loader for that: for each secret below,
+// `<NAME>_FILE` names a file whose contents become `<NAME>`, so nothing
+// downstream has to know where the value came from.
+
+/**
+ * The variables that carry a secret and therefore support `<NAME>_FILE`.
+ *
+ * Deliberately an explicit list rather than a scan for anything ending in
+ * `_FILE`: `_FILE` is also the ordinary suffix for "path to a file" variables,
+ * and a host that exports `SSL_CERT_FILE` or `NIX_SSL_CERT_FILE` — most Linux
+ * CI images do — would otherwise have its CA bundle slurped into an
+ * environment variable, and an unreadable one would abort startup over
+ * something the bot never reads.
+ *
+ * A new provider key belongs here the moment it is added.
+ */
+const FILE_BACKED_SECRETS = [
+    'DISCORD_TOKEN',
+    'CLIENT_SECRET',
+    'SESSION_SECRET',
+    'MONGODB_URI',        // carries the database credentials
+    'OPENAI_API_KEY',
+    'GEMINI_API_KEY',
+    'ANTHROPIC_API_KEY',
+    'OPENROUTER_API_KEY',
+    'IMGFLIP_USERNAME',
+    'IMGFLIP_PASSWORD',
+];
+
+/**
+ * Reads one secret file.
+ *
+ * Trailing whitespace is stripped: `echo "$TOKEN" > /run/secrets/token` leaves
+ * a newline, and a Discord token with a newline on the end fails to
+ * authenticate with an error that says nothing about whitespace. Leading
+ * whitespace is left alone — it cannot come from that mistake, and a
+ * passphrase is entitled to start with a space.
+ */
+function readSecretFile(filePath) {
+    return fs.readFileSync(filePath, 'utf8').replace(/\s+$/, '');
+}
+
+/**
+ * Resolves the `<NAME>_FILE` form of each supported secret into `<NAME>`.
+ *
+ * Precedence: an explicitly set `<NAME>` wins over `<NAME>_FILE`. That way a
+ * one-off `docker run -e DISCORD_TOKEN=…` still overrides a stack that mounts
+ * the secret, and the ambiguity is reported rather than resolved silently.
+ *
+ * An unreadable or empty secret file is fatal. The alternative — carrying on
+ * with the variable unset — turns a mount typo into "the AI features stopped
+ * working" hours later, instead of a startup error naming the file.
+ *
+ * @returns {string[]} the names resolved, for logging.
+ */
+function loadFileSecrets(env = process.env, { log = console, names = FILE_BACKED_SECRETS } = {}) {
+    const resolved = [];
+
+    for (const name of names) {
+        const key = `${name}_FILE`;
+        const filePath = env[key];
+        if (!filePath) continue;
+
+        if (env[name] !== undefined && env[name] !== '') {
+            log.warn?.(`[SECRETS] Both ${name} and ${key} are set; using ${name} and ignoring the file.`);
+            continue;
+        }
+
+        let value;
+        try {
+            value = readSecretFile(filePath);
+        } catch (err) {
+            throw new Error(`[SECRETS] Cannot read ${key} (${filePath}): ${err.message}`);
+        }
+
+        if (!value) {
+            throw new Error(`[SECRETS] ${key} (${filePath}) is empty — ${name} would be blank.`);
+        }
+
+        env[name] = value;
+        resolved.push(name);
+    }
+
+    if (resolved.length) {
+        // The names only — never the values.
+        log.log?.(`[SECRETS] Loaded from file: ${resolved.join(', ')}`);
+    }
+    return resolved;
+}
+
+module.exports = { loadFileSecrets, readSecretFile, FILE_BACKED_SECRETS };

--- a/src/dashboard/lib/discordStrategy.js
+++ b/src/dashboard/lib/discordStrategy.js
@@ -1,0 +1,90 @@
+const OAuth2Strategy = require('passport-oauth2');
+const InternalOAuthError = require('passport-oauth2/lib/errors/internaloautherror');
+
+// Discord OAuth2 for passport, on top of passport-oauth2 rather than a
+// third-party strategy package.
+//
+// This replaces `discord-strategy`, which sat directly on the dashboard's login
+// path: a single-maintainer package that reimplemented passport-oauth2's entire
+// `authenticate()` — several hundred lines of copied control flow, PKCE and
+// state handling included — purely so it could pass a "consumable" helper
+// object as a sixth argument to the verify callback. The dashboard used exactly
+// one method on that object, `guilds()`, and paid for it with a private fork of
+// the security-critical part of OAuth.
+//
+// Everything below is the part that is genuinely Discord-specific: the two
+// endpoints and the profile fetch. `authenticate()`, the session-backed state
+// store that defends the callback against login CSRF, token exchange and
+// refresh all come from passport-oauth2 itself, unforked.
+
+const API_BASE = 'https://discord.com/api/v10';
+const AUTHORIZATION_URL = 'https://discord.com/api/oauth2/authorize';
+const TOKEN_URL = 'https://discord.com/api/oauth2/token';
+
+/** The scopes this dashboard knows how to ask for. */
+const DiscordScope = {
+    Identify: 'identify',
+    Guilds: 'guilds',
+    Email: 'email',
+};
+
+class Strategy extends OAuth2Strategy {
+    constructor(options = {}, verify) {
+        super({
+            authorizationURL: AUTHORIZATION_URL,
+            tokenURL: TOKEN_URL,
+            scopeSeparator: ' ',
+            ...options,
+        }, verify);
+
+        this.name = 'discord';
+        // Discord rejects the access token as a query parameter; it has to be a
+        // Bearer header.
+        this._oauth2.useAuthorizationHeaderforGET(true);
+    }
+
+    /**
+     * Fetches the profile passport hands to the verify callback.
+     *
+     * The guild list is fetched here rather than left to the caller. The
+     * dashboard authorizes every request against it — which servers this user
+     * may configure — so a login that completed with the list missing would be
+     * a login with no permissions rather than a login that failed, and the
+     * difference is not visible from the callback. A failure fails the login.
+     */
+    userProfile(accessToken, done) {
+        this._fetch('/users/@me', accessToken)
+            .then(async profile => {
+                profile.guilds = this._wants(DiscordScope.Guilds)
+                    ? await this._fetch('/users/@me/guilds', accessToken)
+                    : [];
+                done(null, profile);
+            })
+            .catch(err => done(err instanceof InternalOAuthError
+                ? err
+                : new InternalOAuthError('Failed to fetch the Discord user profile', err)));
+    }
+
+    _wants(scope) {
+        const configured = this._scope;
+        if (!configured) return false;
+        return Array.isArray(configured) ? configured.includes(scope) : configured === scope;
+    }
+
+    _fetch(endpoint, accessToken) {
+        return new Promise((resolve, reject) => {
+            this._oauth2.get(`${API_BASE}${endpoint}`, accessToken, (err, body) => {
+                if (err) return reject(new InternalOAuthError(`Failed to fetch ${endpoint}`, err));
+                try {
+                    resolve(JSON.parse(body));
+                } catch {
+                    // A non-JSON body here means Discord returned an error page
+                    // or a gateway did; either way there is no profile to build.
+                    reject(new InternalOAuthError(`Discord returned an unparseable response for ${endpoint}`));
+                }
+            });
+        });
+    }
+}
+
+module.exports = { Strategy, DiscordScope, API_BASE, AUTHORIZATION_URL, TOKEN_URL };

--- a/src/dashboard/lib/discordStrategy.js
+++ b/src/dashboard/lib/discordStrategy.js
@@ -68,7 +68,13 @@ class Strategy extends OAuth2Strategy {
     _wants(scope) {
         const configured = this._scope;
         if (!configured) return false;
-        return Array.isArray(configured) ? configured.includes(scope) : configured === scope;
+        if (Array.isArray(configured)) return configured.includes(scope);
+        // passport-oauth2 accepts `scope` as a pre-joined string as readily as
+        // an array. Comparing the whole string against one scope would miss
+        // "identify guilds" and quietly skip the guild fetch — which the
+        // dashboard reads as "this user administers nothing" rather than as a
+        // misconfiguration.
+        return String(configured).split(this._scopeSeparator).includes(scope);
     }
 
     _fetch(endpoint, accessToken) {

--- a/src/dashboard/public/guild-settings.js
+++ b/src/dashboard/public/guild-settings.js
@@ -1163,10 +1163,22 @@ async function addAutoRole() {
         });
         if (response.ok) {
             const roleName = select.options[select.selectedIndex].text.replace(/^@/, '');
+            // Built with DOM nodes, not innerHTML: a role name is attacker-chosen
+            // text from Discord, so `@${roleName}` in a template literal turns any
+            // role called `<img onerror=...>` into markup that runs for the next
+            // admin to open this panel. textContent renders it as the name it is.
+            // The remove button goes through data-action for the same reason the
+            // rest of this page does — see the delegated handler below.
             const chip = document.createElement('span');
             chip.className = 'role-tag';
             chip.dataset.roleId = roleId;
-            chip.innerHTML = `@${roleName} <button onclick="removeAutoRole('${roleId}')" title="Remove">&times;</button>`;
+            chip.appendChild(document.createTextNode('@' + roleName + ' '));
+            const removeBtn = document.createElement('button');
+            removeBtn.title = 'Remove';
+            removeBtn.dataset.action = 'autorole-remove';
+            removeBtn.dataset.roleId = roleId;
+            removeBtn.textContent = '\u00d7';
+            chip.appendChild(removeBtn);
             document.getElementById('autorole-list').appendChild(chip);
             select.value = '';
             toast('Role added ✓', 'success');
@@ -1737,6 +1749,7 @@ document.addEventListener('click', function(e) {
     else if (d.action === 'mcp-test')       testMcpServer(d.serverName, el.closest('.list-item') && el.closest('.list-item').querySelector('.mcp-test-result'));
     else if (d.action === 'mcp-edit')       editMcpServer(d.serverName);
     else if (d.action === 'mcp-remove')     removeMcpServer(d.serverName);
+    else if (d.action === 'autorole-remove') removeAutoRole(d.roleId);
 });
 
 // mousedown, not click: the dropdown is hidden by the input's blur, which

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -4,7 +4,7 @@ const compression = require('compression');
 const session = require('express-session');
 const MongoStore = require('connect-mongo');
 const passport = require('passport');
-const { Strategy: DiscordStrategy, DiscordScope } = require('discord-strategy');
+const { Strategy: DiscordStrategy, DiscordScope } = require('./lib/discordStrategy');
 const path = require('path');
 const { getStatus } = require('../health');
 const { hasManagePermission } = require('./lib/permissions');
@@ -72,14 +72,11 @@ function setupPassport() {
     console.log(`[DASHBOARD] OAuth callback URL: ${callbackURL}`);
     console.log('[DASHBOARD] This EXACT URL must be added under "OAuth2 → Redirects" in the Discord Developer Portal.');
 
-    passport.use(new DiscordStrategy(discordStrategyOptions(callbackURL), async (accessToken, refreshToken, profile, done, consumable) => {
+    passport.use(new DiscordStrategy(discordStrategyOptions(callbackURL), (accessToken, refreshToken, profile, done) => {
         try {
             if (!profile || !profile.id || !profile.username) {
                 return done(new Error('Invalid Discord profile returned from OAuth'));
             }
-            // discord-strategy only fetches basic identity by default; guilds must
-            // be pulled in explicitly, which populates profile.guilds in place.
-            await consumable.guilds();
 
             // Store only what the dashboard needs — never persist raw OAuth tokens or full profile
             const safeProfile = {

--- a/src/dashboard/views/partials/panels/welcome.ejs
+++ b/src/dashboard/views/partials/panels/welcome.ejs
@@ -48,7 +48,7 @@
                             <% (settings.autoRoles || []).forEach(r => { %>
                                 <% const role = roles.find(ro => ro.id === r.roleId); %>
                                 <% if (role) { %>
-                                    <span class="role-tag" data-role-id="<%= r.roleId %>">@<%= role.name %> <button onclick="removeAutoRole('<%= r.roleId %>')" title="Remove">&times;</button></span>
+                                    <span class="role-tag" data-role-id="<%= r.roleId %>">@<%= role.name %> <button data-action="autorole-remove" data-role-id="<%= r.roleId %>" title="Remove">&times;</button></span>
                                 <% } %>
                             <% }); %>
                         </div>

--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -1,4 +1,9 @@
 require('dotenv').config();
+// Resolves any <NAME>_FILE variable into <NAME>, so secrets can be mounted as
+// files (docker secrets) instead of being readable via `docker inspect`. Runs
+// straight after dotenv so .env can set the *_FILE paths too, and before
+// anything reads process.env.
+require('./config/fileSecrets').loadFileSecrets();
 const { deployCommands } = require('./utils/commandDeployer');
 
 (async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,11 @@ const { connect, connection } = require('mongoose');
 const fs = require('fs');
 const path = require('path');
 require('dotenv').config();
+// Resolves any <NAME>_FILE variable into <NAME>, so secrets can be mounted as
+// files (docker secrets) instead of being readable via `docker inspect`. Runs
+// straight after dotenv so .env can set the *_FILE paths too, and before
+// anything reads process.env.
+require('./config/fileSecrets').loadFileSecrets();
 
 const health = require('./health');
 const { makeCache, sweepers } = require('./utils/cacheOptions');

--- a/src/services/ai/discordChat.js
+++ b/src/services/ai/discordChat.js
@@ -4,7 +4,7 @@ const { providers } = require('./providers');
 const { resolveProviderConfig, streamCompletion, getCompletion } = require('./index');
 const { retrieveKnowledge, buildKnowledgeContext } = require('./knowledge');
 const { loadHistory, appendHistory, clearHistory } = require('./history');
-const { checkRateLimit, checkChannelRateLimit } = require('./rateLimit');
+const { peekRateLimit, peekChannelRateLimit } = require('./rateLimit');
 const { buildActionsAddendum, extractAction, executeAction } = require('./actions');
 
 // Discord transport for the AI chat loop: rate limiting, prompt assembly,
@@ -26,6 +26,11 @@ async function withRetry(fn, { retries = 2, baseDelayMs = 800 } = {}) {
         } catch (err) {
             lastErr = err;
             const status = err?.status || err?.response?.status;
+            // A rate-limited call is refused before the provider is touched, so
+            // retrying it only burns more of the same budget and cannot succeed
+            // inside the window. It has no HTTP status, which the check below
+            // would otherwise read as a transient network failure.
+            if (err?.rateLimited) throw err;
             const retryable = !status || status === 408 || status === 429 || status >= 500;
             if (!retryable || i === retries) throw err;
             await sleep(baseDelayMs * Math.pow(2, i));
@@ -50,7 +55,7 @@ function chunkText(text, size = DISCORD_MAX_LEN) {
 }
 
 async function handleAIChat(message, aiSettings) {
-    const { provider, model, temperature, maxTokens, apiKey, baseUrl, mcpServers } = resolveProviderConfig(aiSettings);
+    const { provider, model, temperature, maxTokens, apiKey, baseUrl, mcpServers, rateLimit } = resolveProviderConfig(aiSettings);
     const providerDef = providers.get(provider);
     const providerLabel = providerDef?.label || provider;
 
@@ -69,11 +74,15 @@ async function handleAIChat(message, aiSettings) {
         return message.reply('Conversation history cleared.');
     }
 
-    if (!checkRateLimit(message.author.id, aiSettings.rateLimitPerUser, aiSettings.rateLimitWindowMin)) {
-        return message.reply(`Rate limit reached (${aiSettings.rateLimitPerUser} per ${aiSettings.rateLimitWindowMin}m). Please slow down.`);
+    // A peek, not a consuming check: the slot is spent inside getCompletion /
+    // streamCompletion, which is what actually bounds provider spend. This is
+    // only here to refuse before the history load, knowledge retrieval and
+    // prompt assembly below, and to say so in the channel where the user asked.
+    if (!peekRateLimit(message.author.id, rateLimit.perUser, rateLimit.windowMin)) {
+        return message.reply(`Rate limit reached (${rateLimit.perUser} per ${rateLimit.windowMin}m). Please slow down.`);
     }
 
-    if (!checkChannelRateLimit(message.channel.id, aiSettings.rateLimitPerChannel, aiSettings.rateLimitWindowMin)) {
+    if (!peekChannelRateLimit(message.channel.id, rateLimit.perChannel, rateLimit.windowMin)) {
         return message.reply(`This channel has reached the AI request limit. Please wait before sending more AI requests here.`);
     }
 
@@ -117,7 +126,10 @@ async function handleAIChat(message, aiSettings) {
         const callArgs = {
             provider, model, apiKey, baseUrl, systemPrompt, history,
             prompt: content, temperature, maxTokens, mcpServers,
-            guildId: message.guild.id, usageOut
+            guildId: message.guild.id, usageOut,
+            // Who the request is for, so the limit is enforced where the spend
+            // happens rather than only in the peek above.
+            rateLimit, userId: message.author.id, channelId: message.channel.id
         };
 
         let fullResponse = '';
@@ -224,6 +236,14 @@ async function handleAIChat(message, aiSettings) {
             }
         }
     } catch (error) {
+        // The peek above passed but somebody else took the last slot in between.
+        if (error?.rateLimited) {
+            const refusal = error.scope === 'channel'
+                ? 'This channel has reached the AI request limit. Please wait before sending more AI requests here.'
+                : `Rate limit reached (${error.limit} per ${error.windowMin}m). Please slow down.`;
+            await message.reply(refusal).catch(() => {});
+            return;
+        }
         console.error(`[AI:${provider}] error:`, error?.message || error);
         const status = error?.status || error?.response?.status;
         let detail = status ? ` (HTTP ${status})` : '';

--- a/src/services/ai/discordChat.js
+++ b/src/services/ai/discordChat.js
@@ -4,7 +4,7 @@ const { providers } = require('./providers');
 const { resolveProviderConfig, streamCompletion, getCompletion } = require('./index');
 const { retrieveKnowledge, buildKnowledgeContext } = require('./knowledge');
 const { loadHistory, appendHistory, clearHistory } = require('./history');
-const { peekRateLimit, peekChannelRateLimit } = require('./rateLimit');
+const { peekRateLimit, peekChannelRateLimit, userRateLimitKey } = require('./rateLimit');
 const { buildActionsAddendum, extractAction, executeAction } = require('./actions');
 
 // Discord transport for the AI chat loop: rate limiting, prompt assembly,
@@ -78,7 +78,8 @@ async function handleAIChat(message, aiSettings) {
     // streamCompletion, which is what actually bounds provider spend. This is
     // only here to refuse before the history load, knowledge retrieval and
     // prompt assembly below, and to say so in the channel where the user asked.
-    if (!peekRateLimit(message.author.id, rateLimit.perUser, rateLimit.windowMin)) {
+    // The same key enforcement will consume, so the peek and the spend agree.
+    if (!peekRateLimit(userRateLimitKey(message.guild.id, message.author.id), rateLimit.perUser, rateLimit.windowMin)) {
         return message.reply(`Rate limit reached (${rateLimit.perUser} per ${rateLimit.windowMin}m). Please slow down.`);
     }
 
@@ -88,6 +89,11 @@ async function handleAIChat(message, aiSettings) {
 
     const maxHistory = aiSettings.maxHistory ?? 20;
     const useStreaming = aiSettings.streaming !== false;
+
+    // The streaming path posts this "…" before the first chunk arrives, so an
+    // error after that point has to land *in* it. Left alone it stays in the
+    // channel as a permanent ellipsis next to a separate error message.
+    let placeholder = null;
 
     // Build system prompt: base + pinned memories + knowledge context + action instructions
     let systemPrompt = aiSettings.systemPrompt || 'You are a helpful Discord bot assistant.';
@@ -135,7 +141,7 @@ async function handleAIChat(message, aiSettings) {
         let fullResponse = '';
 
         if (useStreaming) {
-            const placeholder = await message.reply('…');
+            placeholder = await message.reply('…');
             let lastEdit = 0;
             let currentMsg = placeholder;
             let currentBuf = '';
@@ -236,12 +242,21 @@ async function handleAIChat(message, aiSettings) {
             }
         }
     } catch (error) {
+        // Reuse the streaming placeholder if one is already on screen, so the
+        // failure replaces the "…" instead of leaving it dangling beside it.
+        const report = async text => {
+            if (placeholder) {
+                const edited = await placeholder.edit(text).then(() => true).catch(() => false);
+                if (edited) return;
+            }
+            await message.reply(text).catch(() => {});
+        };
+
         // The peek above passed but somebody else took the last slot in between.
         if (error?.rateLimited) {
-            const refusal = error.scope === 'channel'
+            await report(error.scope === 'channel'
                 ? 'This channel has reached the AI request limit. Please wait before sending more AI requests here.'
-                : `Rate limit reached (${error.limit} per ${error.windowMin}m). Please slow down.`;
-            await message.reply(refusal).catch(() => {});
+                : `Rate limit reached (${error.limit} per ${error.windowMin}m). Please slow down.`);
             return;
         }
         console.error(`[AI:${provider}] error:`, error?.message || error);
@@ -251,7 +266,7 @@ async function handleAIChat(message, aiSettings) {
         else if (status === 404) detail += ' — model not found; check your model name in the AI settings';
         else if (status === 429) detail += ' — rate limit exceeded';
         else if (status === 503) detail += ' — provider unavailable';
-        await message.reply(`Sorry, I hit an error talking to ${providerLabel}${detail}.`).catch(() => {});
+        await report(`Sorry, I hit an error talking to ${providerLabel}${detail}.`);
     }
 }
 

--- a/src/services/ai/index.js
+++ b/src/services/ai/index.js
@@ -51,7 +51,9 @@ function resolveProviderConfig(aiSettings) {
 function streamCompletion({ userId, channelId, rateLimit, ...args }) {
     // Before the provider is touched: every route into a paid API goes through
     // here, so this is the only place a limit has to be applied to bound spend.
-    enforceRateLimit({ userId, channelId, rateLimit });
+    // guildId stays in `args` as well — it is what the usage ledger records
+    // under, and here it is what scopes the per-user window to one server.
+    enforceRateLimit({ guildId: args.guildId, userId, channelId, rateLimit });
     return streamProvider(args);
 }
 
@@ -64,7 +66,7 @@ async function* streamProvider({ provider, guildId, mcp = true, usageOut, ...req
 }
 
 async function getCompletion({ provider, guildId, mcp = true, userId, channelId, rateLimit, ...req }) {
-    enforceRateLimit({ userId, channelId, rateLimit });
+    enforceRateLimit({ guildId, userId, channelId, rateLimit });
     const result = await getProvider(provider).complete({ ...req, useMcp: mcp });
     if (guildId && result.usage) {
         recordUsage(guildId, provider, req.model, result.usage).catch(err =>

--- a/src/services/ai/index.js
+++ b/src/services/ai/index.js
@@ -1,5 +1,6 @@
 const { providers, getProvider, DEFAULT_MODELS } = require('./providers');
 const { recordUsage } = require('./usage');
+const { enforceRateLimit } = require('./rateLimit');
 
 // Core provider dispatch: resolve a guild's AI settings to a provider config
 // and route completions through the provider registry. Both the streaming and
@@ -18,6 +19,16 @@ function resolveProviderConfig(aiSettings) {
     // guild's MCP servers attached without having to know they exist.
     const mcpServers = Array.isArray(aiSettings.mcpServers) ? aiSettings.mcpServers : [];
 
+    // Same idea for the guild's AI limits: they ride along with the config so
+    // getCompletion/streamCompletion can enforce them centrally, instead of
+    // each call site remembering to ask. A caller only has to say *who* the
+    // request is for (userId/channelId); the numbers come from here.
+    const rateLimit = {
+        perUser: aiSettings.rateLimitPerUser ?? 0,
+        perChannel: aiSettings.rateLimitPerChannel ?? 0,
+        windowMin: aiSettings.rateLimitWindowMin ?? 10
+    };
+
     return {
         provider: providerName,
         model,
@@ -25,14 +36,26 @@ function resolveProviderConfig(aiSettings) {
         maxTokens,
         apiKey: auth.apiKey ?? null,
         baseUrl: auth.baseUrl ?? null,
-        mcpServers
+        mcpServers,
+        rateLimit
     };
 }
 
 // `mcp` controls whether configured MCP servers are offered to the model. It is
 // on by default for conversational calls; callers that parse the reply as JSON
 // pass mcp: false so tool output cannot derail the format they expect.
-async function* streamCompletion({ provider, guildId, mcp = true, usageOut, ...req }) {
+// Deliberately not an async generator itself: the limit has to be spent when
+// the caller asks for the stream, not when it pulls the first chunk. The
+// Discord transport posts a placeholder message before it starts iterating, so
+// a lazy check would put "…" on screen for a request that was never allowed.
+function streamCompletion({ userId, channelId, rateLimit, ...args }) {
+    // Before the provider is touched: every route into a paid API goes through
+    // here, so this is the only place a limit has to be applied to bound spend.
+    enforceRateLimit({ userId, channelId, rateLimit });
+    return streamProvider(args);
+}
+
+async function* streamProvider({ provider, guildId, mcp = true, usageOut, ...req }) {
     yield* getProvider(provider).stream({ ...req, usageOut, useMcp: mcp });
     if (guildId && usageOut?.usage) {
         recordUsage(guildId, provider, req.model, usageOut.usage).catch(err =>
@@ -40,7 +63,8 @@ async function* streamCompletion({ provider, guildId, mcp = true, usageOut, ...r
     }
 }
 
-async function getCompletion({ provider, guildId, mcp = true, ...req }) {
+async function getCompletion({ provider, guildId, mcp = true, userId, channelId, rateLimit, ...req }) {
+    enforceRateLimit({ userId, channelId, rateLimit });
     const result = await getProvider(provider).complete({ ...req, useMcp: mcp });
     if (guildId && result.usage) {
         recordUsage(guildId, provider, req.model, result.usage).catch(err =>

--- a/src/services/ai/providers/gemini.js
+++ b/src/services/ai/providers/gemini.js
@@ -1,4 +1,16 @@
-const { GoogleGenerativeAI } = require('@google/generative-ai');
+const { GoogleGenAI } = require('@google/genai');
+
+// Google's current SDK. It replaces `@google/generative-ai`, which Google
+// retired in favour of this one — that package still installs but no longer
+// gets model or API updates, so a new Gemini model would arrive here unusable.
+//
+// The shapes that changed, since they are the whole of the diff:
+//   new GoogleGenerativeAI(key)          → new GoogleGenAI({ apiKey })
+//   client.getGenerativeModel().startChat → client.chats.create()
+//   generationConfig / systemInstruction  → one `config` block
+//   response.text()                       → response.text (a getter)
+//   result.stream                         → the awaited return value itself
+//   usage after the stream, via .response → usageMetadata on the chunks
 
 const PRICING = [
     { match: /flash-lite/i, in: 0.075, out: 0.30 },
@@ -10,13 +22,14 @@ const PRICING = [
 ];
 
 function startChat({ apiKey, model, systemPrompt, history, temperature, maxTokens }) {
-    const client = new GoogleGenerativeAI(apiKey);
-    const generative = client.getGenerativeModel({
+    const client = new GoogleGenAI({ apiKey });
+    return client.chats.create({
         model,
-        systemInstruction: systemPrompt,
-        generationConfig: { temperature, maxOutputTokens: maxTokens }
-    });
-    return generative.startChat({
+        config: {
+            systemInstruction: systemPrompt,
+            temperature,
+            maxOutputTokens: maxTokens
+        },
         history: history.map(h => ({
             role: h.role === 'assistant' ? 'model' : 'user',
             parts: [{ text: h.content }]
@@ -24,37 +37,39 @@ function startChat({ apiKey, model, systemPrompt, history, temperature, maxToken
     });
 }
 
+function usageOf(meta) {
+    if (!meta) return null;
+    return {
+        inputTokens: meta.promptTokenCount || 0,
+        outputTokens: meta.candidatesTokenCount || 0
+    };
+}
+
 async function* stream(req) {
     const chat = startChat(req);
-    const result = await chat.sendMessageStream(req.prompt);
-    for await (const chunk of result.stream) {
-        const text = chunk.text();
+    const result = await chat.sendMessageStream({ message: req.prompt });
+
+    // Usage now rides on the chunks rather than on a separate response object
+    // awaited after the stream. Each chunk that carries it carries the running
+    // total, so the last one seen is the total for the turn.
+    let lastUsage = null;
+    for await (const chunk of result) {
+        if (chunk.usageMetadata) lastUsage = chunk.usageMetadata;
+        const text = chunk.text;
         if (text) yield text;
     }
-    if (req.usageOut) {
-        try {
-            const final = await result.response;
-            const meta = final?.usageMetadata;
-            if (meta) {
-                req.usageOut.usage = {
-                    inputTokens: meta.promptTokenCount || 0,
-                    outputTokens: meta.candidatesTokenCount || 0
-                };
-            }
-        } catch { /* usage metadata unavailable — leave unset */ }
+
+    if (req.usageOut && lastUsage) {
+        req.usageOut.usage = usageOf(lastUsage);
     }
 }
 
 async function complete(req) {
     const chat = startChat(req);
-    const result = await chat.sendMessage(req.prompt);
-    const text = result.response.text();
-    const meta = result.response.usageMetadata;
-    const usage = meta ? {
-        inputTokens: meta.promptTokenCount || 0,
-        outputTokens: meta.candidatesTokenCount || 0
-    } : null;
-    return { text, usage };
+    const response = await chat.sendMessage({ message: req.prompt });
+    // `.text` is undefined when the model returned no text part at all — a
+    // safety block, or a response that was only tool calls.
+    return { text: response.text ?? '', usage: usageOf(response.usageMetadata) };
 }
 
 module.exports = {

--- a/src/services/ai/rateLimit.js
+++ b/src/services/ai/rateLimit.js
@@ -68,24 +68,37 @@ function peekChannelRateLimit(channelId, limit, windowMin) {
  * unattributed — the scheduled digests and newspapers, which run on a fixed
  * cadence the guild configures rather than on demand — and is not bounded here.
  *
+ * The per-user window is keyed per guild. A Discord user ID is global, but the
+ * limit, the window and the API key being billed all belong to one guild, so a
+ * bare user ID would let activity in one server eat another server's allowance
+ * — and the two owners pay separate bills. Channel IDs are already unique
+ * across Discord, so that key is left alone.
+ *
  * Throws AiRateLimitError rather than returning false: the caller is about to
  * spend real provider tokens, so the failure has to be impossible to ignore.
  */
-function enforceRateLimit({ userId, channelId, rateLimit }) {
+function enforceRateLimit({ guildId, userId, channelId, rateLimit }) {
     if (!rateLimit) return;
     const { perUser, perChannel, windowMin } = rateLimit;
+    const userKey = userId && (guildId ? `${guildId}:${userId}` : userId);
 
     // Channel first: it is the wider bound, and refusing on it should not
     // silently spend one of the user's own slots.
     if (channelId && !peekChannelRateLimit(channelId, perChannel, windowMin)) {
         throw new AiRateLimitError('channel', perChannel, windowMin);
     }
-    if (userId && !checkRateLimit(userId, perUser, windowMin)) {
+    if (userKey && !checkRateLimit(userKey, perUser, windowMin)) {
         throw new AiRateLimitError('user', perUser, windowMin);
     }
     if (channelId && !checkChannelRateLimit(channelId, perChannel, windowMin)) {
         throw new AiRateLimitError('channel', perChannel, windowMin);
     }
+}
+
+/** The per-guild key the user window is tracked under. Exported so the
+ *  transports can peek with exactly the key enforcement will consume. */
+function userRateLimitKey(guildId, userId) {
+    return guildId ? `${guildId}:${userId}` : userId;
 }
 
 module.exports = {
@@ -94,5 +107,6 @@ module.exports = {
     peekRateLimit,
     peekChannelRateLimit,
     enforceRateLimit,
+    userRateLimitKey,
     AiRateLimitError
 };

--- a/src/services/ai/rateLimit.js
+++ b/src/services/ai/rateLimit.js
@@ -17,6 +17,25 @@ setInterval(() => {
     channelRateLimits.cleanup(AI_RL_SWEEP_WINDOW_MS);
 }, 15 * 60 * 1000).unref();
 
+/**
+ * Thrown by getCompletion/streamCompletion when a request would exceed the
+ * guild's configured AI limit. It carries the numbers so each transport can
+ * phrase its own refusal, and `rateLimited` marks it as something no retry
+ * loop should re-attempt — the answer will not change inside the window.
+ */
+class AiRateLimitError extends Error {
+    constructor(scope, limit, windowMin) {
+        super(scope === 'channel'
+            ? `AI channel rate limit reached (${limit} per ${windowMin}m)`
+            : `AI rate limit reached (${limit} per ${windowMin}m)`);
+        this.name = 'AiRateLimitError';
+        this.rateLimited = true;
+        this.scope = scope;
+        this.limit = limit;
+        this.windowMin = windowMin;
+    }
+}
+
 function checkRateLimit(userId, limit, windowMin) {
     if (!limit || limit <= 0) return true;
     return rateLimits.check(userId, (windowMin || 10) * 60 * 1000, limit);
@@ -27,4 +46,53 @@ function checkChannelRateLimit(channelId, limit, windowMin) {
     return channelRateLimits.check(channelId, (windowMin || 10) * 60 * 1000, limit);
 }
 
-module.exports = { checkRateLimit, checkChannelRateLimit };
+/** Non-consuming form of checkRateLimit, for refusing before the expensive work. */
+function peekRateLimit(userId, limit, windowMin) {
+    if (!limit || limit <= 0) return true;
+    return rateLimits.peek(userId, (windowMin || 10) * 60 * 1000, limit);
+}
+
+/** Non-consuming form of checkChannelRateLimit. */
+function peekChannelRateLimit(channelId, limit, windowMin) {
+    if (!limit || limit <= 0) return true;
+    return channelRateLimits.peek(channelId, (windowMin || 10) * 60 * 1000, limit);
+}
+
+/**
+ * The single enforcement point for AI limits, called from getCompletion and
+ * streamCompletion so no provider call can route around it.
+ *
+ * `rateLimit` is the block resolveProviderConfig attaches to every provider
+ * config, so any caller that spreads that config carries the guild's limits
+ * without knowing they exist. A call with no `userId` and no `channelId` is
+ * unattributed — the scheduled digests and newspapers, which run on a fixed
+ * cadence the guild configures rather than on demand — and is not bounded here.
+ *
+ * Throws AiRateLimitError rather than returning false: the caller is about to
+ * spend real provider tokens, so the failure has to be impossible to ignore.
+ */
+function enforceRateLimit({ userId, channelId, rateLimit }) {
+    if (!rateLimit) return;
+    const { perUser, perChannel, windowMin } = rateLimit;
+
+    // Channel first: it is the wider bound, and refusing on it should not
+    // silently spend one of the user's own slots.
+    if (channelId && !peekChannelRateLimit(channelId, perChannel, windowMin)) {
+        throw new AiRateLimitError('channel', perChannel, windowMin);
+    }
+    if (userId && !checkRateLimit(userId, perUser, windowMin)) {
+        throw new AiRateLimitError('user', perUser, windowMin);
+    }
+    if (channelId && !checkChannelRateLimit(channelId, perChannel, windowMin)) {
+        throw new AiRateLimitError('channel', perChannel, windowMin);
+    }
+}
+
+module.exports = {
+    checkRateLimit,
+    checkChannelRateLimit,
+    peekRateLimit,
+    peekChannelRateLimit,
+    enforceRateLimit,
+    AiRateLimitError
+};

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -16,7 +16,7 @@ const { handleAIChat } = require('./ai/discordChat');
 const { clearHistory } = require('./ai/history');
 const { retrieveKnowledge } = require('./ai/knowledge');
 const { buildActionsAddendum } = require('./ai/actions');
-const { checkRateLimit, checkChannelRateLimit } = require('./ai/rateLimit');
+const { checkRateLimit, checkChannelRateLimit, peekRateLimit, peekChannelRateLimit, AiRateLimitError } = require('./ai/rateLimit');
 const { recordUsage, getUsageStats, estimateCost } = require('./ai/usage');
 
 module.exports = {
@@ -29,6 +29,9 @@ module.exports = {
     buildActionsAddendum,
     checkRateLimit,
     checkChannelRateLimit,
+    peekRateLimit,
+    peekChannelRateLimit,
+    AiRateLimitError,
     recordUsage,
     getUsageStats,
     estimateCost,

--- a/src/services/dmService.js
+++ b/src/services/dmService.js
@@ -150,13 +150,20 @@ async function beginSession(interaction) {
     try {
         const gs = await Guild.findOne({ guildId: guild.id });
         const aiSettings = gs?.ai || {};
-        const { provider, model, apiKey, baseUrl, mcpServers } = resolveProviderConfig(aiSettings);
+        const { provider, model, apiKey, baseUrl, mcpServers, rateLimit } = resolveProviderConfig(aiSettings);
 
         if (provider !== 'ollama' && !apiKey) {
             return interaction.editReply('AI is not configured for this server. An admin must add an API key.');
         }
 
-        const story = await getCompletion({ provider, model, apiKey, baseUrl, mcpServers, systemPrompt, history: [], prompt: openingPrompt, temperature: 0.9, maxTokens: 600 });
+        // guildId/userId/channelId are what tie this call to the guild's usage
+        // ledger and to its configured AI limits; a DM campaign is otherwise an
+        // unbounded provider bill behind a slash command.
+        const story = await getCompletion({
+            provider, model, apiKey, baseUrl, mcpServers, rateLimit,
+            guildId: guild.id, userId: interaction.user.id, channelId: interaction.channelId,
+            systemPrompt, history: [], prompt: openingPrompt, temperature: 0.9, maxTokens: 600
+        });
 
         await DmSession.findOneAndUpdate(
             { sessionId: session.sessionId },
@@ -179,6 +186,7 @@ async function beginSession(interaction) {
         }
         return;
     } catch (err) {
+        if (err?.rateLimited) return interaction.editReply(aiLimitMessage(err));
         console.error('[DM] begin error:', err.message);
         return interaction.editReply('Failed to generate the opening scene. Please try again.');
     }
@@ -222,13 +230,17 @@ async function takeAction(interaction) {
     try {
         const gs = await Guild.findOne({ guildId: guild.id });
         const aiSettings = gs?.ai || {};
-        const { provider, model, apiKey, baseUrl, mcpServers } = resolveProviderConfig(aiSettings);
+        const { provider, model, apiKey, baseUrl, mcpServers, rateLimit } = resolveProviderConfig(aiSettings);
 
         if (provider !== 'ollama' && !apiKey) {
             return interaction.editReply('AI is not configured for this server.');
         }
 
-        const narrative = await getCompletion({ provider, model, apiKey, baseUrl, mcpServers, systemPrompt, history, prompt, temperature: 0.9, maxTokens: 500 });
+        const narrative = await getCompletion({
+            provider, model, apiKey, baseUrl, mcpServers, rateLimit,
+            guildId: guild.id, userId: user.id, channelId: interaction.channelId,
+            systemPrompt, history, prompt, temperature: 0.9, maxTokens: 500
+        });
 
         // Scope damage/heal detection to this player by name or "you/your"
         const namePattern = escapeRegex(player.name);
@@ -290,6 +302,7 @@ async function takeAction(interaction) {
         }
         return;
     } catch (err) {
+        if (err?.rateLimited) return interaction.editReply(aiLimitMessage(err));
         console.error('[DM] action error:', err.message);
         return interaction.editReply('Failed to generate a response. Please try again.');
     }
@@ -422,7 +435,7 @@ async function handleDmButton(interaction, client) {
     try {
         const gs = await Guild.findOne({ guildId: session.guildId });
         const aiSettings = gs?.ai || {};
-        const { provider, model, apiKey, baseUrl, mcpServers } = resolveProviderConfig(aiSettings);
+        const { provider, model, apiKey, baseUrl, mcpServers, rateLimit } = resolveProviderConfig(aiSettings);
 
         if (provider !== 'ollama' && !apiKey) {
             return interaction.editReply('AI is not configured for this server.');
@@ -430,7 +443,8 @@ async function handleDmButton(interaction, client) {
 
         const logSnippet = session.storyLog.slice(-16).join('\n\n');
         const recap = await getCompletion({
-            provider, model, apiKey, baseUrl, mcpServers,
+            provider, model, apiKey, baseUrl, mcpServers, rateLimit,
+            guildId: session.guildId, userId: interaction.user.id, channelId: interaction.channelId,
             systemPrompt: 'You are a dramatic fantasy narrator. Summarize the story concisely.',
             history: [],
             prompt: `Summarize the following campaign story so far as a dramatic narrator in 3-5 sentences:\n\n${logSnippet}`,
@@ -446,10 +460,19 @@ async function handleDmButton(interaction, client) {
 
         await interaction.editReply({ embeds: [embed] });
     } catch (err) {
+        if (err?.rateLimited) { await interaction.editReply(aiLimitMessage(err)); return true; }
         console.error('[DM] story recap error:', err.message);
         await interaction.editReply('Failed to generate recap. Please try again.');
     }
     return true;
+}
+
+// A limit refusal is not a failure to narrate — telling the party to "try
+// again" when the server's own AI budget is spent just walks them into it.
+function aiLimitMessage(err) {
+    return err.scope === 'channel'
+        ? 'This channel has reached the server\'s AI request limit. Please wait a few minutes.'
+        : `You have reached the server's AI request limit (${err.limit} per ${err.windowMin}m). Please wait a few minutes.`;
 }
 
 function buildDMSystemPrompt() {

--- a/src/services/newspaperService.js
+++ b/src/services/newspaperService.js
@@ -132,7 +132,12 @@ function buildDataSummary(stats, usernameMap, currency, sections) {
     return lines.join('\n');
 }
 
-async function generateNewspaper(client, guildDoc, preloadedGuild) {
+// `requester` attributes an on-demand run (the /newspaper preview) to the user
+// who asked for it, so it counts against the guild's AI limits like any other
+// user-initiated call. The scheduled path passes nothing: it runs on a cadence
+// the guild itself configures, and is bounded by that rather than by a
+// per-user window it has no user for.
+async function generateNewspaper(client, guildDoc, preloadedGuild, requester) {
     const { guildId } = guildDoc;
     const sections = guildDoc.newspaper?.sections ?? {};
     const currency = guildDoc.economy?.currency ?? '💰';
@@ -164,13 +169,15 @@ async function generateNewspaper(client, guildDoc, preloadedGuild) {
     // Use AI if configured
     if (guildDoc.ai?.enabled) {
         try {
-            const { provider, model, temperature, maxTokens, apiKey, baseUrl, mcpServers } = resolveProviderConfig(guildDoc.ai);
+            const { provider, model, temperature, maxTokens, apiKey, baseUrl, mcpServers, rateLimit } = resolveProviderConfig(guildDoc.ai);
             if (apiKey || provider === 'ollama') {
                 const quoteInstruction = includeQuote
                     ? 'End with a witty "Quote of the Week" that you invent yourself based on the server activity.'
                     : '';
                 narrativeText = await getCompletion({
-                    provider, model, apiKey, baseUrl, mcpServers,
+                    provider, model, apiKey, baseUrl, mcpServers, rateLimit,
+                    userId: requester?.userId,
+                    channelId: requester?.channelId,
                     temperature: 0.85,
                     maxTokens: 900,
                     systemPrompt:
@@ -186,6 +193,10 @@ async function generateNewspaper(client, guildDoc, preloadedGuild) {
                 });
             }
         } catch (err) {
+            // A limit refusal is the guild's own setting talking, not a provider
+            // fault: the /newspaper preview should say so rather than silently
+            // hand back the AI-less fallback as if nothing was configured.
+            if (err?.rateLimited && requester) throw err;
             console.error('[newspaper] AI generation failed:', err.message);
         }
     }

--- a/src/services/summaryService.js
+++ b/src/services/summaryService.js
@@ -51,6 +51,10 @@ async function runSummaryJob(job, client) {
     if (!guildSettings?.ai?.enabled) return false;
 
     const config = resolveProviderConfig(guildSettings.ai);
+    // No userId/channelId: this is a scheduled job, not a request. The guild's
+    // per-user AI limit has no user to bill it to, and bounding a digest by a
+    // per-channel window would silently drop the run the guild configured.
+    // Its cadence is the bound.
     const summary = await getCompletion({
         ...config,
         systemPrompt: 'You are a helpful assistant that creates concise summaries of Discord channel activity.',
@@ -145,6 +149,10 @@ async function runDailyDigest(guildSettings, client) {
     const persona = guildSettings.ai?.systemPrompt || 'You are a helpful Discord bot assistant.';
 
     const config = resolveProviderConfig(guildSettings.ai);
+    // No userId/channelId: this is a scheduled job, not a request. The guild's
+    // per-user AI limit has no user to bill it to, and bounding a digest by a
+    // per-channel window would silently drop the run the guild configured.
+    // Its cadence is the bound.
     const summary = await getCompletion({
         ...config,
         systemPrompt: persona,

--- a/src/shard.js
+++ b/src/shard.js
@@ -22,6 +22,11 @@
 // Set SHARD_COUNT to pin a number; leave it unset for Discord's recommendation.
 
 require('dotenv').config();
+// Resolves any <NAME>_FILE variable into <NAME>, so secrets can be mounted as
+// files (docker secrets) instead of being readable via `docker inspect`. Runs
+// straight after dotenv so .env can set the *_FILE paths too, and before
+// anything reads process.env.
+require('./config/fileSecrets').loadFileSecrets();
 
 const path = require('path');
 const { ShardingManager } = require('discord.js');

--- a/src/utils/boundedRateLimiter.js
+++ b/src/utils/boundedRateLimiter.js
@@ -41,6 +41,22 @@ class BoundedRateLimiter {
         return true;
     }
 
+    /**
+     * Reports whether `key` would be allowed right now, without recording it.
+     *
+     * This exists so a caller can refuse early — before doing the database and
+     * network work a request needs — while the one call that actually spends
+     * the budget stays the only thing that consumes a slot. A peek that passes
+     * is not a reservation: another request can take the last slot before the
+     * consuming `check` runs, which is exactly the outcome the limit is for.
+     */
+    peek(key, windowMs, limit) {
+        const now = Date.now();
+        const arr = this._map.get(key);
+        if (!arr) return true;
+        return arr.filter(t => now - t < windowMs).length < limit;
+    }
+
     /** Drops keys whose recorded requests have all aged out of `windowMs`. */
     cleanup(windowMs) {
         const cutoff = Date.now() - windowMs;

--- a/tests/aiRateLimitEnforcement.test.js
+++ b/tests/aiRateLimitEnforcement.test.js
@@ -1,0 +1,205 @@
+'use strict';
+
+// The guild's `ai.rateLimitPerUser` / `rateLimitPerChannel` settings are the
+// only thing standing between a slash command and an unbounded provider bill.
+// They used to be applied by the messageCreate transport alone, so /questgen,
+// /forge and the DM campaign commands spent tokens without ever consulting
+// them. These tests hold the line at the dispatch layer instead: nothing
+// reaches a provider without passing through it.
+
+const fs = require('fs');
+const path = require('path');
+
+jest.mock('../src/services/ai/providers', () => {
+    const complete = jest.fn(async () => ({ text: 'ok', usage: null }));
+    const stream = jest.fn(async function* () { yield 'ok'; });
+    const provider = {
+        name: 'mock', label: 'Mock', defaultModel: 'mock-1',
+        resolveAuth: () => ({ apiKey: 'k' }),
+        complete, stream,
+    };
+    return {
+        providers: new Map([['mock', provider]]),
+        getProvider: () => provider,
+        DEFAULT_MODELS: { mock: 'mock-1' },
+        __complete: complete,
+        __stream: stream,
+    };
+});
+
+const providersMock = require('../src/services/ai/providers');
+const { resolveProviderConfig, getCompletion, streamCompletion } = require('../src/services/ai');
+
+const SETTINGS = {
+    provider: 'mock',
+    model: 'mock-1',
+    rateLimitPerUser: 2,
+    rateLimitPerChannel: 3,
+    rateLimitWindowMin: 10,
+};
+
+// Fresh key per test so the module-level sliding windows never leak between them.
+let seq = 0;
+const nextUser = () => `user-${++seq}`;
+const nextChannel = () => `chan-${++seq}`;
+
+async function drain(iterable) {
+    const out = [];
+    for await (const piece of iterable) out.push(piece);
+    return out;
+}
+
+beforeEach(() => {
+    providersMock.__complete.mockClear();
+    providersMock.__stream.mockClear();
+});
+
+describe('resolveProviderConfig', () => {
+    it('carries the guild\'s limits with the provider config', () => {
+        expect(resolveProviderConfig(SETTINGS).rateLimit)
+            .toEqual({ perUser: 2, perChannel: 3, windowMin: 10 });
+    });
+
+    it('defaults to no limit rather than to an accidental one', () => {
+        expect(resolveProviderConfig({ provider: 'mock' }).rateLimit)
+            .toEqual({ perUser: 0, perChannel: 0, windowMin: 10 });
+    });
+});
+
+describe('getCompletion', () => {
+    it('refuses once the per-user limit is spent, without calling the provider', async () => {
+        const config = resolveProviderConfig(SETTINGS);
+        const userId = nextUser();
+        const call = () => getCompletion({ ...config, userId, prompt: 'hi' });
+
+        await call();
+        await call();
+        await expect(call()).rejects.toMatchObject({ rateLimited: true, scope: 'user', limit: 2 });
+        expect(providersMock.__complete).toHaveBeenCalledTimes(2);
+    });
+
+    it('refuses on the per-channel limit too', async () => {
+        const config = resolveProviderConfig({ ...SETTINGS, rateLimitPerUser: 0 });
+        const channelId = nextChannel();
+        const call = () => getCompletion({ ...config, userId: nextUser(), channelId, prompt: 'hi' });
+
+        await call();
+        await call();
+        await call();
+        await expect(call()).rejects.toMatchObject({ rateLimited: true, scope: 'channel', limit: 3 });
+        expect(providersMock.__complete).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not spend a user slot when the channel is the one that is full', async () => {
+        const config = resolveProviderConfig({ ...SETTINGS, rateLimitPerChannel: 1 });
+        const channelId = nextChannel();
+        const userA = nextUser();
+        const userB = nextUser();
+
+        await getCompletion({ ...config, userId: userA, channelId, prompt: 'hi' });
+        await expect(getCompletion({ ...config, userId: userB, channelId, prompt: 'hi' }))
+            .rejects.toMatchObject({ scope: 'channel' });
+
+        // userB was refused by the channel, so their own window is untouched:
+        // their full per-user allowance must still be available elsewhere.
+        await getCompletion({ ...config, userId: userB, channelId: nextChannel(), prompt: 'hi' });
+        await getCompletion({ ...config, userId: userB, channelId: nextChannel(), prompt: 'hi' });
+        await expect(getCompletion({ ...config, userId: userB, channelId: nextChannel(), prompt: 'hi' }))
+            .rejects.toMatchObject({ scope: 'user' });
+        expect(providersMock.__complete).toHaveBeenCalledTimes(3);
+    });
+
+    it('leaves an unattributed call — the scheduled jobs — unbounded', async () => {
+        const config = resolveProviderConfig({ ...SETTINGS, rateLimitPerUser: 1 });
+        for (let i = 0; i < 5; i++) await getCompletion({ ...config, prompt: 'hi' });
+        expect(providersMock.__complete).toHaveBeenCalledTimes(5);
+    });
+
+    it('does not bound a guild that has left the limits off', async () => {
+        const config = resolveProviderConfig({ provider: 'mock' });
+        const userId = nextUser();
+        for (let i = 0; i < 5; i++) await getCompletion({ ...config, userId, prompt: 'hi' });
+        expect(providersMock.__complete).toHaveBeenCalledTimes(5);
+    });
+});
+
+describe('streamCompletion', () => {
+    it('refuses before the caller pulls a chunk, so no placeholder is posted for a denied turn', async () => {
+        const config = resolveProviderConfig({ ...SETTINGS, rateLimitPerUser: 1 });
+        const userId = nextUser();
+        await drain(streamCompletion({ ...config, userId, prompt: 'hi' }));
+
+        // The throw has to happen on the call, not on the first next().
+        expect(() => streamCompletion({ ...config, userId, prompt: 'hi' }))
+            .toThrow(expect.objectContaining({ rateLimited: true }));
+        expect(providersMock.__stream).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('call sites', () => {
+    const SRC = path.join(__dirname, '..', 'src');
+
+    // Every provider call that a user can trigger has to say who it is for,
+    // or the limits above have nothing to bill it to.
+    const USER_TRIGGERED = [
+        'commands/community/questgen.js',
+        'commands/economy/forge.js',
+        'services/dmService.js',
+        'services/ai/discordChat.js',
+    ];
+
+    it.each(USER_TRIGGERED)('%s names a userId in every inline provider call', file => {
+        const src = fs.readFileSync(path.join(SRC, file), 'utf8');
+        const calls = src.match(/(?:getCompletion|streamCompletion)\(\{[\s\S]*?\n\s*\}\)/g) || [];
+        for (const call of calls) expect(call).toMatch(/userId:/);
+        // The config the call spreads has to be the one carrying the limits.
+        expect(src).toMatch(/rateLimit/);
+    });
+
+    it('builds discordChat\'s prepared args with the attribution too', () => {
+        // The one call site that passes a prebuilt object rather than a literal.
+        const src = fs.readFileSync(path.join(SRC, 'services/ai/discordChat.js'), 'utf8');
+        const callArgs = /const callArgs = \{[\s\S]*?\n\s*\};/.exec(src);
+        expect(callArgs).not.toBeNull();
+        expect(callArgs[0]).toMatch(/userId: message\.author\.id/);
+        expect(callArgs[0]).toMatch(/channelId: message\.channel\.id/);
+        expect(callArgs[0]).toMatch(/rateLimit/);
+    });
+
+    it('covers every user-triggered provider call in the tree', () => {
+        // A new command that calls a provider without attribution is exactly
+        // the regression this whole file exists for, so enumerate the callers
+        // rather than trusting the list above to stay complete.
+        const walk = dir => fs.readdirSync(dir, { withFileTypes: true }).flatMap(e =>
+            e.isDirectory() ? walk(path.join(dir, e.name))
+                : e.name.endsWith('.js') ? [path.join(dir, e.name)] : []);
+
+        // Where a provider call is legitimately unattributed, and why.
+        const SCHEDULED = new Set([
+            'services/summaryService.js',    // cron: scheduled digests
+            'services/newspaperService.js',  // cron, plus an attributed preview
+        ]);
+
+        const unattributed = walk(SRC)
+            .map(f => path.relative(SRC, f).split(path.sep).join('/'))
+            .filter(rel => rel !== 'services/ai/index.js' && rel !== 'services/aiService.js')
+            .filter(rel => {
+                const src = fs.readFileSync(path.join(SRC, rel), 'utf8');
+                return /\b(?:getCompletion|streamCompletion)\(/.test(src) && !/userId/.test(src);
+            })
+            .filter(rel => !SCHEDULED.has(rel));
+
+        expect(unattributed).toEqual([]);
+    });
+
+    it('keeps the enforcement in the dispatch layer, not the transports', () => {
+        const dispatch = fs.readFileSync(path.join(SRC, 'services/ai/index.js'), 'utf8');
+        expect(dispatch).toMatch(/enforceRateLimit\(\{ userId, channelId, rateLimit \}\)/);
+
+        // The transport may peek to refuse early, but it must not be the thing
+        // that spends the slot — that would double-count against the dispatch.
+        const chat = fs.readFileSync(path.join(SRC, 'services/ai/discordChat.js'), 'utf8');
+        expect(chat).not.toMatch(/\bcheckRateLimit\(|\bcheckChannelRateLimit\(/);
+        expect(chat).toMatch(/peekRateLimit\(/);
+    });
+});

--- a/tests/aiRateLimitEnforcement.test.js
+++ b/tests/aiRateLimitEnforcement.test.js
@@ -109,6 +109,35 @@ describe('getCompletion', () => {
         expect(providersMock.__complete).toHaveBeenCalledTimes(3);
     });
 
+    it('gives the same user an independent quota in each guild', async () => {
+        // The limit, the window and the API key being billed all belong to one
+        // guild; a bare user ID would let one server's chatter exhaust another
+        // server's allowance, and the two owners pay separate bills.
+        const config = resolveProviderConfig({ ...SETTINGS, rateLimitPerUser: 1 });
+        const userId = nextUser();
+        const guildA = `guild-${++seq}`;
+        const guildB = `guild-${++seq}`;
+
+        await getCompletion({ ...config, guildId: guildA, userId, prompt: 'hi' });
+        await expect(getCompletion({ ...config, guildId: guildA, userId, prompt: 'hi' }))
+            .rejects.toMatchObject({ scope: 'user' });
+
+        // Same person, different server, untouched allowance.
+        await getCompletion({ ...config, guildId: guildB, userId, prompt: 'hi' });
+        await expect(getCompletion({ ...config, guildId: guildB, userId, prompt: 'hi' }))
+            .rejects.toMatchObject({ scope: 'user' });
+
+        expect(providersMock.__complete).toHaveBeenCalledTimes(2);
+    });
+
+    it('still bounds a call that names no guild', async () => {
+        const config = resolveProviderConfig({ ...SETTINGS, rateLimitPerUser: 1 });
+        const userId = nextUser();
+        await getCompletion({ ...config, userId, prompt: 'hi' });
+        await expect(getCompletion({ ...config, userId, prompt: 'hi' }))
+            .rejects.toMatchObject({ scope: 'user' });
+    });
+
     it('leaves an unattributed call — the scheduled jobs — unbounded', async () => {
         const config = resolveProviderConfig({ ...SETTINGS, rateLimitPerUser: 1 });
         for (let i = 0; i < 5; i++) await getCompletion({ ...config, prompt: 'hi' });
@@ -194,12 +223,22 @@ describe('call sites', () => {
 
     it('keeps the enforcement in the dispatch layer, not the transports', () => {
         const dispatch = fs.readFileSync(path.join(SRC, 'services/ai/index.js'), 'utf8');
-        expect(dispatch).toMatch(/enforceRateLimit\(\{ userId, channelId, rateLimit \}\)/);
+        // Both paths, and each one naming the guild that scopes the user window.
+        const enforced = dispatch.match(/enforceRateLimit\(\{[^}]*\}\)/g) || [];
+        expect(enforced).toHaveLength(2);
+        for (const call of enforced) {
+            expect(call).toMatch(/guildId/);
+            expect(call).toMatch(/userId/);
+            expect(call).toMatch(/channelId/);
+            expect(call).toMatch(/rateLimit/);
+        }
 
         // The transport may peek to refuse early, but it must not be the thing
         // that spends the slot — that would double-count against the dispatch.
         const chat = fs.readFileSync(path.join(SRC, 'services/ai/discordChat.js'), 'utf8');
         expect(chat).not.toMatch(/\bcheckRateLimit\(|\bcheckChannelRateLimit\(/);
-        expect(chat).toMatch(/peekRateLimit\(/);
+        // And it peeks the key enforcement will consume, not a bare user ID —
+        // otherwise the early refusal and the real bound disagree.
+        expect(chat).toMatch(/peekRateLimit\(userRateLimitKey\(message\.guild\.id, message\.author\.id\)/);
     });
 });

--- a/tests/autoroleChipXss.test.js
+++ b/tests/autoroleChipXss.test.js
@@ -159,6 +159,28 @@ describe('autorole chip', () => {
         expect(panel).not.toMatch(/onclick="removeAutoRole/);
     });
 
+    it('escapes the role name in a server-side chip, so the payload stays text', () => {
+        // The template renders these on first page load, before any JS runs —
+        // a second, independent path to the same sink as addAutoRole.
+        const panel = renderPanel('welcome', {
+            settings: { ...guildSettingsLocals().settings, autoRoles: [{ roleId: PAYLOAD_ROLE.id }] },
+        });
+
+        // The raw payload must not survive into the markup as markup.
+        expect(panel).not.toContain(MALICIOUS_ROLE_NAME);
+        expect(panel).toContain('&lt;img src=x onerror=');
+
+        // And parsed as a browser would: the name is text, with no element and
+        // no event handler recovered from it.
+        document.body.innerHTML = panel;
+        const chip = document.querySelector(`[data-role-id="${PAYLOAD_ROLE.id}"]`);
+        expect(chip).not.toBeNull();
+        expect(chip.textContent).toContain(MALICIOUS_ROLE_NAME);
+        expect(chip.querySelector('img')).toBeNull();
+        expect(document.querySelector('img')).toBeNull();
+        expect(window.__xss).toBeUndefined();
+    });
+
     it('never builds an autorole chip with innerHTML', () => {
         const script = fs.readFileSync(path.join(PUBLIC, 'guild-settings.js'), 'utf8');
         // The whole class of bug: a role name concatenated into markup.

--- a/tests/autoroleChipXss.test.js
+++ b/tests/autoroleChipXss.test.js
@@ -1,0 +1,167 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"customExportConditions": ["node"]}
+ */
+process.env.SUPPRESS_JEST_WARNINGS = 'true';
+
+// jsdom omits a few Node globals that mongoose's driver reaches for on require.
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = global.TextEncoder || TextEncoder;
+global.TextDecoder = global.TextDecoder || TextDecoder;
+
+const fs = require('fs');
+const path = require('path');
+const ejs = require('ejs');
+const { guildSettingsLocals } = require('./helpers/guildSettingsLocals');
+
+const VIEWS = path.join(__dirname, '..', 'src', 'dashboard', 'views');
+const PUBLIC = path.join(__dirname, '..', 'src', 'dashboard', 'public');
+
+// A Discord role name is chosen by whoever can manage roles in the guild, and
+// it lands in the dashboard verbatim. This one is a role name that renders as
+// markup the moment it reaches innerHTML.
+const PAYLOAD_ROLE = { id: '42', name: '<img src=x onerror="window.__xss=1">' };
+const MALICIOUS_ROLE_NAME = PAYLOAD_ROLE.name;
+
+const documentListeners = [];
+const addDocumentListener = document.addEventListener.bind(document);
+
+function forgetDocumentListeners() {
+    while (documentListeners.length) {
+        const [type, fn, opts] = documentListeners.pop();
+        document.removeEventListener(type, fn, opts);
+    }
+}
+
+function locals(overrides = {}) {
+    const base = guildSettingsLocals();
+    return guildSettingsLocals({
+        roles: [...base.roles, PAYLOAD_ROLE],
+        ...overrides,
+    });
+}
+
+function renderPage(overrides) {
+    const file = path.join(VIEWS, 'guild-settings.ejs');
+    return ejs.render(fs.readFileSync(file, 'utf8'), locals(overrides), { filename: file });
+}
+
+function renderPanel(name, overrides) {
+    const file = path.join(VIEWS, 'partials', 'panels', `${name}.ejs`);
+    return ejs.render(fs.readFileSync(file, 'utf8'), locals(overrides), { filename: file });
+}
+
+/** Put the rendered page in the document and run its scripts, as a browser would. */
+function bootPage(overrides) {
+    const html = renderPage(overrides);
+    const body = html.slice(html.indexOf('<body'), html.indexOf('</body>'));
+    document.body.innerHTML = body.replace(/^<body[^>]*>/, '');
+
+    window.CSS = window.CSS || {};
+    window.CSS.escape = value => String(value).replace(/[^\w-]/g, c => '\\' + c);
+
+    window.fetch = jest.fn(async url => {
+        const panel = /\/panel\/([a-z]+)(?:$|\?)/.exec(String(url));
+        if (panel) {
+            return { ok: true, status: 200, text: async () => renderPanel(panel[1], overrides) };
+        }
+        return { ok: true, status: 200, json: async () => ({}), text: async () => '{}' };
+    });
+
+    const bootstrap = html.match(/<script nonce="[^"]*">([\s\S]*?)<\/script>/)[1];
+    document.addEventListener = (type, fn, opts) => {
+        documentListeners.push([type, fn, opts]);
+        addDocumentListener(type, fn, opts);
+    };
+    try {
+        window.eval(fs.readFileSync(path.join(PUBLIC, 'esc-html.js'), 'utf8'));
+        window.eval(bootstrap);
+        window.eval(fs.readFileSync(path.join(PUBLIC, 'guild-settings.js'), 'utf8'));
+    } finally {
+        document.addEventListener = addDocumentListener;
+    }
+}
+
+const settle = async () => {
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await new Promise(resolve => setTimeout(resolve, 0));
+};
+
+async function openWelcomePanel() {
+    bootPage();
+    document.querySelector('.nav-item[data-tab="welcome"]')
+        .dispatchEvent(new window.Event('click', { bubbles: true }));
+    await settle();
+}
+
+describe('autorole chip', () => {
+    let errors;
+
+    beforeEach(() => {
+        errors = jest.spyOn(console, 'error').mockImplementation(() => {});
+        document.body.innerHTML = '';
+        delete window.__xss;
+    });
+
+    afterEach(async () => {
+        await settle();
+        forgetDocumentListeners();
+        errors.mockRestore();
+        jest.restoreAllMocks();
+    });
+
+    it('renders a role name as text, not markup, when a role is added', async () => {
+        await openWelcomePanel();
+
+        const select = document.getElementById('autorole-select');
+        select.value = PAYLOAD_ROLE.id;
+        await window.addAutoRole();
+        await settle();
+
+        const chip = document.querySelector(`#autorole-list [data-role-id="${PAYLOAD_ROLE.id}"]`);
+        expect(chip).not.toBeNull();
+        // The payload survives as the visible name and nothing else.
+        expect(chip.textContent).toContain(MALICIOUS_ROLE_NAME);
+        expect(chip.querySelector('img')).toBeNull();
+        expect(window.__xss).toBeUndefined();
+    });
+
+    it('wires the chip\'s remove button through dataset, not an inline handler', async () => {
+        await openWelcomePanel();
+
+        const select = document.getElementById('autorole-select');
+        select.value = PAYLOAD_ROLE.id;
+        await window.addAutoRole();
+        await settle();
+
+        const chip = document.querySelector(`#autorole-list [data-role-id="${PAYLOAD_ROLE.id}"]`);
+        const button = chip.querySelector('button');
+        expect(button.getAttribute('onclick')).toBeNull();
+        expect(button.dataset.action).toBe('autorole-remove');
+        expect(button.dataset.roleId).toBe(PAYLOAD_ROLE.id);
+
+        window.fetch.mockClear();
+        button.dispatchEvent(new window.Event('click', { bubbles: true }));
+        await settle();
+
+        const removeCall = window.fetch.mock.calls
+            .find(c => String(c[0]).includes(`/autorole/${PAYLOAD_ROLE.id}`));
+        expect(removeCall).toBeDefined();
+        expect(removeCall[1].method).toBe('DELETE');
+        expect(document.querySelector(`#autorole-list [data-role-id="${PAYLOAD_ROLE.id}"]`)).toBeNull();
+    });
+
+    it('renders server-side chips through dataset too', async () => {
+        const panel = renderPanel('welcome', {
+            settings: { ...guildSettingsLocals().settings, autoRoles: [{ roleId: PAYLOAD_ROLE.id }] },
+        });
+        expect(panel).toContain('data-action="autorole-remove"');
+        expect(panel).not.toMatch(/onclick="removeAutoRole/);
+    });
+
+    it('never builds an autorole chip with innerHTML', () => {
+        const script = fs.readFileSync(path.join(PUBLIC, 'guild-settings.js'), 'utf8');
+        // The whole class of bug: a role name concatenated into markup.
+        expect(script).not.toMatch(/chip\.innerHTML/);
+    });
+});

--- a/tests/discordStrategy.test.js
+++ b/tests/discordStrategy.test.js
@@ -1,0 +1,174 @@
+'use strict';
+
+// The dashboard's Discord OAuth2 strategy, which sits directly on the login
+// path. It used to be `discord-strategy`, a single-maintainer package that
+// carried its own copy of passport-oauth2's `authenticate()`. What replaced it
+// is a subclass that overrides one method, so these tests pin the two things
+// that method is responsible for — fetching the profile, and fetching the guild
+// list the dashboard authorizes against — plus the fact that everything else
+// still comes from passport-oauth2.
+
+const OAuth2Strategy = require('passport-oauth2');
+const {
+    Strategy: DiscordStrategy,
+    DiscordScope,
+    API_BASE,
+} = require('../src/dashboard/lib/discordStrategy');
+
+const OPTIONS = {
+    clientID: 'client-id',
+    clientSecret: 'client-secret',
+    callbackURL: 'https://dash.example.com/auth/callback',
+    scope: [DiscordScope.Identify, DiscordScope.Guilds],
+    state: true,
+};
+
+const PROFILE = { id: '1', username: 'tester', discriminator: '0', avatar: null };
+const GUILDS = [{ id: '10', name: 'Test Guild', icon: null, permissions: '8' }];
+
+/** Stubs the OAuth2 client's GET so no request leaves the process. */
+function stubApi(strategy, routes) {
+    const seen = [];
+    strategy._oauth2.get = (url, accessToken, cb) => {
+        seen.push({ url, accessToken });
+        const route = routes[url];
+        if (!route) return cb(new Error(`unexpected GET ${url}`));
+        if (route.err) return cb(route.err);
+        process.nextTick(() => cb(null, route.body));
+    };
+    return seen;
+}
+
+const build = (options = OPTIONS) => new DiscordStrategy(options, () => {});
+
+const profileOf = strategy => new Promise((resolve, reject) => {
+    strategy.userProfile('access-token', (err, profile) => (err ? reject(err) : resolve(profile)));
+});
+
+describe('DiscordStrategy', () => {
+    it('is a passport-oauth2 strategy, not a reimplementation of one', () => {
+        const strategy = build();
+        expect(strategy).toBeInstanceOf(OAuth2Strategy);
+        expect(strategy.name).toBe('discord');
+        // authenticate() — token exchange, PKCE, and the state check that
+        // defends the callback against login CSRF — must be the inherited one.
+        expect(Object.prototype.hasOwnProperty.call(DiscordStrategy.prototype, 'authenticate')).toBe(false);
+        expect(strategy.authenticate).toBe(OAuth2Strategy.prototype.authenticate);
+    });
+
+    it('points at Discord\'s own endpoints', () => {
+        const strategy = build();
+        expect(strategy._oauth2._authorizeUrl).toBe('https://discord.com/api/oauth2/authorize');
+        expect(strategy._oauth2._accessTokenUrl).toBe('https://discord.com/api/oauth2/token');
+    });
+
+    it('lets a caller override an endpoint', () => {
+        const strategy = build({ ...OPTIONS, tokenURL: 'https://proxy.example.com/token' });
+        expect(strategy._oauth2._accessTokenUrl).toBe('https://proxy.example.com/token');
+    });
+
+    it('sends the access token as a Bearer header, which Discord requires', () => {
+        expect(build()._oauth2._useAuthorizationHeaderForGET).toBe(true);
+    });
+
+    it('separates scopes with a space, as Discord expects', () => {
+        expect(build()._scopeSeparator).toBe(' ');
+    });
+
+    it('fetches the profile and the guild list the dashboard authorizes against', async () => {
+        const strategy = build();
+        const seen = stubApi(strategy, {
+            [`${API_BASE}/users/@me`]: { body: JSON.stringify(PROFILE) },
+            [`${API_BASE}/users/@me/guilds`]: { body: JSON.stringify(GUILDS) },
+        });
+
+        const profile = await profileOf(strategy);
+        expect(profile.id).toBe('1');
+        expect(profile.guilds).toEqual(GUILDS);
+        expect(seen.map(s => s.url)).toEqual([
+            `${API_BASE}/users/@me`,
+            `${API_BASE}/users/@me/guilds`,
+        ]);
+        expect(seen.every(s => s.accessToken === 'access-token')).toBe(true);
+    });
+
+    it('fails the login when the guild list cannot be fetched', async () => {
+        // Not an empty list: the dashboard reads guilds to decide which servers
+        // this user may configure, so silently dropping them turns a broken
+        // fetch into a successful login with no permissions — indistinguishable,
+        // from the callback, from a user who administers nothing.
+        const strategy = build();
+        stubApi(strategy, {
+            [`${API_BASE}/users/@me`]: { body: JSON.stringify(PROFILE) },
+            [`${API_BASE}/users/@me/guilds`]: { err: new Error('502 from Discord') },
+        });
+
+        await expect(profileOf(strategy)).rejects.toThrow(/users\/@me\/guilds/);
+    });
+
+    it('fails the login when the profile itself cannot be fetched', async () => {
+        const strategy = build();
+        stubApi(strategy, { [`${API_BASE}/users/@me`]: { err: new Error('401') } });
+        await expect(profileOf(strategy)).rejects.toThrow(/users\/@me/);
+    });
+
+    it('fails rather than guessing when Discord returns something unparseable', async () => {
+        const strategy = build();
+        stubApi(strategy, { [`${API_BASE}/users/@me`]: { body: '<html>gateway timeout</html>' } });
+        await expect(profileOf(strategy)).rejects.toThrow(/unparseable/);
+    });
+
+    it('does not request guilds when the scope was not asked for', async () => {
+        const strategy = build({ ...OPTIONS, scope: [DiscordScope.Identify] });
+        const seen = stubApi(strategy, {
+            [`${API_BASE}/users/@me`]: { body: JSON.stringify(PROFILE) },
+        });
+
+        const profile = await profileOf(strategy);
+        expect(profile.guilds).toEqual([]);
+        expect(seen.map(s => s.url)).toEqual([`${API_BASE}/users/@me`]);
+    });
+
+    it('handles a scope given as a single string', async () => {
+        const strategy = build({ ...OPTIONS, scope: DiscordScope.Guilds });
+        stubApi(strategy, {
+            [`${API_BASE}/users/@me`]: { body: JSON.stringify(PROFILE) },
+            [`${API_BASE}/users/@me/guilds`]: { body: JSON.stringify(GUILDS) },
+        });
+        expect((await profileOf(strategy)).guilds).toEqual(GUILDS);
+    });
+});
+
+describe('the dashboard wiring', () => {
+    const savedEnv = {};
+    beforeAll(() => {
+        for (const key of ['CLIENT_ID', 'CLIENT_SECRET']) {
+            savedEnv[key] = process.env[key];
+            process.env[key] = `test-${key.toLowerCase()}`;
+        }
+    });
+    afterAll(() => {
+        for (const [key, value] of Object.entries(savedEnv)) {
+            if (value === undefined) delete process.env[key];
+            else process.env[key] = value;
+        }
+    });
+
+    it('takes a four-argument verify callback, the passport-oauth2 shape', () => {
+        // discord-strategy passed a sixth "consumable" argument that only its
+        // own forked authenticate() knew how to supply. Nothing may depend on
+        // that again.
+        const server = require('../src/dashboard/server');
+        const src = require('fs').readFileSync(
+            require('path').join(__dirname, '..', 'src', 'dashboard', 'server.js'), 'utf8');
+        expect(src).not.toMatch(/consumable/);
+        expect(src).not.toMatch(/require\('discord-strategy'\)/);
+        expect(typeof server.discordStrategyOptions).toBe('function');
+    });
+
+    it('is not shipping discord-strategy any more', () => {
+        const pkg = require('../package.json');
+        expect(pkg.dependencies['discord-strategy']).toBeUndefined();
+        expect(pkg.dependencies['passport-oauth2']).toBeDefined();
+    });
+});

--- a/tests/discordStrategy.test.js
+++ b/tests/discordStrategy.test.js
@@ -137,6 +137,30 @@ describe('DiscordStrategy', () => {
         });
         expect((await profileOf(strategy)).guilds).toEqual(GUILDS);
     });
+
+    it('handles a scope given as one pre-joined string, which passport also accepts', async () => {
+        // 'identify guilds' compared whole against 'guilds' is never equal, so
+        // this configuration used to skip the guild fetch and hand the
+        // dashboard a user who appears to administer nothing.
+        const strategy = build({ ...OPTIONS, scope: 'identify guilds' });
+        const seen = stubApi(strategy, {
+            [`${API_BASE}/users/@me`]: { body: JSON.stringify(PROFILE) },
+            [`${API_BASE}/users/@me/guilds`]: { body: JSON.stringify(GUILDS) },
+        });
+
+        expect((await profileOf(strategy)).guilds).toEqual(GUILDS);
+        expect(seen.map(s => s.url)).toContain(`${API_BASE}/users/@me/guilds`);
+    });
+
+    it('still skips the fetch when a joined scope string omits guilds', async () => {
+        const strategy = build({ ...OPTIONS, scope: 'identify email' });
+        const seen = stubApi(strategy, {
+            [`${API_BASE}/users/@me`]: { body: JSON.stringify(PROFILE) },
+        });
+
+        expect((await profileOf(strategy)).guilds).toEqual([]);
+        expect(seen.map(s => s.url)).toEqual([`${API_BASE}/users/@me`]);
+    });
 });
 
 describe('the dashboard wiring', () => {

--- a/tests/fileSecrets.test.js
+++ b/tests/fileSecrets.test.js
@@ -1,0 +1,161 @@
+'use strict';
+
+// Secrets handed to a container as plain environment variables are readable by
+// anyone who can reach the Docker API — `docker inspect` prints them, and the
+// Portainer UI shows the same values. The <NAME>_FILE convention keeps the
+// value out of the environment; these tests hold its edges.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { loadFileSecrets, FILE_BACKED_SECRETS } = require('../src/config/fileSecrets');
+
+let tmpDir;
+let log;
+
+function secretFile(name, contents) {
+    const p = path.join(tmpDir, name);
+    fs.writeFileSync(p, contents);
+    return p;
+}
+
+beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawdia-secrets-'));
+    log = { log: jest.fn(), warn: jest.fn() };
+});
+
+afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('loadFileSecrets', () => {
+    it('publishes the file contents as the plain variable', () => {
+        const env = { DISCORD_TOKEN_FILE: secretFile('token', 'MTIz.abc.def') };
+        expect(loadFileSecrets(env, { log })).toEqual(['DISCORD_TOKEN']);
+        expect(env.DISCORD_TOKEN).toBe('MTIz.abc.def');
+    });
+
+    it('strips the trailing newline `echo > file` leaves behind', () => {
+        // A Discord token with a newline on the end fails to authenticate with
+        // an error that says nothing about whitespace.
+        const env = { DISCORD_TOKEN_FILE: secretFile('token', 'MTIz.abc.def\n') };
+        loadFileSecrets(env, { log });
+        expect(env.DISCORD_TOKEN).toBe('MTIz.abc.def');
+    });
+
+    it('keeps leading whitespace, which a passphrase is entitled to', () => {
+        const env = { SESSION_SECRET_FILE: secretFile('sess', '  padded  \n') };
+        loadFileSecrets(env, { log });
+        expect(env.SESSION_SECRET).toBe('  padded');
+    });
+
+    it('lets an explicit variable win over the file, and says so', () => {
+        // A one-off `docker run -e DISCORD_TOKEN=…` has to still override a
+        // stack that mounts the secret.
+        const env = {
+            DISCORD_TOKEN: 'from-env',
+            DISCORD_TOKEN_FILE: secretFile('token', 'from-file'),
+        };
+        expect(loadFileSecrets(env, { log })).toEqual([]);
+        expect(env.DISCORD_TOKEN).toBe('from-env');
+        expect(log.warn).toHaveBeenCalledWith(expect.stringMatching(/DISCORD_TOKEN.*ignoring the file/));
+    });
+
+    it('treats an empty variable as unset, so a blank compose default still resolves', () => {
+        // `- DISCORD_TOKEN=${DISCORD_TOKEN}` with nothing set yields "".
+        const env = { DISCORD_TOKEN: '', DISCORD_TOKEN_FILE: secretFile('token', 'from-file') };
+        loadFileSecrets(env, { log });
+        expect(env.DISCORD_TOKEN).toBe('from-file');
+    });
+
+    it('aborts on an unreadable file rather than leaving the variable unset', () => {
+        // A mount typo must fail at startup, not hours later as "the AI stopped
+        // working".
+        const env = { ANTHROPIC_API_KEY_FILE: path.join(tmpDir, 'missing') };
+        expect(() => loadFileSecrets(env, { log })).toThrow(/Cannot read ANTHROPIC_API_KEY_FILE/);
+        expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    });
+
+    it('aborts on an empty file', () => {
+        const env = { SESSION_SECRET_FILE: secretFile('sess', '\n') };
+        expect(() => loadFileSecrets(env, { log })).toThrow(/is empty/);
+    });
+
+    it('ignores a *_FILE variable for anything that is not a known secret', () => {
+        // The reason this is a list and not a scan: `_FILE` is the ordinary
+        // suffix for "path to a file", and most Linux images export these.
+        const env = {
+            SSL_CERT_FILE: '/etc/ssl/certs/ca-certificates.crt',
+            NIX_SSL_CERT_FILE: '/nowhere/at/all',
+            MIGRATION_BACKUP_FILE: '/nowhere/either',
+        };
+        expect(loadFileSecrets(env, { log })).toEqual([]);
+        expect(env.SSL_CERT).toBeUndefined();
+        expect(env.NIX_SSL_CERT).toBeUndefined();
+    });
+
+    it('logs the names it resolved and never a value', () => {
+        const env = {
+            DISCORD_TOKEN_FILE: secretFile('token', 'super-secret-token'),
+            SESSION_SECRET_FILE: secretFile('sess', 'super-secret-session'),
+        };
+        loadFileSecrets(env, { log });
+        const line = log.log.mock.calls.map(c => c[0]).join('\n');
+        expect(line).toContain('DISCORD_TOKEN');
+        expect(line).toContain('SESSION_SECRET');
+        expect(line).not.toContain('super-secret-token');
+        expect(line).not.toContain('super-secret-session');
+    });
+
+    it('says nothing when no secret is file-backed', () => {
+        expect(loadFileSecrets({ DISCORD_TOKEN: 'plain' }, { log })).toEqual([]);
+        expect(log.log).not.toHaveBeenCalled();
+    });
+
+    it('covers every secret the bot actually reads', () => {
+        // A provider key added later without a _FILE form silently loses the
+        // protection, so pin the list against the source tree.
+        const SRC = path.join(__dirname, '..', 'src');
+        const walk = dir => fs.readdirSync(dir, { withFileTypes: true }).flatMap(e =>
+            e.isDirectory() ? walk(path.join(dir, e.name))
+                : e.name.endsWith('.js') ? [path.join(dir, e.name)] : []);
+
+        const used = new Set();
+        for (const file of walk(SRC)) {
+            const src = fs.readFileSync(file, 'utf8');
+            for (const m of src.matchAll(/process\.env\.([A-Z0-9_]+)/g)) used.add(m[1]);
+        }
+
+        // Everything the bot reads that carries a credential. The rest —
+        // CLIENT_ID, DASHBOARD_URL, NODE_ENV, tuning knobs — is not sensitive.
+        const SECRET_SHAPED = [...used].filter(name =>
+            /(_TOKEN|_SECRET|_KEY|_PASSWORD|_USERNAME)$/.test(name) || name === 'MONGODB_URI');
+
+        expect(SECRET_SHAPED.sort()).toEqual([...FILE_BACKED_SECRETS].sort());
+    });
+});
+
+describe('entrypoints', () => {
+    // The loader is only worth anything if it runs before the first read of
+    // process.env, in every process that boots the bot.
+    const ENTRYPOINTS = [
+        'src/index.js',
+        'src/shard.js',
+        'src/deploy-commands.js',
+        'scripts/rollback-migration.js',
+    ];
+
+    it.each(ENTRYPOINTS)('%s loads file secrets straight after dotenv', file => {
+        const src = fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+        const dotenv = src.indexOf("require('dotenv').config()");
+        const secrets = src.indexOf('loadFileSecrets()');
+        expect(dotenv).toBeGreaterThan(-1);
+        expect(secrets).toBeGreaterThan(dotenv);
+
+        // Nothing may read a secret in between. Comments there are allowed to
+        // mention process.env — it is the code that must not touch it.
+        const between = src.slice(dotenv, secrets).replace(/\/\/.*$/gm, '');
+        expect(between).not.toMatch(/process\.env\./);
+    });
+});

--- a/tests/geminiProvider.test.js
+++ b/tests/geminiProvider.test.js
@@ -1,0 +1,195 @@
+'use strict';
+
+// The Gemini provider, after the move from the retired `@google/generative-ai`
+// package to Google's current `@google/genai`. Every shape in the call path
+// changed — the constructor, how a chat is created, where the generation config
+// lives, whether `text` is a method or a getter, and where streaming usage
+// comes from — so these tests pin the ones the ledger and the Discord transport
+// depend on.
+
+const mockSendMessage = jest.fn();
+const mockSendMessageStream = jest.fn();
+const mockChatsCreate = jest.fn(() => ({ sendMessage: mockSendMessage, sendMessageStream: mockSendMessageStream }));
+const mockConstructed = [];
+
+jest.mock('@google/genai', () => ({
+    GoogleGenAI: class {
+        constructor(options) {
+            mockConstructed.push(options);
+            this.chats = { create: mockChatsCreate };
+        }
+    },
+}));
+
+const gemini = require('../src/services/ai/providers/gemini');
+
+const REQ = {
+    apiKey: 'gemini-key',
+    model: 'gemini-2.0-flash',
+    systemPrompt: 'You are a helpful bot.',
+    history: [
+        { role: 'user', content: 'hello' },
+        { role: 'assistant', content: 'hi there' },
+    ],
+    prompt: 'what is the weather?',
+    temperature: 0.7,
+    maxTokens: 512,
+};
+
+const USAGE = { promptTokenCount: 40, candidatesTokenCount: 12 };
+
+async function* chunks(...items) {
+    for (const item of items) yield item;
+}
+
+const collect = async iterable => {
+    const out = [];
+    for await (const piece of iterable) out.push(piece);
+    return out;
+};
+
+beforeEach(() => {
+    mockConstructed.length = 0;
+    jest.clearAllMocks();
+    mockChatsCreate.mockImplementation(() => ({ sendMessage: mockSendMessage, sendMessageStream: mockSendMessageStream }));
+});
+
+describe('chat setup', () => {
+    it('passes the key as an options object, not a positional argument', async () => {
+        mockSendMessage.mockResolvedValue({ text: 'ok' });
+        await gemini.complete(REQ);
+        expect(mockConstructed).toEqual([{ apiKey: 'gemini-key' }]);
+    });
+
+    it('puts the system prompt and generation settings in one config block', async () => {
+        mockSendMessage.mockResolvedValue({ text: 'ok' });
+        await gemini.complete(REQ);
+
+        expect(mockChatsCreate).toHaveBeenCalledWith(expect.objectContaining({
+            model: 'gemini-2.0-flash',
+            config: {
+                systemInstruction: 'You are a helpful bot.',
+                temperature: 0.7,
+                maxOutputTokens: 512,
+            },
+        }));
+    });
+
+    it('renames the assistant role to Gemini\'s "model"', async () => {
+        mockSendMessage.mockResolvedValue({ text: 'ok' });
+        await gemini.complete(REQ);
+
+        expect(mockChatsCreate.mock.calls[0][0].history).toEqual([
+            { role: 'user', parts: [{ text: 'hello' }] },
+            { role: 'model', parts: [{ text: 'hi there' }] },
+        ]);
+    });
+
+    it('sends the prompt as a named message parameter', async () => {
+        mockSendMessage.mockResolvedValue({ text: 'ok' });
+        await gemini.complete(REQ);
+        expect(mockSendMessage).toHaveBeenCalledWith({ message: 'what is the weather?' });
+    });
+});
+
+describe('complete', () => {
+    it('reads text from the getter, not a text() call', async () => {
+        mockSendMessage.mockResolvedValue({ text: 'sunny', usageMetadata: USAGE });
+        const result = await gemini.complete(REQ);
+        expect(result.text).toBe('sunny');
+        expect(result.usage).toEqual({ inputTokens: 40, outputTokens: 12 });
+    });
+
+    it('returns an empty string when the model produced no text part', async () => {
+        // A safety block leaves `.text` undefined; the transports concatenate
+        // and .trim() what comes back, so undefined would throw there.
+        mockSendMessage.mockResolvedValue({ text: undefined, usageMetadata: USAGE });
+        expect((await gemini.complete(REQ)).text).toBe('');
+    });
+
+    it('reports no usage rather than zeros when the response carried none', async () => {
+        mockSendMessage.mockResolvedValue({ text: 'sunny' });
+        expect((await gemini.complete(REQ)).usage).toBeNull();
+    });
+});
+
+describe('stream', () => {
+    it('iterates the awaited return value directly, not a .stream property', async () => {
+        mockSendMessageStream.mockResolvedValue(chunks({ text: 'su' }, { text: 'nny' }));
+        expect(await collect(gemini.stream(REQ))).toEqual(['su', 'nny']);
+        expect(mockSendMessageStream).toHaveBeenCalledWith({ message: 'what is the weather?' });
+    });
+
+    it('takes usage off the chunks, where the new SDK puts it', async () => {
+        // The old SDK exposed it on a separate response object awaited after
+        // the stream; there is no such object now.
+        const usageOut = {};
+        mockSendMessageStream.mockResolvedValue(chunks(
+            { text: 'su' },
+            { text: 'nny', usageMetadata: { promptTokenCount: 40, candidatesTokenCount: 2 } },
+        ));
+
+        await collect(gemini.stream({ ...REQ, usageOut }));
+        expect(usageOut.usage).toEqual({ inputTokens: 40, outputTokens: 2 });
+    });
+
+    it('keeps the last running total when several chunks carry usage', async () => {
+        const usageOut = {};
+        mockSendMessageStream.mockResolvedValue(chunks(
+            { text: 'a', usageMetadata: { promptTokenCount: 40, candidatesTokenCount: 1 } },
+            { text: 'b', usageMetadata: { promptTokenCount: 40, candidatesTokenCount: 9 } },
+        ));
+
+        await collect(gemini.stream({ ...REQ, usageOut }));
+        expect(usageOut.usage).toEqual({ inputTokens: 40, outputTokens: 9 });
+    });
+
+    it('leaves usage unset when no chunk carried any, so nothing bogus is billed', async () => {
+        const usageOut = {};
+        mockSendMessageStream.mockResolvedValue(chunks({ text: 'sunny' }));
+        await collect(gemini.stream({ ...REQ, usageOut }));
+        expect(usageOut.usage).toBeUndefined();
+    });
+
+    it('skips empty chunks instead of yielding blanks', async () => {
+        mockSendMessageStream.mockResolvedValue(chunks({ text: '' }, { text: 'x' }, { text: undefined }));
+        expect(await collect(gemini.stream(REQ))).toEqual(['x']);
+    });
+});
+
+describe('registration', () => {
+    it('is still the same provider from the registry\'s point of view', () => {
+        expect(gemini.name).toBe('gemini');
+        expect(gemini.label).toBe('Gemini');
+        expect(gemini.defaultModel).toBe('gemini-2.0-flash');
+        expect(typeof gemini.resolveAuth).toBe('function');
+    });
+
+    it('resolves the key from settings first, then the environment', () => {
+        const saved = process.env.GEMINI_API_KEY;
+        process.env.GEMINI_API_KEY = 'from-env';
+        try {
+            expect(gemini.resolveAuth({ geminiKey: 'from-settings' }).apiKey).toBe('from-settings');
+            expect(gemini.resolveAuth({}).apiKey).toBe('from-env');
+        } finally {
+            if (saved === undefined) delete process.env.GEMINI_API_KEY;
+            else process.env.GEMINI_API_KEY = saved;
+        }
+    });
+
+    it('is not importing the retired package anywhere', () => {
+        const fs = require('fs');
+        const path = require('path');
+        const SRC = path.join(__dirname, '..', 'src');
+        const walk = dir => fs.readdirSync(dir, { withFileTypes: true }).flatMap(e =>
+            e.isDirectory() ? walk(path.join(dir, e.name))
+                : e.name.endsWith('.js') ? [path.join(dir, e.name)] : []);
+
+        // Requires only — the provider's own comment names the old package to
+        // explain what moved, and that is worth keeping.
+        const stragglers = walk(SRC).filter(f =>
+            /require\(['"]@google\/generative-ai['"]\)/.test(fs.readFileSync(f, 'utf8')));
+        expect(stragglers).toEqual([]);
+        expect(require('../package.json').dependencies['@google/generative-ai']).toBeUndefined();
+    });
+});

--- a/tests/oauthLoginCsrf.test.js
+++ b/tests/oauthLoginCsrf.test.js
@@ -12,7 +12,7 @@
 // builds from it, because "we passed state: true" and "a state store is installed"
 // are different claims and only the second one defends anything.
 
-const { Strategy: DiscordStrategy } = require('discord-strategy');
+const { Strategy: DiscordStrategy } = require('../src/dashboard/lib/discordStrategy');
 const { discordStrategyOptions } = require('../src/dashboard/server');
 
 const CALLBACK = 'https://dash.example.com/auth/callback';


### PR DESCRIPTION
A Discord role name is chosen by whoever can manage roles in the guild, and
`addAutoRole` dropped it straight into `chip.innerHTML` inside a template
literal. A role named `<img src=x onerror=...>` therefore became live markup
in the dashboard for the next admin who added any autorole — with the session
cookie and every guild-settings endpoint behind it.

The name now goes in as a text node and the remove button is a real element,
so nothing in the chip is ever parsed as HTML. Its handler moves to the
`data-action` delegation the rest of this page already uses, which also takes
the role ID out of an `onclick="..."` string — an inline handler's attribute
is HTML-decoded before it is parsed as JS, so escaping cannot protect a
literal built that way. The server-rendered chips in welcome.ejs move to the
same handler so both sources of a chip behave identically.

Closes #560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Docker-compatible file-based secret configuration with clear precedence and validation.
  - Added per-user and per-channel AI usage limits with dedicated limit messages.
  - Added built-in Discord OAuth login support.
  - Migrated Gemini integration to the latest Google AI SDK.
- **Bug Fixes**
  - Improved auto-role handling to prevent role names from being interpreted as markup.
  - Improved reporting when AI request limits are reached.
- **Documentation**
  - Added setup guidance for Docker, Portainer, and secret management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->