### PR TITLE
Add coverage ratchet to prevent test coverage regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,34 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # `--ci` so a missing snapshot fails here instead of being written into
+      # the runner's filesystem and thrown away; `--coverage` because that is
+      # what applies the coverageThreshold ratchet in jest.config.js. Without
+      # it the thresholds exist but nothing ever checks them, which is the
+      # state this replaced (#635).
       - name: Run tests
-        run: npm test
+        run: npm test -- --ci --coverage
+
+      # The four numbers, on the run's summary page rather than buried in the
+      # log. `always()` because the interesting case is the run where the
+      # ratchet just failed and you want to see by how much.
+      - name: Report coverage
+        if: always()
+        run: |
+          if [ -f coverage/coverage-summary.json ]; then
+            {
+              echo '### Coverage'
+              echo
+              echo '| Metric | Covered | Total | % |'
+              echo '|---|---:|---:|---:|'
+              node -e '
+                const t = require("./coverage/coverage-summary.json").total;
+                for (const m of ["statements", "branches", "functions", "lines"]) {
+                  console.log(`| ${m} | ${t[m].covered} | ${t[m].total} | ${t[m].pct}% |`);
+                }
+              '
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       # A step in this job rather than a job of its own: it needs the same
       # `npm ci`, and a second job would pay for that install again to save a

--- a/jest.config.js
+++ b/jest.config.js
@@ -32,18 +32,20 @@ module.exports = {
     // for the step summary below and for anything reading coverage later.
     coverageReporters: ['text-summary', 'json-summary', 'lcov'],
 
-    // Measured at the commit that added this file: statements 33.20,
-    // branches 22.29, functions 35.83, lines 34.26 — over 368 files, of which
-    // 15 have no executed line at all. Floored to the whole percent below each,
-    // which leaves about 70 statements, 70 branches and 75 lines of slack: more
-    // than an unrelated refactor moves, less than a deleted test suite.
+    // Measured by CI over the full suite — 181 suites, 3,139 tests — at the
+    // commit that added this file: statements 33.36, branches 22.34, functions
+    // 36.09, lines 34.42.
     //
-    // That measurement excluded tests/integration/, whose two suites need a
-    // mongod that mongodb-memory-server downloads at run time — CI has it and
-    // the machine this was measured on did not. They cover src/models and
-    // src/migrations, which are already at 70% and 45% without them, so the
-    // number CI sees is under a point higher. These floors are the conservative
-    // end of that, which is the right end for a floor.
+    // Each floor is the whole percent below its measurement, which is not the
+    // arbitrary rounding it looks like: because the four denominators differ by
+    // most of an order of magnitude, one percent of each works out at a comparable
+    // amount of actual code — 122 statements, 79 branches, 54 functions and 125
+    // lines of slack. That is more than an unrelated refactor moves and less
+    // than a deleted test suite, which is the window a ratchet wants.
+    //
+    // It is also why these are not rounded up to the nearest percent instead:
+    // statements, branches and lines are all under a third of a point clear of
+    // the next whole number, so a floor there would fail the run that set it.
     coverageThreshold: {
         global: {
             statements: 33,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,55 @@
+'use strict';
+
+// Coverage measurement and the ratchet that holds it in place (#625, #635).
+//
+// Two things were missing and they only work together. Jest's default
+// `collectCoverageFrom` counts a file only once some test requires it, so the
+// reported percentage is a percentage of the code that is *already* tested —
+// it goes up when you delete a test file and it never mentions the 15 files no
+// test has ever loaded. And CI ran `npm test` with no threshold at all, so a
+// slide from 33% to 10% would have been green.
+//
+// So: measure over all of src/, and fail the run if the numbers go backwards.
+// The thresholds below are a ratchet, not a target. They are set just under
+// the measured coverage of the commit that introduced them, which means the
+// only way past them is to add tests. Raise them when coverage rises; the
+// point is that nothing can quietly lower them.
+
+module.exports = {
+    collectCoverageFrom: [
+        'src/**/*.js',
+        // Chart.js, copied in verbatim and minified by scripts/vendor-chartjs.sh
+        // (#685). eslint.config.js and .prettierignore skip it for the same
+        // reason: it is not ours to test. Counted, it is 5,083 uncovered
+        // statements and 4,590 uncovered branches — 13% and 17% of the
+        // respective denominators — so leaving it in would let an upstream
+        // Chart.js bump move this repo's coverage number.
+        '!src/dashboard/public/vendor/**',
+    ],
+
+    // text-summary prints the four numbers into the CI log next to whichever
+    // threshold failed; json-summary and lcov are the machine-readable forms,
+    // for the step summary below and for anything reading coverage later.
+    coverageReporters: ['text-summary', 'json-summary', 'lcov'],
+
+    // Measured at the commit that added this file: statements 33.20,
+    // branches 22.29, functions 35.83, lines 34.26 — over 368 files, of which
+    // 15 have no executed line at all. Floored to the whole percent below each,
+    // which leaves about 70 statements, 70 branches and 75 lines of slack: more
+    // than an unrelated refactor moves, less than a deleted test suite.
+    //
+    // That measurement excluded tests/integration/, whose two suites need a
+    // mongod that mongodb-memory-server downloads at run time — CI has it and
+    // the machine this was measured on did not. They cover src/models and
+    // src/migrations, which are already at 70% and 45% without them, so the
+    // number CI sees is under a point higher. These floors are the conservative
+    // end of that, which is the right end for a floor.
+    coverageThreshold: {
+        global: {
+            statements: 33,
+            branches: 22,
+            functions: 35,
+            lines: 34,
+        },
+    },
+};

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write",
-    "test": "jest --forceExit"
+    "test": "jest --forceExit",
+    "test:coverage": "jest --forceExit --coverage"
   },
   "keywords": [
     "discord",

--- a/tests/coverageRatchet.test.js
+++ b/tests/coverageRatchet.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const read = file => fs.readFileSync(path.join(root, file), 'utf8');
+
+const config = require('../jest.config.js');
+const pkg = JSON.parse(read('package.json'));
+const ci = read('.github/workflows/ci.yml');
+
+// #625/#635: coverage was 16% and nothing measured it. Two separate holes.
+//
+// Jest's default `collectCoverageFrom` only counts files some test already
+// requires, so the reported number describes the tested subset of the codebase
+// and rises when a test is deleted — the 171 files with no executed line were
+// simply absent from it. And CI ran `npm test` bare, so no threshold applied
+// even once the measurement was right.
+//
+// Both halves are load-bearing and both are one line to undo, which is what
+// this file is here to notice.
+describe('coverage ratchet', () => {
+    test('coverage is measured over all of src, not just the tested part', () => {
+        expect(config.collectCoverageFrom).toContain('src/**/*.js');
+    });
+
+    // The vendored Chart.js bundle is the one exclusion: minified, third-party
+    // and copied in verbatim, so an upstream bump would otherwise move this
+    // repo's coverage number. eslint.config.js and .prettierignore skip it too.
+    test('the only exclusion is the vendored bundle', () => {
+        const negated = config.collectCoverageFrom.filter(pattern => pattern.startsWith('!'));
+        expect(negated).toEqual(['!src/dashboard/public/vendor/**']);
+    });
+
+    test('every metric has a threshold, and none of them is zero', () => {
+        const global = config.coverageThreshold.global;
+        for (const metric of ['statements', 'branches', 'functions', 'lines']) {
+            expect([metric, typeof global[metric]]).toEqual([metric, 'number']);
+            expect([metric, global[metric] > 0]).toEqual([metric, true]);
+        }
+    });
+
+    // A threshold below what the suite already covers is not a ratchet: it is
+    // room to delete tests in. These floors track the measured numbers and are
+    // meant to be raised, never lowered.
+    test('the thresholds sit near the coverage the suite actually has', () => {
+        const global = config.coverageThreshold.global;
+        expect(global.statements).toBeGreaterThanOrEqual(33);
+        expect(global.branches).toBeGreaterThanOrEqual(22);
+        expect(global.functions).toBeGreaterThanOrEqual(35);
+        expect(global.lines).toBeGreaterThanOrEqual(34);
+    });
+
+    test('the summary Jest prints and the JSON the CI step reads are both produced', () => {
+        expect(config.coverageReporters).toEqual(expect.arrayContaining(['text-summary', 'json-summary']));
+    });
+
+    test('CI runs the tests with coverage, which is what applies the thresholds', () => {
+        const testJob = ci.slice(ci.indexOf('\n  test:'), ci.indexOf('\n  publish:'));
+        const run = testJob.match(/run: npm test.*/)?.[0] ?? '';
+        expect(run).toMatch(/--coverage\b/);
+        expect(run).toMatch(/--ci\b/);
+    });
+
+    test('there is a script that runs coverage locally the same way', () => {
+        expect(pkg.scripts['test:coverage']).toMatch(/--coverage\b/);
+    });
+});


### PR DESCRIPTION
## Summary

Implements a coverage ratchet mechanism to prevent test coverage from regressing. This addresses issues #625 and #635 by measuring coverage across the entire `src/` directory and enforcing minimum thresholds in CI.

## Key Changes

- **jest.config.js** (new): Configures Jest to measure coverage over all source files (`src/**/*.js`), excluding only the vendored Chart.js bundle. Sets coverage thresholds for statements (33%), branches (22%), functions (35%), and lines (34%) that must be maintained or improved.

- **tests/coverageRatchet.test.js** (new): Test suite that validates the coverage ratchet configuration is in place and properly configured. Ensures:
  - Coverage is measured over all of `src/`, not just tested files
  - Only the vendored bundle is excluded from coverage
  - All metrics have non-zero thresholds
  - Thresholds are set near actual coverage levels
  - CI runs tests with coverage flags
  - A local script exists to run coverage the same way

- **.github/workflows/ci.yml**: Updated the test step to run with `--ci --coverage` flags, which applies the coverage thresholds and fails the build if they're breached. Added a new "Report coverage" step that displays coverage metrics in the workflow summary.

- **package.json**: Added `test:coverage` script to allow developers to run coverage locally with the same flags as CI.

## Implementation Details

The coverage thresholds are intentionally set just below the measured coverage at the time of implementation (~33-35%), creating a "ratchet" that prevents regression. They can only be increased by adding tests, not decreased. The thresholds include ~70 statements of slack to allow for unrelated refactors without breaking the build.

The vendored Chart.js bundle is explicitly excluded because it's third-party code that shouldn't affect this repo's coverage metrics.

https://claude.ai/code/session_01GDfetfrP2k3srWgcKa3ko8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive code coverage reporting for source files.
  * Enforced minimum coverage thresholds across statements, branches, functions, and lines.
  * Added checks to ensure coverage reports are generated consistently in local and CI test runs.

* **Chores**
  * CI now publishes coverage metrics in the build summary.
  * Added a convenient command for running tests with coverage enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->