### PR TITLE
Optimize database queries and response caching for stats endpoints

### DIFF
--- a/src/commands/leveling/leaderboard.js
+++ b/src/commands/leveling/leaderboard.js
@@ -3,6 +3,23 @@ const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { netWorthOf, topByNetWorth, netWorthRank } = require('../../utils/netWorth');
 
+// A leaderboard page prints ten names and one number each. Hydrating whole user
+// documents to do it dragged the pet, inventory, achievement and quest arrays
+// along for the ride — hundreds of subdocuments per row, discarded unread. Each
+// board therefore names the fields its own rows actually render, and reads them
+// as plain objects.
+const ROW_FIELDS = {
+    levels:       'userId level xp',
+    streaks:      'userId streak.current streak.longest streak.freezes streak.revivalToken',
+    duels:        'userId duelWins duelLosses',
+    achievements: 'userId achievementsCount',
+};
+
+// The "You are here" line is computed for whichever board is showing, so the
+// caller's row is read once with the union of what those branches read. `_id`
+// comes back regardless and is what netWorthRank ties-breaks on.
+const CALLER_FIELDS = 'userId level xp balance bank duelWins duelLosses achievementsCount';
+
 module.exports = {
     cooldown: 10,
     data: new SlashCommandBuilder()
@@ -32,7 +49,11 @@ module.exports = {
                 const sortField = type === 'streaks'
                     ? { 'streak.current': -1 }
                     : { 'streak.longest': -1 };
-                users = await User.find({ guildId: interaction.guild.id, ...(type === 'streaks' ? { 'streak.current': { $gt: 0 } } : {}) }).sort(sortField).limit(10);
+                users = await User.find({ guildId: interaction.guild.id, ...(type === 'streaks' ? { 'streak.current': { $gt: 0 } } : {}) })
+                    .select(ROW_FIELDS.streaks)
+                    .sort(sortField)
+                    .limit(10)
+                    .lean();
                 title = type === 'streaks'
                     ? '🔥 Daily Streak Leaderboard'
                     : '🏆 All-Time Streak Records';
@@ -43,17 +64,23 @@ module.exports = {
                 users = await User.find({
                     guildId: interaction.guild.id,
                     $or: [{ duelWins: { $gt: 0 } }, { duelLosses: { $gt: 0 } }],
-                }).sort({ duelWins: -1 }).limit(10);
+                })
+                    .select(ROW_FIELDS.duels)
+                    .sort({ duelWins: -1 })
+                    .limit(10)
+                    .lean();
                 title = '⚔️ Duel Leaderboard';
                 descriptionHeader = 'Top 10 Duelists by Win Count';
             } else if (type === 'achievements') {
-                const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+                const guildSettings = await Guild.findOne({ guildId: interaction.guild.id }).select('achievements.enabled').lean();
                 if (!guildSettings?.achievements?.enabled) {
                     return interaction.reply({ content: 'Achievements are not enabled on this server.', flags: MessageFlags.Ephemeral });
                 }
                 users = await User.find({ guildId: interaction.guild.id, achievementsCount: { $gt: 0 } })
+                    .select(ROW_FIELDS.achievements)
                     .sort({ achievementsCount: -1 })
-                    .limit(10);
+                    .limit(10)
+                    .lean();
                 title = '🏅 Achievement Leaderboard';
                 descriptionHeader = 'Top 10 by Total Achievements Earned';
             } else if (type === 'economy') {
@@ -63,7 +90,11 @@ module.exports = {
                 title = '🏆 Leaderboard';
                 descriptionHeader = 'Top 10 by Net Worth';
             } else {
-                users = await User.find({ guildId: interaction.guild.id }).sort({ level: -1, xp: -1 }).limit(10);
+                users = await User.find({ guildId: interaction.guild.id })
+                    .select(ROW_FIELDS.levels)
+                    .sort({ level: -1, xp: -1 })
+                    .limit(10)
+                    .lean();
                 title = '🏆 Leaderboard';
                 descriptionHeader = 'Top 10 by Level';
             }
@@ -80,7 +111,9 @@ module.exports = {
             // Find caller's rank for streak leaderboards
             let callerRankLine = '';
             if (type === 'streaks' || type === 'streaks_longest') {
-                const callerUser = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+                const callerUser = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id })
+                    .select(ROW_FIELDS.streaks)
+                    .lean();
                 if (callerUser) {
                     const callerVal = type === 'streaks'
                         ? (callerUser.streak?.current ?? 0)
@@ -152,7 +185,9 @@ module.exports = {
 
             // "You are here" self-rank for types that didn't already compute it above
             if (!callerRankLine && !['streaks', 'streaks_longest'].includes(type)) {
-                const callerUser = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+                const callerUser = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id })
+                    .select(CALLER_FIELDS)
+                    .lean();
                 if (callerUser) {
                     let callerRank, callerDisplay;
                     const div = '━━━━━━━━━━━━━━━━━━━━━━━━━━━';

--- a/src/dashboard/routes/api/stats.js
+++ b/src/dashboard/routes/api/stats.js
@@ -18,125 +18,163 @@ const STATS_GUILD_FIELDS = 'welcome moderation leveling economy rssFeeds';
 // route.
 const CASE_FIELDS = 'type createdAt resolvedAt evidence.jumpUrl';
 
+// The whole payload is memoised, not just the queries inside it. Every panel on
+// the dashboard's overview asks for this route on load, a left-open tab asks for
+// it again on every refresh, and the answer is a summary of the last thirty days
+// — it does not become wrong in a minute. The per-query memos below stay because
+// they are shared with /economy/stats, which asks two of the same questions.
+const STATS_RESPONSE_TTL_MS = 60_000;
+
+async function buildGuildStats(guildId) {
+    // Every one of these touches the guild's whole user collection, and the page
+    // that calls this route also calls /economy/stats, which asks two of the same
+    // questions. Memoised so that costs one scan, not five.
+    const [totalUsers, totalMessages, topLevels, guildSettings, analytics] = await Promise.all([
+        cachedAggregate(`${guildId}:stats:users`, () => User.countDocuments({ guildId })),
+        cachedAggregate(`${guildId}:stats:messages`, () => User.aggregate([
+            { $match: { guildId } },
+            { $group: { _id: null, total: { $sum: '$messages' } } }
+        ])),
+        cachedAggregate(`${guildId}:stats:topLevels`, () => User.find({ guildId })
+            .select('userId level xp')
+            .sort({ level: -1, xp: -1 })
+            .limit(10)
+            .lean()),
+        Guild.findOne({ guildId }).select(STATS_GUILD_FIELDS).lean(),
+        GuildAnalytics.findOne({ guildId }).lean()
+    ]);
+    const memberEvents = analytics?.memberEvents || [];
+    const commandUsage = analytics?.commandUsage || [];
+
+    const { joins30, leaves30, retained7, retained30 } = computeRetention(memberEvents);
+
+    // `commandUsage` is a capped log of the guild's recent command traffic — on a
+    // busy server, thousands of entries. It used to be walked twice, once for the
+    // per-command summary and again for the daily volume series, and the busiest
+    // hour per channel was then found by sorting each channel's hour histogram.
+    // All of it is derivable in a single pass, keeping running maxima instead of
+    // sorting: one traversal, and no per-channel sort.
+    const commandSummary = {};
+    const failedByReason = {};
+    const bestTimesByChannel = new Map();
+    const msgVolMap = {};
+    for (const item of commandUsage) {
+        commandSummary[item.command] = commandSummary[item.command] || { total: 0, failed: 0 };
+        commandSummary[item.command].total += 1;
+        if (!item.success) {
+            commandSummary[item.command].failed += 1;
+            failedByReason[item.reason || 'unknown'] = (failedByReason[item.reason || 'unknown'] || 0) + 1;
+        }
+
+        const channelId = item.channelId || 'unknown';
+        let channel = bestTimesByChannel.get(channelId);
+        if (!channel) {
+            channel = { hours: {}, bestHour: 0, bestCount: 0 };
+            bestTimesByChannel.set(channelId, channel);
+        }
+        const count = (channel.hours[item.hour] || 0) + 1;
+        channel.hours[item.hour] = count;
+        // The sort this replaces ran over `Object.entries(hours)`, whose keys are
+        // small integers and so come back in ascending numeric order; a stable
+        // sort therefore broke ties toward the earlier hour. The running maximum
+        // breaks them the same way rather than toward whichever hour got there
+        // first.
+        if (count > channel.bestCount || (count === channel.bestCount && item.hour < channel.bestHour)) {
+            channel.bestCount = count;
+            channel.bestHour = item.hour;
+        }
+
+        if (item.createdAt) {
+            const day = new Date(item.createdAt).toISOString().slice(0, 10);
+            msgVolMap[day] = (msgVolMap[day] || 0) + 1;
+        }
+    }
+    const bestPostingTimes = [...bestTimesByChannel.entries()]
+        .slice(0, 8)
+        .map(([channelId, channel]) => ({ channelId, hourUtc: Number(channel.bestHour) || 0 }));
+
+    const recommendations = [];
+    if (leaves30 > joins30 * 0.6 && !guildSettings?.welcome?.dmEnabled) recommendations.push('Enable welcome DMs to improve first-week retention.');
+    if (!guildSettings?.moderation?.enabled || !guildSettings?.moderation?.autoModEnabled) recommendations.push('Enable auto-moderation, your raid/spam risk is elevated.');
+    if ((failedByReason.execution_error || 0) > 10) recommendations.push('High command error volume detected. Audit recent command updates.');
+    if ((guildSettings?.rssFeeds?.length || 0) === 0) recommendations.push('Add RSS or Daily News automation to keep channels active.');
+
+    // Member growth: derive from memberEvents (last 30 days). Indexed by date
+    // first, so the thirty lookups below are thirty map hits rather than thirty
+    // linear scans of the event log.
+    const eventsByDate = new Map(memberEvents.map(event => [event.date, event]));
+    const now30 = Date.now();
+    const memberGrowth = [];
+    for (let i = 29; i >= 0; i--) {
+        const d = new Date(now30 - i * 864e5).toISOString().slice(0, 10);
+        const ev = eventsByDate.get(d);
+        memberGrowth.push({ date: d, joins: ev?.joins || 0, leaves: ev?.leaves || 0 });
+    }
+
+    // Message volume proxy: commandUsage events grouped by day (last 30 days),
+    // tallied in the single pass above.
+    const messageVolume = memberGrowth.map(({ date }) => ({ date, count: msgVolMap[date] || 0 }));
+
+    // Economy stats summary
+    const [ecoTotalAgg, ecoActiveCount] = await Promise.all([
+        cachedAggregate(`${guildId}:stats:ecoTotal`, () => User.aggregate([
+            { $match: { guildId } },
+            { $group: { _id: null, total: { $sum: { $add: ['$balance', '$bank'] } }, avgXp: { $avg: '$xp' } } }
+        ])),
+        // Same question, same key as /economy/stats asks it under.
+        cachedAggregate(`${guildId}:economy:active`, () => User.countDocuments({ guildId, $or: [
+            { lastWork:  { $gte: new Date(Date.now() - 7 * 864e5) } },
+            { lastDaily: { $gte: new Date(Date.now() - 7 * 864e5) } },
+            { lastFish:  { $gte: new Date(Date.now() - 7 * 864e5) } },
+            { lastMine:  { $gte: new Date(Date.now() - 7 * 864e5) } },
+            { lastCrime: { $gte: new Date(Date.now() - 7 * 864e5) } },
+            { lastHeist: { $gte: new Date(Date.now() - 7 * 864e5) } },
+            { lastRob:   { $gte: new Date(Date.now() - 7 * 864e5) } }
+        ] }))
+    ]);
+
+    return {
+        totalUsers,
+        totalMessages: totalMessages[0]?.total || 0,
+        topLevels: topLevels.map(u => ({
+            userId: u.userId,
+            level: u.level,
+            xp: u.xp
+        })),
+        analytics: {
+            growthFunnel: { joins30, retained7: Number((retained7 * 100).toFixed(1)), retained30: Number((retained30 * 100).toFixed(1)) },
+            churnAlerts: leaves30 > joins30 * 0.5 ? ['Churn is elevated over the last 30 days.'] : [],
+            likelyCauses: [
+                !guildSettings?.welcome?.enabled ? 'Welcome flow is disabled.' : null,
+                !guildSettings?.leveling?.enabled ? 'No progression loop (leveling disabled).' : null,
+                !guildSettings?.economy?.enabled ? 'No recurring incentive loop (economy disabled).' : null
+            ].filter(Boolean),
+            bestPostingTimes,
+            commandUsage: commandSummary,
+            failedCommands: failedByReason,
+            recommendations,
+            messageVolume,
+            memberGrowth,
+            economyStats: {
+                totalCoins: ecoTotalAgg[0]?.total || 0,
+                activeUsers: ecoActiveCount
+            },
+            xpStats: {
+                avgXp: ecoTotalAgg[0]?.avgXp ? Math.round(ecoTotalAgg[0].avgXp) : 0
+            }
+        }
+    };
+}
+
 router.get('/guild/:guildId/stats', checkAuth, checkGuildAccess, async (req, res) => {
     const { guildId } = req.params;
 
     try {
-        // Every one of these touches the guild's whole user collection, and the page
-        // that calls this route also calls /economy/stats, which asks two of the same
-        // questions. Memoised so that costs one scan, not five.
-        const [totalUsers, totalMessages, topLevels, guildSettings, analytics] = await Promise.all([
-            cachedAggregate(`${guildId}:stats:users`, () => User.countDocuments({ guildId })),
-            cachedAggregate(`${guildId}:stats:messages`, () => User.aggregate([
-                { $match: { guildId } },
-                { $group: { _id: null, total: { $sum: '$messages' } } }
-            ])),
-            cachedAggregate(`${guildId}:stats:topLevels`, () => User.find({ guildId })
-                .select('userId level xp')
-                .sort({ level: -1, xp: -1 })
-                .limit(10)
-                .lean()),
-            Guild.findOne({ guildId }).select(STATS_GUILD_FIELDS).lean(),
-            GuildAnalytics.findOne({ guildId }).lean()
-        ]);
-        const memberEvents = analytics?.memberEvents || [];
-        const commandUsage = analytics?.commandUsage || [];
-
-        const { joins30, leaves30, retained7, retained30 } = computeRetention(memberEvents);
-
-        const commandSummary = {};
-        const failedByReason = {};
-        const bestTimesByChannel = {};
-        for (const item of commandUsage) {
-            commandSummary[item.command] = commandSummary[item.command] || { total: 0, failed: 0 };
-            commandSummary[item.command].total += 1;
-            if (!item.success) {
-                commandSummary[item.command].failed += 1;
-                failedByReason[item.reason || 'unknown'] = (failedByReason[item.reason || 'unknown'] || 0) + 1;
-            }
-            const channel = item.channelId || 'unknown';
-            bestTimesByChannel[channel] = bestTimesByChannel[channel] || {};
-            bestTimesByChannel[channel][item.hour] = (bestTimesByChannel[channel][item.hour] || 0) + 1;
-        }
-        const bestPostingTimes = Object.entries(bestTimesByChannel).map(([channelId, hours]) => {
-            const bestHour = Object.entries(hours).sort((a, b) => b[1] - a[1])[0]?.[0] ?? '0';
-            return { channelId, hourUtc: Number(bestHour) };
-        }).slice(0, 8);
-
-        const recommendations = [];
-        if (leaves30 > joins30 * 0.6 && !guildSettings?.welcome?.dmEnabled) recommendations.push('Enable welcome DMs to improve first-week retention.');
-        if (!guildSettings?.moderation?.enabled || !guildSettings?.moderation?.autoModEnabled) recommendations.push('Enable auto-moderation, your raid/spam risk is elevated.');
-        if ((failedByReason.execution_error || 0) > 10) recommendations.push('High command error volume detected. Audit recent command updates.');
-        if ((guildSettings?.rssFeeds?.length || 0) === 0) recommendations.push('Add RSS or Daily News automation to keep channels active.');
-
-        // Member growth: derive from memberEvents (last 30 days)
-        const now30 = Date.now();
-        const memberGrowth = [];
-        for (let i = 29; i >= 0; i--) {
-            const d = new Date(now30 - i * 864e5).toISOString().slice(0, 10);
-            const ev = memberEvents.find(e => e.date === d);
-            memberGrowth.push({ date: d, joins: ev?.joins || 0, leaves: ev?.leaves || 0 });
-        }
-
-        // Message volume proxy: commandUsage events grouped by day (last 30 days)
-        const msgVolMap = {};
-        for (const ev of commandUsage) {
-            if (ev.createdAt) {
-                const d = new Date(ev.createdAt).toISOString().slice(0, 10);
-                msgVolMap[d] = (msgVolMap[d] || 0) + 1;
-            }
-        }
-        const messageVolume = memberGrowth.map(({ date }) => ({ date, count: msgVolMap[date] || 0 }));
-
-        // Economy stats summary
-        const [ecoTotalAgg, ecoActiveCount] = await Promise.all([
-            cachedAggregate(`${guildId}:stats:ecoTotal`, () => User.aggregate([
-                { $match: { guildId } },
-                { $group: { _id: null, total: { $sum: { $add: ['$balance', '$bank'] } }, avgXp: { $avg: '$xp' } } }
-            ])),
-            // Same question, same key as /economy/stats asks it under.
-            cachedAggregate(`${guildId}:economy:active`, () => User.countDocuments({ guildId, $or: [
-                { lastWork:  { $gte: new Date(Date.now() - 7 * 864e5) } },
-                { lastDaily: { $gte: new Date(Date.now() - 7 * 864e5) } },
-                { lastFish:  { $gte: new Date(Date.now() - 7 * 864e5) } },
-                { lastMine:  { $gte: new Date(Date.now() - 7 * 864e5) } },
-                { lastCrime: { $gte: new Date(Date.now() - 7 * 864e5) } },
-                { lastHeist: { $gte: new Date(Date.now() - 7 * 864e5) } },
-                { lastRob:   { $gte: new Date(Date.now() - 7 * 864e5) } }
-            ] }))
-        ]);
-
-        res.json({
-            totalUsers,
-            totalMessages: totalMessages[0]?.total || 0,
-            topLevels: topLevels.map(u => ({
-                userId: u.userId,
-                level: u.level,
-                xp: u.xp
-            })),
-            analytics: {
-                growthFunnel: { joins30, retained7: Number((retained7 * 100).toFixed(1)), retained30: Number((retained30 * 100).toFixed(1)) },
-                churnAlerts: leaves30 > joins30 * 0.5 ? ['Churn is elevated over the last 30 days.'] : [],
-                likelyCauses: [
-                    !guildSettings?.welcome?.enabled ? 'Welcome flow is disabled.' : null,
-                    !guildSettings?.leveling?.enabled ? 'No progression loop (leveling disabled).' : null,
-                    !guildSettings?.economy?.enabled ? 'No recurring incentive loop (economy disabled).' : null
-                ].filter(Boolean),
-                bestPostingTimes,
-                commandUsage: commandSummary,
-                failedCommands: failedByReason,
-                recommendations,
-                messageVolume,
-                memberGrowth,
-                economyStats: {
-                    totalCoins: ecoTotalAgg[0]?.total || 0,
-                    activeUsers: ecoActiveCount
-                },
-                xpStats: {
-                    avgXp: ecoTotalAgg[0]?.avgXp ? Math.round(ecoTotalAgg[0].avgXp) : 0
-                }
-            }
-        });
+        res.json(await cachedAggregate(
+            `${guildId}:stats:response`,
+            () => buildGuildStats(guildId),
+            STATS_RESPONSE_TTL_MS
+        ));
     } catch (error) {
         console.error('Stats error:', error);
         res.status(500).json({ error: 'Internal server error' });

--- a/src/services/rssService.js
+++ b/src/services/rssService.js
@@ -116,6 +116,12 @@ async function persistSentLinks(guild, profile, newlySentLinks) {
     await guild.save();
 }
 
+// Scheduling a guild's digests needs its id and its profiles, and nothing else.
+// Guild documents also carry embedded image Buffers, so a projection is the
+// difference between reading a few hundred bytes per guild and reading whatever
+// artwork that guild's admins have uploaded.
+const DAILY_NEWS_FIELDS = 'guildId dailyNewsProfiles dailyNews';
+
 function getDailyNewsProfiles(guild) {
     if (Array.isArray(guild.dailyNewsProfiles) && guild.dailyNewsProfiles.length > 0) {
         return guild.dailyNewsProfiles;
@@ -381,7 +387,7 @@ function scheduleProfileJob(client, guildId, profile) {
 }
 
 function scheduleDailyNews(client) {
-    Guild.find({}, 'guildId dailyNewsProfiles dailyNews').lean().then(guilds => {
+    Guild.find({}, DAILY_NEWS_FIELDS).lean().then(guilds => {
         for (const guild of guilds) {
             const profiles = getDailyNewsProfiles(guild)
                 .filter(profile => profile.enabled && Array.isArray(profile.feeds) && profile.feeds.length > 0);
@@ -402,7 +408,10 @@ function rescheduleDailyNews(client, guildId) {
         }
     }
 
-    Guild.findOne({ guildId }).then(guild => {
+    // Same three fields the startup sweep reads. Without the projection this
+    // pulled the guild's shop-item and activity-item image Buffers into memory
+    // on every dashboard save that touched a daily-news setting.
+    Guild.findOne({ guildId }, DAILY_NEWS_FIELDS).lean().then(guild => {
         if (!guild) return;
 
         const profiles = getDailyNewsProfiles(guild)

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -3,7 +3,7 @@ const User  = require('../models/User');
 const SeasonRecord = require('../models/SeasonRecord');
 const { createWarVictoryBanner, createSeasonRecapCard } = require('../utils/cardGenerator');
 const { PET_DEFINITIONS, heartBar } = require('./petService');
-const { ensurePricingFields, nextPrice, decayDemand, trendBucket, HISTORY_CAP } = require('../utils/dynamicPricing');
+const { ensurePricingFields, nextPrice, decayDemand, demandDecayFactor, trendBucket, HISTORY_CAP } = require('../utils/dynamicPricing');
 const { softResetElo, tierFor, makeSeasonId } = require('../utils/duelElo');
 const { topByNetWorth } = require('../utils/netWorth');
 const { grantInventoryItem } = require('../utils/inventoryGrant');
@@ -698,17 +698,55 @@ async function recalcShopPrices(client) {
             if (!guildDoc) continue; // another worker already claimed this window
 
             const shop = Array.isArray(guildDoc.shop) ? guildDoc.shop : [];
+            // Captured before the backfill, because the write below names a field
+            // only where this job is the one that changed it. `basePrice` is set by
+            // admins through the dashboard, and writing back the value we read
+            // would undo an edit made while we were computing.
+            const priorState = shop.map(item => ({
+                hadBasePrice: item.basePrice != null,
+                // `$mul` rejects a null, and treats a missing field as zero — which
+                // is the right answer for an item that predates demand tracking, but
+                // has to be reached with `$set` rather than by multiplying.
+                hadDemandScore: typeof item.demandScore === 'number',
+            }));
             ensurePricingFields(shop);
 
-            const band       = guildDoc.dynamicPricing.priceBand ?? 0.5;
-            const volatility = guildDoc.dynamicPricing.volatility ?? 'medium';
+            const band        = guildDoc.dynamicPricing.priceBand ?? 0.5;
+            const volatility  = guildDoc.dynamicPricing.volatility ?? 'medium';
+            const decayFactor = demandDecayFactor(volatility);
             const changedMovers = [];
             const writes = [];
 
-            for (const item of shop) {
+            for (const [index, item] of shop.entries()) {
                 const prev = item.currentPrice ?? item.basePrice ?? item.price;
+                // Both read the demand score as it was at claim time, which is what
+                // the price is supposed to follow; only the stored score is left to
+                // the database to decay.
                 item.currentPrice = nextPrice(item, band, volatility);
                 item.demandScore  = decayDemand(item, volatility);
+
+                // Nothing else writes `currentPrice`, and this job holds the guild's
+                // recalc lease, so it is the sole author of that field.
+                const set = { 'shop.$.currentPrice': item.currentPrice };
+                if (!priorState[index].hadBasePrice) set['shop.$.basePrice'] = item.basePrice;
+
+                const update = {
+                    $set: set,
+                    $push: {
+                        'shop.$.priceHistory': {
+                            // A snapshot of the score this tick's price was computed
+                            // from; a buy landing during the write moves the stored
+                            // score without rewriting this row.
+                            $each: [{ at: now, price: item.currentPrice, demandScore: item.demandScore }],
+                            $slice: -HISTORY_CAP,
+                        },
+                    },
+                };
+                if (priorState[index].hadDemandScore) {
+                    update.$mul = { 'shop.$.demandScore': decayFactor };
+                } else {
+                    set['shop.$.demandScore'] = item.demandScore;
+                }
 
                 // Matched by subdocument `_id` rather than by array index: an admin
                 // adding or removing a shop item between the read and the write
@@ -718,19 +756,7 @@ async function recalcShopPrices(client) {
                 writes.push({
                     updateOne: {
                         filter: { guildId: guildDoc.guildId, 'shop._id': item._id },
-                        update: {
-                            $set: {
-                                'shop.$.basePrice':    item.basePrice,
-                                'shop.$.currentPrice': item.currentPrice,
-                                'shop.$.demandScore':  item.demandScore,
-                            },
-                            $push: {
-                                'shop.$.priceHistory': {
-                                    $each: [{ at: now, price: item.currentPrice, demandScore: item.demandScore }],
-                                    $slice: -HISTORY_CAP,
-                                },
-                            },
-                        },
+                        update,
                     },
                 });
 

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -753,13 +753,34 @@ async function recalcShopPrices(client) {
                 // shifts the indices, and an index-addressed `$set` would then land
                 // the new price on somebody else's item. A stale `_id` simply
                 // matches nothing.
+                //
+                // Backfilling an item additionally requires that it still have no
+                // basePrice. That is the one field here whose value is read rather
+                // than derived, so an admin setting it between the claim and this
+                // write is a real edit to lose. Failing the predicate skips the item
+                // for this tick — including its currentPrice and history entry,
+                // which were computed from the basePrice that no longer applies —
+                // and the next tick recomputes from the admin's value.
+                //
+                // `{ basePrice: null }` matches an absent field as well as an
+                // explicit null, which is the same set `item.basePrice == null`
+                // selected when priorState was captured.
+                const filter = priorState[index].hadBasePrice
+                    ? { guildId: guildDoc.guildId, 'shop._id': item._id }
+                    : { guildId: guildDoc.guildId, shop: { $elemMatch: { _id: item._id, basePrice: null } } };
+
                 writes.push({
                     updateOne: {
-                        filter: { guildId: guildDoc.guildId, 'shop._id': item._id },
+                        filter,
                         update,
                     },
                 });
 
+                // Movers are collected from the computed values rather than from
+                // what the write matched, since bulkWrite reports matches only in
+                // aggregate. A backfill item losing its predicate could therefore be
+                // named in the embed without its price having landed — cosmetic, and
+                // it needs an admin edit to land inside the same few milliseconds.
                 if (Math.abs(item.currentPrice - prev) / Math.max(1, prev) > 0.05) {
                     changedMovers.push({ name: item.name, prev, next: item.currentPrice, item });
                 }

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -3,7 +3,7 @@ const User  = require('../models/User');
 const SeasonRecord = require('../models/SeasonRecord');
 const { createWarVictoryBanner, createSeasonRecapCard } = require('../utils/cardGenerator');
 const { PET_DEFINITIONS, heartBar } = require('./petService');
-const { ensurePricingFields, nextPrice, decayDemand, pushHistory, trendBucket } = require('../utils/dynamicPricing');
+const { ensurePricingFields, nextPrice, decayDemand, trendBucket, HISTORY_CAP } = require('../utils/dynamicPricing');
 const { softResetElo, tierFor, makeSeasonId } = require('../utils/duelElo');
 const { topByNetWorth } = require('../utils/netWorth');
 const { grantInventoryItem } = require('../utils/inventoryGrant');
@@ -648,10 +648,22 @@ async function announceHourlyWinners(client) {
     }
 }
 
-// ─── Dynamic shop pricing recalculation (issue #354) ─────────────────────────
+// ─── Dynamic shop pricing recalculation (issue #354) ────────────────────────
+//
+// Shop items carry their icon inline, as an `imageData` Buffer on the subdocument
+// (see the `shop` array in models/Guild.js). That makes the whole-document
+// read-mutate-`save()` shape this job used to have proportional to the size of a
+// guild's uploaded artwork rather than to the handful of numbers it changes:
+// every fifteen minutes it pulled every icon of every dynamic-pricing guild into
+// the process, and `markModified('shop')` then wrote all of them back untouched.
+//
+// So the shop is read under a projection that names only the pricing fields, and
+// the new prices go back as a `bulkWrite` of per-item `$set`s. The Buffers are
+// never read and never rewritten.
 async function recalcShopPrices(client) {
     const { EmbedBuilder } = require('discord.js');
-    const guilds = await Guild.find({ 'dynamicPricing.enabled': true });
+    // Only the lease window is needed here; the claim below re-reads the guild.
+    const guilds = await Guild.find({ 'dynamicPricing.enabled': true }, 'guildId dynamicPricing.recalcMinutes').lean();
 
     for (const guildSummary of guilds) {
         try {
@@ -663,6 +675,10 @@ async function recalcShopPrices(client) {
             // succeeds when lastRecalcAt is null or older than the lease window,
             // ensuring concurrent workers (multi-instance deployments) don't
             // both run the recalc for the same guild.
+            //
+            // `priceHistory` is deliberately absent from the projection: the write
+            // below appends to it with `$push`/`$slice` rather than replacing it,
+            // so there is no reason to carry thirty entries per item back and forth.
             const guildDoc = await Guild.findOneAndUpdate(
                 {
                     guildId: guildSummary.guildId,
@@ -673,27 +689,57 @@ async function recalcShopPrices(client) {
                     ],
                 },
                 { $set: { 'dynamicPricing.lastRecalcAt': now } },
-                { new: true }
-            );
+                {
+                    new: true,
+                    projection: 'guildId dynamicPricing economy.announcementChannelId economy.currency '
+                        + 'shop._id shop.name shop.price shop.basePrice shop.currentPrice shop.demandScore',
+                }
+            ).lean();
             if (!guildDoc) continue; // another worker already claimed this window
 
-            ensurePricingFields(guildDoc.shop);
+            const shop = Array.isArray(guildDoc.shop) ? guildDoc.shop : [];
+            ensurePricingFields(shop);
 
             const band       = guildDoc.dynamicPricing.priceBand ?? 0.5;
             const volatility = guildDoc.dynamicPricing.volatility ?? 'medium';
             const changedMovers = [];
+            const writes = [];
 
-            for (const item of guildDoc.shop) {
+            for (const item of shop) {
                 const prev = item.currentPrice ?? item.basePrice ?? item.price;
                 item.currentPrice = nextPrice(item, band, volatility);
                 item.demandScore  = decayDemand(item, volatility);
-                pushHistory(item, now);
+
+                // Matched by subdocument `_id` rather than by array index: an admin
+                // adding or removing a shop item between the read and the write
+                // shifts the indices, and an index-addressed `$set` would then land
+                // the new price on somebody else's item. A stale `_id` simply
+                // matches nothing.
+                writes.push({
+                    updateOne: {
+                        filter: { guildId: guildDoc.guildId, 'shop._id': item._id },
+                        update: {
+                            $set: {
+                                'shop.$.basePrice':    item.basePrice,
+                                'shop.$.currentPrice': item.currentPrice,
+                                'shop.$.demandScore':  item.demandScore,
+                            },
+                            $push: {
+                                'shop.$.priceHistory': {
+                                    $each: [{ at: now, price: item.currentPrice, demandScore: item.demandScore }],
+                                    $slice: -HISTORY_CAP,
+                                },
+                            },
+                        },
+                    },
+                });
+
                 if (Math.abs(item.currentPrice - prev) / Math.max(1, prev) > 0.05) {
                     changedMovers.push({ name: item.name, prev, next: item.currentPrice, item });
                 }
             }
-            guildDoc.markModified('shop');
-            await guildDoc.save();
+
+            if (writes.length) await Guild.bulkWrite(writes);
 
             const channelId = guildDoc.economy?.announcementChannelId;
             if (channelId && changedMovers.length) {

--- a/src/utils/dynamicPricing.js
+++ b/src/utils/dynamicPricing.js
@@ -41,10 +41,19 @@ function nextPrice(item, band, volatility = 'medium') {
     return Math.round(cur + (target - cur) * 0.6);
 }
 
+// The per-tick decay as a plain multiplier, so a caller can hand it to Mongo's
+// `$mul` and let the decay apply to whatever the stored score is at write time
+// rather than to the value it happened to read a moment earlier. Buys `$inc`
+// this field concurrently (see commands/economy/shop.js), and a decayed value
+// written back with `$set` would swallow any that landed in between.
+function demandDecayFactor(volatility = 'medium') {
+    const cfg = VOLATILITY_FACTORS[volatility] || VOLATILITY_FACTORS.medium;
+    return 1 - cfg.decay;
+}
+
 // Decay demand toward zero (oversupply if negative, demand if positive).
 function decayDemand(item, volatility = 'medium') {
-    const cfg = VOLATILITY_FACTORS[volatility] || VOLATILITY_FACTORS.medium;
-    return (item.demandScore ?? 0) * (1 - cfg.decay);
+    return (item.demandScore ?? 0) * demandDecayFactor(volatility);
 }
 
 // Price history is appended by the recalc job's `$push`/`$slice: -HISTORY_CAP`
@@ -70,6 +79,7 @@ module.exports = {
     HISTORY_CAP,
     ensurePricingFields,
     nextPrice,
+    demandDecayFactor,
     decayDemand,
     trendBucket,
 };

--- a/src/utils/dynamicPricing.js
+++ b/src/utils/dynamicPricing.js
@@ -47,18 +47,9 @@ function decayDemand(item, volatility = 'medium') {
     return (item.demandScore ?? 0) * (1 - cfg.decay);
 }
 
-// Record a price-history entry and trim to cap.
-function pushHistory(item, at = new Date()) {
-    if (!Array.isArray(item.priceHistory)) item.priceHistory = [];
-    item.priceHistory.push({
-        at,
-        price: item.currentPrice ?? item.basePrice ?? item.price,
-        demandScore: item.demandScore ?? 0,
-    });
-    if (item.priceHistory.length > HISTORY_CAP) {
-        item.priceHistory.splice(0, item.priceHistory.length - HISTORY_CAP);
-    }
-}
+// Price history is appended by the recalc job's `$push`/`$slice: -HISTORY_CAP`
+// write rather than by rebuilding the array in JS, so the cap is enforced by the
+// database. HISTORY_CAP is exported for that write and for readers of the chart.
 
 // Convenience: % change between currentPrice and basePrice for /market trends display.
 function trendBucket(item) {
@@ -80,6 +71,5 @@ module.exports = {
     ensurePricingFields,
     nextPrice,
     decayDemand,
-    pushHistory,
     trendBucket,
 };

--- a/tests/dynamicPricing.test.js
+++ b/tests/dynamicPricing.test.js
@@ -1,4 +1,4 @@
-const { ensurePricingFields, nextPrice, decayDemand, pushHistory, trendBucket, HISTORY_CAP } = require('../src/utils/dynamicPricing');
+const { ensurePricingFields, nextPrice, decayDemand, trendBucket } = require('../src/utils/dynamicPricing');
 
 describe('dynamicPricing', () => {
     test('ensurePricingFields fills in missing fields once', () => {
@@ -36,14 +36,6 @@ describe('dynamicPricing', () => {
         expect(decayDemand({ demandScore: 100 }, 'medium')).toBeLessThan(100);
         expect(decayDemand({ demandScore: 100 }, 'medium')).toBeGreaterThan(0);
         expect(decayDemand({ demandScore: -100 }, 'medium')).toBeGreaterThan(-100);
-    });
-
-    test('pushHistory trims to cap', () => {
-        const item = { basePrice: 100, currentPrice: 100, demandScore: 0 };
-        for (let i = 0; i < HISTORY_CAP + 10; i++) pushHistory(item, new Date(i));
-        expect(item.priceHistory.length).toBe(HISTORY_CAP);
-        // Oldest dropped first
-        expect(item.priceHistory[0].at.getTime()).toBe(10);
     });
 
     test('trendBucket classifies movement', () => {

--- a/tests/leaderboardUserFetch.test.js
+++ b/tests/leaderboardUserFetch.test.js
@@ -41,9 +41,18 @@ function makeUsers(n) {
     }));
 }
 
-// User.find(...).sort(...).limit(...) resolves to the rows.
+// User.find(...).select(...).sort(...).limit(...).lean() resolves to the rows.
+// `select` is recorded: #586 is that these rows used to arrive as full user
+// documents, pets and inventories included, to print ten names.
+const seen = {};
 function mockRows(rows) {
-    User.find.mockReturnValue({ sort: () => ({ limit: async () => rows }) });
+    const chain = {
+        select(fields) { seen.select = fields; return chain; },
+        sort() { return chain; },
+        limit() { return chain; },
+        lean: async () => rows,
+    };
+    User.find.mockReturnValue(chain);
 }
 
 /**
@@ -79,7 +88,7 @@ function makeInteraction(fetch) {
 beforeEach(() => {
     jest.clearAllMocks();
     // No caller row, so the "you are here" tail is skipped.
-    User.findOne.mockResolvedValue(null);
+    User.findOne.mockReturnValue({ select: () => ({ lean: async () => null }) });
     User.countDocuments.mockResolvedValue(0);
 });
 
@@ -92,6 +101,15 @@ describe('leaderboard row rendering', () => {
 
         expect(trace.calls).toBe(10);
         expect(trace.peakConcurrency).toBe(10);
+    });
+
+    it('reads only the fields the rows print', async () => {
+        mockRows(makeUsers(10));
+        const { fetch } = makeTracingFetch();
+
+        await leaderboard.execute(makeInteraction(fetch));
+
+        expect(seen.select).toBe('userId level xp');
     });
 
     it('still renders every row in rank order', async () => {

--- a/tests/recalcShopPricesWrites.test.js
+++ b/tests/recalcShopPricesWrites.test.js
@@ -1,0 +1,166 @@
+'use strict';
+
+// #603: the fifteen-minute price recalc read every dynamic-pricing guild in
+// full, mutated the shop array in JavaScript, and wrote it back with
+// `markModified('shop')` + `save()`. Shop items store their icon inline as an
+// `imageData` Buffer, so that shape rewrote every uploaded icon in the guild,
+// four times an hour, to change a handful of numbers.
+//
+// The job now names the pricing fields in its projection and writes the new
+// prices back as per-item `$set`s. These tests pin both halves: what it asks
+// for, and what it sends back.
+
+jest.mock('discord.js', () => ({
+    EmbedBuilder: class {
+        setColor() { return this; }
+        setTitle() { return this; }
+        setDescription() { return this; }
+        setFooter() { return this; }
+        setTimestamp() { return this; }
+    },
+}));
+
+jest.mock('../src/models/Guild', () => ({
+    find: jest.fn(),
+    findOne: jest.fn(),
+    findOneAndUpdate: jest.fn(),
+    updateOne: jest.fn(),
+    bulkWrite: jest.fn(),
+}));
+jest.mock('../src/models/User', () => ({ find: jest.fn(), aggregate: jest.fn(), updateOne: jest.fn(), bulkWrite: jest.fn() }));
+
+const Guild = require('../src/models/Guild');
+const { HISTORY_CAP } = require('../src/utils/dynamicPricing');
+const { recalcShopPrices } = require('../src/services/schedulerService');
+
+const client = { guilds: { fetch: async () => null } };
+
+/** Fields named anywhere in a mongoose string projection. */
+function projected(projection) {
+    return String(projection).split(/\s+/).filter(Boolean);
+}
+
+function stubGuild({ shop, dynamicPricing = { enabled: true, priceBand: 0.5, volatility: 'medium' }, economy = {} }) {
+    const seen = {};
+    Guild.find.mockImplementation((filter, projection) => {
+        seen.sweepFilter = filter;
+        seen.sweepProjection = projection;
+        return { lean: async () => [{ guildId: 'g1', dynamicPricing: { recalcMinutes: 15 } }] };
+    });
+    Guild.findOneAndUpdate.mockImplementation((filter, update, options) => {
+        seen.claimFilter = filter;
+        seen.claimUpdate = update;
+        seen.claimOptions = options;
+        return { lean: async () => ({ guildId: 'g1', shop, dynamicPricing, economy }) };
+    });
+    Guild.bulkWrite.mockImplementation(async ops => { seen.writes = ops; });
+    return seen;
+}
+
+const items = () => ([
+    { _id: 'item-a', name: 'Sword',  price: 100, basePrice: 100, currentPrice: 100, demandScore: 40 },
+    { _id: 'item-b', name: 'Shield', price: 200, basePrice: 200, currentPrice: 200, demandScore: 0 },
+]);
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('recalcShopPrices reads', () => {
+    it('projects both reads down to the pricing fields', async () => {
+        const seen = stubGuild({ shop: items() });
+
+        await recalcShopPrices(client);
+
+        // The sweep only needs an id and the lease window.
+        expect(projected(seen.sweepProjection)).toEqual(['guildId', 'dynamicPricing.recalcMinutes']);
+
+        // The claim reads the shop, but only the fields the recalc computes on.
+        const fields = projected(seen.claimOptions.projection);
+        expect(fields).toEqual(expect.arrayContaining([
+            'shop._id', 'shop.name', 'shop.price', 'shop.basePrice', 'shop.currentPrice', 'shop.demandScore',
+        ]));
+        expect(fields).not.toContain('shop');
+        expect(fields).not.toContain('shop.imageData');
+        // Appended to by the write, so there is no reason to read it back.
+        expect(fields).not.toContain('shop.priceHistory');
+    });
+
+    it('still claims the recalc window atomically', async () => {
+        const seen = stubGuild({ shop: items() });
+
+        await recalcShopPrices(client);
+
+        expect(seen.claimFilter['dynamicPricing.enabled']).toBe(true);
+        expect(seen.claimFilter.$or).toHaveLength(2);
+        expect(Object.keys(seen.claimUpdate.$set)).toEqual(['dynamicPricing.lastRecalcAt']);
+        expect(seen.claimOptions.new).toBe(true);
+    });
+
+    it('does nothing when another worker holds the window', async () => {
+        stubGuild({ shop: items() });
+        Guild.findOneAndUpdate.mockReturnValue({ lean: async () => null });
+
+        await recalcShopPrices(client);
+
+        expect(Guild.bulkWrite).not.toHaveBeenCalled();
+    });
+});
+
+describe('recalcShopPrices writes', () => {
+    it('sets only the price fields, addressing items by subdocument id', async () => {
+        const seen = stubGuild({ shop: items() });
+
+        await recalcShopPrices(client);
+
+        expect(seen.writes).toHaveLength(2);
+        const [first] = seen.writes;
+        expect(first.updateOne.filter).toEqual({ guildId: 'g1', 'shop._id': 'item-a' });
+        expect(Object.keys(first.updateOne.update.$set).sort()).toEqual([
+            'shop.$.basePrice', 'shop.$.currentPrice', 'shop.$.demandScore',
+        ]);
+        // Nothing in the write mentions the image, or the shop array as a whole.
+        const serialised = JSON.stringify(seen.writes);
+        expect(serialised).not.toContain('imageData');
+        expect(serialised).not.toMatch(/"shop":/);
+    });
+
+    it('appends one history entry per item and caps it in the database', async () => {
+        const seen = stubGuild({ shop: items() });
+
+        await recalcShopPrices(client);
+
+        for (const op of seen.writes) {
+            const push = op.updateOne.update.$push['shop.$.priceHistory'];
+            expect(push.$each).toHaveLength(1);
+            expect(push.$slice).toBe(-HISTORY_CAP);
+            expect(push.$each[0].price).toEqual(op.updateOne.update.$set['shop.$.currentPrice']);
+        }
+    });
+
+    it('moves a high-demand item up and leaves a neutral one alone', async () => {
+        const seen = stubGuild({ shop: items() });
+
+        await recalcShopPrices(client);
+
+        const [sword, shield] = seen.writes.map(op => op.updateOne.update.$set['shop.$.currentPrice']);
+        expect(sword).toBeGreaterThan(100);
+        expect(shield).toBe(200);
+    });
+
+    it('backfills basePrice for an item that predates dynamic pricing', async () => {
+        const seen = stubGuild({
+            shop: [{ _id: 'item-c', name: 'Potion', price: 50 }],
+        });
+
+        await recalcShopPrices(client);
+
+        expect(seen.writes[0].updateOne.update.$set['shop.$.basePrice']).toBe(50);
+    });
+
+    it('issues no write for a guild with an empty shop', async () => {
+        stubGuild({ shop: [] });
+
+        await recalcShopPrices(client);
+
+        expect(Guild.bulkWrite).not.toHaveBeenCalled();
+    });
+});

--- a/tests/recalcShopPricesWrites.test.js
+++ b/tests/recalcShopPricesWrites.test.js
@@ -225,6 +225,33 @@ describe('recalcShopPrices writes', () => {
         expect(seen.writes[0].updateOne.update.$set['shop.$.basePrice']).toBe(50);
     });
 
+    it('guards the basePrice backfill with a predicate that it is still unset', async () => {
+        const seen = stubGuild({
+            shop: [{ _id: 'item-c', name: 'Potion', price: 50 }],
+        });
+
+        await recalcShopPrices(client);
+
+        // basePrice is the one field here read rather than derived, so an admin
+        // setting it between the claim and this write is a real edit to lose. The
+        // predicate makes the whole item's update a no-op in that case, and the
+        // next tick recomputes from the admin's value.
+        expect(seen.writes[0].updateOne.filter).toEqual({
+            guildId: 'g1',
+            shop: { $elemMatch: { _id: 'item-c', basePrice: null } },
+        });
+    });
+
+    it('does not add that predicate for an item that already has a basePrice', async () => {
+        const seen = stubGuild({ shop: items() });
+
+        await recalcShopPrices(client);
+
+        for (const op of seen.writes) {
+            expect(Object.keys(op.updateOne.filter).sort()).toEqual(['guildId', 'shop._id']);
+        }
+    });
+
     it('issues no write for a guild with an empty shop', async () => {
         stubGuild({ shop: [] });
 

--- a/tests/recalcShopPricesWrites.test.js
+++ b/tests/recalcShopPricesWrites.test.js
@@ -114,13 +114,81 @@ describe('recalcShopPrices writes', () => {
         expect(seen.writes).toHaveLength(2);
         const [first] = seen.writes;
         expect(first.updateOne.filter).toEqual({ guildId: 'g1', 'shop._id': 'item-a' });
-        expect(Object.keys(first.updateOne.update.$set).sort()).toEqual([
-            'shop.$.basePrice', 'shop.$.currentPrice', 'shop.$.demandScore',
-        ]);
         // Nothing in the write mentions the image, or the shop array as a whole.
         const serialised = JSON.stringify(seen.writes);
         expect(serialised).not.toContain('imageData');
         expect(serialised).not.toMatch(/"shop":/);
+    });
+
+    it('leaves an already-set basePrice alone', async () => {
+        const seen = stubGuild({ shop: items() });
+
+        await recalcShopPrices(client);
+
+        // basePrice belongs to whoever edits the shop in the dashboard. Writing
+        // back the value we read would undo an edit made while we computed, so
+        // the only field this job claims outright is the one it authors.
+        for (const op of seen.writes) {
+            expect(Object.keys(op.updateOne.update.$set)).toEqual(['shop.$.currentPrice']);
+        }
+    });
+
+    it('decays demand with $mul so a concurrent buy is not swallowed', async () => {
+        const seen = stubGuild({ shop: items() });
+
+        await recalcShopPrices(client);
+
+        // /shop buy bumps this field with $inc while the recalc is in flight.
+        // Multiplying applies the decay to whatever is stored at write time;
+        // $set-ing a value read a moment earlier would drop the buy.
+        for (const op of seen.writes) {
+            expect(op.updateOne.update.$mul).toEqual({ 'shop.$.demandScore': 1 - 0.10 });
+            expect(op.updateOne.update.$set).not.toHaveProperty('shop.$.demandScore');
+        }
+    });
+
+    it('uses the volatility tier\'s decay factor', async () => {
+        const seen = stubGuild({
+            shop: items(),
+            dynamicPricing: { enabled: true, priceBand: 0.5, volatility: 'high' },
+        });
+
+        await recalcShopPrices(client);
+
+        expect(seen.writes[0].updateOne.update.$mul['shop.$.demandScore']).toBeCloseTo(1 - 0.15);
+    });
+
+    it('seeds rather than multiplies a demand score that was never stored', async () => {
+        const seen = stubGuild({
+            // Predates demand tracking: $mul would reject the null outright, and
+            // treat an absent field as zero without ever seeding it.
+            shop: [
+                { _id: 'old-1', name: 'Relic', price: 10, basePrice: 10, currentPrice: 10, demandScore: null },
+                { _id: 'old-2', name: 'Idol',  price: 10, basePrice: 10, currentPrice: 10 },
+            ],
+        });
+
+        await recalcShopPrices(client);
+
+        for (const op of seen.writes) {
+            expect(op.updateOne.update.$mul).toBeUndefined();
+            expect(op.updateOne.update.$set['shop.$.demandScore']).toBe(0);
+        }
+    });
+
+    it('never names one field in both $set and $mul', async () => {
+        const seen = stubGuild({
+            shop: [...items(), { _id: 'old-1', name: 'Relic', price: 10 }],
+        });
+
+        await recalcShopPrices(client);
+
+        // Mongo rejects the whole update if it does.
+        for (const op of seen.writes) {
+            const setKeys = Object.keys(op.updateOne.update.$set || {});
+            const mulKeys = Object.keys(op.updateOne.update.$mul || {});
+            expect(setKeys.filter(k => mulKeys.includes(k))).toEqual([]);
+        }
     });
 
     it('appends one history entry per item and caps it in the database', async () => {
@@ -153,6 +221,7 @@ describe('recalcShopPrices writes', () => {
 
         await recalcShopPrices(client);
 
+        // The one case where this job does author basePrice: there was none.
         expect(seen.writes[0].updateOne.update.$set['shop.$.basePrice']).toBe(50);
     });
 

--- a/tests/statsResponseCache.test.js
+++ b/tests/statsResponseCache.test.js
@@ -123,21 +123,30 @@ describe('/stats response cache', () => {
 });
 
 describe('/stats command-log aggregation', () => {
+    // The volume series is a rolling thirty days ending today, so the fixture is
+    // dated relative to the run. Fixed dates would have passed until the day they
+    // fell out of the window and then started failing on their own.
+    // Resolved once, so the fixture and the assertions cannot land on opposite
+    // sides of a UTC midnight that passes mid-test.
+    const dayAgo = n => new Date(Date.now() - n * 864e5).toISOString().slice(0, 10);
+    const [today, d3, d4] = [dayAgo(0), dayAgo(3), dayAgo(4)];
+    const at = (date, hour) => `${date}T${String(hour).padStart(2, '0')}:00:00Z`;
+
     // Two commands, three channels, and an hour that ties on count so the
     // tie-break is pinned rather than left to whichever hour was seen first.
     const commandUsage = [
-        { command: 'ping',  success: true,  channelId: 'c1', hour: 9,  createdAt: '2026-08-20T09:00:00Z' },
-        { command: 'ping',  success: true,  channelId: 'c1', hour: 14, createdAt: '2026-08-20T14:00:00Z' },
-        { command: 'ping',  success: false, channelId: 'c1', hour: 14, reason: 'execution_error', createdAt: '2026-08-21T14:00:00Z' },
-        { command: 'ping',  success: true,  channelId: 'c1', hour: 9,  createdAt: '2026-08-21T09:00:00Z' },
-        { command: 'daily', success: false, channelId: 'c2', hour: 3,  reason: 'cooldown', createdAt: '2026-08-21T03:00:00Z' },
-        { command: 'daily', success: true,                   hour: 3,  createdAt: '2026-08-21T03:30:00Z' },
+        { command: 'ping',  success: true,  channelId: 'c1', hour: 9,  createdAt: at(d4, 9) },
+        { command: 'ping',  success: true,  channelId: 'c1', hour: 14, createdAt: at(d4, 14) },
+        { command: 'ping',  success: false, channelId: 'c1', hour: 14, reason: 'execution_error', createdAt: at(d3, 14) },
+        { command: 'ping',  success: true,  channelId: 'c1', hour: 9,  createdAt: at(d3, 9) },
+        { command: 'daily', success: false, channelId: 'c2', hour: 3,  reason: 'cooldown', createdAt: at(d3, 3) },
+        { command: 'daily', success: true,                   hour: 3,  createdAt: at(d3, 3) },
     ];
 
     beforeEach(() => {
         stubAnalytics({
             guildId: 'g1',
-            memberEvents: [{ date: new Date().toISOString().slice(0, 10), joins: 5, leaves: 1 }],
+            memberEvents: [{ date: today, joins: 5, leaves: 1 }],
             commandUsage,
         });
     });
@@ -168,17 +177,18 @@ describe('/stats command-log aggregation', () => {
         const { body } = await get('/guild/g1/stats');
 
         const byDate = Object.fromEntries(body.analytics.messageVolume.map(d => [d.date, d.count]));
-        expect(byDate['2026-08-20']).toBe(2);
-        expect(byDate['2026-08-21']).toBe(4);
+        expect(byDate[d4]).toBe(2);
+        expect(byDate[d3]).toBe(4);
         expect(body.analytics.messageVolume).toHaveLength(30);
+        // Every dated event lands somewhere in the window rather than off its end.
+        const total = body.analytics.messageVolume.reduce((sum, d) => sum + d.count, 0);
+        expect(total).toBe(commandUsage.length);
     });
 
     test('reads member growth by date instead of scanning the event log per day', async () => {
         const { body } = await get('/guild/g1/stats');
 
         expect(body.analytics.memberGrowth).toHaveLength(30);
-        expect(body.analytics.memberGrowth.at(-1)).toEqual({
-            date: new Date().toISOString().slice(0, 10), joins: 5, leaves: 1,
-        });
+        expect(body.analytics.memberGrowth.at(-1)).toEqual({ date: today, joins: 5, leaves: 1 });
     });
 });

--- a/tests/statsResponseCache.test.js
+++ b/tests/statsResponseCache.test.js
@@ -1,0 +1,184 @@
+'use strict';
+
+// #604: /guild/:id/stats is a page-load endpoint. It fanned out five collection
+// -wide reads and then walked the guild's command log twice — once for the
+// per-command summary, once for the daily volume series — with a nested
+// `Object.entries().sort()` per channel on top, and it did all of that again on
+// the very next request. The whole payload is now memoised for a minute, and
+// what it does compute, it computes in one pass.
+
+const express = require('express');
+
+jest.mock('../src/models/Guild', () => ({ findOne: jest.fn(), exists: jest.fn() }));
+jest.mock('../src/models/GuildAnalytics', () => ({ findOne: jest.fn() }));
+jest.mock('../src/models/User', () => ({ aggregate: jest.fn(), find: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../src/models/Case', () => ({ find: jest.fn() }));
+jest.mock('../src/dashboard/lib/middleware', () => ({
+    checkAuth: (req, _res, next) => { req.user = { id: 'admin-1' }; next(); },
+    checkGuildAccess: (_req, _res, next) => next(),
+}));
+
+const Guild = require('../src/models/Guild');
+const GuildAnalytics = require('../src/models/GuildAnalytics');
+const User = require('../src/models/User');
+const { __reset, invalidatePrefix } = require('../src/dashboard/lib/aggregateCache');
+const statsRouter = require('../src/dashboard/routes/api/stats');
+
+let server;
+let baseUrl;
+
+const get = async path => {
+    const resp = await fetch(baseUrl + path);
+    return { status: resp.status, body: await resp.json() };
+};
+
+function stubAnalytics(doc) {
+    GuildAnalytics.findOne.mockImplementation(() => ({ lean: async () => doc }));
+}
+
+beforeAll(async () => {
+    const app = express();
+    app.use('/api', statsRouter);
+    await new Promise(resolve => { server = app.listen(0, resolve); });
+    baseUrl = `http://127.0.0.1:${server.address().port}/api`;
+});
+
+afterAll(async () => {
+    await new Promise(resolve => server.close(resolve));
+});
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    __reset();
+    User.find.mockImplementation(() => {
+        const chain = {
+            select() { return chain; },
+            sort() { return chain; },
+            limit() { return chain; },
+            lean: async () => [],
+        };
+        return chain;
+    });
+    User.countDocuments.mockResolvedValue(0);
+    User.aggregate.mockResolvedValue([]);
+    Guild.findOne.mockImplementation(() => ({ select() { return this; }, lean: async () => ({ guildId: 'g1' }) }));
+    stubAnalytics({ guildId: 'g1', memberEvents: [], commandUsage: [] });
+});
+
+describe('/stats response cache', () => {
+    test('a second request inside the window re-reads nothing', async () => {
+        await get('/guild/g1/stats');
+        const reads = User.countDocuments.mock.calls.length + User.aggregate.mock.calls.length;
+        expect(reads).toBeGreaterThan(0);
+
+        jest.clearAllMocks();
+        stubAnalytics({ guildId: 'g1', memberEvents: [], commandUsage: [] });
+
+        const { status, body } = await get('/guild/g1/stats');
+
+        expect(status).toBe(200);
+        expect(body.totalUsers).toBe(0);
+        expect(User.countDocuments).not.toHaveBeenCalled();
+        expect(User.aggregate).not.toHaveBeenCalled();
+        expect(GuildAnalytics.findOne).not.toHaveBeenCalled();
+    });
+
+    test('concurrent cold requests share one build rather than racing five reads each', async () => {
+        const [a, b, c] = await Promise.all([
+            get('/guild/g1/stats'), get('/guild/g1/stats'), get('/guild/g1/stats'),
+        ]);
+
+        expect([a.status, b.status, c.status]).toEqual([200, 200, 200]);
+        expect(GuildAnalytics.findOne).toHaveBeenCalledTimes(1);
+    });
+
+    test('one guild\'s cached payload is not served to another', async () => {
+        await get('/guild/g1/stats');
+        User.countDocuments.mockResolvedValue(7);
+
+        const { body } = await get('/guild/g2/stats');
+
+        expect(body.totalUsers).toBe(7);
+    });
+
+    test('a write that invalidates the guild drops the payload too', async () => {
+        await get('/guild/g1/stats');
+        // The shape /economy uses after a balance edit.
+        invalidatePrefix('g1:');
+        User.countDocuments.mockResolvedValue(4);
+
+        const { body } = await get('/guild/g1/stats');
+
+        expect(body.totalUsers).toBe(4);
+    });
+
+    test('a failed build is not cached', async () => {
+        GuildAnalytics.findOne.mockImplementation(() => ({ lean: async () => { throw new Error('mongo down'); } }));
+        expect((await get('/guild/g1/stats')).status).toBe(500);
+
+        stubAnalytics({ guildId: 'g1', memberEvents: [], commandUsage: [] });
+
+        expect((await get('/guild/g1/stats')).status).toBe(200);
+    });
+});
+
+describe('/stats command-log aggregation', () => {
+    // Two commands, three channels, and an hour that ties on count so the
+    // tie-break is pinned rather than left to whichever hour was seen first.
+    const commandUsage = [
+        { command: 'ping',  success: true,  channelId: 'c1', hour: 9,  createdAt: '2026-08-20T09:00:00Z' },
+        { command: 'ping',  success: true,  channelId: 'c1', hour: 14, createdAt: '2026-08-20T14:00:00Z' },
+        { command: 'ping',  success: false, channelId: 'c1', hour: 14, reason: 'execution_error', createdAt: '2026-08-21T14:00:00Z' },
+        { command: 'ping',  success: true,  channelId: 'c1', hour: 9,  createdAt: '2026-08-21T09:00:00Z' },
+        { command: 'daily', success: false, channelId: 'c2', hour: 3,  reason: 'cooldown', createdAt: '2026-08-21T03:00:00Z' },
+        { command: 'daily', success: true,                   hour: 3,  createdAt: '2026-08-21T03:30:00Z' },
+    ];
+
+    beforeEach(() => {
+        stubAnalytics({
+            guildId: 'g1',
+            memberEvents: [{ date: new Date().toISOString().slice(0, 10), joins: 5, leaves: 1 }],
+            commandUsage,
+        });
+    });
+
+    test('summarises commands and failure reasons in the single pass', async () => {
+        const { body } = await get('/guild/g1/stats');
+
+        expect(body.analytics.commandUsage).toEqual({
+            ping:  { total: 4, failed: 1 },
+            daily: { total: 2, failed: 1 },
+        });
+        expect(body.analytics.failedCommands).toEqual({ execution_error: 1, cooldown: 1 });
+    });
+
+    test('picks each channel\'s busiest hour, breaking ties toward the earlier one', async () => {
+        const { body } = await get('/guild/g1/stats');
+
+        // c1 has hour 9 twice and hour 14 twice — the sort this replaced ran over
+        // numerically-ordered keys, so a tie went to hour 9.
+        expect(body.analytics.bestPostingTimes).toEqual([
+            { channelId: 'c1', hourUtc: 9 },
+            { channelId: 'c2', hourUtc: 3 },
+            { channelId: 'unknown', hourUtc: 3 },
+        ]);
+    });
+
+    test('tallies daily volume from the same pass', async () => {
+        const { body } = await get('/guild/g1/stats');
+
+        const byDate = Object.fromEntries(body.analytics.messageVolume.map(d => [d.date, d.count]));
+        expect(byDate['2026-08-20']).toBe(2);
+        expect(byDate['2026-08-21']).toBe(4);
+        expect(body.analytics.messageVolume).toHaveLength(30);
+    });
+
+    test('reads member growth by date instead of scanning the event log per day', async () => {
+        const { body } = await get('/guild/g1/stats');
+
+        expect(body.analytics.memberGrowth).toHaveLength(30);
+        expect(body.analytics.memberGrowth.at(-1)).toEqual({
+            date: new Date().toISOString().slice(0, 10), joins: 5, leaves: 1,
+        });
+    });
+});


### PR DESCRIPTION
## Summary

This PR optimizes database query efficiency and response caching across multiple endpoints, reducing unnecessary data transfers and computation. The changes focus on three main areas: stats endpoint response caching, dynamic pricing recalculation efficiency, and leaderboard query optimization.

## Key Changes

### Stats Endpoint Response Caching (#604)
- Extracted stats computation into a `buildGuildStats()` function and memoized the entire response payload for 60 seconds
- Prevents redundant collection-wide reads when multiple dashboard panels request stats on page load
- Optimized command log aggregation to process `commandUsage` in a single pass instead of two, eliminating nested `Object.entries().sort()` calls per channel
- Replaced linear scans of member events with a Map-based lookup by date for O(1) access
- Consolidated daily message volume tallying into the same command log pass
- Added comprehensive test suite (`statsResponseCache.test.js`) covering cache behavior, concurrent requests, and aggregation correctness

### Dynamic Pricing Recalculation (#603)
- Changed shop price recalculation from read-mutate-save pattern to targeted `bulkWrite` with per-item `$set` operations
- Reduced initial sweep query to only fetch `guildId` and `recalcMinutes` (lease window)
- Projected claim query to only read pricing fields (`basePrice`, `currentPrice`, `demandScore`) and item metadata, excluding `imageData` Buffers and `priceHistory` arrays
- Moved price history appending to database-side `$push`/`$slice` operations instead of JavaScript array manipulation
- Removed `pushHistory()` function as history is now managed entirely by MongoDB
- Added detailed comments explaining the rationale for avoiding full document reads/writes
- Added test suite (`recalcShopPricesWrites.test.js`) verifying projection and write shapes

### Leaderboard Query Optimization (#586)
- Added field projections to leaderboard queries, reading only the fields each board type actually renders
- Defined `ROW_FIELDS` constant mapping board types to their required fields (e.g., `'userId level xp'` for levels board)
- Added `CALLER_FIELDS` for the "you are here" row, using the union of all board types' fields
- Applied `.lean()` to all user queries to return plain objects instead of full Mongoose documents
- Updated Guild query for achievements check to use projection
- Updated test mocks to verify `.select()` is called with correct field names

### Supporting Changes
- Updated `rssService.js` to project `DAILY_NEWS_FIELDS` when fetching guilds for daily news scheduling
- Removed `pushHistory` export from `dynamicPricing.js` and updated related tests
- Updated `dynamicPricing.test.js` to remove tests for the now-removed `pushHistory()` function

## Implementation Details

The stats endpoint optimization is particularly significant: the command log aggregation now maintains running maxima for each channel's busiest hour instead of sorting, preserving the original tie-breaking behavior (earlier hour wins) while eliminating O(n log n) sorts per channel. Member growth lookups use a Map indexed by date, converting 30 linear scans into 30 O(1) map hits.

The dynamic pricing changes eliminate unnecessary Buffer transfers: shop items store icons as inline `imageData`, so the old pattern of reading entire documents, mutating a few numbers, and writing everything back was proportional to uploaded artwork size rather than the handful of pricing fields being changed.

All optimizations maintain backward compatibility and existing behavior while reducing database load and memory usage.

https://claude.ai/code/session_014neVuk4TK15Wj1zdGU2uH7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved leaderboard and daily-news loading by retrieving only required information.
  * Added one-minute caching and more efficient processing for dashboard statistics.
  * Reduced resource usage during dynamic shop price updates.

* **Bug Fixes**
  * Improved price-history tracking and capped stored history consistently.
  * Added deterministic handling for busiest posting hours and concurrent statistics requests.

* **Tests**
  * Expanded coverage for statistics caching, leaderboard queries, and shop price recalculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->