### PR TITLE
Take the hot paths off their per-event and per-message reads

### DIFF
--- a/src/commands/leveling/leaderboard.js
+++ b/src/commands/leveling/leaderboard.js
@@ -104,10 +104,20 @@ module.exports = {
                 }
             }
 
+            // One round trip per row turned rendering a ten-name board into ten
+            // serial Discord API calls. Nothing in the loop below depends on the
+            // previous row, so the fetches are issued together and awaited once.
+            // A user the API cannot resolve still yields null and is skipped, and
+            // the medal still comes from the row's rank rather than its position
+            // in the printed list.
+            const discordUsers = await Promise.all(
+                users.map(u => interaction.client.users.fetch(u.userId).catch(() => null))
+            );
+
             let description = descriptionHeader + '\n\n';
             for (let i = 0; i < users.length; i++) {
                 const user = users[i];
-                const discordUser = await interaction.client.users.fetch(user.userId).catch(() => null);
+                const discordUser = discordUsers[i];
                 if (!discordUser) continue;
 
                 const medal = i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : `**${i + 1}.**`;

--- a/src/dashboard/routes/dashboard.js
+++ b/src/dashboard/routes/dashboard.js
@@ -10,6 +10,12 @@ const { ACTIVITY_ITEMS } = require('../../data/activityItems');
 const { REGION_LIST } = require('../../data/exploreData');
 const { SEASONAL_EVENTS } = require('../../data/seasonalEvents');
 
+// A shop item's image is served by /api/item-image/shop/:guildId/:itemId, never
+// inlined into the settings page, so the guild-settings read excludes both
+// fields. Up to 35 items x 512 KB of Buffer per guild that would otherwise be
+// pulled off the wire and deep-copied by toObject() only to be dropped again.
+const SHOP_IMAGES_EXCLUDED = '-shop.imageData -shop.imageType';
+
 function checkAuth(req, res, next) {
     if (req.isAuthenticated()) return next();
     res.redirect('/auth/login');
@@ -80,7 +86,8 @@ async function buildGuildSettingsLocals(req) {
         return { status: 403, message: 'You do not have permission to manage this guild.' };
     }
 
-    let guildSettings = await Guild.findOne({ guildId });
+    let guildSettings = await Guild.findOne({ guildId }, SHOP_IMAGES_EXCLUDED);
+    let shopIsProjected = true;
     const guild = req.bot.getGuild(guildId);
 
     if (!guild) {
@@ -92,10 +99,25 @@ async function buildGuildSettingsLocals(req) {
             guildId: guild.id,
             name: guild.name
         });
+        shopIsProjected = false;
     }
 
+    // Seeding is a rare backfill: a guild the bot joined before a shop category
+    // existed. Running it against the projection keeps the new items on the page
+    // being rendered, but the *write* goes through a fully selected document.
+    // ensureDefaultShopItems only ever appends, so a save here would in practice
+    // emit `$push`; re-reading rather than trusting that is cheap on a path that
+    // runs once per guild, and the alternative failure — a whole guild's shop
+    // images replaced with nothing — is not one worth a judgement call.
     if (ensureDefaultShopItems(guildSettings)) {
-        await guildSettings.save();
+        if (!shopIsProjected) {
+            await guildSettings.save();
+        } else {
+            const fullSettings = await Guild.findOne({ guildId });
+            if (fullSettings && ensureDefaultShopItems(fullSettings)) {
+                await fullSettings.save();
+            }
+        }
     }
 
     const allChannels = req.bot.listChannels(guildId) || [];
@@ -116,6 +138,8 @@ async function buildGuildSettingsLocals(req) {
         xpReward: a.xpReward, coinReward: a.coinReward
     }));
 
+    // imageData/imageType are already projected out above for an existing guild;
+    // the map still runs because a freshly created document is unprojected.
     const safeSettings = guildSettings.toObject();
     if (Array.isArray(safeSettings.shop)) {
         safeSettings.shop = safeSettings.shop.map(({ imageData, imageType, ...rest }) => rest);

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -165,6 +165,11 @@ function createApp({ client = null, bot: injectedBot, sessionStore, configurePas
 
     app.set('view engine', 'ejs');
     app.set('views', path.join(__dirname, 'views'));
+    // No explicit `view cache` here on purpose: guild-settings.ejs is a few
+    // hundred KB and must not be recompiled per render, but Express already
+    // enables the cache whenever NODE_ENV is 'production', which both the
+    // Dockerfile and portainer-stack.yml set. Forcing it on would only take
+    // template reloading away from local development.
 
     // Gzip/deflate every compressible response. The guild settings page alone
     // renders a few hundred KB of HTML, and styles.css is another 70 KB — both

--- a/src/events/channelCreate.js
+++ b/src/events/channelCreate.js
@@ -1,5 +1,5 @@
 const { EmbedBuilder, AuditLogEvent, PermissionFlagsBits } = require('discord.js');
-const Guild = require('../models/Guild');
+const { getGuildSettings } = require('../utils/guildSettingsCache');
 const { trackAction } = require('../services/antiNukeService');
 
 module.exports = {
@@ -9,7 +9,7 @@ module.exports = {
 
         await trackAction(channel.guild, 'channelCreate', AuditLogEvent.ChannelCreate, channel.id).catch(console.error);
 
-        const guildSettings = await Guild.findOne({ guildId: channel.guild.id });
+        const guildSettings = await getGuildSettings(channel.guild.id);
         if (!guildSettings?.eventLog?.enabled || !guildSettings.eventLog.logChannelChanges) return;
 
         const logChannel = channel.guild.channels.cache.get(guildSettings.eventLog.channelId);

--- a/src/events/channelDelete.js
+++ b/src/events/channelDelete.js
@@ -1,5 +1,6 @@
 const { EmbedBuilder, AuditLogEvent, PermissionFlagsBits } = require('discord.js');
 const Guild = require('../models/Guild');
+const { getGuildSettings } = require('../utils/guildSettingsCache');
 const { trackAction } = require('../services/antiNukeService');
 
 module.exports = {
@@ -9,7 +10,7 @@ module.exports = {
 
         await trackAction(channel.guild, 'channelDelete', AuditLogEvent.ChannelDelete, channel.id).catch(console.error);
 
-        const guildSettings = await Guild.findOne({ guildId: channel.guild.id });
+        const guildSettings = await getGuildSettings(channel.guild.id);
 
         // If a temp voice channel was manually deleted, remove it from the active list
         if (guildSettings?.tempVoice?.enabled && guildSettings.tempVoice.activeChannels.includes(channel.id)) {

--- a/src/events/guildMemberAdd.js
+++ b/src/events/guildMemberAdd.js
@@ -1,4 +1,4 @@
-const Guild = require('../models/Guild');
+const { getGuildSettings } = require('../utils/guildSettingsCache');
 const GuildAnalytics = require('../models/GuildAnalytics');
 const { EmbedBuilder, AttachmentBuilder, PermissionFlagsBits } = require('discord.js');
 const { createWelcomeCard } = require('../utils/cardGenerator');
@@ -52,7 +52,7 @@ module.exports = {
             // Raid detection runs next, independently of guild settings load below
             await raidCheck(member, client).catch(console.error);
 
-            const guildSettings = await Guild.findOne({ guildId: member.guild.id });
+            const guildSettings = await getGuildSettings(member.guild.id);
 
             if (!guildSettings) return;
             const dateKey = new Date().toISOString().slice(0, 10);

--- a/src/events/guildMemberRemove.js
+++ b/src/events/guildMemberRemove.js
@@ -1,4 +1,4 @@
-const Guild = require('../models/Guild');
+const { getGuildSettings } = require('../utils/guildSettingsCache');
 const GuildAnalytics = require('../models/GuildAnalytics');
 const { EmbedBuilder, AuditLogEvent, PermissionFlagsBits } = require('discord.js');
 const { trackAction } = require('../services/antiNukeService');
@@ -39,7 +39,7 @@ module.exports = {
             // Detect kick via audit log; bans fire guildBanAdd separately.
             await trackAction(member.guild, 'kick', AuditLogEvent.MemberKick, member.id).catch(console.error);
 
-            const guildSettings = await Guild.findOne({ guildId: member.guild.id });
+            const guildSettings = await getGuildSettings(member.guild.id);
             if (!guildSettings) return;
 
             const dateKey = new Date().toISOString().slice(0, 10);

--- a/src/events/guildMemberUpdate.js
+++ b/src/events/guildMemberUpdate.js
@@ -1,10 +1,10 @@
 const { EmbedBuilder, PermissionFlagsBits } = require('discord.js');
-const Guild = require('../models/Guild');
+const { getGuildSettings } = require('../utils/guildSettingsCache');
 
 module.exports = {
     name: 'guildMemberUpdate',
     async execute(oldMember, newMember, _client) {
-        const guildSettings = await Guild.findOne({ guildId: newMember.guild.id });
+        const guildSettings = await getGuildSettings(newMember.guild.id);
         if (!guildSettings?.eventLog?.enabled || !guildSettings.eventLog.logRoleChanges) return;
 
         const logChannel = newMember.guild.channels.cache.get(guildSettings.eventLog.channelId);

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -18,11 +18,49 @@ const { saveWithBalanceDelta } = require('../utils/balanceDelta');
 const { BoundedRateLimiter } = require('../utils/boundedRateLimiter');
 const { withUserLock } = require('../utils/userMutex');
 
-// Pre-compile base word regexes once at module load — avoids per-message regex construction
-const BASE_BAD_WORD_REGEXES = BASE_BAD_WORDS.map(word => {
+function compileBadWordRegex(word) {
     const escaped = word.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     return new RegExp(`\\b${escaped}\\b`, 'i');
-});
+}
+
+// Pre-compile base word regexes once at module load — avoids per-message regex construction
+const BASE_BAD_WORD_REGEXES = BASE_BAD_WORDS.map(compileBadWordRegex);
+
+// The base list above is compiled once, but a guild's own additions used to be
+// rebuilt from scratch on every message that reached the profanity filter. They
+// change only when an admin edits the word list, so they are compiled once and
+// kept here until that happens.
+//
+// The entry is keyed on the word list itself rather than on a settings version:
+// the cached settings object is replaced wholesale on every invalidation, and a
+// TTL expiry alone would otherwise force a recompile that changed nothing. A
+// guild whose list is unchanged keeps its regexes across settings reloads.
+//
+// guildId -> { signature, regexes }
+const customBadWordRegexes = new Map();
+
+// Bounds memory across a large guild count, the same way guildSettingsCache
+// does: FIFO by insertion order, and an evicted guild simply recompiles on its
+// next filtered message.
+const MAX_CUSTOM_BAD_WORD_GUILDS = 5_000;
+
+function getCustomBadWordRegexes(guildId, customBadWords) {
+    const words = customBadWords || [];
+    if (!words.length) return [];
+
+    // A NUL separator cannot appear in a word an admin typed into the
+    // dashboard, so no two distinct lists share a signature.
+    const signature = words.join('\u0000');
+    const cached = customBadWordRegexes.get(guildId);
+    if (cached && cached.signature === signature) return cached.regexes;
+
+    const regexes = words.map(compileBadWordRegex);
+    if (customBadWordRegexes.size >= MAX_CUSTOM_BAD_WORD_GUILDS && !customBadWordRegexes.has(guildId)) {
+        customBadWordRegexes.delete(customBadWordRegexes.keys().next().value);
+    }
+    customBadWordRegexes.set(guildId, { signature, regexes });
+    return regexes;
+}
 
 // Leet-speak normalization map
 const LEET_MAP = {
@@ -50,6 +88,8 @@ function normalizeToxic(text) {
 
 module.exports = {
     name: 'messageCreate',
+    // Exported for unit testing only
+    _getCustomBadWordRegexes: getCustomBadWordRegexes,
     async execute(message, client) {
         if (message.author.bot || !message.guild) return;
 
@@ -501,11 +541,9 @@ async function handleAutoModeration(message, guildSettings) {
 
     if (mod.profanityFilter && !isModerator) {
         const normalized = normalizeToxic(message.content);
-        const customRegexes = (mod.customBadWords || []).map(word => {
-            const escaped = word.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-            return new RegExp(`\\b${escaped}\\b`, 'i');
-        });
-        const hasBadWord = [...BASE_BAD_WORD_REGEXES, ...customRegexes].some(re => re.test(normalized));
+        const customRegexes = getCustomBadWordRegexes(message.guild.id, mod.customBadWords);
+        const hasBadWord = BASE_BAD_WORD_REGEXES.some(re => re.test(normalized))
+            || customRegexes.some(re => re.test(normalized));
 
         if (hasBadWord) {
             await message.delete().catch(console.error);

--- a/src/events/messageDelete.js
+++ b/src/events/messageDelete.js
@@ -1,12 +1,12 @@
 const { EmbedBuilder, PermissionFlagsBits } = require('discord.js');
-const Guild = require('../models/Guild');
+const { getGuildSettings } = require('../utils/guildSettingsCache');
 
 module.exports = {
     name: 'messageDelete',
     async execute(message, _client) {
         if (message.author?.bot || !message.guild) return;
 
-        const guildSettings = await Guild.findOne({ guildId: message.guild.id });
+        const guildSettings = await getGuildSettings(message.guild.id);
         if (!guildSettings?.eventLog?.enabled || !guildSettings.eventLog.logMessageDelete) return;
 
         const logChannel = message.guild.channels.cache.get(guildSettings.eventLog.channelId);

--- a/src/events/messageReactionAdd.js
+++ b/src/events/messageReactionAdd.js
@@ -1,6 +1,7 @@
 const { EmbedBuilder } = require('discord.js');
 const Guild = require('../models/Guild');
 const User = require('../models/User');
+const { getGuildSettings } = require('../utils/guildSettingsCache');
 const { ensureQuests, onReaction, notifyQuestComplete, notifyQuestNearComplete } = require('../services/questService');
 const { saveWithBalanceDelta } = require('../utils/balanceDelta');
 
@@ -19,7 +20,10 @@ module.exports = {
         const guild = reaction.message.guild;
         if (!guild) return;
 
-        const guildSettings = await Guild.findOne({ guildId: guild.id });
+        // Read-only for three of the four handlers below; the starboard's one
+        // write claims its message with a targeted update rather than saving
+        // this object, which is shared with every other reader of this guild.
+        const guildSettings = await getGuildSettings(guild.id);
         if (!guildSettings) return;
 
         await handleReactionRole(reaction, user, guild, guildSettings);
@@ -100,8 +104,18 @@ async function handleStarboard(reaction, user, guild, guildSettings) {
 
     if (sb.starredMessages.includes(message.id)) return;
 
-    sb.starredMessages.push(message.id);
-    await guildSettings.save();
+    // Claim the message in one atomic update instead of pushing onto the shared
+    // settings object and saving it. The `$ne` in the filter *is* the claim: if
+    // another reaction crossed the threshold first, the update matches nothing
+    // and modifies nothing, so exactly one of them posts the star. The check
+    // above is now only a cheap pre-filter against the cached list — the old
+    // read-modify-write let two concurrent reactions both clear it and post the
+    // same message twice.
+    const claimed = await Guild.updateOne(
+        { guildId: guild.id, 'starboard.starredMessages': { $ne: message.id } },
+        { $push: { 'starboard.starredMessages': message.id } }
+    );
+    if (!claimed.modifiedCount) return;
 
     const starChannel = guild.channels.cache.get(sb.channelId);
     if (!starChannel) return;

--- a/src/events/messageReactionRemove.js
+++ b/src/events/messageReactionRemove.js
@@ -1,4 +1,4 @@
-const Guild = require('../models/Guild');
+const { getGuildSettings } = require('../utils/guildSettingsCache');
 
 module.exports = {
     name: 'messageReactionRemove',
@@ -12,7 +12,7 @@ module.exports = {
         const guild = reaction.message.guild;
         if (!guild) return;
 
-        const guildSettings = await Guild.findOne({ guildId: guild.id });
+        const guildSettings = await getGuildSettings(guild.id);
         if (!guildSettings?.reactionRoles?.length) return;
 
         const emojiKey = reaction.emoji.id

--- a/src/events/messageUpdate.js
+++ b/src/events/messageUpdate.js
@@ -1,5 +1,5 @@
 const { EmbedBuilder, PermissionFlagsBits } = require('discord.js');
-const Guild = require('../models/Guild');
+const { getGuildSettings } = require('../utils/guildSettingsCache');
 
 module.exports = {
     name: 'messageUpdate',
@@ -7,7 +7,7 @@ module.exports = {
         if (newMessage.author?.bot || !newMessage.guild) return;
         if (oldMessage.content === newMessage.content) return;
 
-        const guildSettings = await Guild.findOne({ guildId: newMessage.guild.id });
+        const guildSettings = await getGuildSettings(newMessage.guild.id);
         if (!guildSettings?.eventLog?.enabled || !guildSettings.eventLog.logMessageEdit) return;
 
         const logChannel = newMessage.guild.channels.cache.get(guildSettings.eventLog.channelId);

--- a/src/events/voiceStateUpdate.js
+++ b/src/events/voiceStateUpdate.js
@@ -1,5 +1,5 @@
 const { handleVoiceStateUpdate } = require('../services/tempVoiceService');
-const Guild = require('../models/Guild');
+const { getGuildSettings } = require('../utils/guildSettingsCache');
 const User = require('../models/User');
 const { checkRivalry } = require('../services/rivalryService');
 
@@ -37,7 +37,7 @@ async function handleVoiceXp(oldState, newState, client) {
     voiceJoinTimes.delete(key);
 
     try {
-        const guildSettings = await Guild.findOne({ guildId });
+        const guildSettings = await getGuildSettings(guildId);
         if (!guildSettings?.leveling?.enabled || !guildSettings.leveling.voiceXpEnabled) return;
         if (!guildSettings.leveling.rewardsEnabled) return;
         if (guildSettings.leveling.noXpRoleIds?.length &&

--- a/tests/customBadWordRegexCache.test.js
+++ b/tests/customBadWordRegexCache.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+// #606: the base profanity list is compiled once at module load, but a guild's
+// own additions were rebuilt from scratch on every message that reached the
+// filter. They change only when an admin edits the list, so the compiled
+// patterns are now kept until that happens.
+
+const { _getCustomBadWordRegexes: getCustomBadWordRegexes } = require('../src/events/messageCreate');
+
+describe('custom bad-word regex memoization', () => {
+    it('compiles a guild\'s list once and reuses it', () => {
+        const words = ['frobnicate', 'blorp'];
+
+        const first = getCustomBadWordRegexes('g1', words);
+        const second = getCustomBadWordRegexes('g1', words);
+
+        expect(second).toBe(first);
+    });
+
+    it('reuses the compiled list across separate array instances with the same words', () => {
+        // Each read hands back a fresh settings object, so the array identity
+        // changes even when the admin has not touched the word list. Keying on
+        // identity would recompile on every settings reload.
+        const first = getCustomBadWordRegexes('g2', ['alpha', 'beta']);
+        const second = getCustomBadWordRegexes('g2', ['alpha', 'beta']);
+
+        expect(second).toBe(first);
+    });
+
+    it('recompiles when the guild\'s word list actually changes', () => {
+        const first = getCustomBadWordRegexes('g3', ['alpha']);
+        const second = getCustomBadWordRegexes('g3', ['alpha', 'beta']);
+
+        expect(second).not.toBe(first);
+        expect(second).toHaveLength(2);
+    });
+
+    it('recompiles when a word is removed', () => {
+        getCustomBadWordRegexes('g4', ['alpha', 'beta']);
+        const after = getCustomBadWordRegexes('g4', ['alpha']);
+
+        expect(after).toHaveLength(1);
+        expect(after[0].test('alpha')).toBe(true);
+        expect(after[0].test('beta')).toBe(false);
+    });
+
+    it('does not let one guild see another guild\'s words', () => {
+        const a = getCustomBadWordRegexes('g5', ['onlyhere']);
+        const b = getCustomBadWordRegexes('g6', ['different']);
+
+        expect(b).not.toBe(a);
+        expect(b[0].test('onlyhere')).toBe(false);
+    });
+
+    it('matches on a word boundary and ignores case, as the base list does', () => {
+        const [re] = getCustomBadWordRegexes('g7', ['Blorp']);
+
+        expect(re.test('what a blorp')).toBe(true);
+        expect(re.test('BLORP')).toBe(true);
+        expect(re.test('blorpy')).toBe(false);
+    });
+
+    it('escapes regex metacharacters in an admin-entered word', () => {
+        const [re] = getCustomBadWordRegexes('g8', ['a.c']);
+
+        expect(re.test('a.c')).toBe(true);
+        expect(re.test('abc')).toBe(false);
+    });
+
+    it('returns an empty list without caching anything for a guild with no custom words', () => {
+        expect(getCustomBadWordRegexes('g9', [])).toEqual([]);
+        expect(getCustomBadWordRegexes('g9', undefined)).toEqual([]);
+        expect(getCustomBadWordRegexes('g9', null)).toEqual([]);
+    });
+
+    it('bounds itself so a large guild count cannot grow the map without limit', () => {
+        // 5_000 entries is the cap; the oldest is evicted rather than retained.
+        // An evicted guild simply recompiles on its next filtered message.
+        const first = getCustomBadWordRegexes('evictme', ['word']);
+        for (let i = 0; i < 5_001; i++) getCustomBadWordRegexes(`filler-${i}`, ['word']);
+
+        expect(getCustomBadWordRegexes('evictme', ['word'])).not.toBe(first);
+    });
+});

--- a/tests/eventGuildSettingsCache.test.js
+++ b/tests/eventGuildSettingsCache.test.js
@@ -1,0 +1,226 @@
+'use strict';
+
+// The guild settings cache was built to take the per-event `Guild.findOne` off
+// the hot paths, but only messageCreate and interactionCreate were ever wired
+// into it (#594). These tests hold the rest of the read-only handlers to the
+// same rule: one read per guild per TTL, not one read per event.
+
+jest.mock('discord.js', () => {
+    const EmbedBuilder = jest.fn().mockImplementation(() => {
+        const self = {
+            data: {},
+            setColor: jest.fn().mockReturnThis(),
+            setTitle: jest.fn().mockReturnThis(),
+            setDescription: jest.fn().mockReturnThis(),
+            setThumbnail: jest.fn().mockReturnThis(),
+            setAuthor: jest.fn().mockReturnThis(),
+            setImage: jest.fn().mockReturnThis(),
+            addFields: jest.fn().mockReturnThis(),
+            setTimestamp: jest.fn().mockReturnThis(),
+        };
+        return self;
+    });
+    return {
+        EmbedBuilder,
+        AuditLogEvent: { ChannelCreate: 10, ChannelDelete: 12, MemberKick: 20 },
+        PermissionFlagsBits: { SendMessages: 1n << 11n },
+    };
+});
+
+jest.mock('../src/models/Guild', () => ({ findOne: jest.fn(), updateOne: jest.fn() }));
+jest.mock('../src/models/User', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn(), create: jest.fn() }));
+jest.mock('../src/models/GuildAnalytics', () => ({ updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }) }));
+jest.mock('../src/services/antiNukeService', () => ({ trackAction: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../src/services/questService', () => ({
+    ensureQuests: jest.fn().mockResolvedValue({}),
+    onReaction: jest.fn().mockResolvedValue({ completed: [], nearComplete: [] }),
+    notifyQuestComplete: jest.fn().mockResolvedValue(undefined),
+    notifyQuestNearComplete: jest.fn().mockResolvedValue(undefined),
+}));
+
+const Guild = require('../src/models/Guild');
+const { clearGuildSettingsCache, setGuildSettingsTtl } = require('../src/utils/guildSettingsCache');
+
+const messageDelete = require('../src/events/messageDelete');
+const messageUpdate = require('../src/events/messageUpdate');
+const guildMemberUpdate = require('../src/events/guildMemberUpdate');
+const channelCreate = require('../src/events/channelCreate');
+const channelDelete = require('../src/events/channelDelete');
+const messageReactionRemove = require('../src/events/messageReactionRemove');
+const messageReactionAdd = require('../src/events/messageReactionAdd');
+
+const GUILD_ID = '999888777666555444';
+
+// Stands in for a hydrated Mongoose document: the cache calls toObject() on it.
+function makeDoc(overrides = {}) {
+    const plain = {
+        guildId: GUILD_ID,
+        eventLog: { enabled: false },
+        tempVoice: { enabled: false, activeChannels: [] },
+        reactionRoles: [],
+        starboard: { enabled: false },
+        quests: { enabled: false },
+        ...overrides,
+    };
+    return { ...plain, toObject: () => JSON.parse(JSON.stringify(plain)) };
+}
+
+function makeGuild() {
+    return {
+        id: GUILD_ID,
+        name: 'Cool Server',
+        members: { me: {}, fetch: jest.fn().mockResolvedValue(null) },
+        channels: { cache: { get: jest.fn().mockReturnValue(null) } },
+    };
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    clearGuildSettingsCache();
+    setGuildSettingsTtl(30_000);
+    Guild.findOne.mockResolvedValue(makeDoc());
+    Guild.updateOne.mockResolvedValue({ modifiedCount: 1 });
+});
+
+// Each entry fires its handler twice for the same guild. Before #594 that was
+// two full document reads; through the cache it is one.
+const HANDLERS = [
+    ['messageDelete', () => messageDelete.execute({
+        author: { bot: false }, guild: makeGuild(), channel: { id: 'c1' },
+        content: 'hi', attachments: { size: 0 },
+    })],
+    ['messageUpdate', () => messageUpdate.execute(
+        { content: 'before' },
+        { author: { bot: false }, guild: makeGuild(), channel: { id: 'c1' }, content: 'after', url: 'u' },
+    )],
+    ['guildMemberUpdate', () => {
+        const member = { guild: makeGuild(), roles: { cache: new Map() }, user: {} };
+        return guildMemberUpdate.execute(member, member);
+    }],
+    ['channelCreate', () => channelCreate.execute({ id: 'c9', guild: makeGuild(), name: 'n', type: 0 })],
+    ['channelDelete', () => channelDelete.execute({ id: 'c9', guild: makeGuild(), name: 'n', type: 0 })],
+    ['messageReactionRemove', () => messageReactionRemove.execute(
+        { partial: false, emoji: { name: '⭐' }, message: { id: 'm1', guild: makeGuild() } },
+        { bot: false, id: 'u1' },
+        {},
+    )],
+];
+
+describe('read-only event handlers read through guildSettingsCache', () => {
+    it.each(HANDLERS)('%s issues one document read for two events', async (_name, fire) => {
+        await fire();
+        await fire();
+
+        expect(Guild.findOne).toHaveBeenCalledTimes(1);
+    });
+
+    it.each(HANDLERS)('%s asks for the projection that leaves image Buffers behind', async (_name, fire) => {
+        await fire();
+
+        expect(Guild.findOne.mock.calls[0][1]).toContain('-shop.imageData');
+    });
+});
+
+describe('messageReactionAdd', () => {
+    function makeReaction(overrides = {}) {
+        return {
+            partial: false,
+            emoji: { name: '⭐' },
+            message: {
+                id: 'm1',
+                partial: false,
+                guild: makeGuild(),
+                channel: { id: 'c1' },
+                author: { id: 'someone-else', tag: 't', displayAvatarURL: () => 'a' },
+                content: 'hello',
+                url: 'https://discord/m1',
+                createdAt: new Date(),
+                attachments: { size: 0 },
+                reactions: { cache: { find: () => ({ count: 5 }) } },
+            },
+            ...overrides,
+        };
+    }
+
+    it('reads through the cache rather than per reaction', async () => {
+        await messageReactionAdd.execute(makeReaction(), { bot: false, id: 'u1' }, { user: { id: 'bot' } });
+        await messageReactionAdd.execute(makeReaction(), { bot: false, id: 'u1' }, { user: { id: 'bot' } });
+
+        expect(Guild.findOne).toHaveBeenCalledTimes(1);
+    });
+
+    describe('starboard', () => {
+        const STARBOARD = {
+            starboard: {
+                enabled: true, channelId: 'star-ch', emoji: '⭐',
+                threshold: 3, starredMessages: [],
+            },
+        };
+
+        it('claims the message with a targeted update, never by saving shared settings', async () => {
+            Guild.findOne.mockResolvedValue(makeDoc(STARBOARD));
+
+            await messageReactionAdd.execute(makeReaction(), { bot: false, id: 'u1' }, { user: { id: 'bot' } });
+
+            expect(Guild.updateOne).toHaveBeenCalledTimes(1);
+            const [filter, update] = Guild.updateOne.mock.calls[0];
+            expect(filter).toEqual({
+                guildId: GUILD_ID,
+                'starboard.starredMessages': { $ne: 'm1' },
+            });
+            expect(update).toEqual({ $push: { 'starboard.starredMessages': 'm1' } });
+        });
+
+        it('does not post when another reaction already claimed the message', async () => {
+            // The claim matched nothing, so a concurrent handler got there first.
+            Guild.updateOne.mockResolvedValue({ modifiedCount: 0 });
+            const starChannel = { send: jest.fn().mockResolvedValue(undefined) };
+            const guild = makeGuild();
+            guild.channels.cache.get = jest.fn().mockReturnValue(starChannel);
+
+            const settings = makeDoc(STARBOARD);
+            Guild.findOne.mockResolvedValue(settings);
+
+            const reaction = makeReaction();
+            reaction.message.guild = guild;
+            await messageReactionAdd.execute(reaction, { bot: false, id: 'u1' }, { user: { id: 'bot' } });
+
+            expect(starChannel.send).not.toHaveBeenCalled();
+        });
+
+        it('posts once when the claim succeeds', async () => {
+            const starChannel = { send: jest.fn().mockResolvedValue(undefined) };
+            const guild = makeGuild();
+            guild.channels.cache.get = jest.fn().mockReturnValue(starChannel);
+
+            Guild.findOne.mockResolvedValue(makeDoc(STARBOARD));
+
+            const reaction = makeReaction();
+            reaction.message.guild = guild;
+            await messageReactionAdd.execute(reaction, { bot: false, id: 'u1' }, { user: { id: 'bot' } });
+
+            expect(starChannel.send).toHaveBeenCalledTimes(1);
+        });
+
+        it('leaves the shared settings object untouched', async () => {
+            const settings = makeDoc(STARBOARD);
+            Guild.findOne.mockResolvedValue(settings);
+
+            await messageReactionAdd.execute(makeReaction(), { bot: false, id: 'u1' }, { user: { id: 'bot' } });
+
+            // A cached entry is shared with every other reader of this guild, so
+            // a handler that appended to it would corrupt their view too.
+            expect(settings.starboard.starredMessages).toEqual([]);
+        });
+
+        it('stays below the threshold without claiming anything', async () => {
+            Guild.findOne.mockResolvedValue(makeDoc({
+                starboard: { ...STARBOARD.starboard, threshold: 99 },
+            }));
+
+            await messageReactionAdd.execute(makeReaction(), { bot: false, id: 'u1' }, { user: { id: 'bot' } });
+
+            expect(Guild.updateOne).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/tests/eventLog.test.js
+++ b/tests/eventLog.test.js
@@ -23,6 +23,7 @@ jest.mock('../src/models/Guild', () => ({ findOne: jest.fn() }));
 jest.mock('../src/services/antiNukeService', () => ({ trackAction: jest.fn().mockResolvedValue(undefined) }));
 
 const Guild = require('../src/models/Guild');
+const { clearGuildSettingsCache } = require('../src/utils/guildSettingsCache');
 const messageDeleteEvent = require('../src/events/messageDelete');
 const messageUpdateEvent = require('../src/events/messageUpdate');
 const guildMemberUpdateEvent = require('../src/events/guildMemberUpdate');
@@ -79,7 +80,13 @@ function makeAuthor(overrides = {}) {
     };
 }
 
-beforeEach(() => jest.clearAllMocks());
+// These handlers read through guildSettingsCache. Its invalidation runs off
+// Mongoose middleware, which the Guild mock above does not have, so each test's
+// mockResolvedValue would otherwise be shadowed by the first test's entry.
+beforeEach(() => {
+    jest.clearAllMocks();
+    clearGuildSettingsCache();
+});
 
 // ---------------------------------------------------------------------------
 // messageDelete

--- a/tests/farewell.test.js
+++ b/tests/farewell.test.js
@@ -25,6 +25,7 @@ jest.mock('../src/models/Guild', () => ({ findOne: jest.fn() }));
 jest.mock('../src/models/GuildAnalytics', () => ({ updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }) }));
 jest.mock('../src/services/antiNukeService', () => ({ trackAction: jest.fn().mockResolvedValue(undefined) }));
 
+const { clearGuildSettingsCache } = require('../src/utils/guildSettingsCache');
 const farewellEvent = require('../src/events/guildMemberRemove');
 
 // ---------------------------------------------------------------------------
@@ -63,6 +64,11 @@ describe('farewell applyVariables', () => {
     let member;
 
     beforeEach(() => {
+        // guildMemberRemove reads through guildSettingsCache, whose invalidation
+        // rides on Mongoose middleware the Guild mock above does not have. Without
+        // this, a test's own mockResolvedValue is shadowed by the previous test's
+        // cached entry for the same guild id.
+        clearGuildSettingsCache();
         sendSpy = jest.fn().mockResolvedValue(undefined);
 
         const perms = { has: jest.fn().mockReturnValue(true) };

--- a/tests/guildSettingsShopImages.test.js
+++ b/tests/guildSettingsShopImages.test.js
@@ -1,0 +1,142 @@
+'use strict';
+
+// #605: the guild settings page used to read every shop item's inline image
+// Buffer off the wire and deep-copy it through toObject(), only to strip both
+// fields before rendering. The images are served by their own route and were
+// never on the page — so they are projected out of the read instead.
+
+const express = require('express');
+const path = require('path');
+const { Collection } = require('@discordjs/collection');
+
+jest.mock('../src/models/Guild');
+jest.mock('../src/models/ItemImage');
+
+const Guild = require('../src/models/Guild');
+const ItemImage = require('../src/models/ItemImage');
+const { jsonForScript } = require('../src/dashboard/lib/jsonForScript');
+const { asset } = require('../src/dashboard/lib/assets');
+const { ensureDefaultShopItems } = require('../src/data/defaultShopItems');
+
+let server;
+let baseUrl;
+
+const ActualGuild = jest.requireActual('../src/models/Guild');
+
+// A real settings document, minus a database. `seeded` mirrors what a guild
+// that has already been through ensureDefaultShopItems looks like.
+function guildDoc({ seeded = true, shop } = {}) {
+    const doc = new ActualGuild({ guildId: 'g1', name: 'Test Guild' });
+    doc.shopDefaultsSeeded = seeded;
+    if (shop) doc.shop = shop;
+    doc.save = jest.fn(async () => {});
+    return doc;
+}
+
+function discordGuild() {
+    return {
+        id: 'g1',
+        name: 'Test Guild',
+        icon: null,
+        ownerId: 'admin-1',
+        memberCount: 3,
+        channels: { cache: new Collection([['c1', { id: 'c1', name: 'general', type: 0, parentId: null }]]) },
+        roles: { cache: new Collection([['r1', { id: 'r1', name: 'Member', position: 1, managed: false }]]) },
+    };
+}
+
+beforeAll(done => {
+    const { createBotGateway } = require('../src/bot/gateway');
+    const app = express();
+    app.set('view engine', 'ejs');
+    app.set('views', path.join(__dirname, '..', 'src', 'dashboard', 'views'));
+    app.use((req, res, next) => {
+        req.isAuthenticated = () => true;
+        req.user = { id: 'admin-1', username: 'admin', guilds: [{ id: 'g1', name: 'Test Guild', permissions: '8' }] };
+        req.bot = createBotGateway({ guilds: { cache: new Collection([['g1', discordGuild()]]) } });
+        res.locals.jsonForScript = jsonForScript;
+        res.locals.asset = asset;
+        next();
+    });
+    app.use('/dashboard', require('../src/dashboard/routes/dashboard'));
+    server = app.listen(0, () => {
+        baseUrl = `http://127.0.0.1:${server.address().port}`;
+        done();
+    });
+});
+
+afterAll(done => { server.close(done); });
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    Guild.findOne.mockResolvedValue(guildDoc());
+    ItemImage.find.mockReturnValue({ lean: async () => [] });
+});
+
+describe('guild settings page and shop image Buffers', () => {
+    it('projects the image fields out of the read', async () => {
+        const res = await fetch(`${baseUrl}/dashboard/guild/g1`);
+        expect(res.status).toBe(200);
+
+        const projection = Guild.findOne.mock.calls[0][1];
+        expect(projection).toContain('-shop.imageData');
+        expect(projection).toContain('-shop.imageType');
+    });
+
+    it('projects them out of a panel fragment read too', async () => {
+        const res = await fetch(`${baseUrl}/dashboard/guild/g1/panel/economy`);
+        expect(res.status).toBe(200);
+
+        expect(Guild.findOne.mock.calls[0][1]).toContain('-shop.imageData');
+    });
+
+    it('keeps image bytes out of the rendered page even if a read returns them', async () => {
+        // Belt and braces: the projection is the fix, but a document that
+        // carries the fields anyway (a freshly created one is unprojected) must
+        // still not put a Buffer into the HTML.
+        Guild.findOne.mockResolvedValue(guildDoc({
+            shop: [{
+                itemId: 'lantern', name: 'Lantern', price: 10,
+                imageData: Buffer.from('SECRETIMAGEBYTES'),
+                imageType: 'image/png',
+            }],
+        }));
+
+        const html = await (await fetch(`${baseUrl}/dashboard/guild/g1`)).text();
+
+        expect(html).toContain('Lantern');
+        expect(html).not.toContain('imageData');
+        expect(html).not.toContain('SECRETIMAGEBYTES');
+        expect(html).not.toContain(Buffer.from('SECRETIMAGEBYTES').toString('base64'));
+    });
+
+    it('seeds default shop items against a fully selected document, never the projection', async () => {
+        // Saving a partially selected shop array is how a guild's images get
+        // replaced with nothing, so the rare backfill re-reads without the
+        // projection and writes that document instead.
+        const projected = guildDoc({ seeded: false });
+        const full = guildDoc({ seeded: false });
+        Guild.findOne.mockResolvedValueOnce(projected).mockResolvedValueOnce(full);
+
+        const res = await fetch(`${baseUrl}/dashboard/guild/g1`);
+        expect(res.status).toBe(200);
+
+        expect(projected.save).not.toHaveBeenCalled();
+        expect(full.save).toHaveBeenCalledTimes(1);
+        expect(Guild.findOne.mock.calls[1][1]).toBeUndefined();
+    });
+
+    it('does not re-read or write for a guild whose shop is already complete', async () => {
+        // The common case by far: nothing to seed, so the projected read is the
+        // only read the page makes and no Buffer is touched at all.
+        const doc = guildDoc({ seeded: false });
+        while (ensureDefaultShopItems(doc)) { /* settle */ }
+        doc.save.mockClear();
+        Guild.findOne.mockResolvedValue(doc);
+
+        await fetch(`${baseUrl}/dashboard/guild/g1`);
+
+        expect(doc.save).not.toHaveBeenCalled();
+        expect(Guild.findOne).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/leaderboardUserFetch.test.js
+++ b/tests/leaderboardUserFetch.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+// #588: rendering one ten-name leaderboard page cost ten serial Discord API
+// round trips, because each row awaited its own client.users.fetch(). Nothing
+// in the loop depends on the previous row, so they go out together.
+
+jest.mock('discord.js', () => ({
+    SlashCommandBuilder: jest.fn().mockImplementation(() => {
+        const self = {
+            setName: jest.fn().mockReturnThis(),
+            setDescription: jest.fn().mockReturnThis(),
+            addStringOption: jest.fn().mockReturnThis(),
+            addChoices: jest.fn().mockReturnThis(),
+            setRequired: jest.fn().mockReturnThis(),
+        };
+        return self;
+    }),
+    EmbedBuilder: jest.fn().mockImplementation(() => {
+        const self = {
+            data: {},
+            setColor: jest.fn().mockReturnThis(),
+            setTitle: jest.fn().mockReturnThis(),
+            setDescription: jest.fn().mockImplementation(d => { self.data.description = d; return self; }),
+            setFooter: jest.fn().mockReturnThis(),
+            setTimestamp: jest.fn().mockReturnThis(),
+        };
+        return self;
+    }),
+    MessageFlags: { Ephemeral: 64 },
+}));
+
+jest.mock('../src/models/User', () => ({ find: jest.fn(), findOne: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../src/models/Guild', () => ({ findOne: jest.fn() }));
+
+const User = require('../src/models/User');
+const leaderboard = require('../src/commands/leveling/leaderboard');
+
+function makeUsers(n) {
+    return Array.from({ length: n }, (_, i) => ({
+        userId: `u${i}`, level: 10 - i, xp: 100 - i,
+    }));
+}
+
+// User.find(...).sort(...).limit(...) resolves to the rows.
+function mockRows(rows) {
+    User.find.mockReturnValue({ sort: () => ({ limit: async () => rows }) });
+}
+
+/**
+ * A users.fetch() that records how many calls were outstanding at once, so the
+ * test can tell a parallel batch from a serial chain rather than just counting.
+ */
+function makeTracingFetch({ resolve = id => ({ id, tag: `${id}#0` }) } = {}) {
+    let inFlight = 0;
+    const trace = { peakConcurrency: 0, calls: 0 };
+    const fetch = jest.fn(async id => {
+        trace.calls++;
+        inFlight++;
+        trace.peakConcurrency = Math.max(trace.peakConcurrency, inFlight);
+        await new Promise(r => setImmediate(r));
+        inFlight--;
+        const value = resolve(id);
+        if (value === null) throw new Error('Unknown User');
+        return value;
+    });
+    return { fetch, trace };
+}
+
+function makeInteraction(fetch) {
+    return {
+        options: { getString: () => 'levels' },
+        guild: { id: 'g1', name: 'Test Guild' },
+        user: { id: 'caller' },
+        client: { users: { fetch } },
+        reply: jest.fn().mockResolvedValue(undefined),
+    };
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    // No caller row, so the "you are here" tail is skipped.
+    User.findOne.mockResolvedValue(null);
+    User.countDocuments.mockResolvedValue(0);
+});
+
+describe('leaderboard row rendering', () => {
+    it('issues all ten user fetches together instead of one at a time', async () => {
+        mockRows(makeUsers(10));
+        const { fetch, trace } = makeTracingFetch();
+
+        await leaderboard.execute(makeInteraction(fetch));
+
+        expect(trace.calls).toBe(10);
+        expect(trace.peakConcurrency).toBe(10);
+    });
+
+    it('still renders every row in rank order', async () => {
+        mockRows(makeUsers(3));
+        const { fetch } = makeTracingFetch();
+        const interaction = makeInteraction(fetch);
+
+        await leaderboard.execute(interaction);
+
+        const { description } = interaction.reply.mock.calls[0][0].embeds[0].data;
+        expect(description).toContain('🥇 u0#0 — Level 10');
+        expect(description).toContain('🥈 u1#0 — Level 9');
+        expect(description).toContain('🥉 u2#0 — Level 8');
+    });
+
+    it('skips a user Discord cannot resolve without dropping the others', async () => {
+        mockRows(makeUsers(3));
+        const { fetch } = makeTracingFetch({
+            resolve: id => (id === 'u1' ? null : { id, tag: `${id}#0` }),
+        });
+        const interaction = makeInteraction(fetch);
+
+        await leaderboard.execute(interaction);
+
+        const { description } = interaction.reply.mock.calls[0][0].embeds[0].data;
+        expect(description).toContain('u0#0');
+        expect(description).not.toContain('u1#0');
+        // The medal still comes from the row's rank, not its printed position.
+        expect(description).toContain('🥉 u2#0');
+    });
+});


### PR DESCRIPTION
## Summary

Four performance issues that all come down to work repeated on a path that runs constantly.

- **#594** (High) — `guildSettingsCache` was bypassed by 16 of 18 event handlers
- **#605** (Medium) — the guild-settings route read and deep-cloned shop image Buffers it then threw away
- **#606** (Low) — custom bad-word RegExps recompiled on every message
- **#588** (Low) — sequential `client.users.fetch()` inside the leaderboard render loop

**#684** needed no change — see *Already fixed on main* below.

## Key changes

### Wire the existing settings cache into the rest of the handlers (#594)

`src/utils/guildSettingsCache.js` already existed (added in #534) and its own docstring calls the uncached per-event read "the single biggest scaling limit in the bot" — but only `messageCreate` and `interactionCreate` were ever wired into it. This PR adds no new cache; it connects nine more read-only handlers to the one that was already there:

`messageReactionAdd`, `messageReactionRemove`, `voiceStateUpdate`, `messageUpdate`, `messageDelete`, `guildMemberAdd`, `guildMemberRemove`, `guildMemberUpdate`, `channelCreate`, `channelDelete`.

Each was checked first for the two properties the cache requires of its callers: cached entries are shared plain objects, so a caller must neither mutate them nor call document methods on them. `channelDelete` still writes its `tempVoice` `$pull` through the model directly; the `.sort()` at `voiceStateUpdate.js:75` acts on a `.filter()` copy, not on the shared array.

### Starboard: an atomic claim instead of a shared-object save

`handleStarboard` was the one switched handler that also wrote — it pushed onto `starredMessages` and called `guildSettings.save()`. That is exactly what a shared cache entry cannot support, so it now claims the message in one update:

```js
Guild.updateOne(
    { guildId, 'starboard.starredMessages': { $ne: message.id } },
    { $push: { 'starboard.starredMessages': message.id } }
)
```

The `$ne` in the filter *is* the claim. This is also a behavioral fix worth a look: the old read-modify-write let two reactions crossing the threshold concurrently both clear the `includes()` check and post the same message to the starboard twice.

### Keep shop image Buffers out of the settings page (#605)

`shop.imageData` and `shop.imageType` are now projected out of the read. Up to 35 items × 512 KB per guild were being pulled off the wire and deep-copied by `toObject()` on every page load, only to be stripped before rendering — the images are served by `/api/item-image/shop/:guildId/:itemId` and were never on the page.

Seeding default shop items still writes through a **fully selected** document. `ensureDefaultShopItems` only appends, so a save would in practice emit `$push`, but re-reading on a path that runs once per guild is cheap and the alternative failure — a whole guild's shop images replaced with nothing — is not worth a judgement call.

### Compile a guild's custom bad words once (#606)

The base profanity list was already compiled at module load; only the custom patterns were rebuilt from scratch per message. They're now memoized per guild, keyed on the word list contents rather than array identity — so a settings reload that changed nothing does not force a recompile. Bounded at 5,000 guilds with FIFO eviction, matching `guildSettingsCache`. Also drops the per-message `[...BASE, ...custom]` spread that rebuilt a 57+ element array each time.

### Issue the leaderboard's fetches together (#588)

Still ten Discord API calls, but concurrent rather than serial, so the page costs one round trip's latency instead of ten. Medals continue to come from a row's rank rather than its printed position, so an unresolvable user is skipped without shifting the others.

## Already fixed on main

- **#684** (`express.static` mounted with no options) is fully resolved. `src/dashboard/server.js` mounts it with `maxAge: '1y', immutable: true`, and `src/dashboard/lib/assets.js` stamps every asset URL with a SHA-1 content hash — the stronger end-state the issue described as a later step. It can be closed as done.
- Two sub-points of **#605**: the `ItemImage.find` is already filtered, projected and `.lean()`; and Express enables `view cache` automatically under the `NODE_ENV=production` that the Dockerfile and `portainer-stack.yml` both set. **No view caching is disabled by this PR** — a comment was added recording why nothing is forced there, so local template reloading is unaffected.

## Testing

`npx eslint .` clean. Full suite: **2252 passed / 150 suites** (up from 2217 / 146).

35 tests added across four files, each verified to fail against the pre-change code:

- `tests/eventGuildSettingsCache.test.js` — one document read per guild across two events, the projection is requested, and the starboard's claim filter/update shape, no-double-post, and non-mutation of the shared object
- `tests/guildSettingsShopImages.test.js` — drives the real route: image fields projected out, no Buffer bytes in the rendered HTML, and seeding writes the full document rather than the projection
- `tests/customBadWordRegexCache.test.js` — reuse across separate array instances, recompile on add/remove, per-guild isolation, metacharacter escaping, eviction bound
- `tests/leaderboardUserFetch.test.js` — traces peak in-flight fetches to distinguish a parallel batch from a serial chain

`tests/eventLog.test.js` and `tests/farewell.test.js` needed a `clearGuildSettingsCache()` between cases. They mock the Guild model directly, so the Mongoose middleware that drives invalidation isn't present and one test's settings leaked into the next — a test-harness gap, not a production one.

## Noted, not changed

`src/dashboard/routes/api/itemImages.js:44` loads a guild's entire `shop` array — every image Buffer — to serve a single image. Same class of problem as #605, but outside the lines that issue named. Worth its own issue.