### PR TITLE
Make the dashboard's wide tables and charts reachable

### DIFF
--- a/src/commands/admin/event.js
+++ b/src/commands/admin/event.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder, EmbedBuilder, PermissionFlagsBits, MessageFlags } =
 const Guild = require('../../models/Guild');
 const { SEASONAL_EVENTS } = require('../../data/seasonalEvents');
 const { buildClearedEvent } = require('../../services/seasonalEventService');
+const COLORS = require('../../utils/embedColors');
 
 const EVENT_TYPE_CHOICES = [
     { name: '❄️ Winter Wonderland',   value: 'winter_wonderland' },
@@ -219,7 +220,7 @@ async function handleEnd(interaction) {
 
     return interaction.editReply({
         embeds: [new EmbedBuilder()
-            .setColor('#888888')
+            .setColor(COLORS.NEUTRAL)
             .setTitle('Event Ended')
             .setDescription(`**${current.name}** has been ended early by ${interaction.user}.`)
             .setTimestamp()]

--- a/src/commands/admin/raidmode.js
+++ b/src/commands/admin/raidmode.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, MessageFlags } = require('discord.js');
 const Guild = require('../../models/Guild');
 const { setRaidMode, raidModeActive, raidModeActivatedBy } = require('../../services/raidService');
+const COLORS = require('../../utils/embedColors');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -149,7 +150,7 @@ module.exports = {
             if (!rd?.enabled) {
                 return interaction.editReply({
                     embeds: [new EmbedBuilder()
-                        .setColor('#888888')
+                        .setColor(COLORS.NEUTRAL)
                         .setTitle('Raid Detection: Disabled')
                         .setDescription('Raid detection is not configured. Use `/raidmode raid enabled:true` to set it up.')
                         .setTimestamp()]
@@ -206,7 +207,7 @@ module.exports = {
 
             return interaction.reply({
                 embeds: [new EmbedBuilder()
-                    .setColor('#5865F2')
+                    .setColor(COLORS.INFO)
                     .setTitle('Case Settings Updated')
                     .addFields(
                         { name: 'SLA Hours', value: (slaHours ?? '(unchanged)').toString(), inline: true },

--- a/src/commands/community/achievements.js
+++ b/src/commands/community/achievements.js
@@ -5,6 +5,7 @@ const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { ACHIEVEMENTS } = require('../../data/achievements');
 const COLORS = require('../../utils/embedColors');
+const { ownedBy } = require('../../utils/collectorOwner');
 
 const CATEGORY_ORDER = ['economy', 'leveling', 'hunt', 'fishing', 'exploration', 'community', 'moderation', 'custom'];
 
@@ -152,7 +153,7 @@ module.exports = {
                 if (totalPages > 1) {
                     const msg = await interaction.fetchReply();
                     const col = msg.createMessageComponentCollector({
-                        filter: i => i.user.id === interaction.user.id && [prevId, nextId].includes(i.customId),
+                        filter: ownedBy(interaction.user.id, i => [prevId, nextId].includes(i.customId), "This isn't your list."),
                         time: 120_000,
                     });
                     col.on('collect', async i => {

--- a/src/commands/community/achievements.js
+++ b/src/commands/community/achievements.js
@@ -4,6 +4,7 @@ const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, Butt
 const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { ACHIEVEMENTS } = require('../../data/achievements');
+const COLORS = require('../../utils/embedColors');
 
 const CATEGORY_ORDER = ['economy', 'leveling', 'hunt', 'fishing', 'exploration', 'community', 'moderation', 'custom'];
 
@@ -225,7 +226,7 @@ module.exports = {
                 if (totalCoins) lines.push(`+${totalCoins.toLocaleString()} coins`);
 
                 const embed = new EmbedBuilder()
-                    .setColor(0x2ECC71)
+                    .setColor(COLORS.SUCCESS)
                     .setTitle('🎉 Rewards Claimed!')
                     .setDescription(names.join('\n') || 'No rewards.')
                     .addFields({ name: 'Total rewards', value: lines.join(' · ') || 'None', inline: false });
@@ -335,7 +336,7 @@ async function handlePin(interaction, guildSettings) {
 
     return interaction.reply({
         embeds: [new EmbedBuilder()
-            .setColor(0x2ECC71)
+            .setColor(COLORS.SUCCESS)
             .setTitle('📌 Featured Achievement Set!')
             .setDescription(`${def.emoji} **${def.name}** — ${def.description}\n\nThis achievement will now be displayed prominently on your profile.`)
         ],

--- a/src/commands/community/questgen.js
+++ b/src/commands/community/questgen.js
@@ -5,6 +5,7 @@ const User     = require('../../models/User');
 const Guild    = require('../../models/Guild');
 const AiQuest  = require('../../models/AiQuest');
 const { resolveProviderConfig, getCompletion } = require('../../services/aiService');
+const COLORS = require('../../utils/embedColors');
 
 const COST         = 200;       // coins to generate
 const COOLDOWN_MS  = 23 * 60 * 60 * 1000; // 23h — allow slight drift
@@ -270,7 +271,7 @@ Create a legendary quest that feels fitting for their journey so far.`;
         const mechLabel = MECHANIC_LABELS[mechanic];
 
         const embed = new EmbedBuilder()
-            .setColor(0xFFD700)
+            .setColor(COLORS.PRIZE)
             .setTitle(`⚔️ Legendary Quest Forged!`)
             .setDescription(`*${lore}*`)
             .addFields(

--- a/src/commands/community/quests.js
+++ b/src/commands/community/quests.js
@@ -3,6 +3,7 @@ const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const AiQuest = require('../../models/AiQuest');
 const { ensureQuests, getDailyPool, getWeeklyPool, getCategoryEmojis, getDifficultyColors } = require('../../services/questService');
+const COLORS = require('../../utils/embedColors');
 
 const DIFFICULTY_LABELS = { easy: 'Easy', medium: 'Medium', hard: 'Hard' };
 const AI_MECHANIC_EMOJIS = {
@@ -109,7 +110,7 @@ module.exports = {
         const totalWeekly = weeklyLines.length;
 
         const embed = new EmbedBuilder()
-            .setColor(0x5865F2)
+            .setColor(COLORS.INFO)
             .setAuthor({
                 name: `${interaction.user.displayName}'s Quest Board`,
                 iconURL: interaction.user.displayAvatarURL({ dynamic: true })

--- a/src/commands/community/track.js
+++ b/src/commands/community/track.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
 const Guild = require('../../models/Guild');
+const COLORS = require('../../utils/embedColors');
 
 const TRACK_INFO = {
     none: {
@@ -60,7 +61,7 @@ module.exports = {
             const info = TRACK_INFO[chosen];
             return interaction.reply({
                 embeds: [new EmbedBuilder()
-                    .setColor('#5865F2')
+                    .setColor(COLORS.INFO)
                     .setTitle(`Track Set: ${info.emoji} ${info.label}`)
                     .setDescription(info.description)
                     .setFooter({ text: 'Your XP bonuses will apply from your next message.' })],
@@ -81,7 +82,7 @@ module.exports = {
         });
 
         const embed = new EmbedBuilder()
-            .setColor('#5865F2')
+            .setColor(COLORS.INFO)
             .setTitle('Progression Tracks')
             .setDescription(trackLines.join('\n\n'))
             .setFooter({ text: 'Use /track choose:<track> to switch your track' })

--- a/src/commands/economy/balance.js
+++ b/src/commands/economy/balance.js
@@ -4,6 +4,7 @@ const Guild = require('../../models/Guild');
 const { pruneEffects, EFFECT_CONFIGS, timeRemaining, getServerCoinMultiplier, getServerXpMultiplier } = require('../../services/effectsService');
 const { getStreakMultiplier } = require('../../utils/streakMultiplier');
 const { claimStarterKit } = require('../../utils/starterKit');
+const COLORS = require('../../utils/embedColors');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -53,7 +54,7 @@ module.exports = {
             const titleName = isSelf ? 'Your' : `${targetUser.username}'s`;
 
             const embed = new EmbedBuilder()
-                .setColor('#FFD700')
+                .setColor(COLORS.PRIZE)
                 .setAuthor({ name: `${titleName} Dashboard`, iconURL: targetUser.displayAvatarURL({ dynamic: true }) })
                 .setDescription(
                     `**💰 Wallet** · ${user.balance.toLocaleString()} coins\n` +

--- a/src/commands/economy/bank.js
+++ b/src/commands/economy/bank.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js'
 const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { logTransaction } = require('../../utils/logTransaction');
+const COLORS = require('../../utils/embedColors');
 
 async function getCurrency(guildId) {
     const guildSettings = await Guild.findOne({ guildId });
@@ -53,7 +54,7 @@ async function handleDeposit(interaction) {
         : null;
 
     const depositEmbed = new EmbedBuilder()
-        .setColor('#00ff00')
+        .setColor(COLORS.SUCCESS)
         .setTitle(depositTitle)
         .addFields(
             { name: 'Deposited', value: `${currency}${amount.toLocaleString()}`, inline: true },
@@ -105,7 +106,7 @@ async function handleWithdraw(interaction) {
     });
 
     const embed = new EmbedBuilder()
-        .setColor('#00ff00')
+        .setColor(COLORS.SUCCESS)
         .setTitle('Withdrawal Successful')
         .addFields(
             { name: 'Withdrawn', value: `${currency}${Number(amount).toLocaleString()}`, inline: true },
@@ -161,7 +162,7 @@ async function handleTransfer(interaction) {
         });
 
         const embed = new EmbedBuilder()
-            .setColor('#00ff00')
+            .setColor(COLORS.SUCCESS)
             .setTitle('Transfer Successful')
             .setDescription(`You transferred **${amount.toLocaleString()}** coins to ${recipient}`)
             .addFields({ name: 'Your New Balance', value: `${sender.balance.toLocaleString()} coins` })

--- a/src/commands/economy/boost.js
+++ b/src/commands/economy/boost.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, EmbedBuilder, PermissionFlagsBits, MessageFlags } = require('discord.js');
 const Guild = require('../../models/Guild');
 const { timeRemaining, getServerCoinMultiplier, getServerXpMultiplier } = require('../../services/effectsService');
+const COLORS = require('../../utils/embedColors');
 
 const BOOST_LABELS = {
     coin: { emoji: '💰', label: 'Coin Boost', description: 'Increases coin earnings from work, daily, and games' },
@@ -71,7 +72,7 @@ module.exports = {
 
                 const announcementChannelId = guildSettings.economy?.announcementChannelId;
                 const embed = new EmbedBuilder()
-                    .setColor('#f39c12')
+                    .setColor(COLORS.WARN)
                     .setTitle(`🚀 Server Boost Activated!`)
                     .setDescription(`${info.emoji} **${multiplier}x ${info.label}** is now active!\n${info.description}.`)
                     .addFields(
@@ -106,7 +107,7 @@ module.exports = {
 
                 const info = BOOST_LABELS[endedType];
                 const embed = new EmbedBuilder()
-                    .setColor('#e74c3c')
+                    .setColor(COLORS.ERROR)
                     .setTitle('Server Boost Ended')
                     .setDescription(`${info.emoji} The **${info.label}** has been manually ended.`)
                     .setTimestamp();
@@ -126,7 +127,7 @@ module.exports = {
 
                 const info = BOOST_LABELS[sb.type];
                 const embed = new EmbedBuilder()
-                    .setColor('#2ecc71')
+                    .setColor(COLORS.SUCCESS)
                     .setTitle('🚀 Server Boost Status')
                     .addFields(
                         { name: 'Type',       value: `${info.emoji} ${info.label}`,                inline: true },

--- a/src/commands/economy/craft.js
+++ b/src/commands/economy/craft.js
@@ -12,6 +12,7 @@ const { ensureHuntData, FIELD_TROPHY_FLAGS } = require('../../services/huntServi
 const { FIELD_TROPHIES } = require('../../data/huntData');
 const { ensureMineData } = require('../../services/mineService');
 const { ensureFishingData } = require('../../services/fishService');
+const COLORS = require('../../utils/embedColors');
 
 const ALL_RECIPES   = { ...HUNT_RECIPES, ...MINE_RECIPES, ...FISH_CRAFT_RECIPES, ...CROSS_CRAFT_RECIPES };
 const ALL_MAT_NAMES = { ...HUNT_MAT_NAMES, ...MINE_MAT_NAMES, ...FISH_MAT_NAMES };
@@ -326,7 +327,7 @@ module.exports = {
                           : 'Use /hunt inv materials to check your remaining stock';
 
             const embed = new EmbedBuilder()
-                .setColor('#2ecc71')
+                .setColor(COLORS.SUCCESS)
                 .setTitle(`${recipe.emoji} Crafted: ${recipe.name}`)
                 .setDescription(`You crafted ${outputDesc}!`)
                 .addFields({ name: 'Materials Consumed', value: usedLines, inline: false })

--- a/src/commands/economy/crime.js
+++ b/src/commands/economy/crime.js
@@ -19,6 +19,7 @@ const { getTimeBand } = require('../../utils/timeBand');
 const { logBigWin } = require('../../utils/bigWinLogger');
 const { isDistrictActive } = require('../../services/districtService');
 const COLORS = require('../../utils/embedColors');
+const { ownedBy } = require('../../utils/collectorOwner');
 
 const COOLDOWN_MS    = 1.5 * 3_600_000; // 1.5 hours
 const DEATH_RATE     = 0.08;            // 8% of failures trigger critical death
@@ -223,7 +224,7 @@ module.exports = {
         let crimeButtonInteraction = null;
         try {
             crimeButtonInteraction = await response.awaitMessageComponent({
-                filter: i => i.user.id === interaction.user.id,
+                filter: ownedBy(interaction.user.id, "This isn't your job."),
                 time: 15_000,
             });
             crime = CRIMES.find(c => c.name === crimeButtonInteraction.customId);
@@ -284,7 +285,7 @@ module.exports = {
         let execMethod;
         try {
             const execButtonInteraction = await response.awaitMessageComponent({
-                filter: i => i.user.id === interaction.user.id,
+                filter: ownedBy(interaction.user.id, "This isn't your job."),
                 time: 15_000,
             });
             execMethod = execData.methods.find(m => `exec_${m.id}` === execButtonInteraction.customId);

--- a/src/commands/economy/crime.js
+++ b/src/commands/economy/crime.js
@@ -18,6 +18,7 @@ const { getDailyFeatured, FEATURED_PAYOUT_BONUS } = require('../../data/featured
 const { getTimeBand } = require('../../utils/timeBand');
 const { logBigWin } = require('../../utils/bigWinLogger');
 const { isDistrictActive } = require('../../services/districtService');
+const COLORS = require('../../utils/embedColors');
 
 const COOLDOWN_MS    = 1.5 * 3_600_000; // 1.5 hours
 const DEATH_RATE     = 0.08;            // 8% of failures trigger critical death
@@ -210,7 +211,7 @@ module.exports = {
         }).join('\n\n');
 
         const selectionEmbed = new EmbedBuilder()
-            .setColor('#f39c12')
+            .setColor(COLORS.WARN)
             .setTitle('🌆 Tonight\'s Jobs')
             .setDescription(`Three options on the table. Pick your play — or let the clock decide.\n\n${crimeLines}`)
             .setFooter({ text: `${timeBand.emoji} ${timeBand.label} · 15 seconds. No choice and it gets chosen for you.` })
@@ -463,7 +464,7 @@ module.exports = {
                     const undergroundStr = undergroundActive ? '\n> 🌑 *Underground district active — fine reduced by 15%!*' : '';
 
                     embed = new EmbedBuilder()
-                        .setColor('#e74c3c')
+                        .setColor(COLORS.ERROR)
                         .setTitle(`${crime.emoji} ${crime.displayName} — Busted`)
                         .setDescription(`${bustNarrative}\n\n> *${flavorText}*${undergroundStr}${wantedStr}`)
                         .addFields(
@@ -485,7 +486,7 @@ module.exports = {
 
             // Suspense delay between execution method selection and result reveal
             const suspenseEmbed = new EmbedBuilder()
-                .setColor('#f39c12')
+                .setColor(COLORS.WARN)
                 .setTitle(`${crime.emoji} Running the Job…`)
                 .setDescription(`*${crime.displayName} in progress…*`);
             await interaction.editReply({ embeds: [suspenseEmbed], components: [] });

--- a/src/commands/economy/daily.js
+++ b/src/commands/economy/daily.js
@@ -16,6 +16,7 @@ const { ensureQuests, onEconomyEarn, notifyQuestComplete, notifyQuestNearComplet
 const { saveWithBalanceDelta } = require('../../utils/balanceDelta');
 const { recordMissionProgress } = require('../../services/seasonMissionService');
 const COLORS = require('../../utils/embedColors');
+const { ownedBy } = require('../../utils/collectorOwner');
 
 function getStreakColor(streak) {
     if (streak >= 100) return '#9b59b6';
@@ -245,7 +246,7 @@ module.exports = {
                 try {
                     const resp = await promptReply.awaitMessageComponent({
                         time: 30000,
-                        filter: i => i.user.id === interaction.user.id,
+                        filter: ownedBy(interaction.user.id, "This isn't your claim."),
                     });
 
                     if (resp.customId === 'freeze_restore') {
@@ -557,7 +558,7 @@ module.exports = {
             try {
                 const response = await reply.awaitMessageComponent({
                     time: challenge.timeLimit,
-                    filter: i => i.user.id === interaction.user.id && i.customId !== CALENDAR_BUTTON_ID,
+                    filter: ownedBy(interaction.user.id, i => i.customId !== CALENDAR_BUTTON_ID, "This isn't your claim."),
                 });
                 if (activateTimer) clearTimeout(activateTimer);
 
@@ -631,7 +632,7 @@ module.exports = {
             try {
                 const calendarResponse = await reply.awaitMessageComponent({
                     time: 60_000,
-                    filter: i => i.user.id === interaction.user.id && i.customId === CALENDAR_BUTTON_ID,
+                    filter: ownedBy(interaction.user.id, i => i.customId === CALENDAR_BUTTON_ID, "This isn't your claim."),
                 });
                 const dailyAmountForCalendar = guildSettings?.economy?.dailyAmount ?? 100;
                 const calendarEmbed = buildCalendarEmbed(updated, dailyAmountForCalendar, streakCurrent);

--- a/src/commands/economy/daily.js
+++ b/src/commands/economy/daily.js
@@ -15,6 +15,7 @@ const { claimStarterKit } = require('../../utils/starterKit');
 const { ensureQuests, onEconomyEarn, notifyQuestComplete, notifyQuestNearComplete } = require('../../services/questService');
 const { saveWithBalanceDelta } = require('../../utils/balanceDelta');
 const { recordMissionProgress } = require('../../services/seasonMissionService');
+const COLORS = require('../../utils/embedColors');
 
 function getStreakColor(streak) {
     if (streak >= 100) return '#9b59b6';
@@ -196,7 +197,7 @@ module.exports = {
                 user.streak.revivalToken  = false;
 
                 const revivalEmbed = new EmbedBuilder()
-                    .setColor('#9b59b6')
+                    .setColor(COLORS.RARE)
                     .setTitle('💫 Streak Revival Token Activated!')
                     .setDescription(
                         `Your **Streak Revival Token** automatically restored your streak!\n\n` +
@@ -228,7 +229,7 @@ module.exports = {
                 );
 
                 const freezeEmbed = new EmbedBuilder()
-                    .setColor('#ff4444')
+                    .setColor(COLORS.ERROR)
                     .setTitle('💔 Your streak was broken!')
                     .setDescription(
                         `Your **${currentPendingRestore}-day streak** was broken!\n\n` +
@@ -262,7 +263,7 @@ module.exports = {
                         await resp.update({
                             embeds: [
                                 EmbedBuilder.from(freezeEmbed)
-                                    .setColor('#00ff00')
+                                    .setColor(COLORS.SUCCESS)
                                     .setDescription(
                                         `✅ Streak restored! Your **${currentPendingRestore}-day streak** continues!\n\n` +
                                         `1 Streak Freeze consumed. **${user.streak.freezes}** remaining.`
@@ -281,7 +282,7 @@ module.exports = {
                         await resp.update({
                             embeds: [
                                 EmbedBuilder.from(freezeEmbed)
-                                    .setColor('#888888')
+                                    .setColor(COLORS.NEUTRAL)
                                     .setDescription('Starting fresh! Build that streak back up 💪')
                                     .setFields()
                             ],
@@ -488,7 +489,7 @@ module.exports = {
 
             const challenge = generateDailyChallenge();
             const challengeEmbed = new EmbedBuilder()
-                .setColor('#5865F2')
+                .setColor(COLORS.INFO)
                 .setTitle('⚡ Quick Challenge — Earn +50%')
                 .setDescription(`> ${challenge.description}\n\nYou have **${Math.round(challenge.timeLimit / 1000)} seconds**.`);
 
@@ -601,13 +602,13 @@ module.exports = {
                         buildRewardBlock(actualAmount, streakCurrent, streakMult, coinMult, serverMult, combined, finalBalance, capActive, droppedItem, isMilestone, streakCurrent, currency)
                     );
                     const winChallengeEmbed = new EmbedBuilder()
-                        .setColor('#ffd700')
+                        .setColor(COLORS.PRIZE)
                         .setTitle('⚡ Quick Challenge — Earned!')
                         .setDescription(`✅ Correct! You earned an extra **+${bonusAmount.toLocaleString()} coins**!`);
                     await response.update({ embeds: [rewardEmbed, winChallengeEmbed], components: [calendarRow] });
                 } else {
                     const loseChallengeEmbed = new EmbedBuilder()
-                        .setColor('#5865F2')
+                        .setColor(COLORS.INFO)
                         .setTitle('⚡ Quick Challenge')
                         .setDescription('❌ Wrong answer! No bonus this time — your daily reward is still yours.');
                     await response.update({ embeds: [rewardEmbed, loseChallengeEmbed], components: [calendarRow] });
@@ -616,7 +617,7 @@ module.exports = {
                 if (activateTimer) clearTimeout(activateTimer);
                 if (err.name === 'InteractionCollectorError') {
                     const timeoutChallengeEmbed = new EmbedBuilder()
-                        .setColor('#5865F2')
+                        .setColor(COLORS.INFO)
                         .setTitle('⚡ Quick Challenge')
                         .setDescription("⏱️ Time's up! No bonus this time — your daily reward is still yours.");
                     await reply.edit({ embeds: [rewardEmbed, timeoutChallengeEmbed], components: [calendarRow] }).catch(() => {});

--- a/src/commands/economy/dailychallenge.js
+++ b/src/commands/economy/dailychallenge.js
@@ -5,6 +5,7 @@ const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { hasUnlock } = require('../../utils/prestige');
 const { logTransaction } = require('../../utils/logTransaction');
+const COLORS = require('../../utils/embedColors');
 
 const CLAIM_COOLDOWN_MS = 24 * 3_600_000;
 const BASE_REWARD_COINS = 5_000;
@@ -58,7 +59,7 @@ module.exports = {
         if (onCooldown) {
             const nextAt = Math.floor((lastClaim.getTime() + CLAIM_COOLDOWN_MS) / 1000);
             const embed = new EmbedBuilder()
-                .setColor('#5865F2')
+                .setColor(COLORS.INFO)
                 .setTitle('📋 Daily Challenge Board')
                 .setDescription(
                     `**Today's Objective:** ${objective.emoji} ${objective.text}\n\n` +
@@ -90,7 +91,7 @@ module.exports = {
         if (!updated) {
             const nextAt = Math.floor((Date.now() + CLAIM_COOLDOWN_MS) / 1000);
             const embed = new EmbedBuilder()
-                .setColor('#5865F2')
+                .setColor(COLORS.INFO)
                 .setTitle('📋 Daily Challenge Board')
                 .setDescription(
                     `**Today's Objective:** ${objective.emoji} ${objective.text}\n\n` +
@@ -110,7 +111,7 @@ module.exports = {
         });
 
         const embed = new EmbedBuilder()
-            .setColor('#FFD700')
+            .setColor(COLORS.PRIZE)
             .setTitle('📋 Daily Challenge Board — Claimed!')
             .setDescription(
                 `**Today's Objective:** ${objective.emoji} ${objective.text}\n\n` +

--- a/src/commands/economy/duel.js
+++ b/src/commands/economy/duel.js
@@ -12,6 +12,7 @@ const { advanceMissions } = require('../../services/seasonMissionService');
 const Guild = require('../../models/Guild');
 const { isDistrictActive } = require('../../services/districtService');
 const { START_ELO, tierFor, applyElo, makeSeasonId } = require('../../utils/duelElo');
+const COLORS = require('../../utils/embedColors');
 
 const DUEL_COOLDOWN_MS = 5 * 60_000;
 const ACCEPT_TIMEOUT_MS = 60_000;
@@ -273,7 +274,7 @@ async function finalizeDuel({ interaction, targetUser, challengerId, opponentId,
         const winLine    = winnerPayout.toLocaleString();
 
         const victoryCard = new EmbedBuilder()
-            .setColor('#FFD700')
+            .setColor(COLORS.PRIZE)
             .setTitle('🏆 Duel Victory')
             .setDescription(
                 `<@${winnerUser.id}> defeated <@${loserUser.id}> in a ${GAME_NAMES[game]}\n\n` +
@@ -293,7 +294,7 @@ async function finalizeDuel({ interaction, targetUser, challengerId, opponentId,
 }
 
 function errorEmbed(title, description) {
-    return new EmbedBuilder().setColor('#e74c3c').setTitle(title).setDescription(description).setTimestamp();
+    return new EmbedBuilder().setColor(COLORS.ERROR).setTitle(title).setDescription(description).setTimestamp();
 }
 
 async function runInstantGame(interaction, targetUser, amount, currency, houseCut, game, isRanked = false) {
@@ -341,7 +342,7 @@ async function runRPS(interaction, msg, targetUser, amount, currency, houseCut, 
 
     try {
         await interaction.editReply({
-            embeds: [new EmbedBuilder().setColor('#5865F2').setTitle('✊ Rock Paper Scissors').setDescription(`**${interaction.user.username}**, choose your move! (30s)`).setTimestamp()],
+            embeds: [new EmbedBuilder().setColor(COLORS.INFO).setTitle('✊ Rock Paper Scissors').setDescription(`**${interaction.user.username}**, choose your move! (30s)`).setTimestamp()],
             components: [buildRpsRow('c', duelId)],
         });
     } catch (err) {
@@ -363,7 +364,7 @@ async function runRPS(interaction, msg, targetUser, amount, currency, houseCut, 
             const challengerMove = ci.customId.slice(cPrefix.length);
 
             await interaction.editReply({
-                embeds: [new EmbedBuilder().setColor('#5865F2').setTitle('✊ Rock Paper Scissors').setDescription(`**${targetUser.username}**, choose your move! (30s)`).setTimestamp()],
+                embeds: [new EmbedBuilder().setColor(COLORS.INFO).setTitle('✊ Rock Paper Scissors').setDescription(`**${targetUser.username}**, choose your move! (30s)`).setTimestamp()],
                 components: [buildRpsRow('o', duelId)],
             });
 
@@ -416,7 +417,7 @@ async function runRPS(interaction, msg, targetUser, amount, currency, houseCut, 
                     await settle(async () => {
                         await refundEscrow(interaction.user.id, targetUser.id, guildId, amount).catch(console.error);
                         await interaction.editReply({
-                            embeds: [new EmbedBuilder().setColor('#95a5a6').setTitle('⚔️ Duel Expired').setDescription(`**${targetUser.username}** didn't pick a move in time. Both bets refunded.`).setTimestamp()],
+                            embeds: [new EmbedBuilder().setColor(COLORS.NEUTRAL).setTitle('⚔️ Duel Expired').setDescription(`**${targetUser.username}** didn't pick a move in time. Both bets refunded.`).setTimestamp()],
                             components: [],
                         }).catch(() => {});
                     });
@@ -436,7 +437,7 @@ async function runRPS(interaction, msg, targetUser, amount, currency, houseCut, 
             await settle(async () => {
                 await refundEscrow(interaction.user.id, targetUser.id, guildId, amount).catch(console.error);
                 await interaction.editReply({
-                    embeds: [new EmbedBuilder().setColor('#95a5a6').setTitle('⚔️ Duel Expired').setDescription(`**${interaction.user.username}** didn't pick a move in time. Both bets refunded.`).setTimestamp()],
+                    embeds: [new EmbedBuilder().setColor(COLORS.NEUTRAL).setTitle('⚔️ Duel Expired').setDescription(`**${interaction.user.username}** didn't pick a move in time. Both bets refunded.`).setTimestamp()],
                     components: [],
                 }).catch(() => {});
             });
@@ -541,7 +542,7 @@ async function runChallenge(interaction, isRanked) {
 
             if (i.customId === `duel_decline_${duelId}`) {
                 return interaction.editReply({
-                    embeds: [new EmbedBuilder().setColor('#e74c3c').setTitle('⚔️ Duel Declined').setDescription(`**${target.username}** declined the challenge.`).setTimestamp()],
+                    embeds: [new EmbedBuilder().setColor(COLORS.ERROR).setTitle('⚔️ Duel Declined').setDescription(`**${target.username}** declined the challenge.`).setTimestamp()],
                     components: [],
                 });
             }
@@ -554,7 +555,7 @@ async function runChallenge(interaction, isRanked) {
             if (!cooldownClaim.ok) {
                 const who = cooldownClaim.reason === 'challenger' ? interaction.user.username : target.username;
                 return interaction.editReply({
-                    embeds: [new EmbedBuilder().setColor('#e74c3c').setTitle('⚔️ Duel Cancelled').setDescription(`**${who}** is on duel cooldown.`).setTimestamp()],
+                    embeds: [new EmbedBuilder().setColor(COLORS.ERROR).setTitle('⚔️ Duel Cancelled').setDescription(`**${who}** is on duel cooldown.`).setTimestamp()],
                     components: [],
                 });
             }
@@ -566,7 +567,7 @@ async function runChallenge(interaction, isRanked) {
                 cooldownClaim = null;
                 const who = escrow.reason === 'challenger' ? interaction.user.username : target.username;
                 return interaction.editReply({
-                    embeds: [new EmbedBuilder().setColor('#e74c3c').setTitle('⚔️ Duel Cancelled').setDescription(`**${who}** no longer has enough ${currency}.`).setTimestamp()],
+                    embeds: [new EmbedBuilder().setColor(COLORS.ERROR).setTitle('⚔️ Duel Cancelled').setDescription(`**${who}** no longer has enough ${currency}.`).setTimestamp()],
                     components: [],
                 });
             }
@@ -595,7 +596,7 @@ async function runChallenge(interaction, isRanked) {
     acceptCollector.on('end', async (collected, reason) => {
         if (reason === 'time' && collected.size === 0) {
             await interaction.editReply({
-                embeds: [new EmbedBuilder().setColor('#95a5a6').setTitle('⚔️ Duel Expired').setDescription(`The duel challenge to **${target.username}** expired.`).setTimestamp()],
+                embeds: [new EmbedBuilder().setColor(COLORS.NEUTRAL).setTitle('⚔️ Duel Expired').setDescription(`The duel challenge to **${target.username}** expired.`).setTimestamp()],
                 components: [],
             }).catch(() => {});
         }
@@ -625,7 +626,7 @@ async function runRankView(interaction) {
         ?? makeSeasonId(guildSettings?.rankedDuels?.seasonNumber ?? 1);
 
     const embed = new EmbedBuilder()
-        .setColor('#9b59b6')
+        .setColor(COLORS.RARE)
         .setTitle(`${tier.icon} ${target.username} — ${tier.label}`)
         .setThumbnail(target.displayAvatarURL({ dynamic: true }))
         .setDescription(`Current **${elo}** ELO · Server rank **#${rankPosition}**`)
@@ -678,7 +679,7 @@ async function runLeaderboard(interaction) {
         : '';
 
     const embed = new EmbedBuilder()
-        .setColor('#9b59b6')
+        .setColor(COLORS.RARE)
         .setTitle(`🏆 Ranked Duel Ladder — ${seasonId}`)
         .setDescription(lines.join('\n') + seasonEnds)
         .setFooter({ text: 'Top 3 at season end earn coins, a title, and bragging rights.' })

--- a/src/commands/economy/duel.js
+++ b/src/commands/economy/duel.js
@@ -13,6 +13,7 @@ const Guild = require('../../models/Guild');
 const { isDistrictActive } = require('../../services/districtService');
 const { START_ELO, tierFor, applyElo, makeSeasonId } = require('../../utils/duelElo');
 const COLORS = require('../../utils/embedColors');
+const { ownedBy } = require('../../utils/collectorOwner');
 
 const DUEL_COOLDOWN_MS = 5 * 60_000;
 const ACCEPT_TIMEOUT_MS = 60_000;
@@ -353,7 +354,11 @@ async function runRPS(interaction, msg, targetUser, amount, currency, houseCut, 
 
     const cPrefix = `rpsc_${duelId}_`;
     const challengerCollector = msg.createMessageComponentCollector({
-        filter: i => i.user.id === interaction.user.id && i.customId.startsWith(cPrefix) && RPS_MOVES.includes(i.customId.slice(cPrefix.length)),
+        filter: ownedBy(
+            interaction.user.id,
+            i => i.customId.startsWith(cPrefix) && RPS_MOVES.includes(i.customId.slice(cPrefix.length)),
+            "This isn't your duel.",
+        ),
         time: RPS_TIMEOUT_MS,
         max: 1,
     });
@@ -370,7 +375,11 @@ async function runRPS(interaction, msg, targetUser, amount, currency, houseCut, 
 
             const oPrefix = `rpso_${duelId}_`;
             const opponentCollector = msg.createMessageComponentCollector({
-                filter: i => i.user.id === targetUser.id && i.customId.startsWith(oPrefix) && RPS_MOVES.includes(i.customId.slice(oPrefix.length)),
+                filter: ownedBy(
+                    targetUser.id,
+                    i => i.customId.startsWith(oPrefix) && RPS_MOVES.includes(i.customId.slice(oPrefix.length)),
+                    "This isn't your duel.",
+                ),
                 time: RPS_TIMEOUT_MS,
                 max: 1,
             });
@@ -529,7 +538,11 @@ async function runChallenge(interaction, isRanked) {
     const msg = await interaction.fetchReply();
 
     const acceptCollector = msg.createMessageComponentCollector({
-        filter: i => i.user.id === target.id && (i.customId === `duel_accept_${duelId}` || i.customId === `duel_decline_${duelId}`),
+        filter: ownedBy(
+            target.id,
+            i => i.customId === `duel_accept_${duelId}` || i.customId === `duel_decline_${duelId}`,
+            "This isn't your duel.",
+        ),
         time: ACCEPT_TIMEOUT_MS,
         max: 1,
     });

--- a/src/commands/economy/eventshop.js
+++ b/src/commands/economy/eventshop.js
@@ -10,6 +10,7 @@ const {
 const { addEffect, resolveEffectType } = require('../../services/effectsService');
 const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const { paginate, chunkArray } = require('../../utils/paginator');
+const { fitDescription, truncate } = require('../../utils/embedFields');
 
 // Items that grant effects when purchased (grant via effectsService)
 const EFFECT_ITEMS = new Set(['coin_booster_2x', 'xp_booster_2x', 'lucky_charm', 'lucky_streak', 'salary_raise']);
@@ -92,18 +93,26 @@ async function handleBrowse(interaction, ev, def, currency) {
     const chunks = chunkArray(shop, BROWSE_PAGE_SIZE);
     const totalItems = shop.length;
 
+    // An event shop item's name and description are whatever an admin typed
+    // into the dashboard, with no length cap on either — five of them joined
+    // ran past the 4,096 a description allows, and discord.js throws rather
+    // than truncating, so one long blurb took the whole page down. Cut each
+    // entry to a readable length instead of losing items off the end: they are
+    // bought by name, and a name the page never printed cannot be typed.
+    const ITEM_NAME = 100;
+    const ITEM_BLURB = 400;
     const pages = chunks.map((chunk, pageIndex) => {
         const offset = pageIndex * BROWSE_PAGE_SIZE;
         const lines = chunk.map((item, i) => {
             const stockStr = item.stock === -1 ? '∞' : item.stock.toLocaleString();
-            return `**${offset + i + 1}.** ${item.emoji || '•'} **${item.name}** — \`${item.cost} ${currency.emoji}\`\n` +
-                   `   ${item.description || ''}  •  Stock: ${stockStr}`;
+            return `**${offset + i + 1}.** ${item.emoji || '•'} **${truncate(item.name, ITEM_NAME)}** — \`${item.cost} ${currency.emoji}\`\n` +
+                   `   ${truncate(item.description || '', ITEM_BLURB)}  •  Stock: ${stockStr}`;
         });
 
         return new EmbedBuilder()
             .setColor(ev.color ?? '#5865F2')
             .setTitle(`${ev.emoji ?? '🛒'} ${ev.name} — Event Shop`)
-            .setDescription(lines.join('\n\n'))
+            .setDescription(fitDescription(lines, { separator: '\n\n' }).text)
             .addFields({
                 name: `${currency.emoji} Your Balance`,
                 value: 'Use `/eventshop balance` to check your balance',

--- a/src/commands/economy/eventshop.js
+++ b/src/commands/economy/eventshop.js
@@ -11,6 +11,7 @@ const { addEffect, resolveEffectType } = require('../../services/effectsService'
 const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const { paginate, chunkArray } = require('../../utils/paginator');
 const { fitDescription, truncate } = require('../../utils/embedFields');
+const COLORS = require('../../utils/embedColors');
 
 // Items that grant effects when purchased (grant via effectsService)
 const EFFECT_ITEMS = new Set(['coin_booster_2x', 'xp_booster_2x', 'lucky_charm', 'lucky_streak', 'salary_raise']);
@@ -69,7 +70,7 @@ async function handleBalance(interaction, guildSettings, currency) {
 
     return interaction.reply({
         embeds: [new EmbedBuilder()
-            .setColor('#5865F2')
+            .setColor(COLORS.INFO)
             .setTitle(`${currency.emoji} Event Currency Balance`)
             .setDescription(`You have **${balance.toLocaleString()} ${currency.name}** ${currency.emoji}`)
             .setFooter({ text: 'Earn more through event mini-games and activities!' })

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -64,6 +64,7 @@ const { logBigWin } = require('../../utils/bigWinLogger');
 const { tryUpdateHourlyWinner, getCurrentHourlyLeader } = require('../../utils/hourlyWinner');
 const { progressBar } = require('../../utils/progressBar');
 const { getDailyFeatured, FEATURED_PAYOUT_BONUS } = require('../../data/featuredRotation');
+const COLORS = require('../../utils/embedColors');
 
 const REGION_CHOICES = REGION_LIST.map(r => ({
     name: `${r.emoji} ${r.name}${r.seasonalEventId ? ' (seasonal)' : ''}`,
@@ -632,7 +633,7 @@ async function handleGo(interaction) {
             const announceChannel = resolved?.isTextBased() ? resolved : interaction.channel;
             announceChannel.send({
                 embeds: [new EmbedBuilder()
-                    .setColor('#FFD700')
+                    .setColor(COLORS.PRIZE)
                     .setTitle('✨ A Secret Has Been Found')
                     .setDescription(
                         `<@${interaction.user.id}> just uncovered **${result.secret.name}** in ${region.emoji} **${region.name}**.\n\n` +
@@ -733,11 +734,11 @@ function buildResultEmbed(result, region, user, currency, eventDrop, mainXp, fir
             lines.push(`*${result.landmark.line}*`);
             break;
         case 'lore':
-            embed.setColor('#b39ddb').setTitle('📜 Lore Fragment Recovered');
+            embed.setColor(COLORS.RARE).setTitle('📜 Lore Fragment Recovered');
             lines.push(`*You find words someone meant to be found:*`, '', `> ${result.lore.text}`);
             break;
         case 'secret':
-            embed.setColor('#FFD700').setTitle(`✨ SECRET UNCOVERED — ${result.secret.name}`);
+            embed.setColor(COLORS.PRIZE).setTitle(`✨ SECRET UNCOVERED — ${result.secret.name}`);
             lines.push(`*${result.secret.reveal}*`);
             break;
         case 'treasure': {
@@ -770,7 +771,7 @@ function buildResultEmbed(result, region, user, currency, eventDrop, mainXp, fir
         case 'encounter': {
             const enc = result.encounter;
             if (result.outcome === 'win') {
-                embed.setColor('#00CC55').setTitle(`${enc.emoji} ${enc.name} — Well Played`);
+                embed.setColor(COLORS.SUCCESS).setTitle(`${enc.emoji} ${enc.name} — Well Played`);
                 lines.push(`*${enc.winLine}*`);
             } else if (result.outcome === 'safe') {
                 embed.setColor(region.color).setTitle(`${enc.emoji} ${enc.name} — Watched From the Ferns`);
@@ -783,7 +784,7 @@ function buildResultEmbed(result, region, user, currency, eventDrop, mainXp, fir
             break;
         }
         default:
-            embed.setColor('#78909c').setTitle('🌫️ A Quiet Expedition');
+            embed.setColor(COLORS.NEUTRAL).setTitle('🌫️ A Quiet Expedition');
             lines.push(`*${result.quietLine}*`);
             break;
     }

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -65,6 +65,7 @@ const { tryUpdateHourlyWinner, getCurrentHourlyLeader } = require('../../utils/h
 const { progressBar } = require('../../utils/progressBar');
 const { getDailyFeatured, FEATURED_PAYOUT_BONUS } = require('../../data/featuredRotation');
 const COLORS = require('../../utils/embedColors');
+const { ownedBy } = require('../../utils/collectorOwner');
 
 const REGION_CHOICES = REGION_LIST.map(r => ({
     name: `${r.emoji} ${r.name}${r.seasonalEventId ? ' (seasonal)' : ''}`,
@@ -487,7 +488,7 @@ async function handleGo(interaction) {
             const msg = await interaction.fetchReply();
             const choice = await new Promise(resolve => {
                 const col = msg.createMessageComponentCollector({
-                    filter: i => i.user.id === interaction.user.id && i.customId.startsWith(encId),
+                    filter: ownedBy(interaction.user.id, i => i.customId.startsWith(encId), "This isn't your expedition."),
                     time: 20_000,
                     max: 1,
                 });

--- a/src/commands/economy/featured.js
+++ b/src/commands/economy/featured.js
@@ -4,6 +4,7 @@ const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js'
 const Guild = require('../../models/Guild');
 const { getDailyFeatured, FEATURED_PAYOUT_BONUS, FEATURED_RARE_BONUS } = require('../../data/featuredRotation');
 const { getTimeBand } = require('../../utils/timeBand');
+const COLORS = require('../../utils/embedColors');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -31,7 +32,7 @@ module.exports = {
         const div = '━━━━━━━━━━━━━━━━━━━━━━━━━━';
 
         const embed = new EmbedBuilder()
-            .setColor('#FFD700')
+            .setColor(COLORS.PRIZE)
             .setTitle(`🌟 Today's Featured Rotation`)
             .setDescription(
                 `Resets <t:${resetTs}:R> · **+${payoutPct}% payout** and **+${rarePct}% rare chance** on each featured pick.\n\n` +

--- a/src/commands/economy/feed.js
+++ b/src/commands/economy/feed.js
@@ -3,6 +3,7 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const Guild  = require('../../models/Guild');
 const BigWin = require('../../models/BigWin');
+const COLORS = require('../../utils/embedColors');
 
 const SOURCE_LABELS = {
     hunt:         '🏹 Hunt',
@@ -46,7 +47,7 @@ module.exports = {
             return interaction.reply({
                 embeds: [
                     new EmbedBuilder()
-                        .setColor('#888888')
+                        .setColor(COLORS.NEUTRAL)
                         .setTitle('📡 Big Win Feed')
                         .setDescription('No big wins recorded yet. Hit 50,000+ coins or land a Legendary to appear here!')
                 ],
@@ -61,7 +62,7 @@ module.exports = {
         }).join('\n\n');
 
         const embed = new EmbedBuilder()
-            .setColor('#FFD700')
+            .setColor(COLORS.PRIZE)
             .setTitle('📡 Big Win Feed')
             .setDescription(
                 `The ${wins.length} most recent big wins on **${interaction.guild.name}**.\n` +

--- a/src/commands/economy/fish/cast.js
+++ b/src/commands/economy/fish/cast.js
@@ -44,6 +44,7 @@ const { PITY_COPY } = require('../../../utils/pityBonus');
 const { FISH_TIER_SCORE } = require('./shared');
 const { buildCastEmbed } = require('./embeds');
 const COLORS = require('../../../utils/embedColors');
+const { ownedBy } = require('../../../utils/collectorOwner');
 
 // ─── Staged loot reveal for rare+ drops ──────────────────────────────────────
 async function stagedLootReveal(interaction, tier, finalEmbed) {
@@ -218,7 +219,7 @@ async function handleCast(interaction) {
 
             const reelPressed = await new Promise(resolve => {
                 const col = reelMsg.createMessageComponentCollector({
-                    filter: i => i.user.id === interaction.user.id && i.customId === reelId,
+                    filter: ownedBy(interaction.user.id, i => i.customId === reelId, "This isn't your cast."),
                     time: cfg.window,
                     max: 1,
                 });
@@ -454,7 +455,7 @@ async function handleCast(interaction) {
 
                 return new Promise(resolve => {
                     const collector = fetchReply.createMessageComponentCollector({
-                        filter: i => i.user.id === interaction.user.id && validIds.includes(i.customId),
+                        filter: ownedBy(interaction.user.id, i => validIds.includes(i.customId), "This isn't your cast."),
                         time: 30_000, max: 1
                     });
                     collector.on('collect', async btn => {

--- a/src/commands/economy/fish/cast.js
+++ b/src/commands/economy/fish/cast.js
@@ -43,6 +43,7 @@ const { logBigWin } = require('../../../utils/bigWinLogger');
 const { PITY_COPY } = require('../../../utils/pityBonus');
 const { FISH_TIER_SCORE } = require('./shared');
 const { buildCastEmbed } = require('./embeds');
+const COLORS = require('../../../utils/embedColors');
 
 // ─── Staged loot reveal for rare+ drops ──────────────────────────────────────
 async function stagedLootReveal(interaction, tier, finalEmbed) {
@@ -234,7 +235,7 @@ async function handleCast(interaction) {
                     const durLine = result.durabilityLost > 0 ? ` Rod took ${result.durabilityLost} durability damage.` : '';
                     await interaction.editReply({
                         embeds: [new EmbedBuilder()
-                            .setColor('#888888')
+                            .setColor(COLORS.NEUTRAL)
                             .setTitle('💨 It Got Away!')
                             .setDescription(`*The ${result.fish.name} snapped the line and vanished into the depths.*\n\nStamina spent — nothing to show for it.${durLine}`)
                             .setAuthor(authorOpts)],
@@ -248,7 +249,7 @@ async function handleCast(interaction) {
 
                     await interaction.editReply({
                         embeds: [new EmbedBuilder()
-                            .setColor('#aaaaaa')
+                            .setColor(COLORS.NEUTRAL)
                             .setTitle('😬 Slipped Away Partially…')
                             .setDescription(`*The ${result.fish.name} struggled free but you still pulled something in.*\n\nCatch downgraded to Uncommon.`)
                             .setAuthor(authorOpts)],

--- a/src/commands/economy/fish/craft.js
+++ b/src/commands/economy/fish/craft.js
@@ -11,6 +11,7 @@ const { ensureFishingData } = require('../../../services/fishService');
 const { ensureHuntData } = require('../../../services/huntService');
 const { FISH_CRAFT_RECIPES, CONSUMABLES, MATERIAL_NAMES } = require('../../../data/fishData');
 const { MATERIAL_NAMES: HUNT_MATERIAL_NAMES } = require('../../../data/huntData');
+const COLORS = require('../../../utils/embedColors');
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // CRAFT
@@ -53,7 +54,7 @@ async function handleCraft(interaction, sub) {
         });
 
         const embed = new EmbedBuilder()
-            .setColor('#3498db')
+            .setColor(COLORS.INFO)
             .setTitle('🎣 Fishing Crafting Recipes')
             .setDescription(lines.join('\n\n'))
             .setFooter({ text: '✅ = you can craft now  •  Use /fish craft make <recipe> to craft  •  /fish inv materials to check stock' });
@@ -147,7 +148,7 @@ async function handleCraft(interaction, sub) {
         }).join('\n');
 
         const embed = new EmbedBuilder()
-            .setColor('#2ecc71')
+            .setColor(COLORS.SUCCESS)
             .setTitle(`${recipe.emoji} Crafted: ${recipe.name}`)
             .setDescription(`You crafted ${outputDesc}!`)
             .addFields({ name: 'Materials Consumed', value: usedLines, inline: false })

--- a/src/commands/economy/fish/embeds.js
+++ b/src/commands/economy/fish/embeds.js
@@ -11,6 +11,7 @@ const { getCurrentWeather } = require('../../../services/weatherService');
 const { stackBar } = require('../../../utils/rewardReveal');
 const { buildPityStreakField, PITY_COPY } = require('../../../utils/pityBonus');
 const { formatMs, rodStatusEmoji, durabilityBar, getMaxStamina, xpToNextLevel, getLevelData } = require('../../../services/fishService');
+const COLORS = require('../../../utils/embedColors');
 
 // ─── EMBED BUILDER ────────────────────────────────────────────────────────────
 
@@ -184,7 +185,7 @@ function buildCastEmbed(result, user, location, rod, currency, _discordUser) {
     // ── Failure embed ──────────────────────────────────────────────────────
     const { failure, xpEarned, levelUp } = result;
     const embed = new EmbedBuilder()
-        .setColor('#e74c3c')
+        .setColor(COLORS.ERROR)
         .setTitle(buildFailureTitle(failure.severity.id))
         .setDescription(`*${failure.message}*`)
         .addFields(

--- a/src/commands/economy/fish/location.js
+++ b/src/commands/economy/fish/location.js
@@ -10,6 +10,7 @@ const { attachGrind } = require('../../../utils/grindProfile');
 const { ensureFishingData } = require('../../../services/fishService');
 const { LOCATION_LIST, LOCATIONS } = require('../../../data/fishData');
 const { formatTierWeights } = require('./embeds');
+const COLORS = require('../../../utils/embedColors');
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // LOCATION
@@ -54,7 +55,7 @@ async function showLocationList(interaction, user, currency) {
     });
 
     const embed = new EmbedBuilder()
-        .setColor('#3498db')
+        .setColor(COLORS.INFO)
         .setTitle('🗺️ Fishing Locations')
         .setDescription(locationLines.join('\n\n'))
         .setFooter({ text: 'Unlock new locations with /fish shop unlock • Switch with /fish location set' })
@@ -97,7 +98,7 @@ async function setLocation(interaction, user, _currency) {
     return interaction.reply({
         embeds: [
             new EmbedBuilder()
-                .setColor('#2ecc71')
+                .setColor(COLORS.SUCCESS)
                 .setTitle(`📍 Location Changed`)
                 .setDescription(`You are now fishing at **${location.emoji} ${location.name}**.`)
                 .addFields({ name: 'About', value: location.description, inline: false })

--- a/src/commands/economy/fish/profile.js
+++ b/src/commands/economy/fish/profile.js
@@ -33,6 +33,7 @@ const { chunkByLength } = require('../../../utils/embedFields');
 const { paginate } = require('../../../utils/paginator');
 const { MAX_PRESTIGE, PRESTIGE_BADGES, PRESTIGE_LABELS } = require('./shared');
 const { buildXpBar, formatPrestigeBonuses } = require('./embeds');
+const COLORS = require('../../../utils/embedColors');
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // PROFILE
@@ -224,7 +225,7 @@ async function handlePrestige(interaction) {
     const nextBonuses    = PRESTIGE_BONUSES[nextPrestige];
 
     const confirmEmbed = new EmbedBuilder()
-        .setColor('#f39c12')
+        .setColor(COLORS.WARN)
         .setTitle('⚠️ Fishing Prestige Confirmation')
         .setDescription(
             `You are about to prestige from **P${currentPrestige}** → **P${nextPrestige}** (${PRESTIGE_LABELS[nextPrestige]}).\n\n` +
@@ -300,7 +301,7 @@ async function handlePrestige(interaction) {
         checkGrandPrestige(i.client, freshUser, interaction.guild, interaction.guildId).catch(() => null);
 
         const resultEmbed = new EmbedBuilder()
-            .setColor('#f39c12')
+            .setColor(COLORS.WARN)
             .setTitle(`✨ Fishing Prestige ${ff.prestige} Achieved!`)
             .setDescription(
                 `You are now **${PRESTIGE_LABELS[ff.prestige]}**!\n\n` +
@@ -383,7 +384,7 @@ async function showRods(interaction, user) {
     });
 
     const pages = chunkByLength(lines, { separator: '\n\n', maxPerChunk: 8 }).map((chunk, _i, all) => new EmbedBuilder()
-        .setColor('#3498db')
+        .setColor(COLORS.INFO)
         .setTitle(all.length > 1 ? `🎣 ${interaction.user.username}'s Rods (${f.rods.length})` : `🎣 ${interaction.user.username}'s Rods`)
         .setDescription(chunk.join('\n\n'))
         .setFooter({ text: 'Use /fish inv equip <number> to equip a rod • /fish shop repair to repair' })
@@ -419,7 +420,7 @@ async function equipRod(interaction, user) {
     return interaction.reply({
         embeds: [
             new EmbedBuilder()
-                .setColor('#2ecc71')
+                .setColor(COLORS.SUCCESS)
                 .setTitle('✅ Rod Equipped')
                 .setDescription(`You equipped **${rod.name}** (Slot ${number}).`)
                 .addFields({ name: 'Durability', value: `${durabilityBar(rod.currentDurability, rod.maxDurability)} ${rod.currentDurability}/${rod.maxDurability}`, inline: true })
@@ -455,7 +456,7 @@ async function showBait(interaction, user, _currency) {
     if (f.activeXpScroll) activeLines.push(`📜 XP Scroll queued`);
 
     const embed = new EmbedBuilder()
-        .setColor('#f39c12')
+        .setColor(COLORS.WARN)
         .setTitle(`🎒 ${interaction.user.username}'s Fishing Supplies`)
         .addFields(
             { name: '🪱 Bait Stock', value: baitLines.length ? baitLines.join('\n') : 'None', inline: false },
@@ -482,7 +483,7 @@ async function showMaterials(interaction, user) {
     }).filter(Boolean);
 
     const embed = new EmbedBuilder()
-        .setColor('#95a5a6')
+        .setColor(COLORS.NEUTRAL)
         .setTitle(`🪨 ${interaction.user.username}'s Fishing Materials`)
         .addFields(
             { name: 'Fishing Materials', value: matLines.length ? matLines.join('\n') : 'None yet — catch fish for material drops!', inline: false }
@@ -525,7 +526,7 @@ async function checkGrandPrestige(client, user, guild, guildId) {
 
     if (announceChannelId && client) {
         const broadcastEmbed = new EmbedBuilder()
-            .setColor('#FFD700')
+            .setColor(COLORS.PRIZE)
             .setTitle('⚜️ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ⚜️')
             .setDescription(
                 `**GRAND MASTER ACHIEVED!**\n\n` +

--- a/src/commands/economy/fish/profile.js
+++ b/src/commands/economy/fish/profile.js
@@ -34,6 +34,7 @@ const { paginate } = require('../../../utils/paginator');
 const { MAX_PRESTIGE, PRESTIGE_BADGES, PRESTIGE_LABELS } = require('./shared');
 const { buildXpBar, formatPrestigeBonuses } = require('./embeds');
 const COLORS = require('../../../utils/embedColors');
+const { ownedBy } = require('../../../utils/collectorOwner');
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // PROFILE
@@ -252,8 +253,11 @@ async function handlePrestige(interaction) {
     const reply = await interaction.reply({ embeds: [confirmEmbed], components: [row], fetchReply: true });
 
     const collector = reply.createMessageComponentCollector({
-        filter: i => i.user.id === interaction.user.id &&
-                     ['fishprestige_confirm', 'fishprestige_cancel'].includes(i.customId),
+        filter: ownedBy(
+            interaction.user.id,
+            i => ['fishprestige_confirm', 'fishprestige_cancel'].includes(i.customId),
+            "This isn't your prestige confirmation.",
+        ),
         time:   30_000,
         max:    1
     });

--- a/src/commands/economy/fish/quests.js
+++ b/src/commands/economy/fish/quests.js
@@ -10,6 +10,7 @@ const { ensureFishingData, assignDailyFishQuests, formatMs, applyXp, getLevelDat
 const { FISH_QUEST_TEMPLATES } = require('../../../data/fishData');
 const { saveWithBalanceDelta } = require('../../../utils/balanceDelta');
 const { buildQuestProgressBar } = require('./embeds');
+const COLORS = require('../../../utils/embedColors');
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // QUESTS
@@ -72,7 +73,7 @@ async function showQuests(interaction, user, currency) {
     }).filter(Boolean);
 
     const embed = new EmbedBuilder()
-        .setColor('#f39c12')
+        .setColor(COLORS.WARN)
         .setTitle(`🎣 ${interaction.user.username}'s Daily Fishing Quests`)
         .setDescription(lines.join('\n\n'))
         .setFooter({ text: 'Quests refresh every 24h after all are completed or claimed' })
@@ -135,7 +136,7 @@ async function claimQuest(interaction, user, currency) {
     }
 
     const embed = new EmbedBuilder()
-        .setColor('#2ecc71')
+        .setColor(COLORS.SUCCESS)
         .setTitle(`${template.emoji} Quest Reward Claimed!`)
         .setDescription(`**${template.name}** completed!`)
         .addFields(

--- a/src/commands/economy/fish/shop.js
+++ b/src/commands/economy/fish/shop.js
@@ -30,6 +30,7 @@ const { runShopBrowse } = require('../../../utils/shopBrowse');
 const { getItemImageAttachment } = require('../../../utils/itemImageHelper');
 const GrindProfile = require('../../../models/GrindProfile');
 const { chargeBalance, refundBalance } = require('./shared');
+const COLORS = require('../../../utils/embedColors');
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // SHOP
@@ -158,7 +159,7 @@ async function handleBuyRod(interaction, user, currency) {
     }
 
     const confirmEmbed = new EmbedBuilder()
-        .setColor('#3498db')
+        .setColor(COLORS.WARN)
         .setTitle(`${rodData.emoji} Purchase ${rodData.name}?`)
         .setDescription(rodData.description)
         .addFields(
@@ -246,7 +247,7 @@ async function handleBuyRod(interaction, user, currency) {
         return btn.update({
             embeds: [
                 new EmbedBuilder()
-                    .setColor('#2ecc71')
+                    .setColor(COLORS.SUCCESS)
                     .setTitle(`${rodData.emoji} ${rodData.name} Purchased!`)
                     .setDescription(`You now own a **${rodData.name}**. Equip it with \`/fish inv equip ${rodIndex}\`.`)
                     .addFields(
@@ -298,7 +299,7 @@ async function handleBuyUpgrade(interaction, user, currency) {
     }
 
     const confirmEmbed = new EmbedBuilder()
-        .setColor('#9b59b6')
+        .setColor(COLORS.RARE)
         .setTitle(`${upgradeDef.emoji} Install ${upgradeDef.name}?`)
         .setDescription(`Installing on **${rod.name}**\n${upgradeDef.description}`)
         .addFields(
@@ -371,7 +372,7 @@ async function handleBuyUpgrade(interaction, user, currency) {
         return btn.update({
             embeds: [
                 new EmbedBuilder()
-                    .setColor('#2ecc71')
+                    .setColor(COLORS.SUCCESS)
                     .setTitle(`${upgradeDef.emoji} ${upgradeDef.name} Installed!`)
                     .setDescription(`**${freshRod.name}** now has **${upgradeDef.name}** installed permanently.`)
                     .addFields(
@@ -431,7 +432,7 @@ async function handleBuy(interaction, user, currency) {
         : `${f.consumables[itemId] ?? 0}/${consumable.maxStack ?? 99} in stock`;
 
     const confirmEmbed = new EmbedBuilder()
-        .setColor('#f39c12')
+        .setColor(COLORS.WARN)
         .setTitle(`${itemDef.emoji} Confirm Purchase`)
         .setDescription(itemDef.description ?? '')
         .addFields(
@@ -498,7 +499,7 @@ async function handleBuy(interaction, user, currency) {
                 return interaction.editReply({
                     embeds: [
                         new EmbedBuilder()
-                            .setColor('#2ecc71')
+                            .setColor(COLORS.SUCCESS)
                             .setTitle(`${baitPack.emoji} Purchased!`)
                             .setDescription(`Bought **${quantity}× ${baitPack.name}** (+${addedQty} ${baitPack.baitType.replace(/_/g, ' ')}).`)
                             .addFields(
@@ -547,7 +548,7 @@ async function handleBuy(interaction, user, currency) {
             return interaction.editReply({
                 embeds: [
                     new EmbedBuilder()
-                        .setColor('#2ecc71')
+                        .setColor(COLORS.SUCCESS)
                         .setTitle(`${consumable.emoji} Purchased!`)
                         .setDescription(`Bought **${quantity}× ${consumable.name}**.`)
                         .addFields(
@@ -599,7 +600,7 @@ async function handleUse(interaction, user) {
     return interaction.reply({
         embeds: [
             new EmbedBuilder()
-                .setColor('#9b59b6')
+                .setColor(COLORS.RARE)
                 .setTitle(`${def?.emoji ?? '✅'} ${def?.name ?? itemId} Activated!`)
                 .setDescription(`*${def?.description ?? 'Effect applied.'}*`)
                 .addFields({ name: 'Active Buffs', value: statusLines.length ? statusLines.join('\n') : 'None' })
@@ -654,7 +655,7 @@ async function handleRepair(interaction, user, currency) {
         return interaction.reply({
             embeds: [
                 new EmbedBuilder()
-                    .setColor('#2ecc71')
+                    .setColor(COLORS.SUCCESS)
                     .setTitle(`${kitId === 'repair_kit_small' ? '🔧' : '🔨'} ${kitName} Used`)
                     .addFields(
                         { name: 'Rod',       value: rod.name,                                                                               inline: true },
@@ -706,7 +707,7 @@ async function handleRepair(interaction, user, currency) {
     }
 
     const embed = new EmbedBuilder()
-        .setColor('#2ecc71')
+        .setColor(COLORS.SUCCESS)
         .setTitle('🔧 Rod Repaired')
         .addFields(
             { name: 'Rod',        value: rod.name,                                                                               inline: true },
@@ -719,7 +720,7 @@ async function handleRepair(interaction, user, currency) {
         .setTimestamp();
 
     if (result.condemned) {
-        embed.setColor('#e74c3c');
+        embed.setColor(COLORS.ERROR);
         embed.addFields({ name: '⚠️ Condemned', value: 'This rod has been repaired too many times and cannot be repaired again. Consider buying a new one with `/fish shop rod`.', inline: false });
     } else {
         embed.addFields({ name: 'ℹ️ Note', value: `Max durability slightly reduced to ${rod.maxDurability} after this repair.`, inline: false });
@@ -795,7 +796,7 @@ async function handleUnlock(interaction, user, currency) {
     return interaction.reply({
         embeds: [
             new EmbedBuilder()
-                .setColor('#f39c12')
+                .setColor(COLORS.WARN)
                 .setTitle(`🗺️ ${location.emoji} ${location.name} Unlocked!`)
                 .setDescription(location.description)
                 .addFields(

--- a/src/commands/economy/fish/tournament.js
+++ b/src/commands/economy/fish/tournament.js
@@ -13,6 +13,7 @@ const {
 } = require('../../../services/tournamentService');
 const { EmbedBuilder, MessageFlags } = require('discord.js');
 const Guild = require('../../../models/Guild');
+const COLORS = require('../../../utils/embedColors');
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // TOURNAMENT
@@ -30,7 +31,7 @@ async function handleTournamentStatus(interaction) {
         return interaction.editReply({
             embeds: [
                 new EmbedBuilder()
-                    .setColor('#95a5a6')
+                    .setColor(COLORS.NEUTRAL)
                     .setTitle('🎣 No Active Tournament')
                     .setDescription('There is no fishing tournament running right now.\n\nAdmins can start one with `/fish tournament start`.')
                     .setTimestamp()
@@ -114,7 +115,7 @@ async function handleRecords(interaction) {
     if (!records.length) {
         return interaction.editReply({
             embeds: [new EmbedBuilder()
-                .setColor('#3498db')
+                .setColor(COLORS.INFO)
                 .setTitle('🐟 Server Fishing Records')
                 .setDescription('No records yet — start fishing to claim the top spot!')
                 .setTimestamp()]

--- a/src/commands/economy/gift.js
+++ b/src/commands/economy/gift.js
@@ -4,6 +4,7 @@ const Guild = require('../../models/Guild');
 const { getItemLore } = require('../../data/defaultShopItems');
 const { logTransaction } = require('../../utils/logTransaction');
 const { grantInventoryItem } = require('../../utils/inventoryGrant');
+const COLORS = require('../../utils/embedColors');
 
 const DAILY_COIN_CAP = 10_000;
 // Incoming cap is higher than the outgoing cap (several friends can legitimately
@@ -198,7 +199,7 @@ module.exports = {
                 .setTimestamp();
 
             const recipientEmbed = new EmbedBuilder()
-                .setColor('#2ecc71')
+                .setColor(COLORS.SUCCESS)
                 .setTitle('🎁 You Received a Gift!')
                 .setDescription(`**${interaction.user.username}** sent you **${currency}${amount.toLocaleString()}**!`)
                 .setTimestamp();
@@ -312,7 +313,7 @@ module.exports = {
                 : `**${interaction.user.username}** sent you **${qty}x \`${itemId}\`**!`;
 
             const recipientEmbed = new EmbedBuilder()
-                .setColor('#2ecc71')
+                .setColor(COLORS.SUCCESS)
                 .setTitle('🎁 You Received a Gift!')
                 .setDescription(recipientDesc)
                 .setTimestamp();

--- a/src/commands/economy/hunt/aim.js
+++ b/src/commands/economy/hunt/aim.js
@@ -4,6 +4,7 @@
 // profile that decides what the prompt reads like for the quarry in front of you.
 
 const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const COLORS = require('../../../utils/embedColors');
 
 // ── Aim phase timing ─────────────────────────────────────────────────────────
 // How long the shot stays perfect once the window opens, and how long after
@@ -100,7 +101,7 @@ async function runAimPhase(interaction, huntMsg) {
     if (!shotTaken) {
         await interaction.editReply({
             embeds: [new EmbedBuilder()
-                .setColor('#FF0000')
+                .setColor(COLORS.ERROR)
                 .setTitle('💥 FIRE!')
                 .setDescription('**Take the shot — NOW!**')],
             components: [aimRow],

--- a/src/commands/economy/hunt/aim.js
+++ b/src/commands/economy/hunt/aim.js
@@ -5,6 +5,7 @@
 
 const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const COLORS = require('../../../utils/embedColors');
+const { ownedBy } = require('../../../utils/collectorOwner');
 
 // ── Aim phase timing ─────────────────────────────────────────────────────────
 // How long the shot stays perfect once the window opens, and how long after
@@ -77,7 +78,7 @@ async function runAimPhase(interaction, huntMsg) {
     const aimTime = Date.now();
 
     const collector = huntMsg.createMessageComponentCollector({
-        filter: i => i.user.id === interaction.user.id && i.customId === fireId,
+        filter: ownedBy(interaction.user.id, i => i.customId === fireId, "This isn't your shot."),
         time: aimWaitMs + AIM_LATE_MS,
         max: 1,
     });

--- a/src/commands/economy/hunt/embeds.js
+++ b/src/commands/economy/hunt/embeds.js
@@ -22,6 +22,7 @@ const { randomFrom, HUNT_EMPTY_LINES } = require('../../../utils/copyLines');
 const { buildPityStreakField, PITY_COPY } = require('../../../utils/pityBonus');
 const { FEATURED_PAYOUT_BONUS } = require('../../../data/featuredRotation');
 const { WILDERNESS_YIELD_BONUS } = require('./shared');
+const COLORS = require('../../../utils/embedColors');
 
 function buildHuntEmbed(result, user, zone, weapon, currency, _discordUser) {
     const h = user.hunt;
@@ -137,7 +138,7 @@ function buildHuntEmbed(result, user, zone, weapon, currency, _discordUser) {
 
     const { failure, xpEarned, levelUp, animal: failAnimal, traits: failTraits, traitEffects: failTraitEffects } = result;
     const embed = new EmbedBuilder()
-        .setColor('#e74c3c')
+        .setColor(COLORS.ERROR)
         .setTitle(buildFailureTitle(failure.severity.id))
         .setDescription(failAnimal ? `*Encountered: ${failAnimal.emoji} **${failAnimal.name}***\n${failure.message}` : `*${failure.severity.id === 'clean_miss' ? randomFrom(HUNT_EMPTY_LINES) : failure.message}*`)
         .addFields(

--- a/src/commands/economy/hunt/inventory.js
+++ b/src/commands/economy/hunt/inventory.js
@@ -10,6 +10,7 @@ const { MessageFlags, EmbedBuilder } = require('discord.js');
 const User = require('../../../models/User');
 const { attachGrind } = require('../../../utils/grindProfile');
 const { paginate } = require('../../../utils/paginator');
+const COLORS = require('../../../utils/embedColors');
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // INV (was /huntinv)
@@ -73,7 +74,7 @@ async function executeInv(interaction, sub) {
         }
 
         const pages = buildWeaponPages(h).map((lines, page, all) => new EmbedBuilder()
-            .setColor('#3498db')
+            .setColor(COLORS.INFO)
             .setTitle(all.length > 1 ? `🔫 Your Weapons (${h.weapons.length})` : '🔫 Your Weapons')
             .setDescription(lines.join(WEAPON_SEPARATOR))
             .setFooter({ text: 'Use /hunt inv equip <#> to change weapon • /hunt shop repair to restore durability • /hunt shop upgrade for modules' }));
@@ -99,7 +100,7 @@ async function executeInv(interaction, sub) {
         await user.save();
 
         const embed = new EmbedBuilder()
-            .setColor('#2ecc71')
+            .setColor(COLORS.SUCCESS)
             .setTitle('⚔️ Weapon Equipped')
             .setDescription(`**${weapon.name}** is now equipped and ready for hunting.`)
             .addFields(
@@ -158,7 +159,7 @@ async function executeInv(interaction, sub) {
         if (h.activeXpScroll) activeParts.push(`📜 **XP Scroll** — queued for next hunt`);
 
         const embed = new EmbedBuilder()
-            .setColor('#9b59b6')
+            .setColor(COLORS.RARE)
             .setTitle('🧪 Consumables')
             .addFields({ name: 'In Stock', value: lines.length ? lines.join('\n') : 'None', inline: false });
 
@@ -226,7 +227,7 @@ async function executeInv(interaction, sub) {
         await user.save();
 
         const embed = new EmbedBuilder()
-            .setColor('#e74c3c')
+            .setColor(COLORS.ERROR)
             .setTitle('🗑️ Weapon Discarded')
             .setDescription(`**${weapon.name}** has been discarded.`)
             .setFooter({ text: h.weapons.length === 0 ? 'Buy a new weapon with /hunt shop weapon' : 'Use /hunt inv weapons to view remaining weapons' });

--- a/src/commands/economy/hunt/profile.js
+++ b/src/commands/economy/hunt/profile.js
@@ -24,6 +24,7 @@ const GrindProfile = require('../../../models/GrindProfile');
 const { MAX_PRESTIGE, PRESTIGE_BADGES, PRESTIGE_LABELS } = require('./shared');
 const { buildXpBar, formatBonuses } = require('./embeds');
 const COLORS = require('../../../utils/embedColors');
+const { ownedBy } = require('../../../utils/collectorOwner');
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // PROFILE (was /huntprofile)
@@ -311,8 +312,11 @@ async function executePrestige(interaction) {
     const reply = await interaction.reply({ embeds: [confirmEmbed], components: [row], fetchReply: true });
 
     const collector = reply.createMessageComponentCollector({
-        filter: i => i.user.id === interaction.user.id &&
-                     ['prestige_confirm', 'prestige_cancel'].includes(i.customId),
+        filter: ownedBy(
+            interaction.user.id,
+            i => ['prestige_confirm', 'prestige_cancel'].includes(i.customId),
+            "This isn't your prestige confirmation.",
+        ),
         time:   30_000,
         max:    1
     });

--- a/src/commands/economy/hunt/profile.js
+++ b/src/commands/economy/hunt/profile.js
@@ -23,6 +23,7 @@ const { getActiveSynergies } = require('../../../services/synergyService');
 const GrindProfile = require('../../../models/GrindProfile');
 const { MAX_PRESTIGE, PRESTIGE_BADGES, PRESTIGE_LABELS } = require('./shared');
 const { buildXpBar, formatBonuses } = require('./embeds');
+const COLORS = require('../../../utils/embedColors');
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // PROFILE (was /huntprofile)
@@ -283,7 +284,7 @@ async function executePrestige(interaction) {
     const nextBonuses     = PRESTIGE_BONUSES[nextPrestige];
 
     const confirmEmbed = new EmbedBuilder()
-        .setColor('#f39c12')
+        .setColor(COLORS.WARN)
         .setTitle('⚠️ Prestige Confirmation')
         .setDescription(
             `You are about to prestige from **P${currentPrestige}** → **P${nextPrestige}** (${PRESTIGE_LABELS[nextPrestige]}).\n\n` +
@@ -352,7 +353,7 @@ async function executePrestige(interaction) {
         checkGrandPrestige(i.client, freshUser, interaction.guild, interaction.guildId).catch(() => null);
 
         const resultEmbed = new EmbedBuilder()
-            .setColor('#f39c12')
+            .setColor(COLORS.WARN)
             .setTitle(`✨ Prestige ${fh.prestige} Achieved!`)
             .setDescription(
                 `You are now **${PRESTIGE_LABELS[fh.prestige]}**!\n\n` +
@@ -442,7 +443,7 @@ async function executeRecords(interaction) {
     }
 
     const embed = new EmbedBuilder()
-        .setColor('#c0392b')
+        .setColor(COLORS.ERROR)
         .setTitle('🏹 Server Hunting Records')
         .setDescription('The all-time boards. The hourly leader resets every hour — these never do.')
         .setFooter({ text: 'Records never reset · Your own numbers live in /hunt profile' })
@@ -485,7 +486,7 @@ async function checkGrandPrestige(client, user, guild, guildId) {
     if (announceChannelId && client) {
         const { EmbedBuilder } = require('discord.js');
         const broadcastEmbed = new EmbedBuilder()
-            .setColor('#FFD700')
+            .setColor(COLORS.PRIZE)
             .setTitle('⚜️ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ⚜️')
             .setDescription(
                 `**GRAND MASTER ACHIEVED!**\n\n` +

--- a/src/commands/economy/hunt/quests.js
+++ b/src/commands/economy/hunt/quests.js
@@ -10,6 +10,7 @@ const { ensureHuntData, assignDailyHuntQuests, applyXp, getLevelData } = require
 const { HUNT_QUEST_TEMPLATES } = require('../../../data/huntData');
 const { saveWithBalanceDelta } = require('../../../utils/balanceDelta');
 const { buildProgressBar, formatExpiry } = require('./embeds');
+const COLORS = require('../../../utils/embedColors');
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // QUESTS (was /huntquests)
@@ -152,7 +153,7 @@ async function executeQuests(interaction, sub) {
         }
 
         const embed = new EmbedBuilder()
-            .setColor('#2ecc71')
+            .setColor(COLORS.SUCCESS)
             .setTitle(`${template.emoji} Quest Complete — ${template.name}!`)
             .setDescription(template.description)
             .addFields(

--- a/src/commands/economy/hunt/shop.js
+++ b/src/commands/economy/hunt/shop.js
@@ -36,6 +36,7 @@ const { runShopBrowse } = require('../../../utils/shopBrowse');
 const { getItemImageAttachment } = require('../../../utils/itemImageHelper');
 const GrindProfile = require('../../../models/GrindProfile');
 const { ACTIVATABLE, chargeBalance, refundBalance } = require('./shared');
+const COLORS = require('../../../utils/embedColors');
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // SHOP (was /huntshop)
@@ -198,7 +199,7 @@ async function handleBuyWeapon(interaction, user, currency) {
         : 'None required';
 
     const confirmEmbed = new EmbedBuilder()
-        .setColor('#f39c12')
+        .setColor(COLORS.WARN)
         .setTitle(`${weaponData.emoji} Purchase ${weaponData.name}?`)
         .setDescription(weaponData.description)
         .addFields(
@@ -329,7 +330,7 @@ async function completePurchase(interactionOrBtn, user, weaponData, autoEquip, c
 
     const equipped = h.equippedWeaponIndex === newIndex;
     const embed = new EmbedBuilder()
-        .setColor('#2ecc71')
+        .setColor(COLORS.SUCCESS)
         .setTitle(`${weaponData.emoji} ${weaponData.name} Purchased!`)
         .setDescription(weaponData.description)
         .addFields(
@@ -402,7 +403,7 @@ async function handleBuyUpgrade(interaction, user, currency) {
     return interaction.reply({
         embeds: [
             new EmbedBuilder()
-                .setColor('#2ecc71')
+                .setColor(COLORS.SUCCESS)
                 .setTitle(`${upgradeDef.emoji} Upgrade Installed!`)
                 .setDescription(`**${upgradeDef.name}** has been installed on your **${weapon.name}**.`)
                 .addFields(
@@ -455,7 +456,7 @@ async function handleBuy(interaction, user, currency) {
         : `${quantity}× ${consumableDef.name}`;
 
     const confirmEmbed = new EmbedBuilder()
-        .setColor('#f39c12')
+        .setColor(COLORS.WARN)
         .setTitle(`${itemDef.emoji} Confirm Purchase`)
         .setDescription(itemDef.description ?? '')
         .addFields(
@@ -540,7 +541,7 @@ async function handleBuy(interaction, user, currency) {
             const ammoNote    = isAmmo ? `\nAmmo stock for **${ammoDef.ammoType.replace(/_/g, ' ')}**: ${h.ammo[ammoDef.ammoType]}` : '';
 
             const successEmbed = new EmbedBuilder()
-                .setColor('#2ecc71')
+                .setColor(COLORS.SUCCESS)
                 .setTitle(`${itemDef.emoji} Purchase Successful`)
                 .setDescription(`You bought **${finalGained}** for ${currency}${totalCost.toLocaleString()}.${ammoNote}`)
                 .addFields(
@@ -589,7 +590,7 @@ async function handleUse(interaction, user) {
     return interaction.reply({
         embeds: [
             new EmbedBuilder()
-                .setColor('#2ecc71')
+                .setColor(COLORS.SUCCESS)
                 .setTitle(`${def.emoji} ${def.name} Activated!`)
                 .setDescription(`${def.description}\n${statusMsg}`)
                 .setFooter({ text: 'Go hunt! Use /hunt start' })
@@ -639,7 +640,7 @@ async function handleRepair(interaction, user, currency) {
         return interaction.reply({
             embeds: [
                 new EmbedBuilder()
-                    .setColor('#2ecc71')
+                    .setColor(COLORS.SUCCESS)
                     .setTitle(`${kitDef.emoji} Repair Kit Used`)
                     .setDescription(`Your **${weapon.name}** has been field-repaired.`)
                     .addFields(
@@ -790,7 +791,7 @@ async function handleUnlock(interaction, user, currency) {
         .join(' · ');
 
     const unlockEmbed = new EmbedBuilder()
-        .setColor('#f39c12')
+        .setColor(COLORS.WARN)
         .setTitle(`${zone.emoji} Zone Unlocked: ${zone.name}!`)
         .setDescription(zone.description)
         .addFields(

--- a/src/commands/economy/hunt/start.js
+++ b/src/commands/economy/hunt/start.js
@@ -41,6 +41,7 @@ const { ZONES } = require('../../../data/huntData');
 const { saveWithBalanceDelta } = require('../../../utils/balanceDelta');
 const { pickApproachProfile, runAimPhase } = require('./aim');
 const { buildBonusLines, buildHuntEmbed } = require('./embeds');
+const { ownedBy } = require('../../../utils/collectorOwner');
 
 // ─── Staged loot reveal for rare+ drops ──────────────────────────────────────
 // tier: 'common'|'uncommon'|'rare'|'epic'|'legendary'|'event'|null
@@ -208,7 +209,7 @@ async function executeStart(interaction) {
 
             const pickedId = await new Promise(resolve => {
                 const col = huntMsg.createMessageComponentCollector({
-                    filter: i => i.user.id === interaction.user.id && i.customId.startsWith('stealth_'),
+                    filter: ownedBy(interaction.user.id, i => i.customId.startsWith('stealth_'), "This isn't your hunt."),
                     time: 15_000,
                     max: 1,
                 });
@@ -505,7 +506,7 @@ async function executeStart(interaction) {
                 const fetchReply = prevBtn ? await prevBtn.fetchReply() : await interaction.fetchReply();
                 return new Promise(resolve => {
                     const collector = fetchReply.createMessageComponentCollector({
-                        filter: i => i.user.id === interaction.user.id && validIds.includes(i.customId),
+                        filter: ownedBy(interaction.user.id, i => validIds.includes(i.customId), "This isn't your hunt."),
                         time: 30_000, max: 1
                     });
                     collector.on('collect', async btn => {

--- a/src/commands/economy/hunt/zone.js
+++ b/src/commands/economy/hunt/zone.js
@@ -9,6 +9,7 @@ const User = require('../../../models/User');
 const { attachGrind } = require('../../../utils/grindProfile');
 const { ensureHuntData } = require('../../../services/huntService');
 const { ZONE_LIST, ZONES } = require('../../../data/huntData');
+const COLORS = require('../../../utils/embedColors');
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // ZONE (was /huntzone)
@@ -50,7 +51,7 @@ async function executeZone(interaction, sub) {
         });
 
         const embed = new EmbedBuilder()
-            .setColor('#3498db')
+            .setColor(COLORS.INFO)
             .setTitle('🗺️ Hunting Zones')
             .setDescription(lines.join('\n\n'))
             .setFooter({ text: `Unlock new zones with /hunt shop unlock • Active zone: ${ZONES[h.activeZone]?.name ?? 'Unknown'} • Your level: ${h.level}` });
@@ -89,7 +90,7 @@ async function executeZone(interaction, sub) {
         return interaction.reply({
             embeds: [
                 new EmbedBuilder()
-                    .setColor('#2ecc71')
+                    .setColor(COLORS.SUCCESS)
                     .setTitle('🗺️ Zone Changed')
                     .setDescription(`Switched from **${oldZone?.emoji} ${oldZone?.name}** → **${zone.emoji} ${zone.name}**`)
                     .addFields(

--- a/src/commands/economy/inventory.js
+++ b/src/commands/economy/inventory.js
@@ -7,9 +7,17 @@ const { pruneEffects, EFFECT_CONFIGS, timeRemaining } = require('../../services/
 const { MATERIAL_RARITY, TIER_LABELS, TIER_STARS, TIER_COLORS } = require('../../data/materialRarity');
 const { getItemLore } = require('../../data/defaultShopItems');
 const { getRelicMeta } = require('../../data/exploreData');
-const { packFields } = require('../../utils/embedFields');
+const { packFieldsCapped, EMBED_LIMITS } = require('../../utils/embedFields');
 
 const TOTAL_MATERIALS = Object.keys(MATERIAL_RARITY).length;
+
+// Characters the item sections may spend between them. An embed's ceiling is
+// 6,000 across its title, description and every field — the second budget, the
+// one a per-field cap does not protect: four sections spilling into two 1,024
+// character fields each is 8,192 and a rejected embed, every field of which
+// was individually legal. What is left over from this covers the title, the
+// footer and the relic footnote.
+const SECTIONS_BUDGET = 4_200;
 
 const TAB_KEYS   = ['items', 'hunt', 'fish', 'mine', 'explore'];
 const TAB_LABELS = { items: '🎒 Items', hunt: '⚔️ Hunt', fish: '🎣 Fish', mine: '⛏️ Mine', explore: '🧭 Explore' };
@@ -91,6 +99,46 @@ function buildItemsEmbed(inventory, shopItems, activeEffects, currency, color, f
 
     let hasContent = false;
 
+    // The sections share one budget rather than each holding a fixed number of
+    // fields, and take an even slice of whatever is left when their turn comes
+    // — so a long shop list cannot starve the relics below it, while a player
+    // who only has relics gets the whole allowance for them. Never less than
+    // one field: a section that exists should be visible, even if only its
+    // first few entries are.
+    let budgetLeft = SECTIONS_BUDGET;
+    // Counted up front, effects included, so the last section to be added is
+    // still working from a share and not from whatever happens to be left.
+    let sectionsLeft = activeEffects.length ? 1 : 0;
+
+    /**
+     * Add one packed section to the embed, and say how much of it did not fit.
+     * Returns whether anything was added, for the sections that carry a
+     * footnote of their own.
+     */
+    const addSection = (name, lines, noun) => {
+        if (!lines.length) return false;
+
+        const share = Math.max(0, budgetLeft) / Math.max(1, sectionsLeft);
+        const { fields, omitted } = packFieldsCapped(name, lines, {
+            maxFields: Math.max(1, Math.floor(share / EMBED_LIMITS.FIELD_VALUE)),
+        });
+        embed.addFields(...fields);
+        budgetLeft  -= fields.reduce((n, f) => n + f.name.length + f.value.length, 0);
+        sectionsLeft = Math.max(0, sectionsLeft - 1);
+
+        if (omitted > 0) {
+            const note = {
+                name: `${name} — and more`,
+                value: `*${omitted} further ${noun}${omitted === 1 ? '' : 's'} not shown.*`,
+                inline: false,
+            };
+            embed.addFields(note);
+            budgetLeft -= note.name.length + note.value.length;
+        }
+        hasContent = true;
+        return true;
+    };
+
     if (inventory.length) {
         const shopLines  = [];
         const aiLines    = [];
@@ -123,23 +171,22 @@ function buildItemsEmbed(inventory, shopItems, activeEffects, currency, color, f
                 shopLines.push(`**${displayName}** ×${entry.quantity}${worth}${loreLine}`);
             }
         }
-        if (shopLines.length) {
-            embed.addFields({ name: '🛍️ Shop Items', value: shopLines.join('\n'), inline: false });
-            hasContent = true;
-        }
-        if (aiLines.length) {
-            embed.addFields({ name: '⚒️ Forged Items', value: aiLines.join('\n'), inline: false });
-            hasContent = true;
-        }
-        if (relicLines.length) {
-            // A full collection is 25 relics — well past one field's budget.
-            embed.addFields(...packFields('🏺 Relics', relicLines));
+        // Every one of these grows with what the player owns, and shop and
+        // forged items each carry a lore line on top of the entry — so an
+        // inventory does not have to be remarkable before one joined field is
+        // past 1,024 characters and discord.js throws the whole embed out.
+        // Relics were packed and these two were not, which is the same bug
+        // waiting in the section next to the fix.
+        sectionsLeft += [shopLines, aiLines, relicLines].filter(l => l.length).length;
+        addSection('🛍️ Shop Items',   shopLines,  'shop item');
+        addSection('⚒️ Forged Items', aiLines,    'forged item');
+        // A full collection is 25 relics — well past one field's budget.
+        if (addSection('🏺 Relics', relicLines, 'relic')) {
             embed.addFields({
                 name: '​',
                 value: '*Every distinct relic pays a standing bonus on exploration coins — see `/explore relics`.*',
                 inline: false,
             });
-            hasContent = true;
         }
     }
 
@@ -155,10 +202,7 @@ function buildItemsEmbed(inventory, shopItems, activeEffects, currency, color, f
             return `${cfg.emoji} **${cfg.label}** — ${durationStr}`;
         }).filter(Boolean);
 
-        if (lines.length) {
-            embed.addFields({ name: '✨ Active Effects', value: lines.join('\n'), inline: false });
-            hasContent = true;
-        }
+        addSection('✨ Active Effects', lines, 'active effect');
     }
 
     if (!hasContent) {
@@ -277,5 +321,7 @@ module.exports = {
                 components: [buildTabRow(activeTab, interaction.id, true)]
             }).catch(() => {});
         });
-    }
+    },
+
+    __test__: { buildItemsEmbed },
 };

--- a/src/commands/economy/inventory.js
+++ b/src/commands/economy/inventory.js
@@ -9,6 +9,7 @@ const { getItemLore } = require('../../data/defaultShopItems');
 const { getRelicMeta } = require('../../data/exploreData');
 const { packFieldsCapped, EMBED_LIMITS } = require('../../utils/embedFields');
 const COLORS = require('../../utils/embedColors');
+const { ownedBy } = require('../../utils/collectorOwner');
 
 const TOTAL_MATERIALS = Object.keys(MATERIAL_RARITY).length;
 
@@ -304,8 +305,11 @@ module.exports = {
 
         const collector = message.createMessageComponentCollector({
             componentType: ComponentType.Button,
-            filter: btn => btn.user.id === interaction.user.id
-                && TAB_KEYS.some(k => btn.customId === `inv_${k}_${interaction.id}`),
+            filter: ownedBy(
+                interaction.user.id,
+                btn => TAB_KEYS.some(k => btn.customId === `inv_${k}_${interaction.id}`),
+                "This isn't your inventory — run `/inventory` for your own.",
+            ),
             time: 120_000
         });
 

--- a/src/commands/economy/inventory.js
+++ b/src/commands/economy/inventory.js
@@ -8,6 +8,7 @@ const { MATERIAL_RARITY, TIER_LABELS, TIER_STARS, TIER_COLORS } = require('../..
 const { getItemLore } = require('../../data/defaultShopItems');
 const { getRelicMeta } = require('../../data/exploreData');
 const { packFieldsCapped, EMBED_LIMITS } = require('../../utils/embedFields');
+const COLORS = require('../../utils/embedColors');
 
 const TOTAL_MATERIALS = Object.keys(MATERIAL_RARITY).length;
 
@@ -274,7 +275,7 @@ module.exports = {
 
         if (!hasItems && !hasMaterials) {
             const emptyEmbed = new EmbedBuilder()
-                .setColor('#9e9e9e')
+                .setColor(COLORS.NEUTRAL)
                 .setTitle('🎒 Inventory — Empty')
                 .setDescription('Nothing here yet.\nTry `/hunt`, `/fish`, `/mine`, or `/explore` to find materials.')
                 .setThumbnail(target.displayAvatarURL({ dynamic: true }));

--- a/src/commands/economy/invest.js
+++ b/src/commands/economy/invest.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js'
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { logTransaction } = require('../../utils/logTransaction');
+const COLORS = require('../../utils/embedColors');
 
 const DISTRICTS = [
     {
@@ -117,7 +118,7 @@ module.exports = {
         // ── STATUS ──────────────────────────────────────────────────────────
         if (sub === 'status') {
             const embed = new EmbedBuilder()
-                .setColor('#f39c12')
+                .setColor(COLORS.WARN)
                 .setTitle('🏙️ Server Investment Districts')
                 .setDescription(
                     'Members collectively fund districts. When fully funded, the district activates its ' +
@@ -274,7 +275,7 @@ module.exports = {
                 const announceChannel = interaction.guild?.channels?.cache?.get(announceChannelId);
                 if (announceChannel) {
                     const broadcastEmbed = new EmbedBuilder()
-                        .setColor('#FFD700')
+                        .setColor(COLORS.PRIZE)
                         .setTitle(`🏙️ ${distMeta.emoji} ${distMeta.name} District — FUNDED!`)
                         .setDescription(
                             `The community invested and it paid off!\n\n` +

--- a/src/commands/economy/jobs.js
+++ b/src/commands/economy/jobs.js
@@ -3,6 +3,7 @@ const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const DEFAULT_JOBS = require('../../data/defaultJobs');
 const DEFAULT_TIERS = require('../../data/defaultTiers');
+const COLORS = require('../../utils/embedColors');
 
 const TIER_EMOJIS = { 1: '🟢', 2: '🔵', 3: '🟣', 4: '🟡' };
 
@@ -91,7 +92,7 @@ module.exports = {
             }
 
             const embed = new EmbedBuilder()
-                .setColor('#5865F2')
+                .setColor(COLORS.INFO)
                 .setTitle('📋 Job Listings')
                 .setDescription(header + body)
                 .setFooter({ text: footerText })

--- a/src/commands/economy/lovenote.js
+++ b/src/commands/economy/lovenote.js
@@ -10,6 +10,7 @@ const {
     addEventCurrency,
 } = require('../../services/seasonalEventService');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
+const COLORS = require('../../utils/embedColors');
 
 const COOLDOWN_MS    = 60 * 60 * 1000; // 1 hour
 const HEART_REWARD   = 5;              // event currency
@@ -118,7 +119,7 @@ module.exports = {
             };
 
             embed = new EmbedBuilder()
-                .setColor('#888888')
+                .setColor(COLORS.NEUTRAL)
                 .setTitle(`${rejection.emoji} AWKWARD!`)
                 .setDescription(
                     `**${rejection.name}**\n${rejection.description}\n\n` +

--- a/src/commands/economy/market.js
+++ b/src/commands/economy/market.js
@@ -11,6 +11,7 @@ const { DEFAULT_SHOP_ITEMS, getItemLore, getItemRarity, RARITY_ORDER } = require
 const { EFFECT_CONFIGS } = require('../../services/effectsService');
 const { logTransaction } = require('../../utils/logTransaction');
 const { grantInventoryItem } = require('../../utils/inventoryGrant');
+const COLORS = require('../../utils/embedColors');
 
 const ITEM_META = Object.fromEntries(DEFAULT_SHOP_ITEMS.map(i => [i.itemId, i]));
 
@@ -148,7 +149,7 @@ async function handleList(interaction, currency) {
     }
 
     const embed = new EmbedBuilder()
-        .setColor('#3498db')
+        .setColor(COLORS.INFO)
         .setTitle('📦 Item Listed!')
         .setDescription(`**${qty}x \`${itemId}\`** listed for **${currency}${price.toLocaleString()}** per unit.`)
         .addFields(
@@ -248,7 +249,7 @@ async function handleBrowse(interaction, currency) {
 
         const sortLabel = sortMode === SORT_RARITY ? '🏷️ Rarity sort' : '💰 Price sort';
         return new EmbedBuilder()
-            .setColor('#3498db')
+            .setColor(COLORS.INFO)
             .setTitle(title)
             .setDescription(lines.join('\n\n') || 'No listings.')
             .setFooter({ text: `Page ${safePage + 1}/${totalPages} · ${sorted.length} listings · 5% fee · ${sortLabel}` })
@@ -366,7 +367,7 @@ async function handleBuy(interaction, currency) {
 
         return editReply({
             embeds: [new EmbedBuilder()
-                .setColor('#2ecc71')
+                .setColor(COLORS.SUCCESS)
                 .setTitle('✅ Purchase Complete!')
                 .setDescription(`You bought **${listing.quantity}x \`${listing.itemId}\`** for **${currency}${totalCost.toLocaleString()}**.`)
                 .addFields(
@@ -389,7 +390,7 @@ async function handleBuy(interaction, currency) {
             new ButtonBuilder().setCustomId('mkt_buy_cancel').setLabel('Cancel').setStyle(ButtonStyle.Secondary),
         );
         const confirmEmbed = new EmbedBuilder()
-            .setColor('#f39c12')
+            .setColor(COLORS.WARN)
             .setTitle('🛒 Confirm Market Purchase')
             .setDescription(`Buy **${listing.quantity}x ${displayName}** for **${currency}${totalCost.toLocaleString()}**?`)
             .addFields(

--- a/src/commands/economy/market.js
+++ b/src/commands/economy/market.js
@@ -12,6 +12,7 @@ const { EFFECT_CONFIGS } = require('../../services/effectsService');
 const { logTransaction } = require('../../utils/logTransaction');
 const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const COLORS = require('../../utils/embedColors');
+const { ownedBy } = require('../../utils/collectorOwner');
 
 const ITEM_META = Object.fromEntries(DEFAULT_SHOP_ITEMS.map(i => [i.itemId, i]));
 
@@ -278,7 +279,7 @@ async function handleBrowse(interaction, currency) {
 
     const collector = msg.createMessageComponentCollector({
         componentType: ComponentType.Button,
-        filter: btn => btn.user.id === interaction.user.id,
+        filter: ownedBy(interaction.user.id, "This isn't your listing."),
         time: 3 * 60_000,
     });
 
@@ -403,7 +404,7 @@ async function handleBuy(interaction, currency) {
         const msg = await interaction.reply({ embeds: [confirmEmbed], components: [row], fetchReply: true });
         const collector = msg.createMessageComponentCollector({
             componentType: ComponentType.Button,
-            filter: i => i.user.id === interaction.user.id,
+            filter: ownedBy(interaction.user.id, "This isn't your listing."),
             time: 30_000,
             max: 1,
         });

--- a/src/commands/economy/mine/dig.js
+++ b/src/commands/economy/mine/dig.js
@@ -33,6 +33,7 @@ const { tryUpdateHourlyWinner, getCurrentHourlyLeader } = require('../../../util
 const { randomFrom, MINE_CAVE_LINES } = require('../../../utils/copyLines');
 const { PITY_COPY } = require('../../../utils/pityBonus');
 const { buildMineEmbed } = require('./embeds');
+const { ownedBy } = require('../../../utils/collectorOwner');
 
 // Presentation timings for the pre-dig prompt and the vein read. The ladder itself
 // and the promotion rule live with the rest of the mine's rules, in mineData and
@@ -243,7 +244,7 @@ async function handleDig(interaction) {
         if (!pickedIntensity) {
             const chosenId = await new Promise(resolve => {
                 const col = mineMsg.createMessageComponentCollector({
-                    filter: i => i.user.id === interaction.user.id && i.customId.startsWith('digint_'),
+                    filter: ownedBy(interaction.user.id, i => i.customId.startsWith('digint_'), "This isn't your dig."),
                     time: INTENSITY_PICK_MS,
                     max: 1,
                 });
@@ -295,7 +296,7 @@ async function handleDig(interaction) {
 
         const picked = await new Promise(resolve => {
             const col = mineMsg.createMessageComponentCollector({
-                filter: i => i.user.id === interaction.user.id && i.customId.startsWith('vein_'),
+                filter: ownedBy(interaction.user.id, i => i.customId.startsWith('vein_'), "This isn't your dig."),
                 time: VEIN_ANSWER_MS,
                 max: 1,
             });
@@ -374,7 +375,7 @@ async function handleDig(interaction) {
 
             const caveInChoice = await new Promise(resolve => {
                 const col = caveInMsg.createMessageComponentCollector({
-                    filter: i => i.user.id === interaction.user.id && i.customId.startsWith(caveInId),
+                    filter: ownedBy(interaction.user.id, i => i.customId.startsWith(caveInId), "This isn't your dig."),
                     time: 20_000,
                     max: 1,
                 });

--- a/src/commands/economy/mine/embeds.js
+++ b/src/commands/economy/mine/embeds.js
@@ -19,6 +19,7 @@ const { FEATURED_PAYOUT_BONUS } = require('../../../data/featuredRotation');
 const { stackBar } = require('../../../utils/rewardReveal');
 const { buildPityStreakField, PITY_COPY } = require('../../../utils/pityBonus');
 const { WILDERNESS_YIELD_BONUS } = require('./shared');
+const COLORS = require('../../../utils/embedColors');
 
 function prestigeBonusLines(bonus) {
     return [
@@ -145,7 +146,7 @@ function buildMineEmbed(result, user, depth, pickaxe, currency, _discordUser) {
 
     const { failure, xpEarned, levelUp } = result;
     const embed = new EmbedBuilder()
-        .setColor('#e74c3c')
+        .setColor(COLORS.ERROR)
         .setTitle(buildFailureTitle(failure.severity.id))
         .setDescription(`*${failure.message}*`)
         .addFields(

--- a/src/commands/economy/mine/inventory.js
+++ b/src/commands/economy/mine/inventory.js
@@ -9,6 +9,7 @@ const { attachGrind } = require('../../../utils/grindProfile');
 const { ensureMineData, durabilityBar, pickaxeStatusEmoji } = require('../../../services/mineService');
 const { packFieldsCapped } = require('../../../utils/embedFields');
 const { BLAST_PACKS, CONSUMABLES, MATERIAL_NAMES } = require('../../../data/mineData');
+const COLORS = require('../../../utils/embedColors');
 
 // ─── INV ──────────────────────────────────────────────────────────────────────
 
@@ -180,7 +181,7 @@ async function handleInv(interaction, sub) {
         return interaction.reply({
             embeds: [
                 new EmbedBuilder()
-                    .setColor('#e74c3c')
+                    .setColor(COLORS.ERROR)
                     .setTitle('🗑️ Pickaxe Discarded')
                     .setDescription(
                         `**${pickaxe.name}** has been discarded.` +

--- a/src/commands/economy/mine/inventory.js
+++ b/src/commands/economy/mine/inventory.js
@@ -7,7 +7,7 @@ const { MessageFlags, EmbedBuilder } = require('discord.js');
 const User = require('../../../models/User');
 const { attachGrind } = require('../../../utils/grindProfile');
 const { ensureMineData, durabilityBar, pickaxeStatusEmoji } = require('../../../services/mineService');
-const { packFields } = require('../../../utils/embedFields');
+const { packFieldsCapped } = require('../../../utils/embedFields');
 const { BLAST_PACKS, CONSUMABLES, MATERIAL_NAMES } = require('../../../data/mineData');
 
 // ─── INV ──────────────────────────────────────────────────────────────────────
@@ -48,14 +48,12 @@ async function handleInv(interaction, sub) {
             // but only so many: an embed also has a 6,000-character budget across all
             // of its fields, which unbounded spilling would eventually blow instead.
             const PICKAXE_FIELDS = 3;
-            const fields = packFields('🪓 Pickaxes', lines);
-            embed.addFields(...fields.slice(0, PICKAXE_FIELDS));
-            if (fields.length > PICKAXE_FIELDS) {
-                const shown = fields.slice(0, PICKAXE_FIELDS)
-                    .reduce((n, f) => n + f.value.split('\n').length / 2, 0);
+            const { fields, omitted } = packFieldsCapped('🪓 Pickaxes', lines, { maxFields: PICKAXE_FIELDS });
+            embed.addFields(...fields);
+            if (omitted > 0) {
                 embed.addFields({
                     name: '…and more',
-                    value: `${Math.max(0, m.pickaxes.length - Math.round(shown))} further pickaxe(s) not shown. \`/mine inv discard\` clears broken and condemned ones.`,
+                    value: `${omitted} further pickaxe(s) not shown. \`/mine inv discard\` clears broken and condemned ones.`,
                     inline: false
                 });
             }

--- a/src/commands/economy/mine/profile.js
+++ b/src/commands/economy/mine/profile.js
@@ -21,6 +21,7 @@ const { getActiveSynergies } = require('../../../services/synergyService');
 const GrindProfile = require('../../../models/GrindProfile');
 const { MAX_MINER_LEVEL, MAX_MINE_PRESTIGE, PRESTIGE_BADGES } = require('./shared');
 const { buildXpBar, prestigeBonusLines } = require('./embeds');
+const COLORS = require('../../../utils/embedColors');
 
 async function handlePrestige(interaction) {
     const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
@@ -43,7 +44,7 @@ async function handlePrestige(interaction) {
     if (prestige >= MAX_MINE_PRESTIGE) {
         return interaction.reply({
             embeds: [new EmbedBuilder()
-                .setColor('#f39c12')
+                .setColor(COLORS.WARN)
                 .setTitle(`${badge} Maximum Prestige`)
                 .setDescription(`You are a **P${prestige} Master Miner** — the deepest rank there is.`)
                 .addFields({ name: 'Your Bonuses', value: prestigeBonusLines(PRESTIGE_BONUSES[prestige]).join('\n') || 'None' })
@@ -80,7 +81,7 @@ async function handlePrestige(interaction) {
         .map(syn => `${syn.emoji} ${syn.name}`);
 
     const confirmEmbed = new EmbedBuilder()
-        .setColor('#f39c12')
+        .setColor(COLORS.WARN)
         .setTitle(`${nextBadge} Ascend to Prestige ${prestige + 1}?`)
         .setDescription(
             `You've reached **Miner Level ${MAX_MINER_LEVEL}**. Ascending is permanent and cannot be undone.\n\n` +
@@ -162,7 +163,7 @@ async function handlePrestige(interaction) {
                 m.xp       = 0;
 
                 const embed = new EmbedBuilder()
-                    .setColor('#f39c12')
+                    .setColor(COLORS.WARN)
                     .setTitle(`${nextBadge} Prestige ${prestige + 1} — ${getLevelData(1).title} Again`)
                     .setDescription(
                         `You climb back to the surface, hand in your papers, and start over as a **P${prestige + 1}** miner.\n` +

--- a/src/commands/economy/mine/quests.js
+++ b/src/commands/economy/mine/quests.js
@@ -10,6 +10,7 @@ const { ensureMineData, assignDailyMineQuests, applyXp, getLevelData } = require
 const { MINE_QUEST_TEMPLATES } = require('../../../data/mineData');
 const { saveWithBalanceDelta } = require('../../../utils/balanceDelta');
 const { buildProgressBar, formatExpiry } = require('./embeds');
+const COLORS = require('../../../utils/embedColors');
 
 // ─── QUESTS ───────────────────────────────────────────────────────────────────
 
@@ -148,7 +149,7 @@ async function handleQuests(interaction, sub) {
         }
 
         const embed = new EmbedBuilder()
-            .setColor('#2ecc71')
+            .setColor(COLORS.SUCCESS)
             .setTitle(`${template.emoji} Quest Complete — ${template.name}!`)
             .setDescription(template.description)
             .addFields(

--- a/src/commands/economy/mine/raid.js
+++ b/src/commands/economy/mine/raid.js
@@ -12,6 +12,7 @@ const { RAID_COOLDOWN_MS, RAID_SHIELD_MS, RAID_STEAL_MIN, RAID_STEAL_MAX, MATERI
 const GrindProfile = require('../../../models/GrindProfile');
 const { economyLockKey } = require('../../../utils/economyLock');
 const { tryAcquire: _lockAcquire, release: _lockRelease } = require('../../../utils/activeGameLock');
+const COLORS = require('../../../utils/embedColors');
 
 // ─── RAID ─────────────────────────────────────────────────────────────────────
 
@@ -92,7 +93,7 @@ async function handleRaid(interaction) {
             await raider.save().catch(() => null);
             return interaction.reply({
                 embeds: [new EmbedBuilder()
-                    .setColor('#e74c3c')
+                    .setColor(COLORS.ERROR)
                     .setTitle('🔒 Mine Lock Triggered!')
                     .setDescription(
                         `**${targetUser.username}**'s mine was protected by a **Mine Lock**.\n` +
@@ -242,7 +243,7 @@ async function handleRaid(interaction) {
 
     // Notify defender if possible
     const dmEmbed = new EmbedBuilder()
-        .setColor('#e74c3c')
+        .setColor(COLORS.ERROR)
         .setTitle('⚠️ Your Mine Was Raided!')
         .setDescription(
             `**${interaction.user.username}** broke into your mine on **${interaction.guild.name}** ` +

--- a/src/commands/economy/mine/shop.js
+++ b/src/commands/economy/mine/shop.js
@@ -30,6 +30,7 @@ const { runShopBrowse } = require('../../../utils/shopBrowse');
 const { getItemImageAttachment } = require('../../../utils/itemImageHelper');
 const GrindProfile = require('../../../models/GrindProfile');
 const { chargeBalance, refundBalance, resolveConsumableDef } = require('./shared');
+const COLORS = require('../../../utils/embedColors');
 
 // ─── SHOP ─────────────────────────────────────────────────────────────────────
 
@@ -145,7 +146,7 @@ async function handleShop(interaction, sub) {
         }
 
         const confirmEmbed = new EmbedBuilder()
-            .setColor('#f39c12')
+            .setColor(COLORS.WARN)
             .setTitle(`${pickaxeData.emoji} Purchase ${pickaxeData.name}?`)
             .addFields(
                 { name: 'Cost',          value: `${currency}${pickaxeData.cost.toLocaleString()}`, inline: true },
@@ -350,7 +351,7 @@ async function handleShop(interaction, sub) {
             : `${m.consumables[itemId] ?? 0}/${consumableDef.maxStack} in stock`;
 
         const confirmEmbed = new EmbedBuilder()
-            .setColor('#f39c12')
+            .setColor(COLORS.WARN)
             .setTitle(`${itemDef.emoji ?? '🛒'} Confirm Purchase`)
             .setDescription(itemDef.description ?? '')
             .addFields(
@@ -436,7 +437,7 @@ async function handleShop(interaction, sub) {
                 await interaction.editReply({
                     embeds: [
                         new EmbedBuilder()
-                            .setColor('#2ecc71')
+                            .setColor(COLORS.SUCCESS)
                             .setTitle('✅ Purchase Complete')
                             .setDescription(`Bought **${received}** for **${currency}${totalCost.toLocaleString()}**.`)
                             .addFields({ name: 'Balance', value: `${currency}${balanceUpdated.balance.toLocaleString()}`, inline: true })
@@ -478,7 +479,7 @@ async function handleShop(interaction, sub) {
         return interaction.reply({
             embeds: [
                 new EmbedBuilder()
-                    .setColor('#2ecc71')
+                    .setColor(COLORS.SUCCESS)
                     .setTitle(`${def?.emoji ?? '✅'} ${def?.name ?? itemId} Activated!`)
                     .setDescription(def?.description ?? 'Consumable activated.')
                     .setTimestamp()

--- a/src/commands/economy/pet.js
+++ b/src/commands/economy/pet.js
@@ -52,6 +52,7 @@ const { MATERIAL_RARITY } = require('../../data/materialRarity');
 const { checkAndAward, announceAchievements } = require('../../services/achievementService');
 const { onPetCare, notifyQuestComplete } = require('../../services/questService');
 const COLORS = require('../../utils/embedColors');
+const { ownedBy } = require('../../utils/collectorOwner');
 
 const NO_SUCH_PET = "Couldn't find that pet — pick one from the list `/pet status` shows, or start typing to choose from your pets.";
 const HUNGER_BAR_LENGTH = 10;
@@ -531,7 +532,7 @@ async function executeStatus(interaction) {
     });
 
     const collector = reply.createMessageComponentCollector({
-        filter: i => i.user.id === interaction.user.id,
+        filter: ownedBy(interaction.user.id, "This isn't your pet."),
         time:   90_000,
     });
 
@@ -847,7 +848,7 @@ async function executeRelease(interaction) {
     let choice;
     try {
         choice = await message.awaitMessageComponent({
-            filter: i => i.user.id === interaction.user.id && [confirmId, cancelId].includes(i.customId),
+            filter: ownedBy(interaction.user.id, i => [confirmId, cancelId].includes(i.customId), "This isn't your pet."),
             time: 30_000,
         });
     } catch {
@@ -1130,7 +1131,7 @@ async function pvpBattle(interaction, ctx) {
     const msg = await interaction.fetchReply();
 
     const collector = msg.createMessageComponentCollector({
-        filter: i => i.user.id === opponent.id && [acceptId, declineId].includes(i.customId),
+        filter: ownedBy(opponent.id, i => [acceptId, declineId].includes(i.customId), "This isn't your pet."),
         max: 1, time: 60_000,
     });
 

--- a/src/commands/economy/pet.js
+++ b/src/commands/economy/pet.js
@@ -51,6 +51,7 @@ const { saveWithBalanceDelta } = require('../../utils/balanceDelta');
 const { MATERIAL_RARITY } = require('../../data/materialRarity');
 const { checkAndAward, announceAchievements } = require('../../services/achievementService');
 const { onPetCare, notifyQuestComplete } = require('../../services/questService');
+const COLORS = require('../../utils/embedColors');
 
 const NO_SUCH_PET = "Couldn't find that pet — pick one from the list `/pet status` shows, or start typing to choose from your pets.";
 const HUNGER_BAR_LENGTH = 10;
@@ -482,7 +483,7 @@ async function executeAdopt(interaction) {
     const personalityDef = PERSONALITY_TRAITS[personality];
     const displayName = petName || def.name;
     const embed = new EmbedBuilder()
-        .setColor('#4caf50')
+        .setColor(COLORS.SUCCESS)
         .setTitle(`${def.emoji} New Pet Adopted!`)
         .setDescription(
             `Welcome **${displayName}** to your family! Take good care of them.\n\n` +
@@ -825,7 +826,7 @@ async function executeRelease(interaction) {
     const cancelId  = `pet_release_no:${interaction.id}`;
     const confirm = await interaction.reply({
         embeds: [new EmbedBuilder()
-            .setColor('#e74c3c')
+            .setColor(COLORS.ERROR)
             .setTitle(`Release ${name}?`)
             .setDescription(
                 `${getPetDisplay(pet).emoji} **${getPetDisplay(pet).titledName}** — Lv.${level}, ` +
@@ -1058,7 +1059,7 @@ async function wildBattle(interaction, user, myPetId, currency, guildSettings) {
 
     const da = getPetDisplay(mySnap), db = getPetDisplay(wild);
     const intro = new EmbedBuilder()
-        .setColor('#9b59b6')
+        .setColor(COLORS.RARE)
         .setTitle('⚔️ A wild challenger appears!')
         .setDescription(`${da.emoji} **${da.titledName}** squares off against ${db.emoji} **${db.name}** (Lv.${wild.level})…`);
     await interaction.editReply({ embeds: [intro] });
@@ -1108,7 +1109,7 @@ async function pvpBattle(interaction, ctx) {
     const acceptId  = `petb_accept_${interaction.id}`;
     const declineId = `petb_decline_${interaction.id}`;
     const challengeEmbed = new EmbedBuilder()
-        .setColor('#9b59b6')
+        .setColor(COLORS.RARE)
         .setTitle('⚔️ Pet Battle Challenge!')
         .setDescription(
             `${da.emoji} **${interaction.member?.displayName ?? interaction.user.username}'s ${da.titledName}** (Lv.${myPet.level ?? 1}) ` +
@@ -1135,17 +1136,17 @@ async function pvpBattle(interaction, ctx) {
 
     collector.on('collect', async i => {
         if (i.customId === declineId) {
-            return i.update({ content: null, embeds: [EmbedBuilder.from(challengeEmbed).setColor('#95a5a6').setDescription(`${opponent.username} declined the battle.`)], components: [] }).catch(() => {});
+            return i.update({ content: null, embeds: [EmbedBuilder.from(challengeEmbed).setColor(COLORS.NEUTRAL).setDescription(`${opponent.username} declined the battle.`)], components: [] }).catch(() => {});
         }
 
         // Escrow wagers atomically (challenger then opponent), refund on shortfall
         if (bet > 0) {
             const ch = await User.findOneAndUpdate({ userId: interaction.user.id, guildId, balance: { $gte: bet } }, { $inc: { balance: -bet } });
-            if (!ch) return i.update({ content: null, embeds: [EmbedBuilder.from(challengeEmbed).setColor('#e74c3c').setDescription(`${interaction.user.username} can no longer cover the wager.`)], components: [] }).catch(() => {});
+            if (!ch) return i.update({ content: null, embeds: [EmbedBuilder.from(challengeEmbed).setColor(COLORS.ERROR).setDescription(`${interaction.user.username} can no longer cover the wager.`)], components: [] }).catch(() => {});
             const op = await User.findOneAndUpdate({ userId: opponent.id, guildId, balance: { $gte: bet } }, { $inc: { balance: -bet } });
             if (!op) {
                 await User.updateOne({ userId: interaction.user.id, guildId }, { $inc: { balance: bet } });
-                return i.update({ content: null, embeds: [EmbedBuilder.from(challengeEmbed).setColor('#e74c3c').setDescription(`${opponent.username} can't cover the wager.`)], components: [] }).catch(() => {});
+                return i.update({ content: null, embeds: [EmbedBuilder.from(challengeEmbed).setColor(COLORS.ERROR).setDescription(`${opponent.username} can't cover the wager.`)], components: [] }).catch(() => {});
             }
         }
 
@@ -1170,7 +1171,7 @@ async function pvpBattle(interaction, ctx) {
                 if (rA.status === 'rejected') console.error('[pet battle] refund failed for challenger:', rA.reason);
                 if (rB.status === 'rejected') console.error('[pet battle] refund failed for opponent:', rB.reason);
             }
-            return interaction.editReply({ content: null, embeds: [EmbedBuilder.from(challengeEmbed).setColor('#e74c3c').setDescription(`${reason} — the battle was cancelled${bet > 0 ? ' and any wagers refunded' : ''}.`)], components: [] }).catch(() => {});
+            return interaction.editReply({ content: null, embeds: [EmbedBuilder.from(challengeEmbed).setColor(COLORS.ERROR).setDescription(`${reason} — the battle was cancelled${bet > 0 ? ' and any wagers refunded' : ''}.`)], components: [] }).catch(() => {});
         };
         if (!aPet || !bPet) return refundAndCancel('A pet is no longer available');
         if (!petUsable(aPet).ok || !petUsable(bPet).ok) return refundAndCancel('A pet is no longer battle-ready');
@@ -1182,7 +1183,7 @@ async function pvpBattle(interaction, ctx) {
         const aWon   = result.winner === 'a';
 
         const intro = new EmbedBuilder()
-            .setColor('#9b59b6').setTitle('⚔️ Battle commencing…')
+            .setColor(COLORS.RARE).setTitle('⚔️ Battle commencing…')
             .setDescription(`${getPetDisplay(aPet).emoji} **${getPetDisplay(aPet).titledName}**  🆚  ${getPetDisplay(bPet).emoji} **${getPetDisplay(bPet).titledName}**`);
         await interaction.editReply({ content: null, embeds: [intro], components: [] }).catch(() => {});
         await _delay(1800);
@@ -1271,7 +1272,7 @@ async function pvpBattle(interaction, ctx) {
 
     collector.on('end', (collected, reason) => {
         if (reason === 'time' && collected.size === 0) {
-            interaction.editReply({ content: null, embeds: [EmbedBuilder.from(challengeEmbed).setColor('#95a5a6').setDescription(`${opponent.username} didn't respond in time.`)], components: [] }).catch(() => {});
+            interaction.editReply({ content: null, embeds: [EmbedBuilder.from(challengeEmbed).setColor(COLORS.NEUTRAL).setDescription(`${opponent.username} didn't respond in time.`)], components: [] }).catch(() => {});
         }
     });
 }
@@ -1283,7 +1284,7 @@ async function executeList(interaction) {
                 + `Bonus: +${d.bonusPct}% ${d.bonusType.replace(/_/g, ' ')} → **+${(d.bonusPct * 2.5).toFixed(1)}%** at Lv.${PET_MAX_LEVEL}  |  Fave food: \`${d.favoriteMaterial}\``);
 
     const embed = new EmbedBuilder()
-        .setColor('#ff9800')
+        .setColor(COLORS.WARN)
         .setTitle('🐾 Pet Shop')
         .setDescription(`Pets level up from feeding and battling, and their passive grows with them.\n\n${lines.join('\n\n')}`)
         .setFooter({ text: `Eagle, Shark and Crystal Fox aren't sold — each has a ${Math.round(RARE_PET_DROP_CHANCE * 100)}% chance to appear on a legendary hunt / fish / mine` })
@@ -1347,7 +1348,7 @@ async function executeLeaderboard(interaction) {
     const lines  = top.map((e, i) => lineBuilder(e, medals[i] ?? `${i + 1}.`));
 
     const embed = new EmbedBuilder()
-        .setColor('#ff9800')
+        .setColor(COLORS.WARN)
         .setTitle(`🐾 Pet Leaderboard — ${titleLabel}`)
         .setDescription(lines.length > 0 ? lines.join('\n') : '*No pets in this server yet!*')
         .setFooter({ text: 'Pet of the Week is chosen weekly by most interactions • 🌟 = current POTW' })

--- a/src/commands/economy/prestige.js
+++ b/src/commands/economy/prestige.js
@@ -6,6 +6,7 @@ const {
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
 const COLORS = require('../../utils/embedColors');
+const { ownedBy } = require('../../utils/collectorOwner');
 const {
     PRESTIGE_TIERS, UNLOCK_LABELS, tierFor, titleForExactRank, nextTierAfter, badgeFor,
 } = require('../../utils/prestige');
@@ -142,7 +143,7 @@ async function handleUp(interaction) {
 
     const collector = msg.createMessageComponentCollector({
         componentType: ComponentType.Button,
-        filter: i => i.user.id === interaction.user.id,
+        filter: ownedBy(interaction.user.id, "This isn't your prestige confirmation."),
         time: CONFIRM_TIMEOUT_MS,
         max: 1,
     });

--- a/src/commands/economy/prestige.js
+++ b/src/commands/economy/prestige.js
@@ -5,6 +5,7 @@ const {
 } = require('discord.js');
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
+const COLORS = require('../../utils/embedColors');
 const {
     PRESTIGE_TIERS, UNLOCK_LABELS, tierFor, titleForExactRank, nextTierAfter, badgeFor,
 } = require('../../utils/prestige');
@@ -83,7 +84,7 @@ async function handleStatus(interaction) {
 async function handleInfo(interaction) {
     const lines = PRESTIGE_TIERS.filter(t => t.rank > 0).map(describeTier).join('\n\n');
     const embed = new EmbedBuilder()
-        .setColor('#9b59b6')
+        .setColor(COLORS.RARE)
         .setTitle('✨ Prestige Tiers')
         .setDescription(lines)
         .setFooter({ text: 'Each prestige resets your level to 0 but grants permanent bonuses and exclusive content.' })
@@ -120,7 +121,7 @@ async function handleUp(interaction) {
 
     // Confirmation prompt — prestige is irreversible.
     const confirmEmbed = new EmbedBuilder()
-        .setColor('#f39c12')
+        .setColor(COLORS.WARN)
         .setTitle('✨ Confirm Prestige')
         .setDescription(
             `You're about to **prestige to ${newTier.title || `Rank ${newRank}`}**.\n\n` +
@@ -187,7 +188,7 @@ async function handleUp(interaction) {
             ?? null;
         if (newRank > announcedRank && announceChannelId) {
             const ceremony = new EmbedBuilder()
-                .setColor('#FFD700')
+                .setColor(COLORS.PRIZE)
                 .setTitle('✨ A New Ascension')
                 .setDescription(
                     `<@${interaction.user.id}> has ascended to **${newTier.title || `Rank ${newRank}`}** ` +
@@ -212,7 +213,7 @@ async function handleUp(interaction) {
         }
 
         const doneEmbed = new EmbedBuilder()
-            .setColor('#FFD700')
+            .setColor(COLORS.PRIZE)
             .setTitle(`${badgeFor(newRank)} Welcome to ${newTier.title || `Rank ${newRank}`}`)
             .setDescription(
                 `Your level has been reset, but you carry forward:\n\n` +

--- a/src/commands/economy/quiz.js
+++ b/src/commands/economy/quiz.js
@@ -13,6 +13,7 @@ const Guild = require('../../models/Guild');
 const FALLBACK_QUESTIONS = require('../../data/quizFallback');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
 const { debitUpTo } = require('../../utils/balanceDebit');
+const COLORS = require('../../utils/embedColors');
 
 const THUMB         = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f393.png';
 const TIMER_SECONDS = 30;
@@ -181,7 +182,7 @@ function timeoutEmbed(interaction, question, correctAnswer, difficulty, penalty,
     return new EmbedBuilder()
         .setAuthor(embedAuthor(interaction))
         .setThumbnail(THUMB)
-        .setColor('#ff9900')
+        .setColor(COLORS.WARN)
         .setTitle('🎓 ⏱️ Time\'s Up!')
         .setDescription(`**${question}**\n\n*You ran out of time!*`)
         .addFields(

--- a/src/commands/economy/quiz.js
+++ b/src/commands/economy/quiz.js
@@ -14,6 +14,7 @@ const FALLBACK_QUESTIONS = require('../../data/quizFallback');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
 const { debitUpTo } = require('../../utils/balanceDebit');
 const COLORS = require('../../utils/embedColors');
+const { ownedBy } = require('../../utils/collectorOwner');
 
 const THUMB         = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f393.png';
 const TIMER_SECONDS = 30;
@@ -352,7 +353,7 @@ async function runQuizWithUser(interaction, diffChoice, user, guildSettings = nu
 
     const message   = await interaction.fetchReply();
     const collector = message.createMessageComponentCollector({
-        filter: i => i.user.id === interaction.user.id && i.customId === menuId,
+        filter: ownedBy(interaction.user.id, i => i.customId === menuId, "This isn't your quiz."),
         max:    1,
         time:   TIMER_SECONDS * 1000,
     });

--- a/src/commands/economy/rob.js
+++ b/src/commands/economy/rob.js
@@ -7,6 +7,7 @@ const { getTotalBonus } = require('../../services/petService');
 const { randomFrom, ROB_WIN_LINES, ROB_FAIL_LINES } = require('../../utils/copyLines');
 const { delay } = require('../../utils/delay');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
+const COLORS = require('../../utils/embedColors');
 
 const ROBBER_COOLDOWN_MS  = 1 * 3_600_000; // 1 hour
 const VICTIM_IMMUNITY_MS  = 30 * 60_000;   // 30 minutes
@@ -227,7 +228,7 @@ module.exports = {
                 await robber.save();
                 return interaction.reply({
                     embeds: [new EmbedBuilder()
-                        .setColor('#9b59b6')
+                        .setColor(COLORS.RARE)
                         .setTitle('🧥 Target Invisible!')
                         .setDescription(`**${target.username}** is wearing an Invisibility Cloak. You can't find them! (${timeRemaining(cloak?.expiresAt)} remaining)`)
                         .setFooter({ text: 'Cooldown: 1h' })
@@ -241,7 +242,7 @@ module.exports = {
                 await robber.save();
                 return interaction.reply({
                     embeds: [new EmbedBuilder()
-                        .setColor('#3498db')
+                        .setColor(COLORS.INFO)
                         .setTitle('🛡️ Robbery Blocked!')
                         .setDescription(`**${target.username}** blocked your robbery attempt with a Shield. (${timeRemaining(shield?.expiresAt)} remaining)`)
                         .setFooter({ text: 'Cooldown: 1h' })
@@ -331,14 +332,14 @@ module.exports = {
                     // Trap triggered: suspense then reveal the trap
                     await interaction.editReply({
                         embeds: [new EmbedBuilder()
-                            .setColor('#f39c12')
+                            .setColor(COLORS.WARN)
                             .setTitle('🦹 Successful Heist!')
                             .setDescription(`${randomFrom(ROB_WIN_LINES)} You took **${currency}${stolen.toLocaleString()}** from **${target.username}**.${bagNote}`)]
                     });
                     await delay(900);
 
                     embed = new EmbedBuilder()
-                        .setColor('#e74c3c')
+                        .setColor(COLORS.ERROR)
                         .setTitle('💥 TRAP TRIGGERED!')
                         .setDescription(
                             `**${target.username}** set a **Tripwire**!\n\n` +
@@ -360,7 +361,7 @@ module.exports = {
                         : null;
                     if (announceChannel?.isTextBased()) {
                         const trapAnnounce = new EmbedBuilder()
-                            .setColor('#e74c3c')
+                            .setColor(COLORS.ERROR)
                             .setTitle('🪤 Trap Sprung!')
                             .setDescription(
                                 `<@${target.id}>'s trap just caught <@${interaction.user.id}> red-handed!\n\n` +
@@ -371,7 +372,7 @@ module.exports = {
                     }
                 } else {
                     embed = new EmbedBuilder()
-                        .setColor('#f39c12')
+                        .setColor(COLORS.WARN)
                         .setTitle('🦹 Successful Heist!')
                         .setDescription(`${randomFrom(ROB_WIN_LINES)} You took **${currency}${stolen.toLocaleString()}** from **${target.username}**.${bagNote}`)
                         .addFields(
@@ -447,7 +448,7 @@ module.exports = {
                     await saveRobState(robber, victim, robberSnapshot, null, victimOrigBalance, victimOrigBank);
 
                     embed = new EmbedBuilder()
-                        .setColor('#e74c3c')
+                        .setColor(COLORS.ERROR)
                         .setTitle('🚔 Caught Red-Handed!')
                         .setDescription(`${randomFrom(ROB_FAIL_LINES)} **${target.username}** had you fined **${currency}${paid.toLocaleString()}**, which went straight to them.`)
                         .addFields(

--- a/src/commands/economy/robstatus.js
+++ b/src/commands/economy/robstatus.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js'
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { getPublicProtectionStatus, timeRemaining } = require('../../services/effectsService');
+const COLORS = require('../../utils/embedColors');
 
 const STATUS_COOLDOWN_MS = 2 * 60_000; // 2 minutes
 const VICTIM_IMMUNITY_MS = 30 * 60_000;
@@ -85,7 +86,7 @@ module.exports = {
         const myRate      = myTotal > 0 ? `${Math.round((mySuccesses / myTotal) * 100)}%` : '—';
 
         const embed = new EmbedBuilder()
-            .setColor('#9b59b6')
+            .setColor(COLORS.RARE)
             .setTitle(`🔍 Rob Status: ${target.username}`)
             .setDescription(lines.join('\n'))
             .addFields({

--- a/src/commands/economy/sandcastle.js
+++ b/src/commands/economy/sandcastle.js
@@ -10,6 +10,7 @@ const {
     addEventCurrency,
 } = require('../../services/seasonalEventService');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
+const COLORS = require('../../utils/embedColors');
 
 const COOLDOWN_MS   = 60 * 60 * 1000; // 1 hour
 const SHELL_REWARD  = 5;              // event currency
@@ -118,7 +119,7 @@ module.exports = {
             };
 
             embed = new EmbedBuilder()
-                .setColor('#1565c0')
+                .setColor(COLORS.ERROR)
                 .setTitle(`${wave.emoji} WIPED OUT!`)
                 .setDescription(
                     `**${wave.name}**\n${wave.description}\n\n` +
@@ -149,7 +150,7 @@ module.exports = {
             };
 
             embed = new EmbedBuilder()
-                .setColor('#ffd700')
+                .setColor(COLORS.PRIZE)
                 .setTitle(`${prize.emoji} BUILT! — ${prize.name}`)
                 .setDescription(
                     `Your sandcastle drew a crowd and won a **${prize.name}**!\n\n` +

--- a/src/commands/economy/season.js
+++ b/src/commands/economy/season.js
@@ -12,6 +12,7 @@ const { logTransaction } = require('../../utils/logTransaction');
 const { awardSeasonXp } = require('../../services/questService');
 const { saveWithBalanceDelta } = require('../../utils/balanceDelta');
 const { grantInventoryItem, inventoryAddStages } = require('../../utils/inventoryGrant');
+const { packFieldsCapped } = require('../../utils/embedFields');
 
 // Reset a user's season sub-document to the fresh shape when their stored
 // seasonId is stale (a new season started). Prevents carrying old xp / claimed
@@ -32,6 +33,10 @@ const { TIER_COUNT, XP_PER_TIER, TIER_TABLE, loreForTier } = require('../../data
 
 const MAX_TIERS = TIER_COUNT;
 const DEFAULT_PREMIUM_COST = 100_000;
+// Fields the seasonal event's milestone list may spill into before it is
+// cut short — the embed's other budget is 6,000 characters across all of
+// them, and this embed carries three more.
+const MILESTONE_FIELDS = 3;
 
 function tierDef(tier)     { return TIER_TABLE[tier - 1] ?? null; }
 function rewardFor(tier, premium) {
@@ -839,12 +844,17 @@ async function executeSeasonEvent(interaction) {
         ].join('\n');
     }
 
-    // Milestone list with ✅ / ▶ / ○ indicators
-    const milestoneList = milestones.map(m => {
+    // Milestone list with ✅ / ▶ / ○ indicators. Nothing caps how many
+    // milestones an event carries or how long an admin makes a label, so this
+    // is packed into as many fields as it needs rather than joined into one
+    // that Discord rejects at 1,024 characters.
+    const milestoneLines = milestones.map(m => {
         if (balance >= m.threshold) return `✅ ${m.threshold.toLocaleString()} ${currency.emoji} → ${m.label}`;
         if (m === nextMilestone)    return `▶ ${m.threshold.toLocaleString()} ${currency.emoji} → **${m.label}**  ← next`;
         return `○ ${m.threshold.toLocaleString()} ${currency.emoji} → ${m.label}`;
-    }).join('\n') || '*No milestones defined*';
+    });
+    const { fields: milestoneFields, omitted: milestonesOmitted } =
+        packFieldsCapped('🏆 Milestone Rewards', milestoneLines, { maxFields: MILESTONE_FIELDS });
 
     // Active multiplier info
     const bonusLines = [];
@@ -858,8 +868,19 @@ async function executeSeasonEvent(interaction) {
         .addFields(
             { name: `${currency.emoji} Your ${currency.name}`, value: `**${balance.toLocaleString()}**`, inline: true },
             { name: 'Season Progress', value: progressValue },
-            { name: '🏆 Milestone Rewards', value: milestoneList },
         );
+
+    if (milestoneFields.length) {
+        embed.addFields(...milestoneFields);
+        if (milestonesOmitted > 0) {
+            embed.addFields({
+                name: '🏆 Milestone Rewards — and more',
+                value: `*${milestonesOmitted} further milestone${milestonesOmitted === 1 ? '' : 's'} not shown.*`,
+            });
+        }
+    } else {
+        embed.addFields({ name: '🏆 Milestone Rewards', value: '*No milestones defined*' });
+    }
 
     if (bonusLines.length > 0) {
         embed.addFields({ name: '✨ Active Bonuses', value: bonusLines.join('\n') });

--- a/src/commands/economy/season.js
+++ b/src/commands/economy/season.js
@@ -30,6 +30,7 @@ function normalizeSeason(user, seasonId) {
 // Premium is unlocked with a large coin payment (/season unlock) — the economy's
 // primary deliberate money sink.
 const { TIER_COUNT, XP_PER_TIER, TIER_TABLE, loreForTier } = require('../../data/seasonPass');
+const COLORS = require('../../utils/embedColors');
 
 const MAX_TIERS = TIER_COUNT;
 const DEFAULT_PREMIUM_COST = 100_000;
@@ -347,7 +348,7 @@ async function executeUnlock(interaction) {
 
     const unlockedTier = getTierFromXp(unlocked.season?.xp ?? 0);
     const embed = new EmbedBuilder()
-        .setColor('#ffd700')
+        .setColor(COLORS.PRIZE)
         .setTitle('✨ Premium Season Pass Unlocked!')
         .setDescription(
             `You paid **${currency}${cost.toLocaleString()}** to unlock the **premium track** for **${season.name ?? 'this season'}**.\n\n` +
@@ -387,7 +388,7 @@ async function executeMissions(interaction) {
     resetAt.setUTCHours(24, 0, 0, 0);
 
     const embed = new EmbedBuilder()
-        .setColor('#5865f2')
+        .setColor(COLORS.INFO)
         .setTitle('📋 Daily Missions')
         .setDescription(missionLines.join('\n\n') || '*No missions generated*')
         .setFooter({ text: `Resets at midnight UTC` })
@@ -622,7 +623,7 @@ async function executeLeaderboard(interaction) {
         : '*No end date*';
 
     const embed = new EmbedBuilder()
-        .setColor('#ffd700')
+        .setColor(COLORS.PRIZE)
         .setTitle(`📊 Season Leaderboard — ${currentSeason.name ?? currentSeason.id}`)
         .setDescription(lines.join('\n'))
         .addFields({ name: '⏰ Season Ends', value: endsAt, inline: true })
@@ -654,7 +655,7 @@ async function executeSeasonMe(interaction) {
     }) + 1;
 
     const embed = new EmbedBuilder()
-        .setColor('#5865f2')
+        .setColor(COLORS.INFO)
         .setTitle(`📊 Your Season Stats — ${currentSeason.name ?? currentSeason.id}`)
         .addFields(
             { name: 'Season Rank', value: `#${rank}`, inline: true },
@@ -685,7 +686,7 @@ async function executeHistory(interaction) {
     }));
 
     const embed = new EmbedBuilder()
-        .setColor('#9e9e9e')
+        .setColor(COLORS.NEUTRAL)
         .setTitle('📜 Season History')
         .addFields(fields)
         .setTimestamp();
@@ -778,7 +779,7 @@ async function executeAdminEnd(interaction) {
     ).join('\n') || '*No participants*';
 
     const embed = new EmbedBuilder()
-        .setColor('#ffd700')
+        .setColor(COLORS.PRIZE)
         .setTitle(`🏁 Season Ended: ${currentSeason.name ?? currentSeason.id}`)
         .setDescription('The season leaderboard has been frozen and season coins have been reset.')
         .addFields({ name: '🏆 Final Top 3', value: winnerLines })
@@ -947,7 +948,7 @@ async function executeTierSkip(interaction) {
 
     const newTier = getTierFromXp(updatedUser.season?.xp ?? 0);
     const embed = new EmbedBuilder()
-        .setColor('#FFD700')
+        .setColor(COLORS.PRIZE)
         .setTitle('⏭️ Tier Skipped!')
         .setDescription(
             `Your Tier Skip Token was consumed.\n\n` +

--- a/src/commands/economy/shop.js
+++ b/src/commands/economy/shop.js
@@ -18,6 +18,7 @@ const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const { ensurePricingFields, trendBucket } = require('../../utils/dynamicPricing');
 const { hasUnlock } = require('../../utils/prestige');
 const COLORS = require('../../utils/embedColors');
+const { ownedBy } = require('../../utils/collectorOwner');
 
 const CONFIRM_THRESHOLD = 500;
 const NEW_ITEM_TTL_MS   = 48 * 3_600_000; // 48 hours
@@ -675,7 +676,7 @@ module.exports = {
 
                 const collector = msg.createMessageComponentCollector({
                     componentType: ComponentType.Button,
-                    filter: i => i.user.id === interaction.user.id,
+                    filter: ownedBy(interaction.user.id, "This isn't your purchase."),
                     time: 30_000,
                     max: 1
                 });

--- a/src/commands/economy/shop.js
+++ b/src/commands/economy/shop.js
@@ -17,6 +17,7 @@ const { logTransaction } = require('../../utils/logTransaction');
 const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const { ensurePricingFields, trendBucket } = require('../../utils/dynamicPricing');
 const { hasUnlock } = require('../../utils/prestige');
+const COLORS = require('../../utils/embedColors');
 
 const CONFIRM_THRESHOLD = 500;
 const NEW_ITEM_TTL_MS   = 48 * 3_600_000; // 48 hours
@@ -372,7 +373,7 @@ module.exports = {
                 : 'No recalcs yet — pricing will adjust on the next scheduled run.';
 
             const embed = new EmbedBuilder()
-                .setColor('#3498db')
+                .setColor(COLORS.INFO)
                 .setTitle('📊 Market Trends')
                 .setDescription(lines.length ? lines.join('\n') : 'No price movement yet.')
                 .setFooter({ text: `${recalcStr} · Volatility: ${guildSettings.dynamicPricing.volatility}` })
@@ -612,7 +613,7 @@ module.exports = {
                     ? `You bought ${boughtLabel} for ${currency}${freshTotal.toLocaleString()}.\n\n*${successLore}*`
                     : `You bought ${boughtLabel} for ${currency}${freshTotal.toLocaleString()}.`;
                 const successEmbed = new EmbedBuilder()
-                    .setColor('#00ff00')
+                    .setColor(COLORS.SUCCESS)
                     .setTitle('Purchase Successful')
                     .setDescription(successDesc)
                     .addFields({ name: 'New Balance', value: `${currency}${chargedUser.balance.toLocaleString()}`, inline: true });
@@ -647,7 +648,7 @@ module.exports = {
                     ? `Buy ${buyLabel} for **${currency}${totalCost.toLocaleString()}**?\n\n*${confirmLore}*`
                     : `Buy ${buyLabel} for **${currency}${totalCost.toLocaleString()}**?`;
                 const confirmEmbed = new EmbedBuilder()
-                    .setColor('#f39c12')
+                    .setColor(COLORS.WARN)
                     .setTitle('Confirm Purchase')
                     .setDescription(confirmDesc);
 

--- a/src/commands/economy/showcase.js
+++ b/src/commands/economy/showcase.js
@@ -3,6 +3,7 @@ const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { MATERIAL_RARITY, TIER_STARS, TIER_COLORS } = require('../../data/materialRarity');
 const { ACHIEVEMENTS } = require('../../data/achievements');
+const COLORS = require('../../utils/embedColors');
 
 const ACHIEVEMENT_BY_ID = Object.fromEntries(ACHIEVEMENTS.map(a => [a.id, a]));
 
@@ -90,7 +91,7 @@ module.exports = {
             const hasAnything = topAchs.length > 0 || allMaterials.length > 0;
             if (!hasAnything) {
                 const emptyEmbed = new EmbedBuilder()
-                    .setColor('#9e9e9e')
+                    .setColor(COLORS.NEUTRAL)
                     .setTitle(`✨ Showcase — ${target.username}`)
                     .setThumbnail(target.displayAvatarURL({ dynamic: true }))
                     .setDescription(

--- a/src/commands/economy/syndicate.js
+++ b/src/commands/economy/syndicate.js
@@ -25,6 +25,7 @@ const {
     computeSyndicateOutcome,
 } = require('../../services/syndicateService');
 const { hasUnlock } = require('../../utils/prestige');
+const COLORS = require('../../utils/embedColors');
 
 const CREATION_COST    = 50_000;
 const MAX_MEMBERS      = 10;
@@ -62,7 +63,7 @@ function buildLobbyEmbed(heist, synName, target) {
     const highHeat = heist.heatAtStart > 50;
 
     return new EmbedBuilder()
-        .setColor('#9b59b6')
+        .setColor(COLORS.RARE)
         .setTitle(`${target.emoji} Syndicate Heist — ${target.label}`)
         .setDescription(
             `**Syndicate:** ${synName}\n` +
@@ -119,7 +120,7 @@ async function sendSkillCheck(member, heistId, role) {
     const check = buildSkillCheck(roleMeta.skillType);
 
     const embed = new EmbedBuilder()
-        .setColor('#9b59b6')
+        .setColor(COLORS.RARE)
         .setTitle(`🔒 Syndicate Heist — ${roleMeta.emoji} ${roleMeta.label} Check`)
         .setDescription(
             `**Your role:** ${roleMeta.label}\n${roleMeta.desc}\n\n` +
@@ -467,7 +468,7 @@ async function executeCreate(interaction, guildDoc) {
     });
 
     const embed = new EmbedBuilder()
-        .setColor('#9b59b6')
+        .setColor(COLORS.RARE)
         .setTitle('🦹 Syndicate Founded!')
         .setDescription(
             `**${name}**${tag ? ` [${tag}]` : ''} is now operational.\n\n` +
@@ -519,7 +520,7 @@ async function executeJoin(interaction) {
     );
 
     const embed = new EmbedBuilder()
-        .setColor('#9b59b6')
+        .setColor(COLORS.RARE)
         .setTitle('🦹 Joined Syndicate')
         .setDescription(`You've joined **${synDoc.name}**${synDoc.tag ? ` [${synDoc.tag}]` : ''}! You are member ${synDoc.memberIds.length} of ${memberCap}.`)
         .setTimestamp();
@@ -678,7 +679,7 @@ async function executeInfo(interaction, guildDoc) {
     );
 
     const embed = new EmbedBuilder()
-        .setColor('#9b59b6')
+        .setColor(COLORS.RARE)
         .setTitle(`🦹 ${synDoc.name}${synDoc.tag ? ` [${synDoc.tag}]` : ''}`)
         .addFields(
             { name: '🌡️ Heat',              value: heatBar(effectiveHeat),                                                  inline: false },
@@ -714,7 +715,7 @@ async function executeLeaderboard(interaction, guildDoc) {
     });
 
     const embed = new EmbedBuilder()
-        .setColor('#f39c12')
+        .setColor(COLORS.WARN)
         .setTitle('🏆 Syndicate Leaderboard')
         .setDescription(lines.join('\n'))
         .setTimestamp();
@@ -798,7 +799,7 @@ async function executeHeist(interaction, guildDoc, client) {
         if (heist.players.size < effectiveMinPlayers) {
             await msg.edit({
                 embeds: [new EmbedBuilder()
-                    .setColor('#e74c3c')
+                    .setColor(COLORS.ERROR)
                     .setTitle('❌ Heist Cancelled')
                     .setDescription(`Not enough crew joined (need ${effectiveMinPlayers}, got ${heist.players.size}). **${synDoc.name}**'s operation is called off.`)
                     .setTimestamp()],
@@ -811,7 +812,7 @@ async function executeHeist(interaction, guildDoc, client) {
         endSyndicateLobby(heist.guildId);
         await msg.edit({
             embeds: [new EmbedBuilder()
-                .setColor('#9b59b6')
+                .setColor(COLORS.RARE)
                 .setTitle('🔓 Heist Underway!')
                 .setDescription('Lobby closed. Skill checks are being sent to each crew member via DM.\nResults will post here when everyone responds or time runs out.')
                 .setTimestamp()],
@@ -838,7 +839,7 @@ async function executeHeist(interaction, guildDoc, client) {
                     player.skillPassed = false;
                     await dm.edit({
                         embeds: [new EmbedBuilder()
-                            .setColor('#e74c3c')
+                            .setColor(COLORS.ERROR)
                             .setTitle("⏰ Time's up!")
                             .setDescription(`You ran out of time. The correct answer was **${check.correct}**.`)
                             .setTimestamp()],
@@ -897,7 +898,7 @@ async function executeSabotage(interaction, _guildDoc) {
     activeHeist.sabotageCount++;
 
     const embed = new EmbedBuilder()
-        .setColor('#e74c3c')
+        .setColor(COLORS.ERROR)
         .setTitle('⚡ Sabotage Deployed!')
         .setDescription(
             `**${synDoc.name}** has compromised **${rivalName}**'s ongoing heist!\n\n` +
@@ -946,7 +947,7 @@ async function executeUpgrade(interaction, guildDoc) {
 
     const currency = guildDoc?.economy?.currency ?? '💰';
     const embed = new EmbedBuilder()
-        .setColor('#9b59b6')
+        .setColor(COLORS.RARE)
         .setTitle(`${upgrade.emoji} Upgrade Purchased: ${upgrade.label}`)
         .setDescription(
             `**${synDoc.name}** has unlocked a new upgrade!\n\n` +

--- a/src/commands/economy/trackhunt.js
+++ b/src/commands/economy/trackhunt.js
@@ -10,6 +10,7 @@ const {
     addEventCurrency,
 } = require('../../services/seasonalEventService');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
+const COLORS = require('../../utils/embedColors');
 
 const COOLDOWN_MS    = 60 * 60 * 1000; // 1 hour
 const FROST_REWARD   = 5;              // event currency
@@ -118,7 +119,7 @@ module.exports = {
             };
 
             embed = new EmbedBuilder()
-                .setColor('#888888')
+                .setColor(COLORS.NEUTRAL)
                 .setTitle(`${lost.emoji} TRAIL LOST!`)
                 .setDescription(
                     `**${lost.name}**\n${lost.description}\n\n` +
@@ -149,7 +150,7 @@ module.exports = {
             };
 
             embed = new EmbedBuilder()
-                .setColor('#6ab4f5')
+                .setColor(COLORS.INFO)
                 .setTitle(`${find.emoji} FOUND! — ${find.name}`)
                 .setDescription(
                     `You followed the trail and turned up a **${find.name}**!\n\n` +

--- a/src/commands/economy/trap.js
+++ b/src/commands/economy/trap.js
@@ -4,6 +4,7 @@ const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js'
 const User  = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { logTransaction } = require('../../utils/logTransaction');
+const COLORS = require('../../utils/embedColors');
 
 const TRAP_COST     = 6_000;
 const TRAP_DURATION = 12 * 3_600_000; // 12 hours
@@ -100,7 +101,7 @@ module.exports = {
         });
 
         const embed = new EmbedBuilder()
-            .setColor('#f39c12')
+            .setColor(COLORS.WARN)
             .setTitle('🪤 Trap Set!')
             .setDescription(
                 `You've armed a **Tripwire** on your wallet.\n\n` +

--- a/src/commands/economy/use.js
+++ b/src/commands/economy/use.js
@@ -13,6 +13,7 @@ const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const { SEASONAL_EVENTS, RARITY_COLORS, rollLootBox } = require('../../data/seasonalEvents');
 const { PET_DEFINITIONS, MAX_SLOT_EXPANSIONS, petCapacity, hasFreePetSlot, countSlotPets } = require('../../services/petService');
 const { MAX_STAMINA_UPGRADES } = require('../../data/crossSystemData');
+const COLORS = require('../../utils/embedColors');
 
 // itemId of a seasonal loot box -> the event definition that owns it
 const LOOT_BOX_EVENTS = new Map(
@@ -122,7 +123,7 @@ module.exports = {
             await dropEmptyInventorySlots();
 
             const embed = new EmbedBuilder()
-                .setColor('#2ecc71')
+                .setColor(COLORS.SUCCESS)
                 .setTitle(`${cfg.emoji} Activated: ${cfg.label}`)
                 .setTimestamp();
 
@@ -175,7 +176,7 @@ module.exports = {
 
             const newFreezes = user.streak?.freezes ?? 0;
             const embed = new EmbedBuilder()
-                .setColor('#5dade2')
+                .setColor(COLORS.INFO)
                 .setTitle('🧊 Streak Freeze Banked')
                 .setDescription(
                     `One freeze is now stored. If you miss a daily, it auto-consumes to keep your streak alive.\n\n` +
@@ -296,7 +297,7 @@ module.exports = {
             await dropEmptyInventorySlots();
 
             const embed = new EmbedBuilder()
-                .setColor('#8e44ad')
+                .setColor(COLORS.RARE)
                 .setTitle('🐾 Pet Slot Added')
                 .setDescription(
                     `Room for one more companion.\n\n` +
@@ -461,7 +462,7 @@ module.exports = {
         const genericDesc = loreText ? `${baseDesc}\n\n> *${loreText}*` : baseDesc;
 
         const embed = new EmbedBuilder()
-            .setColor('#2ecc71')
+            .setColor(COLORS.SUCCESS)
             .setTitle(`✅ Used: ${shopItem?.name ?? itemName}`)
             .setDescription(genericDesc)
             .setTimestamp();

--- a/src/commands/economy/work.js
+++ b/src/commands/economy/work.js
@@ -18,6 +18,7 @@ const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
 const { ensureQuests, onEconomyEarn, notifyQuestComplete, notifyQuestNearComplete } = require('../../services/questService');
 const { saveWithBalanceDelta } = require('../../utils/balanceDelta');
 const { recordMissionProgress } = require('../../services/seasonMissionService');
+const { ownedBy } = require('../../utils/collectorOwner');
 
 function resolveTiers(guildSettings) {
     const saved = guildSettings?.jobTiers;
@@ -343,7 +344,7 @@ module.exports = {
                 try {
                     const response = await reply.awaitMessageComponent({
                         time: challenge.timeLimit,
-                        filter: i => i.user.id === interaction.user.id,
+                        filter: ownedBy(interaction.user.id, "This isn't your shift."),
                     });
                     responseRef = response;
                     await responseRef.deferUpdate();

--- a/src/commands/fun/coinflip.js
+++ b/src/commands/fun/coinflip.js
@@ -12,6 +12,7 @@ const { logTransaction } = require('../../utils/logTransaction');
 const { createReplaySession, replayButtonRow } = require('../../utils/replaySession');
 const { refundWager } = require('../../utils/refundWager');
 const { delay } = require('../../utils/delay');
+const COLORS = require('../../utils/embedColors');
 
 const HEADS_THUMB = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1fa99.png';
 
@@ -42,7 +43,7 @@ function spinningEmbed(interaction, frame, stakeLine = null) {
     return new EmbedBuilder()
         .setAuthor(embedAuthor(interaction))
         .setThumbnail(HEADS_THUMB)
-        .setColor('#f39c12')
+        .setColor(COLORS.WARN)
         .setTitle('🪙 Coin Flip')
         .setDescription(`${SPIN_FRAMES[frame % SPIN_FRAMES.length]} **Flipping…**${stakeLine ? `\n\n${stakeLine}` : ''}`)
         .setFooter({ text: 'Heads or Tails?' });
@@ -326,7 +327,7 @@ async function playVersusFlip(interaction, guildSettings, bet, opponent, challen
     const declineId = `cfv_decline_${interaction.id}`;
 
     const challengeEmbed = new EmbedBuilder()
-        .setColor('#f39c12')
+        .setColor(COLORS.WARN)
         .setThumbnail(HEADS_THUMB)
         .setTitle('🪙 Coinflip Challenge!')
         .setDescription(
@@ -442,7 +443,7 @@ async function playVersusFlip(interaction, guildSettings, bet, opponent, challen
             logTransaction({ userId: loserUser.id,  guildId, type: 'coinflip', amount: -bet, balance: loserDoc?.balance ?? 0, relatedUserId: winnerUser.id, note: `PvP coinflip loss (${result})` });
 
             const resultEmbedPvp = new EmbedBuilder()
-                .setColor('#2ecc71')
+                .setColor(COLORS.SUCCESS)
                 .setThumbnail(HEADS_THUMB)
                 .setTitle(result === HEADS ? '🪙 HEADS!' : '🪙 TAILS!')
                 .setDescription(

--- a/src/commands/fun/coinflip.js
+++ b/src/commands/fun/coinflip.js
@@ -13,6 +13,7 @@ const { createReplaySession, replayButtonRow } = require('../../utils/replaySess
 const { refundWager } = require('../../utils/refundWager');
 const { delay } = require('../../utils/delay');
 const COLORS = require('../../utils/embedColors');
+const { rejectOtherUser } = require('../../utils/collectorOwner');
 
 const HEADS_THUMB = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1fa99.png';
 
@@ -352,10 +353,18 @@ async function playVersusFlip(interaction, guildSettings, bet, opponent, challen
     }).catch(() => {});
 
     const collector = message.createMessageComponentCollector({
-        // Decline doubles as the challenger's cancel — misfiring a challenge at
-        // the wrong member otherwise leaves it live for the full minute.
-        filter: i => (i.user.id === opponent.id && [acceptId, declineId].includes(i.customId))
-                  || (i.user.id === interaction.user.id && i.customId === declineId),
+        filter: i => {
+            if (![acceptId, declineId].includes(i.customId)) return false;
+            // Decline doubles as the challenger's cancel — misfiring a
+            // challenge at the wrong member otherwise leaves it live for the
+            // full minute. Accept is the opponent's alone. Everyone else, and
+            // the challenger reaching for Accept, is told so rather than left
+            // looking at a click that failed.
+            const allowed = i.customId === declineId ? [opponent.id, interaction.user.id] : [opponent.id];
+            return !rejectOtherUser(i, allowed, i.user.id === interaction.user.id
+                ? `Only ${opponent} can accept — press Decline to call it off.`
+                : `That challenge is between ${interaction.user} and ${opponent}.`);
+        },
         max:    1,
         time:   ACCEPT_TIMEOUT_MS,
     });

--- a/src/commands/fun/meme.js
+++ b/src/commands/fun/meme.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const axios = require('axios');
 const { checkImageRateLimit } = require('../../utils/imageRateLimit');
+const COLORS = require('../../utils/embedColors');
 
 const TEMPLATES = [
     { name: 'Drake',                  value: '181913649' },
@@ -108,7 +109,7 @@ module.exports = {
 function buildEmbed(interaction, url, templateId) {
     const name = TEMPLATES.find(t => t.value === templateId)?.name || 'Meme';
     return new EmbedBuilder()
-        .setColor('#ff6b6b')
+        .setColor(COLORS.ERROR)
         .setTitle(`🎭 ${name}`)
         .setImage(url)
         .setFooter({

--- a/src/commands/fun/roll.js
+++ b/src/commands/fun/roll.js
@@ -9,6 +9,7 @@ const { logTransaction } = require('../../utils/logTransaction');
 const { createReplaySession, replayButtonRow } = require('../../utils/replaySession');
 const { refundWager } = require('../../utils/refundWager');
 const { delay } = require('../../utils/delay');
+const COLORS = require('../../utils/embedColors');
 
 const THUMB = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3b2.png';
 
@@ -216,7 +217,7 @@ async function playRollBet(interaction, guildSettings, sides, bet, call) {
             embeds: [new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
                 .setThumbnail(THUMB)
-                .setColor('#5865F2')
+                .setColor(COLORS.INFO)
                 .setTitle('🎲 Dice Roll')
                 .setDescription(`🎲 **Rolling…**\n\n${stakeLine}`)
                 .setFooter({ text: `d${sides}` })],

--- a/src/commands/leveling/leaderboard.js
+++ b/src/commands/leveling/leaderboard.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js'
 const User = require('../../models/User');
 const Guild = require('../../models/Guild');
 const { netWorthOf, topByNetWorth, netWorthRank } = require('../../utils/netWorth');
+const COLORS = require('../../utils/embedColors');
 
 // A leaderboard page prints ten names and one number each. Hydrating whole user
 // documents to do it dragged the pet, inventory, achievement and quest arrays
@@ -104,7 +105,7 @@ module.exports = {
             }
 
             const embed = new EmbedBuilder()
-                .setColor('#ffd700')
+                .setColor(COLORS.PRIZE)
                 .setTitle(`${title} — ${interaction.guild.name}`)
                 .setTimestamp();
 

--- a/src/commands/leveling/rank.js
+++ b/src/commands/leveling/rank.js
@@ -6,6 +6,7 @@ const { createRankCard } = require('../../utils/cardGenerator');
 const { pruneEffects, EFFECT_CONFIGS, timeRemaining, getServerCoinMultiplier, getServerXpMultiplier } = require('../../services/effectsService');
 const { badgeFor, titleForExactRank: prestigeTitle } = require('../../utils/prestige');
 const { tierFor: eloTierFor, START_ELO } = require('../../utils/duelElo');
+const COLORS = require('../../utils/embedColors');
 
 const BOOSTER_TYPES  = new Set(['coin_booster_2x', 'xp_booster_2x', 'lucky_streak', 'salary_raise']);
 const BOOST_TYPES    = new Set(['coin_booster_2x', 'xp_booster_2x']);
@@ -113,18 +114,18 @@ module.exports = {
                     lines.push(`${cfg.emoji} **${cfg.label}** — ${timeRemaining(e.expiresAt)}`);
                 }
                 const boosterEmbed = new EmbedBuilder()
-                    .setColor('#f39c12')
+                    .setColor(COLORS.WARN)
                     .addFields({ name: '🚀 Active Boosters', value: lines.join('\n'), inline: false });
                 if (identityField) boosterEmbed.addFields(identityField);
                 if (xpHint) boosterEmbed.setFooter({ text: xpHint });
                 await interaction.reply({ files: [attachment], embeds: [boosterEmbed] });
             } else if (identityField) {
-                const idEmbed = new EmbedBuilder().setColor('#9b59b6').addFields(identityField);
+                const idEmbed = new EmbedBuilder().setColor(COLORS.RARE).addFields(identityField);
                 if (xpHint) idEmbed.setFooter({ text: xpHint });
                 await interaction.reply({ files: [attachment], embeds: [idEmbed] });
             } else if (xpHint) {
                 const hintEmbed = new EmbedBuilder()
-                    .setColor('#95a5a6')
+                    .setColor(COLORS.NEUTRAL)
                     .setFooter({ text: xpHint });
                 await interaction.reply({ files: [attachment], embeds: [hintEmbed] });
             } else {

--- a/src/commands/leveling/setlevel.js
+++ b/src/commands/leveling/setlevel.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
 const Guild = require('../../models/Guild');
+const COLORS = require('../../utils/embedColors');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -73,7 +74,7 @@ module.exports = {
         }
 
         const embed = new EmbedBuilder()
-            .setColor('#5865F2')
+            .setColor(COLORS.INFO)
             .setTitle('Level Assigned')
             .setDescription(`${targetUser} has been set to **level ${newLevel}**.`)
             .addFields(

--- a/src/commands/leveling/xpinfo.js
+++ b/src/commands/leveling/xpinfo.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const Guild = require('../../models/Guild');
+const COLORS = require('../../utils/embedColors');
 
 const XP_COOLDOWN_SECONDS = 60;
 const FIELD_LIMIT = 1024;
@@ -52,7 +53,7 @@ module.exports = {
                 : 'You are currently earning XP normally.';
 
             const embed = new EmbedBuilder()
-                .setColor('#3498db')
+                .setColor(COLORS.INFO)
                 .setTitle(`📊 XP Settings for ${interaction.guild.name}`)
                 .addFields(
                     { name: 'XP Rate', value: xpRateLabel, inline: true },

--- a/src/commands/moderation/appeal.js
+++ b/src/commands/moderation/appeal.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js'
 const { getCase } = require('../../services/caseService');
 const Case = require('../../models/Case');
 const Guild = require('../../models/Guild');
+const COLORS = require('../../utils/embedColors');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -70,7 +71,7 @@ module.exports = {
             if (!channel || !channel.isTextBased()) return;
 
             const embed = new EmbedBuilder()
-                .setColor('#5865F2')
+                .setColor(COLORS.INFO)
                 .setTitle(`Appeal Filed — Case #${caseId}`)
                 .addFields(
                     { name: 'User', value: `${interaction.user.globalName ?? interaction.user.username} (<@${interaction.user.id}>)`, inline: true },

--- a/src/commands/moderation/ban.js
+++ b/src/commands/moderation/ban.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, MessageFlags } =
 const { logModeration } = require('../../services/moderationLogService');
 const { hierarchyDenial, resolveMember } = require('../../utils/moderationHierarchy');
 const TempBan = require('../../models/TempBan');
+const COLORS = require('../../utils/embedColors');
 
 const DURATION_RE = /^(\d+)(m|h|d)$/i;
 
@@ -109,7 +110,7 @@ module.exports = {
             await interaction.guild.members.ban(user, { deleteMessageSeconds: deleteDays * 86400, reason });
 
             const embed = new EmbedBuilder()
-                .setColor('#ff0000')
+                .setColor(COLORS.ERROR)
                 .setTitle(durationMs ? 'User Temporarily Banned' : 'User Banned')
                 .setDescription(`**${user.globalName ?? user.username}** has been banned from the server.`)
                 .addFields(

--- a/src/commands/moderation/cases.js
+++ b/src/commands/moderation/cases.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, MessageFlags } = require('discord.js');
 const { getCasesForUser } = require('../../services/caseService');
+const COLORS = require('../../utils/embedColors');
 
 const TYPE_EMOJI = {
     ban: '🔨', kick: '👢', mute: '🔇', warn: '⚠️',
@@ -35,7 +36,7 @@ module.exports = {
         );
 
         const embed = new EmbedBuilder()
-            .setColor('#5865F2')
+            .setColor(COLORS.INFO)
             .setTitle(`Cases for ${user.globalName ?? user.username}`)
             .setThumbnail(user.displayAvatarURL())
             .setDescription(lines.join('\n'))

--- a/src/commands/moderation/closecase.js
+++ b/src/commands/moderation/closecase.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, MessageFlags } = require('discord.js');
 const { closeCase, getCase } = require('../../services/caseService');
+const COLORS = require('../../utils/embedColors');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -29,7 +30,7 @@ module.exports = {
         await closeCase(interaction.guild.id, caseId, interaction.user.id, resolution);
 
         const embed = new EmbedBuilder()
-            .setColor('#00ff00')
+            .setColor(COLORS.SUCCESS)
             .setTitle(`Case #${caseId} Closed`)
             .addFields(
                 { name: 'Target', value: `<@${modCase.targetUserId}>`, inline: true },

--- a/src/commands/moderation/kick.js
+++ b/src/commands/moderation/kick.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, MessageFlags } = require('discord.js');
 const { logModeration } = require('../../services/moderationLogService');
 const { hierarchyDenial } = require('../../utils/moderationHierarchy');
+const COLORS = require('../../utils/embedColors');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -46,7 +47,7 @@ module.exports = {
             await member.kick(reason);
 
             const embed = new EmbedBuilder()
-                .setColor('#ff9900')
+                .setColor(COLORS.WARN)
                 .setTitle('User Kicked')
                 .setDescription(`**${user.globalName ?? user.username}** has been kicked from the server.`)
                 .addFields(

--- a/src/commands/moderation/mute.js
+++ b/src/commands/moderation/mute.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, MessageFlags } = require('discord.js');
 const { logModeration } = require('../../services/moderationLogService');
 const { hierarchyDenial } = require('../../utils/moderationHierarchy');
+const COLORS = require('../../utils/embedColors');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -49,7 +50,7 @@ module.exports = {
             await member.timeout(duration * 60 * 1000, reason);
 
             const embed = new EmbedBuilder()
-                .setColor('#ff6600')
+                .setColor(COLORS.WARN)
                 .setTitle('User Muted')
                 .setDescription(`**${user.globalName ?? user.username}** has been muted.`)
                 .addFields(

--- a/src/commands/moderation/note.js
+++ b/src/commands/moderation/note.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, MessageFlags } = require('discord.js');
 const { addNote, getCase } = require('../../services/caseService');
 const Case = require('../../models/Case');
+const COLORS = require('../../utils/embedColors');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -40,7 +41,7 @@ module.exports = {
         }
 
         const embed = new EmbedBuilder()
-            .setColor('#888888')
+            .setColor(COLORS.NEUTRAL)
             .setTitle(`Note added to Case #${caseId}`)
             .addFields({ name: 'Note', value: text });
 

--- a/src/commands/moderation/softban.js
+++ b/src/commands/moderation/softban.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, MessageFlags } = require('discord.js');
 const { logModeration } = require('../../services/moderationLogService');
 const { hierarchyDenial, resolveMember } = require('../../utils/moderationHierarchy');
+const COLORS = require('../../utils/embedColors');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -75,7 +76,7 @@ module.exports = {
         }
 
         const embed = new EmbedBuilder()
-            .setColor('#ff9900')
+            .setColor(COLORS.WARN)
             .setTitle('User Softbanned')
             .setDescription(`**${user.globalName ?? user.username}** has been softbanned — their last ${deleteDays} day(s) of messages were removed and they may rejoin.`)
             .addFields(

--- a/src/commands/moderation/unban.js
+++ b/src/commands/moderation/unban.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, MessageFlags } = require('discord.js');
 const { logModeration } = require('../../services/moderationLogService');
+const COLORS = require('../../utils/embedColors');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -36,7 +37,7 @@ module.exports = {
             await interaction.guild.members.unban(userId, reason);
 
             const embed = new EmbedBuilder()
-                .setColor('#00ff00')
+                .setColor(COLORS.SUCCESS)
                 .setTitle('User Unbanned')
                 .setDescription(`**${ban.user.globalName ?? ban.user.username}** has been unbanned.`)
                 .addFields(

--- a/src/commands/moderation/unmute.js
+++ b/src/commands/moderation/unmute.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, MessageFlags } = require('discord.js');
+const COLORS = require('../../utils/embedColors');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -24,7 +25,7 @@ module.exports = {
             await member.timeout(null);
 
             const embed = new EmbedBuilder()
-                .setColor('#00ff00')
+                .setColor(COLORS.SUCCESS)
                 .setTitle('User Unmuted')
                 .setDescription(`**${user.globalName ?? user.username}** has been unmuted.`)
                 .setTimestamp();

--- a/src/commands/moderation/warn.js
+++ b/src/commands/moderation/warn.js
@@ -5,6 +5,7 @@ const { applyEscalation, findStepForCount } = require('../../services/escalation
 const Guild = require('../../models/Guild');
 const User = require('../../models/User');
 const { fitDescription, truncate, EMBED_LIMITS } = require('../../utils/embedFields');
+const COLORS = require('../../utils/embedColors');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -70,7 +71,7 @@ module.exports = {
                     : null;
 
                 const embed = new EmbedBuilder()
-                    .setColor('#ffff00')
+                    .setColor(COLORS.WARN)
                     .setTitle('User Warned')
                     .setDescription(`**${user.globalName ?? user.username}** has been warned.`)
                     .addFields(
@@ -102,7 +103,7 @@ module.exports = {
                     if (result?.applied) {
                         await interaction.followUp({
                             embeds: [new EmbedBuilder()
-                                .setColor('#cc3300')
+                                .setColor(COLORS.WARN)
                                 .setTitle('Auto-Escalation Triggered')
                                 .setDescription(`Threshold **${result.step.threshold}** reached — applied **${result.step.action.toUpperCase()}**${result.step.durationMinutes ? ` for ${result.step.durationMinutes} minute(s)` : ''}.`)
                                 .addFields({ name: 'Target', value: `${user.globalName ?? user.username}`, inline: true })
@@ -155,7 +156,7 @@ module.exports = {
                 const { text, omitted } = fitDescription(lines);
 
                 const embed = new EmbedBuilder()
-                    .setColor('#ffff00')
+                    .setColor(COLORS.WARN)
                     .setTitle(`Warnings for ${user.globalName ?? user.username}`)
                     .setDescription(text)
                     .setFooter({ text: `${warnings.length - omitted} of ${warnings.length} warning(s) shown · use /warn remove <case_id> to clear one` })
@@ -185,7 +186,7 @@ module.exports = {
                 await Case.deleteOne({ _id: warnCase._id });
 
                 const embed = new EmbedBuilder()
-                    .setColor('#00ff00')
+                    .setColor(COLORS.SUCCESS)
                     .setTitle('Warning Removed')
                     .setDescription(`Case **#${caseId}** has been deleted.`)
                     .addFields(

--- a/src/commands/moderation/warn.js
+++ b/src/commands/moderation/warn.js
@@ -4,6 +4,7 @@ const { logModeration } = require('../../services/moderationLogService');
 const { applyEscalation, findStepForCount } = require('../../services/escalationService');
 const Guild = require('../../models/Guild');
 const User = require('../../models/User');
+const { fitDescription, truncate, EMBED_LIMITS } = require('../../utils/embedFields');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -73,7 +74,7 @@ module.exports = {
                     .setTitle('User Warned')
                     .setDescription(`**${user.globalName ?? user.username}** has been warned.`)
                     .addFields(
-                        { name: 'Reason', value: reason },
+                        { name: 'Reason', value: truncate(reason, EMBED_LIMITS.FIELD_VALUE) },
                         { name: 'Total Warnings', value: warningCount.toString() },
                         { name: 'Moderator', value: interaction.user.globalName ?? interaction.user.username }
                     )
@@ -139,16 +140,25 @@ module.exports = {
                     return interaction.reply({ content: `${user.globalName ?? user.username} has no warnings.`, flags: MessageFlags.Ephemeral });
                 }
 
+                // `reason` is a required string option with no length cap, so
+                // it arrives at up to Discord's own 6,000-character ceiling —
+                // one long-winded warning was enough to put this list past the
+                // 4,096 an embed description allows, and discord.js throws
+                // rather than truncating. Cap each line, then drop whole lines
+                // off the end and say how many, so a moderator sees the recent
+                // warnings instead of an error.
+                const PER_WARNING = 300;
                 const lines = warnings.map(w => {
                     const date = w.createdAt.toISOString().slice(0, 10);
-                    return `**#${w.caseId}** \`${date}\` — ${w.reason}`;
+                    return truncate(`**#${w.caseId}** \`${date}\` — ${w.reason}`, PER_WARNING);
                 });
+                const { text, omitted } = fitDescription(lines);
 
                 const embed = new EmbedBuilder()
                     .setColor('#ffff00')
                     .setTitle(`Warnings for ${user.globalName ?? user.username}`)
-                    .setDescription(lines.join('\n'))
-                    .setFooter({ text: `${warnings.length} warning(s) shown · use /warn remove <case_id> to clear one` })
+                    .setDescription(text)
+                    .setFooter({ text: `${warnings.length - omitted} of ${warnings.length} warning(s) shown · use /warn remove <case_id> to clear one` })
                     .setTimestamp();
 
                 await interaction.reply({ embeds: [embed] });
@@ -179,7 +189,7 @@ module.exports = {
                     .setTitle('Warning Removed')
                     .setDescription(`Case **#${caseId}** has been deleted.`)
                     .addFields(
-                        { name: 'Original Reason', value: warnCase.reason },
+                        { name: 'Original Reason', value: truncate(warnCase.reason, EMBED_LIMITS.FIELD_VALUE) },
                         { name: 'Removed by', value: interaction.user.globalName ?? interaction.user.username }
                     )
                     .setTimestamp();

--- a/src/commands/utility/avatar.js
+++ b/src/commands/utility/avatar.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const COLORS = require('../../utils/embedColors');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -12,7 +13,7 @@ module.exports = {
         const user = interaction.options.getUser('user') || interaction.user;
 
         const embed = new EmbedBuilder()
-            .setColor('#00ff00')
+            .setColor(COLORS.INFO)
             .setTitle(`${user.username}'s Avatar`)
             .setImage(user.displayAvatarURL({ dynamic: true, size: 1024 }))
             .setTimestamp();

--- a/src/commands/utility/giveaway.js
+++ b/src/commands/utility/giveaway.js
@@ -3,6 +3,7 @@ const Guild = require('../../models/Guild');
 // Drawing, ending and entrant handling live in the service — `/giveaway end`
 // and the scheduled sweep are two callers of one operation (#614).
 const { endGiveaway, parseDuration, pickWinners, getEntrants } = require('../../services/giveawayService');
+const COLORS = require('../../utils/embedColors');
 
 const GIVEAWAY_EMOJI = '🎉';
 
@@ -51,7 +52,7 @@ module.exports = {
             const endsAt = new Date(Date.now() + durationMs);
 
             const embed = new EmbedBuilder()
-                .setColor('#FFD700')
+                .setColor(COLORS.PRIZE)
                 .setTitle(`${GIVEAWAY_EMOJI} GIVEAWAY ${GIVEAWAY_EMOJI}`)
                 .setDescription(`**Prize:** ${prize}\n\nClick the button below to enter!`)
                 .addFields(

--- a/src/commands/utility/help.js
+++ b/src/commands/utility/help.js
@@ -11,6 +11,7 @@ const {
 // The catalog is derived from the commands this process actually loaded, not
 // from a list kept alongside them — see utils/helpCatalog.js for why (#665).
 const { buildCategories } = require('../../utils/helpCatalog');
+const { ownedBy } = require('../../utils/collectorOwner');
 
 const TIMEOUT_MS = 3 * 60 * 1000;
 const PAGE_SIZE = 10;
@@ -126,7 +127,7 @@ module.exports = {
         const message = await interaction.fetchReply();
 
         const collector = message.createMessageComponentCollector({
-            filter: i => i.user.id === interaction.user.id,
+            filter: ownedBy(interaction.user.id, "This isn't your help menu — run `/help` for your own."),
             time: TIMEOUT_MS,
         });
 

--- a/src/commands/utility/profile.js
+++ b/src/commands/utility/profile.js
@@ -9,6 +9,7 @@ const { getStreakMultiplier, MILESTONES } = require('../../utils/streakMultiplie
 const { badgeFor, titleForExactRank } = require('../../utils/prestige');
 const { getActiveSynergies } = require('../../services/synergyService');
 const { isPetActive } = require('../../services/petService');
+const COLORS = require('../../utils/embedColors');
 
 const PRESTIGE_BADGES = ['', '🥉', '🥈', '🥇', '🏆', '💎'];
 
@@ -200,7 +201,7 @@ module.exports = {
 
             // ── Build embed ───────────────────────────────────────────────────
             const embed = new EmbedBuilder()
-                .setColor('#5865F2')
+                .setColor(COLORS.INFO)
                 .setTitle(`${targetUser.username}'s Profile`)
                 .setThumbnail(targetUser.displayAvatarURL({ dynamic: true }))
                 .addFields(

--- a/src/commands/utility/role.js
+++ b/src/commands/utility/role.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const Guild = require('../../models/Guild');
+const COLORS = require('../../utils/embedColors');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -31,7 +32,7 @@ module.exports = {
 
             const lines = selfRoleIds.map(id => `<@&${id}>`).join('\n');
             const embed = new EmbedBuilder()
-                .setColor('#5865F2')
+                .setColor(COLORS.INFO)
                 .setTitle('Self-Assignable Roles')
                 .setDescription(lines)
                 .setFooter({ text: 'Use /role add <role> to assign one' });

--- a/src/commands/utility/serverinfo.js
+++ b/src/commands/utility/serverinfo.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const Guild = require('../../models/Guild');
 const { raidModeActive, raidModeActivatedBy } = require('../../services/raidService');
+const COLORS = require('../../utils/embedColors');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -24,7 +25,7 @@ module.exports = {
         }
 
         const embed = new EmbedBuilder()
-            .setColor('#00ff00')
+            .setColor(COLORS.INFO)
             .setTitle('Server Information')
             .setThumbnail(guild.iconURL({ dynamic: true }))
             .addFields(

--- a/src/commands/utility/suggest.js
+++ b/src/commands/utility/suggest.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const Guild = require('../../models/Guild');
+const COLORS = require('../../utils/embedColors');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -25,7 +26,7 @@ module.exports = {
         }
 
         const embed = new EmbedBuilder()
-            .setColor('#5865F2')
+            .setColor(COLORS.INFO)
             .setAuthor({
                 name: interaction.member?.displayName || interaction.user.username,
                 iconURL: interaction.user.displayAvatarURL()

--- a/src/commands/utility/userinfo.js
+++ b/src/commands/utility/userinfo.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const COLORS = require('../../utils/embedColors');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -13,7 +14,7 @@ module.exports = {
         const member = interaction.guild.members.cache.get(user.id);
 
         const embed = new EmbedBuilder()
-            .setColor('#00ff00')
+            .setColor(COLORS.INFO)
             .setTitle('User Information')
             .setThumbnail(user.displayAvatarURL({ dynamic: true }))
             .addFields(

--- a/src/dashboard/public/guild-settings.js
+++ b/src/dashboard/public/guild-settings.js
@@ -3597,8 +3597,92 @@ function loadChartJs() {
     return _chartJsLoad;
 }
 
+/**
+ * Give a chart the accessible equivalent a <canvas> cannot have (#669).
+ *
+ * A canvas is an opaque bitmap. With no ARIA it is announced as nothing at
+ * all, so six charts made the whole Insights panel — and the economy command
+ * breakdown — unreadable to a screen reader, WCAG 1.1.1. Each chart gets two
+ * things instead: a role="img" carrying a one-line summary of what it shows,
+ * and the series itself as a real <table> alongside, visually hidden but
+ * navigable with table commands.
+ *
+ * Built from the same arrays the chart is drawn from, and called whether or
+ * not Chart.js loaded — so when the library is unavailable the numbers are
+ * still there rather than the panel being simply blank.
+ *
+ * @param {string} canvasId id of the <canvas>; the table goes in `<id>-data`
+ * @param {object} spec     { title, summary, columns, rows }
+ */
+function describeChart(canvasId, { title, summary, columns = [], rows = [] }) {
+    const canvas = document.getElementById(canvasId);
+    if (canvas) {
+        canvas.setAttribute('role', 'img');
+        canvas.setAttribute('aria-label', summary || `${title} — no data yet`);
+    }
+
+    const host = document.getElementById(`${canvasId}-data`);
+    if (!host) return;
+    host.textContent = '';
+
+    if (!rows.length) {
+        const p = document.createElement('p');
+        p.textContent = summary || `${title} — no data yet`;
+        host.appendChild(p);
+        return;
+    }
+
+    const table = document.createElement('table');
+    const caption = document.createElement('caption');
+    caption.textContent = title;
+    table.appendChild(caption);
+
+    const head = document.createElement('tr');
+    for (const col of columns) {
+        const th = document.createElement('th');
+        th.setAttribute('scope', 'col');
+        th.textContent = col;
+        head.appendChild(th);
+    }
+    const thead = document.createElement('thead');
+    thead.appendChild(head);
+    table.appendChild(thead);
+
+    const tbody = document.createElement('tbody');
+    for (const row of rows) {
+        const tr = document.createElement('tr');
+        // First cell is the row's label — a date, a command, a cohort — so it
+        // is a header, and the ones after it are values it names.
+        row.forEach((cell, i) => {
+            const el = document.createElement(i === 0 ? 'th' : 'td');
+            if (i === 0) el.setAttribute('scope', 'row');
+            el.textContent = String(cell);
+            tr.appendChild(el);
+        });
+        tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    host.appendChild(table);
+}
+
+/** Sum one numeric key across a daily series, for the chart summaries. */
+function sumBy(rows, key) {
+    return rows.reduce((total, row) => total + (Number(row[key]) || 0), 0);
+}
+
 async function renderAnalyticsCharts(data, insights) {
-    await loadChartJs();
+    // The summaries and data tables below are built from the same arrays the
+    // charts are drawn from, and they have to survive a library that would not
+    // load: a reader who cannot see the canvas anyway should not also lose the
+    // numbers because a script fetch failed. So a load failure is reported and
+    // the drawing skipped, rather than the whole render abandoned at the top.
+    let charts = true;
+    try {
+        await loadChartJs();
+    } catch (err) {
+        charts = false;
+        chartsUnavailable(err);
+    }
     const a = data.analytics || {};
     const days = _analyticsRange;
 
@@ -3607,7 +3691,7 @@ async function renderAnalyticsCharts(data, insights) {
     const growthSlice = growthAll.slice(-days);
     if (_chartMemberGrowth) _chartMemberGrowth.destroy();
     const ctxG = document.getElementById('chart-member-growth')?.getContext('2d');
-    if (ctxG) {
+    if (charts && ctxG) {
         _chartMemberGrowth = new Chart(ctxG, {
             type: 'bar',
             data: {
@@ -3621,12 +3705,23 @@ async function renderAnalyticsCharts(data, insights) {
         });
     }
 
+    describeChart('chart-member-growth', {
+        title: `Member growth, last ${days} days`,
+        summary: growthSlice.length
+            ? `Member growth over the last ${days} days: ${sumBy(growthSlice, 'joins')} joins, ${sumBy(growthSlice, 'leaves')} leaves.`
+            : 'Member growth — no data yet',
+        columns: ['Date', 'Joins', 'Leaves'],
+        rows: growthSlice.map(d => [d.date, d.joins || 0, d.leaves || 0]),
+    });
+
     // Command activity chart — real per-command daily counts
     if (_chartCommandActivity) _chartCommandActivity.destroy();
     const ctxCA = document.getElementById('chart-command-activity')?.getContext('2d');
-    if (ctxCA) {
-        const cmdDaily = a.commandDaily || [];
-        const cmdSlice = cmdDaily.slice(-days);
+    const cmdSlice = (a.commandDaily || []).slice(-days);
+    // Fallback when no daily breakdown has been recorded yet: the running
+    // per-command totals, as a horizontal bar.
+    const cmdRows = Object.entries(a.commandUsage || {}).sort((x, y) => y[1].total - x[1].total).slice(0, 8);
+    if (charts && ctxCA) {
         if (cmdSlice.length) {
             _chartCommandActivity = new Chart(ctxCA, {
                 type: 'bar',
@@ -3637,8 +3732,6 @@ async function renderAnalyticsCharts(data, insights) {
                 options: _chartDefaults
             });
         } else {
-            // Fallback: aggregate top commands as horizontal bar
-            const cmdRows = Object.entries(a.commandUsage || {}).sort((x,y) => y[1].total - x[1].total).slice(0, 8);
             _chartCommandActivity = new Chart(ctxCA, {
                 type: 'bar',
                 data: {
@@ -3650,13 +3743,29 @@ async function renderAnalyticsCharts(data, insights) {
         }
     }
 
+    describeChart('chart-command-activity', cmdSlice.length
+        ? {
+            title:   `Command activity, last ${days} days`,
+            summary: `Command activity over the last ${days} days: ${sumBy(cmdSlice, 'count')} commands run.`,
+            columns: ['Date', 'Commands'],
+            rows:    cmdSlice.map(d => [d.date, d.count || 0]),
+        }
+        : {
+            title:   'Most-used commands',
+            summary: cmdRows.length
+                ? `Most-used commands: ${cmdRows.map(([cmd, m]) => `/${cmd}, ${m.total}`).join('; ')}.`
+                : 'Command activity — no data yet',
+            columns: ['Command', 'Total runs'],
+            rows:    cmdRows.map(([cmd, m]) => [`/${cmd}`, m.total || 0]),
+        });
+
     // Retention cohort chart (D7/D30 by join month)
     if (_chartRetention) _chartRetention.destroy();
     const ctxR = document.getElementById('chart-retention')?.getContext('2d');
     const cohorts = insights?.retentionCohorts || [];
     const ret7 = insights?.retention?.retained7Pct || 0;
     const ret30 = insights?.retention?.retained30Pct || 0;
-    if (ctxR) {
+    if (charts && ctxR) {
         if (cohorts.length) {
             _chartRetention = new Chart(ctxR, {
                 type: 'bar',
@@ -3681,6 +3790,21 @@ async function renderAnalyticsCharts(data, insights) {
         }
     }
 
+    describeChart('chart-retention', cohorts.length
+        ? {
+            title:   'Retention by join month',
+            summary: `Retention by join month, ${cohorts.length} cohorts: ` +
+                     `${cohorts.map(c => `${c.month}, D7 ${c.d7Pct || 0}%, D30 ${c.d30Pct || 0}%`).join('; ')}.`,
+            columns: ['Cohort', 'D7 %', 'D30 %'],
+            rows:    cohorts.map(c => [c.month, c.d7Pct || 0, c.d30Pct || 0]),
+        }
+        : {
+            title:   'Retention',
+            summary: `Retention: ${ret7}% of members still active after 7 days, ${ret30}% after 30 days.`,
+            columns: ['Window', 'Retained %'],
+            rows:    [['D7 retention', ret7], ['D30 retention', ret30]],
+        });
+
     // Helper: remove any stale "no data" placeholder from a chart card container
     function clearChartPlaceholder(container) {
         const p = container.querySelector('p.chart-no-data');
@@ -3690,10 +3814,9 @@ async function renderAnalyticsCharts(data, insights) {
     // Economy activity chart
     if (_chartEconomy) _chartEconomy.destroy();
     const ctxE = document.getElementById('chart-economy')?.getContext('2d');
-    if (ctxE) {
+    const ecoSlice = (a.economyDaily || []).slice(-days);
+    if (charts && ctxE) {
         clearChartPlaceholder(ctxE.canvas.parentElement);
-        const ecoDaily = a.economyDaily || [];
-        const ecoSlice = ecoDaily.slice(-days);
         if (ecoSlice.length) {
             _chartEconomy = new Chart(ctxE, {
                 type: 'bar',
@@ -3710,14 +3833,22 @@ async function renderAnalyticsCharts(data, insights) {
             ctxE.canvas.parentElement.insertAdjacentHTML('beforeend', '<p class="chart-no-data" style="text-align:center;opacity:.4;font-size:.82rem;margin-top:.5rem">No economy data yet</p>');
         }
     }
+    describeChart('chart-economy', {
+        title:   `Economy activity, last ${days} days`,
+        summary: ecoSlice.length
+            ? `Economy activity over the last ${days} days: ${sumBy(ecoSlice, 'earned')} coins earned, ` +
+              `${sumBy(ecoSlice, 'spent')} spent.`
+            : 'Economy activity — no data yet',
+        columns: ['Date', 'Coins earned', 'Coins spent'],
+        rows:    ecoSlice.map(d => [d.date, d.earned || 0, d.spent || 0]),
+    });
 
     // Leveling / XP chart
     if (_chartLeveling) _chartLeveling.destroy();
     const ctxL = document.getElementById('chart-leveling')?.getContext('2d');
-    if (ctxL) {
+    const xpSlice = (a.xpDaily || []).slice(-days);
+    if (charts && ctxL) {
         clearChartPlaceholder(ctxL.canvas.parentElement);
-        const xpDaily = a.xpDaily || [];
-        const xpSlice = xpDaily.slice(-days);
         if (xpSlice.length) {
             _chartLeveling = new Chart(ctxL, {
                 type: 'bar',
@@ -3734,14 +3865,22 @@ async function renderAnalyticsCharts(data, insights) {
             ctxL.canvas.parentElement.insertAdjacentHTML('beforeend', '<p class="chart-no-data" style="text-align:center;opacity:.4;font-size:.82rem;margin-top:.5rem">No leveling data yet</p>');
         }
     }
+    describeChart('chart-leveling', {
+        title:   `XP and level-ups, last ${days} days`,
+        summary: xpSlice.length
+            ? `XP and level-ups over the last ${days} days: ${sumBy(xpSlice, 'xp')} XP awarded, ` +
+              `${sumBy(xpSlice, 'levelUps')} level-ups.`
+            : 'XP and level-ups — no data yet',
+        columns: ['Date', 'XP awarded', 'Level-ups'],
+        rows:    xpSlice.map(d => [d.date, d.xp || 0, d.levelUps || 0]),
+    });
 
     // AI requests chart
     if (_chartAiRequests) _chartAiRequests.destroy();
     const ctxAI = document.getElementById('chart-ai-requests')?.getContext('2d');
-    if (ctxAI) {
+    const aiSlice = (a.aiRequestsDaily || []).slice(-days);
+    if (charts && ctxAI) {
         clearChartPlaceholder(ctxAI.canvas.parentElement);
-        const aiDaily = a.aiRequestsDaily || [];
-        const aiSlice = aiDaily.slice(-days);
         if (aiSlice.length) {
             _chartAiRequests = new Chart(ctxAI, {
                 type: 'line',
@@ -3755,6 +3894,14 @@ async function renderAnalyticsCharts(data, insights) {
             ctxAI.canvas.parentElement.insertAdjacentHTML('beforeend', '<p class="chart-no-data" style="text-align:center;opacity:.4;font-size:.82rem;margin-top:.5rem">No AI usage data yet</p>');
         }
     }
+    describeChart('chart-ai-requests', {
+        title:   `AI requests, last ${days} days`,
+        summary: aiSlice.length
+            ? `AI requests over the last ${days} days: ${sumBy(aiSlice, 'count')} in total.`
+            : 'AI requests — no data yet',
+        columns: ['Date', 'Requests'],
+        rows:    aiSlice.map(d => [d.date, d.count || 0]),
+    });
 }
 
 async function loadAnalytics() {
@@ -3864,6 +4011,18 @@ function setSanctionsFilter(filter, btn) {
     if (_sanctionsData) renderSanctions(_sanctionsData);
 }
 
+/** Show or hide a wide table (#668).
+ *
+ *  These tables live inside a `.table-scroll` wrapper, and it is the wrapper —
+ *  not the table — that carries the visibility, because the wrapper is a
+ *  labelled region with a tabindex. Toggling the table alone would leave an
+ *  empty region behind as a tab stop announcing a table that is not there. */
+function setTableVisible(id, visible) {
+    const table = document.getElementById(id);
+    if (!table) return;
+    (table.closest('.table-scroll') || table).style.display = visible ? '' : 'none';
+}
+
 function renderSanctions(data) {
     const items = [
         ...(data.bans || []).map(b => ({ ...b, type: 'ban' })),
@@ -3871,8 +4030,7 @@ function renderSanctions(data) {
     ].filter(i => _sanctionsFilter === 'all' || i.type === _sanctionsFilter);
 
     document.getElementById('sanctions-empty').style.display = items.length ? 'none' : '';
-    const table = document.getElementById('sanctions-table');
-    table.style.display = items.length ? '' : 'none';
+    setTableVisible('sanctions-table', items.length > 0);
     const tbody = document.getElementById('sanctions-tbody');
     tbody.innerHTML = '';
     for (const item of items) {
@@ -3925,7 +4083,7 @@ async function loadActiveSanctions() {
     document.getElementById('sanctions-loading').style.display = '';
     document.getElementById('sanctions-error').style.display = 'none';
     document.getElementById('sanctions-empty').style.display = 'none';
-    document.getElementById('sanctions-table').style.display = 'none';
+    setTableVisible('sanctions-table', false);
     try {
         const resp = await fetch(`/api/v1/guild/${guildId}/sanctions/active`);
         if (!resp.ok) throw new Error('Non-OK');
@@ -3973,7 +4131,7 @@ async function loadCaseHistory(page = 1) {
     document.getElementById('cases-loading').style.display = '';
     document.getElementById('cases-error').style.display = 'none';
     document.getElementById('cases-empty').style.display = 'none';
-    document.getElementById('cases-table').style.display = 'none';
+    setTableVisible('cases-table', false);
     const paginEl = document.getElementById('cases-pagination');
     paginEl.style.display = 'none';
     try {
@@ -4008,7 +4166,7 @@ async function loadCaseHistory(page = 1) {
                 </td>
             </tr>`);
         }
-        document.getElementById('cases-table').style.display = '';
+        setTableVisible('cases-table', true);
         if (pages > 1) {
             paginEl.style.display = 'flex';
             paginEl.innerHTML = '';
@@ -4076,7 +4234,7 @@ async function loadEcoHealth() {
     document.getElementById('eco-top-earners-loading').style.display = '';
     document.getElementById('eco-top-earners-error').style.display = 'none';
     document.getElementById('eco-top-earners-empty').style.display = 'none';
-    document.getElementById('eco-top-earners-table').style.display = 'none';
+    setTableVisible('eco-top-earners-table', false);
     try {
         const resp = await fetch(`/api/v1/guild/${guildId}/economy/stats`);
         if (!resp.ok) throw new Error('Non-OK');
@@ -4088,7 +4246,7 @@ async function loadEcoHealth() {
         if (!topEarners.length) {
             document.getElementById('eco-top-earners-empty').style.display = '';
         } else {
-            document.getElementById('eco-top-earners-table').style.display = '';
+            setTableVisible('eco-top-earners-table', true);
         }
         const tbody = document.getElementById('eco-top-earners-tbody');
         tbody.innerHTML = '';
@@ -4103,6 +4261,14 @@ async function loadEcoHealth() {
         const cmds = stats.commandFrequency || [];
         if (_ecoCmdChart) _ecoCmdChart.destroy();
         const ctx = document.getElementById('eco-cmd-chart')?.getContext('2d');
+        describeChart('eco-cmd-chart', {
+            title:   'Most-used economy commands',
+            summary: cmds.length
+                ? `Most-used economy commands: ${cmds.map(c => `/${c.cmd}, ${c.count} uses`).join('; ')}.`
+                : 'Most-used economy commands — no data yet',
+            columns: ['Command', 'Uses'],
+            rows:    cmds.map(c => [`/${c.cmd}`, c.count || 0]),
+        });
         if (ctx && cmds.length) {
             // Its own try, inside the tab's: Chart.js is fetched on demand now
             // (#685), and a library that would not load must not take down the

--- a/src/dashboard/public/styles.css
+++ b/src/dashboard/public/styles.css
@@ -1520,6 +1520,21 @@ textarea.auto-resize {
 .game-item-upload-btn { cursor: pointer; }
 
 /* ── Cases / Sanctions tables ────────────────────────────────── */
+/* #668. `body { overflow-x: hidden }` above kills page-level horizontal
+   scrolling, so a table wider than the viewport simply had its right-hand
+   columns — Actions, on three of these four — clipped away with no way to
+   reach them. Each wide table gets its own scroll container instead.
+
+   min-width is what makes it scroll at all: `.cases-table` is width:100%, so
+   inside an auto-overflow parent it would otherwise shrink to fit and squeeze
+   the columns to nothing rather than overflow. The wrapper is a labelled
+   region with a tabindex so it can be scrolled by keyboard and not only by
+   touch; it carries the show/hide of the table it wraps (see
+   setTableVisible) so a hidden table never leaves an empty region behind in
+   the tab order. */
+.table-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+.table-scroll > .cases-table { min-width: 34rem; }
+.table-scroll:focus-visible { outline: 2px solid var(--claw-500); outline-offset: 2px; }
 .cases-table { width: 100%; border-collapse: collapse; font-size: .85rem; }
 .cases-table th { text-align: left; padding: .5rem .6rem; color: var(--text-dim); font-weight: 600; border-bottom: 1px solid var(--border); }
 .cases-table td { padding: .45rem .6rem; border-bottom: 1px solid var(--border); vertical-align: middle; }
@@ -1549,6 +1564,22 @@ textarea.auto-resize {
 .analytics-rec-link:hover { text-decoration: underline; }
 .analytics-chart-card { background: var(--surface-2, #1a1510); border: 1px solid var(--border); border-radius: 8px; padding: .85rem 1rem; }
 .analytics-chart-title { font-size: .8rem; font-weight: 600; color: var(--text-dim); margin-bottom: .5rem; text-transform: uppercase; letter-spacing: .04em; }
+/* #669. The numbers behind each chart, as a real table beside the canvas.
+   Clipped rather than `display: none` — a hidden element is dropped from the
+   accessibility tree along with everything in it, which is the very thing this
+   is here to avoid. */
+.chart-a11y-data {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+}
 .analytics-range { opacity: .6; }
 .grant-member-option:hover { background: var(--surface-2, #1a1510); }
 .analytics-range.active { opacity: 1; border-color: var(--claw-500); }

--- a/src/dashboard/views/partials/panels/analytics.ejs
+++ b/src/dashboard/views/partials/panels/analytics.ejs
@@ -36,27 +36,33 @@
                         <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1rem;margin-bottom:1.25rem">
                             <div class="analytics-chart-card">
                                 <div class="analytics-chart-title">Member Growth</div>
-                                <canvas id="chart-member-growth" height="160"></canvas>
+                                <canvas id="chart-member-growth" height="160" role="img" aria-label="Member growth chart — no data loaded yet"></canvas>
+                                <div id="chart-member-growth-data" class="chart-a11y-data"></div>
                             </div>
                             <div class="analytics-chart-card">
                                 <div class="analytics-chart-title">Command Activity</div>
-                                <canvas id="chart-command-activity" height="160"></canvas>
+                                <canvas id="chart-command-activity" height="160" role="img" aria-label="Command activity chart — no data loaded yet"></canvas>
+                                <div id="chart-command-activity-data" class="chart-a11y-data"></div>
                             </div>
                             <div class="analytics-chart-card">
                                 <div class="analytics-chart-title">Retention (D7 / D30)</div>
-                                <canvas id="chart-retention" height="160"></canvas>
+                                <canvas id="chart-retention" height="160" role="img" aria-label="Member retention chart — no data loaded yet"></canvas>
+                                <div id="chart-retention-data" class="chart-a11y-data"></div>
                             </div>
                             <div class="analytics-chart-card">
                                 <div class="analytics-chart-title">Economy Activity</div>
-                                <canvas id="chart-economy" height="160"></canvas>
+                                <canvas id="chart-economy" height="160" role="img" aria-label="Economy activity chart — no data loaded yet"></canvas>
+                                <div id="chart-economy-data" class="chart-a11y-data"></div>
                             </div>
                             <div class="analytics-chart-card">
                                 <div class="analytics-chart-title">XP &amp; Level-ups</div>
-                                <canvas id="chart-leveling" height="160"></canvas>
+                                <canvas id="chart-leveling" height="160" role="img" aria-label="XP and level-ups chart — no data loaded yet"></canvas>
+                                <div id="chart-leveling-data" class="chart-a11y-data"></div>
                             </div>
                             <div class="analytics-chart-card">
                                 <div class="analytics-chart-title">AI Requests</div>
-                                <canvas id="chart-ai-requests" height="160"></canvas>
+                                <canvas id="chart-ai-requests" height="160" role="img" aria-label="AI requests chart — no data loaded yet"></canvas>
+                                <div id="chart-ai-requests-data" class="chart-a11y-data"></div>
                             </div>
                         </div>
 

--- a/src/dashboard/views/partials/panels/economy.ejs
+++ b/src/dashboard/views/partials/panels/economy.ejs
@@ -240,14 +240,17 @@
                             <button class="btn btn-sm" onclick="loadEcoHealth()">Retry</button>
                         </div>
                         <div id="eco-top-earners-empty" style="display:none" class="empty-state"><h3>No economy activity yet</h3><p>Once members earn coins, the richest users will appear here.</p></div>
-                        <table id="eco-top-earners-table" class="cases-table" style="display:none">
-                            <thead><tr><th>Rank</th><th>User</th><th>Wallet</th><th>Bank</th><th>Total</th></tr></thead>
-                            <tbody id="eco-top-earners-tbody"></tbody>
-                        </table>
+                        <div class="table-scroll" role="region" tabindex="0" aria-label="Top earners" style="display:none">
+                            <table id="eco-top-earners-table" class="cases-table">
+                                <thead><tr><th>Rank</th><th>User</th><th>Wallet</th><th>Bank</th><th>Total</th></tr></thead>
+                                <tbody id="eco-top-earners-tbody"></tbody>
+                            </table>
+                        </div>
 
                         <!-- Command frequency chart -->
                         <div class="panel-head" style="margin-top:1.5rem"><h3>Most-Used Economy Commands</h3></div>
-                        <div style="max-width:540px;position:relative"><canvas id="eco-cmd-chart" height="200"></canvas></div>
+                        <div style="max-width:540px;position:relative"><canvas id="eco-cmd-chart" height="200" role="img" aria-label="Most-used economy commands chart — no data loaded yet"></canvas>
+                        <div id="eco-cmd-chart-data" class="chart-a11y-data"></div></div>
                     </div>
 
                     <!-- Hunting item images -->

--- a/src/dashboard/views/partials/panels/leveling.ejs
+++ b/src/dashboard/views/partials/panels/leveling.ejs
@@ -140,10 +140,12 @@
                         <button class="btn btn-sm" onclick="loadLevelLeaderboard(1,true)">Retry</button>
                     </div>
                     <div id="level-leaderboard-content" style="display:none">
-                        <table class="cases-table" style="width:100%">
-                            <thead><tr><th>#</th><th>User ID</th><th>Level</th><th>Total XP</th><th>Messages</th></tr></thead>
-                            <tbody id="level-leaderboard-tbody"></tbody>
-                        </table>
+                        <div class="table-scroll" role="region" tabindex="0" aria-label="Level leaderboard">
+                            <table class="cases-table">
+                                <thead><tr><th>#</th><th>User ID</th><th>Level</th><th>Total XP</th><th>Messages</th></tr></thead>
+                                <tbody id="level-leaderboard-tbody"></tbody>
+                            </table>
+                        </div>
                         <div id="level-leaderboard-pagination" style="display:flex;gap:.5rem;align-items:center;justify-content:center;margin-top:.75rem"></div>
                     </div>
                     <div id="level-leaderboard-empty" style="display:none;padding:1.5rem 0;text-align:center;color:var(--text-dim);font-size:.9rem">No members with XP yet.</div>

--- a/src/dashboard/views/partials/panels/moderation.ejs
+++ b/src/dashboard/views/partials/panels/moderation.ejs
@@ -174,10 +174,12 @@
                             <button class="btn btn-sm" onclick="loadActiveSanctions()">Retry</button>
                         </div>
                         <div id="sanctions-empty" style="display:none" class="empty-state"><h3>No active sanctions</h3><p>There are no active bans or timeouts in this server right now.</p></div>
-                        <table id="sanctions-table" class="cases-table" style="display:none">
-                            <thead><tr><th>User</th><th>Type</th><th>Expires</th><th>Reason</th><th>Actions</th></tr></thead>
-                            <tbody id="sanctions-tbody"></tbody>
-                        </table>
+                        <div class="table-scroll" role="region" tabindex="0" aria-label="Active sanctions" style="display:none">
+                            <table id="sanctions-table" class="cases-table">
+                                <thead><tr><th>User</th><th>Type</th><th>Expires</th><th>Reason</th><th>Actions</th></tr></thead>
+                                <tbody id="sanctions-tbody"></tbody>
+                            </table>
+                        </div>
                     </div>
 
                     <!-- Case History tab -->
@@ -216,10 +218,12 @@
                             <button class="btn btn-sm" onclick="loadCaseHistory(1)">Retry</button>
                         </div>
                         <div id="cases-empty" style="display:none" class="empty-state"><h3>No cases found</h3><p>No moderation cases match the current filters.</p></div>
-                        <table id="cases-table" class="cases-table" style="display:none">
-                            <thead><tr><th>Case #</th><th>User</th><th>Type</th><th>Mod</th><th>Date</th><th>Status</th><th>Actions</th></tr></thead>
-                            <tbody id="cases-tbody"></tbody>
-                        </table>
+                        <div class="table-scroll" role="region" tabindex="0" aria-label="Moderation case history" style="display:none">
+                            <table id="cases-table" class="cases-table">
+                                <thead><tr><th>Case #</th><th>User</th><th>Type</th><th>Mod</th><th>Date</th><th>Status</th><th>Actions</th></tr></thead>
+                                <tbody id="cases-tbody"></tbody>
+                            </table>
+                        </div>
                         <div id="cases-pagination" style="display:none;margin-top:.75rem;gap:.5rem;align-items:center;justify-content:center"></div>
                     </div>
 

--- a/src/events/channelCreate.js
+++ b/src/events/channelCreate.js
@@ -1,6 +1,7 @@
 const { EmbedBuilder, AuditLogEvent, PermissionFlagsBits } = require('discord.js');
 const { getGuildSettings } = require('../utils/guildSettingsCache');
 const { trackAction } = require('../services/antiNukeService');
+const COLORS = require('../utils/embedColors');
 
 module.exports = {
     name: 'channelCreate',
@@ -18,7 +19,7 @@ module.exports = {
         if (!logChannel.permissionsFor(channel.guild.members.me)?.has(PermissionFlagsBits.SendMessages)) return;
 
         const embed = new EmbedBuilder()
-            .setColor('#00ff00')
+            .setColor(COLORS.SUCCESS)
             .setTitle('Channel Created')
             .addFields(
                 { name: 'Name', value: channel.name, inline: true },

--- a/src/events/channelDelete.js
+++ b/src/events/channelDelete.js
@@ -2,6 +2,7 @@ const { EmbedBuilder, AuditLogEvent, PermissionFlagsBits } = require('discord.js
 const Guild = require('../models/Guild');
 const { getGuildSettings } = require('../utils/guildSettingsCache');
 const { trackAction } = require('../services/antiNukeService');
+const COLORS = require('../utils/embedColors');
 
 module.exports = {
     name: 'channelDelete',
@@ -28,7 +29,7 @@ module.exports = {
         if (!logChannel.permissionsFor(channel.guild.members.me)?.has(PermissionFlagsBits.SendMessages)) return;
 
         const embed = new EmbedBuilder()
-            .setColor('#ff0000')
+            .setColor(COLORS.ERROR)
             .setTitle('Channel Deleted')
             .addFields(
                 { name: 'Name', value: channel.name, inline: true },

--- a/src/events/guildMemberAdd.js
+++ b/src/events/guildMemberAdd.js
@@ -4,6 +4,7 @@ const { EmbedBuilder, AttachmentBuilder, PermissionFlagsBits } = require('discor
 const { createWelcomeCard } = require('../utils/cardGenerator');
 const { handleMemberJoin: raidCheck } = require('../services/raidService');
 const { enforceJoinGate } = require('../services/antiNukeService');
+const COLORS = require('../utils/embedColors');
 
 async function trackMemberEvent(guildId, dateKey, field) {
     // Try to atomically increment today's existing entry (fix #8 — simpler, no spurious $push).
@@ -85,7 +86,7 @@ module.exports = {
                             const attachment = new AttachmentBuilder(card, { name: 'welcome.png' });
 
                             const embed = new EmbedBuilder()
-                                .setColor('#5865F2')
+                                .setColor(COLORS.INFO)
                                 .setDescription(message)
                                 .setImage('attachment://welcome.png')
                                 .setTimestamp();
@@ -93,7 +94,7 @@ module.exports = {
                             await channel.send({ embeds: [embed], files: [attachment] });
                         } else {
                             const embed = new EmbedBuilder()
-                                .setColor('#5865F2')
+                                .setColor(COLORS.INFO)
                                 .setTitle('Welcome!')
                                 .setDescription(message)
                                 // Remove deprecated { dynamic: true } option (fix #4)
@@ -129,7 +130,7 @@ module.exports = {
                 const logChannel = member.guild.channels.cache.get(guildSettings.eventLog.channelId);
                 if (logChannel) {
                     const logEmbed = new EmbedBuilder()
-                        .setColor('#5865F2')
+                        .setColor(COLORS.INFO)
                         .setTitle('Member Joined')
                         // Use username instead of deprecated .tag (fix #5); drop deprecated dynamic option (fix #4)
                         .setAuthor({ name: member.user.username, iconURL: member.user.displayAvatarURL() })

--- a/src/events/guildMemberRemove.js
+++ b/src/events/guildMemberRemove.js
@@ -2,6 +2,7 @@ const { getGuildSettings } = require('../utils/guildSettingsCache');
 const GuildAnalytics = require('../models/GuildAnalytics');
 const { EmbedBuilder, AuditLogEvent, PermissionFlagsBits } = require('discord.js');
 const { trackAction } = require('../services/antiNukeService');
+const COLORS = require('../utils/embedColors');
 async function trackMemberEvent(guildId, dateKey, field) {
     const result = await GuildAnalytics.updateOne(
         { guildId, 'memberEvents.date': dateKey },
@@ -63,7 +64,7 @@ module.exports = {
             const message = applyVariables(guildSettings.farewell.message, member);
 
             const embed = new EmbedBuilder()
-                .setColor('#ED4245')
+                .setColor(COLORS.ERROR)
                 .setTitle('Goodbye!')
                 .setDescription(message)
                 .setThumbnail(member.user.displayAvatarURL())
@@ -75,7 +76,7 @@ module.exports = {
                 const logChannel = member.guild.channels.cache.get(guildSettings.eventLog.channelId);
                 if (logChannel) {
                     const logEmbed = new EmbedBuilder()
-                        .setColor('#ED4245')
+                        .setColor(COLORS.ERROR)
                         .setTitle('Member Left')
                         .setAuthor({ name: member.user.username, iconURL: member.user.displayAvatarURL() })
                         .addFields(

--- a/src/events/guildMemberUpdate.js
+++ b/src/events/guildMemberUpdate.js
@@ -1,5 +1,6 @@
 const { EmbedBuilder, PermissionFlagsBits } = require('discord.js');
 const { getGuildSettings } = require('../utils/guildSettingsCache');
+const COLORS = require('../utils/embedColors');
 
 module.exports = {
     name: 'guildMemberUpdate',
@@ -21,7 +22,7 @@ module.exports = {
         if (!added.size && !removed.size) return;
 
         const embed = new EmbedBuilder()
-            .setColor('#5865F2')
+            .setColor(COLORS.INFO)
             .setTitle('Member Roles Updated')
             .setAuthor({ name: newMember.user.globalName ?? newMember.user.username, iconURL: newMember.user.displayAvatarURL() })
             .setTimestamp();

--- a/src/events/messageDelete.js
+++ b/src/events/messageDelete.js
@@ -1,5 +1,6 @@
 const { EmbedBuilder, PermissionFlagsBits } = require('discord.js');
 const { getGuildSettings } = require('../utils/guildSettingsCache');
+const COLORS = require('../utils/embedColors');
 
 module.exports = {
     name: 'messageDelete',
@@ -15,7 +16,7 @@ module.exports = {
         if (!logChannel.permissionsFor(message.guild.members.me)?.has(PermissionFlagsBits.SendMessages)) return;
 
         const embed = new EmbedBuilder()
-            .setColor('#ff0000')
+            .setColor(COLORS.ERROR)
             .setTitle('Message Deleted')
             .setAuthor({ name: message.author?.globalName ?? message.author?.username ?? 'Unknown', iconURL: message.author?.displayAvatarURL() })
             .addFields(

--- a/src/events/messageReactionAdd.js
+++ b/src/events/messageReactionAdd.js
@@ -4,6 +4,7 @@ const User = require('../models/User');
 const { getGuildSettings } = require('../utils/guildSettingsCache');
 const { ensureQuests, onReaction, notifyQuestComplete, notifyQuestNearComplete } = require('../services/questService');
 const { saveWithBalanceDelta } = require('../utils/balanceDelta');
+const COLORS = require('../utils/embedColors');
 
 module.exports = {
     name: 'messageReactionAdd',
@@ -121,7 +122,7 @@ async function handleStarboard(reaction, user, guild, guildSettings) {
     if (!starChannel) return;
 
     const embed = new EmbedBuilder()
-        .setColor('#FFD700')
+        .setColor(COLORS.PRIZE)
         .setAuthor({ name: message.author.tag, iconURL: message.author.displayAvatarURL({ dynamic: true }) })
         .setDescription(message.content || null)
         .addFields({ name: 'Source', value: `[Jump to message](${message.url})` })

--- a/src/events/messageUpdate.js
+++ b/src/events/messageUpdate.js
@@ -1,5 +1,6 @@
 const { EmbedBuilder, PermissionFlagsBits } = require('discord.js');
 const { getGuildSettings } = require('../utils/guildSettingsCache');
+const COLORS = require('../utils/embedColors');
 
 module.exports = {
     name: 'messageUpdate',
@@ -16,7 +17,7 @@ module.exports = {
         if (!logChannel.permissionsFor(newMessage.guild.members.me)?.has(PermissionFlagsBits.SendMessages)) return;
 
         const embed = new EmbedBuilder()
-            .setColor('#FFA500')
+            .setColor(COLORS.WARN)
             .setTitle('Message Edited')
             .setAuthor({ name: newMessage.author.globalName ?? newMessage.author.username, iconURL: newMessage.author.displayAvatarURL() })
             .addFields(

--- a/src/games/casino/blackjack.js
+++ b/src/games/casino/blackjack.js
@@ -11,6 +11,7 @@ const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier, luckySaveEligible } = require('../../services/effectsService');
 const { randomFrom, BJ_WIN_LINES, BJ_LOSE_LINES, BJ_BUST_LINES, BJ_PUSH_LINES } = require('../../utils/copyLines');
+const COLORS = require('../../utils/embedColors');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f0cf.png';
 const MIN_BET = 10;
@@ -137,7 +138,7 @@ function buildDealerRevealEmbed(interaction, dealerHand, playerHand, splitHands,
     const embed = new EmbedBuilder()
         .setAuthor({ name: interaction.member?.displayName || interaction.user.username, iconURL: interaction.user.displayAvatarURL() })
         .setThumbnail(THUMB)
-        .setColor('#5865F2')
+        .setColor(COLORS.INFO)
         .setTitle('🃏 Blackjack — Dealer\'s Turn')
         .setDescription('Dealer flips the hole card…')
         .addFields({ name: `Dealer (${dealerVal})`, value: dealerStr, inline: false })
@@ -272,7 +273,7 @@ module.exports = {
             const embed = new EmbedBuilder()
                 .setAuthor({ name: interaction.member?.displayName || interaction.user.username, iconURL: interaction.user.displayAvatarURL() })
                 .setThumbnail(THUMB)
-                .setColor('#FFD700')
+                .setColor(COLORS.PRIZE)
                 .setTitle('🃏 Blackjack — Natural 21')
                 .setDescription(`> Perfect hand. Pays 3:2.`)
                 .addFields(

--- a/src/games/casino/blackjack.js
+++ b/src/games/casino/blackjack.js
@@ -12,6 +12,7 @@ const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier, luckySaveEligible } = require('../../services/effectsService');
 const { randomFrom, BJ_WIN_LINES, BJ_LOSE_LINES, BJ_BUST_LINES, BJ_PUSH_LINES } = require('../../utils/copyLines');
 const COLORS = require('../../utils/embedColors');
+const { ownedBy } = require('../../utils/collectorOwner');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f0cf.png';
 const MIN_BET = 10;
@@ -314,7 +315,7 @@ module.exports = {
                 const peekMsg = await interaction.fetchReply();
                 try {
                     const insI = await peekMsg.awaitMessageComponent({
-                        filter: i2 => i2.user.id === interaction.user.id && i2.customId === `bj_insurance_${gameId}`,
+                        filter: ownedBy(interaction.user.id, i2 => i2.customId === `bj_insurance_${gameId}`, "This isn't your hand."),
                         time: 15_000,
                     });
                     await insI.deferUpdate();
@@ -374,10 +375,10 @@ module.exports = {
 
         const msg       = await interaction.fetchReply();
         const collector = msg.createMessageComponentCollector({
-            filter: i => i.user.id === interaction.user.id && [
+            filter: ownedBy(interaction.user.id, i => [
                 `bj_hit_${gameId}`, `bj_stand_${gameId}`, `bj_double_${gameId}`,
                 `bj_split_${gameId}`, `bj_insurance_${gameId}`,
-            ].includes(i.customId),
+            ].includes(i.customId), "This isn't your hand."),
             time: 60_000,
         });
 

--- a/src/games/casino/crash.js
+++ b/src/games/casino/crash.js
@@ -10,6 +10,7 @@ const { placeWager } = require('../../utils/placeWager');
 const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, luckySaveEligible } = require('../../services/effectsService');
+const COLORS = require('../../utils/embedColors');
 const {
     LOBBY_JOIN_WINDOW_MS,
     MAX_PLAYERS,
@@ -135,7 +136,7 @@ async function buildWeeklyLeaderboard(guildId, _client) {
 
     if (topUsers.length === 0) {
         return new EmbedBuilder()
-            .setColor('#5865F2')
+            .setColor(COLORS.INFO)
             .setTitle('💥 Crash — Weekly Multiplier Leaderboard')
             .setDescription('No crash cash-outs recorded this week yet. Be the first!')
             .setFooter({ text: 'Resets every Monday at midnight UTC' });
@@ -150,7 +151,7 @@ async function buildWeeklyLeaderboard(guildId, _client) {
     }
 
     return new EmbedBuilder()
-        .setColor('#ffdd00')
+        .setColor(COLORS.PRIZE)
         .setTitle('💥 Crash — Weekly Multiplier Leaderboard')
         .setDescription(lines.join('\n'))
         .setFooter({ text: `Week of ${weekStart.toDateString()} · Resets every Monday` })
@@ -169,7 +170,7 @@ function lobbyEmbed(lobby, playerNames, autoCashout, crashHistory) {
         ? `\n💥 Recent Crashes: ${crashHistory.slice(-5).map(c => `**${multLabel(c)}**`).join(' · ')}\n*Is a big one coming?* 🤔`
         : '';
     return new EmbedBuilder()
-        .setColor('#5865F2')
+        .setColor(COLORS.INFO)
         .setTitle('💥 Crash — Lobby Open')
         .setDescription(
             `**Bet:** ${lobby.bet.toLocaleString()} coins each\n` +
@@ -233,7 +234,7 @@ async function buildFinalEmbed(crashPoint, bet, players, client, _guildId) {
         }
     }
     return new EmbedBuilder()
-        .setColor('#ff3333')
+        .setColor(COLORS.ERROR)
         .setTitle(`💥 Crashed at ${crashLabel}!`)
         .setDescription(lines.join('\n') || '*No players*')
         .setFooter({ text: 'The house always has a 1% edge — play responsibly!' })

--- a/src/games/casino/crash.js
+++ b/src/games/casino/crash.js
@@ -11,6 +11,7 @@ const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, luckySaveEligible } = require('../../services/effectsService');
 const COLORS = require('../../utils/embedColors');
+const { ownedByMembers } = require('../../utils/collectorOwner');
 const {
     LOBBY_JOIN_WINDOW_MS,
     MAX_PLAYERS,
@@ -492,7 +493,11 @@ async function startCrashGame(interaction, lobby, lobbyId) {
     if (!message) { deleteLobby(channelId); return; }
 
     const collector = message.createMessageComponentCollector({
-        filter: i => i.customId === `crash_co_${lobbyId}` && lobby.players.has(i.user.id),
+        filter: ownedByMembers(
+            userId => lobby.players.has(userId),
+            i => i.customId === `crash_co_${lobbyId}`,
+            "You're not in this round — join the next lobby to play.",
+        ),
         time:   collectorMs,
     });
 

--- a/src/games/casino/cupgame.js
+++ b/src/games/casino/cupgame.js
@@ -10,6 +10,7 @@ const { placeWager } = require('../../utils/placeWager');
 const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier, luckySaveEligible } = require('../../services/effectsService');
+const COLORS = require('../../utils/embedColors');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f0bd.png';
 const MIN_BET = 10;
@@ -109,7 +110,7 @@ async function playMonte(interaction, bet, round = 1, releaseLock, onWager) {
             embeds: [new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
                 .setThumbnail(THUMB)
-                .setColor('#5865F2')
+                .setColor(COLORS.INFO)
                 .setTitle(`🃏 Three Card Monte${roundLabel} — Cards Flipped!`)
                 .setDescription(
                     `Cards are now face down — follow the Queen!\n\n` +
@@ -137,7 +138,7 @@ async function playMonte(interaction, bet, round = 1, releaseLock, onWager) {
                 embeds: [new EmbedBuilder()
                     .setAuthor(embedAuthor(interaction))
                     .setThumbnail(THUMB)
-                    .setColor('#5865F2')
+                    .setColor(COLORS.INFO)
                     .setTitle(`🃏 Three Card Monte${roundLabel} — Shuffling…`)
                     .setDescription(
                         `Swap ${step + 1}/${steps} — cards **${a + 1}** ↔ **${b + 1}**\n\n` +
@@ -311,7 +312,7 @@ async function playMonte(interaction, bet, round = 1, releaseLock, onWager) {
                 embeds: [new EmbedBuilder()
                     .setAuthor(embedAuthor(interaction))
                     .setThumbnail(THUMB)
-                    .setColor('#2ecc71')
+                    .setColor(COLORS.SUCCESS)
                     .setTitle(`🃏 Correct! Round ${round}/${MAX_ROUNDS} Complete!`)
                     .setDescription(
                         `> ${reveal.join('   ')}\n> 1️⃣  ·  2️⃣  ·  3️⃣\n\n` +
@@ -356,7 +357,7 @@ async function playMonte(interaction, bet, round = 1, releaseLock, onWager) {
                         embeds: [new EmbedBuilder()
                             .setAuthor(embedAuthor(interaction))
                             .setThumbnail(THUMB)
-                            .setColor('#2ecc71')
+                            .setColor(COLORS.SUCCESS)
                             .setTitle('🃏 Cashed Out!')
                             .setDescription(`> ${reveal.join('   ')}\n> 1️⃣  ·  2️⃣  ·  3️⃣\n\n💰 You took the money after Round ${round}!`)
                             .addFields(

--- a/src/games/casino/cupgame.js
+++ b/src/games/casino/cupgame.js
@@ -11,6 +11,7 @@ const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier, luckySaveEligible } = require('../../services/effectsService');
 const COLORS = require('../../utils/embedColors');
+const { ownedBy } = require('../../utils/collectorOwner');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f0bd.png';
 const MIN_BET = 10;
@@ -188,7 +189,11 @@ async function playMonte(interaction, bet, round = 1, releaseLock, onWager) {
         let guess;
         try {
             const resp = await msg.awaitMessageComponent({
-                filter: i => i.user.id === interaction.user.id && i.customId.startsWith('monte_') && i.customId.endsWith(gameId),
+                filter: ownedBy(
+                    interaction.user.id,
+                    i => i.customId.startsWith('monte_') && i.customId.endsWith(gameId),
+                    "This isn't your game.",
+                ),
                 time: 30_000,
             });
             await resp.deferUpdate();
@@ -290,7 +295,7 @@ async function playMonte(interaction, bet, round = 1, releaseLock, onWager) {
 
             const replyMsg = await interaction.fetchReply();
             replyMsg.createMessageComponentCollector({
-                filter: i => i.user.id === interaction.user.id && i.customId === replayId,
+                filter: ownedBy(interaction.user.id, i => i.customId === replayId, "This isn't your game."),
                 max: 1,
                 time: 60_000,
             }).on('collect', async i => {
@@ -336,7 +341,7 @@ async function playMonte(interaction, bet, round = 1, releaseLock, onWager) {
             let decided = false;
             try {
                 const decision = await decisionMsg.awaitMessageComponent({
-                    filter: i => i.user.id === interaction.user.id && [takeId, doubleId].includes(i.customId),
+                    filter: ownedBy(interaction.user.id, i => [takeId, doubleId].includes(i.customId), "This isn't your game."),
                     time: 30_000,
                 });
                 decided = true;
@@ -374,7 +379,7 @@ async function playMonte(interaction, bet, round = 1, releaseLock, onWager) {
 
                     const replyMsg = await interaction.fetchReply();
                     replyMsg.createMessageComponentCollector({
-                        filter: i => i.user.id === interaction.user.id && i.customId === replayId,
+                        filter: ownedBy(interaction.user.id, i => i.customId === replayId, "This isn't your game."),
                         max: 1, time: 60_000,
                     }).on('collect', async i => {
                         await i.deferUpdate();

--- a/src/games/casino/higherlower.js
+++ b/src/games/casino/higherlower.js
@@ -10,6 +10,7 @@ const { placeWager } = require('../../utils/placeWager');
 const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier, luckySaveEligible } = require('../../services/effectsService');
+const COLORS = require('../../utils/embedColors');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f0cf.png';
 const MIN_BET = 10;
@@ -94,7 +95,7 @@ function questionEmbed(card, bet, history, interaction, streak) {
     return new EmbedBuilder()
         .setAuthor(embedAuthor(interaction))
         .setThumbnail(THUMB)
-        .setColor('#5865F2')
+        .setColor(COLORS.INFO)
         .setTitle('🃏 Higher or Lower')
         .setDescription(`**Current Card**\n\`\`\`\n${cardDisplay(card)}\n\`\`\`${streakLine}`)
         .addFields(
@@ -136,7 +137,7 @@ function lossEmbed(interaction, current, next, pickedHigher, bet, newBalance) {
     return new EmbedBuilder()
         .setAuthor(embedAuthor(interaction))
         .setThumbnail(THUMB)
-        .setColor('#e74c3c')
+        .setColor(COLORS.ERROR)
         .setTitle('🃏 Wrong!')
         .setDescription(`❌ ${cardInline(current)} → ${cardInline(next)} — you guessed **${pickedHigher ? 'Higher' : 'Lower'}** incorrectly.\n\n💀 You lost your bet.`)
         .addFields(
@@ -153,7 +154,7 @@ function cashOutEmbed(interaction, bet, payout, newBalance, streak) {
     return new EmbedBuilder()
         .setAuthor(embedAuthor(interaction))
         .setThumbnail(THUMB)
-        .setColor('#2ecc71')
+        .setColor(COLORS.SUCCESS)
         .setTitle(`🃏 Cashed Out! 🔥×${streak}`)
         .setDescription(`💰 You locked in **${payout.toLocaleString()}** coins at **${mult.toFixed(1)}×**!`)
         .addFields(
@@ -169,7 +170,7 @@ function timeoutEmbed(interaction, card, bet, newBalance) {
     return new EmbedBuilder()
         .setAuthor(embedAuthor(interaction))
         .setThumbnail(THUMB)
-        .setColor('#95a5a6')
+        .setColor(COLORS.NEUTRAL)
         .setTitle('🃏 Higher or Lower — Timed Out')
         .setDescription(`⏱️ You didn't pick in time. Your bet of **${bet.toLocaleString()}** coins has been refunded.`)
         .addFields(
@@ -319,7 +320,7 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
                     embeds: [new EmbedBuilder()
                         .setAuthor(embedAuthor(interaction))
                         .setThumbnail(THUMB)
-                        .setColor('#f39c12')
+                        .setColor(COLORS.WARN)
                         .setTitle('🃏 Wrong — Lucky Save!')
                         .setDescription(`${cardInline(current)} → ${cardInline(next)}\n🍀 **Lucky Charm** returned your bet!`)
                         .addFields({ name: '💰 Balance', value: `**${(updated?.balance ?? 0).toLocaleString()}** coins`, inline: true })
@@ -339,7 +340,7 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
                     embeds: [new EmbedBuilder()
                         .setAuthor(embedAuthor(interaction))
                         .setThumbnail(THUMB)
-                        .setColor('#f39c12')
+                        .setColor(COLORS.WARN)
                         .setTitle('🃏 Wrong — Lucky Streak Save!')
                         .setDescription(`${cardInline(current)} → ${cardInline(next)}\n🎯 **Lucky Streak** returned your bet!`)
                         .addFields({ name: '💰 Balance', value: `**${(updated?.balance ?? 0).toLocaleString()}** coins`, inline: true })

--- a/src/games/casino/higherlower.js
+++ b/src/games/casino/higherlower.js
@@ -11,6 +11,7 @@ const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier, luckySaveEligible } = require('../../services/effectsService');
 const COLORS = require('../../utils/embedColors');
+const { ownedBy } = require('../../utils/collectorOwner');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f0cf.png';
 const MIN_BET = 10;
@@ -283,7 +284,7 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
 
     const message   = await interaction.fetchReply();
     const collector = message.createMessageComponentCollector({
-        filter: i => i.user.id === interaction.user.id && [upId, downId].includes(i.customId),
+        filter: ownedBy(interaction.user.id, i => [upId, downId].includes(i.customId), "This isn't your game."),
         max:    1,
         time:   15_000,
     });
@@ -398,7 +399,7 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
 
             const riskMsg = await interaction.fetchReply();
             const riskCollector = riskMsg.createMessageComponentCollector({
-                filter: r => r.user.id === interaction.user.id && [cashId, riskId].includes(r.customId),
+                filter: ownedBy(interaction.user.id, r => [cashId, riskId].includes(r.customId), "This isn't your game."),
                 max:    1,
                 time:   30_000,
             });
@@ -467,7 +468,7 @@ async function playHigherLower(interaction, bet, userFilter, guildSettings, hist
 
 function attachReplay(message, replayId, interaction, bet, userFilter, guildSettings, onWager) {
     message.createMessageComponentCollector({
-        filter: ri => ri.user.id === interaction.user.id && ri.customId === replayId,
+        filter: ownedBy(interaction.user.id, ri => ri.customId === replayId, "This isn't your game."),
         max: 1,
         time: 60_000,
     }).on('collect', async ri => {

--- a/src/games/casino/keno.js
+++ b/src/games/casino/keno.js
@@ -11,6 +11,7 @@ const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier, luckySaveEligible } = require('../../services/effectsService');
 const COLORS = require('../../utils/embedColors');
+const { ownedBy } = require('../../utils/collectorOwner');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3b1.png';
 const MIN_BET = 10;
@@ -123,7 +124,7 @@ async function playKeno(interaction, bet, picked, alreadyDebited = false, releas
             const msg = await interaction.fetchReply().catch(() => null);
             if (!msg) return;
             skipCollector = msg.createMessageComponentCollector({
-                filter: i => i.user.id === interaction.user.id && i.customId === skipId,
+                filter: ownedBy(interaction.user.id, i => i.customId === skipId, "This isn't your card."),
                 time: 8_000,
             });
             skipCollector.on('collect', async i => {
@@ -367,7 +368,7 @@ async function playKeno(interaction, bet, picked, alreadyDebited = false, releas
 
         const msg = await interaction.fetchReply();
         msg.createMessageComponentCollector({
-            filter: i => i.user.id === interaction.user.id && [replayId, rerollId].includes(i.customId),
+            filter: ownedBy(interaction.user.id, i => [replayId, rerollId].includes(i.customId), "This isn't your card."),
             max: 1,
             time: 60_000,
         }).on('collect', async i => {

--- a/src/games/casino/keno.js
+++ b/src/games/casino/keno.js
@@ -10,6 +10,7 @@ const { placeWager } = require('../../utils/placeWager');
 const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier, luckySaveEligible } = require('../../services/effectsService');
+const COLORS = require('../../utils/embedColors');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3b1.png';
 const MIN_BET = 10;
@@ -137,7 +138,7 @@ async function playKeno(interaction, bet, picked, alreadyDebited = false, releas
             const embed = new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
                 .setThumbnail(THUMB)
-                .setColor('#5865F2')
+                .setColor(COLORS.INFO)
                 .setTitle(phaseTitle(hits, i))
                 .setDescription(formatKenoGrid(picked, drawn, i))
                 .addFields(
@@ -164,7 +165,7 @@ async function playKeno(interaction, bet, picked, alreadyDebited = false, releas
             const midEmbed = new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
                 .setThumbnail(THUMB)
-                .setColor('#5865F2')
+                .setColor(COLORS.INFO)
                 .setTitle('🎱 Halfway — Drawing 6 of 10…')
                 .setDescription(formatKenoGrid(picked, drawn, 5))
                 .addFields(
@@ -182,7 +183,7 @@ async function playKeno(interaction, bet, picked, alreadyDebited = false, releas
             const embed = new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
                 .setThumbnail(THUMB)
-                .setColor('#5865F2')
+                .setColor(COLORS.INFO)
                 .setTitle(phaseTitle(hits, i))
                 .setDescription(formatKenoGrid(picked, drawn, i))
                 .addFields(
@@ -248,7 +249,7 @@ async function playKeno(interaction, bet, picked, alreadyDebited = false, releas
         if (matches === 5 && !animState.skipped) {
             await delay(400);
             const stage1 = new EmbedBuilder()
-                .setColor('#FFD700')
+                .setColor(COLORS.PRIZE)
                 .setTitle('🎱 Wait…')
                 .setDescription('> Counting your matches…')
                 .setAuthor(embedAuthor(interaction));
@@ -256,7 +257,7 @@ async function playKeno(interaction, bet, picked, alreadyDebited = false, releas
             await delay(900);
 
             const stage2 = new EmbedBuilder()
-                .setColor('#FFD700')
+                .setColor(COLORS.PRIZE)
                 .setTitle('🎱 1… 2… 3… 4…')
                 .setDescription('> 🟨🟨🟨🟨 — one more…')
                 .setAuthor(embedAuthor(interaction));
@@ -265,7 +266,7 @@ async function playKeno(interaction, bet, picked, alreadyDebited = false, releas
         } else if (matches === 4 && !animState.skipped) {
             await delay(400);
             const stage1 = new EmbedBuilder()
-                .setColor('#00FF88')
+                .setColor(COLORS.SUCCESS)
                 .setTitle('🎱 4 Matches…')
                 .setDescription('> 🟨🟨🟨🟨 — **That\'s a massive hit!**')
                 .setAuthor(embedAuthor(interaction));

--- a/src/games/casino/poker.js
+++ b/src/games/casino/poker.js
@@ -10,6 +10,7 @@ const { placeWager } = require('../../utils/placeWager');
 const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier, luckySaveEligible } = require('../../services/effectsService');
+const COLORS = require('../../utils/embedColors');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f0cf.png';
 const MIN_BET = 10;
@@ -208,7 +209,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
                 embeds: [new EmbedBuilder()
                     .setAuthor(embedAuthor(interaction))
                     .setThumbnail(THUMB)
-                    .setColor('#2ecc71')
+                    .setColor(COLORS.SUCCESS)
                     .setTitle('♠ Poker — Dealer Folded Pre-Flop!')
                     .setDescription(
                         `The dealer peeked at their hand (**${handStr(dealerHole)}**) and folded immediately.\n\n` +
@@ -253,7 +254,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
             embeds: [new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
                 .setThumbnail(THUMB)
-                .setColor('#5865F2')
+                .setColor(COLORS.INFO)
                 .setTitle('♠ Poker — Pre-Flop')
                 .addFields(
                     { name: '🃏 Your Hand',    value: handStr(playerHole), inline: false },
@@ -307,7 +308,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
             const foldEmbed = new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
                 .setThumbnail(THUMB)
-                .setColor('#e74c3c')
+                .setColor(COLORS.ERROR)
                 .setTitle('♠ Poker — Folded')
                 .setDescription(`You folded. The dealer had: **${handStr(dealerHole)}**`)
                 .addFields({ name: '💰 Balance', value: `**${debited.balance.toLocaleString()}** coins` })
@@ -344,7 +345,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
                 embeds: [new EmbedBuilder()
                     .setAuthor(embedAuthor(interaction))
                     .setThumbnail(THUMB)
-                    .setColor('#2ecc71')
+                    .setColor(COLORS.SUCCESS)
                     .setTitle('♠ Poker — Dealer Folded on the Flop!')
                     .setDescription(
                         `**Flop:** ${flopStr}\n\n` +
@@ -380,7 +381,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
             embeds: [new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
                 .setThumbnail(THUMB)
-                .setColor('#5865F2')
+                .setColor(COLORS.INFO)
                 .setTitle('♠ Poker — The Flop')
                 .addFields(
                     { name: '🃏 Your Hand',  value: handStr(playerHole),          inline: false },
@@ -435,7 +436,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
             const foldEmbed = new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
                 .setThumbnail(THUMB)
-                .setColor('#e74c3c')
+                .setColor(COLORS.ERROR)
                 .setTitle('♠ Poker — Folded')
                 .setDescription(`You folded. The dealer had: **${handStr(dealerHole)}**\nCommunity: **${flopStr} (+ 2 more)**`)
                 .addFields({ name: '💰 Balance', value: `**${debited.balance.toLocaleString()}** coins` })
@@ -471,7 +472,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
                 embeds: [new EmbedBuilder()
                     .setAuthor(embedAuthor(interaction))
                     .setThumbnail(THUMB)
-                    .setColor('#2ecc71')
+                    .setColor(COLORS.SUCCESS)
                     .setTitle('♠ Poker — Dealer Folded on the Turn!')
                     .setDescription(`**Turn:** ${turnStr}\n\nThe dealer couldn't justify calling. You win!\n\n**Dealer's hand:** ${handStr(dealerHole)} → *${bestHand([...dealerHole, ...turnBoard])?.name}*`)
                     .addFields(
@@ -503,7 +504,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
             embeds: [new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
                 .setThumbnail(THUMB)
-                .setColor('#5865F2')
+                .setColor(COLORS.INFO)
                 .setTitle('♠ Poker — The Turn')
                 .addFields(
                     { name: '🃏 Your Hand',  value: handStr(playerHole),                     inline: false },
@@ -556,7 +557,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
             const foldEmbed = new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
                 .setThumbnail(THUMB)
-                .setColor('#e74c3c')
+                .setColor(COLORS.ERROR)
                 .setTitle('♠ Poker — Folded')
                 .setDescription(`You folded. The dealer had: **${handStr(dealerHole)}**\nCommunity: **${flopStr}  ${turnStr} (+ 1 more)**`)
                 .addFields({ name: '💰 Balance', value: `**${debited.balance.toLocaleString()}** coins` })
@@ -592,7 +593,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
                 embeds: [new EmbedBuilder()
                     .setAuthor(embedAuthor(interaction))
                     .setThumbnail(THUMB)
-                    .setColor('#2ecc71')
+                    .setColor(COLORS.SUCCESS)
                     .setTitle('♠ Poker — Dealer Folded on the River!')
                     .setDescription(`**River:** ${riverStr}\n\nThe dealer missed the river and folded. You win!\n\n**Dealer's hand:** ${handStr(dealerHole)} → *${bestHand([...dealerHole, ...riverBoard])?.name}*`)
                     .addFields(
@@ -624,7 +625,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
             embeds: [new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
                 .setThumbnail(THUMB)
-                .setColor('#5865F2')
+                .setColor(COLORS.INFO)
                 .setTitle('♠ Poker — The River')
                 .addFields(
                     { name: '🃏 Your Hand',  value: handStr(playerHole),                     inline: false },
@@ -677,7 +678,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
             const foldEmbed = new EmbedBuilder()
                 .setAuthor(embedAuthor(interaction))
                 .setThumbnail(THUMB)
-                .setColor('#e74c3c')
+                .setColor(COLORS.ERROR)
                 .setTitle('♠ Poker — Folded')
                 .setDescription(`You folded on the river. The dealer had: **${handStr(dealerHole)}**\nCommunity: **${flopStr}  ${turnStr}  ${riverStr}**`)
                 .addFields({ name: '💰 Balance', value: `**${debited.balance.toLocaleString()}** coins` })

--- a/src/games/casino/poker.js
+++ b/src/games/casino/poker.js
@@ -11,6 +11,7 @@ const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier, luckySaveEligible } = require('../../services/effectsService');
 const COLORS = require('../../utils/embedColors');
+const { ownedBy } = require('../../utils/collectorOwner');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f0cf.png';
 const MIN_BET = 10;
@@ -271,7 +272,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
         let preFlopAction;
         try {
             const r = await msg1.awaitMessageComponent({
-                filter: i => i.user.id === interaction.user.id && i.customId.endsWith(gameId),
+                filter: ownedBy(interaction.user.id, i => i.customId.endsWith(gameId), "This isn't your hand."),
                 time: 30_000,
             });
             await r.deferUpdate();
@@ -398,7 +399,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
         let flopAction;
         try {
             const r = await msg2.awaitMessageComponent({
-                filter: i => i.user.id === interaction.user.id && i.customId.endsWith(flopRound),
+                filter: ownedBy(interaction.user.id, i => i.customId.endsWith(flopRound), "This isn't your hand."),
                 time: 30_000,
             });
             await r.deferUpdate();
@@ -521,7 +522,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
         let turnAction;
         try {
             const r = await msg3.awaitMessageComponent({
-                filter: i => i.user.id === interaction.user.id && i.customId.endsWith(turnRound),
+                filter: ownedBy(interaction.user.id, i => i.customId.endsWith(turnRound), "This isn't your hand."),
                 time: 30_000,
             });
             await r.deferUpdate();
@@ -642,7 +643,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
         let riverAction;
         try {
             const r = await msg4.awaitMessageComponent({
-                filter: i => i.user.id === interaction.user.id && i.customId.endsWith(riverRound),
+                filter: ownedBy(interaction.user.id, i => i.customId.endsWith(riverRound), "This isn't your hand."),
                 time: 30_000,
             });
             await r.deferUpdate();
@@ -759,7 +760,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
 
         const replyMsg = await interaction.fetchReply();
         replyMsg.createMessageComponentCollector({
-            filter: i => i.user.id === interaction.user.id && i.customId === replayId,
+            filter: ownedBy(interaction.user.id, i => i.customId === replayId, "This isn't your hand."),
             max: 1,
             time: 60_000,
         }).on('collect', async i => {

--- a/src/games/casino/roulette.js
+++ b/src/games/casino/roulette.js
@@ -10,6 +10,7 @@ const { placeWager } = require('../../utils/placeWager');
 const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, luckySaveEligible } = require('../../services/effectsService');
+const COLORS = require('../../utils/embedColors');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3a1.png';
 const MIN_BET = 10;
@@ -87,7 +88,7 @@ function spinningEmbed(currentIndex, betKey, target, bet, interaction) {
     return new EmbedBuilder()
         .setAuthor(embedAuthor(interaction))
         .setThumbnail(THUMB)
-        .setColor('#c0392b')
+        .setColor(COLORS.ERROR)
         .setTitle('🎡 Roulette — Spinning…')
         .setDescription(
             `${pocketStrip(currentIndex)}\n\n` +

--- a/src/games/casino/roulette.js
+++ b/src/games/casino/roulette.js
@@ -11,6 +11,7 @@ const Guild = require('../../models/Guild');
 const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, luckySaveEligible } = require('../../services/effectsService');
 const COLORS = require('../../utils/embedColors');
+const { ownedBy } = require('../../utils/collectorOwner');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3a1.png';
 const MIN_BET = 10;
@@ -313,7 +314,7 @@ async function playRoulette(interaction, betKey, bet, target, releaseLock, onWag
 
         const msg = await interaction.fetchReply();
         const collector = msg.createMessageComponentCollector({
-            filter: i => i.user.id === interaction.user.id && i.customId === replayId,
+            filter: ownedBy(interaction.user.id, i => i.customId === replayId, "This isn't your spin."),
             max: 1,
             time: 60_000,
         });

--- a/src/games/casino/slots.js
+++ b/src/games/casino/slots.js
@@ -11,6 +11,7 @@ const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultiplier, luckySaveEligible } = require('../../services/effectsService');
 const Guild = require('../../models/Guild');
 const { randomFrom, SLOTS_LOSE_LINES, SLOTS_WIN_LINES } = require('../../utils/copyLines');
+const COLORS = require('../../utils/embedColors');
 
 const THUMB = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3b0.png';
 
@@ -100,7 +101,7 @@ function spinEmbed(display, bet, stage, interaction, jackpotPool) {
     return new EmbedBuilder()
         .setAuthor(embedAuthor(interaction))
         .setThumbnail(THUMB)
-        .setColor('#FFD700')
+        .setColor(COLORS.PRIZE)
         .setTitle('🎰 Slot Machine')
         .setDescription(`${statuses[stage]}\n\n> **[ ${display} ]**`)
         .addFields(
@@ -173,7 +174,7 @@ function jackpotBroadcastEmbed(interaction, wonAmount, newPool) {
 
 function paytableEmbed() {
     return new EmbedBuilder()
-        .setColor('#FFD700')
+        .setColor(COLORS.PRIZE)
         .setThumbnail(THUMB)
         .setTitle('🎰 Slot Machine — Paytable')
         .setDescription('Match **3 symbols** (or **2 + a Wild 🃏**) to win!\n⚡ Boost on any reel multiplies your payout.\n​')
@@ -415,7 +416,7 @@ async function playSlots(interaction, bet, releaseLock, onWager) {
             const announceChannelId = guildSettings?.economy?.announcementChannelId ?? null;
             if (announceChannelId) {
                 const bigWinEmbed = new EmbedBuilder()
-                    .setColor('#FFD700')
+                    .setColor(COLORS.PRIZE)
                     .setDescription(
                         `🎰 ${interaction.user} just hit a **${winMult.toFixed(0)}× ${result.symbol?.name ?? 'win'}** on slots for **${adjustedPayout.toLocaleString()} coins**!`
                     )

--- a/src/games/casino/slots.js
+++ b/src/games/casino/slots.js
@@ -12,6 +12,7 @@ const { hasEffect, getCoinMultiplier, getLuckyStreakBonus, getServerCoinMultipli
 const Guild = require('../../models/Guild');
 const { randomFrom, SLOTS_LOSE_LINES, SLOTS_WIN_LINES } = require('../../utils/copyLines');
 const COLORS = require('../../utils/embedColors');
+const { ownedBy } = require('../../utils/collectorOwner');
 
 const THUMB = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3b0.png';
 
@@ -454,7 +455,11 @@ async function playSlots(interaction, bet, releaseLock, onWager) {
 
         const msg = await interaction.fetchReply();
         const collector = msg.createMessageComponentCollector({
-            filter: i => i.user.id === interaction.user.id && [replayId, paytableId].includes(i.customId),
+            filter: ownedBy(
+                interaction.user.id,
+                i => [replayId, paytableId].includes(i.customId),
+                "This isn't your spin — run `/slots` for your own.",
+            ),
             time: 60_000,
         });
 

--- a/src/services/achievementService.js
+++ b/src/services/achievementService.js
@@ -3,6 +3,7 @@
 const { ACHIEVEMENTS } = require('../data/achievements');
 const { delay } = require('../utils/delay');
 const { createAchievementCard } = require('../utils/cardGenerator');
+const COLORS = require('../utils/embedColors');
 
 /**
  * Check all applicable achievements for a user and award any newly earned ones.
@@ -103,7 +104,7 @@ async function broadcastAchievementUnlock(client, guildSettings, mention, def, r
     if (tier === 'legendary') {
         const bar = '⚡ ════════════════════════ ⚡';
         embed = new EmbedBuilder()
-            .setColor(0xFFD700)
+            .setColor(COLORS.PRIZE)
             .setTitle(`${bar}`)
             .setDescription(
                 `${bar}\n👑 ${mention} just achieved the legendary\n\n` +
@@ -113,7 +114,7 @@ async function broadcastAchievementUnlock(client, guildSettings, mention, def, r
             .setTimestamp();
     } else if (tier === 'secret') {
         embed = new EmbedBuilder()
-            .setColor(0x9c27b0)
+            .setColor(COLORS.RARE)
             .setTitle('✨ Secret Achievement Discovered!')
             .setDescription(
                 `${mention} just discovered a **secret achievement**…\n\n🔒 *"[REDACTED]"*\n\nCan you find it too?`
@@ -157,7 +158,7 @@ async function announceAchievements(client, guildSettings, user, member, achieve
 
         // Step 1 — mystery beat
         const mysteryEmbed = new EmbedBuilder()
-            .setColor(0x5865F2)
+            .setColor(COLORS.INFO)
             .setTitle('🏅 Achievement Unlocked...')
             .setDescription('???');
 

--- a/src/services/antiNukeService.js
+++ b/src/services/antiNukeService.js
@@ -1,5 +1,6 @@
 const { EmbedBuilder, AuditLogEvent, PermissionFlagsBits, PermissionsBitField, ChannelType } = require('discord.js');
 const Guild = require('../models/Guild');
+const COLORS = require('../utils/embedColors');
 
 // Permission keys the lockdown engine touches. Used to compute proper
 // per-key restoration from the original allow/deny bitfields.
@@ -88,7 +89,7 @@ async function punish(member, settings, action, count) {
     const reason = `[AntiNuke] Burst of ${action} (${count} in ${an.windowSeconds || 30}s)`;
 
     const embed = new EmbedBuilder()
-        .setColor('#ff0000')
+        .setColor(COLORS.ERROR)
         .setTitle('Anti-Nuke Triggered')
         .setDescription(`Detected destructive burst by ${member.user.tag} (${member.id})`)
         .addFields(
@@ -211,7 +212,7 @@ async function startLockdown(guild, client, { startedBy, reason }) {
     });
 
     const embed = new EmbedBuilder()
-        .setColor('#ff0000')
+        .setColor(COLORS.ERROR)
         .setTitle('SERVER LOCKDOWN')
         .setDescription(reason || 'Manual lockdown initiated.')
         .addFields({ name: 'Channels Locked', value: affected.length.toString(), inline: true })
@@ -270,7 +271,7 @@ async function endLockdown(guild, { endedBy } = {}) {
     });
 
     const embed = new EmbedBuilder()
-        .setColor('#00ff00')
+        .setColor(COLORS.SUCCESS)
         .setTitle('Lockdown Lifted')
         .addFields(
             { name: 'Channels Restored', value: restored.toString(), inline: true },
@@ -313,7 +314,7 @@ async function enforceJoinGate(member, settings) {
     }
 
     const embed = new EmbedBuilder()
-        .setColor('#ff9900')
+        .setColor(COLORS.WARN)
         .setTitle('Join Gate Triggered')
         .addFields(
             { name: 'User', value: `${member.user.tag} (${member.id})`, inline: false },

--- a/src/services/caseService.js
+++ b/src/services/caseService.js
@@ -3,6 +3,7 @@ const { EmbedBuilder } = require('discord.js');
 const Case = require('../models/Case');
 const Guild = require('../models/Guild');
 const { runJob } = require('../utils/jobRunner');
+const COLORS = require('../utils/embedColors');
 
 async function getNextCaseId(guildId) {
     // Aggregation-pipeline update atomically initializes nextCaseId to 1 when the field
@@ -104,7 +105,7 @@ function startSlaMonitor(client) {
                 if (!channel) continue;
 
                 const embed = new EmbedBuilder()
-                    .setColor('#ff9900')
+                    .setColor(COLORS.WARN)
                     .setTitle('SLA Overdue — Open Case')
                     .setDescription(`Case **#${modCase.caseId}** has exceeded its SLA deadline and is still open.`)
                     .addFields(

--- a/src/services/chatEventService.js
+++ b/src/services/chatEventService.js
@@ -17,6 +17,7 @@ const User = require('../models/User');
 const { logTransaction } = require('../utils/logTransaction');
 const { grantInventoryItem } = require('../utils/inventoryGrant');
 const QUIZ_FALLBACK = require('../data/quizFallback');
+const COLORS = require('../utils/embedColors');
 
 const EVENT_CHANCE         = 0.04;
 const MIN_MESSAGES_BETWEEN = 20;
@@ -134,7 +135,7 @@ async function spawnAirdrop(message, guildSettings) {
 
         await i.update({
             embeds: [EmbedBuilder.from(embed)
-                .setColor('#2ecc71')
+                .setColor(COLORS.SUCCESS)
                 .setTitle('🪂 Supply drop claimed!')
                 .setDescription(`**${i.member?.displayName ?? i.user.username}** grabbed **${currency}${amount.toLocaleString()}**! 💨`)
                 .setFooter({ text: 'Keep chatting — more drops are coming.' })],
@@ -146,7 +147,7 @@ async function spawnAirdrop(message, guildSettings) {
         if (reason !== 'claimed') {
             sent.edit({
                 embeds: [EmbedBuilder.from(embed)
-                    .setColor('#95a5a6')
+                    .setColor(COLORS.NEUTRAL)
                     .setTitle('🪂 The supply drop drifted away…')
                     .setDescription('Nobody grabbed it in time.')
                     .setFooter({ text: 'Stay alert for the next one!' })],
@@ -201,7 +202,7 @@ async function spawnCrate(message, _guildSettings) {
 
         await i.update({
             embeds: [EmbedBuilder.from(embed)
-                .setColor('#2ecc71')
+                .setColor(COLORS.SUCCESS)
                 .setTitle('📦 Crate cracked open!')
                 .setDescription(`**${i.member?.displayName ?? i.user.username}** found ${item.emoji} **${item.name}** inside!\n\n> Use it with \`/use ${item.itemId}\``)
                 .setFooter({ text: 'Keep chatting — more crates are coming.' })],
@@ -213,7 +214,7 @@ async function spawnCrate(message, _guildSettings) {
         if (reason !== 'claimed') {
             sent.edit({
                 embeds: [EmbedBuilder.from(embed)
-                    .setColor('#95a5a6')
+                    .setColor(COLORS.NEUTRAL)
                     .setTitle('📦 The crate crumbled to dust…')
                     .setDescription('Nobody opened it in time.')
                     .setFooter({ text: 'Stay alert for the next one!' })],
@@ -235,7 +236,7 @@ async function spawnTrivia(message, guildSettings) {
     const baseId  = `chatev_triv_${message.id}`;
 
     const embed = new EmbedBuilder()
-        .setColor('#9b59b6')
+        .setColor(COLORS.RARE)
         .setTitle('⚡ Flash Trivia!')
         .setDescription(`**${q.question}**\n\nFirst correct answer wins **${currency}${TRIVIA_REWARD.toLocaleString()}**. One guess each!`)
         .setFooter({ text: 'Expires in 60 seconds' });
@@ -294,7 +295,7 @@ async function spawnTrivia(message, guildSettings) {
 
         await i.update({
             embeds: [EmbedBuilder.from(embed)
-                .setColor('#2ecc71')
+                .setColor(COLORS.SUCCESS)
                 .setTitle('⚡ Trivia solved!')
                 .setDescription(`**${i.member?.displayName ?? i.user.username}** nailed it — **${q.correct_answer}** — and wins **${currency}${TRIVIA_REWARD.toLocaleString()}**! 🧠`)
                 .setFooter({ text: 'Keep chatting — more trivia is coming.' })],
@@ -306,7 +307,7 @@ async function spawnTrivia(message, guildSettings) {
         if (reason !== 'solved') {
             sent.edit({
                 embeds: [EmbedBuilder.from(embed)
-                    .setColor('#95a5a6')
+                    .setColor(COLORS.NEUTRAL)
                     .setTitle('⚡ Trivia expired…')
                     .setDescription(`Nobody got it. The answer was **${q.correct_answer}**.`)
                     .setFooter({ text: 'Stay sharp for the next one!' })],

--- a/src/services/dmService.js
+++ b/src/services/dmService.js
@@ -2,6 +2,7 @@ const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags
 const DmSession = require('../models/DmSession');
 const { getCompletion, resolveProviderConfig } = require('./aiService');
 const Guild = require('../models/Guild');
+const COLORS = require('../utils/embedColors');
 
 const MAX_PLAYERS = 6;
 const MAX_STORY_LOG = 20;
@@ -108,7 +109,7 @@ async function joinSession(interaction) {
 
     const embed = new EmbedBuilder()
         .setTitle('🧙 New Adventurer Joined!')
-        .setColor('#4169e1')
+        .setColor(COLORS.INFO)
         .setDescription(
             `**${characterName}** (${characterClass}) has joined the party!\n` +
             `HP: **${hp}** | Inventory: ${inventory.join(', ')}\n\n` +
@@ -357,7 +358,7 @@ async function stopSession(interaction) {
 
     const embed = new EmbedBuilder()
         .setTitle('🏁 Session Ended')
-        .setColor('#808080')
+        .setColor(COLORS.NEUTRAL)
         .setDescription(`The DM session has been ended by **${user.displayName || user.username}**.\n\nStory entries recorded: **${session.storyLog.length}**`)
         .setFooter({ text: 'Thanks for playing!' });
 
@@ -391,7 +392,7 @@ function buildStatCardEmbed(session) {
 
     return new EmbedBuilder()
         .setTitle('🗡️ Party Status')
-        .setColor('#2f3136')
+        .setColor(COLORS.NEUTRAL)
         .addFields(fields)
         .setFooter({ text: 'Updated after each action' })
         .setTimestamp();

--- a/src/services/escalationService.js
+++ b/src/services/escalationService.js
@@ -3,6 +3,7 @@ const Guild = require('../models/Guild');
 const Case = require('../models/Case');
 const TempBan = require('../models/TempBan');
 const { createCase } = require('./caseService');
+const COLORS = require('../utils/embedColors');
 
 const MAX_TIMEOUT_MS = 28 * 24 * 60 * 60 * 1000;
 
@@ -105,7 +106,7 @@ async function applyEscalation({ guild, targetUser, warningCount, triggeringCase
     });
 
     const embed = new EmbedBuilder()
-        .setColor('#cc3300')
+        .setColor(COLORS.WARN)
         .setTitle(`AutoMod | ${step.action.toUpperCase()} | ${targetUser.globalName ?? targetUser.username}`)
         .setDescription(`Triggered by warning threshold **${step.threshold}** (user reached **${warningCount}** active warnings).`)
         .addFields(

--- a/src/services/giveawayService.js
+++ b/src/services/giveawayService.js
@@ -13,6 +13,7 @@
 
 const { EmbedBuilder } = require('discord.js');
 const Guild = require('../models/Guild');
+const COLORS = require('../utils/embedColors');
 
 // Ended giveaways are kept around so `/giveaway reroll` still works, but not
 // forever: each one carries a full entrant list, and nothing else prunes the
@@ -114,7 +115,7 @@ async function endGiveaway(client, guildSettings, ga) {
         : 'No valid entrants';
 
     const endEmbed = new EmbedBuilder()
-        .setColor('#ff0000')
+        .setColor(COLORS.NEUTRAL)
         .setTitle('🎉 GIVEAWAY ENDED 🎉')
         .setDescription(`**Prize:** ${ga.prize}\n\n**Winner${winners.length !== 1 ? 's' : ''}:** ${winnerText}`)
         .addFields({ name: 'Hosted by', value: `<@${ga.hostId}>` })

--- a/src/services/heistService.js
+++ b/src/services/heistService.js
@@ -17,6 +17,7 @@ const { logTransaction } = require('../utils/logTransaction');
 const { debitUpTo } = require('../utils/balanceDebit');
 const { ROLES, TARGETS } = require('../data/heistData');
 const { makeSkillRow, buildLobbyEmbed, buildLobbyRows } = require('../views/heistView');
+const COLORS = require('../utils/embedColors');
 
 const SKILL_TIMEOUT_MS = 30_000;
 const LOBBY_POLL_MS    = 5_000; // edit the lobby message every 5s
@@ -225,7 +226,7 @@ async function sendSkillCheck(member, heistId, role) {
     const check = buildSkillCheck(role);
     const roleMeta = ROLES[role];
     const embed = new EmbedBuilder()
-        .setColor('#e74c3c')
+        .setColor(COLORS.ERROR)
         .setTitle(`🔒 Heist In Progress — ${roleMeta.emoji} ${roleMeta.label} Check`)
         .setDescription(
             `**Your role:** ${roleMeta.label}\n${roleMeta.desc}\n\n` +
@@ -475,7 +476,7 @@ function startLobbyCountdown(client, heist, msg, { minPlayers = 2, lobbyDuration
 
         if (heist.players.size < minPlayers) {
             await msg.edit({
-                embeds: [new EmbedBuilder().setColor('#e74c3c').setTitle('❌ Heist Cancelled').setDescription(`Not enough crew members joined (need at least ${minPlayers}). Heist called off.`).setTimestamp()],
+                embeds: [new EmbedBuilder().setColor(COLORS.ERROR).setTitle('❌ Heist Cancelled').setDescription(`Not enough crew members joined (need at least ${minPlayers}). Heist called off.`).setTimestamp()],
                 components: []
             }).catch(() => {});
             clearHeist(heist.guildId);
@@ -484,7 +485,7 @@ function startLobbyCountdown(client, heist, msg, { minPlayers = 2, lobbyDuration
 
         endLobby(heist.guildId);
         await msg.edit({
-            embeds: [new EmbedBuilder().setColor('#9b59b6').setTitle('🔓 Heist Begins!').setDescription('The lobby is closed. Skill checks are being sent to each crew member via DM…\nResults will be posted here when everyone responds or time runs out.').setTimestamp()],
+            embeds: [new EmbedBuilder().setColor(COLORS.RARE).setTitle('🔓 Heist Begins!').setDescription('The lobby is closed. Skill checks are being sent to each crew member via DM…\nResults will be posted here when everyone responds or time runs out.').setTimestamp()],
             components: []
         }).catch(() => {});
 
@@ -510,7 +511,7 @@ function startLobbyCountdown(client, heist, msg, { minPlayers = 2, lobbyDuration
                     if (player.skillPassed !== null) return;
                     player.skillPassed = false;
                     await dm.edit({
-                        embeds: [new EmbedBuilder().setColor('#e74c3c').setTitle('⏰ Time\'s up!').setDescription(`You ran out of time. The correct answer was **${check.correct}**.`).setTimestamp()],
+                        embeds: [new EmbedBuilder().setColor(COLORS.ERROR).setTitle('⏰ Time\'s up!').setDescription(`You ran out of time. The correct answer was **${check.correct}**.`).setTimestamp()],
                         components: []
                     }).catch(() => {});
                     const allDone = [...heist.players.values()].every(p => p.skillPassed !== null);

--- a/src/services/raidService.js
+++ b/src/services/raidService.js
@@ -1,6 +1,7 @@
 const { EmbedBuilder } = require('discord.js');
 const Guild = require('../models/Guild');
 const { assertGuildAffinity } = require('../utils/sharding');
+const COLORS = require('../utils/embedColors');
 
 // guildId -> [{timestamp, userId, accountAgeDays}]
 //
@@ -101,7 +102,7 @@ async function handleMemberJoin(member, _client, settings) {
     const newAccounts = entries.filter(e => e.accountAgeDays < minAccountAgeDays).length;
 
     const embed = new EmbedBuilder()
-        .setColor('#ff0000')
+        .setColor(COLORS.ERROR)
         .setTitle('⚠️ Raid Detected! Raid Mode Auto-Enabled')
         .setDescription(
             `**${entries.length}** members joined within **${rd.windowSeconds}s** (threshold: ${threshold})`
@@ -167,7 +168,7 @@ async function setRaidMode(guildId, guild, active, guildSettings) {
 
         if (alertChannel) {
             const embed = new EmbedBuilder()
-                .setColor('#ff9900')
+                .setColor(COLORS.WARN)
                 .setTitle('🔒 Raid Mode Manually Enabled')
                 .setDescription('Raid mode has been manually enabled by a moderator.')
                 .setTimestamp();
@@ -187,7 +188,7 @@ async function setRaidMode(guildId, guild, active, guildSettings) {
 
         if (alertChannel) {
             const embed = new EmbedBuilder()
-                .setColor('#00ff00')
+                .setColor(COLORS.SUCCESS)
                 .setTitle('🔓 Raid Mode Manually Disabled')
                 .setDescription('Raid mode has been manually disabled by a moderator.')
                 .setTimestamp();
@@ -261,7 +262,7 @@ async function sweepRaidModes(client) {
 
         if (alertChannel) {
             const embed = new EmbedBuilder()
-                .setColor('#00ff00')
+                .setColor(COLORS.SUCCESS)
                 .setTitle('✅ Raid Stopped — Raid Mode Auto-Disabled')
                 .setDescription('Raid appears to have stopped. Raid mode auto-disabled.')
                 .setTimestamp();

--- a/src/services/rssService.js
+++ b/src/services/rssService.js
@@ -5,6 +5,7 @@ const cron = require('node-cron');
 
 const { safeFetchFeed } = require('../utils/safeFeedFetch');
 const { runJob } = require('../utils/jobRunner');
+const COLORS = require('../utils/embedColors');
 
 const parser = new Parser();
 
@@ -176,7 +177,7 @@ async function deliverFeedUpdate(client, guild, feed, parsedFeed, latestItem, it
 
         if (channel) {
             const embed = new EmbedBuilder()
-                .setColor('#00ff00')
+                .setColor(COLORS.INFO)
                 .setTitle(latestItem.title || 'New Post')
                 .setURL(latestItem.link)
                 .setDescription(latestItem.contentSnippet?.substring(0, 200) || 'No description available')
@@ -312,7 +313,7 @@ async function sendDailyNewsForProfile(client, guild, profile) {
     uniqueItems.sort(compareByDateDesc);
 
     const embed = new EmbedBuilder()
-        .setColor('#0099ff')
+        .setColor(COLORS.INFO)
         .setTitle(profile.title)
         .setDescription('Here are the top stories from the last 24 hours:')
         .setTimestamp();

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -7,6 +7,7 @@ const { ensurePricingFields, nextPrice, decayDemand, demandDecayFactor, trendBuc
 const { softResetElo, tierFor, makeSeasonId } = require('../utils/duelElo');
 const { topByNetWorth } = require('../utils/netWorth');
 const { grantInventoryItem } = require('../utils/inventoryGrant');
+const COLORS = require('../utils/embedColors');
 
 const WAR_BOOSTER_DURATION_MS = 24 * 60 * 60 * 1000;
 const WAR_BADGE_DURATION_MS   = 30 * 24 * 60 * 60 * 1000;
@@ -118,7 +119,7 @@ async function resolveOneWar(client, guildDoc) {
         // perspective: 'winner' | 'loser' | 'tie'
         if (perspective === 'tie') {
             return new EmbedBuilder()
-                .setColor('#95a5a6')
+                .setColor(COLORS.NEUTRAL)
                 .setTitle('⚔️ War Ended — Tie!')
                 .setDescription(
                     `The war between **${guildDoc.name}** and **${oppName}** ended in a tie!\n\n` +
@@ -128,7 +129,7 @@ async function resolveOneWar(client, guildDoc) {
         }
         if (perspective === 'winner') {
             const embed = new EmbedBuilder()
-                .setColor('#FFD700')
+                .setColor(COLORS.PRIZE)
                 .setTitle(`🏆 ${winnerName} WINS THE WAR`)
                 .setDescription(
                     `**${winnerName}** has crushed **${loserName}**!\n\n` +
@@ -143,7 +144,7 @@ async function resolveOneWar(client, guildDoc) {
         }
         // loser perspective
         return new EmbedBuilder()
-            .setColor('#e74c3c')
+            .setColor(COLORS.ERROR)
             .setTitle('⚔️ War Lost')
             .setDescription(
                 `**${oppName}** has defeated **${guildDoc.name}**.\n\n` +
@@ -315,7 +316,7 @@ async function resolveOneSeason(client, guildDoc) {
     ).join('\n') || '*No participants*';
 
     const embed = new EmbedBuilder()
-        .setColor('#ffd700')
+        .setColor(COLORS.PRIZE)
         .setTitle(`🏁 Season Ended: ${season.name ?? season.id}`)
         .setDescription('The season leaderboard has been frozen and season coins have been reset.')
         .addFields({ name: '🏆 Final Top 3', value: winnerLines })
@@ -431,7 +432,7 @@ async function awardWeeklyLeaderboardBadges(client) {
             }
 
             const embed = new EmbedBuilder()
-                .setColor('#ffd700')
+                .setColor(COLORS.PRIZE)
                 .setTitle('👑 Last Week\'s Champions')
                 .setDescription(
                     'These legends dominated the leaderboards this week.\n' +
@@ -538,7 +539,7 @@ async function selectPetOfTheWeek(client) {
             const bondDays = Math.floor((Date.now() - new Date(bestPet.adoptedAt).getTime()) / 86400000);
 
             const embed = new EmbedBuilder()
-                .setColor('#ffd700')
+                .setColor(COLORS.PRIZE)
                 .setTitle('🌟 Pet of the Week!')
                 .setDescription(
                     `This week's most beloved pet is:\n\n` +
@@ -635,7 +636,7 @@ async function announceHourlyWinners(client) {
             if (!lines.length) continue;
 
             const embed = new EmbedBuilder()
-                .setColor('#FFD700')
+                .setColor(COLORS.PRIZE)
                 .setTitle('🏆 Last Hour\'s Champions')
                 .setDescription(lines.join('\n\n'))
                 .setFooter({ text: 'Hourly micro-competitions reset each hour. Hunt, fish, mine and explore to compete!' })
@@ -799,7 +800,7 @@ async function recalcShopPrices(client) {
                     return `${tb.arrow} **${m.name}** — ${currency}${m.prev.toLocaleString()} → ${currency}${m.next.toLocaleString()}`;
                 });
                 const embed = new EmbedBuilder()
-                    .setColor('#3498db')
+                    .setColor(COLORS.INFO)
                     .setTitle('📊 Market Update')
                     .setDescription(lines.join('\n'))
                     .setFooter({ text: 'Supply and demand shifted shop prices. Use /shop trends for the full board.' })
@@ -938,7 +939,7 @@ async function resolveRankedSeasons(client) {
                     ? top.map((u, i) => `${medals[i]} <@${u.userId}> — ${u.ranked?.seasonPeakElo ?? 1000} ELO · earned **${currency}${rewards[i].toLocaleString()}** + title *"${seasonId} ${i === 0 ? 'Champion' : i === 1 ? 'Runner-Up' : 'Third Place'}"*`).join('\n')
                     : '_No ranked games played this season._';
                 const embed = new EmbedBuilder()
-                    .setColor('#9b59b6')
+                    .setColor(COLORS.RARE)
                     .setTitle(`🏆 Ranked Season Ended — ${seasonId}`)
                     .setDescription(lines)
                     .setFooter({ text: `Season ${newSeasonNumber} starts now — ELO soft-reset toward 1200.` })

--- a/src/services/seasonalEventService.js
+++ b/src/services/seasonalEventService.js
@@ -1,5 +1,6 @@
 const Guild = require('../models/Guild');
 const { SEASONAL_EVENTS, getActiveSeasonalEvent } = require('../data/seasonalEvents');
+const COLORS = require('../utils/embedColors');
 
 /**
  * Check all guilds for seasonal event auto-start/auto-end and apply changes.
@@ -203,7 +204,7 @@ async function announceEventEnd(discordGuild, eventData, guildDoc) {
         if (!channel?.isTextBased()) return;
         const { EmbedBuilder } = require('discord.js');
         const embed = new EmbedBuilder()
-            .setColor('#888888')
+            .setColor(COLORS.NEUTRAL)
             .setTitle(`${eventData.emoji ?? '🎉'} ${eventData.name} Has Ended`)
             .setDescription('Thank you for participating! The event has concluded.')
             .setTimestamp();

--- a/src/services/summaryService.js
+++ b/src/services/summaryService.js
@@ -4,6 +4,7 @@ const Guild = require('../models/Guild');
 const { getCompletion, resolveProviderConfig } = require('./aiService');
 const { runJob } = require('../utils/jobRunner');
 const { EmbedBuilder } = require('discord.js');
+const COLORS = require('../utils/embedColors');
 
 const MAX_TRANSCRIPT_CHARS = 6000;
 const DIGEST_LOOKBACK_MS = 24 * 60 * 60 * 1000;
@@ -137,7 +138,7 @@ async function runDailyDigest(guildSettings, client) {
         const embed = new EmbedBuilder()
             .setTitle('Daily Server Digest')
             .setDescription('No activity in the last 24 hours.')
-            .setColor(0x5865F2)
+            .setColor(COLORS.INFO)
             .setTimestamp();
         await dstChannel.send({ embeds: [embed] });
         guildSettings.ai.dailyDigest.lastRun = new Date();
@@ -170,7 +171,7 @@ async function runDailyDigest(guildSettings, client) {
         .setTitle('Daily Server Digest')
         .setDescription(summary?.slice(0, 4096) || '(no summary generated)')
         .setFooter({ text: date })
-        .setColor(0x5865F2)
+        .setColor(COLORS.INFO)
         .setTimestamp();
 
     await dstChannel.send({ embeds: [embed] });

--- a/src/services/tournamentService.js
+++ b/src/services/tournamentService.js
@@ -4,6 +4,7 @@ const FishingTournament = require('../models/FishingTournament');
 const User = require('../models/User');
 const { logTransaction } = require('../utils/logTransaction');
 const { EmbedBuilder } = require('discord.js');
+const COLORS = require('../utils/embedColors');
 
 const PRIZE_SPLITS = [0.60, 0.25, 0.15];
 
@@ -178,7 +179,7 @@ function buildWinnersEmbed(tournament, currency = '💰') {
     });
 
     return new EmbedBuilder()
-        .setColor('#FFD700')
+        .setColor(COLORS.PRIZE)
         .setTitle('🏆 Fishing Tournament Results!')
         .setDescription(lines.length ? lines.join('\n') : '*No participants.*')
         .setTimestamp();

--- a/src/utils/collectorOwner.js
+++ b/src/utils/collectorOwner.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const { MessageFlags } = require('discord.js');
+
+/**
+ * Collector filters that answer the wrong member instead of ignoring them
+ * (#666).
+ *
+ * Forty-odd collectors filtered with `i => i.user.id === interaction.user.id`.
+ * A filter returning false does not decline the interaction — it drops it, and
+ * Discord's client, having waited three seconds for a response that was never
+ * coming, shows the member a red "This interaction failed". Most of these
+ * buttons sit on a public message, so the second person to reach for the
+ * Replay button on someone else's slot spin was told the bot was broken.
+ *
+ * The check stays in the filter rather than moving into `on('collect')`, which
+ * is the other way to write this. What the filter returns is also what decides
+ * whether a collection counts, so a check moved into the handler would let a
+ * passer-by's click spend a `max: 1` collector's one collection, or resolve an
+ * `awaitMessageComponent` as though they had answered the prompt — the two
+ * places a silent drop was doing something useful. Returning false here keeps
+ * that, and the reply is what the drop was missing.
+ *
+ * Where a collector has no `max` and no await behind it, the equivalent check
+ * at the top of `on('collect')` is just as correct; several confirmations are
+ * written that way already and are left alone.
+ */
+
+const NOT_YOURS = "This isn't yours — run the command yourself for your own.";
+
+/**
+ * Tell a member the component they clicked belongs to someone else.
+ *
+ * Ephemeral, so it is answered without a public message every time somebody
+ * reaches for a button in a busy channel. Failures are swallowed: a reply that
+ * did not land (the interaction already expired, the bot lost the channel)
+ * must not take the collector down with it.
+ *
+ * @returns {boolean} true when the click was not the owner's and has been
+ *                    answered — collector filters return the negation of this.
+ */
+function rejectOtherUser(componentInteraction, owners, message = NOT_YOURS) {
+    const allowed = Array.isArray(owners) ? owners : [owners];
+    if (allowed.includes(componentInteraction.user.id)) return false;
+
+    componentInteraction.reply({ content: message, flags: MessageFlags.Ephemeral }).catch(() => {});
+    return true;
+}
+
+/**
+ * Build a collector filter that accepts only `owners` and says so to everyone
+ * else.
+ *
+ * @param {string|string[]} owners  user id, or ids, the components belong to
+ * @param {(i: object) => boolean} [matches]  the customId test this replaces —
+ *        run first, so a click on some unrelated component on the same message
+ *        is still ignored in silence rather than answered with a refusal that
+ *        makes no sense.
+ * @param {string} [message]  what to tell everyone else
+ */
+function ownedBy(owners, matches = () => true, message = NOT_YOURS) {
+    return componentInteraction => {
+        if (!matches(componentInteraction)) return false;
+        return !rejectOtherUser(componentInteraction, owners, message);
+    };
+}
+
+/**
+ * ownedBy for the collectors whose audience is not one user but a set that
+ * changes while the collector runs — a crash lobby's players, say. `isMember`
+ * is asked at click time rather than a list being captured up front.
+ */
+function ownedByMembers(isMember, matches = () => true, message = NOT_YOURS) {
+    return componentInteraction => {
+        if (!matches(componentInteraction)) return false;
+        if (isMember(componentInteraction.user.id)) return true;
+        componentInteraction.reply({ content: message, flags: MessageFlags.Ephemeral }).catch(() => {});
+        return false;
+    };
+}
+
+module.exports = { NOT_YOURS, rejectOtherUser, ownedBy, ownedByMembers };

--- a/src/utils/confirmBet.js
+++ b/src/utils/confirmBet.js
@@ -1,4 +1,5 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, MessageFlags } = require('discord.js');
+const { ownedBy } = require('../utils/collectorOwner');
 
 const DEFAULT_THRESHOLD = 10_000;
 
@@ -42,7 +43,7 @@ async function confirmBet(interaction, amount, walletBalance, gameName, guildSet
     try {
         const response = await reply.awaitMessageComponent({
             time: 15_000,
-            filter: i => i.user.id === interaction.user.id,
+            filter: ownedBy(interaction.user.id, "This isn't your bet."),
         });
 
         if (response.customId === 'confirm_large_bet') {

--- a/src/utils/embedColors.js
+++ b/src/utils/embedColors.js
@@ -1,0 +1,55 @@
+'use strict';
+
+/**
+ * The colours an embed uses to say what kind of thing just happened (#664).
+ *
+ * There were sixty-one distinct hex literals across a hundred and twenty files
+ * and no module holding any of them, so the same event wore a different colour
+ * depending on which command produced it. Success was `#2ecc71` in the economy,
+ * `#00ff00` in moderation, `#4caf50` when a pet was adopted and `#00cc55` out
+ * on an expedition; failure was `#e74c3c`, `#ff0000`, `#ff3333`, `#ff6b6b` and
+ * `#c0392b`. None of that was a decision anyone made — it is what happens when
+ * every call site picks its own red.
+ *
+ * Seven roles, one value each:
+ *
+ *   SUCCESS  it worked — bought, claimed, unbanned, crafted, equipped
+ *   ERROR    it failed, was refused, or was cancelled against the user's wish
+ *   WARN     confirm first, or something needs attention but nothing is broken
+ *   INFO     a listing, a profile, a settings readout — a neutral statement
+ *   NEUTRAL  nothing happened: expired, timed out, empty, no longer running
+ *   RARE     the uncommon and the earned — prestige, ranked tiers, rare finds
+ *   PRIZE    a win, a payout, a leaderboard — the moment worth celebrating
+ *
+ * PRIZE is a seventh the issue's six did not name, and it earns its place the
+ * same way the others do: `#ffd700` was retyped in twenty-one files, all of
+ * them saying "you won something". Leaving it out would have left the largest
+ * single family of repeated literals exactly where it was.
+ *
+ * ── What this deliberately does not cover ──────────────────────────────────
+ *
+ * A colour that belongs to one feature rather than to an outcome is that
+ * feature's own, and stays where it is used: mining's browns, the magenta a
+ * progressive jackpot arrives in, the near-black of an apex predator, the
+ * severity ramp in the hunt and fishing failure embeds, the masthead of the
+ * weekly newspaper. Those were never the problem the issue described — nobody
+ * is confused about which command they are in. Flattening them into these
+ * seven would trade a real inconsistency for a real loss.
+ *
+ * The rule that separates them: a hex spelling one of these roles across
+ * several features belongs here. A hex that only ever appears inside a single
+ * feature is that feature's identity, and belongs at its call sites.
+ * tests/embedColors.test.js holds that line.
+ */
+// Imported as a namespace — `const COLORS = require(...)` and `COLORS.SUCCESS`
+// — so a call site reads as the role it means without a bare `SUCCESS` floating
+// loose in a nine-hundred-line command file.
+module.exports = Object.freeze({
+    SUCCESS: '#2ecc71',
+    ERROR:   '#e74c3c',
+    WARN:    '#f39c12',
+    INFO:    '#5865f2',
+    NEUTRAL: '#95a5a6',
+    RARE:    '#9b59b6',
+    PRIZE:   '#ffd700',
+});

--- a/src/utils/embedFields.js
+++ b/src/utils/embedFields.js
@@ -23,7 +23,29 @@ const EMBED_LIMITS = {
  * @param {object} [opts]  { limit, separator, inline, maxFields }
  * @returns {Array<{name: string, value: string, inline: boolean}>}
  */
-function packFields(name, lines, {
+function packFields(name, lines, opts = {}) {
+    return packFieldsCapped(name, lines, opts).fields;
+}
+
+/**
+ * packFields, told how many fields it may spend and reporting how many lines
+ * did not fit in them.
+ *
+ * An embed has two budgets, not one: 1,024 characters per field value and
+ * 6,000 across the whole embed. Spilling into continuation fields respects the
+ * first and eventually blows the second, so a section that grows with player
+ * progress caps its spill and says what was left out — a count the caller can
+ * print, rather than entries that quietly stop appearing.
+ *
+ * The count is of input lines, kept as the packing runs. It cannot be
+ * recovered afterwards by splitting the packed values on the separator: a
+ * single line may contain the separator itself (an item and its lore line are
+ * one entry joined by a newline), which is how you end up dividing a split
+ * length by two and hoping.
+ *
+ * @returns {{ fields: Array<{name: string, value: string, inline: boolean}>, omitted: number }}
+ */
+function packFieldsCapped(name, lines, {
     limit = EMBED_LIMITS.FIELD_VALUE,
     separator = '\n',
     inline = false,
@@ -31,32 +53,42 @@ function packFields(name, lines, {
 } = {}) {
     const fields = [];
     let current = '';
+    let held  = 0;   // input lines sitting in `current`
+    let shown = 0;   // input lines that reached a field
 
+    /** Push `current` as a field. False when the cap leaves no room for it. */
     const flush = () => {
-        if (!current) return;
+        if (!current) return true;
+        if (fields.length >= maxFields) return false;
         fields.push({
             name: fields.length === 0 ? name : `${name} (cont.)`,
             value: current,
             inline,
         });
+        shown += held;
         current = '';
+        held = 0;
+        return true;
     };
 
     for (const line of lines) {
         const piece = truncate(line, limit);
         if (!current) {
             current = piece;
+            held = 1;
         } else if (current.length + separator.length + piece.length <= limit) {
             current += separator + piece;
+            held += 1;
+        } else if (!flush()) {
+            return { fields, omitted: lines.length - shown };
         } else {
-            flush();
-            if (fields.length >= maxFields) return fields;
             current = piece;
+            held = 1;
         }
     }
     flush();
 
-    return fields.length > maxFields ? fields.slice(0, maxFields) : fields;
+    return { fields, omitted: lines.length - shown };
 }
 
 /**
@@ -129,4 +161,4 @@ function truncate(text, limit) {
     return `${text.slice(0, Math.max(0, limit - 1)).trimEnd()}…`;
 }
 
-module.exports = { EMBED_LIMITS, packFields, fitDescription, chunkByLength, truncate };
+module.exports = { EMBED_LIMITS, packFields, packFieldsCapped, fitDescription, chunkByLength, truncate };

--- a/src/utils/paginator.js
+++ b/src/utils/paginator.js
@@ -1,4 +1,5 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, ComponentType, EmbedBuilder, MessageFlags } = require('discord.js');
+const { ownedBy } = require('../utils/collectorOwner');
 
 function chunkArray(items, chunkSize) {
     if (!Array.isArray(items) || chunkSize <= 0) return [];
@@ -58,7 +59,11 @@ async function paginate(interaction, pages) {
 
     const collector = message.createMessageComponentCollector({
         componentType: ComponentType.Button,
-        filter: btn => btn.user.id === interaction.user.id && (btn.customId === prevId || btn.customId === nextId),
+        filter: ownedBy(
+            interaction.user.id,
+            btn => btn.customId === prevId || btn.customId === nextId,
+            "This isn't your list — run the command yourself to page through your own.",
+        ),
         time: 120_000
     });
 

--- a/src/views/heistView.js
+++ b/src/views/heistView.js
@@ -13,6 +13,7 @@
 
 const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const { ROLES, TARGETS } = require('../data/heistData');
+const COLORS = require('../utils/embedColors');
 
 function makeSkillRow(heistId, userId, check) {
     const row = new ActionRowBuilder();
@@ -36,7 +37,7 @@ function buildLobbyEmbed(heist) {
     });
 
     return new EmbedBuilder()
-        .setColor('#f39c12')
+        .setColor(COLORS.WARN)
         .setTitle(`🎭 Heist Lobby — ${target.label}`)
         .setDescription(
             `**Initiator:** <@${heist.initiatorId}>\n\n` +

--- a/tests/collectorOwner.test.js
+++ b/tests/collectorOwner.test.js
@@ -1,0 +1,145 @@
+'use strict';
+
+/**
+ * #666. Forty-odd collectors filtered with
+ * `filter: i => i.user.id === interaction.user.id`. A filter returning false
+ * does not decline an interaction — it drops it, and Discord's client, after
+ * waiting three seconds for a response that was never coming, shows the member
+ * a red "This interaction failed". Most of these buttons are on a public
+ * message, so the second person to reach for the Replay button under someone
+ * else's slot spin was told the bot was broken.
+ */
+const fs = require('fs');
+const path = require('path');
+const { MessageFlags } = require('discord.js');
+
+const { NOT_YOURS, rejectOtherUser, ownedBy, ownedByMembers } = require('../src/utils/collectorOwner');
+
+const SRC = path.join(__dirname, '..', 'src');
+
+/** A component interaction that records what it was replied with. */
+function click(userId, customId = 'x') {
+    const replies = [];
+    return {
+        replies,
+        user: { id: userId },
+        customId,
+        reply: payload => { replies.push(payload); return Promise.resolve(); },
+    };
+}
+
+describe('ownedBy', () => {
+    it('lets the owner through without saying anything', () => {
+        const i = click('owner');
+        expect(ownedBy('owner')(i)).toBe(true);
+        expect(i.replies).toEqual([]);
+    });
+
+    it('turns everyone else away with an ephemeral explanation', () => {
+        const i = click('stranger');
+        expect(ownedBy('owner')(i)).toBe(false);
+        expect(i.replies).toEqual([{ content: NOT_YOURS, flags: MessageFlags.Ephemeral }]);
+    });
+
+    it('says what the caller asked it to say', () => {
+        const i = click('stranger');
+        ownedBy('owner', () => true, "This isn't your spin.")(i);
+        expect(i.replies[0].content).toBe("This isn't your spin.");
+    });
+
+    it('accepts a set of owners, for the two-party prompts', () => {
+        expect(ownedBy(['a', 'b'])(click('b'))).toBe(true);
+        expect(ownedBy(['a', 'b'])(click('c'))).toBe(false);
+    });
+
+    it('ignores an unrelated component in silence, rather than refusing it', () => {
+        // Another command's buttons can share a message. Answering "this isn't
+        // yours" to a click the collector was never interested in would be a
+        // second kind of wrong reply.
+        const i = click('stranger', 'someone_elses_button');
+        expect(ownedBy('owner', c => c.customId === 'ours')(i)).toBe(false);
+        expect(i.replies).toEqual([]);
+    });
+
+    it('checks the customId before the user, so the owner is filtered too', () => {
+        const i = click('owner', 'not_ours');
+        expect(ownedBy('owner', c => c.customId === 'ours')(i)).toBe(false);
+        expect(i.replies).toEqual([]);
+    });
+
+    it('survives a reply that never lands', () => {
+        // The interaction may already have expired, or the bot may have lost
+        // the channel. Neither may take the collector down.
+        const i = { user: { id: 'stranger' }, customId: 'x', reply: () => Promise.reject(new Error('10062')) };
+        expect(() => ownedBy('owner')(i)).not.toThrow();
+    });
+});
+
+describe('ownedByMembers', () => {
+    const players = new Set(['a']);
+
+    it('asks at click time, not when the collector was built', () => {
+        const filter = ownedByMembers(id => players.has(id));
+        expect(filter(click('b'))).toBe(false);
+        players.add('b');
+        expect(filter(click('b'))).toBe(true);
+    });
+
+    it('tells a non-member why nothing happened', () => {
+        const i = click('nobody');
+        ownedByMembers(id => players.has(id), () => true, "You're not in this round.")(i);
+        expect(i.replies).toEqual([{ content: "You're not in this round.", flags: MessageFlags.Ephemeral }]);
+    });
+});
+
+describe('rejectOtherUser', () => {
+    it('reports whether it handled the click, so a filter can negate it', () => {
+        expect(rejectOtherUser(click('owner'), 'owner')).toBe(false);
+        expect(rejectOtherUser(click('stranger'), 'owner')).toBe(true);
+    });
+});
+
+describe('no collector drops another member\'s click in silence', () => {
+    function componentFilters() {
+        const found = [];
+        const walk = dir => {
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                const full = path.join(dir, entry.name);
+                if (entry.isDirectory()) {
+                    if (entry.name !== 'dashboard') walk(full);
+                } else if (entry.name.endsWith('.js')) {
+                    fs.readFileSync(full, 'utf8').split('\n').forEach((line, i) => {
+                        if (/^\s*filter:.*\.user\.id\s*===/.test(line)) {
+                            found.push(`${path.relative(SRC, full)}:${i + 1}`);
+                        }
+                    });
+                }
+            }
+        };
+        walk(SRC);
+        return found;
+    }
+
+    it('leaves no bare user check in a collector filter', () => {
+        // Bare, meaning: returns false for the wrong member and says nothing.
+        // ownedBy / ownedByMembers / rejectOtherUser all answer first.
+        expect(componentFilters()).toEqual([]);
+    });
+
+    it('actually reached the call sites', () => {
+        // A sweep that derives its own input reports the same green for
+        // "nothing was wrong" as for "nothing was looked at".
+        const uses = [];
+        const walk = dir => {
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                const full = path.join(dir, entry.name);
+                if (entry.isDirectory()) { if (entry.name !== 'dashboard') walk(full); }
+                else if (entry.name.endsWith('.js') && full !== path.join(SRC, 'utils', 'collectorOwner.js')) {
+                    if (/collectorOwner/.test(fs.readFileSync(full, 'utf8'))) uses.push(full);
+                }
+            }
+        };
+        walk(SRC);
+        expect(uses.length).toBeGreaterThan(25);
+    });
+});

--- a/tests/dashboardAccessibility.test.js
+++ b/tests/dashboardAccessibility.test.js
@@ -14,7 +14,9 @@ global.TextDecoder = global.TextDecoder || TextDecoder;
 // left the nav inert without JS, and reported the selected section with
 // aria-pressed. The toast, the dashboard's only feedback channel, was not a
 // live region and told success from failure by border colour alone.
-const { bootPage, clickTab, settle, forgetDocumentListeners } = require('./helpers/guildSettingsPage');
+const fs = require('fs');
+const path = require('path');
+const { PUBLIC, renderPanel, bootPage, clickTab, settle, forgetDocumentListeners } = require('./helpers/guildSettingsPage');
 
 describe('sidebar navigation', () => {
     beforeEach(() => {
@@ -207,5 +209,206 @@ describe('toast', () => {
         // make it interactive, or it covers whatever sits underneath it.
         expect(toastEl().classList.contains('show')).toBe(false);
         expect(toastEl().className).toBe('toast');
+    });
+});
+
+// #668. `.cases-table` is up to seven columns wide and `body` is
+// `overflow-x: hidden`, so on a narrow screen the right-hand columns — the
+// Actions column on three of these four — were clipped with nothing that could
+// scroll to them.
+describe('wide tables', () => {
+    beforeEach(() => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        document.body.innerHTML = '';
+        bootPage();
+    });
+
+    afterEach(async () => {
+        await settle();
+        forgetDocumentListeners();
+        jest.restoreAllMocks();
+    });
+
+    const styles = fs.readFileSync(path.join(PUBLIC, 'styles.css'), 'utf8');
+
+    it('gives every wide table a container that can actually scroll', () => {
+        const rule = /\.table-scroll\s*\{([^}]*)\}/.exec(styles);
+        expect(rule).not.toBeNull();
+        expect(rule[1]).toMatch(/overflow-x:\s*auto/);
+
+        // Without a min-width the table is width:100% inside an auto-overflow
+        // parent, so it shrinks to fit and squeezes the columns rather than
+        // overflowing — nothing to scroll, and the clipping just moves inside
+        // the cells.
+        expect(styles).toMatch(/\.table-scroll\s*>\s*\.cases-table\s*\{[^}]*min-width:/);
+    });
+
+    it.each(['moderation', 'economy', 'leveling'])('wraps every table in the %s panel', panel => {
+        document.body.insertAdjacentHTML('beforeend', renderPanel(panel));
+        const tables = [...document.querySelectorAll('table.cases-table')];
+        expect(tables.length).toBeGreaterThan(0);
+
+        for (const table of tables) {
+            const wrap = table.parentElement;
+            expect([table.id, wrap.classList.contains('table-scroll')]).toEqual([table.id, true]);
+            // Scrollable by keyboard and not only by touch, and named so the
+            // region it becomes says which table it holds.
+            expect(wrap.getAttribute('tabindex')).toBe('0');
+            expect(wrap.getAttribute('role')).toBe('region');
+            expect(wrap.getAttribute('aria-label')).toBeTruthy();
+        }
+    });
+
+    it('hides the wrapper with the table, leaving no empty region in the tab order', async () => {
+        document.body.insertAdjacentHTML('beforeend', renderPanel('moderation'));
+        const wrap = document.getElementById('cases-table').closest('.table-scroll');
+
+        // The three data tables start hidden behind their empty states, and a
+        // focusable labelled region announcing a table that is not rendered is
+        // worse than no region at all.
+        expect(wrap.style.display).toBe('none');
+
+        window.setTableVisible('cases-table', true);
+        expect(wrap.style.display).toBe('');
+
+        window.setTableVisible('cases-table', false);
+        expect(wrap.style.display).toBe('none');
+    });
+});
+
+// #669. Six analytics charts, plus the economy command breakdown, drew into
+// bare <canvas> elements: no role, no label, no fallback and no table. A canvas
+// is an opaque bitmap, so the whole Insights panel was announced as nothing at
+// all — WCAG 1.1.1.
+describe('analytics charts', () => {
+    const ANALYTICS = {
+        analytics: {
+            memberGrowth:    [{ date: '2026-08-01', joins: 4, leaves: 1 }, { date: '2026-08-02', joins: 6, leaves: 2 }],
+            commandDaily:    [{ date: '2026-08-01', count: 30 }, { date: '2026-08-02', count: 12 }],
+            economyDaily:    [{ date: '2026-08-01', earned: 500, spent: 200 }],
+            xpDaily:         [{ date: '2026-08-01', xp: 900, levelUps: 3 }],
+            aiRequestsDaily: [{ date: '2026-08-01', count: 7 }],
+        },
+    };
+    const INSIGHTS = { retention: { retained7Pct: 61, retained30Pct: 44 } };
+
+    const CANVASES = [
+        'chart-member-growth', 'chart-command-activity', 'chart-retention',
+        'chart-economy', 'chart-leveling', 'chart-ai-requests',
+    ];
+
+    /** Chart.js stands in for the real library, which jsdom cannot run. */
+    function stubChartJs() {
+        window.Chart = function Chart() { this.destroy = () => {}; };
+    }
+
+    beforeEach(() => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        document.head.innerHTML = '';
+        document.body.innerHTML = '';
+        bootPage();
+        document.body.insertAdjacentHTML('beforeend', renderPanel('analytics'));
+    });
+
+    afterEach(async () => {
+        await settle();
+        forgetDocumentListeners();
+        delete window.Chart;
+        jest.restoreAllMocks();
+    });
+
+    it('ships every canvas already labelled, before any data arrives', () => {
+        for (const id of CANVASES) {
+            const canvas = document.getElementById(id);
+            expect([id, canvas.getAttribute('role')]).toEqual([id, 'img']);
+            expect(canvas.getAttribute('aria-label')).toBeTruthy();
+            // The table alternative has somewhere to land.
+            expect(document.getElementById(`${id}-data`)).not.toBeNull();
+        }
+    });
+
+    it('names each chart with the numbers it is drawing, not just its title', async () => {
+        stubChartJs();
+        await window.renderAnalyticsCharts(ANALYTICS, INSIGHTS);
+
+        const label = id => document.getElementById(id).getAttribute('aria-label');
+        expect(label('chart-member-growth')).toMatch(/10 joins.*3 leaves/);
+        expect(label('chart-command-activity')).toMatch(/42 commands/);
+        expect(label('chart-retention')).toMatch(/61%.*44%/);
+        expect(label('chart-economy')).toMatch(/500 coins earned.*200 spent/);
+        expect(label('chart-leveling')).toMatch(/900 XP awarded.*3 level-ups/);
+        expect(label('chart-ai-requests')).toMatch(/7 in total/);
+    });
+
+    it('puts the series itself beside the canvas as a real table', async () => {
+        stubChartJs();
+        await window.renderAnalyticsCharts(ANALYTICS, INSIGHTS);
+
+        const table = document.querySelector('#chart-member-growth-data table');
+        expect(table).not.toBeNull();
+        expect(table.querySelector('caption').textContent).toMatch(/Member growth/);
+        expect([...table.querySelectorAll('thead th')].map(th => th.textContent))
+            .toEqual(['Date', 'Joins', 'Leaves']);
+        // Every column header scoped, and the date leading each row a header of
+        // its own, so the numbers are announced with what they belong to.
+        expect([...table.querySelectorAll('thead th')].every(th => th.getAttribute('scope') === 'col')).toBe(true);
+        expect([...table.querySelectorAll('tbody tr')].map(tr => [...tr.children].map(c => c.textContent)))
+            .toEqual([['2026-08-01', '4', '1'], ['2026-08-02', '6', '2']]);
+        expect(table.querySelector('tbody th').getAttribute('scope')).toBe('row');
+
+        for (const id of CANVASES) {
+            expect([id, !!document.querySelector(`#${id}-data table`)]).toEqual([id, true]);
+        }
+    });
+
+    it('hides the tables from sight without hiding them from the reader', () => {
+        // `display: none` would take the table out of the accessibility tree
+        // along with everything in it, which is the whole point of having it.
+        const styles = fs.readFileSync(path.join(PUBLIC, 'styles.css'), 'utf8');
+        const rule = /\.chart-a11y-data\s*\{([^}]*)\}/.exec(styles);
+        expect(rule).not.toBeNull();
+        expect(rule[1]).not.toMatch(/display:\s*none/);
+        expect(rule[1]).not.toMatch(/visibility:\s*hidden/);
+        expect(rule[1]).toMatch(/clip-path:|clip:/);
+    });
+
+    it('still gives the numbers when Chart.js does not load', async () => {
+        // The reader who needs the table is exactly the one who gets nothing
+        // from the canvas, so a failed script fetch must not take it with it.
+        const render = window.renderAnalyticsCharts(ANALYTICS, INSIGHTS);
+        const script = [...document.head.querySelectorAll('script[src]')].pop();
+        script.onerror(new window.Event('error'));
+        await render;
+
+        expect(document.querySelector('#chart-member-growth-data table')).not.toBeNull();
+        expect(document.getElementById('chart-member-growth').getAttribute('aria-label')).toMatch(/10 joins/);
+    });
+
+    it('covers the economy panel\'s command chart too', async () => {
+        document.body.insertAdjacentHTML('beforeend', renderPanel('economy'));
+        const canvas = document.getElementById('eco-cmd-chart');
+        expect(canvas.getAttribute('role')).toBe('img');
+        expect(document.getElementById('eco-cmd-chart-data')).not.toBeNull();
+
+        window.fetch = jest.fn(async () => ({
+            ok: true, status: 200,
+            json: async () => ({ topEarners: [], commandFrequency: [{ cmd: 'daily', count: 91 }] }),
+        }));
+        stubChartJs();
+        await window.loadEcoHealth();
+
+        expect(canvas.getAttribute('aria-label')).toMatch(/\/daily, 91 uses/);
+        expect([...document.querySelectorAll('#eco-cmd-chart-data tbody tr')]
+            .map(tr => [...tr.children].map(c => c.textContent))).toEqual([['/daily', '91']]);
+    });
+
+    it('says so in the label when a chart has no data at all', async () => {
+        stubChartJs();
+        await window.renderAnalyticsCharts({ analytics: {} }, {});
+
+        const canvas = document.getElementById('chart-economy');
+        expect(canvas.getAttribute('aria-label')).toMatch(/no data/i);
+        expect(document.querySelector('#chart-economy-data table')).toBeNull();
+        expect(document.getElementById('chart-economy-data').textContent).toMatch(/no data/i);
     });
 });

--- a/tests/dashboardInlineAttributes.test.js
+++ b/tests/dashboardInlineAttributes.test.js
@@ -45,7 +45,7 @@ const BASELINE = {
     'partials/panels/eventlog.ejs': [6, 1],
     'partials/panels/exploration.ejs': [5, 1],
     'partials/panels/farewell.ejs': [0, 2],
-    'partials/panels/leveling.ejs': [29, 14],
+    'partials/panels/leveling.ejs': [28, 14],
     'partials/panels/moderation.ejs': [28, 19],
     'partials/panels/newspaper.ejs': [4, 1],
     'partials/panels/overview.ejs': [20, 7],

--- a/tests/embedColors.test.js
+++ b/tests/embedColors.test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+/**
+ * #664. Sixty-one distinct hex literals across a hundred and twenty files that
+ * build an EmbedBuilder inline, and no module holding any of them — so the same
+ * event wore a different colour depending on which command produced it.
+ * Success was `#2ecc71` in the economy, `#00ff00` in moderation, `#4caf50` when
+ * a pet was adopted; failure was `#e74c3c`, `#ff0000`, `#ff3333`, `#ff6b6b`
+ * and `#c0392b`.
+ *
+ * src/utils/embedColors.js holds the roles now. This is the line that keeps
+ * them held: a retired spelling must not reappear, and a canonical value must
+ * not be retyped as a literal by someone who did not know the module exists.
+ *
+ * A colour that belongs to one feature rather than to an outcome is not a role
+ * and is deliberately left alone — see the module's own comment. Those are not
+ * listed here, and nothing below should be read as a ban on them.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const COLORS = require('../src/utils/embedColors');
+
+const SRC = path.join(__dirname, '..', 'src');
+// The dashboard is HTML and CSS with its own palette; these are Discord embeds.
+const SKIP = path.join(SRC, 'dashboard');
+
+/** Every hex or 0x literal handed to setColor(), with where it came from. */
+function literalColorSites() {
+    const found = [];
+    const walk = dir => {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            const full = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+                if (full !== SKIP) walk(full);
+            } else if (entry.name.endsWith('.js')) {
+                fs.readFileSync(full, 'utf8').split('\n').forEach((line, i) => {
+                    const m = /setColor\(\s*(?:['"](#[0-9a-fA-F]{6})['"]|(0[xX][0-9a-fA-F]{6}))/.exec(line);
+                    if (m) found.push({
+                        file: path.relative(SRC, full),
+                        line: i + 1,
+                        color: (m[1] ?? m[2]).toLowerCase().replace(/^0x/, '#'),
+                    });
+                });
+            }
+        }
+    };
+    walk(SRC);
+    return found;
+}
+
+// The second, third and fourth spellings each role had picked up.
+const RETIRED = {
+    SUCCESS: ['#00ff00', '#4caf50', '#00cc55', '#00ff88'],
+    ERROR:   ['#ff0000', '#ff3333', '#ff6b6b', '#c0392b', '#ed4245'],
+    WARN:    ['#ff9900', '#ffa500', '#ff9800', '#ff6600', '#ffff00', '#cc3300'],
+    INFO:    ['#3498db', '#0099ff', '#5dade2', '#6ab4f5', '#1565c0', '#4169e1'],
+    NEUTRAL: ['#888888', '#9e9e9e', '#aaaaaa', '#808080', '#2f3136', '#78909c'],
+    RARE:    ['#8e44ad', '#b39ddb', '#9c27b0'],
+    PRIZE:   ['#ffdd00'],
+};
+
+describe('embedColors', () => {
+    it('names every role the call sites need', () => {
+        expect(Object.keys(COLORS).sort())
+            .toEqual(['ERROR', 'INFO', 'NEUTRAL', 'PRIZE', 'RARE', 'SUCCESS', 'WARN']);
+        for (const [role, value] of Object.entries(COLORS)) {
+            expect([role, value]).toEqual([role, expect.stringMatching(/^#[0-9a-f]{6}$/)]);
+        }
+    });
+
+    it('gives each role a colour of its own', () => {
+        expect(new Set(Object.values(COLORS)).size).toBe(Object.keys(COLORS).length);
+    });
+
+    it('cannot be edited into a different palette at runtime', () => {
+        expect(Object.isFrozen(COLORS)).toBe(true);
+    });
+});
+
+describe('no embed retypes a colour the module already names', () => {
+    const sites = literalColorSites();
+
+    it('finds call sites at all', () => {
+        // A sweep that derives its own input reports the same green for
+        // "nothing was wrong" as for "nothing was looked at".
+        expect(sites.length).toBeGreaterThan(0);
+    });
+
+    it.each(Object.entries(COLORS))('%s is imported, never written out again', (role, value) => {
+        const offenders = sites.filter(s => s.color === value).map(s => `${s.file}:${s.line}`);
+        expect(offenders).toEqual([]);
+    });
+
+    it.each(Object.entries(RETIRED))('no second spelling of %s comes back', (role, retired) => {
+        const offenders = sites
+            .filter(s => retired.includes(s.color))
+            .map(s => `${s.file}:${s.line} (${s.color} — use COLORS.${role})`);
+        expect(offenders).toEqual([]);
+    });
+});
+
+describe('the roles the issue named are actually in use', () => {
+    const source = () => {
+        const out = [];
+        const walk = dir => {
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                const full = path.join(dir, entry.name);
+                if (entry.isDirectory()) { if (full !== SKIP) walk(full); }
+                else if (entry.name.endsWith('.js')) out.push(fs.readFileSync(full, 'utf8'));
+            }
+        };
+        walk(SRC);
+        return out.join('\n');
+    };
+
+    it.each(Object.keys(COLORS))('%s reaches at least one embed', role => {
+        // A constant nobody calls is the same as no constant: the migration has
+        // to have happened, not just the module.
+        expect(source()).toContain(`COLORS.${role}`);
+    });
+});

--- a/tests/embedOverflowBudgets.test.js
+++ b/tests/embedOverflowBudgets.test.js
@@ -1,0 +1,196 @@
+'use strict';
+
+/**
+ * #667. src/utils/embedFields.js existed to stop exactly one failure — a list
+ * that grows with what a player owns or an admin types, joined into an embed
+ * that Discord then rejects, because discord.js throws rather than truncating
+ * and the whole command dies with it. The helper was applied to one section of
+ * one command and not to the section immediately next to it.
+ *
+ * These are the worst cases at the sites where the input has no length cap of
+ * its own: an inventory nobody ever cleared out, a moderator who writes essays
+ * into `/warn`, and an event shop whose blurbs came from a dashboard textarea.
+ */
+
+jest.mock('../src/models/Case', () => ({ find: jest.fn() }));
+jest.mock('../src/models/User', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../src/models/Guild', () => ({ findOne: jest.fn() }));
+jest.mock('../src/models/AiItem', () => ({ find: jest.fn() }));
+
+const Case = require('../src/models/Case');
+const { EMBED_LIMITS, packFieldsCapped } = require('../src/utils/embedFields');
+const { __test__: inventoryTest } = require('../src/commands/economy/inventory');
+const warn = require('../src/commands/moderation/warn');
+const { RELIC_LIST } = require('../src/data/exploreData');
+
+const MAX_FIELDS = 25;
+const MAX_EMBED_TOTAL = 6_000;
+
+/** What Discord actually measures: title, description and every field. */
+function embedSize(data) {
+    return (data.title?.length ?? 0)
+        + (data.description?.length ?? 0)
+        + (data.footer?.text?.length ?? 0)
+        + (data.fields ?? []).reduce((n, f) => n + f.name.length + f.value.length, 0);
+}
+
+function expectWithinDiscordBudgets(embed) {
+    const data = embed.data ?? embed;
+    expect((data.fields ?? []).length).toBeLessThanOrEqual(MAX_FIELDS);
+    for (const field of data.fields ?? []) {
+        expect([field.name, field.value.length <= EMBED_LIMITS.FIELD_VALUE]).toEqual([field.name, true]);
+    }
+    expect((data.description ?? '').length).toBeLessThanOrEqual(EMBED_LIMITS.DESCRIPTION);
+    expect(embedSize(data)).toBeLessThanOrEqual(MAX_EMBED_TOTAL);
+}
+
+describe('packFieldsCapped', () => {
+    test('spends no more fields than it is given', () => {
+        const lines = Array.from({ length: 200 }, (_, i) => `${'x'.repeat(200)}${i}`);
+        const { fields } = packFieldsCapped('Items', lines, { maxFields: 2 });
+        expect(fields).toHaveLength(2);
+        for (const field of fields) {
+            expect(field.value.length).toBeLessThanOrEqual(EMBED_LIMITS.FIELD_VALUE);
+        }
+    });
+
+    test('counts what did not fit, so the caller can say so', () => {
+        const lines = Array.from({ length: 200 }, (_, i) => `${'x'.repeat(200)}${i}`);
+        const { fields, omitted } = packFieldsCapped('Items', lines, { maxFields: 2 });
+        const shown = fields.map(f => f.value).join('\n').split('\n').length;
+        expect(shown + omitted).toBe(lines.length);
+        expect(omitted).toBeGreaterThan(0);
+    });
+
+    test('counts lines, not separators — an entry may contain the separator itself', () => {
+        // An item and its lore line are one entry joined by a newline. Deriving
+        // the count afterwards by splitting the packed value would report twice
+        // as many entries as there are.
+        const lines = Array.from({ length: 40 }, (_, i) => `**Item ${i}** ×1\n*${'lore '.repeat(20)}*`);
+        const { omitted } = packFieldsCapped('Items', lines, { maxFields: 1 });
+        const perField = Math.floor(EMBED_LIMITS.FIELD_VALUE / (lines[0].length + 1));
+        expect(omitted).toBe(lines.length - perField);
+    });
+
+    test('omits nothing when the cap is never reached', () => {
+        expect(packFieldsCapped('Items', ['a', 'b'], { maxFields: 3 }).omitted).toBe(0);
+        expect(packFieldsCapped('Items', [], { maxFields: 3 })).toEqual({ fields: [], omitted: 0 });
+    });
+});
+
+describe('/inventory with an inventory nobody ever cleared out', () => {
+    const LORE = 'A long and self-indulgent description of an item, kept for flavour.';
+
+    /** Shop items, forged items and a full relic case, all at once. */
+    function maximalInventory() {
+        const relics = RELIC_LIST.map(r => ({ itemId: r.itemId, quantity: 3 }));
+        const shop = Array.from({ length: 60 }, (_, i) => ({ itemId: `widget_${i}`, quantity: 99 }));
+        const forged = Array.from({ length: 60 }, (_, i) => ({ itemId: `ai_forged_${i}`, quantity: 12 }));
+        return [...relics, ...shop, ...forged];
+    }
+
+    function build() {
+        const inventory = maximalInventory();
+        const shopItems = inventory
+            .filter(e => e.itemId.startsWith('widget_'))
+            .map(e => ({ name: e.itemId, itemId: e.itemId, price: 12_345 }));
+        const aiItemMap = Object.fromEntries(inventory
+            .filter(e => e.itemId.startsWith('ai_'))
+            .map(e => [e.itemId, { name: `Forged ${e.itemId}`, emoji: '✨', rarity: 'legendary', lore: LORE }]));
+        const effects = Array.from({ length: 12 }, () => ({ type: 'coin_boost', charges: 5 }));
+
+        return inventoryTest.buildItemsEmbed(
+            inventory, shopItems, effects, '💰', '#2ecc71', 'footer',
+            { username: 'collector' }, 'https://cdn.example/avatar.png', aiItemMap,
+        );
+    }
+
+    test('the embed Discord is handed is one it will accept', () => {
+        expectWithinDiscordBudgets(build());
+    });
+
+    test('every section is packed, not just the relics', () => {
+        // The bug was that relics were packed and the two sections beside them
+        // were joined raw, so the fix has to be visible on all three.
+        const names = build().data.fields.map(f => f.name);
+        expect(names).toEqual(expect.arrayContaining(['🛍️ Shop Items', '⚒️ Forged Items', '🏺 Relics']));
+    });
+
+    test('says how much it could not show rather than dropping it in silence', () => {
+        const notes = build().data.fields.filter(f => /and more/.test(f.name));
+        expect(notes.length).toBeGreaterThan(0);
+        for (const note of notes) {
+            expect(note.value).toMatch(/\d+ further .+ not shown/);
+        }
+    });
+
+    test('still renders a small inventory as plain single fields', () => {
+        const embed = inventoryTest.buildItemsEmbed(
+            [{ itemId: 'rock', quantity: 2 }], [{ name: 'rock', price: 5 }], [], '💰', '#2ecc71',
+            'footer', { username: 'novice' }, 'https://cdn.example/avatar.png', {},
+        );
+        expect(embed.data.fields.map(f => f.name)).toEqual(['🛍️ Shop Items']);
+        expect(embed.data.fields[0].value).toContain('rock');
+    });
+});
+
+describe('/warn list with reasons nobody capped', () => {
+    // `reason` is a required string option with no setMaxLength, so Discord's
+    // own 6,000-character ceiling is the only limit on one of these.
+    const HUGE_REASON = 'because '.repeat(700);
+
+    function interactionFor(warnings) {
+        Case.find.mockReturnValue({
+            sort: () => ({ limit: async () => warnings }),
+        });
+        const replies = [];
+        return {
+            replies,
+            options: {
+                getSubcommand: () => 'list',
+                getUser: () => ({ id: '2', username: 'offender', globalName: null }),
+            },
+            guild: { id: '1' },
+            replied: false,
+            reply: async payload => { replies.push(payload); },
+        };
+    }
+
+    const warningsOf = (count, reason) => Array.from({ length: count }, (_, i) => ({
+        caseId: 1000 + i,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        reason,
+    }));
+
+    beforeEach(() => jest.clearAllMocks());
+
+    test('twenty essay-length warnings still produce a sendable embed', async () => {
+        const interaction = interactionFor(warningsOf(20, HUGE_REASON));
+        await warn.execute(interaction);
+
+        const [{ embeds: [embed] }] = interaction.replies;
+        expectWithinDiscordBudgets(embed);
+    });
+
+    test('says how many of them it managed to show', async () => {
+        const interaction = interactionFor(warningsOf(20, HUGE_REASON));
+        await warn.execute(interaction);
+
+        const [{ embeds: [embed] }] = interaction.replies;
+        const [, shown, total] = /(\d+) of (\d+) warning/.exec(embed.data.footer.text);
+        expect(Number(total)).toBe(20);
+        expect(Number(shown)).toBeGreaterThan(0);
+        expect(Number(shown)).toBeLessThanOrEqual(20);
+        // Whole lines only — never half a warning.
+        expect(embed.data.description.split('\n')).toHaveLength(Number(shown));
+    });
+
+    test('shows all of them, and says so, when they are ordinary length', async () => {
+        const interaction = interactionFor(warningsOf(20, 'spamming'));
+        await warn.execute(interaction);
+
+        const [{ embeds: [embed] }] = interaction.replies;
+        expect(embed.data.footer.text).toMatch(/^20 of 20 warning/);
+        expect(embed.data.description.split('\n')).toHaveLength(20);
+    });
+});


### PR DESCRIPTION
Two ways the dashboard showed data that some readers simply could not get to.

`.cases-table` is up to seven columns, and `body { overflow-x: hidden }` kills
page-level horizontal scrolling — so on a narrow screen the right-hand columns
were clipped away with nothing that could scroll to them, and on three of the
four tables the clipped column was Actions. Each now sits in its own
`.table-scroll` container: a labelled region with a tabindex, so it scrolls by
keyboard as well as by touch. The min-width matters as much as the overflow —
`.cases-table` is width:100%, so inside an auto-overflow parent it would shrink
to fit and squeeze the columns instead of overflowing. The wrapper carries the
table's visibility rather than the table doing it itself, or a hidden table
would leave an empty labelled region behind in the tab order; setTableVisible()
is what the five show/hide sites call now.

The six analytics charts, and the economy command breakdown, drew into bare
canvas elements — no role, no label, no fallback, no table. A canvas is an
opaque bitmap, so the whole Insights panel was announced as nothing at all
(WCAG 1.1.1). Each canvas is now a role="img" whose label carries the numbers
it is drawing, with the series beside it as a real table: captioned, column and
row headers scoped, clipped out of sight rather than display:none so it stays
in the accessibility tree. It is built from the same arrays the chart is drawn
from and rendered whether or not Chart.js loaded, so a failed script fetch no
longer takes the numbers with it — the reader who needs the table is exactly
the one the canvas was never going to serve.

Closes #668
Closes #669