### PR TITLE
Stop a guild admin from aiming the AI provider at the private network

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ the files a change already touches.
 - `GEMINI_API_KEY` - (Optional) Google Gemini API key for AI features
 - `ANTHROPIC_API_KEY` - (Optional) Anthropic Claude API key for AI features
 - `OPENROUTER_API_KEY` - (Optional) OpenRouter API key for AI features
-- `OLLAMA_BASE_URL` - (Optional) Local Ollama endpoint (e.g., `http://localhost:11434`)
+- `OLLAMA_BASE_URL` - (Optional) Local Ollama endpoint (e.g., `http://localhost:11434`). This is the operator's endpoint: a base URL a server admin types into the dashboard is only allowed to reach a private or internal address if it matches this value (or the `localhost:11434` default), so set it when Ollama runs somewhere on your LAN or compose network
 - `MCP_SERVERS_CONFIG` - (Optional) Path to the MCP server list (default: `config/mcp-servers.json`)
 - `MCP_ALLOW_GUILD_SERVERS` - (Optional) Set to `false` to disable dashboard-managed MCP servers
 - `IMGFLIP_USERNAME` / `IMGFLIP_PASSWORD` - (Optional) Imgflip credentials for `/meme` command
@@ -321,6 +321,10 @@ Configuration that previously lived behind slash commands (settings link, level 
    - Point `OLLAMA_BASE_URL` to your local instance
    - Configure `OLLAMA_MODEL` in dashboard (e.g., `llama3.2`, `mistral`)
    - Ideal for private, zero-cost inference
+   - The per-server base URL in the dashboard must be an `http(s)` address that
+     does not resolve into private or reserved space — otherwise a server admin
+     could aim the bot at anything reachable from its container. Your own
+     endpoint is exempt: set it as `OLLAMA_BASE_URL`
 
 ### MCP Servers (Anthropic only)
 

--- a/src/bot/gateway.js
+++ b/src/bot/gateway.js
@@ -15,6 +15,8 @@
 // single route changing. Anything the dashboard needs from Discord gets a
 // method here; anything it needs from the database it reads from Mongo itself.
 
+const { PermissionFlagsBits } = require('discord.js');
+
 // Discord channel type numbers, named so routes filter by meaning.
 const CHANNEL_TYPES = {
     TEXT: 0,
@@ -80,6 +82,49 @@ function createBotGateway(client) {
         /** Is the bot in this guild? The check every permission gate makes. */
         hasGuild(guildId) {
             return client.guilds.cache.has(guildId);
+        },
+
+        /**
+         * Does this user administer the guild *right now*?
+         *
+         * The dashboard's session carries the guild list Discord returned at
+         * OAuth time and nothing refreshes it, so an admin who is demoted or
+         * kicked keeps that snapshot's privileges for as long as the cookie
+         * lives (#558). This is the second opinion: the member is fetched and
+         * their effective guild permissions read, which is what Discord will
+         * enforce anyway the moment the bot acts on their behalf.
+         *
+         * @returns {Promise<boolean|null>} true/false when Discord answered;
+         *   null when it could not be asked — the bot is not in the guild, or
+         *   the fetch failed for a reason other than the member being absent.
+         *   Callers must not read null as a denial; see verifyLiveGuildAccess.
+         */
+        async canManageGuild(guildId, userId) {
+            const guild = guildOf(guildId);
+            if (!guild || !userId) return null;
+            // Ownership is reported by the guild itself and outranks the
+            // bitfield, so it never depends on a member fetch succeeding.
+            if (guild.ownerId === userId) return true;
+
+            let member;
+            try {
+                // `force` skips the member cache. A cached member is exactly the
+                // stale snapshot this method exists to replace — the answer has
+                // to come from Discord. The dashboard caches the result for a
+                // minute (verifyLiveGuildAccess), so this is at most one request
+                // per user per guild per minute.
+                member = await guild.members.fetch({ user: userId, force: true });
+            } catch (err) {
+                // 10007 Unknown Member / 10013 Unknown User is the answer, not a
+                // failure: they are not in this guild any more, so they may not
+                // administer it. Anything else (a 5xx, a timeout, a missing
+                // intent) means Discord did not say, and null is that.
+                if (err?.code === 10007 || err?.code === 10013) return false;
+                return null;
+            }
+            if (!member) return false;
+            return member.permissions.has(PermissionFlagsBits.Administrator)
+                || member.permissions.has(PermissionFlagsBits.ManageGuild);
         },
 
         getGuild(guildId) {

--- a/src/commands/economy/fish/shop.js
+++ b/src/commands/economy/fish/shop.js
@@ -129,6 +129,9 @@ async function showShopList(interaction, user, currency) {
         activity: 'fish',
         title:    'Fishing Shop',
         currency,
+        // Activity images are per guild since #561; without this the browse view
+        // only ever finds the shared pre-#561 rows.
+        guildId:  interaction.guild.id,
         footer:   'rod • upgrade • buy • use • repair • unlock',
         pages: [
             { id: 'rods',        label: 'Rods',        emoji: '🎣',  subtitle: 'Better rods, better catches.',           items: rodItems,        listText: rodList        },
@@ -168,7 +171,7 @@ async function handleBuyRod(interaction, user, currency) {
         )
         .setFooter({ text: 'Confirmation expires in 30 seconds' });
 
-    const rodImg = await getItemImageAttachment(`fish:${rodData.slug || rodData.id}`).catch(() => null);
+    const rodImg = await getItemImageAttachment(`fish:${rodData.slug || rodData.id}`, interaction.guild.id).catch(() => null);
     if (rodImg) confirmEmbed.setThumbnail(rodImg.url);
 
     const row = new ActionRowBuilder().addComponents(

--- a/src/commands/economy/hunt/shop.js
+++ b/src/commands/economy/hunt/shop.js
@@ -164,6 +164,9 @@ async function showShopList(interaction, user, currency) {
         activity: 'hunt',
         title:    'Hunt Shop',
         currency,
+        // Activity images are per guild since #561; without this the browse view
+        // only ever finds the shared pre-#561 rows.
+        guildId:  interaction.guild.id,
         footer:   'weapon • upgrade • buy • use • repair • unlock',
         pages: [
             { id: 'weapons',     label: 'Weapons',     emoji: '🔫',  subtitle: 'Pick your tier — better gear, better trophies.', items: weaponItems,     listText: weaponList     },
@@ -227,7 +230,7 @@ async function handleBuyWeapon(interaction, user, currency) {
         });
     }
 
-    const weaponImg = await getItemImageAttachment(`hunt:${weaponData.slug || weaponData.id}`).catch(() => null);
+    const weaponImg = await getItemImageAttachment(`hunt:${weaponData.slug || weaponData.id}`, interaction.guild.id).catch(() => null);
     if (weaponImg) confirmEmbed.setThumbnail(weaponImg.url);
 
     const row = new ActionRowBuilder().addComponents(

--- a/src/commands/economy/mine/shop.js
+++ b/src/commands/economy/mine/shop.js
@@ -116,6 +116,9 @@ async function handleShop(interaction, sub) {
             activity: 'mine',
             title:    'Mining Shop',
             currency,
+            // Activity images are per guild since #561; without this the browse
+            // view only ever finds the shared pre-#561 rows.
+            guildId:  interaction.guild.id,
             footer:   'pickaxe • upgrade • buy • use • repair • unlock',
             pages: [
                 { id: 'pickaxes',    label: 'Pickaxes',    emoji: '🪓',  subtitle: 'Stronger picks bite deeper veins.',     items: pickaxeItems,    listText: pickaxeList    },
@@ -153,7 +156,7 @@ async function handleShop(interaction, sub) {
             )
             .setFooter({ text: 'Confirmation expires in 30 seconds' });
 
-        const pickaxeImg = await getItemImageAttachment(`mine:${pickaxeData.slug || pickaxeData.id}`).catch(() => null);
+        const pickaxeImg = await getItemImageAttachment(`mine:${pickaxeData.slug || pickaxeData.id}`, interaction.guild.id).catch(() => null);
         if (pickaxeImg) confirmEmbed.setThumbnail(pickaxeImg.url);
 
         const row = new ActionRowBuilder().addComponents(

--- a/src/dashboard/lib/middleware.js
+++ b/src/dashboard/lib/middleware.js
@@ -1,6 +1,6 @@
 // Shared Express middleware for the dashboard API routes.
 
-const { hasManagePermission } = require('./permissions');
+const { hasManagePermission, verifyLiveGuildAccess } = require('./permissions');
 const { BoundedRateLimiter } = require('../../utils/boundedRateLimiter');
 
 const WRITE_RL_WINDOW_MS = 60 * 1000;
@@ -25,13 +25,30 @@ function checkAuth(req, res, next) {
     res.status(401).json({ error: 'Unauthorized' });
 }
 
-function checkGuildAccess(req, res, next) {
+// Two gates, in cost order.
+//
+// The first is the session's own guild list, which is free to read and rejects
+// every request from someone who never administered this guild. The second asks
+// Discord whether they still do (#558): that list was captured once, at OAuth
+// time, and `maxAge` is the only thing that ever retires it, so on its own it
+// hands a demoted or kicked admin full write access until their cookie expires.
+//
+// `verifyLiveGuildAccess` answers null when nobody could say — a Discord
+// outage, a gateway that predates the method — and null falls through to the
+// snapshot rather than to a 403, because the alternative is that an unrelated
+// Discord incident locks every operator out of their own dashboard. That is a
+// deliberate soft edge on the *unknown* answer only; a definite `false` denies.
+async function checkGuildAccess(req, res, next) {
     const { guildId } = req.params;
     const userGuilds = req.user.guilds.filter(guild =>
         hasManagePermission(guild) && req.bot.hasGuild(guild.id)
     );
 
     if (!userGuilds.find(g => g.id === guildId)) {
+        return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    if (await verifyLiveGuildAccess(req.bot, guildId, req.user.id) === false) {
         return res.status(403).json({ error: 'Forbidden' });
     }
 
@@ -58,17 +75,38 @@ function checkReadRateLimit(req, res, next) {
     next();
 }
 
-// M2: CSRF origin validation for all state-changing API requests.
-// Complements sameSite: 'lax' cookies — rejects cross-origin POST/PUT/DELETE that
-// carry an Origin header pointing to a different host than the dashboard.
+// M2: CSRF origin validation for all state-changing API requests, applied
+// router-wide in routes/api.js. Complements sameSite: 'lax' cookies — a
+// POST/PUT/DELETE is admitted only when the browser says, one way or another,
+// that it came from the dashboard's own origin.
 function checkCsrfOrigin(req, res, next) {
-    const origin = req.headers.origin;
-    if (!origin) return next(); // same-origin requests may omit Origin
+    const reject = () => res.status(403).json({ error: 'Forbidden: cross-origin request rejected' });
     const dashboardUrl = process.env.DASHBOARD_URL || `http://localhost:${process.env.DASHBOARD_PORT || 3000}`;
-    try {
-        if (new URL(origin).origin === new URL(dashboardUrl).origin) return next();
-    } catch { /* fall through to reject */ }
-    return res.status(403).json({ error: 'Forbidden: cross-origin request rejected' });
+
+    const origin = req.headers.origin;
+    if (origin) {
+        try {
+            if (new URL(origin).origin === new URL(dashboardUrl).origin) return next();
+        } catch { /* unparseable Origin — fall through to reject */ }
+        return reject();
+    }
+
+    // No Origin at all. This used to be waved through (#563), which made the
+    // header check fail open: with no CSRF token anywhere in the dashboard, a
+    // request that simply omits Origin was accepted on nothing but SameSite=Lax.
+    //
+    // Nothing is lost by refusing. The Fetch standard requires a browser to
+    // send Origin on every request whose method is not GET or HEAD, and this
+    // middleware only runs on those methods (see routes/api.js) — so a real
+    // browser write always carries one. Fetch Metadata is accepted as the
+    // fallback for the same reason it exists: `same-origin` and `none` (a
+    // user-typed URL or a bookmark) are both statements the *browser* makes and
+    // a cross-site page cannot forge. Everything else — a stray proxy, a
+    // scripted client, an old browser sending neither header — is refused
+    // rather than trusted by default.
+    const site = req.headers['sec-fetch-site'];
+    if (site === 'same-origin' || site === 'none') return next();
+    return reject();
 }
 
 function checkAnyGuildAdmin(req, res, next) {

--- a/src/dashboard/lib/middleware.js
+++ b/src/dashboard/lib/middleware.js
@@ -109,11 +109,10 @@ function checkCsrfOrigin(req, res, next) {
     return reject();
 }
 
-function checkAnyGuildAdmin(req, res, next) {
-    if (!req.isAuthenticated()) return res.status(401).json({ error: 'Unauthorized' });
-    const adminGuilds = req.user.guilds.filter(g => hasManagePermission(g) && req.bot.hasGuild(g.id));
-    if (!adminGuilds.length) return res.status(403).json({ error: 'Forbidden' });
-    next();
-}
+// `checkAnyGuildAdmin` — "an admin of any guild the bot is in" — used to live
+// here, and the two routes that used it were the cross-tenant write in #561.
+// It is gone with them: on a multi-tenant dashboard there is no request whose
+// correct authorization is "administers something, somewhere", and leaving the
+// helper in place is an invitation for the next route to reach for it.
 
-module.exports = { checkAuth, checkGuildAccess, checkWriteRateLimit, checkReadRateLimit, checkCsrfOrigin, checkAnyGuildAdmin };
+module.exports = { checkAuth, checkGuildAccess, checkWriteRateLimit, checkReadRateLimit, checkCsrfOrigin };

--- a/src/dashboard/lib/permissions.js
+++ b/src/dashboard/lib/permissions.js
@@ -35,4 +35,81 @@ function hasManagePermission(guild) {
     }
 }
 
-module.exports = { hasManagePermission, ADMINISTRATOR, MANAGE_GUILD };
+const LIVE_ACCESS_TTL_MS = 60_000;
+// FIFO-evicted, like every other cache in the bot: the ceiling is what keeps a
+// stream of distinct user/guild pairs from growing the map without bound.
+const LIVE_ACCESS_MAX_ENTRIES = 5_000;
+
+const liveAccessCache = new Map(); // `${guildId}:${userId}` -> { expiresAt, allowed }
+
+function cacheLiveAccess(key, allowed) {
+    if (!liveAccessCache.has(key) && liveAccessCache.size >= LIVE_ACCESS_MAX_ENTRIES) {
+        liveAccessCache.delete(liveAccessCache.keys().next().value);
+    }
+    liveAccessCache.set(key, { expiresAt: Date.now() + LIVE_ACCESS_TTL_MS, allowed });
+}
+
+/**
+ * Whether Discord *currently* says this user administers the guild.
+ *
+ * `hasManagePermission` above answers the same question from `req.user.guilds`,
+ * which is a snapshot taken once at OAuth time and then kept in the session for
+ * as long as the session lives (#558). Nothing refreshes it: an admin whose
+ * MANAGE_GUILD is revoked, or who is kicked from the guild outright, keeps
+ * every dashboard privilege the snapshot recorded until the cookie expires.
+ * So the snapshot is treated as a claim to be checked rather than as the
+ * authority, and the gateway — which is talking to Discord — is asked.
+ *
+ * Three answers, and the third is the interesting one:
+ *
+ *   true   the member is there and holds ADMINISTRATOR or MANAGE_GUILD.
+ *   false  the member is gone, or no longer holds either. Deny.
+ *   null   nobody could say: the bot is not in the guild, Discord refused the
+ *          fetch, or the caller passed a gateway without the method. Denying on
+ *          null would mean a Discord outage locks every operator out of their
+ *          own dashboard, so the session snapshot — which the caller has
+ *          already checked — stands in until an answer is available.
+ *
+ * Answers are cached briefly because this runs on every API request and each
+ * miss is a member fetch. LIVE_ACCESS_TTL_MS is therefore the real revocation
+ * window: a minute, against the 24 hours it replaces.
+ *
+ * @returns {Promise<boolean|null>}
+ */
+async function verifyLiveGuildAccess(bot, guildId, userId) {
+    if (!guildId || !userId || typeof bot?.canManageGuild !== 'function') return null;
+
+    const key = `${guildId}:${userId}`;
+    const hit = liveAccessCache.get(key);
+    if (hit && hit.expiresAt > Date.now()) return hit.allowed;
+
+    let allowed;
+    try {
+        allowed = await bot.canManageGuild(guildId, userId);
+    } catch (err) {
+        console.warn(`[DASHBOARD] Live permission check failed for ${userId} in ${guildId}: ${err.message}`);
+        return null;
+    }
+    if (allowed !== true && allowed !== false) return null;
+
+    cacheLiveAccess(key, allowed);
+    return allowed;
+}
+
+/**
+ * Drops a cached answer, so the next check asks Discord again. Exported for
+ * tests, and for any future path that knows an answer has just gone stale.
+ */
+function forgetLiveGuildAccess(guildId, userId) {
+    if (guildId === undefined && userId === undefined) return liveAccessCache.clear();
+    liveAccessCache.delete(`${guildId}:${userId}`);
+}
+
+module.exports = {
+    hasManagePermission,
+    verifyLiveGuildAccess,
+    forgetLiveGuildAccess,
+    LIVE_ACCESS_TTL_MS,
+    ADMINISTRATOR,
+    MANAGE_GUILD,
+};

--- a/src/dashboard/public/guild-settings.js
+++ b/src/dashboard/public/guild-settings.js
@@ -1124,6 +1124,13 @@ async function saveSettings(section) {
     }
 }
 
+// Activity images belong to this guild, not to every guild the bot is in (#561),
+// so the guild id is part of the path. `_guildId` is assigned further down this
+// file; both callers run on a click, long after the script has finished.
+function activityImageUrl(itemId) {
+    return '/api/item-image/activity/' + encodeURIComponent(_guildId) + '/' + encodeURIComponent(itemId);
+}
+
 async function uploadActivityImage(itemId, input) {
     const file = input.files[0];
     if (!file) return;
@@ -1132,7 +1139,7 @@ async function uploadActivityImage(itemId, input) {
     const fd = new FormData();
     fd.append('image', file);
     try {
-        const r = await fetch('/api/item-image/activity/' + encodeURIComponent(itemId), { method: 'POST', body: fd });
+        const r = await fetch(activityImageUrl(itemId), { method: 'POST', body: fd });
         if (r.ok) {
             const dataUrl = await new Promise(function(res) {
                 const reader = new FileReader();
@@ -1167,7 +1174,7 @@ async function removeActivityImage(itemId) {
     const ok = await showConfirm({ title: 'Remove image', body: 'Remove the image for this activity item?', okText: 'Remove' });
     if (!ok) return;
     try {
-        const r = await fetch('/api/item-image/activity/' + encodeURIComponent(itemId), { method: 'DELETE' });
+        const r = await fetch(activityImageUrl(itemId), { method: 'DELETE' });
         if (r.ok) {
             const imgEl = document.getElementById('gic-img-' + itemId);
             const emojiEl = document.getElementById('gic-emoji-' + itemId);

--- a/src/dashboard/routes/api/itemImages.js
+++ b/src/dashboard/routes/api/itemImages.js
@@ -2,7 +2,8 @@ const express = require('express');
 const router = express.Router();
 const multer = require('multer');
 const ItemImage = require('../../../models/ItemImage');
-const { checkAuth, checkGuildAccess, checkWriteRateLimit, checkAnyGuildAdmin } = require('../../lib/middleware');
+const { checkAuth, checkGuildAccess, checkWriteRateLimit } = require('../../lib/middleware');
+const { isActivityItemId } = require('../../../data/activityItems');
 
 // M4: Validate image files by magic bytes rather than trusting the client-supplied
 // MIME type. Prevents disguised file uploads (e.g. PHP named as image/jpeg).
@@ -87,28 +88,57 @@ router.delete('/item-image/shop/:guildId/:itemId', checkAuth, checkGuildAccess, 
     }
 });
 
-// Serve a global activity item image (hunt/fish/mine)
-router.get('/item-image/activity/:itemId', async (req, res) => {
+// Activity item images (hunt/fish/mine) are per guild.
+//
+// They were not (#561). `ItemImage` had no guildId, the collection was keyed on
+// itemId alone, and the write routes were gated on "admin of *any* guild the bot
+// is in" — so an admin of one server could replace, or delete, the icons every
+// other server sees. The routes are guild-scoped now and carry the same
+// checkGuildAccess every other guild-scoped route does; the id in the path is
+// the guild whose images are being changed, so administering that guild is
+// exactly the permission required.
+//
+// Documents with `guildId: null` are the images uploaded before this change.
+// They are read as a fallback so nothing disappeared on deploy, and no route
+// writes them: an upload lands on the caller's own guild, a delete removes only
+// that guild's row. See migration 014.
+function invalidItemId(itemId) {
+    // The shape check first, so a wildly malformed id is rejected as malformed,
+    // then membership of the catalog the game actually renders. The catalog is
+    // also what bounds this collection: without it any id at all could be
+    // stored, at 512 KB and 60 writes a minute.
+    if (typeof itemId !== 'string' || !/^[a-z0-9_:-]{1,64}$/.test(itemId)) return 'Invalid itemId';
+    if (!isActivityItemId(itemId)) return 'Unknown activity item';
+    return null;
+}
+
+// Serve a guild's activity item image, falling back to the shared pre-#561 one.
+router.get('/item-image/activity/:guildId/:itemId', async (req, res) => {
+    const { guildId, itemId } = req.params;
     try {
-        const img = await ItemImage.findOne({ itemId: req.params.itemId });
+        const img = await ItemImage.findOne({ guildId, itemId })
+            || await ItemImage.findOne({ guildId: null, itemId });
         if (!img?.imageData?.length) return res.status(404).end();
         res.set('Content-Type', img.imageType || 'image/png');
+        // Per guild, so the cache key must be too: this URL carries the guild id,
+        // and the response varies by nothing else.
         res.set('Cache-Control', 'public, max-age=86400');
         res.send(img.imageData);
     } catch { res.status(500).end(); }
 });
 
-// Upload/replace a global activity item image (any guild admin)
-router.post('/item-image/activity/:itemId', checkAuth, checkAnyGuildAdmin, checkWriteRateLimit, uploadImage, async (req, res) => {
+// Upload/replace one guild's activity item image
+router.post('/item-image/activity/:guildId/:itemId', checkAuth, checkGuildAccess, checkWriteRateLimit, uploadImage, async (req, res) => {
     if (!req.file) return res.status(400).json({ error: 'No image file provided' });
-    const { itemId } = req.params;
-    if (!/^[a-z0-9_:-]{1,64}$/.test(itemId)) return res.status(400).json({ error: 'Invalid itemId' });
+    const { guildId, itemId } = req.params;
+    const idError = invalidItemId(itemId);
+    if (idError) return res.status(400).json({ error: idError });
     // M4: Verify file contents match a known image signature.
     const detectedType = detectImageType(req.file.buffer);
     if (!detectedType) return res.status(400).json({ error: 'Invalid image file: unrecognized format' });
     try {
         await ItemImage.findOneAndUpdate(
-            { itemId },
+            { guildId, itemId },
             { imageData: req.file.buffer, imageType: detectedType, updatedAt: new Date() },
             { upsert: true }
         );
@@ -119,10 +149,16 @@ router.post('/item-image/activity/:itemId', checkAuth, checkAnyGuildAdmin, check
     }
 });
 
-// Remove a global activity item image
-router.delete('/item-image/activity/:itemId', checkAuth, checkAnyGuildAdmin, checkWriteRateLimit, async (req, res) => {
+// Remove one guild's activity item image. The shared fallback is not reachable
+// from here: `guildId` is always the caller's own guild, never null.
+router.delete('/item-image/activity/:guildId/:itemId', checkAuth, checkGuildAccess, checkWriteRateLimit, async (req, res) => {
+    const { guildId, itemId } = req.params;
+    // The POST validated the id and the DELETE did not, which is how a delete
+    // ends up matching on something the upload path could never have written.
+    const idError = invalidItemId(itemId);
+    if (idError) return res.status(400).json({ error: idError });
     try {
-        await ItemImage.deleteOne({ itemId: req.params.itemId });
+        await ItemImage.deleteOne({ guildId, itemId });
         res.json({ success: true });
     } catch (err) {
         console.error('Activity item image delete error:', err);

--- a/src/dashboard/routes/api/settings.js
+++ b/src/dashboard/routes/api/settings.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const Guild = require('../../../models/Guild');
 const { checkAuth, checkGuildAccess, checkWriteRateLimit } = require('../../lib/middleware');
 const { sanitizeMongoValue, logAuditEvent } = require('../../lib/apiHelpers');
+const { validateBaseUrl: validateOllamaBaseUrl } = require('../../../services/ai/providers/ollama');
 
 // Top-level Guild schema keys that the dashboard is allowed to update.
 // This whitelist prevents prototype pollution (__proto__, constructor, etc.)
@@ -248,6 +249,31 @@ function validateDynamicPricingUpdate(updates) {
     return null;
 }
 
+// `ai` is a whitelisted settings parent with no per-field validation, and one of
+// its fields is a URL the bot then makes a request to (#559). An unparsed value
+// there is an outbound request a guild admin writes: `file://`, or a scheme a
+// client library treats specially, or an address chosen to be somewhere inside
+// the operator's network.
+//
+// The rule is the provider's, not this file's — see validateBaseUrl in
+// services/ai/providers/ollama.js — so the form rejects exactly what the request
+// path would refuse, and accepts the operator's own endpoint even when that is a
+// private address. Empty and null mean "use the operator's endpoint" and are
+// left alone. Where a *hostname* actually resolves to is settled when the
+// request is made: DNS at save time proves nothing about DNS an hour later.
+function validateAiUpdate(updates) {
+    for (const [key, value] of Object.entries(updates)) {
+        let baseUrl;
+        if (key === 'ai.ollamaBaseUrl') baseUrl = value;
+        else if (key === 'ai' && value && typeof value === 'object') baseUrl = value.ollamaBaseUrl;
+        else continue;
+
+        const error = validateOllamaBaseUrl(baseUrl);
+        if (error) return error;
+    }
+    return null;
+}
+
 function validateHeistUpdate(updates) {
     for (const [key, value] of Object.entries(updates)) {
         if (!key.startsWith('heist.') && key !== 'heist') continue;
@@ -296,6 +322,9 @@ router.post('/guild/:guildId/settings', checkAuth, checkGuildAccess, checkWriteR
 
     const heistError = validateHeistUpdate(updates);
     if (heistError) return res.status(400).json({ error: heistError });
+
+    const aiError = validateAiUpdate(updates);
+    if (aiError) return res.status(400).json({ error: aiError });
 
     const explorationError = validateExplorationUpdate(updates);
     if (explorationError) return res.status(400).json({ error: explorationError });
@@ -362,3 +391,4 @@ router.post('/guild/:guildId/settings', checkAuth, checkGuildAccess, checkWriteR
 
 module.exports = router;
 module.exports.validateEventLogUpdate = validateEventLogUpdate;
+module.exports.validateAiUpdate = validateAiUpdate;

--- a/src/dashboard/routes/dashboard.js
+++ b/src/dashboard/routes/dashboard.js
@@ -6,9 +6,7 @@ const DEFAULT_JOBS = require('../../data/defaultJobs');
 const DEFAULT_TIERS = require('../../data/defaultTiers');
 const { ACHIEVEMENTS } = require('../../data/achievements');
 const { ensureDefaultShopItems } = require('../../data/defaultShopItems');
-const { WEAPON_TIERS, AMMO_PACKS, CONSUMABLES: HUNT_CONSUMABLES, WEAPON_UPGRADES } = require('../../data/huntData');
-const { ROD_TIERS, BAIT_PACKS, CONSUMABLES: FISH_CONSUMABLES, ROD_UPGRADES } = require('../../data/fishData');
-const { PICKAXE_TIERS, BLAST_PACKS, CONSUMABLES: MINE_CONSUMABLES, PICKAXE_UPGRADES } = require('../../data/mineData');
+const { ACTIVITY_ITEMS } = require('../../data/activityItems');
 const { REGION_LIST } = require('../../data/exploreData');
 const { SEASONAL_EVENTS } = require('../../data/seasonalEvents');
 
@@ -131,33 +129,28 @@ async function buildGuildSettingsLocals(req) {
     }
 
     // Pre-load the set of activity item images that actually exist so the
-    // template can skip rendering <img> tags that would otherwise 404.
-    const uploadedImageDocs = await ItemImage.find({}, { itemId: 1 }).lean();
+    // template can skip rendering <img> tags that would otherwise 404. Scoped to
+    // this guild plus the shared pre-#561 rows, which is exactly what the image
+    // route will serve back for these ids.
+    const uploadedImageDocs = await ItemImage.find(
+        { guildId: { $in: [guildId, null] } },
+        { itemId: 1 },
+    ).lean();
     const uploadedImageIds = new Set(uploadedImageDocs.map(d => d.itemId));
 
-    const toItem = (ns, item, idField = 'id') => {
-        const id = `${ns}:${item[idField]}`;
-        return { id, label: item.name, emoji: item.emoji || '📦', hasImage: uploadedImageIds.has(id) };
-    };
+    // The item list itself comes from data/activityItems.js, which is also what
+    // the upload route validates against — one catalog, so the panel cannot
+    // offer an id the route would refuse.
+    const withImageFlags = groups => Object.fromEntries(
+        Object.entries(groups).map(([group, items]) => [
+            group,
+            items.map(item => ({ ...item, hasImage: uploadedImageIds.has(item.id) })),
+        ])
+    );
 
-    const huntItems = {
-        weapons:     WEAPON_TIERS.map(w => toItem('hunt', w, 'slug')),
-        upgrades:    Object.values(WEAPON_UPGRADES).map(u => toItem('hunt', u)),
-        ammo:        AMMO_PACKS.map(a => toItem('hunt', a)),
-        consumables: Object.values(HUNT_CONSUMABLES).map(c => toItem('hunt', c))
-    };
-    const fishItems = {
-        rods:        ROD_TIERS.map(r => toItem('fish', r, 'slug')),
-        upgrades:    Object.values(ROD_UPGRADES).map(u => toItem('fish', u)),
-        bait:        BAIT_PACKS.map(b => toItem('fish', b)),
-        consumables: Object.values(FISH_CONSUMABLES).map(c => toItem('fish', c))
-    };
-    const mineItems = {
-        pickaxes:    PICKAXE_TIERS.map(p => toItem('mine', p, 'slug')),
-        upgrades:    Object.values(PICKAXE_UPGRADES).map(u => toItem('mine', u)),
-        blasts:      BLAST_PACKS.map(b => toItem('mine', b)),
-        consumables: Object.values(MINE_CONSUMABLES).map(c => toItem('mine', c))
-    };
+    const huntItems = withImageFlags(ACTIVITY_ITEMS.hunt);
+    const fishItems = withImageFlags(ACTIVITY_ITEMS.fish);
+    const mineItems = withImageFlags(ACTIVITY_ITEMS.mine);
 
     // Canonical exploration region catalog for the dashboard panel —
     // derived from exploreData so the template never drifts from the game data.

--- a/src/dashboard/routes/dashboard.js
+++ b/src/dashboard/routes/dashboard.js
@@ -17,7 +17,7 @@ function checkAuth(req, res, next) {
     res.redirect('/auth/login');
 }
 
-const { hasManagePermission } = require('../lib/permissions');
+const { hasManagePermission, verifyLiveGuildAccess } = require('../lib/permissions');
 const { CHANNEL_TYPES } = require('../../bot/gateway');
 const { PANELS, DEFAULT_PANEL, isPanel } = require('../lib/panels');
 
@@ -68,6 +68,17 @@ async function buildGuildSettingsLocals(req) {
     const userGuilds = getManageableGuilds(req);
 
     if (!userGuilds.find(g => g.id === guildId)) {
+        return { status: 403, message: 'You do not have permission to manage this guild.' };
+    }
+
+    // The session's guild list is a snapshot from OAuth time, so the panel asks
+    // Discord whether it is still true before rendering a guild's settings
+    // (#558) — the same second opinion the API middleware takes, and for the
+    // same reason: without it a demoted or kicked admin keeps reading this page
+    // until their cookie expires. The guild *list* on /dashboard is still drawn
+    // from the snapshot: it is the guild names the session already holds, and
+    // checking it would mean a member fetch per card.
+    if (await verifyLiveGuildAccess(req.bot, guildId, req.user.id) === false) {
         return { status: 403, message: 'You do not have permission to manage this guild.' };
     }
 

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -227,13 +227,26 @@ function createApp({ client = null, bot: injectedBot, sessionStore, configurePas
         next();
     });
 
+    // The session is what the dashboard's authorization rests on, so its
+    // lifetime is part of that rule (#558). It used to be a flat 24 hours from
+    // login, which was also how long a revoked admin kept their access, since
+    // `req.user.guilds` is captured once at OAuth time and never refreshed.
+    //
+    // Two changes: four hours instead of twenty-four, and `rolling: true`, so
+    // the window is an *idle* timeout rather than an absolute one — someone
+    // working in the dashboard is not signed out mid-edit, and a session left
+    // alone is gone in four hours instead of a day. The live permission check
+    // in lib/permissions.js is what closes the window properly (a minute); this
+    // bounds how long a stale snapshot can survive when Discord cannot be
+    // reached to take that second opinion.
     app.use(session({
         store: sessionStore ?? MongoStore.create({ mongoUrl: process.env.MONGODB_URI, collectionName: 'sessions' }),
         secret: process.env.SESSION_SECRET,
         resave: false,
+        rolling: true,
         saveUninitialized: false,
         cookie: {
-            maxAge: 86400000,
+            maxAge: 4 * 60 * 60 * 1000,
             httpOnly: true,
             secure: isProduction,
             sameSite: 'lax'

--- a/src/dashboard/views/partials/game-item-card.ejs
+++ b/src/dashboard/views/partials/game-item-card.ejs
@@ -4,7 +4,7 @@
             <img
                 class="game-item-img"
                 id="gic-img-<%= item.id %>"
-                src="/api/item-image/activity/<%= item.id %>"
+                src="/api/item-image/activity/<%= guild.id %>/<%= item.id %>"
                 alt=""
                 onerror="this.style.display='none';document.getElementById('gic-emoji-<%= item.id %>').style.display='flex'"
                 onload="document.getElementById('gic-emoji-<%= item.id %>').style.display='none'"

--- a/src/data/activityItems.js
+++ b/src/data/activityItems.js
@@ -1,0 +1,64 @@
+'use strict';
+
+/**
+ * The canonical list of hunt/fish/mine items the dashboard can attach an image
+ * to, derived from the game data rather than restated beside it.
+ *
+ * The dashboard panel already built this list to render its item cards. It is
+ * pulled out here because the upload route needs the same list for a different
+ * reason: the item id used to be free text matching `[a-z0-9_:-]{1,64}`, so a
+ * caller could store an image under any id they liked, forever, at 512 KB a
+ * time. Bounding writes to ids the game actually reads turns "how much can be
+ * stored" from a question about the caller's patience into a property of this
+ * file.
+ */
+
+const { WEAPON_TIERS, AMMO_PACKS, CONSUMABLES: HUNT_CONSUMABLES, WEAPON_UPGRADES } = require('./huntData');
+const { ROD_TIERS, BAIT_PACKS, CONSUMABLES: FISH_CONSUMABLES, ROD_UPGRADES } = require('./fishData');
+const { PICKAXE_TIERS, BLAST_PACKS, CONSUMABLES: MINE_CONSUMABLES, PICKAXE_UPGRADES } = require('./mineData');
+
+// Tiered gear is keyed by `slug`; everything else by `id`. That difference is
+// in the game data, so it is honoured here rather than normalised away — the
+// ids these produce are the ones the commands ask for at render time.
+function toItem(namespace, item, idField = 'id') {
+    return {
+        id: `${namespace}:${item[idField]}`,
+        label: item.name,
+        emoji: item.emoji || '📦',
+    };
+}
+
+const ACTIVITY_ITEMS = {
+    hunt: {
+        weapons:     WEAPON_TIERS.map(w => toItem('hunt', w, 'slug')),
+        upgrades:    Object.values(WEAPON_UPGRADES).map(u => toItem('hunt', u)),
+        ammo:        AMMO_PACKS.map(a => toItem('hunt', a)),
+        consumables: Object.values(HUNT_CONSUMABLES).map(c => toItem('hunt', c)),
+    },
+    fish: {
+        rods:        ROD_TIERS.map(r => toItem('fish', r, 'slug')),
+        upgrades:    Object.values(ROD_UPGRADES).map(u => toItem('fish', u)),
+        bait:        BAIT_PACKS.map(b => toItem('fish', b)),
+        consumables: Object.values(FISH_CONSUMABLES).map(c => toItem('fish', c)),
+    },
+    mine: {
+        pickaxes:    PICKAXE_TIERS.map(p => toItem('mine', p, 'slug')),
+        upgrades:    Object.values(PICKAXE_UPGRADES).map(u => toItem('mine', u)),
+        blasts:      BLAST_PACKS.map(b => toItem('mine', b)),
+        consumables: Object.values(MINE_CONSUMABLES).map(c => toItem('mine', c)),
+    },
+};
+
+const ACTIVITY_ITEM_IDS = new Set(
+    Object.values(ACTIVITY_ITEMS)
+        .flatMap(groups => Object.values(groups))
+        .flat()
+        .map(item => item.id)
+);
+
+/** Whether `itemId` names an activity item that exists in the game data. */
+function isActivityItemId(itemId) {
+    return typeof itemId === 'string' && ACTIVITY_ITEM_IDS.has(itemId);
+}
+
+module.exports = { ACTIVITY_ITEMS, ACTIVITY_ITEM_IDS, isActivityItemId };

--- a/src/data/activityItems.js
+++ b/src/data/activityItems.js
@@ -11,11 +11,18 @@
  * time. Bounding writes to ids the game actually reads turns "how much can be
  * stored" from a question about the caller's patience into a property of this
  * file.
+ *
+ * Which makes the list's completeness load-bearing: an id the shop renders and
+ * this file omits is an image nobody can upload. So the groups here are every
+ * group the `/hunt shop`, `/fish shop` and `/mine shop` browse views ask for an
+ * image by — gear, upgrades, packs and consumables, *and* the zones, locations
+ * and depths those views also draw. The panel renders a subset of these; the
+ * route validates against all of them.
  */
 
-const { WEAPON_TIERS, AMMO_PACKS, CONSUMABLES: HUNT_CONSUMABLES, WEAPON_UPGRADES } = require('./huntData');
-const { ROD_TIERS, BAIT_PACKS, CONSUMABLES: FISH_CONSUMABLES, ROD_UPGRADES } = require('./fishData');
-const { PICKAXE_TIERS, BLAST_PACKS, CONSUMABLES: MINE_CONSUMABLES, PICKAXE_UPGRADES } = require('./mineData');
+const { WEAPON_TIERS, AMMO_PACKS, CONSUMABLES: HUNT_CONSUMABLES, WEAPON_UPGRADES, ZONE_LIST } = require('./huntData');
+const { ROD_TIERS, BAIT_PACKS, CONSUMABLES: FISH_CONSUMABLES, ROD_UPGRADES, LOCATION_LIST } = require('./fishData');
+const { PICKAXE_TIERS, BLAST_PACKS, CONSUMABLES: MINE_CONSUMABLES, PICKAXE_UPGRADES, DEPTH_LIST } = require('./mineData');
 
 // Tiered gear is keyed by `slug`; everything else by `id`. That difference is
 // in the game data, so it is honoured here rather than normalised away — the
@@ -34,18 +41,21 @@ const ACTIVITY_ITEMS = {
         upgrades:    Object.values(WEAPON_UPGRADES).map(u => toItem('hunt', u)),
         ammo:        AMMO_PACKS.map(a => toItem('hunt', a)),
         consumables: Object.values(HUNT_CONSUMABLES).map(c => toItem('hunt', c)),
+        zones:       ZONE_LIST.map(z => toItem('hunt', z)),
     },
     fish: {
         rods:        ROD_TIERS.map(r => toItem('fish', r, 'slug')),
         upgrades:    Object.values(ROD_UPGRADES).map(u => toItem('fish', u)),
         bait:        BAIT_PACKS.map(b => toItem('fish', b)),
         consumables: Object.values(FISH_CONSUMABLES).map(c => toItem('fish', c)),
+        locations:   LOCATION_LIST.map(l => toItem('fish', l)),
     },
     mine: {
         pickaxes:    PICKAXE_TIERS.map(p => toItem('mine', p, 'slug')),
         upgrades:    Object.values(PICKAXE_UPGRADES).map(u => toItem('mine', u)),
         blasts:      BLAST_PACKS.map(b => toItem('mine', b)),
         consumables: Object.values(MINE_CONSUMABLES).map(c => toItem('mine', c)),
+        depths:      DEPTH_LIST.map(d => toItem('mine', d)),
     },
 };
 

--- a/src/migrations/014_scope_item_images_per_guild.js
+++ b/src/migrations/014_scope_item_images_per_guild.js
@@ -1,0 +1,72 @@
+const mongoose = require('mongoose');
+
+/**
+ * Re-keys the itemimages collection from `{ itemId }` to `{ guildId, itemId }`.
+ *
+ * Activity item images were stored globally and written by any admin of any
+ * guild the bot is in, so one guild's admin could overwrite or delete the icons
+ * every other guild sees (#561). The fix is per-guild documents, and the old
+ * unique index on `itemId` is what makes those impossible: with it in place the
+ * second guild to upload the same item gets a duplicate-key error instead of
+ * its own row.
+ *
+ * Dropping an index is not something Mongoose does on its own — declaring the
+ * new compound index in the model leaves the old one exactly where it is — so
+ * it happens here, before the routes that rely on the new key are serving.
+ *
+ * Existing documents are left with `guildId: null` rather than being assigned
+ * to a guild: there is no record of who uploaded them and no guild has a better
+ * claim than any other. They stay readable as a shared fallback (see
+ * ItemImage.js and utils/itemImageHelper.js) and nothing writes them again.
+ */
+module.exports = {
+    name: '014_scope_item_images_per_guild',
+
+    async up() {
+        const images = mongoose.connection.db.collection('itemimages');
+
+        // Pre-#561 rows have no guildId at all. The compound unique index treats
+        // a missing field and an explicit null as the same key, but the reads
+        // that fall back to the shared image match on `guildId: null`, so the
+        // field is written out rather than left absent.
+        await images.updateMany({ guildId: { $exists: false } }, { $set: { guildId: null } });
+
+        // The old key. Named by Mongoose's convention when it built it from
+        // `unique: true` on the field; a database that never had it just skips.
+        await images.dropIndex('itemId_1').catch(err => {
+            if (err?.codeName !== 'IndexNotFound' && err?.code !== 26) throw err;
+        });
+
+        await images.createIndex(
+            { guildId: 1, itemId: 1 },
+            { name: 'idx_itemimage_guild_item', unique: true },
+        );
+
+        const built = (await images.indexes()).find(i => i.name === 'idx_itemimage_guild_item');
+        if (!built?.unique) {
+            throw new Error(
+                'itemimages { guildId, itemId } unique index missing after createIndex — ' +
+                'per-guild image writes would collide without it, so startup must not continue.',
+            );
+        }
+    },
+
+    /**
+     * Unwinding this restores the shared collection, which is only safe if the
+     * per-guild documents it now holds are removed first: two guilds' rows for
+     * the same item cannot both survive a unique index on `itemId`. The rows
+     * written since the migration ran are therefore dropped, and the pre-#561
+     * shared images (`guildId: null`) are what remain — the exact state `up`
+     * started from.
+     */
+    async down() {
+        const images = mongoose.connection.db.collection('itemimages');
+
+        await images.deleteMany({ guildId: { $ne: null } });
+
+        await images.dropIndex('idx_itemimage_guild_item').catch(err => {
+            if (err?.codeName !== 'IndexNotFound' && err?.code !== 26) throw err;
+        });
+        await images.createIndex({ itemId: 1 }, { name: 'itemId_1', unique: true });
+    },
+};

--- a/src/models/ItemImage.js
+++ b/src/models/ItemImage.js
@@ -1,10 +1,30 @@
 const mongoose = require('mongoose');
 
+/**
+ * Images for hunt/fish/mine items, one document per guild per item.
+ *
+ * This collection used to be global: `itemId` alone was the unique key, and the
+ * dashboard route that wrote it accepted any admin of any guild the bot is in
+ * (#561). One server's admin replacing their pickaxe icon replaced it for every
+ * server, and deleting it deleted it everywhere.
+ *
+ * `guildId: null` is the pre-#561 document — the images that were uploaded while
+ * the collection was shared. They are kept as a read-only fallback so nobody's
+ * icons vanish on deploy, and nothing writes them any more: an upload always
+ * lands on the uploading guild's own document, and a delete only ever removes
+ * that one. See migration 014.
+ */
 const itemImageSchema = new mongoose.Schema({
-    itemId:    { type: String, required: true, unique: true },
+    guildId:   { type: String, default: null },
+    itemId:    { type: String, required: true },
     imageData: { type: Buffer, required: true },
     imageType: { type: String, default: 'image/png' },
     updatedAt: { type: Date,   default: Date.now }
 });
+
+// One image per item per guild. Declared here so a fresh database gets it, and
+// created explicitly in migration 014 — which also drops the old single-field
+// unique index on itemId, since that index makes per-guild rows impossible.
+itemImageSchema.index({ guildId: 1, itemId: 1 }, { unique: true, name: 'idx_itemimage_guild_item' });
 
 module.exports = mongoose.model('ItemImage', itemImageSchema);

--- a/src/services/ai/providers/ollama.js
+++ b/src/services/ai/providers/ollama.js
@@ -1,7 +1,52 @@
 const axios = require('axios');
+const { guardedAgents, assertPublicHttpUrl } = require('../../../utils/outboundGuard');
 
-function chatUrl(baseUrl) {
-    return `${(baseUrl || 'http://localhost:11434').replace(/\/$/, '')}/api/chat`;
+// The endpoint the *operator* runs, from the environment or the shipped default.
+// A guild's `ai.ollamaBaseUrl` is a dashboard setting, so it is attacker input
+// the moment one guild admin is untrusted; this is not. The two localhost forms
+// are both listed because the shipped default is one of them and an operator
+// who types the other means the same machine.
+const OPERATOR_DEFAULT = 'http://localhost:11434';
+const LOCAL_ALIASES = ['http://localhost:11434', 'http://127.0.0.1:11434'];
+
+// Trailing slashes only; anything else is compared verbatim, so "the operator's
+// endpoint" means exactly that and not "any path on that host".
+function normalize(baseUrl) {
+    return String(baseUrl || '').trim().replace(/\/+$/, '');
+}
+
+function operatorEndpoints() {
+    const configured = normalize(process.env.OLLAMA_BASE_URL);
+    return new Set(configured ? [configured, ...LOCAL_ALIASES] : LOCAL_ALIASES);
+}
+
+/**
+ * Where this request may go, and how it is allowed to get there (#559).
+ *
+ * `ai` is a whitelisted settings parent, so any guild admin can write
+ * `ai.ollamaBaseUrl`, and it used to reach `axios.post` unexamined — with the
+ * response echoed back into a Discord channel. From inside the container that
+ * reaches the metadata service, the Mongo host on the compose network, and
+ * anything else the bot can see: a read primitive against the operator's own
+ * infrastructure, driven from a settings field and rendered as a chat reply.
+ *
+ * Requests to the operator's own endpoint are made as they always were — it is
+ * the operator's machine, usually localhost, and the whole point of the
+ * provider. Any *other* base URL is somebody's configuration, so it must be a
+ * plain http(s) URL, it must not be a literal private address, and it is
+ * dialled through agents that refuse to open a socket to private or reserved
+ * space. Those checks sit where the connection is made, so they also cover a
+ * hostname that resolves privately only sometimes, and every hop of any
+ * redirect axios follows.
+ */
+function resolveEndpoint(baseUrl) {
+    const configured = normalize(baseUrl) || OPERATOR_DEFAULT;
+    const url = `${configured}/api/chat`;
+
+    if (operatorEndpoints().has(configured)) return { url, agents: {} };
+
+    assertPublicHttpUrl(configured, 'ai.ollamaBaseUrl');
+    return { url, agents: guardedAgents() };
 }
 
 function buildMessages({ systemPrompt, history, prompt }) {
@@ -13,12 +58,13 @@ function buildMessages({ systemPrompt, history, prompt }) {
 }
 
 async function* stream({ baseUrl, model, systemPrompt, history, prompt, temperature, maxTokens, usageOut }) {
-    const response = await axios.post(chatUrl(baseUrl), {
+    const { url, agents } = resolveEndpoint(baseUrl);
+    const response = await axios.post(url, {
         model,
         messages: buildMessages({ systemPrompt, history, prompt }),
         stream: true,
         options: { temperature, num_predict: maxTokens }
-    }, { responseType: 'stream', timeout: 120000 });
+    }, { responseType: 'stream', timeout: 120000, ...agents });
 
     let buf = '';
     for await (const chunk of response.data) {
@@ -46,18 +92,37 @@ async function* stream({ baseUrl, model, systemPrompt, history, prompt, temperat
 }
 
 async function complete({ baseUrl, model, systemPrompt, history, prompt, temperature, maxTokens }) {
-    const response = await axios.post(chatUrl(baseUrl), {
+    const { url, agents } = resolveEndpoint(baseUrl);
+    const response = await axios.post(url, {
         model,
         messages: buildMessages({ systemPrompt, history, prompt }),
         stream: false,
         options: { temperature, num_predict: maxTokens }
-    }, { timeout: 120000 });
+    }, { timeout: 120000, ...agents });
     const text = response.data?.message?.content || '';
     const usage = (response.data?.prompt_eval_count != null || response.data?.eval_count != null) ? {
         inputTokens: response.data.prompt_eval_count || 0,
         outputTokens: response.data.eval_count || 0
     } : null;
     return { text, usage };
+}
+
+/**
+ * The same policy, phrased for the dashboard: an error string, or null when the
+ * value is one this provider would accept. Settings validation calls this
+ * rather than re-deriving the rule, so what the form accepts and what the
+ * request path allows cannot drift — including the operator's own endpoint,
+ * which is legitimate however private its address is.
+ */
+function validateBaseUrl(raw) {
+    if (raw === null || raw === undefined || raw === '') return null;
+    if (typeof raw !== 'string') return 'ai.ollamaBaseUrl must be a string';
+    try {
+        resolveEndpoint(raw);
+        return null;
+    } catch (err) {
+        return err.message;
+    }
 }
 
 module.exports = {
@@ -67,8 +132,12 @@ module.exports = {
     // Local inference: no per-token cost.
     pricing: [{ match: /.*/, in: 0, out: 0 }],
     resolveAuth: aiSettings => ({
-        baseUrl: aiSettings.ollamaBaseUrl || process.env.OLLAMA_BASE_URL || 'http://localhost:11434'
+        baseUrl: aiSettings.ollamaBaseUrl || process.env.OLLAMA_BASE_URL || OPERATOR_DEFAULT
     }),
     stream,
-    complete
+    complete,
+    // Exported for settings validation, and for the tests that assert which
+    // endpoints are dialled directly and which are forced through the guard.
+    resolveEndpoint,
+    validateBaseUrl
 };

--- a/src/utils/itemImageHelper.js
+++ b/src/utils/itemImageHelper.js
@@ -2,31 +2,37 @@ const { AttachmentBuilder } = require('discord.js');
 
 /**
  * Returns { attachment, url } for use in Discord embeds, or null if no image is stored.
- * For guild shop items pass guildId; for activity items (hunt/fish/mine) pass only itemId.
- * Checks the guild shop first, then falls back to the global ItemImage collection.
+ *
+ * `guildId` is the server the image is being rendered for, and every caller
+ * should pass it: activity images (hunt/fish/mine) are per guild since #561,
+ * and a lookup without one can only find the shared pre-#561 image.
+ *
+ * Three places are checked, most specific first: the guild's own shop item,
+ * then that guild's activity image, then the shared image left over from when
+ * the collection was global.
  */
 async function getItemImageAttachment(itemId, guildId = null) {
+    const ItemImage = require('../models/ItemImage');
     let imageData = null;
     let imageType = 'image/png';
+
+    const take = source => {
+        if (!source?.imageData?.length) return false;
+        imageData = source.imageData;
+        imageType = source.imageType || 'image/png';
+        return true;
+    };
 
     if (guildId) {
         const Guild = require('../models/Guild');
         const guild = await Guild.findOne({ guildId }, { shop: 1 });
         const shopItem = guild?.shop?.find(i => i.itemId === itemId);
-        if (shopItem?.imageData?.length) {
-            imageData = shopItem.imageData;
-            imageType = shopItem.imageType || 'image/png';
-        }
+        take(shopItem);
+
+        if (!imageData) take(await ItemImage.findOne({ guildId, itemId }));
     }
 
-    if (!imageData) {
-        const ItemImage = require('../models/ItemImage');
-        const img = await ItemImage.findOne({ itemId });
-        if (img?.imageData?.length) {
-            imageData = img.imageData;
-            imageType = img.imageType || 'image/png';
-        }
-    }
+    if (!imageData) take(await ItemImage.findOne({ guildId: null, itemId }));
 
     if (!imageData) return null;
 

--- a/src/utils/outboundGuard.js
+++ b/src/utils/outboundGuard.js
@@ -1,0 +1,181 @@
+'use strict';
+
+/**
+ * SSRF guards for outbound HTTP that a *user* pointed at something.
+ *
+ * `safeFeedFetch.js` already does this for RSS, and does it by hand: it
+ * resolves the hostname itself, checks every returned address, then connects to
+ * the one it checked. That shape is right for a fetcher that owns its own
+ * request loop and has to re-run the check on each redirect hop, and it stays
+ * where it is.
+ *
+ * This module is the same guarantee for the requests the bot makes through a
+ * client library — axios, an SDK — where the connection is not ours to build.
+ * Rather than resolving up front and hoping the library connects to the same
+ * address (it will not: it resolves again, and DNS can answer differently the
+ * second time), the checks are moved to where the socket is opened: into the
+ * resolver for hostnames, and into the agent's `createConnection` for literal
+ * addresses, which never reach a resolver at all. The address that is validated
+ * is by construction the address that is dialled, so there is no window between
+ * the two for a rebind to land in — on the first request or on a redirect.
+ *
+ * `isPrivateIp` is imported from safeFeedFetch rather than copied: the list of
+ * ranges that must never be reached is one rule, and two copies of it drift.
+ */
+
+const dns = require('dns');
+const http = require('http');
+const https = require('https');
+const net = require('net');
+const { isPrivateIp } = require('./safeFeedFetch');
+
+// A URL's hostname keeps IPv6 in brackets; `net.isIP` and `isPrivateIp` do not.
+function bareHost(host) {
+    const text = String(host || '');
+    return text.startsWith('[') && text.endsWith(']') ? text.slice(1, -1) : text;
+}
+
+/**
+ * The error for connecting to a literal address in private or reserved space,
+ * or null when `host` is not a literal address at all.
+ *
+ * This exists because `guardedLookup` below is not enough on its own:
+ * `net.connect` skips DNS entirely when the host is already an IP, so a lookup
+ * hook never sees `http://169.254.169.254/` — which is the first address anyone
+ * tries. Every literal therefore has to be checked where the socket is opened.
+ */
+function literalAddressError(host) {
+    const address = bareHost(host);
+    if (!net.isIP(address) || !isPrivateIp(address)) return null;
+    const error = new Error(
+        `Refusing to connect to ${address}: it is a private or reserved address.`
+    );
+    error.code = 'EPRIVATEADDR';
+    return error;
+}
+
+/**
+ * A `dns.lookup` drop-in that refuses to resolve to private or reserved space.
+ *
+ * Node hands `lookup` to `net.connect` with whatever shape the caller used, and
+ * expects the matching shape back: an array when it asked for `all` (which
+ * Happy Eyeballs does by default since Node 20), a single address otherwise.
+ * Both are handled, and the underlying query always asks for every address so
+ * that a hostname answering with one public and one private address is refused
+ * rather than being allowed on whichever the resolver happened to order first.
+ */
+function guardedLookup(hostname, options, callback) {
+    const cb = typeof options === 'function' ? options : callback;
+    const opts = typeof options === 'function' ? {}
+        : typeof options === 'number' ? { family: options }
+        : options || {};
+
+    dns.lookup(hostname, { ...opts, all: true }, (err, addresses) => {
+        if (err) return cb(err);
+
+        const list = Array.isArray(addresses) ? addresses : [addresses];
+        if (!list.length) return cb(new Error(`"${hostname}" resolved to no addresses.`));
+
+        const blocked = list.find(entry => isPrivateIp(entry.address));
+        if (blocked) {
+            const error = new Error(
+                `Refusing to connect to "${hostname}": it resolves to ${blocked.address}, ` +
+                'which is a private or reserved address.'
+            );
+            error.code = 'EPRIVATEADDR';
+            return cb(error);
+        }
+
+        if (opts.all) return cb(null, list);
+        return cb(null, list[0].address, list[0].family);
+    });
+}
+
+// Two checks per connection, because they cover different inputs: `lookup`
+// handles hostnames, and the override handles the literal addresses `lookup`
+// never sees. `createConnection` is where a connection is actually opened, so a
+// redirect to a private address is checked exactly like the first request was —
+// which is what makes this hold for a library whose redirect handling we do not
+// write.
+function guardConnection(agentClass) {
+    return class GuardedAgent extends agentClass {
+        createConnection(options, callback) {
+            const error = literalAddressError(options.host ?? options.hostname);
+            if (!error) return super.createConnection(options, callback);
+            // Reporting through the callback rather than throwing keeps the
+            // failure on the request, where a caller can catch it, instead of
+            // unwinding through the agent's internals.
+            process.nextTick(() => callback(error));
+            return undefined;
+        }
+    };
+}
+
+const GuardedHttpAgent = guardConnection(http.Agent);
+const GuardedHttpsAgent = guardConnection(https.Agent);
+
+// One pair for the process. Agents are pooled by design and these carry no
+// per-request state; keepAlive is left off (the default), so no socket outlives
+// the request that validated its address.
+let agents = null;
+
+/**
+ * `{ httpAgent, httpsAgent }` for handing to axios (or any library that takes
+ * Node agents).
+ */
+function guardedAgents() {
+    if (!agents) {
+        agents = {
+            httpAgent: new GuardedHttpAgent({ lookup: guardedLookup }),
+            httpsAgent: new GuardedHttpsAgent({ lookup: guardedLookup }),
+        };
+    }
+    return agents;
+}
+
+/**
+ * Parses a user-supplied URL and throws unless it is a plain http(s) address.
+ *
+ * Rejected here: anything that is not a URL at all, schemes that are not
+ * http/https (file:, gopher:, redis:), embedded credentials — which no
+ * legitimate configured endpoint needs and which exist mostly to smuggle a host
+ * past a naive parser — and a literal address in private or reserved space.
+ *
+ * Where a *hostname* points is not settled here, because it is not knowable
+ * when a setting is saved; that is what the agents above are for.
+ *
+ * @returns {URL} the parsed URL, so callers can use the normalised form.
+ */
+function assertPublicHttpUrl(raw, label = 'URL') {
+    const text = typeof raw === 'string' ? raw.trim() : '';
+    if (!text) throw new Error(`${label} must be a non-empty URL.`);
+    if (text.length > 512) throw new Error(`${label} is too long (max 512 characters).`);
+
+    let url;
+    try {
+        url = new URL(text);
+    } catch {
+        throw new Error(`${label} is not a valid URL.`);
+    }
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        throw new Error(`${label} must use http:// or https:// (got "${url.protocol}//").`);
+    }
+    if (url.username || url.password) {
+        throw new Error(`${label} must not embed credentials.`);
+    }
+    if (!url.hostname) {
+        throw new Error(`${label} must include a hostname.`);
+    }
+
+    // A literal address is the one case where the destination *is* knowable now,
+    // and it is also the common one: 169.254.169.254 and 127.0.0.1 are typed
+    // directly, not resolved. Saying so when the value is saved beats accepting
+    // it and refusing every request it produces.
+    const literal = literalAddressError(url.hostname);
+    if (literal) throw new Error(`${label}: ${literal.message}`);
+
+    return url;
+}
+
+module.exports = { guardedLookup, guardedAgents, assertPublicHttpUrl, literalAddressError };

--- a/src/utils/shopBrowse.js
+++ b/src/utils/shopBrowse.js
@@ -46,8 +46,16 @@ async function loadImagesByItemIds(itemIds, guildId = null) {
 
     const missing = ids.filter(id => !out[id]);
     if (missing.length) {
-        const docs = await ItemImage.find({ itemId: { $in: missing } });
-        for (const d of docs) {
+        // Activity images are per guild since #561, with the pre-#561 shared
+        // rows (guildId: null) still readable as a fallback. Both are fetched in
+        // one query and the shared ones applied first, so a guild's own image
+        // overwrites the shared one rather than racing it.
+        const docs = await ItemImage.find({
+            itemId: { $in: missing },
+            guildId: { $in: [guildId || null, null] },
+        });
+        const sharedFirst = [...docs].sort((a, b) => (a.guildId == null ? 0 : 1) - (b.guildId == null ? 0 : 1));
+        for (const d of sharedFirst) {
             const buf = toBuffer(d.imageData);
             if (buf) out[d.itemId] = buf;
         }

--- a/tests/activityItemCatalog.test.js
+++ b/tests/activityItemCatalog.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+// The catalog in data/activityItems.js is what the image upload route validates
+// against (#561), so an id the game renders and the catalog omits is an image
+// nobody can upload — which is exactly what happened to the zone, location and
+// depth cards: the shop views ask for an image for each of them, and the first
+// version of the catalog listed only gear, upgrades, packs and consumables.
+//
+// Two kinds of check, because the first alone would not have caught that: the
+// ids each source list produces are in the catalog, and the *number of groups*
+// the catalog carries matches the number of image slots the shop view actually
+// draws. The second is the drift guard — a sixth group added to a shop view
+// fails here rather than silently becoming un-uploadable.
+
+const fs = require('fs');
+const path = require('path');
+
+const { ACTIVITY_ITEMS, ACTIVITY_ITEM_IDS, isActivityItemId } = require('../src/data/activityItems');
+const { WEAPON_TIERS, AMMO_PACKS, CONSUMABLES: HUNT_CONSUMABLES, WEAPON_UPGRADES, ZONE_LIST } = require('../src/data/huntData');
+const { ROD_TIERS, BAIT_PACKS, CONSUMABLES: FISH_CONSUMABLES, ROD_UPGRADES, LOCATION_LIST } = require('../src/data/fishData');
+const { PICKAXE_TIERS, BLAST_PACKS, CONSUMABLES: MINE_CONSUMABLES, PICKAXE_UPGRADES, DEPTH_LIST } = require('../src/data/mineData');
+
+// The shape the upload route requires of an id before it even reaches the
+// catalog. A catalog entry that cannot pass it is unreachable.
+const ROUTE_ID_SHAPE = /^[a-z0-9_:-]{1,64}$/;
+
+const ids = list => list.map(item => item.id);
+const slugs = list => list.map(item => item.slug);
+
+describe('every id the shop views render is in the catalog', () => {
+    const cases = [
+        ['hunt weapons',     'hunt', slugs(WEAPON_TIERS)],
+        ['hunt upgrades',    'hunt', ids(Object.values(WEAPON_UPGRADES))],
+        ['hunt ammo',        'hunt', ids(AMMO_PACKS)],
+        ['hunt consumables', 'hunt', ids(Object.values(HUNT_CONSUMABLES))],
+        ['hunt zones',       'hunt', ids(ZONE_LIST)],
+        ['fish rods',        'fish', slugs(ROD_TIERS)],
+        ['fish upgrades',    'fish', ids(Object.values(ROD_UPGRADES))],
+        ['fish bait',        'fish', ids(BAIT_PACKS)],
+        ['fish consumables', 'fish', ids(Object.values(FISH_CONSUMABLES))],
+        ['fish locations',   'fish', ids(LOCATION_LIST)],
+        ['mine pickaxes',    'mine', slugs(PICKAXE_TIERS)],
+        ['mine upgrades',    'mine', ids(Object.values(PICKAXE_UPGRADES))],
+        ['mine blasts',      'mine', ids(BLAST_PACKS)],
+        ['mine consumables', 'mine', ids(Object.values(MINE_CONSUMABLES))],
+        ['mine depths',      'mine', ids(DEPTH_LIST)],
+    ];
+
+    test.each(cases)('%s', (_label, namespace, memberIds) => {
+        expect(memberIds.length).toBeGreaterThan(0);
+        const missing = memberIds.filter(id => !isActivityItemId(`${namespace}:${id}`));
+        expect(missing).toEqual([]);
+    });
+
+    test('every catalog id can pass the upload route\'s own shape check', () => {
+        const malformed = [...ACTIVITY_ITEM_IDS].filter(id => !ROUTE_ID_SHAPE.test(id));
+        expect(malformed).toEqual([]);
+    });
+
+    test('ids are unique across the whole catalog', () => {
+        const all = Object.values(ACTIVITY_ITEMS).flatMap(groups => Object.values(groups)).flat();
+        expect(ACTIVITY_ITEM_IDS.size).toBe(all.length);
+    });
+});
+
+// The drift guard. Each `imageId:` in a shop view is a slot the browse UI draws
+// an image into; each group in the catalog is a set of ids that may fill one.
+// The counts have to match, or some slot is rendering an id nothing can upload.
+describe('the catalog covers every image slot the shop views draw', () => {
+    const shopFile = rel => fs.readFileSync(path.join(__dirname, '..', 'src', 'commands', 'economy', rel), 'utf8');
+
+    test.each([
+        ['hunt', 'hunt/shop.js'],
+        ['fish', 'fish/shop.js'],
+        ['mine', 'mine/shop.js'],
+    ])('%s', (activity, rel) => {
+        const slots = shopFile(rel).match(new RegExp(`imageId:\\s*\`${activity}:`, 'g')) || [];
+        expect(slots.length).toBeGreaterThan(0);
+        expect(Object.keys(ACTIVITY_ITEMS[activity])).toHaveLength(slots.length);
+    });
+});

--- a/tests/aiOllamaSsrf.test.js
+++ b/tests/aiOllamaSsrf.test.js
@@ -1,0 +1,228 @@
+'use strict';
+
+// #559: `ai.ollamaBaseUrl` is a dashboard setting any guild admin can write, and
+// it reached `axios.post` unexamined — the one user-supplied fetch in the bot
+// that went around safeFeedFetch's guard, with the response echoed back into a
+// Discord channel. From inside the container that is a read primitive against
+// the operator's own network.
+//
+// Two halves are tested here, because either alone is bypassable: the syntactic
+// check the dashboard applies when the setting is saved, and the resolver-level
+// check applied when the request is actually made (DNS at save time says
+// nothing about DNS an hour later).
+
+const http = require('http');
+const axios = require('axios');
+
+const { guardedLookup, assertPublicHttpUrl } = require('../src/utils/outboundGuard');
+const ollama = require('../src/services/ai/providers/ollama');
+const { validateAiUpdate } = require('../src/dashboard/routes/api/settings');
+
+const lookup = (hostname, options = {}) => new Promise((resolve, reject) => {
+    guardedLookup(hostname, options, (err, ...rest) => (err ? reject(err) : resolve(rest)));
+});
+
+describe('guardedLookup', () => {
+    test.each([
+        ['127.0.0.1', 'loopback'],
+        ['169.254.169.254', 'the cloud metadata address'],
+        ['10.1.2.3', 'RFC1918'],
+        ['172.16.0.9', 'RFC1918'],
+        ['192.168.1.1', 'RFC1918'],
+        ['::1', 'IPv6 loopback'],
+    ])('refuses %s (%s)', async address => {
+        await expect(lookup(address)).rejects.toMatchObject({ code: 'EPRIVATEADDR' });
+    });
+
+    test('allows a public address, in both the shapes Node asks for', async () => {
+        await expect(lookup('8.8.8.8')).resolves.toEqual(['8.8.8.8', 4]);
+        await expect(lookup('8.8.8.8', { all: true })).resolves.toEqual([
+            [{ address: '8.8.8.8', family: 4 }],
+        ]);
+    });
+
+    // Happy Eyeballs asks for every address; a name answering with one public
+    // and one private address must not be allowed on the public one.
+    test('refuses a hostname whose answers are not all public', async () => {
+        const dns = require('dns');
+        const spy = jest.spyOn(dns, 'lookup').mockImplementation((host, opts, cb) => {
+            cb(null, [{ address: '93.184.216.34', family: 4 }, { address: '127.0.0.1', family: 4 }]);
+        });
+        try {
+            await expect(lookup('split-horizon.example')).rejects.toMatchObject({ code: 'EPRIVATEADDR' });
+        } finally {
+            spy.mockRestore();
+        }
+    });
+});
+
+describe('assertPublicHttpUrl', () => {
+    test.each([
+        'file:///etc/passwd',
+        'gopher://127.0.0.1:11211/_stats',
+        'redis://cache:6379',
+        'not a url',
+        '',
+        'http://user:password@ollama.example.com:11434',
+        'http://169.254.169.254/latest/meta-data',
+        'http://127.0.0.1:27017',
+        'http://[::1]:11434',
+        'http://10.0.0.5:27017',
+    ])('rejects %s', raw => {
+        expect(() => assertPublicHttpUrl(raw, 'ai.ollamaBaseUrl')).toThrow(/ai\.ollamaBaseUrl/);
+    });
+
+    test('accepts a plain http(s) URL and hands back the parsed form', () => {
+        expect(assertPublicHttpUrl('https://ollama.example.com:11434').host).toBe('ollama.example.com:11434');
+    });
+});
+
+describe('settings validation for ai.ollamaBaseUrl', () => {
+    test('rejects a scheme the provider should never dial', () => {
+        expect(validateAiUpdate({ 'ai.ollamaBaseUrl': 'file:///etc/passwd' }))
+            .toMatch(/ai\.ollamaBaseUrl must use http/);
+    });
+
+    test('rejects the addresses the attack in #559 is written against', () => {
+        expect(validateAiUpdate({ 'ai.ollamaBaseUrl': 'http://169.254.169.254/latest/meta-data' }))
+            .toMatch(/private or reserved address/);
+        expect(validateAiUpdate({ 'ai.ollamaBaseUrl': 'http://127.0.0.1:27017' }))
+            .toMatch(/private or reserved address/);
+    });
+
+    test('rejects a non-string, and reads the field out of a whole-object write too', () => {
+        expect(validateAiUpdate({ 'ai.ollamaBaseUrl': 42 })).toBe('ai.ollamaBaseUrl must be a string');
+        expect(validateAiUpdate({ ai: { ollamaBaseUrl: 'javascript:alert(1)' } })).toMatch(/ai\.ollamaBaseUrl/);
+    });
+
+    test('leaves empty and null alone — both mean "use the operator\'s endpoint"', () => {
+        expect(validateAiUpdate({ 'ai.ollamaBaseUrl': '' })).toBeNull();
+        expect(validateAiUpdate({ 'ai.ollamaBaseUrl': null })).toBeNull();
+        expect(validateAiUpdate({ 'ai.ollamaBaseUrl': 'http://ollama.internal.example.com:11434' })).toBeNull();
+    });
+
+    test('ignores settings that are not ai settings', () => {
+        expect(validateAiUpdate({ 'welcome.message': 'file:///etc/passwd' })).toBeNull();
+    });
+
+    // The form must accept what the request path allows, or an operator running
+    // Ollama on a private address cannot enter it.
+    test("accepts the operator's own endpoint even though it is private", () => {
+        const saved = process.env.OLLAMA_BASE_URL;
+        process.env.OLLAMA_BASE_URL = 'http://192.168.1.50:11434';
+        try {
+            expect(validateAiUpdate({ 'ai.ollamaBaseUrl': 'http://192.168.1.50:11434' })).toBeNull();
+            expect(validateAiUpdate({ 'ai.ollamaBaseUrl': 'http://192.168.1.51:11434' })).toMatch(/private or reserved/);
+        } finally {
+            if (saved === undefined) delete process.env.OLLAMA_BASE_URL;
+            else process.env.OLLAMA_BASE_URL = saved;
+        }
+    });
+});
+
+describe('ollama endpoint policy', () => {
+    const savedEnv = process.env.OLLAMA_BASE_URL;
+    afterEach(() => {
+        if (savedEnv === undefined) delete process.env.OLLAMA_BASE_URL;
+        else process.env.OLLAMA_BASE_URL = savedEnv;
+    });
+
+    test("the operator's own endpoint is dialled directly", () => {
+        delete process.env.OLLAMA_BASE_URL;
+        for (const baseUrl of ['http://localhost:11434', 'http://127.0.0.1:11434/', '']) {
+            const { url, agents } = ollama.resolveEndpoint(baseUrl);
+            expect(url).toMatch(/\/api\/chat$/);
+            expect(agents).toEqual({});
+        }
+    });
+
+    test('OLLAMA_BASE_URL names an operator endpoint, however private it is', () => {
+        process.env.OLLAMA_BASE_URL = 'http://ollama.internal:11434';
+        expect(ollama.resolveEndpoint('http://ollama.internal:11434').agents).toEqual({});
+    });
+
+    // The attack from the issue: a guild admin points the setting at a host on
+    // the compose network. The name is resolved through the guarded resolver,
+    // which is where "mongodb" turns out to be private.
+    test('any other endpoint is forced through the guarded resolver', () => {
+        delete process.env.OLLAMA_BASE_URL;
+        for (const baseUrl of ['http://mongodb:27017', 'http://localhost:27017', 'https://ollama.example.com']) {
+            const { agents } = ollama.resolveEndpoint(baseUrl);
+            expect(agents.httpAgent).toBeDefined();
+            expect(agents.httpsAgent).toBeDefined();
+            expect(agents.httpAgent.options.lookup).toBe(guardedLookup);
+        }
+    });
+
+    // The other half of the issue's attack — a literal address, which no
+    // resolver is ever asked about.
+    test('a literal private address is refused outright', () => {
+        delete process.env.OLLAMA_BASE_URL;
+        for (const baseUrl of ['http://169.254.169.254/latest/meta-data', 'http://127.0.0.1:27017']) {
+            expect(() => ollama.resolveEndpoint(baseUrl)).toThrow(/private or reserved address/);
+        }
+    });
+
+    test('a base URL that is not http(s) is refused outright', () => {
+        expect(() => ollama.resolveEndpoint('file:///etc/passwd')).toThrow(/ai\.ollamaBaseUrl/);
+    });
+});
+
+describe('the provider actually uses the policy', () => {
+    let post;
+    beforeEach(() => {
+        post = jest.spyOn(axios, 'post').mockResolvedValue({ data: { message: { content: 'hi' } } });
+    });
+    afterEach(() => post.mockRestore());
+
+    const args = { model: 'llama3.2', systemPrompt: 's', history: [], prompt: 'p', temperature: 0.7, maxTokens: 64 };
+
+    test('complete() sends the guarded agents for a guild-supplied endpoint', async () => {
+        await ollama.complete({ ...args, baseUrl: 'http://mongodb:27017' });
+
+        const [url, , config] = post.mock.calls[0];
+        expect(url).toBe('http://mongodb:27017/api/chat');
+        expect(config.httpAgent).toBeDefined();
+        expect(config.httpsAgent).toBeDefined();
+    });
+
+    test("complete() leaves the operator's endpoint unproxied", async () => {
+        await ollama.complete({ ...args, baseUrl: 'http://localhost:11434' });
+
+        const [, , config] = post.mock.calls[0];
+        expect(config.httpAgent).toBeUndefined();
+        expect(config.httpsAgent).toBeUndefined();
+    });
+
+    test('stream() applies the same policy', async () => {
+        post.mockResolvedValue({ data: (async function* () { yield Buffer.from('{"done":true}\n'); })() });
+
+        // eslint-disable-next-line no-unused-vars
+        for await (const _chunk of ollama.stream({ ...args, baseUrl: 'http://attacker.example.com' })) { /* drain */ }
+
+        expect(post.mock.calls[0][2].httpAgent).toBeDefined();
+    });
+});
+
+// The whole point is that nothing reaches the address, so the test is a real
+// server on a real loopback port that must never see a request.
+describe('end to end: a private endpoint is not connected to', () => {
+    let server;
+    let port;
+    let hits = 0;
+
+    beforeAll(done => {
+        server = http.createServer((req, res) => { hits++; res.end('{}'); });
+        server.listen(0, '127.0.0.1', () => { port = server.address().port; done(); });
+    });
+    afterAll(done => { server.close(() => done()); });
+
+    test('complete() against loopback is refused before the socket opens', async () => {
+        await expect(ollama.complete({
+            baseUrl: `http://127.0.0.1:${port}`,
+            model: 'llama3.2', systemPrompt: 's', history: [], prompt: 'p', temperature: 0.7, maxTokens: 64,
+        })).rejects.toThrow(/private or reserved address/);
+
+        expect(hits).toBe(0);
+    });
+});

--- a/tests/botGateway.test.js
+++ b/tests/botGateway.test.js
@@ -89,6 +89,72 @@ function stubGuild(overrides = {}) {
     };
 }
 
+// #558: the dashboard's session carries the guild list Discord returned at OAuth
+// time and nothing refreshes it, so the gateway is where a second opinion has to
+// come from. `null` is a distinct answer from `false` here — it means nobody
+// could say, and callers treat it as "fall back to the snapshot" rather than as
+// a denial, so a stub that conflates the two would hide a lockout or a bypass.
+describe('canManageGuild', () => {
+    const { PermissionFlagsBits } = require('discord.js');
+
+    function memberWith(bits) {
+        return { permissions: { has: bit => (bits & bit) === bit } };
+    }
+
+    function gatewayFor(fetchImpl, { ownerId = 'owner-1' } = {}) {
+        const fixture = stubGuild({ ownerId, members: { fetch: fetchImpl } });
+        return createBotGateway(stubClient({ guilds: { g1: fixture.guild } }));
+    }
+
+    test('true for a member holding MANAGE_GUILD, and for one holding ADMINISTRATOR', async () => {
+        for (const bits of [PermissionFlagsBits.ManageGuild, PermissionFlagsBits.Administrator]) {
+            const bot = gatewayFor(async () => memberWith(bits));
+            await expect(bot.canManageGuild('g1', 'u1')).resolves.toBe(true);
+        }
+    });
+
+    test('true for the owner without any member fetch at all', async () => {
+        const fetchMember = jest.fn();
+        const bot = gatewayFor(fetchMember, { ownerId: 'u1' });
+
+        await expect(bot.canManageGuild('g1', 'u1')).resolves.toBe(true);
+        expect(fetchMember).not.toHaveBeenCalled();
+    });
+
+    // A cached member is the stale snapshot this method exists to replace, so
+    // the fetch has to go to Discord rather than answer from the cache.
+    test('forces the fetch past the member cache', async () => {
+        const fetchMember = jest.fn(async () => memberWith(PermissionFlagsBits.ManageGuild));
+        const bot = gatewayFor(fetchMember);
+
+        await bot.canManageGuild('g1', 'u1');
+
+        expect(fetchMember).toHaveBeenCalledWith({ user: 'u1', force: true });
+    });
+
+    test('false for a member who holds neither permission', async () => {
+        const bot = gatewayFor(async () => memberWith(PermissionFlagsBits.SendMessages));
+        await expect(bot.canManageGuild('g1', 'u1')).resolves.toBe(false);
+    });
+
+    // Kicked or banned: Discord answered, and the answer is no.
+    test('false when Discord says there is no such member', async () => {
+        for (const code of [10007, 10013]) {
+            const bot = gatewayFor(async () => { throw Object.assign(new Error('Unknown Member'), { code }); });
+            await expect(bot.canManageGuild('g1', 'u1')).resolves.toBe(false);
+        }
+    });
+
+    test('null when the question could not be asked', async () => {
+        const failing = gatewayFor(async () => { throw Object.assign(new Error('Service Unavailable'), { code: 500 }); });
+        await expect(failing.canManageGuild('g1', 'u1')).resolves.toBeNull();
+
+        const elsewhere = gatewayFor(async () => memberWith(PermissionFlagsBits.ManageGuild));
+        await expect(elsewhere.canManageGuild('nope', 'u1')).resolves.toBeNull();
+        await expect(elsewhere.canManageGuild('g1', undefined)).resolves.toBeNull();
+    });
+});
+
 describe('botGateway hands out data, never live objects', () => {
     let fixture;
     let bot;

--- a/tests/dashboardAuthEnforcement.test.js
+++ b/tests/dashboardAuthEnforcement.test.js
@@ -18,7 +18,6 @@ const {
     checkAuth,
     checkGuildAccess,
     checkCsrfOrigin,
-    checkAnyGuildAdmin,
 } = require('../src/dashboard/lib/middleware');
 const { forgetLiveGuildAccess } = require('../src/dashboard/lib/permissions');
 
@@ -217,48 +216,6 @@ describe('checkGuildAccess', () => {
     });
 });
 
-describe('checkAnyGuildAdmin', () => {
-    test('rejects an unauthenticated caller with 401', () => {
-        const res = makeRes();
-        const next = jest.fn();
-
-        checkAnyGuildAdmin(makeReq({ authenticated: false }), res, next);
-
-        expect(next).not.toHaveBeenCalled();
-        expect(res.statusCode).toBe(401);
-    });
-
-    test('rejects a signed-in user who administers nothing', () => {
-        const res = makeRes();
-        const next = jest.fn();
-
-        checkAnyGuildAdmin(makeReq({ guilds: [memberOf('g1')], botGuilds: ['g1'] }), res, next);
-
-        expect(next).not.toHaveBeenCalled();
-        expect(res.statusCode).toBe(403);
-        expect(res.body).toEqual({ error: 'Forbidden' });
-    });
-
-    test('rejects an admin whose only guilds are ones the bot is absent from', () => {
-        const res = makeRes();
-        const next = jest.fn();
-
-        checkAnyGuildAdmin(makeReq({ guilds: [adminOf('g1')], botGuilds: [] }), res, next);
-
-        expect(next).not.toHaveBeenCalled();
-        expect(res.statusCode).toBe(403);
-    });
-
-    test('admits an admin of at least one shared guild', () => {
-        const res = makeRes();
-        const next = jest.fn();
-
-        checkAnyGuildAdmin(makeReq({ guilds: [adminOf('g1')], botGuilds: ['g1'] }), res, next);
-
-        expect(next).toHaveBeenCalledTimes(1);
-    });
-});
-
 describe('checkCsrfOrigin', () => {
     const DASHBOARD = 'https://dash.example.com';
     let saved;
@@ -395,7 +352,7 @@ describe('every API route mounts its guards', () => {
     // saying why, not slipping past a wildcard.
     const PUBLIC_ROUTES = new Set([
         'itemImages.js GET /item-image/shop/:guildId/:itemId',
-        'itemImages.js GET /item-image/activity/:itemId',
+        'itemImages.js GET /item-image/activity/:guildId/:itemId',
     ]);
 
     const guarded = routes.filter(r => !PUBLIC_ROUTES.has(label(r)));

--- a/tests/dashboardAuthEnforcement.test.js
+++ b/tests/dashboardAuthEnforcement.test.js
@@ -20,6 +20,7 @@ const {
     checkCsrfOrigin,
     checkAnyGuildAdmin,
 } = require('../src/dashboard/lib/middleware');
+const { forgetLiveGuildAccess } = require('../src/dashboard/lib/permissions');
 
 const MANAGE_GUILD = (0x20n).toString();
 const NO_PERMS     = '0';
@@ -36,15 +37,26 @@ function makeRes() {
 // `guilds` is what Discord's /users/@me/guilds returned for this session;
 // `botGuilds` is what the bot is actually in. Both matter: dashboard access needs
 // the user to administer the guild *and* the bot to be present in it.
-function makeReq({ authenticated = true, guilds = [], botGuilds = [], params = {}, headers = {} } = {}) {
+// `live` is what Discord says about this user *now*, which is the second gate
+// checkGuildAccess takes (#558): true/false when it answered, null when it could
+// not be asked. The default is null — the answer a gateway gives during an
+// outage — so every pre-existing case below still describes the snapshot rule.
+function makeReq({ authenticated = true, guilds = [], botGuilds = [], params = {}, headers = {}, live = null } = {}) {
     return {
         isAuthenticated: () => authenticated,
         user: authenticated ? { id: 'user-1', guilds } : undefined,
-        bot: { hasGuild: id => botGuilds.includes(id) },
+        bot: {
+            hasGuild: id => botGuilds.includes(id),
+            canManageGuild: async () => live,
+        },
         params,
         headers,
     };
 }
+
+// Live answers are cached for a minute, and every case here reuses the same
+// user and guild ids.
+beforeEach(() => forgetLiveGuildAccess());
 
 const adminOf   = id => ({ id, name: `guild ${id}`, permissions: MANAGE_GUILD });
 const memberOf  = id => ({ id, name: `guild ${id}`, permissions: NO_PERMS });
@@ -73,7 +85,7 @@ describe('checkAuth', () => {
 });
 
 describe('checkGuildAccess', () => {
-    test('rejects a guild the user only belongs to, with no manage permission', () => {
+    test('rejects a guild the user only belongs to, with no manage permission', async () => {
         const res = makeRes();
         const next = jest.fn();
         const req = makeReq({
@@ -82,7 +94,7 @@ describe('checkGuildAccess', () => {
             params: { guildId: 'g1' },
         });
 
-        checkGuildAccess(req, res, next);
+        await checkGuildAccess(req, res, next);
 
         expect(next).not.toHaveBeenCalled();
         expect(res.statusCode).toBe(403);
@@ -90,7 +102,7 @@ describe('checkGuildAccess', () => {
     });
 
     // The IDOR shape: authenticated, genuinely an admin — just not of this guild.
-    test('rejects an admin of one guild reaching for another', () => {
+    test('rejects an admin of one guild reaching for another', async () => {
         const res = makeRes();
         const next = jest.fn();
         const req = makeReq({
@@ -99,13 +111,13 @@ describe('checkGuildAccess', () => {
             params: { guildId: 'g2' },
         });
 
-        checkGuildAccess(req, res, next);
+        await checkGuildAccess(req, res, next);
 
         expect(next).not.toHaveBeenCalled();
         expect(res.statusCode).toBe(403);
     });
 
-    test('rejects a guild the user administers but the bot is not in', () => {
+    test('rejects a guild the user administers but the bot is not in', async () => {
         const res = makeRes();
         const next = jest.fn();
         const req = makeReq({
@@ -114,13 +126,13 @@ describe('checkGuildAccess', () => {
             params: { guildId: 'g1' },
         });
 
-        checkGuildAccess(req, res, next);
+        await checkGuildAccess(req, res, next);
 
         expect(next).not.toHaveBeenCalled();
         expect(res.statusCode).toBe(403);
     });
 
-    test('rejects a guild id the session has never heard of', () => {
+    test('rejects a guild id the session has never heard of', async () => {
         const res = makeRes();
         const next = jest.fn();
         const req = makeReq({
@@ -129,24 +141,79 @@ describe('checkGuildAccess', () => {
             params: { guildId: 'g9' },
         });
 
-        checkGuildAccess(req, res, next);
+        await checkGuildAccess(req, res, next);
 
         expect(res.statusCode).toBe(403);
     });
 
-    test('admits an admin of a guild the bot shares', () => {
+    test('admits an admin of a guild the bot shares', async () => {
         const res = makeRes();
         const next = jest.fn();
         const req = makeReq({
             guilds: [adminOf('g1')],
             botGuilds: ['g1'],
             params: { guildId: 'g1' },
+            live: true,
         });
 
-        checkGuildAccess(req, res, next);
+        await checkGuildAccess(req, res, next);
 
         expect(next).toHaveBeenCalledTimes(1);
         expect(res.statusCode).toBeNull();
+    });
+
+    // #558: the session's guild list is a snapshot from OAuth time and nothing
+    // refreshes it, so this is the only thing standing between a revoked admin
+    // and full write access for the rest of the cookie's life. The snapshot in
+    // this request still says MANAGE_GUILD — that is the point.
+    test('rejects a snapshot admin whom Discord no longer counts as one', async () => {
+        const res = makeRes();
+        const next = jest.fn();
+        const req = makeReq({
+            guilds: [adminOf('g1')],
+            botGuilds: ['g1'],
+            params: { guildId: 'g1' },
+            live: false,
+        });
+
+        await checkGuildAccess(req, res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(403);
+        expect(res.body).toEqual({ error: 'Forbidden' });
+    });
+
+    // The unknown answer is not a denial: an operator must not lose their own
+    // dashboard because Discord is having an incident.
+    test('falls back to the snapshot when the live check cannot answer', async () => {
+        for (const bot of [
+            { hasGuild: () => true, canManageGuild: async () => null },
+            { hasGuild: () => true, canManageGuild: async () => { throw new Error('Discord is down'); } },
+            { hasGuild: () => true }, // a gateway with no such method at all
+        ]) {
+            forgetLiveGuildAccess();
+            const res = makeRes();
+            const next = jest.fn();
+            const req = makeReq({ guilds: [adminOf('g1')], botGuilds: ['g1'], params: { guildId: 'g1' } });
+            req.bot = bot;
+
+            await checkGuildAccess(req, res, next);
+
+            expect(next).toHaveBeenCalledTimes(1);
+            expect(res.statusCode).toBeNull();
+        }
+    });
+
+    test('asks Discord once per user and guild, not once per request', async () => {
+        const canManageGuild = jest.fn().mockResolvedValue(true);
+        const req = makeReq({ guilds: [adminOf('g1')], botGuilds: ['g1'], params: { guildId: 'g1' } });
+        req.bot = { hasGuild: () => true, canManageGuild };
+
+        await checkGuildAccess(req, makeRes(), jest.fn());
+        await checkGuildAccess(req, makeRes(), jest.fn());
+
+        expect(canManageGuild).toHaveBeenCalledTimes(1);
+        expect(canManageGuild).toHaveBeenCalledWith('g1', 'user-1');
     });
 });
 
@@ -242,14 +309,59 @@ describe('checkCsrfOrigin', () => {
         expect(res.statusCode).toBe(403);
     });
 
-    test('admits a matching Origin, and a request that sends none', () => {
-        for (const headers of [{ origin: DASHBOARD }, {}]) {
+    test('admits a matching Origin', () => {
+        const res = makeRes();
+        const next = jest.fn();
+        checkCsrfOrigin(makeReq({ headers: { origin: DASHBOARD } }), res, next);
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(res.statusCode).toBeNull();
+    });
+
+    // #563: a missing Origin used to be waved through, which made the whole
+    // check optional to anything that simply omitted the header — and there is
+    // no CSRF token behind it to catch what got past. This middleware only runs
+    // on state-changing methods, and the Fetch standard has browsers send Origin
+    // on all of those, so nothing legitimate is turned away.
+    test('rejects a write that carries neither Origin nor Fetch Metadata', () => {
+        const res = makeRes();
+        const next = jest.fn();
+
+        checkCsrfOrigin(makeReq({ headers: {} }), res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(403);
+    });
+
+    test('accepts Fetch Metadata as the fallback when Origin is absent', () => {
+        for (const site of ['same-origin', 'none']) {
             const res = makeRes();
             const next = jest.fn();
-            checkCsrfOrigin(makeReq({ headers }), res, next);
+            checkCsrfOrigin(makeReq({ headers: { 'sec-fetch-site': site } }), res, next);
             expect(next).toHaveBeenCalledTimes(1);
             expect(res.statusCode).toBeNull();
         }
+    });
+
+    test('rejects the cross-site Fetch Metadata values', () => {
+        for (const site of ['cross-site', 'same-site', 'nonsense']) {
+            const res = makeRes();
+            checkCsrfOrigin(makeReq({ headers: { 'sec-fetch-site': site } }), res, jest.fn());
+            expect(res.statusCode).toBe(403);
+        }
+    });
+
+    // Origin is the stronger signal, so a forged Sec-Fetch-Site alongside a
+    // foreign Origin must not rescue the request.
+    test('a same-origin Sec-Fetch-Site does not override a foreign Origin', () => {
+        const res = makeRes();
+        const next = jest.fn();
+
+        checkCsrfOrigin(makeReq({
+            headers: { origin: 'https://evil.example.com', 'sec-fetch-site': 'same-origin' },
+        }), res, next);
+
+        expect(next).not.toHaveBeenCalled();
+        expect(res.statusCode).toBe(403);
     });
 });
 

--- a/tests/itemImageHelper.test.js
+++ b/tests/itemImageHelper.test.js
@@ -26,7 +26,7 @@ describe('getItemImageAttachment', () => {
         expect(result).not.toBeNull();
         expect(result.url).toBe('attachment://item-hunt_wooden_rifle.png');
         expect(result.attachment.name).toBe('item-hunt_wooden_rifle.png');
-        expect(ItemImage.findOne).toHaveBeenCalledWith({ itemId: 'hunt:wooden_rifle' });
+        expect(ItemImage.findOne).toHaveBeenCalledWith({ guildId: null, itemId: 'hunt:wooden_rifle' });
     });
 
     test('leaves plain itemIds untouched', async () => {
@@ -54,5 +54,32 @@ describe('getItemImageAttachment', () => {
 
         expect(result.url).toBe('attachment://item-fish_bamboo_rod.png');
         expect(ItemImage.findOne).not.toHaveBeenCalled();
+    });
+
+    // #561: activity images belong to a guild now. The guild's own row is what
+    // it must render — the shared pre-#561 row is a fallback, not a peer.
+    test('prefers the guild\'s own activity image over the shared one', async () => {
+        Guild.findOne.mockResolvedValue({ shop: [] });
+        ItemImage.findOne.mockImplementation(async ({ guildId }) => ({
+            imageData: Buffer.from(guildId === 'g1' ? 'guild-bytes' : 'shared-bytes'),
+            imageType: guildId === 'g1' ? 'image/png' : 'image/gif',
+        }));
+
+        const result = await getItemImageAttachment('mine:stone_pickaxe', 'g1');
+
+        expect(ItemImage.findOne).toHaveBeenCalledWith({ guildId: 'g1', itemId: 'mine:stone_pickaxe' });
+        expect(result.attachment.name).toBe('item-mine_stone_pickaxe.png');
+    });
+
+    test('falls back to the shared image when this guild has none of its own', async () => {
+        Guild.findOne.mockResolvedValue({ shop: [] });
+        ItemImage.findOne.mockImplementation(async ({ guildId }) =>
+            guildId === null ? { imageData: Buffer.from('shared-bytes'), imageType: 'image/gif' } : null);
+
+        const result = await getItemImageAttachment('mine:stone_pickaxe', 'g1');
+
+        expect(ItemImage.findOne).toHaveBeenNthCalledWith(1, { guildId: 'g1', itemId: 'mine:stone_pickaxe' });
+        expect(ItemImage.findOne).toHaveBeenNthCalledWith(2, { guildId: null, itemId: 'mine:stone_pickaxe' });
+        expect(result.attachment.name).toBe('item-mine_stone_pickaxe.gif');
     });
 });

--- a/tests/itemImageTenancy.test.js
+++ b/tests/itemImageTenancy.test.js
@@ -136,6 +136,26 @@ describe('what may be written', () => {
         expect(ItemImage.findOneAndUpdate).not.toHaveBeenCalled();
     });
 
+    // The catalog has to cover every id the shop views render, not just the ones
+    // the dashboard panel shows cards for — the browse views draw a zone,
+    // location and depth image too, and those were briefly un-uploadable.
+    test.each([
+        ['hunt', require('../src/data/huntData').ZONE_LIST[0].id],
+        ['fish', require('../src/data/fishData').LOCATION_LIST[0].id],
+        ['mine', require('../src/data/mineData').DEPTH_LIST[0].id],
+    ])('accepts a %s id the browse view renders but the panel does not list', async (namespace, id) => {
+        const itemId = `${namespace}:${id}`;
+
+        const res = await upload('g1', itemId);
+
+        expect(res.status).toBe(200);
+        expect(ItemImage.findOneAndUpdate).toHaveBeenCalledWith(
+            { guildId: 'g1', itemId },
+            expect.objectContaining({ imageType: 'image/png' }),
+            { upsert: true },
+        );
+    });
+
     test('a malformed id is refused as malformed', async () => {
         const res = await upload('g1', 'Hunt:../../etc/passwd');
 

--- a/tests/itemImageTenancy.test.js
+++ b/tests/itemImageTenancy.test.js
@@ -1,0 +1,189 @@
+'use strict';
+
+// #561: activity item images (hunt/fish/mine) lived in a collection keyed on
+// itemId alone, written by any admin of any guild the bot is in. One server's
+// admin could replace — or delete — the icons every other server sees, and could
+// keep writing rows under ids nothing reads, 512 KB at a time.
+//
+// The routes are driven through a real express app with the model stubbed, so
+// what is asserted is the query the route actually issues, not a description of
+// it: a filter missing its guildId is the whole bug.
+
+const express = require('express');
+
+jest.mock('../src/models/ItemImage');
+
+const ItemImage = require('../src/models/ItemImage');
+
+const PNG = Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]),
+    Buffer.alloc(16),
+]);
+
+// An id that exists in the game data, so the catalog check is not what a test
+// about tenancy is passing or failing on.
+const ITEM = 'hunt:wooden_rifle';
+
+let server;
+let baseUrl;
+let session;
+
+beforeAll(done => {
+    const app = express();
+    app.use((req, res, next) => {
+        req.isAuthenticated = () => session.authenticated !== false;
+        req.user = { id: session.userId, guilds: session.guilds };
+        req.bot = {
+            hasGuild: id => session.botGuilds.includes(id),
+            canManageGuild: async () => session.live,
+        };
+        next();
+    });
+    app.use('/api', require('../src/dashboard/routes/api/itemImages'));
+    server = app.listen(0, () => {
+        baseUrl = `http://127.0.0.1:${server.address().port}`;
+        done();
+    });
+});
+
+afterAll(done => { server.close(() => done()); });
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    require('../src/dashboard/lib/permissions').forgetLiveGuildAccess();
+    session = {
+        // Admin of g1 only. Under the old gate — "admin of any guild" — this
+        // session could write every guild's images.
+        userId: 'admin-1',
+        guilds: [{ id: 'g1', name: 'One', permissions: '32' }],
+        botGuilds: ['g1', 'g2'],
+        live: true,
+    };
+    ItemImage.findOne.mockResolvedValue(null);
+    ItemImage.findOneAndUpdate.mockResolvedValue({});
+    ItemImage.deleteOne.mockResolvedValue({ deletedCount: 1 });
+});
+
+function upload(guildId, itemId, bytes = PNG) {
+    const body = new FormData();
+    body.append('image', new Blob([bytes], { type: 'image/png' }), 'icon.png');
+    return fetch(`${baseUrl}/api/item-image/activity/${guildId}/${encodeURIComponent(itemId)}`, {
+        method: 'POST',
+        body,
+    });
+}
+
+const remove = (guildId, itemId) =>
+    fetch(`${baseUrl}/api/item-image/activity/${guildId}/${encodeURIComponent(itemId)}`, { method: 'DELETE' });
+
+describe('activity image writes are scoped to one guild', () => {
+    test('an upload lands on the uploading guild, not on every guild', async () => {
+        const res = await upload('g1', ITEM);
+
+        expect(res.status).toBe(200);
+        expect(ItemImage.findOneAndUpdate).toHaveBeenCalledWith(
+            { guildId: 'g1', itemId: ITEM },
+            expect.objectContaining({ imageType: 'image/png' }),
+            { upsert: true },
+        );
+    });
+
+    // The cross-tenant write itself: an admin of g1 reaching into g2.
+    test('an admin of one guild cannot write another guild\'s image', async () => {
+        const res = await upload('g2', ITEM);
+
+        expect(res.status).toBe(403);
+        expect(ItemImage.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    test('nor delete another guild\'s image', async () => {
+        const res = await remove('g2', ITEM);
+
+        expect(res.status).toBe(403);
+        expect(ItemImage.deleteOne).not.toHaveBeenCalled();
+    });
+
+    test('a delete only removes this guild\'s row, never the shared one', async () => {
+        const res = await remove('g1', ITEM);
+
+        expect(res.status).toBe(200);
+        expect(ItemImage.deleteOne).toHaveBeenCalledWith({ guildId: 'g1', itemId: ITEM });
+    });
+
+    test('an anonymous caller writes nothing', async () => {
+        session.authenticated = false;
+        expect((await upload('g1', ITEM)).status).toBe(401);
+        expect((await remove('g1', ITEM)).status).toBe(401);
+        expect(ItemImage.findOneAndUpdate).not.toHaveBeenCalled();
+        expect(ItemImage.deleteOne).not.toHaveBeenCalled();
+    });
+
+    // #558 rides along here: the session says g1, Discord says otherwise.
+    test('a revoked admin is refused even though the session still says admin', async () => {
+        session.live = false;
+
+        expect((await upload('g1', ITEM)).status).toBe(403);
+        expect(ItemImage.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+});
+
+describe('what may be written', () => {
+    test('an id outside the game catalog is refused, so the collection stays bounded', async () => {
+        const res = await upload('g1', 'hunt:not_a_real_weapon');
+
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toBe('Unknown activity item');
+        expect(ItemImage.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    test('a malformed id is refused as malformed', async () => {
+        const res = await upload('g1', 'Hunt:../../etc/passwd');
+
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toBe('Invalid itemId');
+    });
+
+    // The DELETE path skipped the id check the POST applied, so it could match
+    // rows the upload path could never have written.
+    test('DELETE validates the id too', async () => {
+        const res = await remove('g1', 'hunt:not_a_real_weapon');
+
+        expect(res.status).toBe(400);
+        expect(ItemImage.deleteOne).not.toHaveBeenCalled();
+    });
+
+    test('a file that is not really an image is refused', async () => {
+        const res = await upload('g1', ITEM, Buffer.from('<?php echo 1; ?>'));
+
+        expect(res.status).toBe(400);
+        expect(ItemImage.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+});
+
+describe('reads', () => {
+    test("a guild's own image wins over the shared pre-#561 one", async () => {
+        ItemImage.findOne.mockImplementation(async ({ guildId }) =>
+            ({ imageData: Buffer.from(guildId === 'g1' ? 'own' : 'shared'), imageType: 'image/png' }));
+
+        const res = await fetch(`${baseUrl}/api/item-image/activity/g1/${ITEM}`);
+
+        expect(res.status).toBe(200);
+        expect(ItemImage.findOne).toHaveBeenCalledWith({ guildId: 'g1', itemId: ITEM });
+        expect(Buffer.from(await res.arrayBuffer()).toString()).toBe('own');
+    });
+
+    test('the shared image is still served to a guild that has none of its own', async () => {
+        ItemImage.findOne.mockImplementation(async ({ guildId }) =>
+            (guildId === null ? { imageData: Buffer.from('shared'), imageType: 'image/gif' } : null));
+
+        const res = await fetch(`${baseUrl}/api/item-image/activity/g9/${ITEM}`);
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get('content-type')).toBe('image/gif');
+        expect(Buffer.from(await res.arrayBuffer()).toString()).toBe('shared');
+    });
+
+    test('404 when there is no image anywhere', async () => {
+        expect((await fetch(`${baseUrl}/api/item-image/activity/g1/${ITEM}`)).status).toBe(404);
+    });
+});

--- a/tests/migrationIndexes.test.js
+++ b/tests/migrationIndexes.test.js
@@ -37,3 +37,29 @@ describe('009_drop_stale_grind_indexes', () => {
             .toBeGreaterThan(files.indexOf('005_grind_profiles.js'));
     });
 });
+
+// 014 re-keys itemimages from { itemId } to { guildId, itemId } so one guild's
+// admin can no longer overwrite every guild's images (#561). Two things have to
+// agree for that to hold, and neither is visible from the other file: the model
+// declares the compound index, and the migration drops the single-field unique
+// index Mongoose built from the old `unique: true` — which Mongoose will never
+// drop on its own, and which makes a second guild's row a duplicate-key error.
+describe('014_scope_item_images_per_guild', () => {
+    const source = read('014_scope_item_images_per_guild.js');
+    const model = fs.readFileSync(path.join(__dirname, '..', 'src', 'models', 'ItemImage.js'), 'utf8');
+
+    test('creates the index the model declares, under the same name', () => {
+        expect(indexNamesIn(source)).toContain('idx_itemimage_guild_item');
+        expect(model).toContain("name: 'idx_itemimage_guild_item'");
+        expect(model).toContain('unique: true');
+    });
+
+    test('drops the legacy unique index, and the model no longer declares it', () => {
+        expect(source).toContain("dropIndex('itemId_1')");
+        expect(model).not.toMatch(/itemId:\s*\{[^}]*unique/);
+    });
+
+    test('swallows IndexNotFound so a fresh database is not a failure', () => {
+        expect(source).toContain("codeName !== 'IndexNotFound'");
+    });
+});


### PR DESCRIPTION
`ai` is a whitelisted settings parent, so any guild admin can write
`ai.ollamaBaseUrl`, and it reached `axios.post` unexamined. Setting the
provider to ollama and the base URL to http://169.254.169.254/… or to a
host on the compose network turned the bot into a read primitive against
the operator's own infrastructure, with the response echoed back into a
Discord channel. It was the one user-supplied fetch that went around the
guard in safeFeedFetch.js.

The rule now lives with the provider, and the settings form asks it
rather than restating it, so what the dashboard accepts is exactly what
the request path allows:

  - the operator's own endpoint (OLLAMA_BASE_URL, or the shipped
    localhost default) is dialled as before — it is the operator's
    machine, and self-hosted Ollama is usually on localhost;
  - anything else must be a plain http(s) URL with no credentials and no
    literal private address, and is dialled through agents that refuse to
    open a socket into private or reserved space.

The checks sit where the connection is made rather than up front:
`lookup` covers hostnames, and the agent's `createConnection` covers
literal addresses, which never reach a resolver at all — net.connect
skips DNS entirely for those, so a lookup hook alone would have missed
169.254.169.254, the first address anyone tries. Both run again on each
redirect hop, which is what makes this hold through axios's own redirect
handling. `isPrivateIp` is imported from safeFeedFetch rather than
copied; the list of ranges that must never be reached is one rule.

Fixes #559

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity item images are now scoped per server, with shared images available as fallbacks.
  * Dashboard permissions are verified against current server access, including revoked privileges.
  * Ollama endpoints support safer validation and protected outbound connections.
* **Bug Fixes**
  * Fishing, hunting, and mining shops now display the correct server-specific images.
  * Dashboard sessions refresh during activity and expire after four hours of inactivity.
* **Security**
  * Improved CSRF protection and validation for server-specific image management and Ollama settings.
* **Documentation**
  * Clarified Ollama network configuration and private-address requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->