### PR TITLE
Fix three docs-accuracy issues: stale provider guide, phantom music dir, dead schema field

### DIFF
--- a/AI_COMPARISON.md
+++ b/AI_COMPARISON.md
@@ -1,383 +1,71 @@
-# AI Provider Comparison: OpenAI vs Google Gemini
-
-## Quick Comparison
-
-| Feature | OpenAI GPT-3.5 | OpenAI GPT-4 | Google Gemini Pro |
-|---------|----------------|--------------|-------------------|
-| **Cost** | $0.002 / 1K tokens | $0.03 / 1K tokens | Free tier available |
-| **Speed** | ⚡ Fast | 🐌 Slower | ⚡⚡ Very Fast |
-| **Free Tier** | ❌ No | ❌ No | ✅ Yes (60 req/min) |
-| **Context Window** | 4K tokens | 8K-32K tokens | 32K tokens |
-| **Best For** | General chat | Complex reasoning | High-volume, testing |
-| **Setup Difficulty** | Easy | Easy | Easy |
-| **Response Quality** | ⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ |
-
-## Detailed Comparison
-
-### OpenAI GPT-3.5 Turbo
-
-**Pros:**
-- ✅ Well-established and reliable
-- ✅ Fast response times
-- ✅ Excellent for most use cases
-- ✅ Good at following instructions
-- ✅ Wide knowledge base
-- ✅ Strong coding assistance
-
-**Cons:**
-- ❌ Requires payment (no free tier)
-- ❌ Need credit card even for trial
-- ❌ Rate limits on free trial
-- ❌ Smaller context window than GPT-4
-
-**Best Use Cases:**
-- General Discord chat bot
-- Q&A bot
-- Coding help
-- Content generation
-- Moderate server traffic
-
-**Pricing:**
-- Input: $0.0015 per 1K tokens
-- Output: $0.002 per 1K tokens
-- Approximately: $0.50 per 100K words
-
-**Example Monthly Cost (small server):**
-- 1000 messages/day at ~500 tokens each = ~$0.75/day
-- Monthly: ~$22.50
-
-### OpenAI GPT-4
-
-**Pros:**
-- ✅ Best reasoning capabilities
-- ✅ More accurate responses
-- ✅ Better at complex tasks
-- ✅ Larger context window
-- ✅ Superior creative writing
-
-**Cons:**
-- ❌ Expensive ($0.03-0.06 per 1K tokens)
-- ❌ Slower response time (3-5 seconds+)
-- ❌ Can be overkill for simple chat
-- ❌ Higher monthly costs
-
-**Best Use Cases:**
-- Premium bot features
-- Complex problem solving
-- Research assistance
-- Professional use
-- Low traffic, high quality needs
-
-**Pricing:**
-- GPT-4: $0.03-0.06 per 1K tokens
-- GPT-4 Turbo: $0.01-0.03 per 1K tokens
-
-**Example Monthly Cost (small server):**
-- 1000 messages/day at ~500 tokens each = ~$15/day
-- Monthly: ~$450 (significantly more expensive)
-
-### Google Gemini Pro
-
-**Pros:**
-- ✅ **FREE tier** with generous limits
-- ✅ Very fast response times
-- ✅ 32K token context window
-- ✅ No credit card required
-- ✅ Good for testing and development
-- ✅ Easy Google account setup
-- ✅ Multimodal capabilities (future)
-
-**Cons:**
-- ❌ Newer platform (less proven)
-- ❌ Occasionally less accurate than GPT-4
-- ❌ Fewer fine-tuning options
-- ❌ Developer ecosystem still growing
-
-**Best Use Cases:**
-- Starting a new bot
-- High-volume free bot
-- Testing and development
-- Budget-conscious projects
-- Community/hobby servers
-
-**Pricing:**
-- **Free Tier:**
-  - 60 requests per minute
-  - 1,500 requests per day
-  - 1 million tokens per month
-- **Paid Tier (if you exceed free):**
-  - Very competitive pricing
-  - Pay-as-you-go model
-
-**Example Monthly Cost (small server):**
-- 1000 messages/day = **$0** (within free tier)
-- Can handle ~50K messages/month for FREE
-
-## Feature Comparison
-
-### Response Quality
-
-**General Questions:**
-- GPT-4: ⭐⭐⭐⭐⭐ (Best)
-- GPT-3.5: ⭐⭐⭐⭐
-- Gemini: ⭐⭐⭐⭐
-
-**Coding Assistance:**
-- GPT-4: ⭐⭐⭐⭐⭐
-- GPT-3.5: ⭐⭐⭐⭐
-- Gemini: ⭐⭐⭐
-
-**Creative Writing:**
-- GPT-4: ⭐⭐⭐⭐⭐
-- GPT-3.5: ⭐⭐⭐⭐
-- Gemini: ⭐⭐⭐⭐
-
-**Speed:**
-- Gemini: ⚡⚡⚡ (~1 second)
-- GPT-3.5: ⚡⚡ (~1-2 seconds)
-- GPT-4: ⚡ (~3-5 seconds)
-
-**Following Instructions:**
-- GPT-4: ⭐⭐⭐⭐⭐
-- GPT-3.5: ⭐⭐⭐⭐
-- Gemini: ⭐⭐⭐⭐
-
-## Cost Examples
-
-### Small Server (100 active users)
-**Usage:** ~1,000 AI messages per day
-
-| Provider | Daily Cost | Monthly Cost |
-|----------|-----------|--------------|
-| **Gemini** | $0 | $0 (free tier) |
-| **GPT-3.5** | ~$0.75 | ~$22.50 |
-| **GPT-4** | ~$15 | ~$450 |
-
-### Medium Server (500 active users)
-**Usage:** ~5,000 AI messages per day
-
-| Provider | Daily Cost | Monthly Cost |
-|----------|-----------|--------------|
-| **Gemini** | $0-5* | $0-150* |
-| **GPT-3.5** | ~$3.75 | ~$112.50 |
-| **GPT-4** | ~$75 | ~$2,250 |
-
-*Exceeds free tier, would need paid plan
-
-### Large Server (2000+ active users)
-**Usage:** ~20,000 AI messages per day
-
-| Provider | Daily Cost | Monthly Cost |
-|----------|-----------|--------------|
-| **Gemini** | ~$15-20 | ~$450-600 |
-| **GPT-3.5** | ~$15 | ~$450 |
-| **GPT-4** | ~$300 | ~$9,000 |
-
-## Recommendations by Use Case
-
-### 🎮 Gaming Community Bot
-**Recommendation: Gemini**
-- High message volume
-- Fast responses important
-- Budget-friendly
-- Good enough quality for chat
-
-**Alternative:** GPT-3.5 for premium features
-
-### 📚 Educational/Study Bot
-**Recommendation: GPT-4**
-- Accuracy is critical
-- Complex explanations needed
-- Lower message volume
-- Worth the cost for quality
-
-**Alternative:** GPT-3.5 for budget option
-
-### 💼 Professional/Business Bot
-**Recommendation: GPT-4**
-- Professional responses
-- Complex queries
-- Cost is acceptable for business
-- Accuracy and reliability critical
-
-**Alternative:** GPT-3.5 for internal/casual use
-
-### 🎨 Creative Community
-**Recommendation: GPT-4 or GPT-3.5**
-- Creative writing quality important
-- Moderate message volume
-- Community may fund premium features
-
-**Alternative:** Gemini for high-volume, lower-budget
-
-### 🆓 Free/Hobby Bot
-**Recommendation: Gemini**
-- No budget
-- Testing/learning
-- Free tier perfect for hobby projects
-- Easy to upgrade later
-
-### 🏢 Enterprise/High-Volume
-**Recommendation: GPT-3.5**
-- Balance of cost and quality
-- Proven reliability
-- Good for high volume
-- Predictable costs
-
-**Alternative:** Gemini if volume is extreme
-
-## Migration Strategy
-
-### Starting with Gemini, Moving to OpenAI
-
-**Phase 1: Launch (Months 1-3)**
-- Use Gemini free tier
-- Test features and gather feedback
-- Zero AI costs while building community
-
-**Phase 2: Growth (Months 3-6)**
-- Stay on Gemini if within free limits
-- Or switch to GPT-3.5 as you grow
-- Monetize or get sponsors
-
-**Phase 3: Scale (6+ Months)**
-- GPT-3.5 for main bot
-- GPT-4 for premium tiers
-- Gemini for high-volume, low-value queries
-
-### Starting with OpenAI, Adding Gemini
-
-**Use Case:**
-- OpenAI for important/complex queries
-- Gemini for simple/high-volume queries
-- Cost optimization strategy
-
-**Implementation:**
-```javascript
-// Route based on query complexity
-if (isComplexQuery(message)) {
-    provider = 'openai'; // Use GPT-3.5 or GPT-4
-} else {
-    provider = 'gemini'; // Use free tier
-}
-```
-
-## Rate Limits
-
-### OpenAI (Tier 1 - Default)
-- **GPT-3.5:** 3,500 RPM (requests per minute)
-- **GPT-4:** 500 RPM
-- Increases with usage tier
-
-### Google Gemini (Free)
-- **Requests:** 60 per minute
-- **Daily:** 1,500 requests
-- **Monthly:** 1M tokens
-
-## How to Choose
-
-### Choose OpenAI GPT-3.5 if:
-- ✅ You need proven reliability
-- ✅ Budget allows ~$20-100/month
-- ✅ Response quality is important
-- ✅ Moderate message volume
-- ✅ Want excellent documentation/support
-
-### Choose OpenAI GPT-4 if:
-- ✅ Quality is paramount
-- ✅ Professional/business use
-- ✅ Budget allows $100-500+/month
-- ✅ Complex queries are common
-- ✅ Low-medium volume, high-value
-
-### Choose Google Gemini if:
-- ✅ You're just starting out
-- ✅ Budget is limited or $0
-- ✅ High message volume
-- ✅ Speed is more important than perfect accuracy
-- ✅ Want to test/prototype quickly
-
-## Hybrid Approach (Best of Both Worlds)
-
-Configure per-server in the dashboard:
-
-**Free Servers:** Use Gemini (your API key)
-**Premium Servers:** Use OpenAI (their API key)
-**Your Testing Server:** Use Gemini (free)
-
-This way:
-- You can offer free bot to everyone
-- Premium servers can upgrade to GPT
-- You don't pay for other people's usage
-- Maximum flexibility
-
-## Getting API Keys
-
-### OpenAI
-1. Visit [OpenAI Platform](https://platform.openai.com/)
-2. Sign up/login
-3. Go to API Keys
-4. Create new key
-5. Add payment method (required)
-6. Start with free trial credits
-
-**Free Trial:** $5 credit (expires in 3 months)
-
-### Google Gemini
-1. Visit [Google AI Studio](https://makersuite.google.com/app/apikey)
-2. Sign in with Google account
-3. Click "Create API Key"
-4. Select/create project
-5. Copy key (starts with AIza...)
-6. Start using immediately
-
-**Free Tier:** No credit card required!
-
-## Real-World Performance
-
-### Response Time Tests
-
-**Simple Question:** "What is the capital of France?"
-- Gemini: ~0.8 seconds ⚡
-- GPT-3.5: ~1.2 seconds
-- GPT-4: ~3.5 seconds
-
-**Complex Question:** "Explain quantum computing in simple terms"
-- Gemini: ~1.5 seconds
-- GPT-3.5: ~2.0 seconds
-- GPT-4: ~5.0 seconds
-
-**Code Generation:** "Write a Python function to sort a list"
-- Gemini: ~2.0 seconds
-- GPT-3.5: ~2.5 seconds
-- GPT-4: ~6.0 seconds
-
-### Accuracy Tests
-
-Based on community feedback:
-- **GPT-4:** 95% accurate, best reasoning
-- **GPT-3.5:** 90% accurate, reliable
-- **Gemini:** 85-90% accurate, improving
-
-## Conclusion
-
-**For most users starting out: Use Gemini**
-- It's free, fast, and good enough
-- Easy to test without commitment
-- Can always upgrade later
-
-**For serious/business bots: Use GPT-3.5**
-- Proven reliability
-- Acceptable cost
-- Great quality
-
-**For premium experiences: Use GPT-4**
-- Best quality available
-- Justify cost with premium features
-- Lower volume use cases
-
-**Best strategy: Start with Gemini, upgrade as needed!**
-
----
-
-Remember: You can switch providers anytime in the dashboard. Test both and see which works best for your community! 🚀
+# Choosing an AI Provider
+
+Clawdia ships five AI providers. Each is a module in
+[`src/services/ai/providers/`](src/services/ai/providers/) implementing one
+interface and registered in `providers/index.js` — that registry is the source
+of truth for everything in the table below.
+
+Pick a provider per server in the dashboard under **AI Chat**, or set a
+process-wide default with the environment variable. Setup steps for each key
+live in [SETUP_GUIDE.md](SETUP_GUIDE.md#ai-integration).
+
+## The providers
+
+| Provider | Default model | Credential | Cost estimates | Notes |
+| --- | --- | --- | --- | --- |
+| **OpenAI** | `gpt-4o-mini` | `OPENAI_API_KEY` | Yes | GPT-4o, GPT-4.1, o1 and o3 families |
+| **Gemini** | `gemini-2.0-flash` | `GEMINI_API_KEY` | Yes | Has a free tier; Flash models are the cheap end |
+| **Claude** | `claude-haiku-4-5` | `ANTHROPIC_API_KEY` | Yes | The only provider that can call [MCP servers](README.md#mcp-servers-anthropic-only) |
+| **Ollama** | `llama3.2` | `OLLAMA_BASE_URL` | Always $0 | Runs on your own hardware; no key, no per-token cost |
+| **OpenRouter** | `openai/gpt-4o-mini` | `OPENROUTER_API_KEY` | No | One key, many vendors' models; names must be `vendor/model` |
+
+## What actually differs
+
+**MCP tool use is Anthropic-only.** If you want the bot to reach a GitHub repo,
+a calendar, or an internal search through
+[MCP](https://modelcontextprotocol.io), Claude is the only option — the other
+four providers ignore MCP configuration entirely.
+
+**Cost tracking depends on a pricing table.** `estimateCost` in
+`src/services/ai/usage.js` matches the model name against the provider's
+`pricing` array. OpenAI, Gemini and Claude carry per-model rates, so the
+dashboard shows spend. Ollama is pinned at zero. OpenRouter ships an empty
+table because its catalogue spans many vendors, so token counts are recorded
+but the dashboard shows no dollar figure for it.
+
+**OpenRouter validates model names.** A model without a `/` is rejected before
+the request goes out, because OpenRouter addresses everything as
+`vendor/model`.
+
+**Ollama's base URL is guarded.** A per-server URL set in the dashboard must be
+an `http(s)` address that does not resolve into private or reserved space —
+otherwise a server admin could aim the bot at anything reachable from its
+container. The operator's own endpoint is exempt: set it as `OLLAMA_BASE_URL`.
+
+## Rough guidance
+
+- **Trying it out** — Gemini. The free tier is generous enough to exercise the
+  bot without a card on file.
+- **General use, paying by the token** — the defaults are chosen to be cheap.
+  `gpt-4o-mini` and `gemini-2.0-flash` are the low-cost tiers of their
+  families; move up a tier only if answers are visibly weak.
+- **Tool use** — Claude, for MCP.
+- **Private or zero-cost** — Ollama. Nothing leaves your network, and quality
+  tracks whatever model you can host.
+- **Comparing models often** — OpenRouter, so you can switch vendors by editing
+  a model name rather than provisioning another key. Accept that you lose
+  dashboard cost figures.
+
+## Pricing
+
+Token prices move, so this file does not restate them. The rates the bot uses
+for its own estimates are the `pricing` arrays in each provider module; the
+vendors' current numbers are at:
+
+- [OpenAI](https://openai.com/api/pricing/)
+- [Google Gemini](https://ai.google.dev/pricing)
+- [Anthropic](https://www.anthropic.com/pricing)
+- [OpenRouter](https://openrouter.ai/models) (per-model)
+
+If a vendor changes a rate, update that provider's `pricing` array — the
+dashboard's spend figures come from it, not from this document.

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -11,11 +11,11 @@ src/
 ├── commands/          # Slash commands by category
 │   ├── admin/        # Administrator commands
 │   ├── ai/           # AI-related commands
+│   ├── community/    # Community and social commands
 │   ├── economy/      # Economy system
 │   ├── fun/          # Fun/entertainment
 │   ├── leveling/     # XP and leveling
 │   ├── moderation/   # Moderation tools
-│   ├── music/        # Music player
 │   └── utility/      # Utility commands
 ├── dashboard/        # Web dashboard
 │   ├── public/       # Static files (CSS, JS)

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -633,15 +633,6 @@ open work items, not wording problems:
 
 ## 🔧 Advanced Features
 
-### Custom Commands
-
-Create simple text response commands in dashboard:
-
-```text
-Trigger: !website
-Response: Visit us at https://example.com
-```
-
 ### Auto-Roles
 
 Automatically assign roles to new members:

--- a/README.md
+++ b/README.md
@@ -298,9 +298,13 @@ Configuration that previously lived behind slash commands (settings link, level 
 
 ## AI Chat Configuration
 
+Five providers are supported. For what actually differs between them — MCP
+support, cost tracking, model naming — see
+[AI_COMPARISON.md](AI_COMPARISON.md).
+
 ### Supported Providers
 
-1. **OpenAI (GPT-3.5/GPT-4)**
+1. **OpenAI**
    - Get your API key from https://platform.openai.com/
    - Add to `.env` as `OPENAI_API_KEY` or configure per-server in dashboard
 

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -57,7 +57,7 @@ https://discord.com/api/oauth2/authorize?client_id=CLIENT_ID&permissions=8&scope
 
 ## AI Integration
 
-### OpenAI (GPT-3.5/GPT-4)
+### OpenAI
 
 1. Go to [OpenAI Platform](https://platform.openai.com/)
 2. Create an account or sign in
@@ -68,10 +68,8 @@ https://discord.com/api/oauth2/authorize?client_id=CLIENT_ID&permissions=8&scope
 
 **Alternative:** Add the API key per-server in the bot dashboard under AI Chat settings.
 
-**Pricing:** 
-- GPT-3.5 Turbo: ~$0.002 per 1K tokens
-- GPT-4: ~$0.03 per 1K tokens
-- Check latest pricing at [OpenAI Pricing](https://openai.com/pricing)
+**Default model:** `gpt-4o-mini`. Current rates are at
+[OpenAI Pricing](https://openai.com/api/pricing/).
 
 ### Google Gemini
 
@@ -83,21 +81,17 @@ https://discord.com/api/oauth2/authorize?client_id=CLIENT_ID&permissions=8&scope
 
 **Alternative:** Add the API key per-server in the bot dashboard under AI Chat settings.
 
-**Pricing:**
-- Gemini Pro: Free tier available (60 requests per minute)
-- Check latest pricing at [Google AI Pricing](https://ai.google.dev/pricing)
+**Default model:** `gemini-2.0-flash`. There is a free tier; current rates and
+its limits are at [Google AI Pricing](https://ai.google.dev/pricing).
 
-### Choosing Between OpenAI and Gemini
+### Choosing a provider
 
-**OpenAI (GPT-3.5/4):**
-- Pros: More mature, better for complex tasks, extensive fine-tuning
-- Cons: Costs money after free trial, requires payment method
+OpenAI and Gemini are two of five. Clawdia also supports Anthropic (Claude),
+OpenRouter, and a local Ollama instance — configured the same way, with
+`ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, and `OLLAMA_BASE_URL`.
 
-**Google Gemini:**
-- Pros: Free tier available, fast responses, good for general tasks
-- Cons: Newer platform, fewer customization options
-
-**Recommendation:** Start with Gemini for testing (free), then add OpenAI if you need more advanced capabilities.
+[AI_COMPARISON.md](AI_COMPARISON.md) covers what differs between them and which
+to start with.
 
 ### MCP Servers (Anthropic only)
 

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -348,11 +348,6 @@ const guildSchema = new Schema({
         }
     },
 
-    customCommands: [{
-        name: { type: String, required: true },
-        response: { type: String, required: true }
-    }],
-
     autoRoles: [{
         roleId: { type: String, required: true }
     }],


### PR DESCRIPTION
## Summary

Closes three documentation-accuracy issues where shipped docs described things the code does not do.

Closes #700
Closes #701
Closes #703

## Changes by issue

### #703 — `AI_COMPARISON.md` was a 2023-era buying guide

382 lines comparing GPT-3.5, GPT-4 and Gemini Pro — none of them a current default — quoting 4K context windows and per-1K-token prices against a codebase that ships **five** providers defaulting to `gpt-4o-mini`, `gemini-2.0-flash`, `claude-haiku-4-5`, `llama3.2` and `openai/gpt-4o-mini`. Anthropic and OpenRouter, the two a reader would most need explained, were absent entirely. The file also carried invented "Real-World Performance" benchmark tables. Nothing linked to it.

Rewritten to 71 lines derived from the provider registry in `src/services/ai/providers/index.js`, covering the differences that actually decide the choice:

- MCP tool use is Anthropic-only
- OpenRouter ships an empty `pricing` array, so the dashboard records tokens but shows no spend
- Ollama is pinned at zero cost
- OpenRouter rejects a model name without a `vendor/model` prefix

Prices are linked rather than restated, so the file cannot go stale the same way.

`README.md` and `SETUP_GUIDE.md` carried the same defect — `OpenAI (GPT-3.5/GPT-4)` headings, the same 2023 rates, and a "Choosing Between OpenAI and Gemini" section framing two of five providers. Fixing only the file named in the issue would have left those contradicting the corrected guide, so both now point at it instead.

### #701 — phantom music feature

`API_REFERENCE.md`'s canonical project structure listed a `src/commands/music/` directory. There is no music code, no `/play`, and no audio dependency; `FEATURES.md`'s matching `/play` cooldown had already been removed. Dropped the line, and added the `community/` directory the same tree block had been missing.

### #700 — `customCommands` was a dead schema field

`FEATURES.md` documented custom commands under "Advanced Features" with a worked example (trigger `!website`), implying a shipped feature. The only trace in the repo was the array declared on the Guild schema — no message handler consulted it, no dashboard panel edited it, no API route wrote to it. Its neighbours `autoRoles` and `reactionRoles` are each wired through an events handler, a dashboard panel and a route; this one was never connected to anything.

Removed the field and the documentation section. Nothing ever wrote the array, so no stored data becomes unreachable.

## Files

| File | Change |
| --- | --- |
| `AI_COMPARISON.md` | Rewritten, 382 → 71 lines (#703) |
| `SETUP_GUIDE.md` | Stale rates and two-provider framing replaced (#703) |
| `README.md` | Stale `GPT-3.5/GPT-4` heading fixed; links to the guide (#703) |
| `API_REFERENCE.md` | `music/` removed, `community/` added (#701) |
| `FEATURES.md` | "Custom Commands" section removed (#700) |
| `src/models/Guild.js` | `customCommands` field removed (#700) |

## Verification

- `npm run lint` — clean
- `npm test` — 2598 passing across 156 suites
- `npm run docs:commands -- --check` — README command block up to date

## Not changed

Two related issues were already resolved on `main` and needed no work here:

- **#695** — `PRODUCTIONREADY.md` already carries an explicit note that the `ticket.js` claims were struck.
- **#702** — every priority item is done: all 9 `index.ejs` links and the `git clone` snippet point at `clawdia`, the OpenRouter referer is correct, container and network names are `clawdia-*`. The remaining `ultrabot` strings are the deliberate path the issue anticipated — the DB name is kept on purpose with explanatory comments, backup scripts prune the old prefix for compatibility, and a migration guide exists. Renaming the database is a data-migration decision, not a sweep.

https://claude.ai/code/session_01GF8MQ1E2541x4sztr7QN5V