### PR TITLE
Add the MIT LICENSE file package.json has always claimed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# Matches prettier.config.js. This is the half an editor can apply without any
+# tooling installed, which is most of what kept the tree consistent before there
+# was a linter at all.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.sh]
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,16 @@ jobs:
       - name: Run tests
         run: npm test
 
+      # A step in this job rather than a job of its own: it needs the same
+      # `npm ci`, and a second job would pay for that install again to save a
+      # few seconds. After the tests, with `always()`, so the two signals are
+      # independent — an unused variable never hides which tests failed, and a
+      # failing test never hides the lint result either. Both still fail the
+      # job, which is what `publish: needs: test` is gating on.
+      - name: Lint
+        if: always()
+        run: npm run lint
+
   # Publishing lives here, behind `needs: test`, rather than in its own
   # workflow. It used to be a separate file triggered on `push: main`, which
   # ran alongside the tests instead of after them: a commit that broke the

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+coverage
+package-lock.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 TheShield2594
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,23 @@ once per deployment rather than once per shard runs on shard 0 only: the
 dashboard, schema migrations, and the cron scheduler. `src/utils/sharding.js`
 has the full reasoning.
 
+## Development
+
+```bash
+npm test                       # Jest, ~20s
+npm run lint                   # ESLint (flat config, eslint.config.js)
+npm run lint:fix               # …and apply what it can fix
+npm run format -- <paths>      # Prettier, on the files you name
+```
+
+CI runs the tests and the lint, and the Docker image is only published when
+both pass.
+
+`npm run format` takes explicit paths on purpose. Prettier's settings match the
+style the tree is already written in, but it has never been applied wholesale —
+doing that rewrites ~45,000 lines and every `git blame` with them — so run it on
+the files a change already touches.
+
 ## Configuration
 
 1. Invite the bot to your server

--- a/README.md
+++ b/README.md
@@ -390,4 +390,4 @@ Use the **Send digest now** button in the dashboard's Daily News panel.
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,116 @@
+'use strict';
+
+// Flat config. Three kinds of JavaScript live in this repo and they do not share
+// an environment, so each gets its own block rather than one union of globals
+// that would let a browser-only API through in bot code (#714).
+//
+// The rules are deliberately close to `js.configs.recommended`: this is a
+// 63k-line codebase that has been written without a linter and is tidy anyway,
+// so the job here is to stop drift — unused variables, undefined globals,
+// accidental redeclarations — not to relitigate its style. Stylistic questions
+// belong to Prettier (.prettierrc), and eslint-config-prettier is applied last
+// so the two can never disagree about the same line.
+
+const js = require('@eslint/js');
+const globals = require('globals');
+const prettier = require('eslint-config-prettier/flat');
+
+const shared = {
+    // `_`-prefixed arguments and catch bindings are the established way here of
+    // saying "this is part of the signature and deliberately unused".
+    'no-unused-vars': ['error', {
+        args: 'after-used',
+        argsIgnorePattern: '^_',
+        caughtErrors: 'all',
+        caughtErrorsIgnorePattern: '^_',
+        ignoreRestSiblings: true,
+    }],
+    eqeqeq: ['error', 'always', { null: 'ignore' }],
+    'no-var': 'error',
+    'prefer-const': ['error', { destructuring: 'all' }],
+    'no-throw-literal': 'error',
+    // `catch {}` — no binding, no body — is this codebase's way of writing "this
+    // side effect was best-effort and the fallback below is the real path". A
+    // bare empty block anywhere else is still an error.
+    'no-empty': ['error', { allowEmptyCatch: true }],
+    'no-new-func': 'error',
+    'no-implied-eval': 'error',
+    // Embeds are laid out with ideographic spaces — Discord collapses runs of
+    // ASCII spaces, so U+3000 is the only way to centre a line. Those sit inside
+    // template literals, which this rule looks into by default.
+    'no-irregular-whitespace': ['error', { skipStrings: true, skipTemplates: true }],
+    // An `await` inside a loop is how the sequential Discord and Mongo calls in
+    // this codebase are written on purpose, and console logging is how the bot
+    // reports for itself. Neither is a defect here.
+    'no-console': 'off',
+};
+
+module.exports = [
+    {
+        ignores: ['node_modules/**', 'coverage/**'],
+    },
+
+    // ── The bot and the dashboard server: CommonJS on Node ──────────────
+    {
+        files: ['src/**/*.js', 'scripts/**/*.js', '*.js'],
+        ignores: ['src/dashboard/public/**'],
+        languageOptions: {
+            ecmaVersion: 2024,
+            sourceType: 'commonjs',
+            globals: { ...globals.node },
+        },
+        rules: { ...js.configs.recommended.rules, ...shared },
+    },
+
+    // ── The dashboard's browser scripts ─────────────────────────────────
+    // These are <script> tags, not modules: their top-level functions are the
+    // globals that the views' inline handlers call, which is why unused *global*
+    // declarations are allowed here and nowhere else. `escHtml` comes from
+    // esc-html.js, `Chart` from the CDN bundle the page loads.
+    {
+        files: ['src/dashboard/public/**/*.js'],
+        languageOptions: {
+            ecmaVersion: 2024,
+            sourceType: 'script',
+            // `module` because esc-html.js feature-detects CommonJS so the tests
+            // can require it.
+            globals: { ...globals.browser, module: 'readonly' },
+        },
+        rules: {
+            ...js.configs.recommended.rules,
+            ...shared,
+            'no-unused-vars': ['error', { ...shared['no-unused-vars'][1], vars: 'local' }],
+            // Top-level `var` in these files is deliberate: a classic script's
+            // `var` is a property of the window, which is what the views' inline
+            // `onclick` handlers resolve against (`_confirmResolve` in
+            // guild-settings.ejs, among others). ESLint has no "top level only"
+            // option here, and its own fixer already declines to convert them
+            // for the same reason.
+            'no-var': 'off',
+        },
+    },
+
+    // guild-settings.js consumes two globals it does not declare: escHtml from
+    // esc-html.js, loaded as its own <script>, and Chart from the CDN bundle
+    // the page pulls in. Scoped to this file so esc-html.js is still checked
+    // against its own declaration.
+    {
+        files: ['src/dashboard/public/guild-settings.js'],
+        languageOptions: {
+            globals: { escHtml: 'readonly', Chart: 'readonly' },
+        },
+    },
+
+    // ── Tests ───────────────────────────────────────────────────────────
+    {
+        files: ['tests/**/*.js'],
+        languageOptions: {
+            ecmaVersion: 2024,
+            sourceType: 'commonjs',
+            globals: { ...globals.node, ...globals.jest, ...globals.browser },
+        },
+        rules: { ...js.configs.recommended.rules, ...shared },
+    },
+
+    prettier,
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,9 +29,14 @@
         "rss-parser": "^3.13.0"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
+        "eslint": "^10.9.0",
+        "eslint-config-prettier": "^10.1.8",
+        "globals": "^17.11.0",
         "jest": "^30.4.2",
         "jest-environment-jsdom": "^30.4.1",
-        "nodemon": "^3.0.2"
+        "nodemon": "^3.0.2",
+        "prettier": "^3.9.6"
       },
       "engines": {
         "node": ">=24.19.0"
@@ -886,6 +891,173 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@google/genai": {
       "version": "2.18.0",
       "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.18.0.tgz",
@@ -908,6 +1080,72 @@
         "@modelcontextprotocol/sdk": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1620,6 +1858,20 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -1658,6 +1910,13 @@
         "@types/tough-cookie": "*",
         "parse5": "^7.0.0"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.6.0",
@@ -2131,6 +2390,29 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -2141,6 +2423,23 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-escapes": {
@@ -3216,6 +3515,13 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -3442,9 +3748,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3494,6 +3800,245 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.0.tgz",
+      "integrity": "sha512-5KeEOJZBfEVA47boFiBsf+6MmmJpffM7qEBg4pLla2e4nlKgdKlqCW0oSLOGsT8Wl5uCGJptLV1bkaiShj90Gw==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.7.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -3506,6 +4051,52 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -3763,6 +4354,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-sha256": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
@@ -3800,6 +4398,19 @@
       },
       "engines": {
         "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -3849,6 +4460,27 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -4209,6 +4841,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/globals": {
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/google-auth-library": {
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
@@ -4439,6 +5084,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
@@ -5485,6 +6140,13 @@
         "bignumber.js": "^9.0.0"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -5504,6 +6166,20 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -5548,6 +6224,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/kruptein": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/kruptein/-/kruptein-3.3.0.tgz",
@@ -5568,6 +6254,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -6269,6 +6969,24 @@
         }
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -6581,6 +7299,32 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {
@@ -7712,6 +8456,19 @@
         "node": "*"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -7872,6 +8629,16 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -8016,6 +8783,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clawdia",
   "version": "1.0.0",
-  "description": "Clawdia \u2014 a chill, self-hosted Discord bot with a full-featured admin dashboard",
+  "description": "Clawdia — a chill, self-hosted Discord bot with a full-featured admin dashboard",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",
@@ -9,6 +9,9 @@
     "dev": "nodemon src/index.js",
     "deploy": "node src/deploy-commands.js",
     "migrate:rollback": "node scripts/rollback-migration.js",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write",
     "test": "jest --forceExit"
   },
   "keywords": [
@@ -40,9 +43,14 @@
     "rss-parser": "^3.13.0"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "eslint": "^10.9.0",
+    "eslint-config-prettier": "^10.1.8",
+    "globals": "^17.11.0",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
-    "nodemon": "^3.0.2"
+    "nodemon": "^3.0.2",
+    "prettier": "^3.9.6"
   },
   "engines": {
     "node": ">=24.19.0"

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -23,4 +23,14 @@ module.exports = {
     bracketSpacing: true,
     arrowParens: 'avoid',
     endOfLine: 'lf',
+
+    // package.json, the compose files and the workflows are all two-space and
+    // always have been, and .editorconfig tells editors the same. Without this
+    // override `npm run format` would reindent any of them to four.
+    overrides: [
+        {
+            files: ['*.json', '*.yml', '*.yaml'],
+            options: { tabWidth: 2 },
+        },
+    ],
 };

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,26 @@
+'use strict';
+
+// Prettier settings chosen to match what this codebase already does, so a file
+// you format is not also reindented: four spaces, single quotes, semicolons,
+// no parentheses round a lone arrow parameter.
+//
+// Deliberately NOT applied to the tree wholesale. Running it over all 278 files
+// rewrites about 45,000 lines — every `git blame` line in the repo, every open
+// branch put into conflict, and the column alignment the data tables and option
+// lists are written with (`{ key: 'levels',    sort: ... }`) collapsed. None of
+// that is worth buying here. `npm run format` takes explicit paths so it is
+// applied to the files a change already touches, and ESLint — which is what CI
+// enforces — is configured with eslint-config-prettier so the two never
+// disagree about the same line.
+module.exports = {
+    printWidth: 120,
+    tabWidth: 4,
+    useTabs: false,
+    semi: true,
+    singleQuote: true,
+    quoteProps: 'as-needed',
+    trailingComma: 'es5',
+    bracketSpacing: true,
+    arrowParens: 'avoid',
+    endOfLine: 'lf',
+};

--- a/src/commands/ai/ai.js
+++ b/src/commands/ai/ai.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags } = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
 
 const MEMORY_CAP = 10;

--- a/src/commands/community/achievements.js
+++ b/src/commands/community/achievements.js
@@ -3,7 +3,7 @@
 const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
 const Guild = require('../../models/Guild');
-const { ACHIEVEMENTS, CATEGORY_LABELS, CATEGORY_EMOJIS } = require('../../data/achievements');
+const { ACHIEVEMENTS } = require('../../data/achievements');
 
 const CATEGORY_ORDER = ['economy', 'leveling', 'hunt', 'fishing', 'exploration', 'community', 'moderation', 'custom'];
 
@@ -279,7 +279,7 @@ async function handleTop(interaction, guildSettings) {
     return interaction.reply({ embeds: [embed] });
 }
 
-async function handleLeaderboard(interaction, guildSettings) {
+async function handleLeaderboard(interaction, _guildSettings) {
     const topUsers = await User.find(
         { guildId: interaction.guild.id, achievementsCount: { $gt: 0 } },
         'userId achievementsCount'

--- a/src/commands/community/quests.js
+++ b/src/commands/community/quests.js
@@ -4,7 +4,6 @@ const Guild = require('../../models/Guild');
 const AiQuest = require('../../models/AiQuest');
 const { ensureQuests, getDailyPool, getWeeklyPool, getCategoryEmojis, getDifficultyColors } = require('../../services/questService');
 
-const DIFFICULTY_EMBED_COLORS = { easy: 0x57F287, medium: 0xFEE75C, hard: 0xED4245 };
 const DIFFICULTY_LABELS = { easy: 'Easy', medium: 'Medium', hard: 'Hard' };
 const AI_MECHANIC_EMOJIS = {
     hunt:    '🏹',

--- a/src/commands/economy/boost.js
+++ b/src/commands/economy/boost.js
@@ -49,7 +49,7 @@ module.exports = {
         const sub = interaction.options.getSubcommand();
 
         try {
-            let guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+            const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
             if (!guildSettings) {
                 return interaction.reply({ content: 'Guild settings not found.', flags: MessageFlags.Ephemeral });
             }

--- a/src/commands/economy/casino.js
+++ b/src/commands/economy/casino.js
@@ -17,9 +17,22 @@ const games = [
     require('../../games/casino/slots'),
 ];
 
+// Discord rejects a command description longer than this.
+const DESCRIPTION_LIMIT = 100;
+
+// Named off the `games` array rather than beside it. The old description was a
+// hand-written copy, and it had gone stale: it still advertised baccarat,
+// wheel, plinko and doubleornothing long after they were removed, and never
+// mentioned cupgame, keno or poker (#665). A roster that outgrows the
+// description limit elides here rather than failing the deploy.
+const gameRoster = `Play casino games: ${games.map(game => game.name).join(', ')}.`;
+const description = gameRoster.length <= DESCRIPTION_LIMIT
+    ? gameRoster
+    : `${gameRoster.slice(0, DESCRIPTION_LIMIT - 1).trimEnd()}…`;
+
 const builder = new SlashCommandBuilder()
     .setName('casino')
-    .setDescription('Play casino games: blackjack, crash, cupgame, higher/lower, keno, poker, roulette, and slots.')
+    .setDescription(description)
     .addSubcommand(sub => sub.setName('jackpot').setDescription('View the current progressive jackpot pool.'))
     .addSubcommand(sub => sub
         .setName('setlimit')

--- a/src/commands/economy/casino.js
+++ b/src/commands/economy/casino.js
@@ -87,7 +87,7 @@ module.exports = {
         }
 
         if (sub === 'jackpot') {
-            const { pool, hot, display } = await getJackpotDisplay(interaction.guild.id);
+            const { hot, display } = await getJackpotDisplay(interaction.guild.id);
             const lastWinner = guildSettings?.casinoJackpot?.lastWinnerName;
             const lastWon    = guildSettings?.casinoJackpot?.lastWonAmount;
             const embed = new EmbedBuilder()

--- a/src/commands/economy/crime.js
+++ b/src/commands/economy/crime.js
@@ -10,7 +10,7 @@ const { clampMultiplier } = require('../../config/economy');
 const { logTransaction } = require('../../utils/logTransaction');
 const { debitUpTo, incExpr } = require('../../utils/balanceDebit');
 const { getTotalBonus } = require('../../services/petService');
-const { randomFrom, CRIME_WIN_LINES, CRIME_BUST_LINES, getCrimeFlavorText } = require('../../utils/copyLines');
+const { getCrimeFlavorText } = require('../../utils/copyLines');
 const { stackBar } = require('../../utils/rewardReveal');
 const { delay } = require('../../utils/delay');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
@@ -183,7 +183,7 @@ module.exports = {
         const timeBand = getTimeBand();
 
         const shuffled = [...CRIMES].sort(() => Math.random() - 0.5);
-        let choices = shuffled.slice(0, 3);
+        const choices = shuffled.slice(0, 3);
         if (!choices.some(c => c.name === featured.crime.name)) {
             choices[Math.floor(Math.random() * 3)] = CRIMES.find(c => c.name === featured.crime.name) ?? choices[0];
         }
@@ -341,7 +341,7 @@ module.exports = {
                     logBigWin({ guildId: interaction.guild.id, userId: interaction.user.id, username: interaction.user.username, amount: earned, source: 'crime', details: crime.displayName });
                 }
 
-                let flavorWin = getCrimeFlavorText(crime.name, 'win')
+                const flavorWin = getCrimeFlavorText(crime.name, 'win')
                     .replace('{amount}', earned.toLocaleString());
                 let desc = flavorWin;
                 if (luckyActive) desc += `\n> 🍀 *Lucky Charm boosted your success chance!*`;

--- a/src/commands/economy/duel.js
+++ b/src/commands/economy/duel.js
@@ -11,7 +11,7 @@ const User = require('../../models/User');
 const { advanceMissions } = require('../../services/seasonMissionService');
 const Guild = require('../../models/Guild');
 const { isDistrictActive } = require('../../services/districtService');
-const { RANK_TIERS, START_ELO, tierFor, applyElo, makeSeasonId } = require('../../utils/duelElo');
+const { START_ELO, tierFor, applyElo, makeSeasonId } = require('../../utils/duelElo');
 
 const DUEL_COOLDOWN_MS = 5 * 60_000;
 const ACCEPT_TIMEOUT_MS = 60_000;

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -519,7 +519,7 @@ async function handleGo(interaction) {
         // Expedition quests count the trip; the coin quests count the haul. A
         // quiet walk still advances the first and rightly not the second.
         const trip = await onExplore(user, guildSettings);
-        let questsDone = [...trip.completed], questsNear = [...trip.nearComplete];
+        const questsDone = [...trip.completed], questsNear = [...trip.nearComplete];
         if (result.payout > 0) {
             const earn = await onEconomyEarn(user, guildSettings, result.payout);
             questsDone.push(...earn.completed);

--- a/src/commands/economy/fish/cast.js
+++ b/src/commands/economy/fish/cast.js
@@ -449,7 +449,6 @@ async function handleCast(interaction) {
             await interaction.editReply({ embeds: [embed, buildBossPhaseEmbed(0, [])], components: [buildPhaseRow(0)] });
 
             const runPhase = async (phaseIndex, prevResults, prevBtn) => {
-                const responder  = prevBtn ?? interaction;
                 const fetchReply = prevBtn ? await prevBtn.fetchReply() : await interaction.fetchReply();
 
                 return new Promise(resolve => {

--- a/src/commands/economy/fish/embeds.js
+++ b/src/commands/economy/fish/embeds.js
@@ -14,9 +14,7 @@ const { formatMs, rodStatusEmoji, durabilityBar, getMaxStamina, xpToNextLevel, g
 
 // ─── EMBED BUILDER ────────────────────────────────────────────────────────────
 
-function buildCastEmbed(result, user, location, rod, currency, discordUser) {
-    const f = user.fishing;
-
+function buildCastEmbed(result, user, location, rod, currency, _discordUser) {
     if (result.success) {
         const { catchType, finalPayout, xpEarned, levelUp, cappedByHard } = result;
 

--- a/src/commands/economy/fish/location.js
+++ b/src/commands/economy/fish/location.js
@@ -63,7 +63,7 @@ async function showLocationList(interaction, user, currency) {
     return interaction.reply({ embeds: [embed] });
 }
 
-async function setLocation(interaction, user, currency) {
+async function setLocation(interaction, user, _currency) {
     const f          = user.fishing;
     const locationId = interaction.options.getString('location');
     const location   = LOCATIONS[locationId];

--- a/src/commands/economy/fish/profile.js
+++ b/src/commands/economy/fish/profile.js
@@ -428,7 +428,7 @@ async function equipRod(interaction, user) {
     });
 }
 
-async function showBait(interaction, user, currency) {
+async function showBait(interaction, user, _currency) {
     const f = user.fishing;
 
     const baitLines = Object.entries(f.bait ?? {})

--- a/src/commands/economy/hunt/embeds.js
+++ b/src/commands/economy/hunt/embeds.js
@@ -23,7 +23,7 @@ const { buildPityStreakField, PITY_COPY } = require('../../../utils/pityBonus');
 const { FEATURED_PAYOUT_BONUS } = require('../../../data/featuredRotation');
 const { WILDERNESS_YIELD_BONUS } = require('./shared');
 
-function buildHuntEmbed(result, user, zone, weapon, currency, discordUser) {
+function buildHuntEmbed(result, user, zone, weapon, currency, _discordUser) {
     const h = user.hunt;
 
     if (result.success) {

--- a/src/commands/economy/invest.js
+++ b/src/commands/economy/invest.js
@@ -197,7 +197,7 @@ module.exports = {
 
         // Atomically increment the district pool to prevent concurrent contributions
         // from overwriting each other. The $inc is safe against race conditions.
-        let freshGuild = await Guild.findOneAndUpdate(
+        const freshGuild = await Guild.findOneAndUpdate(
             {
                 guildId: interaction.guild.id,
                 districts: { $elemMatch: { districtId, activeUntil: { $not: { $gt: new Date() } } } },

--- a/src/commands/economy/market.js
+++ b/src/commands/economy/market.js
@@ -428,7 +428,7 @@ async function handleBuy(interaction, currency) {
     await executePurchase(opts => interaction.editReply(opts));
 }
 
-async function handleCancel(interaction, currency) {
+async function handleCancel(interaction, _currency) {
     const rawId = interaction.options.getString('listing_id');
 
     let listing;

--- a/src/commands/economy/mine/embeds.js
+++ b/src/commands/economy/mine/embeds.js
@@ -31,9 +31,7 @@ function prestigeBonusLines(bonus) {
 
 // ─── EMBED BUILDERS / HELPERS ─────────────────────────────────────────────────
 
-function buildMineEmbed(result, user, depth, pickaxe, currency, discordUser) {
-    const m = user.mining;
-
+function buildMineEmbed(result, user, depth, pickaxe, currency, _discordUser) {
     if (result.success) {
         const { ore, tier, finalPayout, isCrit, critMultiplier, specialDrop, xpEarned, levelUp, cappedByHard } = result;
         // An event catch keeps its own colour even on a critical: the tier is the

--- a/src/commands/economy/pet.js
+++ b/src/commands/economy/pet.js
@@ -13,7 +13,6 @@ const {
     PET_DEFINITIONS,
     PERSONALITY_TRAITS,
     STARVING_THRESHOLD,
-    RUNAWAY_DAYS,
     applyHungerDecay,
     effectiveHunger,
     isPetActive,
@@ -235,7 +234,6 @@ async function syncHungerAndRunaway(user, interaction) {
 
 function buildPetEmbed(pet, index, total, ownerAvatarURL) {
     const def         = PET_DEFINITIONS[pet.petId];
-    const displayName = pet.name || def?.name || pet.petId;
     const bondDays    = Math.floor((Date.now() - new Date(pet.adoptedAt).getTime()) / 86400000);
     const hunger      = effectiveHunger(pet);
     const moodLine    = getMoodLine(pet);
@@ -936,7 +934,7 @@ function petSnapshot(pet) {
 // petA/petB must be PRE-battle snapshots: result.finalHpA/B and the HP-bar
 // denominators (max HP) are computed from pre-battle stats, so rendering from
 // post-XP pets would mismatch the bars and show the wrong level.
-function battleResultEmbed({ color, title, petA, petB, result, currency, payoutLine, xpLineA, xpLineB }) {
+function battleResultEmbed({ color, title, petA, petB, result, _currency, payoutLine, xpLineA, xpLineB }) {
     const da = getPetDisplay(petA), db = getPetDisplay(petB);
     const sa = getPetStats(petA),   sb = getPetStats(petB);
     return new EmbedBuilder()

--- a/src/commands/economy/prestige.js
+++ b/src/commands/economy/prestige.js
@@ -6,7 +6,7 @@ const {
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
 const {
-    PRESTIGE_TIERS, UNLOCK_LABELS, tierFor, titleForExactRank, nextTierAfter, badgeFor, roman,
+    PRESTIGE_TIERS, UNLOCK_LABELS, tierFor, titleForExactRank, nextTierAfter, badgeFor,
 } = require('../../utils/prestige');
 
 const CONFIRM_TIMEOUT_MS = 30_000;

--- a/src/commands/economy/season.js
+++ b/src/commands/economy/season.js
@@ -736,7 +736,7 @@ async function executeAdminEnd(interaction) {
         .limit(10)
         .select('userId seasonCoins');
 
-    let resolvedNames = {};
+    const resolvedNames = {};
     try {
         for (const u of topUsers.slice(0, 3)) {
             const member = await interaction.guild.members.fetch(u.userId).catch(() => null);

--- a/src/commands/economy/snowball.js
+++ b/src/commands/economy/snowball.js
@@ -99,10 +99,7 @@ module.exports = {
 
         const hit = Math.random() < HIT_CHANCE;
 
-        let coinsGained = 0;
-        let stolen = 0;
-        let defender = null;
-        let description = '';
+        let coinsGained, stolen, defender, description;
 
         if (hit) {
             // Debit the defender first, atomically guarded against their balance

--- a/src/commands/economy/syndicate.js
+++ b/src/commands/economy/syndicate.js
@@ -143,7 +143,7 @@ async function resolveHeist(client, heist) {
     heist.resolving = true;
 
     const target = SYNDICATE_TARGETS[heist.target];
-    const { outcome, payout, perPlayer, passedCount } = computeSyndicateOutcome(heist);
+    const { outcome, payout, perPlayer } = computeSyndicateOutcome(heist);
 
     const guildDoc = await Guild.findOne({ guildId: heist.guildId }, 'economy').lean();
     const currency = guildDoc?.economy?.currency ?? '💰';
@@ -856,7 +856,7 @@ async function executeHeist(interaction, guildDoc, client) {
     }, LOBBY_DURATION_S * 1000);
 }
 
-async function executeSabotage(interaction, guildDoc) {
+async function executeSabotage(interaction, _guildDoc) {
     const userDoc = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }, 'syndicateId').lean();
     if (!userDoc?.syndicateId) return interaction.reply({ content: 'You are not in a syndicate.', flags: MessageFlags.Ephemeral });
 

--- a/src/commands/economy/trap.js
+++ b/src/commands/economy/trap.js
@@ -103,8 +103,8 @@ module.exports = {
             .setColor('#f39c12')
             .setTitle('🪤 Trap Set!')
             .setDescription(
-                `You\'ve armed a **Tripwire** on your wallet.\n\n` +
-                `The trap is **invisible** — any robber has no way to know it\'s there.\n\n` +
+                `You've armed a **Tripwire** on your wallet.\n\n` +
+                `The trap is **invisible** — any robber has no way to know it's there.\n\n` +
                 `> **If a rob attempt succeeds:**\n` +
                 `> The robber pays **2× the normal fine** — straight to you.\n\n` +
                 `> **If a rob attempt fails:**\n` +

--- a/src/commands/economy/war.js
+++ b/src/commands/economy/war.js
@@ -186,7 +186,6 @@ async function executeStatus(interaction) {
 
     const now = Date.now();
     const endsAt = new Date(war.endsAt).getTime();
-    const totalMs = WAR_DURATION_MS;
     const elapsed = now - new Date(war.startedAt).getTime();
     const day = Math.min(WAR_DURATION_DAYS, Math.ceil(elapsed / 86400000));
 

--- a/src/commands/moderation/appeal.js
+++ b/src/commands/moderation/appeal.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, EmbedBuilder, PermissionFlagsBits, MessageFlags } = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const { getCase } = require('../../services/caseService');
 const Case = require('../../models/Case');
 const Guild = require('../../models/Guild');

--- a/src/commands/utility/help.js
+++ b/src/commands/utility/help.js
@@ -8,140 +8,16 @@ const {
     ButtonStyle,
 } = require('discord.js');
 
+// The catalog is derived from the commands this process actually loaded, not
+// from a list kept alongside them — see utils/helpCatalog.js for why (#665).
+const { buildCategories } = require('../../utils/helpCatalog');
+
 const TIMEOUT_MS = 3 * 60 * 1000;
 const PAGE_SIZE = 10;
 const COLOR = '#5865F2';
 
-const CATEGORIES = [
-    {
-        id: 'economy',
-        emoji: '📦',
-        label: 'Economy',
-        preview: 'balance, work, hunt, fish, games',
-        commands: [
-            { name: 'balance',        description: 'Check your wallet and bank balance' },
-            { name: 'daily',          description: 'Claim your daily coin reward (24h cooldown)' },
-            { name: 'work',           description: 'Earn coins by working a shift (1h cooldown)' },
-            { name: 'bank',           description: 'Bank actions: deposit, withdraw, transfer' },
-            { name: 'inventory',      description: 'View your or another user\'s inventory' },
-            { name: 'shop',           description: 'Browse the item shop' },
-            { name: 'use',            description: 'Use an item from your inventory' },
-            { name: 'jobs',           description: 'Browse all available jobs and pay ranges' },
-            { name: 'crime',          description: 'Attempt a crime for coins (40% success, 2.5h cooldown)' },
-            { name: 'rob',            description: 'Try to rob another member\'s wallet' },
-            { name: 'mine',           description: 'Dig for ore in the mines (2h cooldown)' },
-            { name: 'explore',        description: 'Set out on narrated expeditions — chart regions, find treasure, lore, and secrets' },
-            { name: 'hunt',           description: 'Hunt animals, manage gear, quests, zones, and prestige — all in one place' },
-            { name: 'craft',          description: 'Craft items from hunting materials' },
-            { name: 'fish',           description: 'Fishing: cast lines, manage gear, shop, craft, quests, locations, and prestige' },
-            { name: 'casino',         description: 'Casino games: blackjack, crash, cupgame, higherlower, keno, poker, roulette, slots' },
-            { name: 'duel',           description: 'Challenge another user to a coin duel' },
-            { name: 'quiz',           description: 'Answer trivia questions to win coins' },
-        ],
-    },
-    {
-        id: 'moderation',
-        emoji: '🛡️',
-        label: 'Moderation',
-        preview: 'ban, kick, warn, cases, appeals',
-        commands: [
-            { name: 'ban',       description: 'Ban a member from the server' },
-            { name: 'kick',      description: 'Kick a member from the server' },
-            { name: 'warn',      description: 'Manage member warnings' },
-            { name: 'mute',      description: 'Timeout a member' },
-            { name: 'unmute',    description: 'Remove timeout from a member' },
-            { name: 'unban',     description: 'Unban a user from the server' },
-            { name: 'softban',   description: 'Ban then unban to purge recent messages' },
-            { name: 'massban',   description: 'Ban multiple users by ID (raid cleanup)' },
-            { name: 'clear',     description: 'Delete multiple messages' },
-            { name: 'slowmode',  description: 'Set or clear slowmode for a channel' },
-            { name: 'lockdown',  description: 'Lock or unlock all text channels server-wide' },
-            { name: 'case',      description: 'View a moderation case' },
-            { name: 'cases',     description: 'List moderation cases for a user' },
-            { name: 'closecase', description: 'Close a moderation case' },
-            { name: 'note',      description: 'Add a note to a case or assign/label it' },
-            { name: 'appeal',    description: 'Appeal a moderation case against you' },
-        ],
-    },
-    {
-        id: 'leveling',
-        emoji: '⭐',
-        label: 'Leveling',
-        preview: 'rank, leaderboard, level roles',
-        commands: [
-            { name: 'rank',        description: 'View your rank card showing level, XP, and position' },
-            { name: 'leaderboard', description: 'View the top 10 members on the server leaderboard' },
-            { name: 'setlevel',    description: 'Directly assign a level to a member (admin)' },
-        ],
-    },
-    {
-        id: 'fun',
-        emoji: '🎮',
-        label: 'Fun',
-        preview: '8ball, coinflip, roll',
-        commands: [
-            { name: '8ball',    description: 'Ask the magic 8-ball a yes/no question — shake again or ask another' },
-            { name: 'coinflip', description: 'Flip a coin: call heads or tails, bet coins, or challenge a member' },
-            { name: 'roll',     description: 'Roll a 2-100 sided die, optionally betting high, low, or an exact number' },
-        ],
-    },
-    {
-        id: 'utility',
-        emoji: '🔧',
-        label: 'Utility',
-        preview: 'avatar, polls, giveaway, bible',
-        commands: [
-            { name: 'avatar',     description: 'Fetch and display a user\'s full-size avatar' },
-            { name: 'userinfo',   description: 'Show info about a user (account age, roles, etc.)' },
-            { name: 'serverinfo', description: 'Display server stats: members, channels, boost level' },
-            { name: 'ping',       description: 'Check the bot\'s latency' },
-            { name: 'poll',       description: 'Create a button-based poll' },
-            { name: 'giveaway',   description: 'Manage giveaways' },
-            { name: 'birthday',   description: 'Manage birthdays' },
-            { name: 'bible',      description: 'Look up a Bible verse or get the daily verse' },
-            { name: 'suggest',    description: 'Submit a suggestion to the server' },
-            { name: 'role',       description: 'Self-assign or remove a role from reaction role panels' },
-            { name: 'vc',         description: 'Manage your temporary voice channel' },
-            { name: 'timezone',   description: 'Set your timezone so reminders and times are computed correctly for you' },
-        ],
-    },
-    {
-        id: 'ai',
-        emoji: '🤖',
-        label: 'AI',
-        preview: 'AI chat & reminders',
-        commands: [
-            { name: 'remind',   description: 'Set a reminder — posted in this channel (or DMed if that channel is no longer reachable), optionally recurring' },
-            { name: 'reminders', description: 'List or cancel your open reminders' },
-            { name: '@Clawdia', description: 'Mention or ping the bot to start an AI conversation', mention: true },
-        ],
-    },
-    {
-        id: 'community',
-        emoji: '👥',
-        label: 'Community',
-        preview: 'season, quests, streak, track',
-        commands: [
-            { name: 'quests', description: 'View your active daily and weekly quests' },
-            { name: 'season', description: 'View season pass progress or manage the current season' },
-            { name: 'streak', description: 'View your activity streak' },
-            { name: 'track',  description: 'View or set your progression track' },
-        ],
-    },
-    {
-        id: 'admin',
-        emoji: '⚙️',
-        label: 'Admin',
-        preview: 'raid mode, events',
-        commands: [
-            { name: 'raidmode',  description: 'Configure raid detection and case management settings' },
-            { name: 'event',     description: 'Manage seasonal events (admin)' },
-        ],
-    },
-];
-
-function buildLandingEmbed() {
-    const lines = CATEGORIES.map(cat =>
+function buildLandingEmbed(categories) {
+    const lines = categories.map(cat =>
         `${cat.emoji} **${cat.label}** — ${cat.commands.length} commands: ${cat.preview}`
     );
     return new EmbedBuilder()
@@ -175,16 +51,16 @@ function buildCategoryEmbed(cat, page) {
         .setFooter({ text: `Page ${page + 1} of ${totalPages} • ${cat.commands.length} commands total` });
 }
 
-function buildSelectRow(disabled = false) {
+function buildSelectRow(categories, disabled = false) {
     const menu = new StringSelectMenuBuilder()
         .setCustomId('help_category')
         .setPlaceholder('Select a category…')
         .setDisabled(disabled)
         .addOptions(
-            CATEGORIES.map(cat =>
+            categories.map(cat =>
                 new StringSelectMenuOptionBuilder()
                     .setLabel(`${cat.emoji} ${cat.label}`)
-                    .setDescription(`${cat.commands.length} commands: ${cat.preview}`)
+                    .setDescription(cat.summary)
                     .setValue(cat.id)
             )
         );
@@ -224,11 +100,27 @@ module.exports = {
         .setDescription('Browse all bot commands by category'),
     async execute(interaction) {
         const id = interaction.id;
+        const categories = buildCategories(interaction.client?.commands?.values?.() || []);
+
+        // Only reachable if the collection is empty, which startup refuses to
+        // run with — but a select menu with no options is a Discord API error
+        // rather than an empty menu, so it cannot just fall through.
+        if (!categories.length) {
+            await interaction.reply({
+                embeds: [new EmbedBuilder()
+                    .setColor(COLOR)
+                    .setTitle('🐾 Clawdia Help')
+                    .setDescription('No commands are loaded right now. Try again in a moment.')],
+            });
+            return;
+        }
+
+        const findCategory = catId => categories.find(c => c.id === catId);
         const state = { view: 'landing', catId: null, page: 0 };
 
         await interaction.reply({
-            embeds: [buildLandingEmbed()],
-            components: [buildSelectRow()],
+            embeds: [buildLandingEmbed(categories)],
+            components: [buildSelectRow(categories)],
         });
 
         const message = await interaction.fetchReply();
@@ -240,7 +132,8 @@ module.exports = {
 
         collector.on('collect', async i => {
             if (i.customId === 'help_category') {
-                const cat = CATEGORIES.find(c => c.id === i.values[0]);
+                const cat = findCategory(i.values[0]);
+                if (!cat) return;
                 state.view = 'category';
                 state.catId = cat.id;
                 state.page = 0;
@@ -253,21 +146,15 @@ module.exports = {
                 state.catId = null;
                 state.page = 0;
                 await i.update({
-                    embeds: [buildLandingEmbed()],
-                    components: [buildSelectRow()],
+                    embeds: [buildLandingEmbed(categories)],
+                    components: [buildSelectRow(categories)],
                 });
-            } else if (i.customId === `help_prev_${id}`) {
-                const cat = CATEGORIES.find(c => c.id === state.catId);
+            } else if (i.customId === `help_prev_${id}` || i.customId === `help_next_${id}`) {
+                const cat = findCategory(state.catId);
+                if (!cat) return;
+                const step = i.customId === `help_next_${id}` ? 1 : -1;
                 const totalPages = Math.ceil(cat.commands.length / PAGE_SIZE);
-                state.page = Math.max(0, Math.min(state.page - 1, totalPages - 1));
-                await i.update({
-                    embeds: [buildCategoryEmbed(cat, state.page)],
-                    components: [buildNavRow(id, cat, state.page)],
-                });
-            } else if (i.customId === `help_next_${id}`) {
-                const cat = CATEGORIES.find(c => c.id === state.catId);
-                const totalPages = Math.ceil(cat.commands.length / PAGE_SIZE);
-                state.page = Math.max(0, Math.min(state.page + 1, totalPages - 1));
+                state.page = Math.max(0, Math.min(state.page + step, totalPages - 1));
                 await i.update({
                     embeds: [buildCategoryEmbed(cat, state.page)],
                     components: [buildNavRow(id, cat, state.page)],
@@ -277,14 +164,11 @@ module.exports = {
 
         collector.on('end', async (_, reason) => {
             if (reason !== 'time') return;
-            if (state.view === 'landing') {
-                await interaction.editReply({ components: [buildSelectRow(true)] }).catch(() => {});
-            } else {
-                const cat = CATEGORIES.find(c => c.id === state.catId);
-                await interaction.editReply({
-                    components: [buildNavRow(id, cat, state.page, true)],
-                }).catch(() => {});
-            }
+            const cat = state.view === 'landing' ? null : findCategory(state.catId);
+            const components = cat
+                ? [buildNavRow(id, cat, state.page, true)]
+                : [buildSelectRow(categories, true)];
+            await interaction.editReply({ components }).catch(() => {});
         });
     },
 };

--- a/src/commands/utility/profile.js
+++ b/src/commands/utility/profile.js
@@ -6,7 +6,7 @@ const { attachGrind } = require('../../utils/grindProfile');
 const Guild = require('../../models/Guild');
 const { pruneEffects, EFFECT_CONFIGS, timeRemaining } = require('../../services/effectsService');
 const { getStreakMultiplier, MILESTONES } = require('../../utils/streakMultiplier');
-const { badgeFor, titleForExactRank, getBonusMultipliers } = require('../../utils/prestige');
+const { badgeFor, titleForExactRank } = require('../../utils/prestige');
 const { getActiveSynergies } = require('../../services/synergyService');
 const { isPetActive } = require('../../services/petService');
 

--- a/src/commands/utility/vc.js
+++ b/src/commands/utility/vc.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, EmbedBuilder, PermissionFlagsBits, MessageFlags } = require('discord.js');
+const { SlashCommandBuilder, PermissionFlagsBits, MessageFlags } = require('discord.js');
 const Guild = require('../../models/Guild');
 
 module.exports = {

--- a/src/config/fileSecrets.js
+++ b/src/config/fileSecrets.js
@@ -81,7 +81,7 @@ function loadFileSecrets(env = process.env, { log = console, names = FILE_BACKED
         try {
             value = readSecretFile(filePath);
         } catch (err) {
-            throw new Error(`[SECRETS] Cannot read ${key} (${filePath}): ${err.message}`);
+            throw new Error(`[SECRETS] Cannot read ${key} (${filePath}): ${err.message}`, { cause: err });
         }
 
         if (!value) {

--- a/src/dashboard/public/guild-settings.js
+++ b/src/dashboard/public/guild-settings.js
@@ -99,15 +99,18 @@ let ESCALATION_LADDER = boot('escalationLadder');
 const navItems = document.querySelectorAll('.nav-item');
 const topbarSection = document.getElementById('topbar-section');
 
-// Keyboard + ARIA accessibility for nav items
-navItems.forEach(item => {
-    item.setAttribute('role', 'button');
-    item.setAttribute('tabindex', '0');
-    item.setAttribute('aria-pressed', item.classList.contains('active') ? 'true' : 'false');
-    item.addEventListener('keydown', e => {
-        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); item.click(); }
-    });
-});
+// The nav items used to be plain <li> elements that this file dressed up at
+// runtime: role="button" and tabindex injected onto each one, plus a keydown
+// handler standing in for Enter and Space. That stripped `listitem` off the
+// <ul>'s children — role="button" replaces the implicit role rather than
+// adding to it — and left the whole nav inert to the keyboard if the script
+// failed to load. They are <button> elements in the markup now, so the roles,
+// the focusability and the key handling are all the browser's (#660).
+//
+// The state they carry is aria-current="page", not aria-pressed: these select
+// which section is being viewed, which is not the same claim as a toggle
+// button being held down.
+const mainContent = document.getElementById('dash-main-content');
 
 // The tab the reader last asked for. A panel that is still being fetched when
 // the reader moves on must not steal the view when it finally arrives.
@@ -119,11 +122,11 @@ async function activateTab(tab) {
     if (!item) return null;
     requestedTab = tab;
 
-    navItems.forEach(n => { n.classList.remove('active'); n.setAttribute('aria-pressed', 'false'); });
+    navItems.forEach(n => { n.classList.remove('active'); n.removeAttribute('aria-current'); });
     document.querySelectorAll('.panel').forEach(p => { p.classList.remove('active'); p.style.display = 'none'; });
     document.querySelectorAll('.panel-stub').forEach(p => { p.style.display = 'none'; });
     item.classList.add('active');
-    item.setAttribute('aria-pressed', 'true');
+    item.setAttribute('aria-current', 'page');
     if (topbarSection) topbarSection.textContent = item.querySelector('span:last-child')?.textContent || tab;
     if (history.replaceState) {
         const innerToParent = { knowledgebase: 'ai', aisummaries: 'ai', aipersonas: 'ai', dailynews: 'rss' };
@@ -155,7 +158,17 @@ async function activateTab(tab) {
 }
 
 navItems.forEach(item => {
-    item.addEventListener('click', () => { activateTab(item.dataset.tab); });
+    item.addEventListener('click', async () => {
+        await activateTab(item.dataset.tab);
+        // Land the reader in the section they just opened. Without this, a
+        // keyboard user picking the last item in the sidebar has to tab back
+        // through every item below it to reach the settings — 25 stops on
+        // every visit. `preventScroll` keeps the mouse path unchanged, and the
+        // target is tabindex="-1", so this adds no tab stop of its own.
+        if (mainContent && document.activeElement === item) {
+            mainContent.focus({ preventScroll: true });
+        }
+    });
 });
 
 // Module card click-to-navigate. Delegated, because the cards sit inside a panel.
@@ -296,11 +309,14 @@ function filterSidebarNav(query) {
         const navList = label.nextElementSibling;
         if (!navList) return;
         let groupVisible = false;
-        navList.querySelectorAll('li').forEach(li => {
-            const text = li.textContent.toLowerCase();
-            const keywords = (li.dataset.keywords || '').toLowerCase();
+        navList.querySelectorAll('.nav-item').forEach(item => {
+            const text = item.textContent.toLowerCase();
+            const keywords = (item.dataset.keywords || '').toLowerCase();
             const matches = text.includes(q) || keywords.includes(q);
-            li.style.display = matches ? '' : 'none';
+            // Hide the <li>, not the button: `display: none` on the list item
+            // takes the button out of the tab order and the accessibility tree
+            // with it, and leaves the list itself intact.
+            item.closest('li').style.display = matches ? '' : 'none';
             if (matches) { groupVisible = true; anyVisible = true; }
         });
         label.style.display = groupVisible ? '' : 'none';
@@ -326,7 +342,7 @@ async function sendWelcomeCardPreview() {
             body: JSON.stringify({ channelId })
         });
         if (resp.ok) {
-            toast('Preview sent to channel ✓', 'success');
+            toast('Preview sent to channel', 'success');
         } else {
             const d = await resp.json().catch(() => ({}));
             toast(d.error || 'Failed to send preview', 'error');
@@ -381,15 +397,50 @@ onPanel('welcome',   () => updateMsgPreview('welcome-message', 'welcome-preview'
 onPanel('farewell',  () => updateMsgPreview('farewell-message', 'farewell-preview'));
 onPanel('birthdays', () => updateMsgPreview('birthday-message', 'birthday-preview'));
 
-// Toast helper
+// ── Toast ─────────────────────────────────────────────────────────────
+// The only feedback channel the dashboard has: every save, delete and failure
+// reports through this one element. That makes three things load-bearing (#659):
+//
+//   * The element is a live region (role="status" in the markup), so a screen
+//     reader announces the result instead of the reader being left guessing.
+//   * Success and failure are told apart by an icon and a word, not by a
+//     0.4-alpha border colour — WCAG 1.4.1 rules colour-only out, and the
+//     border was invisible to most people anyway.
+//   * There is a dismiss button, and an error stays up long enough to read.
+//     The old fixed 2.8 s auto-dismiss could take a message away mid-sentence
+//     with no way to bring it back.
 const toastEl = document.getElementById('toast');
+const toastIcon = document.getElementById('toast-icon');
+const toastMessage = document.getElementById('toast-message');
+const toastClose = document.getElementById('toast-close');
 let toastTimer;
-function toast(message, kind) {
-    toastEl.textContent = message;
-    toastEl.className = 'toast show' + (kind ? ' ' + kind : '');
+
+const TOAST_KINDS = {
+    success: { icon: '✓', prefix: 'Success' },
+    error:   { icon: '⚠', prefix: 'Error' },
+    info:    { icon: 'ℹ', prefix: 'Note' },
+};
+const TOAST_DISMISS_MS = { success: 2800, error: 8000, info: 4500 };
+
+function hideToast() {
     clearTimeout(toastTimer);
-    toastTimer = setTimeout(() => toastEl.classList.remove('show'), 2800);
+    toastEl.classList.remove('show');
 }
+
+function toast(message, kind) {
+    const style = TOAST_KINDS[kind];
+    toastIcon.textContent = style ? style.icon : '';
+    // The prefix is what a screen reader hears first, so it carries the
+    // outcome even when the message itself reads the same either way
+    // ("Network error" is only an error because we say so).
+    toastMessage.textContent = style ? `${style.prefix}: ${message}` : message;
+    toastEl.className = 'toast show' + (kind ? ' ' + kind : '');
+
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => toastEl.classList.remove('show'), TOAST_DISMISS_MS[kind] || 2800);
+}
+
+if (toastClose) toastClose.addEventListener('click', hideToast);
 
 const AI_MODEL_DEFAULTS = {
     openai: 'gpt-4o-mini',
@@ -1057,10 +1108,10 @@ async function saveSettings(section) {
             else {
                 Object.keys(_shopItemPendingImages).forEach(k => delete _shopItemPendingImages[k]);
                 _shopItemClearedImages.clear();
-                toast('Settings saved ✓', 'success');
+                toast('Settings saved', 'success');
             }
         } else {
-            toast('Settings saved ✓', 'success');
+            toast('Settings saved', 'success');
         }
     } catch (error) {
         console.error(error);
@@ -1096,7 +1147,7 @@ async function uploadActivityImage(itemId, input) {
                 imgEl.style.display = 'block';
             }
             if (emojiEl) emojiEl.style.display = 'none';
-            toast('Image uploaded ✓', 'success');
+            toast('Image uploaded', 'success');
         } else {
             var err = await r.json().catch(function(){ return {}; });
             toast(err.error || 'Upload failed', 'error');
@@ -1136,7 +1187,7 @@ async function triggerDailyNewsNow() {
     if (!ok) return;
     try {
         const response = await fetch(`/api/guild/${guildId}/dailynews/trigger`, { method: 'POST' });
-        if (response.ok) toast('Digest sent ✓', 'success');
+        if (response.ok) toast('Digest sent', 'success');
         else {
             const err = await response.json().catch(() => ({}));
             toast(err.error || 'Failed to send digest', 'error');
@@ -1181,7 +1232,7 @@ async function addAutoRole() {
             chip.appendChild(removeBtn);
             document.getElementById('autorole-list').appendChild(chip);
             select.value = '';
-            toast('Role added ✓', 'success');
+            toast('Role added', 'success');
         } else toast('Failed to add role', 'error');
     } catch (error) {
         console.error(error);
@@ -1196,7 +1247,7 @@ async function removeAutoRole(roleId) {
         if (response.ok) {
             const chip = document.querySelector(`#autorole-list [data-role-id="${roleId}"]`);
             if (chip) chip.remove();
-            toast('Role removed ✓', 'success');
+            toast('Role removed', 'success');
         } else toast('Failed to remove role', 'error');
     } catch (error) {
         console.error(error);
@@ -1215,7 +1266,7 @@ async function addRssFeed() {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ url, channelId })
         });
-        if (response.ok) { toast('RSS feed added ✓', 'success'); setTimeout(() => location.reload(), 600); }
+        if (response.ok) { toast('RSS feed added', 'success'); setTimeout(() => location.reload(), 600); }
         else toast('Failed to add RSS feed', 'error');
     } catch (error) {
         console.error(error);
@@ -1229,7 +1280,7 @@ async function deleteRssFeed(index) {
     const guildId = BOOT.guildId;
     try {
         const response = await fetch(`/api/guild/${guildId}/rss/${index}`, { method: 'DELETE' });
-        if (response.ok) { toast('RSS feed removed ✓', 'success'); setTimeout(() => location.reload(), 600); }
+        if (response.ok) { toast('RSS feed removed', 'success'); setTimeout(() => location.reload(), 600); }
         else toast('Failed to delete RSS feed', 'error');
     } catch (error) {
         console.error(error);
@@ -2107,7 +2158,7 @@ async function publishRrPanel() {
         });
         var data = await response.json();
         if (response.ok) {
-            toast('Panel published ✓', 'success');
+            toast('Panel published', 'success');
             setTimeout(function() { location.reload(); }, 800);
         } else {
             toast(data.error || 'Failed to publish panel', 'error');
@@ -2125,7 +2176,7 @@ async function deleteRrPanel(messageId) {
     try {
         var response = await fetch('/api/guild/' + guildId + '/reactionrole/panel/' + messageId, { method: 'DELETE' });
         if (response.ok) {
-            toast('Panel deleted ✓', 'success');
+            toast('Panel deleted', 'success');
             setTimeout(function() { location.reload(); }, 600);
         } else {
             toast('Failed to delete panel', 'error');
@@ -2232,7 +2283,7 @@ async function saveKbEntry(id) {
         });
         var data = await resp.json();
         if (resp.ok) {
-            toast('Entry updated ✓', 'success');
+            toast('Entry updated', 'success');
             kbLoaded = false;
             loadKnowledgeBase();
         } else {
@@ -2259,7 +2310,7 @@ async function addKbEntry() {
         });
         var data = await resp.json();
         if (resp.ok) {
-            toast('Entry added ✓', 'success');
+            toast('Entry added', 'success');
             document.getElementById('kb-title').value = '';
             document.getElementById('kb-content').value = '';
             document.getElementById('kb-tags').value = '';
@@ -2281,7 +2332,7 @@ async function deleteKbEntry(id) {
     try {
         var resp = await fetch('/api/guild/' + guildId + '/knowledge-base/' + id, { method: 'DELETE' });
         if (resp.ok) {
-            toast('Entry removed ✓', 'success');
+            toast('Entry removed', 'success');
             kbLoaded = false;
             loadKnowledgeBase();
         } else {
@@ -2394,7 +2445,7 @@ async function saveDailyDigest() {
         });
         var data = await resp.json();
         if (resp.ok) {
-            toast('Daily digest settings saved ✓', 'success');
+            toast('Daily digest settings saved', 'success');
         } else {
             toast(data.error || 'Failed to save digest settings', 'error');
         }
@@ -2420,7 +2471,7 @@ async function addSummaryJob() {
         });
         var data = await resp.json();
         if (resp.ok) {
-            toast('Summary job added ✓', 'success');
+            toast('Summary job added', 'success');
             document.getElementById('summary-source').value = '';
             document.getElementById('summary-target').value = '';
             document.getElementById('summary-hour').value = '9';
@@ -2444,7 +2495,7 @@ async function deleteSummaryJob(jobId) {
     try {
         var resp = await fetch('/api/guild/' + guildId + '/summary-jobs/' + jobId, { method: 'DELETE' });
         if (resp.ok) {
-            toast('Summary job removed ✓', 'success');
+            toast('Summary job removed', 'success');
             summaryJobsLoaded = false;
             loadSummaryJobs();
         } else {
@@ -2509,7 +2560,7 @@ async function addPersona() {
         });
         var data = await resp.json();
         if (resp.ok) {
-            toast('Persona saved ✓', 'success');
+            toast('Persona saved', 'success');
             document.getElementById('persona-channel').value = '';
             document.getElementById('persona-name').value = '';
             document.getElementById('persona-prompt').value = '';
@@ -2531,7 +2582,7 @@ async function removePersona(channelId) {
     try {
         var resp = await fetch('/api/guild/' + guildId + '/persona/' + encodeURIComponent(channelId), { method: 'DELETE' });
         if (resp.ok) {
-            toast('Persona removed ✓', 'success');
+            toast('Persona removed', 'success');
             _personas = _personas.filter(function(p) { return p.channelId !== channelId; });
             renderPersonas();
         } else {
@@ -2759,7 +2810,7 @@ async function saveMcpServer() {
         });
         var data = await resp.json();
         if (!resp.ok) { toast(data.error || 'Failed to save connection', 'error'); return; }
-        toast('Connection saved ✓', 'success');
+        toast('Connection saved', 'success');
         _mcpServers = data.servers || [];
         resetMcpForm();
         renderMcpServers();
@@ -2781,7 +2832,7 @@ async function removeMcpServer(name) {
         var resp = await fetch('/api/guild/' + guildId + '/mcp-servers/' + encodeURIComponent(name), { method: 'DELETE' });
         var data = await resp.json();
         if (!resp.ok) { toast(data.error || 'Failed to remove', 'error'); return; }
-        toast('Connection removed ✓', 'success');
+        toast('Connection removed', 'success');
         _mcpServers = data.servers || [];
         if (_mcpEditing === name) resetMcpForm();
         renderMcpServers();

--- a/src/dashboard/public/guild-settings.js
+++ b/src/dashboard/public/guild-settings.js
@@ -425,6 +425,10 @@ const TOAST_DISMISS_MS = { success: 2800, error: 8000, info: 4500 };
 function hideToast() {
     clearTimeout(toastTimer);
     toastEl.classList.remove('show');
+    // The toast is only faded out, not display:none, so without this the
+    // dismiss button stays in the tab order — an unlabelled stop in the corner
+    // of every page, dismissing nothing. It ships `hidden` for the same reason.
+    if (toastClose) toastClose.hidden = true;
 }
 
 function toast(message, kind) {
@@ -435,9 +439,10 @@ function toast(message, kind) {
     // ("Network error" is only an error because we say so).
     toastMessage.textContent = style ? `${style.prefix}: ${message}` : message;
     toastEl.className = 'toast show' + (kind ? ' ' + kind : '');
+    if (toastClose) toastClose.hidden = false;
 
     clearTimeout(toastTimer);
-    toastTimer = setTimeout(() => toastEl.classList.remove('show'), TOAST_DISMISS_MS[kind] || 2800);
+    toastTimer = setTimeout(hideToast, TOAST_DISMISS_MS[kind] || 2800);
 }
 
 if (toastClose) toastClose.addEventListener('click', hideToast);

--- a/src/dashboard/public/guild-settings.js
+++ b/src/dashboard/public/guild-settings.js
@@ -953,7 +953,7 @@ async function saveSettings(section) {
         // EJS renders the saved systemPrompt verbatim, so pre-existing values
         // can exceed the textarea's maxlength (e.g. set via the API).
         // Validate here so we never POST an oversized prompt.
-        var aiPromptVal = document.getElementById('ai-prompt').value;
+        const aiPromptVal = document.getElementById('ai-prompt').value;
         if (aiPromptVal.length > 4000) {
             updatePromptCount('ai-prompt');
             toast('System prompt is ' + aiPromptVal.length + ' chars — maximum is 4000.', 'error');
@@ -1120,17 +1120,17 @@ async function saveSettings(section) {
 }
 
 async function uploadActivityImage(itemId, input) {
-    var file = input.files[0];
+    const file = input.files[0];
     if (!file) return;
-    var emojiEl = document.getElementById('gic-emoji-' + itemId);
-    var imgEl = document.getElementById('gic-img-' + itemId);
-    var fd = new FormData();
+    const emojiEl = document.getElementById('gic-emoji-' + itemId);
+    let imgEl = document.getElementById('gic-img-' + itemId);
+    const fd = new FormData();
     fd.append('image', file);
     try {
-        var r = await fetch('/api/item-image/activity/' + encodeURIComponent(itemId), { method: 'POST', body: fd });
+        const r = await fetch('/api/item-image/activity/' + encodeURIComponent(itemId), { method: 'POST', body: fd });
         if (r.ok) {
-            var dataUrl = await new Promise(function(res) {
-                var reader = new FileReader();
+            const dataUrl = await new Promise(function(res) {
+                const reader = new FileReader();
                 reader.onload = function(e) { res(e.target.result); };
                 reader.readAsDataURL(file);
             });
@@ -1149,10 +1149,10 @@ async function uploadActivityImage(itemId, input) {
             if (emojiEl) emojiEl.style.display = 'none';
             toast('Image uploaded', 'success');
         } else {
-            var err = await r.json().catch(function(){ return {}; });
+            const err = await r.json().catch(function(){ return {}; });
             toast(err.error || 'Upload failed', 'error');
         }
-    } catch(e) {
+    } catch {
         toast('Upload error', 'error');
     }
     input.value = '';
@@ -1162,10 +1162,10 @@ async function removeActivityImage(itemId) {
     const ok = await showConfirm({ title: 'Remove image', body: 'Remove the image for this activity item?', okText: 'Remove' });
     if (!ok) return;
     try {
-        var r = await fetch('/api/item-image/activity/' + encodeURIComponent(itemId), { method: 'DELETE' });
+        const r = await fetch('/api/item-image/activity/' + encodeURIComponent(itemId), { method: 'DELETE' });
         if (r.ok) {
-            var imgEl = document.getElementById('gic-img-' + itemId);
-            var emojiEl = document.getElementById('gic-emoji-' + itemId);
+            const imgEl = document.getElementById('gic-img-' + itemId);
+            const emojiEl = document.getElementById('gic-emoji-' + itemId);
             if (imgEl) {
                 imgEl.src = '';
                 imgEl.style.display = 'none';
@@ -1173,10 +1173,10 @@ async function removeActivityImage(itemId) {
             if (emojiEl) emojiEl.style.display = 'flex';
             toast('Image removed', 'success');
         } else {
-            var err = await r.json().catch(function(){ return {}; });
+            const err = await r.json().catch(function(){ return {}; });
             toast(err.error || 'Remove failed', 'error');
         }
-    } catch(e) {
+    } catch {
         toast('Error removing image', 'error');
     }
 }
@@ -1301,7 +1301,7 @@ var _confirmPrevFocus = null;
 var _confirmTrapHandler = null;
 
 function _confirmFocusables() {
-    var modal = document.getElementById('confirm-modal');
+    const modal = document.getElementById('confirm-modal');
     return Array.from(modal.querySelectorAll(
         'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
     )).filter(function(el) { return el.offsetParent !== null; });
@@ -1309,15 +1309,15 @@ function _confirmFocusables() {
 
 function showConfirm(opts) {
     return new Promise(function(resolve) {
-        var title  = opts.title  || 'Are you sure?';
-        var body   = opts.body   || 'This action cannot be undone.';
-        var okText = opts.okText || 'Confirm';
-        var typeRequired = opts.typeRequired || null;
+        const title  = opts.title  || 'Are you sure?';
+        const body   = opts.body   || 'This action cannot be undone.';
+        const okText = opts.okText || 'Confirm';
+        const typeRequired = opts.typeRequired || null;
         document.getElementById('confirm-modal-title').textContent = title;
         document.getElementById('confirm-modal-body').textContent  = body;
         document.getElementById('confirm-modal-ok').textContent    = okText;
-        var typeArea  = document.getElementById('confirm-modal-type-reset');
-        var typeInput = document.getElementById('confirm-type-input');
+        const typeArea  = document.getElementById('confirm-modal-type-reset');
+        const typeInput = document.getElementById('confirm-type-input');
         if (typeRequired) {
             document.getElementById('confirm-type-label').innerHTML = 'Type <strong>' + escHtml(typeRequired) + '</strong> to confirm';
             typeInput.value = '';
@@ -1326,7 +1326,7 @@ function showConfirm(opts) {
         } else {
             typeArea.style.display = 'none';
         }
-        var modal = document.getElementById('confirm-modal');
+        const modal = document.getElementById('confirm-modal');
         _confirmPrevFocus = document.activeElement;
         modal.setAttribute('aria-hidden', 'false');
         modal.style.display = 'flex';
@@ -1341,9 +1341,9 @@ function showConfirm(opts) {
         _confirmTrapHandler = function(e) {
             if (e.key === 'Escape') { e.preventDefault(); _confirmResolve(false); return; }
             if (e.key !== 'Tab') return;
-            var focusables = _confirmFocusables();
+            const focusables = _confirmFocusables();
             if (!focusables.length) { e.preventDefault(); return; }
-            var first = focusables[0], last = focusables[focusables.length - 1];
+            const first = focusables[0], last = focusables[focusables.length - 1];
             if (e.shiftKey) {
                 if (document.activeElement === first) { e.preventDefault(); last.focus(); }
             } else {
@@ -1373,10 +1373,10 @@ function showConfirm(opts) {
 }
 
 function renderCpRules() {
-    var list = document.getElementById('cp-rules-list');
+    const list = document.getElementById('cp-rules-list');
     if (!_cpRules.length) { list.innerHTML = '<p style="color:var(--text-dim);font-size:.88rem;">No rules — click <strong>+ Add rule</strong> to add one.</p>'; return; }
     list.innerHTML = _cpRules.map(function(r, i) {
-        var color = r.effect === 'allow' ? '#2ecc71' : '#e74c3c';
+        const color = r.effect === 'allow' ? '#2ecc71' : '#e74c3c';
         return '<div class="store-item-card" style="padding:.6rem .9rem;display:flex;align-items:center;gap:.75rem;">' +
             '<span style="flex:1"><strong>' + escHtml(r.command) + '</strong> — <span style="color:' + color + '">' + escHtml(r.effect) + '</span></span>' +
             '<button class="btn btn-sm" onclick="openCpRuleModal(' + i + ')">Edit</button>' +
@@ -1385,10 +1385,10 @@ function renderCpRules() {
 }
 var _cpRoleMap = boot('roleNames');
 function renderCpCooldowns() {
-    var list = document.getElementById('cp-cooldowns-list');
+    const list = document.getElementById('cp-cooldowns-list');
     if (!_cpCooldowns.length) { list.innerHTML = '<p style="color:var(--text-dim);font-size:.88rem;">No cooldown overrides — click <strong>+ Add override</strong>.</p>'; return; }
     list.innerHTML = _cpCooldowns.map(function(c, i) {
-        var roleName = _cpRoleMap[c.roleId] ? '@' + _cpRoleMap[c.roleId] : escHtml(c.roleId);
+        const roleName = _cpRoleMap[c.roleId] ? '@' + _cpRoleMap[c.roleId] : escHtml(c.roleId);
         return '<div class="store-item-card" style="padding:.6rem .9rem;display:flex;align-items:center;gap:.75rem;">' +
             '<span style="flex:1"><strong>' + escHtml(c.command) + '</strong> — ' + escHtml(roleName) + ' → ' + escHtml(c.cooldownSeconds) + 's</span>' +
             '<button class="btn btn-sm" onclick="openCpCooldownModal(' + i + ')">Edit</button>' +
@@ -1397,13 +1397,13 @@ function renderCpCooldowns() {
 }
 function openCpRuleModal(idx) {
     _cpRuleIdx = idx;
-    var r = idx === -1 ? {} : _cpRules[idx];
+    const r = idx === -1 ? {} : _cpRules[idx];
     document.getElementById('cp-rule-modal-title').textContent = idx === -1 ? 'Add Rule' : 'Edit Rule';
     document.getElementById('cp-r-command').value   = r.command || '';
     document.getElementById('cp-r-effect').value    = r.effect || 'allow';
-    var rRoles = r.roleIds || [];
+    const rRoles = r.roleIds || [];
     Array.from(document.getElementById('cp-r-roles').options).forEach(function(o) { o.selected = rRoles.includes(o.value); });
-    var rChans = r.channelIds || [];
+    const rChans = r.channelIds || [];
     Array.from(document.getElementById('cp-r-channels').options).forEach(function(o) { o.selected = rChans.includes(o.value); });
     document.getElementById('cp-r-start-hour').value = r.startHourUtc != null ? r.startHourUtc : '';
     document.getElementById('cp-r-end-hour').value   = r.endHourUtc   != null ? r.endHourUtc   : '';
@@ -1411,11 +1411,11 @@ function openCpRuleModal(idx) {
 }
 function closeCpRuleModal() { document.getElementById('cp-rule-modal').style.display = 'none'; }
 function saveCpRuleModal() {
-    var cmd = document.getElementById('cp-r-command').value.trim();
+    const cmd = document.getElementById('cp-r-command').value.trim();
     if (!cmd) { toast('Command name is required', 'error'); return; }
-    var sh = document.getElementById('cp-r-start-hour').value;
-    var eh = document.getElementById('cp-r-end-hour').value;
-    var rule = {
+    const sh = document.getElementById('cp-r-start-hour').value;
+    const eh = document.getElementById('cp-r-end-hour').value;
+    const rule = {
         command: cmd,
         effect: document.getElementById('cp-r-effect').value,
         roleIds: Array.from(document.getElementById('cp-r-roles').selectedOptions).map(function(o){return o.value;}),
@@ -1429,7 +1429,7 @@ function saveCpRuleModal() {
 }
 function openCpCooldownModal(idx) {
     _cpCdIdx = idx;
-    var c = idx === -1 ? {} : _cpCooldowns[idx];
+    const c = idx === -1 ? {} : _cpCooldowns[idx];
     document.getElementById('cp-cd-command').value = c.command || '';
     document.getElementById('cp-cd-role').value    = c.roleId  || '';
     document.getElementById('cp-cd-seconds').value = c.cooldownSeconds != null ? c.cooldownSeconds : '';
@@ -1437,26 +1437,26 @@ function openCpCooldownModal(idx) {
 }
 function closeCpCooldownModal() { document.getElementById('cp-cooldown-modal').style.display = 'none'; }
 function saveCpCooldownModal() {
-    var cmd = document.getElementById('cp-cd-command').value.trim();
-    var role = document.getElementById('cp-cd-role').value.trim();
+    const cmd = document.getElementById('cp-cd-command').value.trim();
+    const role = document.getElementById('cp-cd-role').value.trim();
     if (!cmd || !role) { toast('Command and role are required', 'error'); return; }
-    var entry = { command: cmd, roleId: role, cooldownSeconds: parseInt(document.getElementById('cp-cd-seconds').value, 10) || 0 };
+    const entry = { command: cmd, roleId: role, cooldownSeconds: parseInt(document.getElementById('cp-cd-seconds').value, 10) || 0 };
     if (_cpCdIdx === -1) _cpCooldowns.push(entry); else _cpCooldowns[_cpCdIdx] = entry;
     closeCpCooldownModal(); renderCpCooldowns();
 }
 
 function addCpExcRole() {
-    var sel = document.getElementById('cp-exc-roles-select');
-    var roleId = sel.value;
-    var roleName = sel.options[sel.selectedIndex] ? sel.options[sel.selectedIndex].text : roleId;
+    const sel = document.getElementById('cp-exc-roles-select');
+    const roleId = sel.value;
+    const roleName = sel.options[sel.selectedIndex] ? sel.options[sel.selectedIndex].text : roleId;
     if (!roleId) return;
     if (document.querySelector('#cp-exc-roles-list [data-role-id="' + CSS.escape(roleId) + '"]')) { toast('Role already added', 'error'); return; }
-    var list = document.getElementById('cp-exc-roles-list');
-    var tag = document.createElement('span');
+    const list = document.getElementById('cp-exc-roles-list');
+    const tag = document.createElement('span');
     tag.className = 'role-tag';
     tag.dataset.roleId = roleId;
     tag.textContent = roleName + ' ';
-    var btn = document.createElement('button');
+    const btn = document.createElement('button');
     btn.type = 'button';
     btn.title = 'Remove';
     btn.textContent = '×';
@@ -1487,18 +1487,18 @@ var _shopItemClearedImages = new Set(); // itemIds whose images were explicitly 
 var _guildId = BOOT.guildId;
 
 function renderStoreItems() {
-    var grid = document.getElementById('store-items-grid');
+    const grid = document.getElementById('store-items-grid');
     if (!storeItems.length) {
         grid.innerHTML = '<div class="empty-state"><h3>No store items yet</h3><p>Click <strong>+ Add item</strong> to create your first shop listing.</p></div>';
         return;
     }
     grid.innerHTML = storeItems.map(function(item, i) {
-        var roleName = item.roleId ? (_roleMap[item.roleId] || item.roleId) : null;
-        var stockText = (item.stock === -1 || item.stock == null) ? '∞ Unlimited' : item.stock + ' left';
-        var imgSrc = (item.itemId && _shopItemPendingImages[item.itemId])
+        const roleName = item.roleId ? (_roleMap[item.roleId] || item.roleId) : null;
+        const stockText = (item.stock === -1 || item.stock == null) ? '∞ Unlimited' : item.stock + ' left';
+        const imgSrc = (item.itemId && _shopItemPendingImages[item.itemId])
             ? _shopItemPendingImages[item.itemId].dataUrl
             : (item.itemId ? '/api/item-image/shop/' + _guildId + '/' + escHtml(item.itemId) : '');
-        var thumbHtml = imgSrc ? '<img class="store-card-thumb" src="' + imgSrc + '" alt="" onerror="this.style.display=\'none\'">' : '';
+        const thumbHtml = imgSrc ? '<img class="store-card-thumb" src="' + imgSrc + '" alt="" onerror="this.style.display=\'none\'">' : '';
         return '<div class="store-card">' +
             (thumbHtml ? '<div class="store-card-thumb-wrap">' + thumbHtml + '</div>' : '') +
             '<div class="store-card-body">' +
@@ -1523,11 +1523,11 @@ function _genItemId() {
 }
 
 function previewShopItemImage(input) {
-    var file = input.files[0];
+    const file = input.files[0];
     if (!file) return;
-    var reader = new FileReader();
+    const reader = new FileReader();
     reader.onload = function(e) {
-        var dataUrl = e.target.result;
+        const dataUrl = e.target.result;
         document.getElementById('shop-img-preview').src = dataUrl;
         document.getElementById('shop-img-preview').style.display = 'block';
         document.getElementById('shop-img-placeholder').style.display = 'none';
@@ -1543,7 +1543,7 @@ function clearShopItemImage() {
     document.getElementById('shop-img-preview').style.display = 'none';
     document.getElementById('shop-img-placeholder').style.display = 'block';
     document.getElementById('shop-img-clear-btn').style.display = 'none';
-    var fileInput = document.getElementById('modal-item-image-file');
+    const fileInput = document.getElementById('modal-item-image-file');
     fileInput._pendingFile = null;
     fileInput._pendingDataUrl = null;
     fileInput.value = '';
@@ -1553,33 +1553,33 @@ function clearShopItemImage() {
 function openItemModal(idx) {
     editingItemIdx = idx;
     document.getElementById('item-modal-title').textContent = idx === -1 ? 'Add Store Item' : 'Edit Store Item';
-    var item = idx === -1 ? {} : storeItems[idx];
+    const item = idx === -1 ? {} : storeItems[idx];
     document.getElementById('modal-item-name').value = item.name || '';
     document.getElementById('modal-item-desc').value = item.description || '';
     document.getElementById('modal-item-price').value = item.price != null ? item.price : '';
     document.getElementById('modal-item-role').value = item.roleId || '';
-    var isUnlimited = (item.stock == null || item.stock === -1);
+    const isUnlimited = (item.stock == null || item.stock === -1);
     document.getElementById('modal-item-unlimited').checked = isUnlimited;
     document.getElementById('modal-item-stock').style.display = isUnlimited ? 'none' : '';
     document.getElementById('modal-item-stock').value = isUnlimited ? '' : item.stock;
 
     // Reset image preview
-    var fileInput = document.getElementById('modal-item-image-file');
+    const fileInput = document.getElementById('modal-item-image-file');
     fileInput.value = '';
     fileInput._pendingFile = null;
     fileInput._pendingDataUrl = null;
     fileInput._clearExisting = false;
-    var preview = document.getElementById('shop-img-preview');
-    var placeholder = document.getElementById('shop-img-placeholder');
-    var clearBtn = document.getElementById('shop-img-clear-btn');
-    var pending = item.itemId && _shopItemPendingImages[item.itemId];
+    const preview = document.getElementById('shop-img-preview');
+    const placeholder = document.getElementById('shop-img-placeholder');
+    const clearBtn = document.getElementById('shop-img-clear-btn');
+    const pending = item.itemId && _shopItemPendingImages[item.itemId];
     if (pending) {
         preview.src = pending.dataUrl;
         preview.style.display = 'block';
         placeholder.style.display = 'none';
         clearBtn.style.display = 'inline-flex';
     } else if (item.itemId) {
-        var imgSrc = '/api/item-image/shop/' + _guildId + '/' + item.itemId;
+        const imgSrc = '/api/item-image/shop/' + _guildId + '/' + item.itemId;
         preview.src = imgSrc;
         preview.style.display = 'block';
         placeholder.style.display = 'none';
@@ -1603,19 +1603,19 @@ function toggleStockInput(cb) {
 }
 
 function saveItemModal() {
-    var name = document.getElementById('modal-item-name').value.trim();
-    var price = parseInt(document.getElementById('modal-item-price').value, 10);
+    const name = document.getElementById('modal-item-name').value.trim();
+    const price = parseInt(document.getElementById('modal-item-price').value, 10);
     if (!name) { toast('Item name is required', 'error'); return; }
     if (!Number.isFinite(price) || price < 0) { toast('Enter a valid price', 'error'); return; }
-    var isUnlimited = document.getElementById('modal-item-unlimited').checked;
-    var parsedStock = isUnlimited ? -1 : parseInt(document.getElementById('modal-item-stock').value, 10);
+    const isUnlimited = document.getElementById('modal-item-unlimited').checked;
+    const parsedStock = isUnlimited ? -1 : parseInt(document.getElementById('modal-item-stock').value, 10);
     if (!isUnlimited && (!Number.isFinite(parsedStock) || parsedStock < 1)) { toast('Enter a valid stock quantity', 'error'); return; }
-    var fileInput = document.getElementById('modal-item-image-file');
+    const fileInput = document.getElementById('modal-item-image-file');
 
-    var existingItem = editingItemIdx === -1 ? null : storeItems[editingItemIdx];
-    var itemId = (existingItem && existingItem.itemId) ? existingItem.itemId : _genItemId();
+    const existingItem = editingItemIdx === -1 ? null : storeItems[editingItemIdx];
+    const itemId = (existingItem && existingItem.itemId) ? existingItem.itemId : _genItemId();
 
-    var item = {
+    const item = {
         name: name,
         itemId: itemId,
         description: document.getElementById('modal-item-desc').value.trim(),
@@ -1649,11 +1649,11 @@ var JOB_TIER_COLORS = ['#2ecc71','#3498db','#9b59b6','#f39c12'];
 var JOB_TIER_BADGES = ['🟢','🔵','🟣','🟡'];
 
 function renderJobTiers() {
-    var grid = document.getElementById('job-tiers-grid');
+    const grid = document.getElementById('job-tiers-grid');
     grid.innerHTML = jobTiersList.map(function(t, i) {
-        var color = JOB_TIER_COLORS[i] || '#888';
-        var badge = JOB_TIER_BADGES[i] || '⚪';
-        var isFirst = t.minShifts === 0;
+        const color = JOB_TIER_COLORS[i] || '#888';
+        const badge = JOB_TIER_BADGES[i] || '⚪';
+        const isFirst = t.minShifts === 0;
         return '<div class="job-tier-row" style="border-left:3px solid ' + color + '">' +
             '<span class="job-tier-row-badge">' + badge + ' Tier ' + t.tier + '</span>' +
             '<input class="job-tier-name-input" data-tier-idx="' + i + '" data-field="name" value="' + escHtml(t.name) + '" placeholder="Tier name" oninput="updateTierField(this)">' +
@@ -1666,8 +1666,8 @@ function renderJobTiers() {
 }
 
 function updateTierField(el) {
-    var idx = parseInt(el.dataset.tierIdx, 10);
-    var field = el.dataset.field;
+    const idx = parseInt(el.dataset.tierIdx, 10);
+    const field = el.dataset.field;
     jobTiersList[idx][field] = field === 'minShifts' ? (parseInt(el.value, 10) || 0) : el.value;
 }
 
@@ -1679,32 +1679,32 @@ var JOB_TIER_META = [
 ];
 
 function renderJobs() {
-    var list = document.getElementById('jobs-list');
+    const list = document.getElementById('jobs-list');
     if (!jobsList.length) {
         list.innerHTML = '<p style="color:var(--text-dim);font-size:.88rem;padding:.5rem 0">No jobs — click <strong>+ Add job</strong> to add one.</p>';
         return;
     }
 
     // Sort by tier then name
-    var sorted = jobsList.map(function(j, i) { return { job: j, idx: i }; });
+    const sorted = jobsList.map(function(j, i) { return { job: j, idx: i }; });
     sorted.sort(function(a, b) {
-        var ta = a.job.tier || 1, tb = b.job.tier || 1;
+        const ta = a.job.tier || 1, tb = b.job.tier || 1;
         return ta !== tb ? ta - tb : a.job.name.localeCompare(b.job.name);
     });
 
     // Build tier name lookup from live jobTiersList so names stay in sync
-    var tierNameMap = {};
+    const tierNameMap = {};
     jobTiersList.forEach(function(t) { tierNameMap[t.tier] = t.name; });
 
     // Group into tiers
-    var html = '';
-    var lastTier = null;
+    let html = '';
+    let lastTier = null;
     sorted.forEach(function(entry) {
-        var job = entry.job, i = entry.idx;
-        var tier = job.tier || 1;
-        var color = JOB_TIER_COLORS[tier - 1] || '#888';
-        var badge = JOB_TIER_BADGES[tier - 1] || '⚪';
-        var tierName = tierNameMap[tier] || ('Tier ' + tier);
+        const job = entry.job, i = entry.idx;
+        const tier = job.tier || 1;
+        const color = JOB_TIER_COLORS[tier - 1] || '#888';
+        const badge = JOB_TIER_BADGES[tier - 1] || '⚪';
+        const tierName = tierNameMap[tier] || ('Tier ' + tier);
         if (tier !== lastTier) {
             if (lastTier !== null) html += '</div>';
             html += '<div class="job-tier-group">' +
@@ -1713,8 +1713,8 @@ function renderJobs() {
                 '</div>';
             lastTier = tier;
         }
-        var minPay = job.minPay != null ? job.minPay : '?';
-        var maxPay = job.maxPay != null ? job.maxPay : '?';
+        const minPay = job.minPay != null ? job.minPay : '?';
+        const maxPay = job.maxPay != null ? job.maxPay : '?';
         html += '<div class="job-chip">' +
             (job.emoji ? '<span class="job-chip-emoji">' + escHtml(job.emoji) + '</span>' : '') +
             '<span class="job-name">' + escHtml(job.name) + '</span>' +
@@ -1730,7 +1730,7 @@ function renderJobs() {
 function openJobModal(idx) {
     editingJobIdx = idx;
     document.getElementById('job-modal-title').textContent = idx === -1 ? 'Add Job' : 'Edit Job';
-    var job = idx === -1 ? {} : jobsList[idx];
+    const job = idx === -1 ? {} : jobsList[idx];
     document.getElementById('modal-job-name').value = job.name || '';
     document.getElementById('modal-job-emoji').value = job.emoji || '';
     document.getElementById('modal-job-tier').value = String(job.tier || 1);
@@ -1742,13 +1742,13 @@ function openJobModal(idx) {
 function closeJobModal() { document.getElementById('job-modal').style.display = 'none'; }
 
 function saveJobModal() {
-    var name = document.getElementById('modal-job-name').value.trim();
+    const name = document.getElementById('modal-job-name').value.trim();
     if (!name) { toast('Job name is required', 'error'); return; }
-    var minPay = parseInt(document.getElementById('modal-job-min-pay').value, 10);
-    var maxPay = parseInt(document.getElementById('modal-job-max-pay').value, 10);
+    const minPay = parseInt(document.getElementById('modal-job-min-pay').value, 10);
+    const maxPay = parseInt(document.getElementById('modal-job-max-pay').value, 10);
     if (!Number.isFinite(minPay) || minPay < 0) { toast('Enter a valid min pay', 'error'); return; }
     if (!Number.isFinite(maxPay) || maxPay < minPay) { toast('Max pay must be ≥ min pay', 'error'); return; }
-    var job = {
+    const job = {
         name: name,
         emoji: document.getElementById('modal-job-emoji').value.trim(),
         tier: parseInt(document.getElementById('modal-job-tier').value, 10) || 1,
@@ -1791,9 +1791,9 @@ document.addEventListener('click', function(e) {
 // `&#39;` from escHtml turns back into a quote and closes the string it
 // was meant to sit inside.
 document.addEventListener('click', function(e) {
-    var el = e.target.closest && e.target.closest('[data-action]');
+    const el = e.target.closest && e.target.closest('[data-action]');
     if (!el) return;
-    var d = el.dataset;
+    const d = el.dataset;
     if (d.action === 'ach-grant')      openAchGrantModal(d.achId, d.achName);
     else if (d.action === 'summary-delete') deleteSummaryJob(d.jobId);
     else if (d.action === 'persona-remove') removePersona(d.channelId);
@@ -1806,12 +1806,12 @@ document.addEventListener('click', function(e) {
 // mousedown, not click: the dropdown is hidden by the input's blur, which
 // fires first on a click.
 document.addEventListener('mousedown', function(e) {
-    var el = e.target.closest && e.target.closest('[data-action="member-select"]');
+    const el = e.target.closest && e.target.closest('[data-action="member-select"]');
     if (el) selectGrantMember(el.dataset.memberId, el.dataset.memberName);
 });
 
 document.addEventListener('change', function(e) {
-    var el = e.target.closest && e.target.closest('[data-builtin-ach-id]');
+    const el = e.target.closest && e.target.closest('[data-builtin-ach-id]');
     if (el) toggleBuiltinAch(el.dataset.builtinAchId, el.checked);
 });
 
@@ -1825,11 +1825,11 @@ var ACH_CAT_LABELS = { economy:'Economy', leveling:'Leveling', hunt:'Hunt', fish
 var ACH_CAT_EMOJIS = { economy:'💰', leveling:'📈', hunt:'🏹', fishing:'🎣', community:'👥', moderation:'🛡️', custom:'⚙️' };
 
 function renderBuiltinAchievements() {
-    var list = document.getElementById('builtin-ach-list');
+    const list = document.getElementById('builtin-ach-list');
     if (!_BUILTIN_ACHS.length) { list.innerHTML = '<p style="color:var(--text-dim);font-size:.88rem">No built-in achievements loaded.</p>'; return; }
     list.innerHTML = _BUILTIN_ACHS.map(function(a) {
-        var disabled = _disabledAchievements.indexOf(a.id) !== -1;
-        var catLabel = (ACH_CAT_EMOJIS[a.category] || '🔹') + ' ' + (ACH_CAT_LABELS[a.category] || a.category);
+        const disabled = _disabledAchievements.indexOf(a.id) !== -1;
+        const catLabel = (ACH_CAT_EMOJIS[a.category] || '🔹') + ' ' + (ACH_CAT_LABELS[a.category] || a.category);
         return '<div class="store-item-card" style="padding:.6rem .9rem;display:flex;align-items:center;gap:.75rem;">' +
             '<span style="font-size:1.4rem">' + escHtml(a.emoji) + '</span>' +
             '<span style="flex:1"><strong>' + escHtml(a.name) + '</strong> <span style="font-size:.8rem;color:var(--text-dim)">' + catLabel + '</span><br>' +
@@ -1851,13 +1851,13 @@ function toggleBuiltinAch(id, enabled) {
 }
 
 function renderCustomAchievements() {
-    var list = document.getElementById('custom-ach-list');
+    const list = document.getElementById('custom-ach-list');
     if (!_customAchievements.length) {
         list.innerHTML = '<p style="color:var(--text-dim);font-size:.88rem;padding:.25rem 0">No custom achievements yet — click <strong>+ Add achievement</strong> to create one.</p>';
         return;
     }
     list.innerHTML = _customAchievements.map(function(a, i) {
-        var catLabel = (ACH_CAT_EMOJIS[a.category] || '🔹') + ' ' + (ACH_CAT_LABELS[a.category] || a.category);
+        const catLabel = (ACH_CAT_EMOJIS[a.category] || '🔹') + ' ' + (ACH_CAT_LABELS[a.category] || a.category);
         return '<div class="store-card">' +
             '<div class="store-card-body">' +
                 '<div class="store-card-name">' + escHtml(a.emoji || '🏆') + ' ' + escHtml(a.name) + '</div>' +
@@ -1880,7 +1880,7 @@ function renderCustomAchievements() {
 function openAchModal(idx) {
     _editingAchIdx = idx;
     document.getElementById('ach-modal-title').textContent = idx === -1 ? 'Add Achievement' : 'Edit Achievement';
-    var a = idx === -1 ? {} : _customAchievements[idx];
+    const a = idx === -1 ? {} : _customAchievements[idx];
     document.getElementById('modal-ach-name').value     = a.name        || '';
     document.getElementById('modal-ach-desc').value     = a.description || '';
     document.getElementById('modal-ach-emoji').value    = a.emoji       || '🏆';
@@ -1893,11 +1893,11 @@ function openAchModal(idx) {
 function closeAchModal() { document.getElementById('ach-modal').style.display = 'none'; }
 
 function saveAchModal() {
-    var name = document.getElementById('modal-ach-name').value.trim();
-    var desc = document.getElementById('modal-ach-desc').value.trim();
+    const name = document.getElementById('modal-ach-name').value.trim();
+    const desc = document.getElementById('modal-ach-desc').value.trim();
     if (!name) { toast('Achievement name is required', 'error'); return; }
     if (!desc) { toast('Description is required', 'error'); return; }
-    var entry = {
+    const entry = {
         id:          (_editingAchIdx === -1 ? 'custom_' + Date.now() : _customAchievements[_editingAchIdx].id),
         name:        name,
         description: desc,
@@ -1944,14 +1944,14 @@ function debouncedMemberSearch() {
 }
 
 async function runMemberSearch() {
-    var q = document.getElementById('grant-member-search').value.trim();
-    var resultsEl = document.getElementById('grant-member-results');
+    const q = document.getElementById('grant-member-search').value.trim();
+    const resultsEl = document.getElementById('grant-member-results');
     if (q.length < 2) { resultsEl.style.display = 'none'; return; }
-    var guildId = BOOT.guildId;
+    const guildId = BOOT.guildId;
     try {
-        var resp = await fetch('/api/guild/' + guildId + '/members/search?q=' + encodeURIComponent(q));
+        const resp = await fetch('/api/guild/' + guildId + '/members/search?q=' + encodeURIComponent(q));
         if (!resp.ok) throw new Error('non-ok');
-        var members = await resp.json();
+        const members = await resp.json();
         if (!members.length) {
             resultsEl.innerHTML = '<div style="padding:.5rem .75rem;font-size:.88rem;color:var(--text-dim)">No members found</div>';
         } else {
@@ -1965,7 +1965,7 @@ async function runMemberSearch() {
             }).join('');
         }
         resultsEl.style.display = '';
-    } catch (e) {
+    } catch {
         resultsEl.innerHTML = '<div style="padding:.5rem .75rem;font-size:.88rem;color:var(--bad)">Search failed</div>';
         resultsEl.style.display = '';
     }
@@ -1975,27 +1975,27 @@ function selectGrantMember(userId, displayName) {
     document.getElementById('grant-member-id').value = userId;
     document.getElementById('grant-member-search').value = displayName;
     document.getElementById('grant-member-results').style.display = 'none';
-    var sel = document.getElementById('grant-selected-member');
+    const sel = document.getElementById('grant-selected-member');
     sel.textContent = 'Selected: ' + displayName + ' (' + userId + ')';
     sel.style.display = '';
 }
 
 async function submitAchGrant() {
-    var userId = document.getElementById('grant-member-id').value.trim();
-    var achId  = document.getElementById('grant-ach-id').value.trim();
+    const userId = document.getElementById('grant-member-id').value.trim();
+    const achId  = document.getElementById('grant-ach-id').value.trim();
     if (!userId) { toast('Select a member first', 'error'); return; }
-    var guildId = BOOT.guildId;
+    const guildId = BOOT.guildId;
     try {
-        var resp = await fetch('/api/guild/' + guildId + '/achievements/grant', {
+        const resp = await fetch('/api/guild/' + guildId + '/achievements/grant', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ userId: userId, achievementId: achId })
         });
-        var data = await resp.json();
+        const data = await resp.json();
         if (!resp.ok) { toast(data.error || 'Grant failed', 'error'); return; }
         toast(data.granted ? 'Achievement granted!' : 'Member already has this achievement', data.granted ? 'success' : 'info');
         closeAchGrantModal();
-    } catch (e) {
+    } catch {
         toast('Grant failed', 'error');
     }
 }
@@ -2007,44 +2007,44 @@ var _levelLeaderboardLoaded = false;
 function loadLevelLeaderboard(page, force) {
     page = page || 1;
     if (_levelLeaderboardLoaded && !force && page === _levelLeaderboardPage) return;
-    var skel    = document.getElementById('level-leaderboard-skeleton');
-    var err     = document.getElementById('level-leaderboard-error');
-    var content = document.getElementById('level-leaderboard-content');
-    var empty   = document.getElementById('level-leaderboard-empty');
+    const skel    = document.getElementById('level-leaderboard-skeleton');
+    const err     = document.getElementById('level-leaderboard-error');
+    const content = document.getElementById('level-leaderboard-content');
+    const empty   = document.getElementById('level-leaderboard-empty');
     skel.style.display = ''; err.style.display = 'none';
     content.style.display = 'none'; empty.style.display = 'none';
-    var guildId = BOOT.guildId;
+    const guildId = BOOT.guildId;
     fetch('/api/guild/' + guildId + '/leveling/leaderboard?page=' + page)
         .then(function(r) { if (!r.ok) throw new Error('non-ok'); return r.json(); })
         .then(function(data) {
             skel.style.display = 'none';
-            var entries = data.entries || [];
+            const entries = data.entries || [];
             if (!entries.length) { empty.style.display = ''; return; }
-            var medals = ['🥇','🥈','🥉'];
-            var tbody = document.getElementById('level-leaderboard-tbody');
+            const medals = ['🥇','🥈','🥉'];
+            const tbody = document.getElementById('level-leaderboard-tbody');
             tbody.innerHTML = entries.map(function(u) {
-                var rank = medals[u.rank - 1] || u.rank;
+                const rank = medals[u.rank - 1] || u.rank;
                 return '<tr><td>' + rank + '</td>' +
                     '<td style="font-family:monospace;font-size:.82rem">' + escHtml(u.userId) + '</td>' +
                     '<td>' + escHtml(String(u.level)) + '</td>' +
                     '<td>' + Number(u.xp).toLocaleString() + '</td>' +
                     '<td>' + Number(u.messages || 0).toLocaleString() + '</td></tr>';
             }).join('');
-            var pag = document.getElementById('level-leaderboard-pagination');
+            const pag = document.getElementById('level-leaderboard-pagination');
             pag.innerHTML = '';
             if (data.pages > 1) {
                 if (page > 1) {
-                    var prev = document.createElement('button');
+                    const prev = document.createElement('button');
                     prev.className = 'btn btn-sm'; prev.textContent = '← Prev';
                     prev.onclick = function() { loadLevelLeaderboard(page - 1, true); };
                     pag.appendChild(prev);
                 }
-                var info = document.createElement('span');
+                const info = document.createElement('span');
                 info.style.cssText = 'font-size:.85rem;opacity:.7';
                 info.textContent = 'Page ' + page + ' of ' + data.pages;
                 pag.appendChild(info);
                 if (page < data.pages) {
-                    var next = document.createElement('button');
+                    const next = document.createElement('button');
                     next.className = 'btn btn-sm'; next.textContent = 'Next →';
                     next.onclick = function() { loadLevelLeaderboard(page + 1, true); };
                     pag.appendChild(next);
@@ -2062,54 +2062,54 @@ function loadLevelLeaderboard(page, force) {
 
 // ── Leveling Admin Actions ──────────────────────────────────────────────────
 async function levelAdminAction(action) {
-    var guildId = BOOT.guildId;
-    var userId  = document.getElementById('level-admin-user-id').value.trim();
-    var amount  = parseInt(document.getElementById('level-admin-amount').value, 10);
-    var msgEl   = document.getElementById('level-admin-msg');
+    const guildId = BOOT.guildId;
+    const userId  = document.getElementById('level-admin-user-id').value.trim();
+    const amount  = parseInt(document.getElementById('level-admin-amount').value, 10);
+    const msgEl   = document.getElementById('level-admin-msg');
     if (!userId) { msgEl.style.color = 'var(--bad)'; msgEl.textContent = 'Enter a Discord user ID.'; return; }
     if (['give','take','set_level'].includes(action) && (!Number.isFinite(amount) || amount < 0)) {
         msgEl.style.color = 'var(--bad)'; msgEl.textContent = 'Enter a valid amount / level.'; return;
     }
     msgEl.style.color = ''; msgEl.textContent = 'Working…';
     try {
-        var resp = await fetch('/api/guild/' + guildId + '/leveling/adjust', {
+        const resp = await fetch('/api/guild/' + guildId + '/leveling/adjust', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ userId, action, amount })
         });
-        var data = await resp.json();
+        const data = await resp.json();
         if (!resp.ok) { msgEl.style.color = 'var(--bad)'; msgEl.textContent = data.error || 'Failed.'; return; }
         msgEl.style.color = 'var(--good)';
         msgEl.textContent = 'Done — level: ' + data.level + ' · XP: ' + Number(data.xp).toLocaleString();
         loadLevelLeaderboard(1, true);
-    } catch (e) {
+    } catch {
         msgEl.style.color = 'var(--bad)'; msgEl.textContent = 'Request failed.';
     }
 }
 
 // ── Leveling Boost Events ──────────────────────────────────────────────────
 async function startBoostEvent() {
-    var guildId    = BOOT.guildId;
-    var multiplier = parseFloat(document.getElementById('boost-multiplier').value);
-    var hours      = parseInt(document.getElementById('boost-duration').value, 10);
-    var msgEl      = document.getElementById('level-boost-msg');
+    const guildId    = BOOT.guildId;
+    const multiplier = parseFloat(document.getElementById('boost-multiplier').value);
+    const hours      = parseInt(document.getElementById('boost-duration').value, 10);
+    const msgEl      = document.getElementById('level-boost-msg');
     if (!Number.isFinite(multiplier) || multiplier < 1.1) { msgEl.style.color = 'var(--bad)'; msgEl.textContent = 'Multiplier must be at least 1.1×.'; return; }
     if (!Number.isFinite(hours) || hours < 1) { msgEl.style.color = 'var(--bad)'; msgEl.textContent = 'Duration must be at least 1 hour.'; return; }
     msgEl.style.color = ''; msgEl.textContent = 'Activating…';
     try {
-        var resp = await fetch('/api/guild/' + guildId + '/leveling/xp-event', {
+        const resp = await fetch('/api/guild/' + guildId + '/leveling/xp-event', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ multiplier, durationHours: hours })
         });
-        var data = await resp.json();
+        const data = await resp.json();
         if (!resp.ok) { msgEl.style.color = 'var(--bad)'; msgEl.textContent = data.error || 'Failed.'; return; }
         msgEl.style.color = 'var(--good)'; msgEl.textContent = '';
-        var active = document.getElementById('level-boost-active');
-        var end = new Date(data.endTime);
+        const active = document.getElementById('level-boost-active');
+        const end = new Date(data.endTime);
         active.style.display = '';
         active.innerHTML = '⚡ <strong>' + multiplier + '× XP boost active</strong> — expires ' + end.toLocaleString();
-    } catch (e) {
+    } catch {
         msgEl.style.color = 'var(--bad)'; msgEl.textContent = 'Request failed.';
     }
 }
@@ -2118,8 +2118,8 @@ async function startBoostEvent() {
 var rrRoles = boot('roles');
 
 function addRrMapping() {
-    var list = document.getElementById('rr-mappings-list');
-    var row = document.createElement('div');
+    const list = document.getElementById('rr-mappings-list');
+    const row = document.createElement('div');
     row.style.cssText = 'display:grid;grid-template-columns:1fr 2fr auto;gap:.5rem;align-items:center;';
     row.innerHTML =
         '<input type="text" placeholder="Emoji (e.g. 👍)" class="rr-emoji" style="font-size:1.1rem;">' +
@@ -2131,22 +2131,22 @@ function addRrMapping() {
 }
 
 async function publishRrPanel() {
-    var channelId = document.getElementById('rr-channel').value;
+    const channelId = document.getElementById('rr-channel').value;
     if (!channelId) { toast('Select a target channel', 'error'); return; }
 
-    var rows = document.querySelectorAll('#rr-mappings-list > div');
-    var mappings = [];
+    const rows = document.querySelectorAll('#rr-mappings-list > div');
+    const mappings = [];
     rows.forEach(function(row) {
-        var emoji = row.querySelector('.rr-emoji').value.trim();
-        var roleId = row.querySelector('.rr-role').value;
+        const emoji = row.querySelector('.rr-emoji').value.trim();
+        const roleId = row.querySelector('.rr-role').value;
         if (emoji && roleId) mappings.push({ emoji: emoji, roleId: roleId });
     });
 
     if (!mappings.length) { toast('Add at least one emoji → role mapping', 'error'); return; }
 
-    var guildId = BOOT.guildId;
+    const guildId = BOOT.guildId;
     try {
-        var response = await fetch('/api/guild/' + guildId + '/reactionrole/panel', {
+        const response = await fetch('/api/guild/' + guildId + '/reactionrole/panel', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -2156,7 +2156,7 @@ async function publishRrPanel() {
                 mappings: mappings
             })
         });
-        var data = await response.json();
+        const data = await response.json();
         if (response.ok) {
             toast('Panel published', 'success');
             setTimeout(function() { location.reload(); }, 800);
@@ -2172,9 +2172,9 @@ async function publishRrPanel() {
 async function deleteRrPanel(messageId) {
     const ok = await showConfirm({ title: 'Delete reaction role panel', body: 'Delete this panel? The Discord message will also be permanently deleted and all reaction mappings will be removed.', okText: 'Delete panel' });
     if (!ok) return;
-    var guildId = BOOT.guildId;
+    const guildId = BOOT.guildId;
     try {
-        var response = await fetch('/api/guild/' + guildId + '/reactionrole/panel/' + messageId, { method: 'DELETE' });
+        const response = await fetch('/api/guild/' + guildId + '/reactionrole/panel/' + messageId, { method: 'DELETE' });
         if (response.ok) {
             toast('Panel deleted', 'success');
             setTimeout(function() { location.reload(); }, 600);
@@ -2192,19 +2192,19 @@ var kbLoaded = false;
 
 async function loadKnowledgeBase() {
     if (kbLoaded) return;
-    var guildId = BOOT.guildId;
-    var skel = document.getElementById('kb-skeleton');
-    var err  = document.getElementById('kb-error');
+    const guildId = BOOT.guildId;
+    const skel = document.getElementById('kb-skeleton');
+    const err  = document.getElementById('kb-error');
     if (skel) skel.style.display = '';
     if (err)  err.style.display  = 'none';
     try {
-        var resp = await fetch('/api/guild/' + guildId + '/knowledge-base');
+        const resp = await fetch('/api/guild/' + guildId + '/knowledge-base');
         if (!resp.ok) throw new Error('non-ok');
-        var entries = await resp.json();
+        const entries = await resp.json();
         kbLoaded = true;
         if (skel) skel.style.display = 'none';
         renderKbEntries(entries);
-    } catch (e) {
+    } catch {
         if (skel) skel.style.display = 'none';
         if (err)  err.style.display  = '';
     }
@@ -2213,7 +2213,7 @@ async function loadKnowledgeBase() {
 function retryLoadKnowledgeBase() { kbLoaded = false; loadKnowledgeBase(); }
 
 function renderKbEntries(entries) {
-    var container = document.getElementById('kb-list');
+    const container = document.getElementById('kb-list');
     if (!Array.isArray(entries) || !entries.length) {
         container.innerHTML = '<div class="empty-state" style="padding:2rem 1.5rem;"><h3>No entries yet</h3><p>Add your first knowledge base entry below.</p></div>';
         return;
@@ -2225,11 +2225,11 @@ function renderKbEntries(entries) {
 }
 
 function buildKbRow(entry) {
-    var div = document.createElement('div');
+    const div = document.createElement('div');
     div.className = 'list-item';
     div.id = 'kb-row-' + entry._id;
-    var preview = entry.content.length > 120 ? entry.content.slice(0, 120) + '…' : entry.content;
-    var tagsHtml = (entry.tags && entry.tags.length)
+    const preview = entry.content.length > 120 ? entry.content.slice(0, 120) + '…' : entry.content;
+    const tagsHtml = (entry.tags && entry.tags.length)
         ? '<div style="margin-top:.3rem;">' + entry.tags.map(function(t) { return '<span style="background:var(--surface-2);border-radius:4px;padding:1px 6px;font-size:.76rem;margin-right:4px;">' + escHtml(t) + '</span>'; }).join('') + '</div>'
         : '';
     div.innerHTML =
@@ -2246,11 +2246,11 @@ function buildKbRow(entry) {
 }
 
 function editKbEntry(id, encodedTitle, encodedContent, encodedTags) {
-    var row = document.getElementById('kb-row-' + id);
+    const row = document.getElementById('kb-row-' + id);
     if (!row) return;
-    var title = decodeURIComponent(encodedTitle);
-    var content = decodeURIComponent(encodedContent);
-    var tags = decodeURIComponent(encodedTags);
+    const title = decodeURIComponent(encodedTitle);
+    const content = decodeURIComponent(encodedContent);
+    const tags = decodeURIComponent(encodedTags);
     row.innerHTML =
         '<div style="flex:1;display:flex;flex-direction:column;gap:.5rem;">' +
             '<input id="kb-edit-title-' + id + '" class="field-input" value="' + escHtml(title) + '" placeholder="Title" style="width:100%;">' +
@@ -2269,19 +2269,19 @@ function cancelKbEdit() {
 }
 
 async function saveKbEntry(id) {
-    var guildId = BOOT.guildId;
-    var title = document.getElementById('kb-edit-title-' + id).value.trim();
-    var content = document.getElementById('kb-edit-content-' + id).value.trim();
-    var tagsRaw = document.getElementById('kb-edit-tags-' + id).value.trim();
-    var tags = tagsRaw ? tagsRaw.split(',').map(function(t) { return t.trim(); }).filter(Boolean) : [];
+    const guildId = BOOT.guildId;
+    const title = document.getElementById('kb-edit-title-' + id).value.trim();
+    const content = document.getElementById('kb-edit-content-' + id).value.trim();
+    const tagsRaw = document.getElementById('kb-edit-tags-' + id).value.trim();
+    const tags = tagsRaw ? tagsRaw.split(',').map(function(t) { return t.trim(); }).filter(Boolean) : [];
     if (!title || !content) { toast('Title and content are required', 'error'); return; }
     try {
-        var resp = await fetch('/api/guild/' + guildId + '/knowledge-base/' + id, {
+        const resp = await fetch('/api/guild/' + guildId + '/knowledge-base/' + id, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ title: title, content: content, tags: tags })
         });
-        var data = await resp.json();
+        const data = await resp.json();
         if (resp.ok) {
             toast('Entry updated', 'success');
             kbLoaded = false;
@@ -2296,19 +2296,19 @@ async function saveKbEntry(id) {
 }
 
 async function addKbEntry() {
-    var guildId = BOOT.guildId;
-    var title = document.getElementById('kb-title').value.trim();
-    var content = document.getElementById('kb-content').value.trim();
-    var tagsRaw = document.getElementById('kb-tags').value.trim();
-    var tags = tagsRaw ? tagsRaw.split(',').map(function(t) { return t.trim(); }).filter(Boolean) : [];
+    const guildId = BOOT.guildId;
+    const title = document.getElementById('kb-title').value.trim();
+    const content = document.getElementById('kb-content').value.trim();
+    const tagsRaw = document.getElementById('kb-tags').value.trim();
+    const tags = tagsRaw ? tagsRaw.split(',').map(function(t) { return t.trim(); }).filter(Boolean) : [];
     if (!title || !content) { toast('Title and content are required', 'error'); return; }
     try {
-        var resp = await fetch('/api/guild/' + guildId + '/knowledge-base', {
+        const resp = await fetch('/api/guild/' + guildId + '/knowledge-base', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ title: title, content: content, tags: tags })
         });
-        var data = await resp.json();
+        const data = await resp.json();
         if (resp.ok) {
             toast('Entry added', 'success');
             document.getElementById('kb-title').value = '';
@@ -2328,9 +2328,9 @@ async function addKbEntry() {
 async function deleteKbEntry(id) {
     const ok = await showConfirm({ title: 'Delete knowledge base entry', body: 'Remove this entry? The AI will no longer have access to this context.', okText: 'Delete' });
     if (!ok) return;
-    var guildId = BOOT.guildId;
+    const guildId = BOOT.guildId;
     try {
-        var resp = await fetch('/api/guild/' + guildId + '/knowledge-base/' + id, { method: 'DELETE' });
+        const resp = await fetch('/api/guild/' + guildId + '/knowledge-base/' + id, { method: 'DELETE' });
         if (resp.ok) {
             toast('Entry removed', 'success');
             kbLoaded = false;
@@ -2346,14 +2346,14 @@ async function deleteKbEntry(id) {
 
 // KB static button listeners (inline onclick blocked by CSP)
 onPanel('ai', function() {
-    var addBtn = document.getElementById('kb-add-btn');
+    const addBtn = document.getElementById('kb-add-btn');
     if (addBtn) addBtn.addEventListener('click', addKbEntry);
-    var retryBtn = document.getElementById('kb-retry-btn');
+    const retryBtn = document.getElementById('kb-retry-btn');
     if (retryBtn) retryBtn.addEventListener('click', retryLoadKnowledgeBase);
-    var kbList = document.getElementById('kb-list');
+    const kbList = document.getElementById('kb-list');
     if (kbList) {
         kbList.addEventListener('click', function(e) {
-            var t = e.target;
+            const t = e.target;
             if (t.classList.contains('kb-edit-btn')) {
                 editKbEntry(t.dataset.id, t.dataset.title, t.dataset.content, t.dataset.tags);
             } else if (t.classList.contains('kb-delete-btn')) {
@@ -2373,19 +2373,19 @@ var _channelNameMap = boot('channelNames');
 
 async function loadSummaryJobs() {
     if (summaryJobsLoaded) return;
-    var guildId = BOOT.guildId;
-    var skel = document.getElementById('summary-jobs-skeleton');
-    var err  = document.getElementById('summary-jobs-error');
+    const guildId = BOOT.guildId;
+    const skel = document.getElementById('summary-jobs-skeleton');
+    const err  = document.getElementById('summary-jobs-error');
     if (skel) skel.style.display = '';
     if (err)  err.style.display  = 'none';
     try {
-        var resp = await fetch('/api/guild/' + guildId + '/summary-jobs');
+        const resp = await fetch('/api/guild/' + guildId + '/summary-jobs');
         if (!resp.ok) throw new Error('non-ok');
-        var jobs = await resp.json();
+        const jobs = await resp.json();
         summaryJobsLoaded = true;
         if (skel) skel.style.display = 'none';
         renderSummaryJobs(jobs);
-    } catch (e) {
+    } catch {
         if (skel) skel.style.display = 'none';
         if (err)  err.style.display  = '';
     }
@@ -2394,20 +2394,20 @@ async function loadSummaryJobs() {
 function retryLoadSummaryJobs() { summaryJobsLoaded = false; loadSummaryJobs(); }
 
 function renderSummaryJobs(jobs) {
-    var container = document.getElementById('summary-jobs-list');
+    const container = document.getElementById('summary-jobs-list');
     if (!Array.isArray(jobs) || !jobs.length) {
         container.innerHTML = '<div class="empty-state" style="padding:2rem 1.5rem;"><h3>No summary jobs yet</h3><p>Add your first scheduled summary below.</p></div>';
         return;
     }
     container.innerHTML = '';
     jobs.forEach(function(job) {
-        var div = document.createElement('div');
+        const div = document.createElement('div');
         div.className = 'list-item';
-        var hh = String(job.hour).padStart(2, '0');
-        var mm = String(job.minute).padStart(2, '0');
-        var srcName = _channelNameMap[job.sourceChannelId] ? '#' + escHtml(_channelNameMap[job.sourceChannelId]) : escHtml(job.sourceChannelId);
-        var tgtName = _channelNameMap[job.targetChannelId] ? '#' + escHtml(_channelNameMap[job.targetChannelId]) : escHtml(job.targetChannelId);
-        var lastRun = job.lastRun ? new Date(job.lastRun).toLocaleString() : 'Never';
+        const hh = String(job.hour).padStart(2, '0');
+        const mm = String(job.minute).padStart(2, '0');
+        const srcName = _channelNameMap[job.sourceChannelId] ? '#' + escHtml(_channelNameMap[job.sourceChannelId]) : escHtml(job.sourceChannelId);
+        const tgtName = _channelNameMap[job.targetChannelId] ? '#' + escHtml(_channelNameMap[job.targetChannelId]) : escHtml(job.targetChannelId);
+        const lastRun = job.lastRun ? new Date(job.lastRun).toLocaleString() : 'Never';
         div.innerHTML =
             '<div style="min-width:0;flex:1;">' +
                 '<strong>' + escHtml(job.label) + '</strong>' +
@@ -2421,29 +2421,29 @@ function renderSummaryJobs(jobs) {
 }
 
 async function saveDailyDigest() {
-    var guildId = BOOT.guildId;
-    var enabled = document.getElementById('digest-enabled').checked;
-    var channelId = document.getElementById('digest-channel').value;
-    var sourceOpts = Array.from(document.getElementById('digest-sources').selectedOptions).map(o => o.value);
-    var hourRaw = document.getElementById('digest-hour').value.trim();
-    var minuteRaw = document.getElementById('digest-minute').value.trim();
-    var tzInput = document.getElementById('digest-timezone');
-    var timezone = tzInput.value.trim() || 'UTC';
+    const guildId = BOOT.guildId;
+    const enabled = document.getElementById('digest-enabled').checked;
+    const channelId = document.getElementById('digest-channel').value;
+    const sourceOpts = Array.from(document.getElementById('digest-sources').selectedOptions).map(o => o.value);
+    const hourRaw = document.getElementById('digest-hour').value.trim();
+    const minuteRaw = document.getElementById('digest-minute').value.trim();
+    const tzInput = document.getElementById('digest-timezone');
+    const timezone = tzInput.value.trim() || 'UTC';
 
     if (enabled && !channelId) { toast('Please select a digest channel', 'error'); return; }
-    var hour = parseInt(hourRaw, 10);
-    var minute = parseInt(minuteRaw, 10);
+    const hour = parseInt(hourRaw, 10);
+    const minute = parseInt(minuteRaw, 10);
     if (!/^\d+$/.test(hourRaw) || hour < 0 || hour > 23) { toast('Hour must be a number between 0 and 23', 'error'); return; }
     if (!/^\d+$/.test(minuteRaw) || minute < 0 || minute > 59) { toast('Minute must be a number between 0 and 59', 'error'); return; }
     if (!validateTimezoneInput(tzInput)) { toast('Please enter a valid IANA timezone (e.g. UTC, America/New_York)', 'error'); return; }
 
     try {
-        var resp = await fetch('/api/guild/' + guildId + '/daily-digest', {
+        const resp = await fetch('/api/guild/' + guildId + '/daily-digest', {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ enabled, channelId, sourceChannelIds: sourceOpts, hour, minute, timezone })
         });
-        var data = await resp.json();
+        const data = await resp.json();
         if (resp.ok) {
             toast('Daily digest settings saved', 'success');
         } else {
@@ -2456,20 +2456,20 @@ async function saveDailyDigest() {
 }
 
 async function addSummaryJob() {
-    var guildId = BOOT.guildId;
-    var sourceChannelId = document.getElementById('summary-source').value;
-    var targetChannelId = document.getElementById('summary-target').value;
-    var hour = parseInt(document.getElementById('summary-hour').value, 10);
-    var minute = parseInt(document.getElementById('summary-minute').value, 10);
-    var label = document.getElementById('summary-label').value.trim();
+    const guildId = BOOT.guildId;
+    const sourceChannelId = document.getElementById('summary-source').value;
+    const targetChannelId = document.getElementById('summary-target').value;
+    const hour = parseInt(document.getElementById('summary-hour').value, 10);
+    const minute = parseInt(document.getElementById('summary-minute').value, 10);
+    const label = document.getElementById('summary-label').value.trim();
     if (!sourceChannelId || !targetChannelId) { toast('Please select both source and target channels', 'error'); return; }
     try {
-        var resp = await fetch('/api/guild/' + guildId + '/summary-jobs', {
+        const resp = await fetch('/api/guild/' + guildId + '/summary-jobs', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ sourceChannelId: sourceChannelId, targetChannelId: targetChannelId, hour: hour, minute: minute, label: label })
         });
-        var data = await resp.json();
+        const data = await resp.json();
         if (resp.ok) {
             toast('Summary job added', 'success');
             document.getElementById('summary-source').value = '';
@@ -2491,9 +2491,9 @@ async function addSummaryJob() {
 async function deleteSummaryJob(jobId) {
     const ok = await showConfirm({ title: 'Delete summary job', body: 'Remove this scheduled summary job? It will no longer run.', okText: 'Delete' });
     if (!ok) return;
-    var guildId = BOOT.guildId;
+    const guildId = BOOT.guildId;
     try {
-        var resp = await fetch('/api/guild/' + guildId + '/summary-jobs/' + jobId, { method: 'DELETE' });
+        const resp = await fetch('/api/guild/' + guildId + '/summary-jobs/' + jobId, { method: 'DELETE' });
         if (resp.ok) {
             toast('Summary job removed', 'success');
             summaryJobsLoaded = false;
@@ -2511,20 +2511,20 @@ async function deleteSummaryJob(jobId) {
 var _personas = boot('personas');
 
 function updatePersonaChannelWarning() {
-    var aiChannel = document.getElementById('ai-channel');
-    var warning = document.getElementById('persona-channel-warning');
+    const aiChannel = document.getElementById('ai-channel');
+    const warning = document.getElementById('persona-channel-warning');
     if (!aiChannel || !warning) return;
     warning.style.display = aiChannel.value ? '' : 'none';
 }
 
 onPanel('ai', function() {
-    var aiChannel = document.getElementById('ai-channel');
+    const aiChannel = document.getElementById('ai-channel');
     if (aiChannel) aiChannel.addEventListener('change', updatePersonaChannelWarning);
 });
 
 function renderPersonas() {
     updatePersonaChannelWarning();
-    var container = document.getElementById('personas-list');
+    const container = document.getElementById('personas-list');
     if (!container) return;
     if (!_personas.length) {
         container.innerHTML = '<div class="empty-state" style="padding:2rem 1.5rem;"><h3>No personas configured</h3><p>Add a persona below to give the AI a distinct identity in specific channels.</p></div>';
@@ -2532,10 +2532,10 @@ function renderPersonas() {
     }
     container.innerHTML = '';
     _personas.forEach(function(p) {
-        var div = document.createElement('div');
+        const div = document.createElement('div');
         div.className = 'list-item';
-        var chanName = _channelNameMap[p.channelId] ? '#' + escHtml(_channelNameMap[p.channelId]) : escHtml(p.channelId);
-        var preview = p.systemPrompt.length > 120 ? p.systemPrompt.slice(0, 120) + '…' : p.systemPrompt;
+        const chanName = _channelNameMap[p.channelId] ? '#' + escHtml(_channelNameMap[p.channelId]) : escHtml(p.channelId);
+        const preview = p.systemPrompt.length > 120 ? p.systemPrompt.slice(0, 120) + '…' : p.systemPrompt;
         div.innerHTML =
             '<div style="min-width:0;flex:1;">' +
                 '<strong>' + escHtml(p.personaName) + '</strong> <span style="color:var(--text-mute);font-size:.85rem;">(' + chanName + ')</span>' +
@@ -2547,18 +2547,18 @@ function renderPersonas() {
 }
 
 async function addPersona() {
-    var guildId = BOOT.guildId;
-    var channelId = document.getElementById('persona-channel').value;
-    var personaName = document.getElementById('persona-name').value.trim();
-    var systemPrompt = document.getElementById('persona-prompt').value.trim();
+    const guildId = BOOT.guildId;
+    const channelId = document.getElementById('persona-channel').value;
+    const personaName = document.getElementById('persona-name').value.trim();
+    const systemPrompt = document.getElementById('persona-prompt').value.trim();
     if (!channelId || !personaName || !systemPrompt) { toast('All fields are required', 'error'); return; }
     try {
-        var resp = await fetch('/api/guild/' + guildId + '/persona', {
+        const resp = await fetch('/api/guild/' + guildId + '/persona', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ channelId: channelId, personaName: personaName, systemPrompt: systemPrompt })
         });
-        var data = await resp.json();
+        const data = await resp.json();
         if (resp.ok) {
             toast('Persona saved', 'success');
             document.getElementById('persona-channel').value = '';
@@ -2578,9 +2578,9 @@ async function addPersona() {
 async function removePersona(channelId) {
     const ok = await showConfirm({ title: 'Remove persona', body: 'Remove this channel persona? The AI will revert to the default system prompt for this channel.', okText: 'Remove' });
     if (!ok) return;
-    var guildId = BOOT.guildId;
+    const guildId = BOOT.guildId;
     try {
-        var resp = await fetch('/api/guild/' + guildId + '/persona/' + encodeURIComponent(channelId), { method: 'DELETE' });
+        const resp = await fetch('/api/guild/' + guildId + '/persona/' + encodeURIComponent(channelId), { method: 'DELETE' });
         if (resp.ok) {
             toast('Persona removed', 'success');
             _personas = _personas.filter(function(p) { return p.channelId !== channelId; });
@@ -2612,10 +2612,10 @@ function mcpEl(id) { return document.getElementById(id); }
 
 async function loadMcpServers(force) {
     if (_mcpServers && !force) { renderMcpServers(); return; }
-    var guildId = BOOT.guildId;
+    const guildId = BOOT.guildId;
     try {
-        var resp = await fetch('/api/guild/' + guildId + '/mcp-servers');
-        var data = await resp.json();
+        const resp = await fetch('/api/guild/' + guildId + '/mcp-servers');
+        const data = await resp.json();
         if (!resp.ok) throw new Error(data.error || 'Failed to load');
         _mcpServers = data.servers || [];
         _mcpGlobal = data.globalServers || [];
@@ -2626,17 +2626,17 @@ async function loadMcpServers(force) {
         renderMcpServers(data.provider);
     } catch (e) {
         console.error(e);
-        var list = mcpEl('mcp-list');
+        const list = mcpEl('mcp-list');
         if (list) list.innerHTML = '<div class="empty-state" style="padding:1.5rem;"><p>Could not load MCP connections.</p></div>';
     }
 }
 
 function renderMcpPresets() {
-    var select = mcpEl('mcp-preset');
+    const select = mcpEl('mcp-preset');
     if (!select) return;
     select.innerHTML = '<option value="">Custom server…</option>';
     _mcpPresets.forEach(function(preset) {
-        var opt = document.createElement('option');
+        const opt = document.createElement('option');
         opt.value = preset.id;
         opt.textContent = preset.label;
         select.appendChild(opt);
@@ -2652,10 +2652,10 @@ function resetMcpHints() {
 }
 
 function applyMcpPreset() {
-    var select = mcpEl('mcp-preset');
-    var hint = mcpEl('mcp-preset-hint');
-    var tokenHint = mcpEl('mcp-token-hint');
-    var preset = _mcpPresets.find(function(p) { return p.id === select.value; });
+    const select = mcpEl('mcp-preset');
+    const hint = mcpEl('mcp-preset-hint');
+    const tokenHint = mcpEl('mcp-token-hint');
+    const preset = _mcpPresets.find(function(p) { return p.id === select.value; });
     if (!preset) {
         resetMcpHints();
         return;
@@ -2672,27 +2672,27 @@ function applyMcpPreset() {
 }
 
 function renderMcpServers(provider) {
-    var providerWarn = mcpEl('mcp-provider-warning');
+    const providerWarn = mcpEl('mcp-provider-warning');
     if (providerWarn) {
-        var selected = provider || (mcpEl('ai-provider') ? mcpEl('ai-provider').value : null);
+        const selected = provider || (mcpEl('ai-provider') ? mcpEl('ai-provider').value : null);
         providerWarn.style.display = selected && selected !== 'anthropic' ? '' : 'none';
     }
-    var disabledWarn = mcpEl('mcp-disabled-warning');
+    const disabledWarn = mcpEl('mcp-disabled-warning');
     if (disabledWarn) disabledWarn.style.display = _mcpEditable ? 'none' : '';
     updateMcpFormState();
 
-    var container = mcpEl('mcp-list');
+    const container = mcpEl('mcp-list');
     if (!container) return;
     if (!_mcpServers || !_mcpServers.length) {
         container.innerHTML = '<div class="empty-state" style="padding:2rem 1.5rem;"><h3>No connections yet</h3><p>Add one below to let Claude use another service\'s tools during a conversation.</p></div>';
     } else {
         container.innerHTML = '';
         _mcpServers.forEach(function(srv) {
-            var bits = [];
+            const bits = [];
             bits.push(srv.hasToken ? '🔑 token stored' : 'no token');
             if (srv.allowedTools.length) bits.push('only ' + srv.allowedTools.length + ' tool(s)');
             if (srv.blockedTools.length) bits.push(srv.blockedTools.length + ' blocked');
-            var div = document.createElement('div');
+            const div = document.createElement('div');
             div.className = 'list-item';
             div.innerHTML =
                 '<div style="min-width:0;flex:1;">' +
@@ -2711,7 +2711,7 @@ function renderMcpServers(provider) {
         });
     }
 
-    var globalBox = mcpEl('mcp-global-list');
+    const globalBox = mcpEl('mcp-global-list');
     if (globalBox) {
         if (!_mcpGlobal.length) {
             globalBox.innerHTML = '';
@@ -2728,8 +2728,8 @@ function renderMcpServers(provider) {
 // when the guild is already at its cap. Editing an existing connection
 // stays available in the cap case — it does not add another one.
 function updateMcpFormState() {
-    var atCap = !_mcpEditing && (_mcpServers || []).length >= _mcpMaxServers;
-    var locked = !_mcpEditable || atCap;
+    const atCap = !_mcpEditing && (_mcpServers || []).length >= _mcpMaxServers;
+    const locked = !_mcpEditable || atCap;
 
     ['mcp-preset', 'mcp-url', 'mcp-token', 'mcp-allowed', 'mcp-blocked', 'mcp-enabled', 'mcp-save-btn'].forEach(function(id) {
         if (mcpEl(id)) mcpEl(id).disabled = locked;
@@ -2737,7 +2737,7 @@ function updateMcpFormState() {
     // The name is fixed while editing — the API keys the record on it.
     if (mcpEl('mcp-name')) mcpEl('mcp-name').disabled = locked || Boolean(_mcpEditing);
 
-    var capWarn = mcpEl('mcp-cap-warning');
+    const capWarn = mcpEl('mcp-cap-warning');
     if (capWarn) {
         capWarn.style.display = _mcpEditable && atCap ? '' : 'none';
         capWarn.textContent = '⚠️ This server is at the limit of ' + _mcpMaxServers +
@@ -2765,7 +2765,7 @@ function resetMcpForm() {
 }
 
 function editMcpServer(name) {
-    var srv = (_mcpServers || []).find(function(s) { return s.name === name; });
+    const srv = (_mcpServers || []).find(function(s) { return s.name === name; });
     if (!srv) return;
     _mcpEditing = name;
     mcpEl('mcp-preset').value = '';
@@ -2785,12 +2785,12 @@ function editMcpServer(name) {
 }
 
 async function saveMcpServer() {
-    var guildId = BOOT.guildId;
-    var name = (_mcpEditing || mcpEl('mcp-name').value).trim();
-    var url = mcpEl('mcp-url').value.trim();
+    const guildId = BOOT.guildId;
+    const name = (_mcpEditing || mcpEl('mcp-name').value).trim();
+    const url = mcpEl('mcp-url').value.trim();
     if (!name || !url) { toast('Name and URL are required', 'error'); return; }
 
-    var body = {
+    const body = {
         url: url,
         enabled: mcpEl('mcp-enabled').checked,
         allowedTools: splitToolNames(mcpEl('mcp-allowed').value),
@@ -2799,16 +2799,16 @@ async function saveMcpServer() {
     // Only send the token when one was typed — an absent field means
     // "keep whatever is stored", which is how editing without
     // re-entering the secret works.
-    var token = mcpEl('mcp-token').value;
+    const token = mcpEl('mcp-token').value;
     if (token) body.authorizationToken = token;
 
     try {
-        var resp = await fetch('/api/guild/' + guildId + '/mcp-servers/' + encodeURIComponent(name), {
+        const resp = await fetch('/api/guild/' + guildId + '/mcp-servers/' + encodeURIComponent(name), {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(body)
         });
-        var data = await resp.json();
+        const data = await resp.json();
         if (!resp.ok) { toast(data.error || 'Failed to save connection', 'error'); return; }
         toast('Connection saved', 'success');
         _mcpServers = data.servers || [];
@@ -2827,10 +2827,10 @@ async function removeMcpServer(name) {
         okText: 'Remove'
     });
     if (!ok) return;
-    var guildId = BOOT.guildId;
+    const guildId = BOOT.guildId;
     try {
-        var resp = await fetch('/api/guild/' + guildId + '/mcp-servers/' + encodeURIComponent(name), { method: 'DELETE' });
-        var data = await resp.json();
+        const resp = await fetch('/api/guild/' + guildId + '/mcp-servers/' + encodeURIComponent(name), { method: 'DELETE' });
+        const data = await resp.json();
         if (!resp.ok) { toast(data.error || 'Failed to remove', 'error'); return; }
         toast('Connection removed', 'success');
         _mcpServers = data.servers || [];
@@ -2846,13 +2846,13 @@ async function removeMcpServer(name) {
 // built from the server name — a name is operator-supplied text and does
 // not survive round-tripping through an id selector.
 async function testMcpServer(name, out) {
-    var guildId = BOOT.guildId;
+    const guildId = BOOT.guildId;
     if (out) { out.className = 'mcp-test-result'; out.textContent = 'Testing…'; }
     try {
-        var resp = await fetch('/api/guild/' + guildId + '/mcp-servers/' + encodeURIComponent(name) + '/test', { method: 'POST' });
-        var data = await resp.json();
+        const resp = await fetch('/api/guild/' + guildId + '/mcp-servers/' + encodeURIComponent(name) + '/test', { method: 'POST' });
+        const data = await resp.json();
         if (!out) return;
-        var okay = resp.ok && data.success;
+        const okay = resp.ok && data.success;
         out.className = 'mcp-test-result ' + (okay ? 'ok' : 'bad');
         out.textContent = (okay ? '✓ ' : '✗ ') + (data.message || data.error || (okay ? 'Connected' : 'Failed'));
     } catch (e) {
@@ -2863,11 +2863,11 @@ async function testMcpServer(name, out) {
 
 // ── Prompt editor: char counter + full-screen modal ─────────────────
 function updatePromptCount(textareaId) {
-    var ta = document.getElementById(textareaId);
-    var counter = document.getElementById(textareaId + '-count');
+    const ta = document.getElementById(textareaId);
+    const counter = document.getElementById(textareaId + '-count');
     if (!ta || !counter) return;
-    var max = parseInt(ta.getAttribute('maxlength'), 10) || 4000;
-    var len = ta.value.length;
+    const max = parseInt(ta.getAttribute('maxlength'), 10) || 4000;
+    const len = ta.value.length;
     counter.textContent = len + ' / ' + max;
     counter.classList.toggle('over', len >= max);
 }
@@ -2883,11 +2883,11 @@ function _promptEditorKeydown(e) {
     }
 }
 function openPromptEditor(textareaId, title) {
-    var ta = document.getElementById(textareaId);
+    const ta = document.getElementById(textareaId);
     if (!ta) return;
     _promptEditorTarget = textareaId;
     document.getElementById('prompt-editor-title').textContent = title || 'Edit prompt';
-    var editor = document.getElementById('prompt-editor-textarea');
+    const editor = document.getElementById('prompt-editor-textarea');
     editor.value = ta.value;
     editor.setAttribute('maxlength', ta.getAttribute('maxlength') || 4000);
     document.getElementById('prompt-editor-modal').style.display = 'flex';
@@ -2896,17 +2896,17 @@ function openPromptEditor(textareaId, title) {
     setTimeout(function() { editor.focus(); }, 50);
 }
 function updatePromptEditorCount() {
-    var editor = document.getElementById('prompt-editor-textarea');
-    var counter = document.getElementById('prompt-editor-count');
-    var max = parseInt(editor.getAttribute('maxlength'), 10) || 4000;
-    var len = editor.value.length;
+    const editor = document.getElementById('prompt-editor-textarea');
+    const counter = document.getElementById('prompt-editor-count');
+    const max = parseInt(editor.getAttribute('maxlength'), 10) || 4000;
+    const len = editor.value.length;
     counter.textContent = len + ' / ' + max;
     counter.classList.toggle('over', len >= max);
 }
 function closePromptEditor(commit) {
-    var modal = document.getElementById('prompt-editor-modal');
+    const modal = document.getElementById('prompt-editor-modal');
     if (commit && _promptEditorTarget) {
-        var ta = document.getElementById(_promptEditorTarget);
+        const ta = document.getElementById(_promptEditorTarget);
         if (ta) {
             ta.value = document.getElementById('prompt-editor-textarea').value;
             updatePromptCount(_promptEditorTarget);
@@ -2932,27 +2932,26 @@ function formatTokens(n) {
 function formatCost(n, costKnown) {
     if (n == null) return '';
     if (!costKnown && n === 0) return 'cost unavailable';
-    var prefix = costKnown ? '' : '≥ ';
+    const prefix = costKnown ? '' : '≥ ';
     if (n < 0.01 && n > 0) return prefix + '< $0.01';
     return prefix + '$' + n.toFixed(2);
 }
 function renderSparkline(daily) {
-    var svg = document.getElementById('ai-usage-sparkline');
+    const svg = document.getElementById('ai-usage-sparkline');
     if (!svg) return;
-    var W = 280, H = 60, pad = 4;
-    var values = daily.map(function(d) { return d.inputTokens + d.outputTokens; });
-    var max = Math.max.apply(null, values.concat([1]));
+    const W = 280, H = 60, pad = 4;
+    const values = daily.map(function(d) { return d.inputTokens + d.outputTokens; });
+    let max = Math.max.apply(null, values.concat([1]));
     if (max <= 0) max = 1;
-    var n = values.length;
-    var stepX = (W - pad * 2) / Math.max(1, n - 1);
+    const n = values.length;
     // Build bars instead of a line — easier to read for small token counts
-    var barW = Math.max(2, (W - pad * 2) / n - 2);
-    var bars = '';
-    for (var i = 0; i < n; i++) {
-        var v = values[i];
-        var h = max > 0 ? (v / max) * (H - pad * 2) : 0;
-        var x = pad + i * ((W - pad * 2) / n);
-        var y = H - pad - h;
+    const barW = Math.max(2, (W - pad * 2) / n - 2);
+    let bars = '';
+    for (let i = 0; i < n; i++) {
+        const v = values[i];
+        const h = max > 0 ? (v / max) * (H - pad * 2) : 0;
+        const x = pad + i * ((W - pad * 2) / n);
+        const y = H - pad - h;
         bars += '<rect x="' + x.toFixed(1) + '" y="' + y.toFixed(1) +
                 '" width="' + barW.toFixed(1) + '" height="' + h.toFixed(1) +
                 '" fill="currentColor" opacity="' + (v > 0 ? 0.7 : 0.2) + '">' +
@@ -2962,14 +2961,14 @@ function renderSparkline(daily) {
     svg.style.color = 'var(--accent, #7aa7ff)';
 }
 function renderUsageBreakdown(byModel) {
-    var el = document.getElementById('ai-usage-breakdown');
+    const el = document.getElementById('ai-usage-breakdown');
     if (!el) return;
     if (!byModel.length) { el.innerHTML = ''; return; }
-    var rows = byModel
+    const rows = byModel
         .sort(function(a, b) { return (b.inputTokens + b.outputTokens) - (a.inputTokens + a.outputTokens); })
         .map(function(m) {
-            var total = m.inputTokens + m.outputTokens;
-            var costStr = m.costKnown ? '$' + (m.cost || 0).toFixed(4) : '—';
+            const total = m.inputTokens + m.outputTokens;
+            const costStr = m.costKnown ? '$' + (m.cost || 0).toFixed(4) : '—';
             return '<tr>' +
                 '<td>' + escHtml(m.provider) + '</td>' +
                 '<td>' + escHtml(m.model) + '</td>' +
@@ -2988,12 +2987,12 @@ function renderUsageBreakdown(byModel) {
         '</tr></thead><tbody>' + rows + '</tbody></table>';
 }
 async function loadAiUsage() {
-    var guildId = BOOT.guildId;
-    var statusEl = document.getElementById('ai-usage-status');
+    const guildId = BOOT.guildId;
+    const statusEl = document.getElementById('ai-usage-status');
     try {
-        var resp = await fetch('/api/guild/' + guildId + '/ai/usage?days=14');
+        const resp = await fetch('/api/guild/' + guildId + '/ai/usage?days=14');
         if (!resp.ok) throw new Error('HTTP ' + resp.status);
-        var data = await resp.json();
+        const data = await resp.json();
         document.getElementById('ai-usage-today-tokens').textContent = formatTokens(data.today.tokens);
         document.getElementById('ai-usage-week-tokens').textContent  = formatTokens(data.week.tokens);
         document.getElementById('ai-usage-month-tokens').textContent = formatTokens(data.month.tokens);
@@ -3003,11 +3002,11 @@ async function loadAiUsage() {
         renderSparkline(data.daily || []);
         renderUsageBreakdown(data.byModel || []);
 
-        var rl = data.rateLimit || {};
-        var rlParts = [];
+        const rl = data.rateLimit || {};
+        const rlParts = [];
         if (rl.perUser)    rlParts.push(rl.perUser + '/user');
         if (rl.perChannel) rlParts.push(rl.perChannel + '/channel');
-        var rlStr = rlParts.length
+        const rlStr = rlParts.length
             ? 'Limit: ' + rlParts.join(', ') + ' per ' + (rl.windowMin || 10) + 'm'
             : 'No rate limit set';
         statusEl.textContent = rlStr;
@@ -3022,8 +3021,8 @@ async function loadAiUsage() {
 // routing, and initial page load without coupling to the nav implementation.
 onPanel('ai', function(aiPanel) {
     if (!aiPanel) return;
-    var loaded = false;
-    var inFlight = false;
+    let loaded = false;
+    let inFlight = false;
     function check() {
         if (loaded || inFlight) return;
         if (!aiPanel.classList.contains('active')) return;
@@ -3034,7 +3033,7 @@ onPanel('ai', function(aiPanel) {
             .finally(function() { inFlight = false; });
     }
     check();
-    var obs = new MutationObserver(check);
+    const obs = new MutationObserver(check);
     obs.observe(aiPanel, { attributes: true, attributeFilter: ['class'] });
 });
 
@@ -3292,7 +3291,7 @@ async function loadOverviewStats() {
                 </div>`
             ).join('');
         }
-    } catch (err) {
+    } catch {
         const msgEl = document.getElementById('clawdia-msg');
         if (msgEl) msgEl.innerHTML = `Open <a href="#" onclick="document.querySelector('.nav-item[data-tab=analytics]').click();return false">Analytics</a> to review server health.`;
         const actionsEl = document.getElementById('clawdia-actions');
@@ -3419,7 +3418,7 @@ function renderAnalyticsCharts(data, insights) {
 
     // Helper: remove any stale "no data" placeholder from a chart card container
     function clearChartPlaceholder(container) {
-        var p = container.querySelector('p.chart-no-data');
+        const p = container.querySelector('p.chart-no-data');
         if (p) p.remove();
     }
 
@@ -3581,7 +3580,7 @@ async function loadAnalytics() {
                 recCont.insertAdjacentHTML('beforeend', `<div class="analytics-rec-card"><span>💡 ${rec}</span>${linkHtml}</div>`);
             }
         }
-    } catch (error) {
+    } catch {
         document.getElementById('analytics-skeleton').style.display = 'none';
         document.getElementById('analytics-error').style.display = '';
     }

--- a/src/dashboard/public/styles.css
+++ b/src/dashboard/public/styles.css
@@ -822,10 +822,21 @@ textarea { resize: vertical; min-height: 80px; }
 }
 .skip-link:focus { transform: translateY(0); }
 
-/* The skip link and the nav both move focus here programmatically. It is
-   tabindex="-1", so it is never a tab stop of its own and never needs a ring —
-   :focus-visible does not match a programmatic focus. */
-.dash-main:focus { outline: none; }
+/* The skip link and the nav both move focus here programmatically, so this is
+   where a keyboard user lands and it has to show that it did — an unmarked jump
+   is as disorienting as no jump. The ring is drawn inset so it frames the
+   content rather than the viewport edge.
+
+   Only for :focus-visible, which browsers match when the focus move followed
+   keyboard interaction. Clicking a nav item also focuses this element (the
+   button takes focus on mousedown), and outlining the whole main column on
+   every mouse click would be noise. */
+.dash-main:focus-visible {
+    outline: 2px solid var(--claw-500);
+    outline-offset: -3px;
+    border-radius: 8px;
+}
+.dash-main:focus:not(:focus-visible) { outline: none; }
 
 @media (max-width: 860px) {
     .settings-layout { grid-template-columns: 1fr; }

--- a/src/dashboard/public/styles.css
+++ b/src/dashboard/public/styles.css
@@ -747,15 +747,25 @@ textarea { resize: vertical; min-height: 80px; }
     white-space: nowrap;
 }
 
+/* The dashboard's only feedback channel. Success and failure used to differ by
+   nothing but a 0.4-alpha border tint, which WCAG 1.4.1 rules out and which
+   almost nobody could see either way. The icon below is the signal now; the
+   colour on the icon and the accent bar reinforces it rather than carrying it
+   alone. See the toast helper in guild-settings.js (#659). */
 .toast {
     position: fixed;
     right: 1.5rem;
     bottom: 1.5rem;
     z-index: 100;
-    padding: 0.9rem 1.2rem;
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    max-width: min(30rem, calc(100vw - 3rem));
+    padding: 0.9rem 0.9rem 0.9rem 1.1rem;
     border-radius: 12px;
     background: rgba(20, 18, 16, 0.95);
     border: 1px solid var(--border-strong);
+    border-left: 4px solid var(--border-strong);
     color: var(--text);
     font-size: 0.92rem;
     backdrop-filter: blur(14px);
@@ -765,9 +775,57 @@ textarea { resize: vertical; min-height: 80px; }
     transition: opacity .25s ease, transform .25s ease;
     pointer-events: none;
 }
-.toast.show { opacity: 1; transform: translateY(0); }
-.toast.error { border-color: rgba(248,113,113,0.4); }
-.toast.success { border-color: rgba(52,211,153,0.4); }
+/* Only reachable once it is on screen — otherwise the dismiss button would sit
+   invisible in the corner swallowing clicks meant for the page behind it. */
+.toast.show { opacity: 1; transform: translateY(0); pointer-events: auto; }
+.toast-icon { flex-shrink: 0; font-size: 1.05rem; line-height: 1; }
+.toast-icon:empty { display: none; }
+.toast-message { flex: 1; min-width: 0; }
+.toast-close {
+    flex-shrink: 0;
+    padding: 0.2rem 0.4rem;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text-dim);
+    font: inherit;
+    line-height: 1;
+    cursor: pointer;
+    transition: background .15s ease, color .15s ease;
+}
+.toast-close:hover { background: rgba(255,255,255,0.09); color: var(--text); }
+.toast-close:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.toast.error { border-color: rgba(248,113,113,0.4); border-left-color: #f87171; }
+.toast.error .toast-icon { color: #f87171; }
+.toast.success { border-color: rgba(52,211,153,0.4); border-left-color: #34d399; }
+.toast.success .toast-icon { color: #34d399; }
+.toast.info { border-color: rgba(147,197,253,0.4); border-left-color: #93c5fd; }
+.toast.info .toast-icon { color: #93c5fd; }
+
+/* Skip link: off screen until it takes focus, then the first thing on the page.
+   The sidebar is 25 items long, so without it a keyboard user walks the whole
+   nav before reaching the settings they opened (#660). */
+.skip-link {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 200;
+    transform: translateY(-120%);
+    padding: 0.7rem 1.1rem;
+    border-radius: 0 0 10px 0;
+    background: var(--claw-500, #f97316);
+    color: #fff;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform .15s ease;
+}
+.skip-link:focus { transform: translateY(0); }
+
+/* The skip link and the nav both move focus here programmatically. It is
+   tabindex="-1", so it is never a tab stop of its own and never needs a ring —
+   :focus-visible does not match a programmatic focus. */
+.dash-main:focus { outline: none; }
 
 @media (max-width: 860px) {
     .settings-layout { grid-template-columns: 1fr; }
@@ -1270,11 +1328,15 @@ textarea.auto-resize {
 .dash-server-name span { font-size: 11.5px; color: var(--ink-400); }
 .dash-nav-label { font-family: 'JetBrains Mono', monospace; font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--ink-500); margin: 18px 8px 8px; }
 .dash-nav { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 1px; }
-.dash-nav li { display: flex; align-items: center; gap: 10px; padding: 9px 12px; border-radius: 10px; font-size: 14px; color: var(--ink-200); cursor: pointer; border: none; background: transparent; width: 100%; text-align: left; font-family: inherit; transition: background .12s, color .12s; }
-.dash-nav li:hover { background: var(--ink-850); color: var(--cream-50); }
-.dash-nav li.active { background: var(--claw-500); color: #fff; }
-.dash-nav li.active .badge { background: rgba(255,255,255,.2); color: #fff; }
-.dash-nav li svg { flex-shrink: 0; color: inherit; }
+/* The <li> is a plain wrapper; the button inside it is what is styled, focused
+   and clicked. Keeping the list item intact is the point — the old markup put
+   role="button" on the <li> itself, which took `listitem` away from it (#660). */
+.dash-nav li { display: block; }
+.dash-nav .nav-item { display: flex; align-items: center; gap: 10px; padding: 9px 12px; border-radius: 10px; font-size: 14px; color: var(--ink-200); cursor: pointer; border: none; background: transparent; width: 100%; text-align: left; font-family: inherit; transition: background .12s, color .12s; }
+.dash-nav .nav-item:hover { background: var(--ink-850); color: var(--cream-50); }
+.dash-nav .nav-item.active { background: var(--claw-500); color: #fff; }
+.dash-nav .nav-item.active .badge { background: rgba(255,255,255,.2); color: #fff; }
+.dash-nav .nav-item svg { flex-shrink: 0; color: inherit; }
 .dash-nav .nav-emoji { font-size: 15px; width: 17px; display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0; }
 .dash-nav .badge { margin-left: auto; background: var(--ink-800); color: var(--ink-300); font-size: 10.5px; padding: 2px 7px; border-radius: 999px; font-family: 'JetBrains Mono', monospace; }
 .dash-side-footer { margin-top: auto; padding-top: 18px; border-top: 1px solid var(--ink-800); }
@@ -1360,7 +1422,7 @@ textarea.auto-resize {
 .dash-bot-btn:hover { background: rgba(0,0,0,.4); }
 
 /* Nav item keyboard focus */
-.dash-nav li:focus-visible { outline: 2px solid var(--claw-500); outline-offset: 2px; border-radius: 10px; }
+.dash-nav .nav-item:focus-visible { outline: 2px solid var(--claw-500); outline-offset: 2px; border-radius: 10px; }
 
 /* Sidebar search */
 .dash-nav-search-wrap { position: relative; margin-bottom: 14px; }

--- a/src/dashboard/routes/api/itemImages.js
+++ b/src/dashboard/routes/api/itemImages.js
@@ -102,7 +102,7 @@ router.get('/item-image/activity/:itemId', async (req, res) => {
 router.post('/item-image/activity/:itemId', checkAuth, checkAnyGuildAdmin, checkWriteRateLimit, uploadImage, async (req, res) => {
     if (!req.file) return res.status(400).json({ error: 'No image file provided' });
     const { itemId } = req.params;
-    if (!/^[a-z0-9_:\-]{1,64}$/.test(itemId)) return res.status(400).json({ error: 'Invalid itemId' });
+    if (!/^[a-z0-9_:-]{1,64}$/.test(itemId)) return res.status(400).json({ error: 'Invalid itemId' });
     // M4: Verify file contents match a known image signature.
     const detectedType = detectImageType(req.file.buffer);
     if (!detectedType) return res.status(400).json({ error: 'Invalid image file: unrecognized format' });

--- a/src/dashboard/routes/api/stats.js
+++ b/src/dashboard/routes/api/stats.js
@@ -42,7 +42,7 @@ router.get('/guild/:guildId/stats', checkAuth, checkGuildAccess, async (req, res
         const memberEvents = analytics?.memberEvents || [];
         const commandUsage = analytics?.commandUsage || [];
 
-        const { joins7, leaves7, joins30, leaves30, retained7, retained30 } = computeRetention(memberEvents);
+        const { joins30, leaves30, retained7, retained30 } = computeRetention(memberEvents);
 
         const commandSummary = {};
         const failedByReason = {};

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -216,7 +216,7 @@ function start(client) {
         res.render('index', { user: req.user });
     });
 
-    app.use((err, req, res, next) => {
+    app.use((err, req, res, _next) => {
         console.error('[DASHBOARD] Unhandled error:', err);
         res.status(500).json({ error: 'Internal server error' });
     });

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -175,7 +175,7 @@
     <div class="toast" id="toast" role="status" aria-live="polite" aria-atomic="true">
         <span class="toast-icon" id="toast-icon" aria-hidden="true"></span>
         <span class="toast-message" id="toast-message"></span>
-        <button type="button" class="toast-close" id="toast-close" aria-label="Dismiss message">✕</button>
+        <button type="button" class="toast-close" id="toast-close" aria-label="Dismiss message" hidden>✕</button>
     </div>
 
     <!-- Generic confirm modal -->

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -11,6 +11,10 @@
     <script src="<%= asset('/esc-html.js') %>"></script>
 </head>
 <body style="background:var(--ink-950);margin:0;">
+<%# First tab stop on the page. The sidebar is 25 items long and is rebuilt on
+    every panel visit, so without this a keyboard user walks all of it to reach
+    the settings they just opened. Visible only while focused. %>
+<a class="skip-link" href="#dash-main-content">Skip to main content</a>
 <div class="dash">
 
     <!-- ── SIDEBAR ───────────────────────────────────────────── -->
@@ -45,6 +49,11 @@
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M8 9l4-4 4 4M8 15l4 4 4-4"/></svg>
         </a>
 
+        <%# A landmark, so a screen reader can jump to the section list — and
+            can skip past it — instead of walking the sidebar from the top.
+            The search filters this list, so it lives inside the landmark. %>
+        <nav class="dash-side-nav" aria-label="Dashboard sections">
+
         <!-- Sidebar search -->
         <div class="dash-nav-search-wrap">
             <svg class="dash-nav-search-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
@@ -53,64 +62,66 @@
         <div id="sidebar-no-results" role="status" aria-live="polite" aria-atomic="true" aria-hidden="true" style="display:none;font-size:.8rem;color:var(--ink-500);padding:6px 8px;">No sections match</div>
 
         <!-- Configure -->
-        <div class="dash-nav-label">// Configure</div>
-        <ul class="dash-nav">
-            <li class="nav-item active" data-tab="overview" data-keywords="stats kpis dashboard home"><span class="nav-emoji" aria-hidden="true">📊</span><span>Overview</span></li>
-            <li class="nav-item" data-tab="welcome" data-keywords="join greet card dm autorole message"><span class="nav-emoji" aria-hidden="true">👋</span><span>Welcome</span></li>
-            <li class="nav-item" data-tab="farewell" data-keywords="leave goodbye departure"><span class="nav-emoji" aria-hidden="true">🚪</span><span>Farewell</span></li>
-            <li class="nav-item" data-tab="leveling" data-keywords="xp level rank points progression"><span class="nav-emoji" aria-hidden="true">📈</span><span>Leveling</span></li>
-            <li class="nav-item" data-tab="economy" data-keywords="coins currency shop store jobs work daily"><span class="nav-emoji" aria-hidden="true">💰</span><span>Economy</span></li>
-            <li class="nav-item" data-tab="birthdays" data-keywords="birthday celebration age"><span class="nav-emoji">🎂</span><span>Birthdays</span></li>
+        <div class="dash-nav-label" id="nav-group-configure">// Configure</div>
+        <ul class="dash-nav" aria-labelledby="nav-group-configure">
+            <li><button type="button" class="nav-item active" data-tab="overview" data-keywords="stats kpis dashboard home" aria-current="page"><span class="nav-emoji" aria-hidden="true">📊</span><span>Overview</span></button></li>
+            <li><button type="button" class="nav-item" data-tab="welcome" data-keywords="join greet card dm autorole message"><span class="nav-emoji" aria-hidden="true">👋</span><span>Welcome</span></button></li>
+            <li><button type="button" class="nav-item" data-tab="farewell" data-keywords="leave goodbye departure"><span class="nav-emoji" aria-hidden="true">🚪</span><span>Farewell</span></button></li>
+            <li><button type="button" class="nav-item" data-tab="leveling" data-keywords="xp level rank points progression"><span class="nav-emoji" aria-hidden="true">📈</span><span>Leveling</span></button></li>
+            <li><button type="button" class="nav-item" data-tab="economy" data-keywords="coins currency shop store jobs work daily"><span class="nav-emoji" aria-hidden="true">💰</span><span>Economy</span></button></li>
+            <li><button type="button" class="nav-item" data-tab="birthdays" data-keywords="birthday celebration age"><span class="nav-emoji" aria-hidden="true">🎂</span><span>Birthdays</span></button></li>
         </ul>
 
         <!-- Moderation -->
-        <div class="dash-nav-label">// Moderation</div>
-        <ul class="dash-nav">
-            <li class="nav-item" data-tab="moderation" data-keywords="ban kick mute warn automod spam filter profanity caps"><span class="nav-emoji" aria-hidden="true">🛡️</span><span>Moderation</span></li>
-            <li class="nav-item" data-tab="raiddetection" data-keywords="raid bot attack lockdown"><span class="nav-emoji">🚨</span><span>Raid Detection</span></li>
-            <li class="nav-item" data-tab="antinuke" data-keywords="nuke protect security whitelist threshold"><span class="nav-emoji" aria-hidden="true">🔒</span><span>Anti-Nuke</span></li>
+        <div class="dash-nav-label" id="nav-group-moderation">// Moderation</div>
+        <ul class="dash-nav" aria-labelledby="nav-group-moderation">
+            <li><button type="button" class="nav-item" data-tab="moderation" data-keywords="ban kick mute warn automod spam filter profanity caps"><span class="nav-emoji" aria-hidden="true">🛡️</span><span>Moderation</span></button></li>
+            <li><button type="button" class="nav-item" data-tab="raiddetection" data-keywords="raid bot attack lockdown"><span class="nav-emoji" aria-hidden="true">🚨</span><span>Raid Detection</span></button></li>
+            <li><button type="button" class="nav-item" data-tab="antinuke" data-keywords="nuke protect security whitelist threshold"><span class="nav-emoji" aria-hidden="true">🔒</span><span>Anti-Nuke</span></button></li>
         </ul>
 
         <!-- Progression -->
-        <div class="dash-nav-label">// Progression</div>
-        <ul class="dash-nav">
-            <li class="nav-item" data-tab="achievements" data-keywords="badge milestone unlock reward"><span class="nav-emoji">🏅</span><span>Achievements</span></li>
-            <li class="nav-item" data-tab="quests" data-keywords="task challenge daily weekly mission"><span class="nav-emoji">🗺️</span><span>Quests</span></li>
-            <li class="nav-item" data-tab="exploration" data-keywords="explore expedition region map secret treasure relic wilds"><span class="nav-emoji">🥾</span><span>Exploration</span></li>
-            <li class="nav-item" data-tab="season" data-keywords="seasonal pass battle tier"><span class="nav-emoji">🏆</span><span>Season Pass</span></li>
-            <li class="nav-item" data-tab="progressiontracks" data-keywords="track creator helper raider bonus xp multiplier"><span class="nav-emoji">🧭</span><span>Progression Tracks</span></li>
+        <div class="dash-nav-label" id="nav-group-progression">// Progression</div>
+        <ul class="dash-nav" aria-labelledby="nav-group-progression">
+            <li><button type="button" class="nav-item" data-tab="achievements" data-keywords="badge milestone unlock reward"><span class="nav-emoji" aria-hidden="true">🏅</span><span>Achievements</span></button></li>
+            <li><button type="button" class="nav-item" data-tab="quests" data-keywords="task challenge daily weekly mission"><span class="nav-emoji" aria-hidden="true">🗺️</span><span>Quests</span></button></li>
+            <li><button type="button" class="nav-item" data-tab="exploration" data-keywords="explore expedition region map secret treasure relic wilds"><span class="nav-emoji" aria-hidden="true">🥾</span><span>Exploration</span></button></li>
+            <li><button type="button" class="nav-item" data-tab="season" data-keywords="seasonal pass battle tier"><span class="nav-emoji" aria-hidden="true">🏆</span><span>Season Pass</span></button></li>
+            <li><button type="button" class="nav-item" data-tab="progressiontracks" data-keywords="track creator helper raider bonus xp multiplier"><span class="nav-emoji" aria-hidden="true">🧭</span><span>Progression Tracks</span></button></li>
         </ul>
 
         <!-- Community -->
-        <div class="dash-nav-label">// Community</div>
-        <ul class="dash-nav">
-            <li class="nav-item" data-tab="starboard" data-keywords="star highlight pin featured"><span class="nav-emoji">⭐</span><span>Starboard</span></li>
-            <li class="nav-item" data-tab="suggestions" data-keywords="ideas feedback vote upvote downvote approve staff anonymous"><span class="nav-emoji">💡</span><span>Suggestions</span></li>
-            <li class="nav-item" data-tab="reactionroles" data-keywords="self assign emoji role react"><span class="nav-emoji">🎭</span><span>Reaction Roles</span></li>
+        <div class="dash-nav-label" id="nav-group-community">// Community</div>
+        <ul class="dash-nav" aria-labelledby="nav-group-community">
+            <li><button type="button" class="nav-item" data-tab="starboard" data-keywords="star highlight pin featured"><span class="nav-emoji" aria-hidden="true">⭐</span><span>Starboard</span></button></li>
+            <li><button type="button" class="nav-item" data-tab="suggestions" data-keywords="ideas feedback vote upvote downvote approve staff anonymous"><span class="nav-emoji" aria-hidden="true">💡</span><span>Suggestions</span></button></li>
+            <li><button type="button" class="nav-item" data-tab="reactionroles" data-keywords="self assign emoji role react"><span class="nav-emoji" aria-hidden="true">🎭</span><span>Reaction Roles</span></button></li>
         </ul>
 
         <!-- Tools -->
-        <div class="dash-nav-label">// Tools</div>
-        <ul class="dash-nav">
-            <li class="nav-item" data-tab="commandpolicies" data-keywords="permissions restrict cooldown command disable"><span class="nav-emoji" aria-hidden="true">⚙️</span><span>Command Policies</span></li>
-            <li class="nav-item" data-tab="ai" data-keywords="chatbot gpt openai knowledge persona summary"><span class="nav-emoji" aria-hidden="true">🤖</span><span>AI Chat</span></li>
-            <li class="nav-item" data-tab="tempvoice" data-keywords="voice channel temporary dynamic create"><span class="nav-emoji">🔊</span><span>Temp Voice</span></li>
+        <div class="dash-nav-label" id="nav-group-tools">// Tools</div>
+        <ul class="dash-nav" aria-labelledby="nav-group-tools">
+            <li><button type="button" class="nav-item" data-tab="commandpolicies" data-keywords="permissions restrict cooldown command disable"><span class="nav-emoji" aria-hidden="true">⚙️</span><span>Command Policies</span></button></li>
+            <li><button type="button" class="nav-item" data-tab="ai" data-keywords="chatbot gpt openai knowledge persona summary"><span class="nav-emoji" aria-hidden="true">🤖</span><span>AI Chat</span></button></li>
+            <li><button type="button" class="nav-item" data-tab="tempvoice" data-keywords="voice channel temporary dynamic create"><span class="nav-emoji" aria-hidden="true">🔊</span><span>Temp Voice</span></button></li>
         </ul>
 
         <!-- Feeds & Automation -->
-        <div class="dash-nav-label">// Feeds &amp; Automation</div>
-        <ul class="dash-nav">
-            <li class="nav-item" data-tab="newspaper" data-keywords="news daily digest article ai"><span class="nav-emoji">📰</span><span>Newspaper</span></li>
-            <li class="nav-item" data-tab="bibleverses" data-keywords="bible verse scripture daily scripture"><span class="nav-emoji">📖</span><span>Bible Verses</span></li>
-            <li class="nav-item" data-tab="rss" data-keywords="feed rss atom url news blog"><span class="nav-emoji" aria-hidden="true">📡</span><span>RSS Feeds</span></li>
+        <div class="dash-nav-label" id="nav-group-feeds">// Feeds &amp; Automation</div>
+        <ul class="dash-nav" aria-labelledby="nav-group-feeds">
+            <li><button type="button" class="nav-item" data-tab="newspaper" data-keywords="news daily digest article ai"><span class="nav-emoji" aria-hidden="true">📰</span><span>Newspaper</span></button></li>
+            <li><button type="button" class="nav-item" data-tab="bibleverses" data-keywords="bible verse scripture daily scripture"><span class="nav-emoji" aria-hidden="true">📖</span><span>Bible Verses</span></button></li>
+            <li><button type="button" class="nav-item" data-tab="rss" data-keywords="feed rss atom url news blog"><span class="nav-emoji" aria-hidden="true">📡</span><span>RSS Feeds</span></button></li>
         </ul>
 
         <!-- Insights -->
-        <div class="dash-nav-label">// Insights</div>
-        <ul class="dash-nav">
-            <li class="nav-item" data-tab="analytics" data-keywords="stats graphs reports activity commands usage"><span class="nav-emoji" aria-hidden="true">📊</span><span>Analytics</span></li>
-            <li class="nav-item" data-tab="eventlog" data-keywords="log audit events voice messages members server"><span class="nav-emoji">📋</span><span>Event Log</span></li>
+        <div class="dash-nav-label" id="nav-group-insights">// Insights</div>
+        <ul class="dash-nav" aria-labelledby="nav-group-insights">
+            <li><button type="button" class="nav-item" data-tab="analytics" data-keywords="stats graphs reports activity commands usage"><span class="nav-emoji" aria-hidden="true">📊</span><span>Analytics</span></button></li>
+            <li><button type="button" class="nav-item" data-tab="eventlog" data-keywords="log audit events voice messages members server"><span class="nav-emoji" aria-hidden="true">📋</span><span>Event Log</span></button></li>
         </ul>
+
+        </nav><!-- /.dash-side-nav -->
 
         <!-- User footer -->
         <div class="dash-side-footer">
@@ -130,7 +141,7 @@
     </aside><!-- /.dash-side -->
 
     <!-- ── MAIN ──────────────────────────────────────────────── -->
-    <main class="dash-main">
+    <main class="dash-main" id="dash-main-content" tabindex="-1">
 
         <!-- Top bar -->
         <div class="dash-topbar">
@@ -154,7 +165,18 @@
 
 </div><!-- /.dash -->
 
-    <div class="toast" id="toast"></div>
+    <%# Every save, delete and failure in the dashboard reports through this
+        one element, so it has to be announced: without a live region a screen
+        reader user gets no confirmation that anything happened at all. The
+        icon and the "Error"/"Saved" prefix guild-settings.js writes are what
+        carry the outcome — the border colour alone did, which WCAG 1.4.1
+        rules out. `polite` rather than `assertive`: these follow an action
+        the reader just took, so they do not need to cut in. %>
+    <div class="toast" id="toast" role="status" aria-live="polite" aria-atomic="true">
+        <span class="toast-icon" id="toast-icon" aria-hidden="true"></span>
+        <span class="toast-message" id="toast-message"></span>
+        <button type="button" class="toast-close" id="toast-close" aria-label="Dismiss message">✕</button>
+    </div>
 
     <!-- Generic confirm modal -->
     <div id="confirm-modal" class="modal-overlay" style="display:none;" aria-modal="true" aria-hidden="true" role="dialog" onclick="if(event.target===this)_confirmResolve(false)">

--- a/src/data/defaultShopItems.js
+++ b/src/data/defaultShopItems.js
@@ -118,7 +118,6 @@ function ensureDefaultShopItems(guildSettings) {
             guildSettings.shop.push({ ...item, roleId: null, stock: -1, imageUrl: '' });
             existingIds.add(id);
             existingNames.add(item.name.toLowerCase());
-            changed = true;
         }
         guildSettings.shopDefaultsSeeded = true;
         return true;

--- a/src/events/channelCreate.js
+++ b/src/events/channelCreate.js
@@ -4,7 +4,7 @@ const { trackAction } = require('../services/antiNukeService');
 
 module.exports = {
     name: 'channelCreate',
-    async execute(channel, client) {
+    async execute(channel, _client) {
         if (!channel.guild) return;
 
         await trackAction(channel.guild, 'channelCreate', AuditLogEvent.ChannelCreate, channel.id).catch(console.error);

--- a/src/events/channelDelete.js
+++ b/src/events/channelDelete.js
@@ -4,7 +4,7 @@ const { trackAction } = require('../services/antiNukeService');
 
 module.exports = {
     name: 'channelDelete',
-    async execute(channel, client) {
+    async execute(channel, _client) {
         if (!channel.guild) return;
 
         await trackAction(channel.guild, 'channelDelete', AuditLogEvent.ChannelDelete, channel.id).catch(console.error);

--- a/src/events/guildCreate.js
+++ b/src/events/guildCreate.js
@@ -3,7 +3,7 @@ const { ensureDefaultShopItems } = require('../data/defaultShopItems');
 
 module.exports = {
     name: 'guildCreate',
-    async execute(guild, client) {
+    async execute(guild, _client) {
         console.log(`[GUILD] Joined new guild: ${guild.name} (${guild.id})`);
 
         try {

--- a/src/events/guildMemberRemove.js
+++ b/src/events/guildMemberRemove.js
@@ -34,7 +34,7 @@ function applyVariables(template, member) {
 
 module.exports = {
     name: 'guildMemberRemove',
-    async execute(member, client) {
+    async execute(member, _client) {
         try {
             // Detect kick via audit log; bans fire guildBanAdd separately.
             await trackAction(member.guild, 'kick', AuditLogEvent.MemberKick, member.id).catch(console.error);

--- a/src/events/guildMemberUpdate.js
+++ b/src/events/guildMemberUpdate.js
@@ -1,9 +1,9 @@
-const { EmbedBuilder, AuditLogEvent, PermissionFlagsBits } = require('discord.js');
+const { EmbedBuilder, PermissionFlagsBits } = require('discord.js');
 const Guild = require('../models/Guild');
 
 module.exports = {
     name: 'guildMemberUpdate',
-    async execute(oldMember, newMember, client) {
+    async execute(oldMember, newMember, _client) {
         const guildSettings = await Guild.findOne({ guildId: newMember.guild.id });
         if (!guildSettings?.eventLog?.enabled || !guildSettings.eventLog.logRoleChanges) return;
 

--- a/src/events/messageDelete.js
+++ b/src/events/messageDelete.js
@@ -3,7 +3,7 @@ const Guild = require('../models/Guild');
 
 module.exports = {
     name: 'messageDelete',
-    async execute(message, client) {
+    async execute(message, _client) {
         if (message.author?.bot || !message.guild) return;
 
         const guildSettings = await Guild.findOne({ guildId: message.guild.id });

--- a/src/events/messageReactionAdd.js
+++ b/src/events/messageReactionAdd.js
@@ -31,7 +31,7 @@ module.exports = {
 
 async function handleReactionQuests(reaction, discordUser, guild, guildSettings) {
     if (!guildSettings?.quests?.enabled) return;
-    let userDoc = await User.findOneAndUpdate(
+    const userDoc = await User.findOneAndUpdate(
         { userId: discordUser.id, guildId: guild.id },
         { $setOnInsert: { userId: discordUser.id, guildId: guild.id } },
         { upsert: true, new: true }

--- a/src/events/messageReactionRemove.js
+++ b/src/events/messageReactionRemove.js
@@ -2,7 +2,7 @@ const Guild = require('../models/Guild');
 
 module.exports = {
     name: 'messageReactionRemove',
-    async execute(reaction, user, client) {
+    async execute(reaction, user, _client) {
         if (user.bot) return;
 
         if (reaction.partial) {

--- a/src/events/messageUpdate.js
+++ b/src/events/messageUpdate.js
@@ -3,7 +3,7 @@ const Guild = require('../models/Guild');
 
 module.exports = {
     name: 'messageUpdate',
-    async execute(oldMessage, newMessage, client) {
+    async execute(oldMessage, newMessage, _client) {
         if (newMessage.author?.bot || !newMessage.guild) return;
         if (oldMessage.content === newMessage.content) return;
 

--- a/src/games/casino/blackjack.js
+++ b/src/games/casino/blackjack.js
@@ -130,7 +130,7 @@ function buildButtons(gameId, disabled = false, opts = {}) {
     return [row1];
 }
 
-function buildDealerRevealEmbed(interaction, dealerHand, playerHand, splitHands, currency, bet) {
+function buildDealerRevealEmbed(interaction, dealerHand, playerHand, splitHands, _currency, _bet) {
     const dealerStr = displayHand(dealerHand);
     const dealerVal = handTotal(dealerHand);
 

--- a/src/games/casino/crash.js
+++ b/src/games/casino/crash.js
@@ -120,7 +120,7 @@ async function updateCrashStats(userId, guildId, multiplier, username) {
     }
 }
 
-async function buildWeeklyLeaderboard(guildId, client) {
+async function buildWeeklyLeaderboard(guildId, _client) {
     const weekStart = getCurrentWeekStart();
 
     const topUsers = await User.find({
@@ -218,7 +218,7 @@ function liveMultiEmbed(multiplier, bet, playerLines) {
 
 // ── Final result embed ───────────────────────────────────────────────────────
 
-async function buildFinalEmbed(crashPoint, bet, players, client, guildId) {
+async function buildFinalEmbed(crashPoint, bet, players, client, _guildId) {
     const crashLabel = multLabel(crashPoint);
     const lines = [];
     for (const [uid, state] of players.entries()) {
@@ -388,7 +388,7 @@ async function openLobby(interaction, bet, hostAutoCashout, releaseLock, onWager
         await updateLobbyEmbed();
     });
 
-    joinCollector.on('end', async (_, reason) => {
+    joinCollector.on('end', async (_, _reason) => {
         if (lobby.locked) return;
         lobby.locked = true;
 

--- a/src/games/casino/cupgame.js
+++ b/src/games/casino/cupgame.js
@@ -58,7 +58,6 @@ async function playMonte(interaction, bet, round = 1, releaseLock, onWager) {
     // Only debit on round 1 — subsequent rounds reuse the same session bet
     if (round === 1) {
         try {
-            const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
             debited = await placeWager(userFilter, bet, { onWager });
 
             if (!debited) {

--- a/src/games/casino/keno.js
+++ b/src/games/casino/keno.js
@@ -73,7 +73,7 @@ function nearMissCount(picked, drawn) {
     return picked.filter(p => drawn.some(d => Math.abs(d - p) <= 2 && !drawn.includes(p))).length;
 }
 
-function phaseTitle(hits, total) {
+function phaseTitle(hits, _total) {
     if (hits === 0) return '🎱 Drawing… no hits yet';
     if (hits === 1) return '🎱 One match!';
     if (hits === 2) return '🎱 Two matches!';

--- a/src/games/casino/poker.js
+++ b/src/games/casino/poker.js
@@ -189,7 +189,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
 
         // Dealer acts pre-flop before player sees their choice
         const dealerPreAction = dealerPreFlopAction(dealerCategory);
-        let dealerRaised = dealerPreAction === 'raise';
+        const dealerRaised = dealerPreAction === 'raise';
 
         // If dealer folds pre-flop (very weak hand), player wins immediately
         if (dealerPreAction === 'fold') {

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ require('./config/fileSecrets').loadFileSecrets();
 
 const health = require('./health');
 const { makeCache, sweepers } = require('./utils/cacheOptions');
-const { isPrimaryShard, shardTag, shardCount } = require('./utils/sharding');
+const { isPrimaryShard, shardTag } = require('./utils/sharding');
 const { loadCommandModules } = require('./utils/commandLoader');
 
 // Validate required environment variables before doing anything else.

--- a/src/services/antiNukeService.js
+++ b/src/services/antiNukeService.js
@@ -127,7 +127,7 @@ async function punish(member, settings, action, count) {
     }
 }
 
-async function trackAction(guild, action, auditType, targetId, client) {
+async function trackAction(guild, action, auditType, targetId, _client) {
     let settings;
     try {
         settings = await Guild.findOne({ guildId: guild.id });

--- a/src/services/chatEventService.js
+++ b/src/services/chatEventService.js
@@ -158,7 +158,7 @@ async function spawnAirdrop(message, guildSettings) {
 
 // ── Supply crate (item drop) ─────────────────────────────────────────────────
 
-async function spawnCrate(message, guildSettings) {
+async function spawnCrate(message, _guildSettings) {
     const item    = weightedPick(CRATE_ITEMS);
     const claimId = `chatev_crate_${message.id}`;
 

--- a/src/services/dmService.js
+++ b/src/services/dmService.js
@@ -415,7 +415,7 @@ async function postOrUpdateStatCard(channel, session) {
     );
 }
 
-async function handleDmButton(interaction, client) {
+async function handleDmButton(interaction, _client) {
     if (!interaction.customId.startsWith('dm_storysofar_')) return false;
 
     const sessionId = interaction.customId.slice('dm_storysofar_'.length);

--- a/src/services/escalationService.js
+++ b/src/services/escalationService.js
@@ -46,8 +46,8 @@ async function applyEscalation({ guild, targetUser, warningCount, triggeringCase
     const reason = formatReason(step.reason, warningCount);
     const botUser = client.user;
     const member = await guild.members.fetch(targetUser.id).catch(() => null);
-    let actionTaken = step.action;
-    let durationMs = step.durationMinutes ? step.durationMinutes * 60 * 1000 : null;
+    const actionTaken = step.action;
+    const durationMs = step.durationMinutes ? step.durationMinutes * 60 * 1000 : null;
 
     if (step.dmUser) {
         const actionPast = ACTION_PAST_TENSE[step.action] || step.action;

--- a/src/services/fishService.js
+++ b/src/services/fishService.js
@@ -1,11 +1,9 @@
 'use strict';
 
 const {
-    ROD_TIERS,
     ROD_BY_TIER,
     ROD_UPGRADES,
     LOCATIONS,
-    FISH,
     FISH_BY_TIER,
     JUNK_ITEMS,
     TREASURE_ITEMS,
@@ -1007,7 +1005,7 @@ function resolveBossEncounter(user, fish, tier, choicesMade, bossType) {
     const correctCount = phaseResults.filter(p => p.correct).length;
     const lineSnapped  = lineIntegrity <= 0;
 
-    let bonusPayout = 0, durabilityLost = 0, outcome = '';
+    let bonusPayout = 0, durabilityLost = 0, outcome;
 
     if (lineSnapped || correctCount === 0) {
         outcome = 'escaped';

--- a/src/services/huntService.js
+++ b/src/services/huntService.js
@@ -5,7 +5,6 @@ const {
     WEAPON_BY_TIER,
     WEAPON_UPGRADES,
     ZONES,
-    ANIMALS,
     ANIMALS_BY_TIER,
     HUNTER_LEVELS,
     LIMITS,
@@ -1453,7 +1452,7 @@ function resolveApexEncounter(user, animal, tier, choicesMade, apexType, weaponI
     // four outcomes stay ordered against each other on any single encounter.
     const basePayout = apexBasePayout(animal, options.killPayout);
 
-    let bonusPayout = 0, durabilityLost = 0, outcome = '';
+    let bonusPayout = 0, durabilityLost = 0, outcome;
 
     if (broken || correctCount === 0) {
         outcome = 'escaped';

--- a/src/services/mineService.js
+++ b/src/services/mineService.js
@@ -1,11 +1,9 @@
 'use strict';
 
 const {
-    PICKAXE_TIERS,
     PICKAXE_BY_TIER,
     PICKAXE_UPGRADES,
     DEPTHS,
-    ORES,
     ORES_BY_TIER,
     MINER_LEVELS,
     LIMITS,

--- a/src/services/newspaperService.js
+++ b/src/services/newspaperService.js
@@ -7,8 +7,6 @@ const GrindProfile = require('../models/GrindProfile');
 const { getCompletion, resolveProviderConfig } = require('./aiService');
 const { topByNetWorth } = require('../utils/netWorth');
 
-const DAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-
 async function collectStats(guildId, sections) {
     const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
     const data = {};
@@ -169,7 +167,7 @@ async function generateNewspaper(client, guildDoc, preloadedGuild, requester) {
     // Use AI if configured
     if (guildDoc.ai?.enabled) {
         try {
-            const { provider, model, temperature, maxTokens, apiKey, baseUrl, mcpServers, rateLimit } = resolveProviderConfig(guildDoc.ai);
+            const { provider, model, apiKey, baseUrl, mcpServers, rateLimit } = resolveProviderConfig(guildDoc.ai);
             if (apiKey || provider === 'ollama') {
                 const quoteInstruction = includeQuote
                     ? 'End with a witty "Quote of the Week" that you invent yourself based on the server activity.'

--- a/src/services/questService.js
+++ b/src/services/questService.js
@@ -1,5 +1,3 @@
-const User = require('../models/User');
-const Guild = require('../models/Guild');
 const { getStreakMultiplier } = require('../utils/streakMultiplier');
 
 // difficulty → reward multiplier

--- a/src/services/raidService.js
+++ b/src/services/raidService.js
@@ -42,7 +42,7 @@ async function applyRaidAction(member, rd, minAccountAgeDays) {
     }
 }
 
-async function handleMemberJoin(member, client) {
+async function handleMemberJoin(member, _client) {
     const guildId = member.guild.id;
 
     let guildSettings;

--- a/src/services/rssService.js
+++ b/src/services/rssService.js
@@ -17,7 +17,7 @@ const parser = new Parser();
 async function parseFeedUrl(url) {
     return parser.parseString(await safeFetchFeed(url));
 }
-let dailyNewsJobs = new Map();
+const dailyNewsJobs = new Map();
 const runtimeTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
 // Consecutive failure counts per feed URL. Feeds are skipped after DEAD_FEED_THRESHOLD failures,
@@ -140,7 +140,7 @@ function normalizeArticleLink(link = '') {
 
 
 async function fetchSendableChannel(client, channelId) {
-    let channel = null;
+    let channel;
 
     try {
         channel = await client.channels.fetch(channelId);

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -233,7 +233,7 @@ async function resolveOneSeason(client, guildDoc) {
             ?? null;
     } catch {}
 
-    let resolvedNames = {};
+    const resolvedNames = {};
     if (seasonDiscordGuild) {
         for (const u of topUsers.slice(0, 3)) {
             const member = await seasonDiscordGuild.members.fetch(u.userId).catch(() => null);
@@ -356,8 +356,15 @@ async function awardWeeklyLeaderboardBadges(client) {
             const leased = await Guild.findOneAndUpdate(
                 {
                     guildId,
-                    $or: [{ badgesLastAwardedAt: null }, { badgesLastAwardedAt: { $lte: weekAgo } }],
-                    $or: [{ badgesAwardLeaseAt: null }, { badgesAwardLeaseAt: { $lte: new Date() } }],
+                    // Both conditions, under $and. They were two `$or` keys in
+                    // one object literal, so the second silently replaced the
+                    // first and only the lease was ever checked: the weekly
+                    // cadence was not enforced at all, and badges could be
+                    // re-awarded as soon as a five-minute lease lapsed.
+                    $and: [
+                        { $or: [{ badgesLastAwardedAt: null }, { badgesLastAwardedAt: { $lte: weekAgo } }] },
+                        { $or: [{ badgesAwardLeaseAt: null }, { badgesAwardLeaseAt: { $lte: new Date() } }] },
+                    ],
                 },
                 { $set: { badgesAwardLeaseAt: leaseUntil } },
                 { new: false }

--- a/src/services/summaryService.js
+++ b/src/services/summaryService.js
@@ -103,7 +103,7 @@ async function runDailyDigest(guildSettings, client) {
         ? digest.sourceChannelIds
         : guild.channels.cache.filter(c => c.isTextBased()).map(c => c.id);
 
-    let lines = [];
+    const lines = [];
     for (const channelId of sourceIds) {
         const channel = guild.channels.cache.get(channelId)
             || await guild.channels.fetch(channelId).catch(() => null);

--- a/src/services/tempVoiceService.js
+++ b/src/services/tempVoiceService.js
@@ -1,7 +1,7 @@
 const { ChannelType, PermissionFlagsBits } = require('discord.js');
 const Guild = require('../models/Guild');
 
-async function handleVoiceStateUpdate(oldState, newState, client) {
+async function handleVoiceStateUpdate(oldState, newState, _client) {
     const guild = newState.guild ?? oldState.guild;
     if (!guild) return;
 

--- a/src/services/tournamentService.js
+++ b/src/services/tournamentService.js
@@ -133,7 +133,7 @@ async function endTournament(tournamentId) {
 /**
  * Build the live leaderboard embed.
  */
-function buildLeaderboardEmbed(tournament, client) {
+function buildLeaderboardEmbed(tournament, _client) {
     const sorted   = getSortedEntries(tournament);
     const now      = new Date();
     const msLeft   = Math.max(0, tournament.endsAt - now);

--- a/src/services/weatherService.js
+++ b/src/services/weatherService.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { WEATHER_LIST, WEATHER_TYPES } = require('../data/fishData');
+const { WEATHER_TYPES } = require('../data/fishData');
 
 // ─── GLOBAL WEATHER STATE ─────────────────────────────────────────────────────
 // Shared across all guilds; rotates on a timer.

--- a/src/utils/commandLoader.js
+++ b/src/utils/commandLoader.js
@@ -98,6 +98,14 @@ function loadCommandModules(foldersPath = COMMANDS_ROOT) {
             continue;
         }
 
+        // The folder a command lives in is its category, and it is the only
+        // record of that: `client.commands` is keyed by name, so by the time
+        // /help reads the collection the directory walk is long gone. Stamping
+        // it here keeps the category derived from disk rather than from a
+        // hand-maintained list that drifts (#665). Modules are singletons in
+        // the require cache, so this is idempotent across repeat loads.
+        command.category = entry.dir;
+
         commands.push({ entry, command });
     }
 

--- a/src/utils/helpCatalog.js
+++ b/src/utils/helpCatalog.js
@@ -1,0 +1,107 @@
+'use strict';
+
+// The command catalog /help renders.
+//
+// This used to be a hand-maintained literal inside help.js, and it had drifted:
+// 37 of 98 commands were missing from it, and it advertised four casino games
+// that had been removed a release earlier (#665). Nothing kept the two in step,
+// and nothing could — a parallel list of every command is a list that is wrong
+// the moment someone adds a file.
+//
+// So the catalog is derived instead, from the collection the process is running:
+// the name and description come from each command's own SlashCommandBuilder, and
+// the category from the folder it was loaded out of (stamped by commandLoader).
+// A new command file is in /help as soon as it is in `client.commands`, with no
+// second place to update.
+
+// How each category is presented, and the order the categories appear in. This
+// is the only hand-written part, and it is presentation only: a folder missing
+// from here still shows up, under a generated label. Adding an entry changes how
+// a category looks, never which commands are in it.
+const CATEGORY_META = new Map([
+    ['economy',    { emoji: '📦',  label: 'Economy' }],
+    ['moderation', { emoji: '🛡️', label: 'Moderation' }],
+    ['leveling',   { emoji: '⭐',  label: 'Leveling' }],
+    ['fun',        { emoji: '🎮',  label: 'Fun' }],
+    ['utility',    { emoji: '🔧',  label: 'Utility' }],
+    ['ai',         { emoji: '🤖',  label: 'AI' }],
+    ['community',  { emoji: '👥',  label: 'Community' }],
+    ['admin',      { emoji: '⚙️',  label: 'Admin' }],
+]);
+
+const FALLBACK_META = { emoji: '📁' };
+
+// Things a reader can use that are not slash commands, so they have no command
+// file to be discovered from. Only added to a category that already has
+// commands, so removing the AI commands does not leave a category behind.
+const EXTRA_ENTRIES = new Map([
+    ['ai', [{ name: '@Clawdia', description: 'Mention or ping the bot to start an AI conversation', mention: true }]],
+]);
+
+// Commands named in the category preview line before it is elided.
+const PREVIEW_COMMANDS = 4;
+
+// Discord rejects a select option whose description runs past this.
+const SELECT_DESCRIPTION_LIMIT = 100;
+
+function labelFor(id) {
+    return id.charAt(0).toUpperCase() + id.slice(1);
+}
+
+function truncate(text, limit) {
+    return text.length <= limit ? text : `${text.slice(0, limit - 1).trimEnd()}…`;
+}
+
+/**
+ * Build the category list /help renders.
+ *
+ * @param {Iterable<object>} commands loaded command modules — `client.commands.values()`
+ *   at runtime. Each needs a `data.name`; `data.description` and `category` are
+ *   used when present.
+ * @returns {Array<{id: string, emoji: string, label: string, preview: string,
+ *   summary: string, commands: Array<{name: string, description: string, mention?: boolean}>}>}
+ *   Categories in CATEGORY_META order, then any unrecognised folder alphabetically.
+ *   Empty when nothing was loaded — callers have to cope, because a select menu
+ *   with no options is a Discord error rather than an empty menu.
+ */
+function buildCategories(commands) {
+    const byCategory = new Map();
+
+    for (const command of commands || []) {
+        const name = command?.data?.name;
+        if (!name) continue;
+        const id = command.category || 'other';
+        if (!byCategory.has(id)) byCategory.set(id, []);
+        byCategory.get(id).push({
+            name,
+            description: command.data.description || 'No description provided',
+        });
+    }
+
+    for (const [id, extras] of EXTRA_ENTRIES) {
+        if (byCategory.has(id)) byCategory.get(id).push(...extras.map(entry => ({ ...entry })));
+    }
+
+    const known = [...CATEGORY_META.keys()].filter(id => byCategory.has(id));
+    const unknown = [...byCategory.keys()].filter(id => !CATEGORY_META.has(id)).sort();
+
+    return [...known, ...unknown].map(id => {
+        const meta = CATEGORY_META.get(id) || { ...FALLBACK_META, label: labelFor(id) };
+        const entries = byCategory.get(id).sort((a, b) => a.name.localeCompare(b.name));
+        const names = entries.map(entry => entry.name);
+        const preview = names.length > PREVIEW_COMMANDS
+            ? `${names.slice(0, PREVIEW_COMMANDS).join(', ')}, …`
+            : names.join(', ');
+
+        return {
+            id,
+            emoji: meta.emoji,
+            label: meta.label,
+            preview,
+            summary: truncate(`${entries.length} commands: ${preview}`, SELECT_DESCRIPTION_LIMIT),
+            commands: entries,
+        };
+    });
+}
+
+module.exports = { buildCategories, CATEGORY_META, SELECT_DESCRIPTION_LIMIT };

--- a/tests/analytics.test.js
+++ b/tests/analytics.test.js
@@ -72,7 +72,6 @@ jest.mock('express', () => {
 });
 
 const { computeRetention } = require('../src/dashboard/routes/api');
-const Guild = require('../src/models/Guild');
 const guildMemberAdd = require('../src/events/guildMemberAdd');
 const guildMemberRemove = require('../src/events/guildMemberRemove');
 const interactionCreate = require('../src/events/interactionCreate');

--- a/tests/dashboardAccessibility.test.js
+++ b/tests/dashboardAccessibility.test.js
@@ -163,9 +163,28 @@ describe('toast', () => {
 
         const close = document.getElementById('toast-close');
         expect(close.getAttribute('aria-label')).toBeTruthy();
+        expect(close.hidden).toBe(false);
         close.dispatchEvent(new window.Event('click', { bubbles: true }));
 
         expect(toastEl().classList.contains('show')).toBe(false);
+    });
+
+    // The toast is faded out rather than display:none, so its button would
+    // otherwise be a tab stop on every page that dismisses nothing.
+    it('keeps the dismiss button out of the tab order with nothing to dismiss', () => {
+        expect(document.getElementById('toast-close').hidden).toBe(true);
+
+        window.toast('Settings saved', 'success');
+        expect(document.getElementById('toast-close').hidden).toBe(false);
+
+        jest.useFakeTimers();
+        try {
+            window.toast('Settings saved', 'success');
+            jest.advanceTimersByTime(2800);
+            expect(document.getElementById('toast-close').hidden).toBe(true);
+        } finally {
+            jest.useRealTimers();
+        }
     });
 
     it('leaves an error up longer than a success', () => {

--- a/tests/dashboardAccessibility.test.js
+++ b/tests/dashboardAccessibility.test.js
@@ -1,0 +1,192 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"customExportConditions": ["node"]}
+ */
+process.env.SUPPRESS_JEST_WARNINGS = 'true';
+
+// jsdom omits a few Node globals that mongoose's driver reaches for on require.
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = global.TextEncoder || TextEncoder;
+global.TextDecoder = global.TextDecoder || TextDecoder;
+
+// #660 and #659. The sidebar used to be 25 <li> elements that the script gave
+// role="button" and a tabindex at runtime — which took `listitem` off the list,
+// left the nav inert without JS, and reported the selected section with
+// aria-pressed. The toast, the dashboard's only feedback channel, was not a
+// live region and told success from failure by border colour alone.
+const { bootPage, clickTab, settle, forgetDocumentListeners } = require('./helpers/guildSettingsPage');
+
+describe('sidebar navigation', () => {
+    beforeEach(() => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        document.body.innerHTML = '';
+        bootPage();
+    });
+
+    afterEach(async () => {
+        await settle();
+        forgetDocumentListeners();
+        jest.restoreAllMocks();
+    });
+
+    it('is a navigation landmark with a name of its own', () => {
+        const nav = document.querySelector('nav.dash-side-nav');
+        expect(nav).not.toBeNull();
+        expect(nav.getAttribute('aria-label')).toBeTruthy();
+        expect(nav.querySelectorAll('.nav-item').length).toBe(document.querySelectorAll('.nav-item').length);
+    });
+
+    it('keeps every list a list of list items', () => {
+        for (const list of document.querySelectorAll('ul.dash-nav')) {
+            expect([...list.children].map(el => el.tagName)).toEqual([...list.children].map(() => 'LI'));
+            expect(list.getAttribute('aria-labelledby')).toBeTruthy();
+            expect(document.getElementById(list.getAttribute('aria-labelledby'))).not.toBeNull();
+        }
+    });
+
+    it('ships focusable buttons rather than dressing list items up at runtime', () => {
+        const items = [...document.querySelectorAll('.nav-item')];
+        expect(items.length).toBeGreaterThan(0);
+
+        for (const item of items) {
+            expect([item.dataset.tab, item.tagName]).toEqual([item.dataset.tab, 'BUTTON']);
+            expect(item.getAttribute('type')).toBe('button');
+            expect(item.parentElement.tagName).toBe('LI');
+            // The runtime ARIA the script used to inject, and must not any more.
+            expect(item.getAttribute('role')).toBeNull();
+            expect(item.getAttribute('tabindex')).toBeNull();
+            expect(item.getAttribute('aria-pressed')).toBeNull();
+        }
+    });
+
+    it('reports the open section with aria-current, and moves it on navigation', async () => {
+        const current = () => [...document.querySelectorAll('.nav-item[aria-current="page"]')].map(i => i.dataset.tab);
+        expect(current()).toEqual(['overview']);
+
+        clickTab('economy');
+        await settle();
+
+        expect(current()).toEqual(['economy']);
+        expect(document.querySelector('.nav-item[data-tab="economy"]').classList.contains('active')).toBe(true);
+    });
+
+    it('offers a skip link as the first focusable thing on the page', () => {
+        const focusable = document.querySelectorAll('a[href], button, input, select, textarea');
+        const skip = document.querySelector('.skip-link');
+
+        expect(skip).not.toBeNull();
+        expect(focusable[0]).toBe(skip);
+
+        const target = document.getElementById(skip.getAttribute('href').slice(1));
+        expect(target).not.toBeNull();
+        expect(target.tagName).toBe('MAIN');
+        // -1 so it can take focus without becoming a tab stop of its own.
+        expect(target.getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('lands keyboard focus in the section a nav item opened', async () => {
+        const item = document.querySelector('.nav-item[data-tab="leveling"]');
+        item.focus();
+        item.dispatchEvent(new window.Event('click', { bubbles: true }));
+        await settle();
+
+        expect(document.activeElement).toBe(document.getElementById('dash-main-content'));
+    });
+
+    it('still filters the sidebar, hiding the list item and not just the button', () => {
+        const search = document.getElementById('sidebar-search');
+        search.value = 'starboard';
+        search.dispatchEvent(new window.Event('input', { bubbles: true }));
+
+        const visible = [...document.querySelectorAll('.nav-item')]
+            .filter(item => item.closest('li').style.display !== 'none')
+            .map(item => item.dataset.tab);
+        expect(visible).toEqual(['starboard']);
+        expect(document.getElementById('sidebar-no-results').style.display).toBe('none');
+
+        search.value = '';
+        search.dispatchEvent(new window.Event('input', { bubbles: true }));
+        expect([...document.querySelectorAll('.dash-nav li')].every(li => li.style.display === '')).toBe(true);
+    });
+
+    it('reports no matches through a live region', () => {
+        const search = document.getElementById('sidebar-search');
+        search.value = 'nothing matches this';
+        search.dispatchEvent(new window.Event('input', { bubbles: true }));
+
+        const noResults = document.getElementById('sidebar-no-results');
+        expect(noResults.style.display).toBe('');
+        expect(noResults.getAttribute('aria-live')).toBe('polite');
+    });
+});
+
+describe('toast', () => {
+    beforeEach(() => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        document.body.innerHTML = '';
+        bootPage();
+    });
+
+    afterEach(async () => {
+        await settle();
+        forgetDocumentListeners();
+        jest.restoreAllMocks();
+    });
+
+    const toastEl = () => document.getElementById('toast');
+
+    it('is a polite live region, so a save is announced at all', () => {
+        expect(toastEl().getAttribute('role')).toBe('status');
+        expect(toastEl().getAttribute('aria-live')).toBe('polite');
+        expect(toastEl().getAttribute('aria-atomic')).toBe('true');
+    });
+
+    it('says which outcome it is in text, not only in the border colour', () => {
+        window.toast('Settings saved', 'success');
+        const saved = toastEl().textContent;
+        expect(saved).toContain('Success');
+        expect(saved).toContain('Settings saved');
+        expect(document.getElementById('toast-icon').textContent).toBe('✓');
+
+        window.toast('Settings saved', 'error');
+        const failed = toastEl().textContent;
+        expect(failed).toContain('Error');
+        expect(document.getElementById('toast-icon').textContent).toBe('⚠');
+
+        // The point of the issue: the two must differ with the classes ignored.
+        expect(failed).not.toBe(saved);
+    });
+
+    it('can be dismissed instead of only timing out', () => {
+        window.toast('Settings saved', 'success');
+        expect(toastEl().classList.contains('show')).toBe(true);
+
+        const close = document.getElementById('toast-close');
+        expect(close.getAttribute('aria-label')).toBeTruthy();
+        close.dispatchEvent(new window.Event('click', { bubbles: true }));
+
+        expect(toastEl().classList.contains('show')).toBe(false);
+    });
+
+    it('leaves an error up longer than a success', () => {
+        jest.useFakeTimers();
+        try {
+            window.toast('Failed to save settings', 'error');
+            jest.advanceTimersByTime(2800);
+            expect(toastEl().classList.contains('show')).toBe(true);
+
+            window.toast('Settings saved', 'success');
+            jest.advanceTimersByTime(2800);
+            expect(toastEl().classList.contains('show')).toBe(false);
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    it('does not swallow clicks on the page while it is hidden', () => {
+        // The element is fixed in the corner at all times; only `.show` may
+        // make it interactive, or it covers whatever sits underneath it.
+        expect(toastEl().classList.contains('show')).toBe(false);
+        expect(toastEl().className).toBe('toast');
+    });
+});

--- a/tests/giveaway.test.js
+++ b/tests/giveaway.test.js
@@ -3,7 +3,7 @@
 // discord.js and the Guild model both load fine without a gateway or DB
 // connection, so this suite exercises the real command module.
 
-const { parseDuration, pickWinners, getEntrants } = require('../src/commands/utility/giveaway');
+const { parseDuration, pickWinners } = require('../src/commands/utility/giveaway');
 
 describe('parseDuration', () => {
     it('parses each supported unit', () => {

--- a/tests/guildSettingsPanels.test.js
+++ b/tests/guildSettingsPanels.test.js
@@ -9,84 +9,14 @@ const { TextEncoder, TextDecoder } = require('util');
 global.TextEncoder = global.TextEncoder || TextEncoder;
 global.TextDecoder = global.TextDecoder || TextDecoder;
 
-const fs = require('fs');
-const path = require('path');
-const ejs = require('ejs');
-const { guildSettingsLocals } = require('./helpers/guildSettingsLocals');
 const { PANELS, DEFAULT_PANEL } = require('../src/dashboard/lib/panels');
-
-const VIEWS = path.join(__dirname, '..', 'src', 'dashboard', 'views');
-const PUBLIC = path.join(__dirname, '..', 'src', 'dashboard', 'public');
-
-function renderPage() {
-    const file = path.join(VIEWS, 'guild-settings.ejs');
-    return ejs.render(fs.readFileSync(file, 'utf8'), guildSettingsLocals(), { filename: file });
-}
-
-function renderPanel(name) {
-    const file = path.join(VIEWS, 'partials', 'panels', `${name}.ejs`);
-    return ejs.render(fs.readFileSync(file, 'utf8'), guildSettingsLocals(), { filename: file });
-}
-
-// The script wires delegated handlers onto `document`, which survives a body
-// swap. Record them at boot so each test can start from a clean document.
-const documentListeners = [];
-const addDocumentListener = document.addEventListener.bind(document);
-
-function forgetDocumentListeners() {
-    while (documentListeners.length) {
-        const [type, fn, opts] = documentListeners.pop();
-        document.removeEventListener(type, fn, opts);
-    }
-}
-
-/** Put the rendered page in the document and run its scripts, as a browser would. */
-function bootPage({ panelFetch } = {}) {
-    const html = renderPage();
-    const body = html.slice(html.indexOf('<body'), html.indexOf('</body>'));
-    document.body.innerHTML = body.replace(/^<body[^>]*>/, '');
-
-    // jsdom has no CSS.escape; every browser that can run this page does.
-    window.CSS = window.CSS || {};
-    window.CSS.escape = value => String(value).replace(/[^\w-]/g, c => '\\' + c);
-
-    window.fetch = jest.fn(async url => {
-        const panel = /\/panel\/([a-z]+)(?:$|\?)/.exec(String(url));
-        if (panel) {
-            if (panelFetch) return panelFetch(panel[1]);
-            return { ok: true, status: 200, text: async () => renderPanel(panel[1]) };
-        }
-        // Every other call is one of the panels' own data endpoints. Most cope
-        // with an empty object; the AI usage widget reads into nested keys.
-        const body = /\/ai\/usage/.test(String(url))
-            ? { today: {}, week: {}, month: {}, daily: [], byModel: [], rateLimit: {} }
-            : {};
-        return { ok: true, status: 200, json: async () => body, text: async () => JSON.stringify(body) };
-    });
-
-    const bootstrap = html.match(/<script nonce="[^"]*">([\s\S]*?)<\/script>/)[1];
-    document.addEventListener = (type, fn, opts) => {
-        documentListeners.push([type, fn, opts]);
-        addDocumentListener(type, fn, opts);
-    };
-    try {
-        window.eval(fs.readFileSync(path.join(PUBLIC, 'esc-html.js'), 'utf8'));
-        window.eval(bootstrap);
-        window.eval(fs.readFileSync(path.join(PUBLIC, 'guild-settings.js'), 'utf8'));
-    } finally {
-        document.addEventListener = addDocumentListener;
-    }
-}
-
-/** Let the fetch chain inside loadPanel() settle. */
-const settle = async () => {
-    await new Promise(resolve => setTimeout(resolve, 0));
-    await new Promise(resolve => setTimeout(resolve, 0));
-};
-
-function clickTab(id) {
-    document.querySelector(`.nav-item[data-tab="${id}"]`).dispatchEvent(new window.Event('click', { bubbles: true }));
-}
+const {
+    bootPage,
+    clickTab,
+    renderPanel,
+    settle,
+    forgetDocumentListeners,
+} = require('./helpers/guildSettingsPage');
 
 describe('lazily loaded settings panels', () => {
     let errors;

--- a/tests/helpCatalog.test.js
+++ b/tests/helpCatalog.test.js
@@ -1,0 +1,143 @@
+'use strict';
+
+// #665: /help was a hand-maintained list that had drifted from src/commands —
+// 37 of 98 commands were missing from it, and it named four casino games that
+// no longer existed. These tests hold the catalog to the loaded command set, so
+// the two cannot come apart again without a red build.
+
+const fs = require('fs');
+const path = require('path');
+const { buildCategories, CATEGORY_META, SELECT_DESCRIPTION_LIMIT } = require('../src/utils/helpCatalog');
+const { loadCommandModules, listCommandFiles } = require('../src/utils/commandLoader');
+
+const fake = (name, category, description = `${name} description`) => ({
+    data: { name, description },
+    category,
+});
+
+describe('buildCategories', () => {
+    test('groups commands by the folder they were loaded from', () => {
+        const categories = buildCategories([
+            fake('ban', 'moderation'),
+            fake('daily', 'economy'),
+            fake('work', 'economy'),
+        ]);
+
+        expect(categories.map(c => c.id)).toEqual(['economy', 'moderation']);
+        expect(categories[0].commands.map(c => c.name)).toEqual(['daily', 'work']);
+        expect(categories[1].commands.map(c => c.name)).toEqual(['ban']);
+    });
+
+    test('orders categories as CATEGORY_META does, whatever order commands arrive in', () => {
+        const shuffled = [...CATEGORY_META.keys()].reverse().map(id => fake(`cmd-${id}`, id));
+
+        expect(buildCategories(shuffled).map(c => c.id)).toEqual([...CATEGORY_META.keys()]);
+    });
+
+    test('takes the description from the command, not from a second copy of it', () => {
+        const [category] = buildCategories([fake('work', 'economy', 'Earn coins by working a shift')]);
+
+        expect(category.commands[0].description).toBe('Earn coins by working a shift');
+    });
+
+    // The whole point of deriving the catalog: a category nobody thought to add
+    // display metadata for still lists its commands, rather than hiding them.
+    test('surfaces a folder that has no metadata rather than dropping it', () => {
+        const categories = buildCategories([fake('ban', 'moderation'), fake('brew', 'alchemy')]);
+
+        expect(categories.map(c => c.id)).toEqual(['moderation', 'alchemy']);
+        expect(categories[1].label).toBe('Alchemy');
+        expect(categories[1].commands.map(c => c.name)).toEqual(['brew']);
+    });
+
+    test('skips anything without a command name, and returns nothing for an empty set', () => {
+        expect(buildCategories([])).toEqual([]);
+        expect(buildCategories(null)).toEqual([]);
+        expect(buildCategories([{ data: {} }, null])).toEqual([]);
+    });
+
+    // Discord rejects the whole select menu if one option's description is over
+    // the limit, so a category with many long command names must elide.
+    test('keeps every select description inside the Discord limit', () => {
+        const many = Array.from({ length: 40 }, (_, i) => fake(`economy-command-number-${i}`, 'economy'));
+        const [category] = buildCategories(many);
+
+        expect(category.summary.length).toBeLessThanOrEqual(SELECT_DESCRIPTION_LIMIT);
+        expect(category.summary).toContain('40 commands:');
+    });
+
+    test('lists the AI mention alongside the AI commands', () => {
+        const [category] = buildCategories([fake('remind', 'ai')]);
+
+        expect(category.commands.find(c => c.name === '@Clawdia')).toMatchObject({ mention: true });
+    });
+
+    test('does not invent an AI category when no AI command loaded', () => {
+        expect(buildCategories([fake('ban', 'moderation')]).map(c => c.id)).toEqual(['moderation']);
+    });
+});
+
+describe('the catalog against the real command tree', () => {
+    const { commands, failures } = loadCommandModules();
+    const categories = buildCategories(commands.map(c => c.command));
+
+    test('every command file loaded', () => {
+        expect(failures).toEqual([]);
+        expect(commands.length).toBe(listCommandFiles().length);
+    });
+
+    // This is the guard the hand-maintained list never had.
+    test('lists every registered command exactly once', () => {
+        const listed = categories.flatMap(c => c.commands.map(cmd => cmd.name));
+        const registered = commands.map(c => c.command.data.name).sort();
+
+        expect(listed.filter(name => !name.startsWith('@')).sort()).toEqual(registered);
+        expect(new Set(listed).size).toBe(listed.length);
+    });
+
+    test('every listed command carries the description Discord was given', () => {
+        const byName = new Map(commands.map(c => [c.command.data.name, c.command.data.description]));
+
+        for (const category of categories) {
+            for (const cmd of category.commands) {
+                if (cmd.mention) continue;
+                expect([cmd.name, cmd.description]).toEqual([cmd.name, byName.get(cmd.name)]);
+            }
+        }
+    });
+
+    test('every select description fits, for the real command set', () => {
+        for (const category of categories) {
+            expect([category.id, category.summary.length <= SELECT_DESCRIPTION_LIMIT]).toEqual([category.id, true]);
+        }
+    });
+});
+
+describe('/casino advertises the games it actually has', () => {
+    const casino = require('../src/commands/economy/casino');
+    const gamesDir = path.join(__dirname, '..', 'src', 'games', 'casino');
+    const gameNames = fs.readdirSync(gamesDir)
+        .filter(file => file.endsWith('.js'))
+        .map(file => require(path.join(gamesDir, file)).name)
+        .sort();
+
+    test('registers one subcommand per game module', () => {
+        const subcommands = casino.data.toJSON().options.map(opt => opt.name);
+
+        expect(gameNames.every(name => subcommands.includes(name))).toBe(true);
+    });
+
+    test('names every game in the description, and nothing else', () => {
+        const named = casino.data.description
+            .replace(/^Play casino games: /, '')
+            .replace(/\.$/, '')
+            .split(', ')
+            .sort();
+
+        expect(named).toEqual(gameNames);
+    });
+
+    test('fits inside the Discord description limit', () => {
+        expect(casino.data.description.length).toBeLessThanOrEqual(100);
+    });
+});

--- a/tests/helpers/guildSettingsPage.js
+++ b/tests/helpers/guildSettingsPage.js
@@ -1,0 +1,86 @@
+// Boots views/guild-settings.ejs inside jsdom the way a browser would: render
+// the page, put its body in the document, then run esc-html.js, the inline
+// bootstrap block and guild-settings.js in order.
+//
+// Shared by every suite that exercises the dashboard page, so the panel tests
+// and the accessibility tests boot the same way rather than each keeping its
+// own copy of the setup.
+
+const fs = require('fs');
+const path = require('path');
+const ejs = require('ejs');
+const { guildSettingsLocals } = require('./guildSettingsLocals');
+
+const VIEWS = path.join(__dirname, '..', '..', 'src', 'dashboard', 'views');
+const PUBLIC = path.join(__dirname, '..', '..', 'src', 'dashboard', 'public');
+
+function renderPage(overrides) {
+    const file = path.join(VIEWS, 'guild-settings.ejs');
+    return ejs.render(fs.readFileSync(file, 'utf8'), guildSettingsLocals(overrides), { filename: file });
+}
+
+function renderPanel(name) {
+    const file = path.join(VIEWS, 'partials', 'panels', `${name}.ejs`);
+    return ejs.render(fs.readFileSync(file, 'utf8'), guildSettingsLocals(), { filename: file });
+}
+
+// The script wires delegated handlers onto `document`, which survives a body
+// swap. Record them so each test can start from a clean document.
+const documentListeners = [];
+
+function forgetDocumentListeners() {
+    while (documentListeners.length) {
+        const [type, fn, opts] = documentListeners.pop();
+        document.removeEventListener(type, fn, opts);
+    }
+}
+
+/** Let the fetch chain inside loadPanel() settle. */
+async function settle() {
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+function bootPage({ panelFetch } = {}) {
+    const html = renderPage();
+    const body = html.slice(html.indexOf('<body'), html.indexOf('</body>'));
+    document.body.innerHTML = body.replace(/^<body[^>]*>/, '');
+
+    // jsdom has no CSS.escape; every browser that can run this page does.
+    window.CSS = window.CSS || {};
+    window.CSS.escape = value => String(value).replace(/[^\w-]/g, c => '\\' + c);
+
+    window.fetch = jest.fn(async url => {
+        const panel = /\/panel\/([a-z]+)(?:$|\?)/.exec(String(url));
+        if (panel) {
+            if (panelFetch) return panelFetch(panel[1]);
+            return { ok: true, status: 200, text: async () => renderPanel(panel[1]) };
+        }
+        // Every other call is one of the panels' own data endpoints. Most cope
+        // with an empty object; the AI usage widget reads into nested keys.
+        const payload = /\/ai\/usage/.test(String(url))
+            ? { today: {}, week: {}, month: {}, daily: [], byModel: [], rateLimit: {} }
+            : {};
+        return { ok: true, status: 200, json: async () => payload, text: async () => JSON.stringify(payload) };
+    });
+
+    const bootstrap = html.match(/<script nonce="[^"]*">([\s\S]*?)<\/script>/)[1];
+    const addDocumentListener = document.addEventListener.bind(document);
+    document.addEventListener = (type, fn, opts) => {
+        documentListeners.push([type, fn, opts]);
+        addDocumentListener(type, fn, opts);
+    };
+    try {
+        window.eval(fs.readFileSync(path.join(PUBLIC, 'esc-html.js'), 'utf8'));
+        window.eval(bootstrap);
+        window.eval(fs.readFileSync(path.join(PUBLIC, 'guild-settings.js'), 'utf8'));
+    } finally {
+        document.addEventListener = addDocumentListener;
+    }
+}
+
+function clickTab(id) {
+    document.querySelector(`.nav-item[data-tab="${id}"]`).dispatchEvent(new window.Event('click', { bubbles: true }));
+}
+
+module.exports = { VIEWS, PUBLIC, renderPage, renderPanel, bootPage, clickTab, settle, forgetDocumentListeners };

--- a/tests/huntMaterialSinks.test.js
+++ b/tests/huntMaterialSinks.test.js
@@ -15,7 +15,7 @@ const {
     FIELD_TROPHY_FLAGS,
 } = require('../src/services/huntService');
 const {
-    ANIMALS, CRAFT_RECIPES, FIELD_TROPHIES, ZONES, ZONE_LIST, LIMITS, WEAPON_BY_TIER,
+    ANIMALS, CRAFT_RECIPES, FIELD_TROPHIES, ZONES, ZONE_LIST,
 } = require('../src/data/huntData');
 const { CROSS_CRAFT_RECIPES } = require('../src/data/crossSystemData');
 const { __test__ } = require('../src/commands/economy/hunt');

--- a/tests/leaderboardBadgeLease.test.js
+++ b/tests/leaderboardBadgeLease.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+// The weekly leaderboard-badge job leases each guild before awarding, so two
+// shards cannot both hand out the 👑 badges. Its filter carried two `$or` keys
+// in one object literal — the cadence check and the lease check — and the
+// second silently replaced the first, because a duplicate key in a JS object
+// literal is the last one wins. Only the lease was ever evaluated, so the job
+// would re-award as soon as a five-minute lease lapsed rather than once a week.
+//
+// Found by the linter added in #714, which is the point of having one.
+
+jest.mock('discord.js', () => ({
+    EmbedBuilder: class {
+        setColor() { return this; }
+        setTitle() { return this; }
+        setDescription() { return this; }
+        setFooter() { return this; }
+        setTimestamp() { return this; }
+    },
+}));
+
+jest.mock('../src/models/Guild', () => ({ find: jest.fn(), findOneAndUpdate: jest.fn(), updateOne: jest.fn() }));
+jest.mock('../src/models/User', () => ({ find: jest.fn(), aggregate: jest.fn(), updateOne: jest.fn(), bulkWrite: jest.fn() }));
+
+const Guild = require('../src/models/Guild');
+const { awardWeeklyLeaderboardBadges } = require('../src/services/schedulerService');
+
+/** Every condition in the lease filter, flattened out of any $and wrapper. */
+function conditions(filter) {
+    return (filter.$and || []).concat(
+        Object.entries(filter)
+            .filter(([key]) => key !== '$and')
+            .map(([key, value]) => ({ [key]: value }))
+    );
+}
+
+function fieldsChecked(filter) {
+    return conditions(filter)
+        .flatMap(clause => (clause.$or || [clause]))
+        .flatMap(clause => Object.keys(clause))
+        .sort();
+}
+
+describe('weekly leaderboard badge lease', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        Guild.find.mockReturnValue({ lean: async () => [{ guildId: 'g1', name: 'Guild', economy: {} }] });
+        // Refusing the lease ends the job for that guild, which is all these
+        // assertions need — the filter has already been built by then.
+        Guild.findOneAndUpdate.mockResolvedValue(null);
+    });
+
+    it('checks the weekly cadence as well as the lease', async () => {
+        await awardWeeklyLeaderboardBadges({});
+
+        expect(Guild.findOneAndUpdate).toHaveBeenCalledTimes(1);
+        const [filter] = Guild.findOneAndUpdate.mock.calls[0];
+
+        expect(fieldsChecked(filter)).toEqual([
+            'badgesAwardLeaseAt',
+            'badgesAwardLeaseAt',
+            'badgesLastAwardedAt',
+            'badgesLastAwardedAt',
+            'guildId',
+        ]);
+    });
+
+    // Two conditions that share a key can only both survive under $and — as
+    // sibling keys of one object, the second overwrites the first.
+    it('carries the two $or conditions as separate clauses', async () => {
+        await awardWeeklyLeaderboardBadges({});
+
+        const [filter] = Guild.findOneAndUpdate.mock.calls[0];
+        expect(conditions(filter).filter(clause => clause.$or)).toHaveLength(2);
+    });
+
+    it('leases only a guild whose current lease has lapsed', async () => {
+        await awardWeeklyLeaderboardBadges({});
+
+        const [filter, update] = Guild.findOneAndUpdate.mock.calls[0];
+        const lease = conditions(filter).find(clause =>
+            (clause.$or || []).some(part => 'badgesAwardLeaseAt' in part));
+
+        expect(lease.$or).toContainEqual({ badgesAwardLeaseAt: null });
+        expect(update.$set.badgesAwardLeaseAt.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('leases only a guild whose badges are at least a week old', async () => {
+        await awardWeeklyLeaderboardBadges({});
+
+        const [filter] = Guild.findOneAndUpdate.mock.calls[0];
+        const cadence = conditions(filter).find(clause =>
+            (clause.$or || []).some(part => 'badgesLastAwardedAt' in part));
+
+        expect(cadence).toBeDefined();
+        const weekAgo = cadence.$or.find(part => part.badgesLastAwardedAt?.$lte).badgesLastAwardedAt.$lte;
+        const ageMs = Date.now() - weekAgo.getTime();
+        expect(ageMs).toBeGreaterThanOrEqual(7 * 24 * 60 * 60 * 1000 - 5000);
+        expect(ageMs).toBeLessThanOrEqual(7 * 24 * 60 * 60 * 1000 + 5000);
+    });
+});

--- a/tests/lintGate.test.js
+++ b/tests/lintGate.test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// #714: 63k lines across 278 files with no linter and no formatter config, and
+// a CI that ran only the tests. The config is only half of the fix — a linter
+// nobody runs is the same as no linter — so this pins the other half: the
+// script exists, CI runs it, and the config still covers all three of the
+// environments this repo's JavaScript lives in.
+
+const root = path.join(__dirname, '..');
+const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+const ci = fs.readFileSync(path.join(root, '.github', 'workflows', 'ci.yml'), 'utf8');
+
+describe('lint gate', () => {
+    test('npm run lint exists and runs ESLint over the repo', () => {
+        expect(pkg.scripts.lint).toMatch(/\beslint\b/);
+        expect(pkg.scripts.lint).not.toMatch(/--fix/);
+    });
+
+    test('CI runs it, in the job the image publish depends on', () => {
+        const testJob = ci.slice(ci.indexOf('\n  test:'), ci.indexOf('\n  publish:'));
+        expect(testJob).toMatch(/run: npm run lint/);
+        expect(ci).toMatch(/needs: test/);
+    });
+
+    // Without `if: always()` a failing test hides the lint result and vice
+    // versa, and a reviewer has to push twice to see both.
+    test('the lint step reports even when the tests failed', () => {
+        expect(ci).toMatch(/if: always\(\)\n\s*run: npm run lint/);
+    });
+
+    test('ESLint and Prettier are pinned as devDependencies', () => {
+        for (const dep of ['eslint', '@eslint/js', 'prettier', 'eslint-config-prettier', 'globals']) {
+            expect([dep, dep in pkg.devDependencies]).toEqual([dep, true]);
+        }
+        expect(pkg.dependencies.eslint).toBeUndefined();
+    });
+
+    test('the flat config covers the bot, the browser scripts and the tests', () => {
+        const config = require('../eslint.config.js');
+        const covered = config.flatMap(block => block.files || []);
+
+        expect(covered).toEqual(expect.arrayContaining([
+            'src/**/*.js',
+            'src/dashboard/public/**/*.js',
+            'tests/**/*.js',
+        ]));
+    });
+
+    test('Prettier is wired to defer to ESLint rather than fight it', () => {
+        // eslint-config-prettier turns off every rule Prettier would restyle;
+        // it only works if it is applied after the blocks that set them.
+        const config = require('../eslint.config.js');
+        const last = config[config.length - 1];
+        expect(last.name || '').toMatch(/prettier/i);
+    });
+});

--- a/tests/seasonPass.test.js
+++ b/tests/seasonPass.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { TIER_COUNT, XP_PER_TIER, TIER_TABLE, loreForTier } = require('../src/data/seasonPass');
+const { TIER_COUNT, TIER_TABLE, loreForTier } = require('../src/data/seasonPass');
 const { awardSeasonXp } = require('../src/services/questService');
 
 describe('season pass tier table', () => {


### PR DESCRIPTION
package.json has declared "license": "MIT" since the first commit, but no
LICENSE file existed. For a project whose setup guide is built around cloning
and self-hosting, that leaves the terms legally unstated: a bare metadata field
is not a grant, so every fork was operating on an assumption.

Adds the MIT text with the repo owner as the copyright holder, and points the
README's License section at it.

Closes #713

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Help content and casino game listings now update automatically as commands and games change.
  * Dashboard navigation and notifications include improved keyboard, screen-reader, focus, and dismissal support.
  * Added an MIT license and expanded development guidance.

* **Bug Fixes**
  * Corrected weekly leaderboard badge award timing and lease handling.

* **Chores**
  * Added linting and formatting tools, configuration, and CI checks.
  * Removed unused code and improved code quality across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->