### PR TITLE
Cover the unwatched moderation and scheduled-job paths, and give the deploy a rollback target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,13 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
+            # `main` and `latest` both move: they name whatever built last, so
+            # neither can name the build that was running before this one. This
+            # is the immutable one (#637) — sha-<full commit> is published for
+            # every build and never repointed, so a deploy that goes bad has a
+            # known-good reference to roll back to. portainer-stack.yml takes
+            # the tag from CLAWDIA_IMAGE_TAG for exactly that.
+            type=sha,format=long
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,11 +153,16 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             # `main` and `latest` both move: they name whatever built last, so
-            # neither can name the build that was running before this one. This
-            # is the immutable one (#637) — sha-<full commit> is published for
-            # every build and never repointed, so a deploy that goes bad has a
-            # known-good reference to roll back to. portainer-stack.yml takes
-            # the tag from CLAWDIA_IMAGE_TAG for exactly that.
+            # neither can name the build that was running before this one.
+            # sha-<full commit> is published for every build and is the rollback
+            # target portainer-stack.yml's CLAWDIA_IMAGE_TAG takes (#637).
+            #
+            # It is stable, not immutable: re-running this workflow on the same
+            # commit rebuilds and repoints it, and the rebuild can differ because
+            # dependency resolution is not pinned to the lockfile alone. The
+            # digest published alongside it is the reference that cannot move —
+            # see the summary step after the build, and docs/RELEASING.md for
+            # pinning to one.
             type=sha,format=long
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -168,6 +173,7 @@ jobs:
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -176,3 +182,20 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # The digest, on the run's summary page. Every tag above can be repointed
+      # by a later build — including sha-<commit>, by a re-run of this very
+      # workflow — so the digest is the only reference that always names *this*
+      # build. Recording it here is what makes it available at rollback time,
+      # when the run that produced it is weeks old and nobody wants to go
+      # spelunking in the registry API for it.
+      - name: Record image digest
+        run: |
+          {
+            echo '### Image'
+            echo
+            echo '| | |'
+            echo '|---|---|'
+            echo "| digest | \`${{ steps.build.outputs.digest }}\` |"
+            echo "| rollback to this build | \`CLAWDIA_IMAGE_TAG=latest@${{ steps.build.outputs.digest }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     # Tag the local build with the same name portainer-stack.yml pulls, so
     # `docker compose build` produces the image the production stack expects
     # and `docker compose push` publishes it.
-    image: ghcr.io/theshield2594/clawdia:latest
+    image: ghcr.io/theshield2594/clawdia:${CLAWDIA_IMAGE_TAG:-latest}
     container_name: clawdia
     restart: unless-stopped
     env_file:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -53,9 +53,15 @@ run `docker/metadata-action` derives these tags from `v4.2.1`:
 - `ghcr.io/theshield2594/clawdia:latest` (default branch only)
 - `ghcr.io/theshield2594/clawdia:sha-<40-char commit sha>`
 
-The last one is published for **every** build, tagged or not, and is the only
-one that never moves. `latest`, `main` and `4.2` all get repointed by the next
-push, so none of them can name the build that was running before a bad deploy.
+The last one is published for **every** build, tagged or not. `latest`, `main`
+and `4.2` all get repointed by the next push, so none of them can name the build
+that was running before a bad deploy.
+
+`sha-<commit>` is stable but not immutable: re-running the workflow on the same
+commit rebuilds and repoints it, and the rebuild can differ, because a lockfile
+does not pin the base image or the apt packages under it. For a rollback target
+that cannot move at all, use the **digest** — the publish job writes it to the
+run's summary page, along with the exact `CLAWDIA_IMAGE_TAG` value to paste.
 
 ## Pinning the deploy
 
@@ -68,18 +74,28 @@ image: ghcr.io/theshield2594/clawdia:${CLAWDIA_IMAGE_TAG:-latest}
 Set it in the stack's environment — Portainer > Stacks > Environment variables,
 or the `.env` beside the file — to a released version or a commit sha:
 
-```
+```dotenv
 CLAWDIA_IMAGE_TAG=4.2.1
 ```
 
 Unset, it falls back to `latest`. That is fine for a first deploy and is why it
 is the default, but it leaves nothing to roll back to the next time.
 
+To pin to a digest instead of a tag, keep a tag in front of it and append the
+digest — Docker accepts `name:tag@sha256:…` and resolves by the digest, so this
+needs no change to the stack file:
+
+```dotenv
+CLAWDIA_IMAGE_TAG=latest@sha256:3f8a…
+```
+
 ## Rolling back
 
-1. Find the tag the previous deploy was on. If it was pinned, it is the previous
-   value of `CLAWDIA_IMAGE_TAG`; otherwise take the commit sha of the build from
-   the Actions run and use `sha-<full sha>`.
+1. Find the reference the previous deploy was on. If it was pinned, it is the
+   previous value of `CLAWDIA_IMAGE_TAG`. Otherwise open that build's Actions
+   run: its summary page carries the digest and the `CLAWDIA_IMAGE_TAG` line to
+   paste. Falling back to `sha-<full sha>` also works, with the caveat above
+   that a re-run of the workflow will have rebuilt it.
 2. Check the CHANGELOG: the target version's migration high-water mark must not
    be behind one that has already run against the database. The mark is recorded
    per release for exactly this check.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -46,22 +46,46 @@ working.
 
 `.github/workflows/ci.yml` runs on `push: tags: v*`, and the publish job is
 behind `needs: test`, so a tag whose tests fail publishes nothing. On a green
-run `docker/metadata-action` derives three tags from `v4.2.1`:
+run `docker/metadata-action` derives these tags from `v4.2.1`:
 
 - `ghcr.io/theshield2594/clawdia:4.2.1`
 - `ghcr.io/theshield2594/clawdia:4.2`
 - `ghcr.io/theshield2594/clawdia:latest` (default branch only)
+- `ghcr.io/theshield2594/clawdia:sha-<40-char commit sha>`
+
+The last one is published for **every** build, tagged or not, and is the only
+one that never moves. `latest`, `main` and `4.2` all get repointed by the next
+push, so none of them can name the build that was running before a bad deploy.
 
 ## Pinning the deploy
 
-`portainer-stack.yml` deploys `:latest`, which is why a bad build reaches
-production and cannot be backed out of. With versioned tags published, pin it:
+`portainer-stack.yml` reads its tag from `CLAWDIA_IMAGE_TAG`:
 
 ```yaml
-image: ghcr.io/theshield2594/clawdia:4.2.1
+image: ghcr.io/theshield2594/clawdia:${CLAWDIA_IMAGE_TAG:-latest}
 ```
 
-Rolling back is then editing that line to the previous version and redeploying
-— provided the CHANGELOG says that version's migration high-water mark is not
-behind one that has already run against the database. That check is why the
-mark is recorded per release.
+Set it in the stack's environment — Portainer > Stacks > Environment variables,
+or the `.env` beside the file — to a released version or a commit sha:
+
+```
+CLAWDIA_IMAGE_TAG=4.2.1
+```
+
+Unset, it falls back to `latest`. That is fine for a first deploy and is why it
+is the default, but it leaves nothing to roll back to the next time.
+
+## Rolling back
+
+1. Find the tag the previous deploy was on. If it was pinned, it is the previous
+   value of `CLAWDIA_IMAGE_TAG`; otherwise take the commit sha of the build from
+   the Actions run and use `sha-<full sha>`.
+2. Check the CHANGELOG: the target version's migration high-water mark must not
+   be behind one that has already run against the database. The mark is recorded
+   per release for exactly this check.
+3. Set `CLAWDIA_IMAGE_TAG` to that tag and redeploy the stack.
+
+The schema does not roll back with the image. Migrations here are forward-only
+and destructive, so a rollback across a migration boundary — step 2 failing —
+also needs the pre-migration dump the runner writes to `/app/backups` before an
+irreversible migration. Restore that dump first, then redeploy the old image.

--- a/jest.config.js
+++ b/jest.config.js
@@ -32,9 +32,11 @@ module.exports = {
     // for the step summary below and for anything reading coverage later.
     coverageReporters: ['text-summary', 'json-summary', 'lcov'],
 
-    // Measured by CI over the full suite — 181 suites, 3,139 tests — at the
-    // commit that added this file: statements 33.36, branches 22.34, functions
-    // 36.09, lines 34.42.
+    // Measured over the suite at the commit that raised these — 202 suites,
+    // 3,582 tests, integration excluded: statements 36.69, branches 25.90,
+    // functions 38.76, lines 37.80. Raised from 33/22/35/34 by the moderation
+    // and scheduled-job tests in #783 and #784; the measurement excludes the
+    // two integration suites, so the number CI sees is this or better.
     //
     // Each floor is the whole percent below its measurement, which is not the
     // arbitrary rounding it looks like: because the four denominators differ by
@@ -48,10 +50,10 @@ module.exports = {
     // the next whole number, so a floor there would fail the run that set it.
     coverageThreshold: {
         global: {
-            statements: 33,
-            branches: 22,
-            functions: 35,
-            lines: 34,
+            statements: 36,
+            branches: 25,
+            functions: 38,
+            lines: 37,
         },
     },
 };

--- a/portainer-stack.yml
+++ b/portainer-stack.yml
@@ -63,7 +63,24 @@ services:
           memory: 1g
 
   bot:
-    image: ghcr.io/theshield2594/clawdia:latest
+    # Not a bare `:latest` (#637). `latest` moves with every push to main, so it
+    # cannot name the build that was running before a bad deploy — pulling it
+    # again just fetches the same broken image. CI publishes an immutable
+    # sha-<full commit> tag for every build, so pin this to one and bump it
+    # deliberately:
+    #
+    #     CLAWDIA_IMAGE_TAG=sha-<40-char commit sha>
+    #
+    # in the stack's environment (Portainer > Stacks > Environment variables, or
+    # the .env beside this file). To roll back, set it to the previous deploy's
+    # sha and redeploy. Unset it and you are back on `latest` — which is fine
+    # for a first deploy and is why that is still the default, but leaves you
+    # with no rollback target the next time.
+    #
+    # The schema does not roll back with the image: migrations here are
+    # forward-only and destructive, so an image rollback across a migration
+    # boundary also needs the pre-migration dump from /app/backups.
+    image: ghcr.io/theshield2594/clawdia:${CLAWDIA_IMAGE_TAG:-latest}
     container_name: clawdia
     restart: unless-stopped
     environment:

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -597,9 +597,14 @@ async function applyAutoModAction(message, guildSettings, reason, scoreWeight = 
         await user.save();
 
         const score = user.behaviorScore;
-        const banAt = mod.behaviorScoreBanAt || 30;
-        const kickAt = mod.behaviorScoreKickAt || 20;
-        const muteAt = mod.behaviorScoreMuteAt || 10;
+        // `??`, not `||`. Each of these is documented as "0 = disabled" beside
+        // its dashboard field, the schema allows `min: 0`, and the guards below
+        // test `> 0` for exactly that reason — but `||` reads 0 as absent and
+        // hands back the default, so an operator who turned auto-ban off got it
+        // silently re-armed at 30 and the `> 0` guards were unreachable (#783).
+        const banAt = mod.behaviorScoreBanAt ?? 30;
+        const kickAt = mod.behaviorScoreKickAt ?? 20;
+        const muteAt = mod.behaviorScoreMuteAt ?? 10;
 
         if (banAt > 0 && score >= banAt && member.bannable) {
             await member.ban({ reason: `[AutoMod] Behavior score ${Math.round(score)} reached ban threshold` });

--- a/tests/automodEscalation.test.js
+++ b/tests/automodEscalation.test.js
@@ -1,0 +1,349 @@
+'use strict';
+
+/**
+ * #783. `applyAutoModAction` is the ladder that turns an accumulated behaviour
+ * score into warn / timeout / kick / ban, and it was uncovered from `:563`
+ * onward. Nothing proved the ladder picks the right action for a given score,
+ * that the score decays the way the setting says, or that the warning-count
+ * fallback underneath it fires when the score band does not.
+ *
+ * This is the part of the bot that bans people without a human in the loop, so
+ * every band is driven at its boundary — one under, exactly on, and over.
+ */
+
+jest.mock('../src/models/User',     () => ({ findOne: jest.fn(), create: jest.fn() }));
+jest.mock('../src/models/Guild',    () => ({ create: jest.fn(), findOne: jest.fn() }));
+jest.mock('../src/models/Case',     () => ({ findOne: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../src/models/Reminder', () => ({ create: jest.fn() }));
+jest.mock('../src/services/moderationLogService', () => ({ logModeration: jest.fn() }));
+jest.mock('../src/services/aiService', () => ({ handleAIChat: jest.fn() }));
+jest.mock('../src/utils/guildSettingsCache', () => ({ getGuildSettings: jest.fn() }));
+
+const User = require('../src/models/User');
+const Case = require('../src/models/Case');
+const { logModeration } = require('../src/services/moderationLogService');
+const { getGuildSettings } = require('../src/utils/guildSettingsCache');
+const { makeMessage, makeModerationSettings } = require('./helpers/messageCreateMessage');
+const messageCreate = require('../src/events/messageCreate');
+
+const run = message => messageCreate.execute(message, { user: { id: 'bot1' } });
+
+const DAY = 86_400_000;
+
+/** A link, so exactly one filter fires and it is worth exactly one point. */
+const offend = (over = {}) => makeMessage({ content: 'https://example.com', ...over });
+
+/** Auto-moderation with the link filter armed and the ladder thresholds under test. */
+const ladder = (over = {}) => makeModerationSettings({ linkFilter: true, ...over });
+
+function userDoc(over = {}) {
+    const doc = { userId: 'author1', guildId: 'guild1', behaviorScore: 0, lastScoreDecay: null, ...over };
+    doc.save = jest.fn(async () => {});
+    return doc;
+}
+
+/** Runs one offence against a starting score and reports what the member was subjected to. */
+async function offence({ score = 0, settings = {}, member = {}, warnCount = 0 } = {}) {
+    const doc = userDoc({ behaviorScore: score });
+    User.findOne.mockResolvedValue(doc);
+    Case.countDocuments.mockResolvedValue(warnCount);
+    getGuildSettings.mockResolvedValue(ladder(settings));
+
+    const msg = offend({ bannable: true, kickable: true, moderatable: true, ...member });
+    await run(msg);
+
+    const actions = logModeration.mock.calls.map(c => c[1]);
+    return {
+        doc, msg,
+        banned:    msg.member.ban.mock.calls,
+        kicked:    msg.member.kick.mock.calls,
+        timedOut:  msg.member.timeout.mock.calls,
+        dms:       msg.author.send.mock.calls.map(c => c[0]),
+        // The `warn` entry is the offence itself; anything after it is the ladder.
+        escalation: actions.slice(1),
+    };
+}
+
+let quiet;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    quiet = jest.spyOn(console, 'error').mockImplementation(() => {});
+    Case.findOne.mockResolvedValue(null);
+    logModeration.mockResolvedValue({ caseId: 7 });
+    User.create.mockImplementation(async doc => userDoc(doc));
+});
+
+afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    quiet.mockRestore();
+});
+
+describe('the behaviour score', () => {
+    test('every offence adds its weight and is persisted', async () => {
+        const { doc } = await offence({ score: 4 });
+
+        expect(doc.behaviorScore).toBe(5);
+        expect(doc.save).toHaveBeenCalledTimes(1);
+    });
+
+    test('a first-time offender gets a document rather than being skipped', async () => {
+        User.findOne.mockResolvedValue(null);
+        getGuildSettings.mockResolvedValue(ladder());
+
+        await run(offend());
+
+        expect(User.create).toHaveBeenCalledWith({ userId: 'author1', guildId: 'guild1' });
+    });
+
+    test('halves once per elapsed decay period', async () => {
+        const { doc } = await offence({
+            score: 16,
+            settings: { behaviorScoreDecayDays: 7 },
+            // 21 days is three whole periods: 16 → 8 → 4 → 2, then +1 for this offence.
+        });
+        expect(doc.behaviorScore).toBe(17);   // no decay stamp yet, so nothing decayed
+
+        const aged = userDoc({ behaviorScore: 16, lastScoreDecay: new Date(Date.now() - 21 * DAY) });
+        User.findOne.mockResolvedValue(aged);
+        await run(offend());
+
+        expect(aged.behaviorScore).toBe(3);
+        expect(aged.lastScoreDecay.getTime()).toBeCloseTo(Date.now(), -3);
+    });
+
+    test('does not decay before a full period has passed', async () => {
+        const doc = userDoc({ behaviorScore: 16, lastScoreDecay: new Date(Date.now() - 6 * DAY) });
+        User.findOne.mockResolvedValue(doc);
+        getGuildSettings.mockResolvedValue(ladder({ behaviorScoreDecayDays: 7 }));
+
+        await run(offend());
+
+        // Decaying early forgives a run of offences a user is still in the
+        // middle of committing.
+        expect(doc.behaviorScore).toBe(17);
+    });
+
+    test('honours a guild’s configured decay window', async () => {
+        const doc = userDoc({ behaviorScore: 8, lastScoreDecay: new Date(Date.now() - 2 * DAY) });
+        User.findOne.mockResolvedValue(doc);
+        getGuildSettings.mockResolvedValue(ladder({ behaviorScoreDecayDays: 1 }));
+
+        await run(offend());
+
+        expect(doc.behaviorScore).toBe(3);   // 8 → 4 → 2, +1
+    });
+
+    test('stamps the first offence so the clock starts from it', async () => {
+        const { doc } = await offence({ score: 0 });
+        expect(doc.lastScoreDecay).toBeInstanceOf(Date);
+    });
+});
+
+describe('the ladder', () => {
+    const bands = { behaviorScoreMuteAt: 10, behaviorScoreKickAt: 20, behaviorScoreBanAt: 30 };
+
+    test.each([
+        ['nothing', 8,  { banned: 0, kicked: 0, timedOut: 0 }],
+        ['a mute',  9,  { banned: 0, kicked: 0, timedOut: 1 }],
+        ['a mute',  15, { banned: 0, kicked: 0, timedOut: 1 }],
+        ['a kick',  19, { banned: 0, kicked: 1, timedOut: 0 }],
+        ['a kick',  25, { banned: 0, kicked: 1, timedOut: 0 }],
+        ['a ban',   29, { banned: 1, kicked: 0, timedOut: 0 }],
+        ['a ban',   60, { banned: 1, kicked: 0, timedOut: 0 }],
+    ])('a score reaching %s at %i', async (_label, score, expected) => {
+        // Scores are the pre-offence value; the offence itself adds one, so
+        // `9` is the message that lands the user exactly on the mute band.
+        const result = await offence({ score, settings: bands });
+
+        expect({
+            banned:   result.banned.length,
+            kicked:   result.kicked.length,
+            timedOut: result.timedOut.length,
+        }).toEqual(expected);
+    });
+
+    test('takes the highest band a score qualifies for, not the first', async () => {
+        const { banned, kicked, timedOut } = await offence({ score: 100, settings: bands });
+
+        expect([banned.length, kicked.length, timedOut.length]).toEqual([1, 0, 0]);
+    });
+
+    test('mutes for ten minutes and logs the duration', async () => {
+        const { timedOut, escalation } = await offence({ score: 9, settings: bands });
+
+        expect(timedOut[0][0]).toBe(10 * 60 * 1000);
+        expect(escalation).toEqual(['mute']);
+        expect(logModeration.mock.calls[1][5]).toEqual({ duration: 10 });
+    });
+
+    test('names the score and the threshold in the reason it files', async () => {
+        const { escalation } = await offence({ score: 29, settings: bands });
+
+        expect(escalation).toEqual(['ban']);
+        expect(logModeration.mock.calls[1][4]).toBe('[AutoMod] Behavior score 30 >= 30');
+        // The reason on the ban itself is what the audit log shows.
+        expect(logModeration.mock.calls[1][1]).toBe('ban');
+    });
+
+    test('a band set to zero is off, and the next one down still applies', async () => {
+        // Each field is labelled "0 = disabled" on the dashboard and the guards
+        // in the ladder test `> 0` for that reason — but the defaults were read
+        // with `||`, which reads 0 as absent and handed back 30. An operator who
+        // turned auto-ban off got it re-armed at the default instead (#783).
+        const { banned, kicked } = await offence({
+            score: 100,
+            settings: { ...bands, behaviorScoreBanAt: 0 },
+        });
+
+        expect([banned.length, kicked.length]).toEqual([0, 1]);
+    });
+
+    test('every band set to zero leaves the ladder off entirely', async () => {
+        const { banned, kicked, timedOut } = await offence({
+            score: 500,
+            settings: { behaviorScoreMuteAt: 0, behaviorScoreKickAt: 0, behaviorScoreBanAt: 0 },
+        });
+
+        expect([banned.length, kicked.length, timedOut.length]).toEqual([0, 0, 0]);
+    });
+
+    test('an unconfigured guild still gets the documented defaults', async () => {
+        // `??` must not turn "never set" into "disabled": a guild that has
+        // never opened the panel is meant to have the ladder on.
+        const { timedOut } = await offence({ score: 9, settings: {} });
+        expect(timedOut).toHaveLength(1);
+    });
+
+    test.each([
+        ['ban',  'bannable',    { bannable: false }, 'banned'],
+        ['kick', 'kickable',    { kickable: false }, 'kicked'],
+        ['mute', 'moderatable', { moderatable: false }, 'timedOut'],
+    ])('a member the bot cannot %s falls through rather than throwing', async (_action, _flag, member, key) => {
+        const score = { banned: 29, kicked: 19, timedOut: 9 }[key];
+        const result = await offence({ score, settings: bands, member });
+
+        expect(result[key]).toHaveLength(0);
+        // A permission the bot lacks must not swallow the offence: the score is
+        // still recorded, so the next moderator sees why.
+        expect(result.doc.save).toHaveBeenCalled();
+    });
+
+    test('DMs an appeal route with the case id when appeals are on', async () => {
+        Case.findOne.mockResolvedValue({ caseId: 42 });
+        const { dms } = await offence({ score: 9, settings: { ...bands, appealsEnabled: true } });
+
+        expect(dms[0]).toContain('auto-muted in **Guild One**');
+        expect(dms[0]).toContain('Case ID **#42**');
+    });
+
+    test('says nothing when there is no case to appeal against', async () => {
+        Case.findOne.mockResolvedValue(null);
+        const { dms } = await offence({ score: 9, settings: { ...bands, appealsEnabled: true } });
+
+        expect(dms).toEqual([]);
+    });
+
+    test('does not DM when appeals are off', async () => {
+        Case.findOne.mockResolvedValue({ caseId: 42 });
+        const { dms } = await offence({ score: 9, settings: bands });
+
+        expect(dms).toEqual([]);
+    });
+
+    test('a closed DM does not cost the mute', async () => {
+        Case.findOne.mockResolvedValue({ caseId: 42 });
+        const doc = userDoc({ behaviorScore: 9 });
+        User.findOne.mockResolvedValue(doc);
+        getGuildSettings.mockResolvedValue(ladder({ ...bands, appealsEnabled: true }));
+        const msg = offend({ moderatable: true });
+        msg.author.send.mockRejectedValue(new Error('Cannot send messages to this user'));
+
+        await run(msg);
+
+        expect(msg.member.timeout).toHaveBeenCalled();
+    });
+});
+
+describe('the warning-count fallback under the ladder', () => {
+    // Reached only when no behaviour-score band fires, which is where a guild
+    // that never configured scores lives.
+    const quietBands = { behaviorScoreMuteAt: 999, behaviorScoreKickAt: 999, behaviorScoreBanAt: 999 };
+
+    test('bans on the warning count when the score band did not fire', async () => {
+        const { banned, escalation } = await offence({
+            warnCount: 10,
+            settings: { ...quietBands, banThreshold: 10 },
+        });
+
+        expect(banned).toHaveLength(1);
+        expect(escalation).toEqual(['ban']);
+        expect(logModeration.mock.calls[1][4]).toBe('[AutoMod] Warning count 10 >= ban threshold 10');
+    });
+
+    test('kicks on the warning count, and the ban threshold wins when both are met', async () => {
+        const kickOnly = await offence({ warnCount: 5, settings: { ...quietBands, kickThreshold: 5, banThreshold: 10 } });
+        expect([kickOnly.banned.length, kickOnly.kicked.length]).toEqual([0, 1]);
+
+        const both = await offence({ warnCount: 10, settings: { ...quietBands, kickThreshold: 5, banThreshold: 10 } });
+        expect([both.banned.length, both.kicked.length]).toEqual([1, 0]);
+    });
+
+    test('a threshold of zero is off, not "on every warning"', async () => {
+        const { banned, kicked } = await offence({
+            warnCount: 3,
+            settings: { ...quietBands, kickThreshold: 0, banThreshold: 0 },
+        });
+
+        // `warnCount >= 0` is true for everyone; reading zero as a live
+        // threshold bans the whole server on its first offence.
+        expect([banned.length, kicked.length]).toEqual([0, 0]);
+    });
+
+    test('warns the user directly once they pass the warn threshold', async () => {
+        const { dms, banned, kicked } = await offence({ warnCount: 3, settings: quietBands });
+
+        expect([banned.length, kicked.length]).toEqual([0, 0]);
+        expect(dms[0]).toContain('**3** warnings in **Guild One**');
+    });
+
+    test('stays quiet below the warn threshold', async () => {
+        const { dms } = await offence({ warnCount: 2, settings: quietBands });
+        expect(dms).toEqual([]);
+    });
+
+    test('counts only warnings, and only this user’s, in this guild', async () => {
+        await offence({ warnCount: 1, settings: quietBands });
+
+        expect(Case.countDocuments).toHaveBeenCalledWith({
+            guildId: 'guild1', targetUserId: 'author1', type: 'warn',
+        });
+    });
+});
+
+describe('when the ladder itself fails', () => {
+    test('a failed score write does not take the message deletion with it', async () => {
+        const doc = userDoc();
+        doc.save.mockRejectedValue(new Error('mongo down'));
+        User.findOne.mockResolvedValue(doc);
+        getGuildSettings.mockResolvedValue(ladder());
+        const msg = offend();
+
+        await expect(run(msg)).resolves.toBeUndefined();
+
+        expect(msg.delete).toHaveBeenCalledTimes(1);
+        expect(quiet.mock.calls.flat().join(' ')).toContain('AutoMod action error');
+    });
+
+    test('a message from outside a guild member context is left alone', async () => {
+        getGuildSettings.mockResolvedValue(ladder());
+        const msg = offend();
+        msg.member = null;
+
+        await expect(run(msg)).resolves.toBeUndefined();
+
+        expect(logModeration).not.toHaveBeenCalled();
+    });
+});

--- a/tests/automodFilters.test.js
+++ b/tests/automodFilters.test.js
@@ -1,0 +1,363 @@
+'use strict';
+
+/**
+ * #783. `handleAutoModeration` is the only part of the bot that punishes real
+ * users with no human in the loop, and every one of its nine filter bodies was
+ * unexecuted — 37 of 154 statements, 45 of 146 branches. The block was only
+ * ever *entered*, on the early-return path.
+ *
+ * Each filter has a configurable threshold and an `isModerator` bypass, and
+ * neither was exercised for any of them. A false positive deletes a legitimate
+ * message and files a case against its author; a false negative lets a raid
+ * through. So each filter is driven three ways: a message that trips it, one
+ * that sits just under, and one from a member with moderator permissions.
+ */
+
+jest.mock('../src/models/User',     () => ({ findOne: jest.fn(), create: jest.fn() }));
+jest.mock('../src/models/Guild',    () => ({ create: jest.fn(), findOne: jest.fn() }));
+jest.mock('../src/models/Case',     () => ({ findOne: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../src/models/Reminder', () => ({ create: jest.fn() }));
+jest.mock('../src/services/moderationLogService', () => ({ logModeration: jest.fn() }));
+jest.mock('../src/services/aiService', () => ({ handleAIChat: jest.fn() }));
+jest.mock('../src/utils/guildSettingsCache', () => ({ getGuildSettings: jest.fn() }));
+
+const User = require('../src/models/User');
+const Case = require('../src/models/Case');
+const { logModeration } = require('../src/services/moderationLogService');
+const { getGuildSettings } = require('../src/utils/guildSettingsCache');
+const { makeMessage, makeModerationSettings } = require('./helpers/messageCreateMessage');
+const messageCreate = require('../src/events/messageCreate');
+
+const run = message => messageCreate.execute(message, { user: { id: 'bot1' } });
+
+/** A user document quiet enough that no ladder rung fires — the filters are what is under test. */
+function calmUser() {
+    return {
+        userId: 'author1', guildId: 'guild1', behaviorScore: 0, lastScoreDecay: null,
+        save: jest.fn(async () => {}),
+    };
+}
+
+let quiet;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    // The handlers past auto-moderation are not mocked here and complain; this
+    // file is about what auto-moderation does, not about what follows it.
+    quiet = jest.spyOn(console, 'error').mockImplementation(() => {});
+    User.findOne.mockResolvedValue(calmUser());
+    Case.countDocuments.mockResolvedValue(0);
+    Case.findOne.mockResolvedValue(null);
+    logModeration.mockResolvedValue({ caseId: 7 });
+});
+
+afterEach(() => {
+    // Each filter schedules its own warning for deletion five seconds out.
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    quiet.mockRestore();
+});
+
+// ---------------------------------------------------------------------------
+// One row per filter: the setting that arms it, a message that trips it, and a
+// message that sits just under the same threshold.
+// ---------------------------------------------------------------------------
+
+const REPEATED = 'aaaaaaaaaaaaaaaaaaaa spam';    // 20 a's, over the 12-char floor
+const ZALGO    = 'h' + '́'.repeat(6);
+
+const FILTERS = [
+    {
+        name:    'invite links',
+        setting: { inviteFilter: true },
+        trips:   'join us at discord.gg/raidserver',
+        under:   'join us at example.com/raidserver',
+        warning: /invite links are not allowed/,
+        weight:  2,
+        reason:  'posting an invite link',
+    },
+    {
+        name:    'links',
+        setting: { linkFilter: true },
+        trips:   'look at https://example.com',
+        under:   'look at example.com',
+        warning: /links are not allowed/,
+        weight:  1,
+        reason:  'posting a link',
+    },
+    {
+        name:    'repeated text',
+        setting: { repeatedTextFilter: true },
+        trips:   REPEATED,
+        // Same character, one repeat short of the run the filter looks for.
+        under:   'aaaaaaaa is fine here',
+        warning: /repeated\/spammy text/,
+        weight:  1,
+        reason:  'repeated text spam',
+    },
+    {
+        name:    'excessive caps',
+        setting: { excessiveCapsFilter: true },
+        trips:   'STOP SHOUTING AT EVERYONE',
+        under:   'stop shouting at everyone',
+        warning: /excessive caps/,
+        weight:  1,
+        reason:  'excessive caps',
+    },
+    {
+        name:    'excessive emojis',
+        setting: { excessiveEmojisFilter: true },
+        trips:   '🎉'.repeat(8),
+        under:   '🎉'.repeat(7),
+        warning: /too many emojis/,
+        weight:  1,
+        reason:  'excessive emojis',
+    },
+    {
+        name:    'zalgo',
+        setting: { zalgoFilter: true },
+        trips:   ZALGO,
+        under:   'h' + '́'.repeat(5),
+        warning: /zalgo\/combining text/,
+        weight:  1,
+        reason:  'zalgo text',
+    },
+    {
+        name:    'excessive mentions',
+        setting: { excessiveMentionsFilter: true },
+        trips:   { content: 'hey', mentionedUsers: 5 },
+        under:   { content: 'hey', mentionedUsers: 4 },
+        warning: /too many mentions/,
+        weight:  1,
+        reason:  'excessive mentions',
+    },
+    {
+        name:    'profanity',
+        setting: { profanityFilter: true, customBadWords: ['flibbertigibbet'] },
+        trips:   'you absolute flibbertigibbet',
+        under:   'you absolute delight',
+        warning: /watch your language/,
+        weight:  2,
+        reason:  'using prohibited language',
+    },
+];
+
+const message = spec => (typeof spec === 'string' ? makeMessage(spec) : makeMessage(spec));
+
+describe.each(FILTERS)('$name filter', ({ setting, trips, under, warning, weight, reason }) => {
+    test('deletes a message that trips it and warns the author', async () => {
+        getGuildSettings.mockResolvedValue(makeModerationSettings(setting));
+        const msg = message(trips);
+
+        await run(msg);
+
+        expect(msg.delete).toHaveBeenCalledTimes(1);
+        expect(msg.channel.sent[0]).toMatch(warning);
+        expect(msg.channel.sent[0]).toContain('<@author1>');
+    });
+
+    test('leaves a message that sits just under the threshold alone', async () => {
+        getGuildSettings.mockResolvedValue(makeModerationSettings(setting));
+        const msg = message(under);
+
+        await run(msg);
+
+        expect(msg.delete).not.toHaveBeenCalled();
+        expect(msg.channel.sent).toEqual([]);
+        expect(logModeration).not.toHaveBeenCalled();
+    });
+
+    test('exempts a member with ManageMessages', async () => {
+        getGuildSettings.mockResolvedValue(makeModerationSettings(setting));
+        const msg = message(typeof trips === 'string' ? { content: trips, isModerator: true } : { ...trips, isModerator: true });
+
+        await run(msg);
+
+        expect(msg.delete).not.toHaveBeenCalled();
+    });
+
+    test('exempts a member holding an immunity role', async () => {
+        getGuildSettings.mockResolvedValue(makeModerationSettings({ ...setting, immunityRoleIds: ['trusted'] }));
+        const msg = message(typeof trips === 'string' ? { content: trips, roleIds: ['trusted'] } : { ...trips, roleIds: ['trusted'] });
+
+        await run(msg);
+
+        expect(msg.delete).not.toHaveBeenCalled();
+    });
+
+    test('does nothing when the filter itself is off', async () => {
+        getGuildSettings.mockResolvedValue(makeModerationSettings({}));
+        const msg = message(trips);
+
+        await run(msg);
+
+        expect(msg.delete).not.toHaveBeenCalled();
+    });
+
+    test('files the offence at its own weight', async () => {
+        getGuildSettings.mockResolvedValue(makeModerationSettings(setting));
+        const doc = calmUser();
+        User.findOne.mockResolvedValue(doc);
+
+        await run(message(trips));
+
+        // Weights are what make an invite or a slur count for more than a
+        // stray link; a filter that files everything at 1 flattens the ladder.
+        expect(doc.behaviorScore).toBe(weight);
+        expect(logModeration).toHaveBeenCalledWith(
+            'guild1', 'warn', expect.anything(), expect.anything(),
+            `[AutoMod] ${reason}`, expect.objectContaining({ evidence: expect.anything() }),
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The spam window is stateful, so it does not fit the table above.
+// ---------------------------------------------------------------------------
+
+describe('spam window filter', () => {
+    const spamSettings = (over = {}) => makeModerationSettings({ spamProtection: true, spamThreshold: 3, spamWindow: 5, ...over });
+
+    // The tracker is module state keyed on (guild, user) and fake timers freeze
+    // the clock, so each test gets its own author rather than inheriting the
+    // previous one's timestamps.
+    const burst = who => makeMessage({ content: 'hi', userId: who });
+
+    test('lets a burst under the threshold through', async () => {
+        getGuildSettings.mockResolvedValue(spamSettings());
+        const sent = [burst('under'), burst('under')];
+
+        for (const m of sent) await run(m);
+
+        expect(sent.every(m => m.delete.mock.calls.length === 0)).toBe(true);
+    });
+
+    test('trips on the message that reaches the threshold', async () => {
+        getGuildSettings.mockResolvedValue(spamSettings());
+        const sent = [burst('trips'), burst('trips'), burst('trips')];
+
+        for (const m of sent) await run(m);
+
+        expect(sent[2].delete).toHaveBeenCalledTimes(1);
+        expect(sent[2].channel.sent[0]).toMatch(/slow down/);
+        // Only the message that tripped it is deleted; the two before it stand.
+        expect(sent[0].delete).not.toHaveBeenCalled();
+    });
+
+    test('forgets timestamps that fall out of the window', async () => {
+        getGuildSettings.mockResolvedValue(spamSettings());
+        await run(burst('window'));
+        await run(burst('window'));
+
+        jest.advanceTimersByTime(6_000);   // window is 5s
+        const late = burst('window');
+        await run(late);
+
+        // Without the window filter this third message is the third in the
+        // tracker and trips — which is the false positive on a slow chatter.
+        expect(late.delete).not.toHaveBeenCalled();
+    });
+
+    test('resets the window after it fires, so the next message is not also deleted', async () => {
+        getGuildSettings.mockResolvedValue(spamSettings());
+        for (let i = 0; i < 3; i++) await run(burst('reset'));
+
+        const next = burst('reset');
+        await run(next);
+
+        expect(next.delete).not.toHaveBeenCalled();
+    });
+
+    test('honours a configured threshold rather than the default of five', async () => {
+        getGuildSettings.mockResolvedValue(spamSettings({ spamThreshold: 2 }));
+        const sent = [makeMessage({ content: 'hi', userId: 'fast' }), makeMessage({ content: 'hi', userId: 'fast' })];
+
+        for (const m of sent) await run(m);
+
+        expect(sent[1].delete).toHaveBeenCalledTimes(1);
+    });
+
+    test('exempts a moderator, however fast they type', async () => {
+        getGuildSettings.mockResolvedValue(spamSettings());
+        const sent = Array.from({ length: 5 }, () => makeMessage({ content: 'hi', userId: 'modspam', isModerator: true }));
+
+        for (const m of sent) await run(m);
+
+        expect(sent.every(m => m.delete.mock.calls.length === 0)).toBe(true);
+    });
+
+    test('tracks each user separately', async () => {
+        getGuildSettings.mockResolvedValue(spamSettings());
+        for (const userId of ['a', 'b', 'c']) {
+            await run(makeMessage({ content: 'hi', userId }));
+        }
+        const fourth = makeMessage({ content: 'hi', userId: 'd' });
+
+        await run(fourth);
+
+        // Three messages in the window, but one each — a shared counter here
+        // would punish a busy channel rather than a spammer.
+        expect(fourth.delete).not.toHaveBeenCalled();
+    });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('the gate in front of all of them', () => {
+    test('an armed filter does nothing while autoModEnabled is off', async () => {
+        getGuildSettings.mockResolvedValue(makeModerationSettings({ autoModEnabled: false, linkFilter: true }));
+        const msg = makeMessage('https://example.com');
+
+        await run(msg);
+
+        expect(msg.delete).not.toHaveBeenCalled();
+    });
+
+    test('the first matching filter wins, and the rest are not evaluated', async () => {
+        getGuildSettings.mockResolvedValue(makeModerationSettings({ inviteFilter: true, linkFilter: true }));
+        const msg = makeMessage('https://discord.gg/raidserver');
+
+        await run(msg);
+
+        // Both match. Falling through would delete once and file two cases.
+        expect(msg.delete).toHaveBeenCalledTimes(1);
+        expect(logModeration).toHaveBeenCalledTimes(1);
+        expect(logModeration.mock.calls[0][4]).toBe('[AutoMod] posting an invite link');
+    });
+
+    test('a delete the bot is not allowed to make does not stop the case being filed', async () => {
+        getGuildSettings.mockResolvedValue(makeModerationSettings({ linkFilter: true }));
+        const msg = makeMessage('https://example.com');
+        msg.delete.mockRejectedValue(new Error('Missing Permissions'));
+
+        await run(msg);
+
+        expect(logModeration).toHaveBeenCalledTimes(1);
+    });
+
+    test('records the offending message as evidence before deleting it', async () => {
+        getGuildSettings.mockResolvedValue(makeModerationSettings({ linkFilter: true }));
+        const msg = makeMessage({ content: 'https://example.com', attachmentUrls: ['https://cdn/1.png'] });
+
+        await run(msg);
+
+        // The message is gone by the time a moderator reviews the case, so the
+        // case is the only remaining record of what was actually said.
+        const { evidence } = logModeration.mock.calls[0][5];
+        expect(evidence).toEqual({
+            messageId: 'msg1',
+            jumpUrl: msg.url,
+            content: 'https://example.com',
+            attachmentUrls: ['https://cdn/1.png'],
+        });
+    });
+
+    test('truncates very long evidence rather than storing the whole message', async () => {
+        getGuildSettings.mockResolvedValue(makeModerationSettings({ linkFilter: true }));
+
+        await run(makeMessage('https://example.com/' + 'x'.repeat(3_000)));
+
+        expect(logModeration.mock.calls[0][5].evidence.content).toHaveLength(500);
+    });
+});

--- a/tests/automodFilters.test.js
+++ b/tests/automodFilters.test.js
@@ -143,12 +143,10 @@ const FILTERS = [
     },
 ];
 
-const message = spec => (typeof spec === 'string' ? makeMessage(spec) : makeMessage(spec));
-
 describe.each(FILTERS)('$name filter', ({ setting, trips, under, warning, weight, reason }) => {
     test('deletes a message that trips it and warns the author', async () => {
         getGuildSettings.mockResolvedValue(makeModerationSettings(setting));
-        const msg = message(trips);
+        const msg = makeMessage(trips);
 
         await run(msg);
 
@@ -159,7 +157,7 @@ describe.each(FILTERS)('$name filter', ({ setting, trips, under, warning, weight
 
     test('leaves a message that sits just under the threshold alone', async () => {
         getGuildSettings.mockResolvedValue(makeModerationSettings(setting));
-        const msg = message(under);
+        const msg = makeMessage(under);
 
         await run(msg);
 
@@ -170,7 +168,7 @@ describe.each(FILTERS)('$name filter', ({ setting, trips, under, warning, weight
 
     test('exempts a member with ManageMessages', async () => {
         getGuildSettings.mockResolvedValue(makeModerationSettings(setting));
-        const msg = message(typeof trips === 'string' ? { content: trips, isModerator: true } : { ...trips, isModerator: true });
+        const msg = makeMessage(trips, { isModerator: true });
 
         await run(msg);
 
@@ -179,7 +177,7 @@ describe.each(FILTERS)('$name filter', ({ setting, trips, under, warning, weight
 
     test('exempts a member holding an immunity role', async () => {
         getGuildSettings.mockResolvedValue(makeModerationSettings({ ...setting, immunityRoleIds: ['trusted'] }));
-        const msg = message(typeof trips === 'string' ? { content: trips, roleIds: ['trusted'] } : { ...trips, roleIds: ['trusted'] });
+        const msg = makeMessage(trips, { roleIds: ['trusted'] });
 
         await run(msg);
 
@@ -188,7 +186,7 @@ describe.each(FILTERS)('$name filter', ({ setting, trips, under, warning, weight
 
     test('does nothing when the filter itself is off', async () => {
         getGuildSettings.mockResolvedValue(makeModerationSettings({}));
-        const msg = message(trips);
+        const msg = makeMessage(trips);
 
         await run(msg);
 
@@ -200,7 +198,7 @@ describe.each(FILTERS)('$name filter', ({ setting, trips, under, warning, weight
         const doc = calmUser();
         User.findOne.mockResolvedValue(doc);
 
-        await run(message(trips));
+        await run(makeMessage(trips));
 
         // Weights are what make an invite or a slur count for more than a
         // stray link; a filter that files everything at 1 flattens the ladder.

--- a/tests/casinoJackpotPayout.test.js
+++ b/tests/casinoJackpotPayout.test.js
@@ -103,19 +103,18 @@ describe('processJackpotBet — the bet that does not win', () => {
     });
 
     test('the trigger chance climbs with the bets since the last drop', async () => {
-        const rolls = [];
-        jest.spyOn(Math, 'random').mockImplementation(() => { rolls.push(null); return 0.9999; });
+        // One roll, held between the two rates: above what a freshly reset pool
+        // (betsCount 0) drops at, below what a pool cold for 100 bets does. The
+        // same roll therefore has to lose the first and win the second, which is
+        // the climb itself rather than a restatement of the formula.
+        const between = (BASE_TRIGGER_RATE + (BASE_TRIGGER_RATE + 100 * TRIGGER_INCREMENT)) / 2;
+        jest.spyOn(Math, 'random').mockReturnValue(between);
 
-        for (const betsCount of [0, 100]) {
-            Guild.findOne.mockResolvedValue({ guildId: 'g1', casinoJackpot: jackpot({ betsCount }) });
-            await processJackpotBet(bet());
-        }
+        Guild.findOne.mockResolvedValue({ guildId: 'g1', casinoJackpot: jackpot({ betsCount: 0 }) });
+        expect(await processJackpotBet(bet())).toMatchObject({ triggered: false });
 
-        // Not directly observable, so assert the rate the job would compare
-        // against: a pool that has gone cold for 100 bets is 11× likelier to
-        // drop than a freshly reset one.
-        expect(BASE_TRIGGER_RATE + 100 * TRIGGER_INCREMENT).toBeCloseTo(11 * BASE_TRIGGER_RATE, 10);
-        expect(rolls).toHaveLength(2);
+        Guild.findOne.mockResolvedValue({ guildId: 'g1', casinoJackpot: jackpot({ betsCount: 100 }) });
+        expect(await processJackpotBet(bet())).toMatchObject({ triggered: true });
     });
 });
 

--- a/tests/casinoJackpotPayout.test.js
+++ b/tests/casinoJackpotPayout.test.js
@@ -1,0 +1,278 @@
+'use strict';
+
+/**
+ * #784. `casinoJackpotService` was at 14.6% lines and **0% branches** — every
+ * decision in it unexecuted. It is a payout path: the pool is claimed and reset
+ * in one atomic write, and the winner is credited afterwards in a separate,
+ * non-transactional one. That gap is deliberate (replica-set transactions are
+ * not assumed), and everything that keeps it from losing coins — reading the
+ * pre-update pool, retrying the credit, restoring the pool when the credit will
+ * not land — lives in branches nothing was taking.
+ *
+ * `Math.random` is stubbed throughout: the trigger is a probability, and a test
+ * that waits for a 0.01% event is not a test.
+ */
+
+jest.mock('discord.js', () => {
+    class EmbedBuilder {
+        constructor() { this.fields = []; }
+        setColor(c) { this.color = c; return this; }
+        setThumbnail(t) { this.thumbnail = t; return this; }
+        setTitle(t) { this.title = t; return this; }
+        setDescription(d) { this.description = d; return this; }
+        setTimestamp() { return this; }
+    }
+    return { EmbedBuilder };
+});
+
+jest.mock('../src/models/Guild', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn(), updateOne: jest.fn() }));
+jest.mock('../src/models/User',  () => ({ findOneAndUpdate: jest.fn() }));
+jest.mock('../src/utils/logTransaction', () => ({ logTransaction: jest.fn() }));
+
+const Guild = require('../src/models/Guild');
+const User  = require('../src/models/User');
+const { logTransaction } = require('../src/utils/logTransaction');
+const { processJackpotBet, getJackpotDisplay, HOT_POOL_THRESHOLD } = require('../src/services/casinoJackpotService');
+
+const BASE_TRIGGER_RATE = 0.0001;
+const TRIGGER_INCREMENT = 0.00001;
+
+/** Forces the trigger roll one way or the other, deterministically. */
+function roll(trigger) {
+    jest.spyOn(Math, 'random').mockReturnValue(trigger ? 0 : 0.9999);
+}
+
+function jackpot(over = {}) {
+    return { pool: 250_000, betsCount: 40, contributionRate: 0.005, seedAmount: 10_000, ...over };
+}
+
+function bet(over = {}) {
+    return { guildId: 'g1', userId: 'u1', username: 'Ada', bet: 10_000, ...over };
+}
+
+let errorLog;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    Guild.findOne.mockResolvedValue({ guildId: 'g1', casinoJackpot: jackpot() });
+    Guild.findOneAndUpdate.mockResolvedValue({ guildId: 'g1', casinoJackpot: jackpot() });
+    Guild.updateOne.mockResolvedValue({});
+    User.findOneAndUpdate.mockResolvedValue({ balance: 999 });
+    errorLog = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('processJackpotBet — the bet that does not win', () => {
+    test('grows the pool by the contribution and counts the bet', async () => {
+        roll(false);
+
+        const result = await processJackpotBet(bet());
+
+        expect(Guild.updateOne).toHaveBeenCalledWith({ guildId: 'g1' }, {
+            $inc: { 'casinoJackpot.pool': 50, 'casinoJackpot.betsCount': 1 },
+        });
+        expect(result).toEqual({ triggered: false, newPool: 250_050 });
+        expect(User.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    test('a bet too small to round to a contribution still contributes one coin', async () => {
+        roll(false);
+
+        // floor(10 * 0.005) is 0, and a pool that never grows is not a jackpot.
+        await processJackpotBet(bet({ bet: 10 }));
+
+        expect(Guild.updateOne.mock.calls[0][1].$inc['casinoJackpot.pool']).toBe(1);
+    });
+
+    test('an unconfigured guild uses the documented defaults', async () => {
+        roll(false);
+        Guild.findOne.mockResolvedValue({ guildId: 'g1' });
+
+        const result = await processJackpotBet(bet());
+
+        // 0.5% rate, and a pool that reads as the 10,000 seed.
+        expect(Guild.updateOne.mock.calls[0][1].$inc['casinoJackpot.pool']).toBe(50);
+        expect(result.newPool).toBe(10_050);
+    });
+
+    test('a guild with no document at all is left alone', async () => {
+        Guild.findOne.mockResolvedValue(null);
+
+        expect(await processJackpotBet(bet())).toEqual({ triggered: false });
+        expect(Guild.updateOne).not.toHaveBeenCalled();
+    });
+
+    test('the trigger chance climbs with the bets since the last drop', async () => {
+        const rolls = [];
+        jest.spyOn(Math, 'random').mockImplementation(() => { rolls.push(null); return 0.9999; });
+
+        for (const betsCount of [0, 100]) {
+            Guild.findOne.mockResolvedValue({ guildId: 'g1', casinoJackpot: jackpot({ betsCount }) });
+            await processJackpotBet(bet());
+        }
+
+        // Not directly observable, so assert the rate the job would compare
+        // against: a pool that has gone cold for 100 bets is 11× likelier to
+        // drop than a freshly reset one.
+        expect(BASE_TRIGGER_RATE + 100 * TRIGGER_INCREMENT).toBeCloseTo(11 * BASE_TRIGGER_RATE, 10);
+        expect(rolls).toHaveLength(2);
+    });
+});
+
+describe('processJackpotBet — the winning bet', () => {
+    test('claims the pool and resets it in one atomic write', async () => {
+        roll(true);
+
+        await processJackpotBet(bet());
+
+        const [filter, update, options] = Guild.findOneAndUpdate.mock.calls[0];
+        expect(filter).toEqual({ guildId: 'g1' });
+        expect(update.$set).toMatchObject({
+            'casinoJackpot.pool': 10_000,
+            'casinoJackpot.betsCount': 0,
+            'casinoJackpot.lastWinnerId': 'u1',
+            'casinoJackpot.lastWinnerName': 'Ada',
+        });
+        // `new: false` is load-bearing: the payout is computed from the pool as
+        // it stood at the win, not from the seed the same write just installed.
+        expect(options).toEqual({ new: false });
+    });
+
+    test('pays the pre-reset pool plus this bet’s contribution', async () => {
+        roll(true);
+
+        const result = await processJackpotBet(bet());
+
+        expect(result).toEqual({ triggered: true, wonAmount: 250_050, newPool: 10_000 });
+        expect(User.findOneAndUpdate).toHaveBeenCalledWith(
+            { userId: 'u1', guildId: 'g1' },
+            { $inc: { balance: 250_050 } },
+            { new: true },
+        );
+    });
+
+    test('a concurrent bet that claimed first leaves the seed as the payout floor', async () => {
+        roll(true);
+        Guild.findOneAndUpdate.mockResolvedValue(null);
+
+        const result = await processJackpotBet(bet());
+
+        expect(result.wonAmount).toBe(10_050);
+    });
+
+    test('records the amount won and files the ledger entry', async () => {
+        roll(true);
+
+        await processJackpotBet(bet());
+
+        expect(Guild.updateOne).toHaveBeenCalledWith({ guildId: 'g1' }, {
+            $set: { 'casinoJackpot.lastWonAmount': 250_050 },
+        });
+        expect(logTransaction).toHaveBeenCalledWith(expect.objectContaining({
+            userId: 'u1', guildId: 'g1', type: 'casino_jackpot', amount: 250_050, balance: 999,
+        }));
+    });
+
+    test('retries a credit that fails, and pays exactly once when a retry lands', async () => {
+        roll(true);
+        User.findOneAndUpdate
+            .mockRejectedValueOnce(new Error('mongo down'))
+            .mockResolvedValueOnce({ balance: 250_999 });
+
+        const result = await processJackpotBet(bet());
+
+        expect(User.findOneAndUpdate).toHaveBeenCalledTimes(2);
+        expect(result.triggered).toBe(true);
+        expect(logTransaction).toHaveBeenCalledWith(expect.objectContaining({ balance: 250_999 }));
+    });
+
+    test('restores the pool when the credit will not land at all', async () => {
+        roll(true);
+        User.findOneAndUpdate.mockRejectedValue(new Error('mongo down'));
+
+        const result = await processJackpotBet(bet());
+
+        expect(User.findOneAndUpdate).toHaveBeenCalledTimes(3);
+        const restore = Guild.updateOne.mock.calls.find(([, u]) => u.$inc);
+        // A `$inc` delta back to what was claimed, not a `$set`: bets that
+        // landed while the credit was failing keep their contributions.
+        expect(restore[1]).toEqual({ $inc: { 'casinoJackpot.pool': 240_050 } });
+        // And no win is reported, so nothing downstream announces a payout
+        // nobody received.
+        expect(result).toEqual({ triggered: false, newPool: 250_050 });
+        expect(logTransaction).not.toHaveBeenCalled();
+    });
+
+    test('a restore that also fails is logged rather than thrown at the caller', async () => {
+        roll(true);
+        User.findOneAndUpdate.mockRejectedValue(new Error('mongo down'));
+        Guild.updateOne.mockRejectedValue(new Error('mongo still down'));
+
+        await expect(processJackpotBet(bet())).resolves.toMatchObject({ triggered: false });
+
+        expect(errorLog.mock.calls.flat().join(' ')).toContain('pool restore also failed');
+    });
+
+    test('announces the drop in the configured channel', async () => {
+        roll(true);
+        const sent = [];
+        const announceChannel = { send: async p => sent.push(['announce', p]) };
+        Guild.findOneAndUpdate.mockResolvedValue({
+            guildId: 'g1',
+            casinoJackpot: { ...jackpot(), announceChannelId: 'jackpot-c' },
+        });
+
+        await processJackpotBet(bet({ interaction: {
+            user: { displayAvatarURL: () => 'avatar', toString: () => '<@u1>' },
+            guild: { channels: { cache: new Map([['jackpot-c', announceChannel]]) } },
+            channel: { send: async p => sent.push(['fallback', p]) },
+        } }));
+
+        expect(sent.map(([where]) => where)).toEqual(['announce']);
+        expect(sent[0][1].embeds[0].description).toContain('250,050');
+        expect(sent[0][1].embeds[0].description).toContain('10,000');
+    });
+
+    test('falls back to the channel the bet was placed in', async () => {
+        roll(true);
+        const sent = [];
+
+        await processJackpotBet(bet({ interaction: {
+            user: { displayAvatarURL: () => 'avatar', toString: () => '<@u1>' },
+            guild: { channels: { cache: new Map() } },
+            channel: { send: async p => sent.push(p) },
+        } }));
+
+        expect(sent).toHaveLength(1);
+    });
+
+    test('an announcement that throws does not cost the winner their win', async () => {
+        roll(true);
+
+        const result = await processJackpotBet(bet({ interaction: {
+            user: { displayAvatarURL: () => { throw new Error('no avatar'); } },
+            channel: { send: async () => {} },
+        } }));
+
+        expect(result).toEqual({ triggered: true, wonAmount: 250_050, newPool: 10_000 });
+    });
+});
+
+describe('getJackpotDisplay', () => {
+    test('marks a pool hot once it crosses the threshold', async () => {
+        Guild.findOne.mockResolvedValue({ casinoJackpot: { pool: HOT_POOL_THRESHOLD } });
+        expect(await getJackpotDisplay('g1')).toEqual({
+            pool: HOT_POOL_THRESHOLD, hot: true, display: '🔥 **500,000** coins',
+        });
+    });
+
+    test('a pool just under it is not hot', async () => {
+        Guild.findOne.mockResolvedValue({ casinoJackpot: { pool: HOT_POOL_THRESHOLD - 1 } });
+        expect(await getJackpotDisplay('g1')).toMatchObject({ hot: false, display: '🏆 **499,999** coins' });
+    });
+
+    test('an unconfigured guild reads as the seed rather than as an error', async () => {
+        Guild.findOne.mockResolvedValue(null);
+        expect(await getJackpotDisplay('g1')).toMatchObject({ pool: 10_000, hot: false });
+    });
+});

--- a/tests/coverageRatchet.test.js
+++ b/tests/coverageRatchet.test.js
@@ -46,10 +46,10 @@ describe('coverage ratchet', () => {
     // meant to be raised, never lowered.
     test('the thresholds sit near the coverage the suite actually has', () => {
         const global = config.coverageThreshold.global;
-        expect(global.statements).toBeGreaterThanOrEqual(33);
-        expect(global.branches).toBeGreaterThanOrEqual(22);
-        expect(global.functions).toBeGreaterThanOrEqual(35);
-        expect(global.lines).toBeGreaterThanOrEqual(34);
+        expect(global.statements).toBeGreaterThanOrEqual(36);
+        expect(global.branches).toBeGreaterThanOrEqual(25);
+        expect(global.functions).toBeGreaterThanOrEqual(38);
+        expect(global.lines).toBeGreaterThanOrEqual(37);
     });
 
     test('the summary Jest prints and the JSON the CI step reads are both produced', () => {

--- a/tests/escalationLadder.test.js
+++ b/tests/escalationLadder.test.js
@@ -1,0 +1,327 @@
+'use strict';
+
+/**
+ * #783. `escalationService` was at 11.9% lines and **0% branches**. It is the
+ * warning ladder behind `/warn`: cross a configured threshold and it mutes,
+ * kicks, bans or temp-bans without anyone confirming it.
+ *
+ * The branches that were unexecuted are the ones that decide whether the action
+ * can happen at all — a member who has already left, a member the bot is not
+ * permitted to act on, a tempban step with no duration — and each of them has to
+ * skip rather than half-apply, because a half-applied step files a case for a
+ * punishment nobody received.
+ */
+
+jest.mock('discord.js', () => {
+    class EmbedBuilder {
+        constructor() { this.fields = []; }
+        setColor(c) { this.color = c; return this; }
+        setTitle(t) { this.title = t; return this; }
+        setDescription(d) { this.description = d; return this; }
+        setTimestamp() { return this; }
+        addFields(...f) { this.fields.push(...f.flat()); return this; }
+    }
+    return { EmbedBuilder };
+});
+jest.mock('../src/models/Guild',   () => ({ findOne: jest.fn() }));
+jest.mock('../src/models/Case',    () => ({ countDocuments: jest.fn() }));
+jest.mock('../src/models/TempBan', () => ({ findOneAndUpdate: jest.fn() }));
+jest.mock('../src/services/caseService', () => ({ createCase: jest.fn() }));
+
+const Guild   = require('../src/models/Guild');
+const Case    = require('../src/models/Case');
+const TempBan = require('../src/models/TempBan');
+const { createCase } = require('../src/services/caseService');
+const {
+    applyEscalation, simulate, findStepForCount, countWarnings, formatReason,
+} = require('../src/services/escalationService');
+
+const MAX_TIMEOUT_MS = 28 * 24 * 60 * 60 * 1000;
+
+const LADDER = [
+    { threshold: 3, action: 'mute',    durationMinutes: 10, reason: '{count} warnings', dmUser: true },
+    { threshold: 5, action: 'kick',    reason: 'kicked at {count}' },
+    { threshold: 7, action: 'tempban', durationMinutes: 1440 },
+    { threshold: 9, action: 'ban' },
+];
+
+function member(over = {}) {
+    return {
+        id: 'u1',
+        moderatable: true, kickable: true, bannable: true,
+        timeout: jest.fn(async () => {}),
+        kick:    jest.fn(async () => {}),
+        ...over,
+    };
+}
+
+function fakeGuild({ theMember = member(), channel = null } = {}) {
+    return {
+        id: 'g1',
+        name: 'Guild One',
+        members: { fetch: jest.fn(async () => theMember), ban: jest.fn(async () => {}) },
+        channels: { cache: new Map(channel ? [['log1', channel]] : []) },
+    };
+}
+
+const targetUser = () => ({ id: 'u1', username: 'Ada', send: jest.fn(async () => {}) });
+const client = { user: { id: 'bot1', username: 'Clawdia' } };
+
+const apply = (over = {}) => applyEscalation({
+    guild: fakeGuild(), targetUser: targetUser(), warningCount: 3, client, ...over,
+});
+
+let errorLog;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    Guild.findOne.mockResolvedValue({ moderation: { escalation: { enabled: true, ladder: LADDER } } });
+    createCase.mockResolvedValue({ caseId: 42 });
+    TempBan.findOneAndUpdate.mockResolvedValue({});
+    errorLog = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => errorLog.mockRestore());
+
+describe('picking a rung', () => {
+    test('matches a threshold exactly, not "at least"', () => {
+        expect(findStepForCount(LADDER, 3).action).toBe('mute');
+        // 4 is past the mute rung but short of the kick one. Treating the ladder
+        // as ">=" would re-mute on every warning between rungs.
+        expect(findStepForCount(LADDER, 4)).toBeNull();
+        expect(findStepForCount(LADDER, 5).action).toBe('kick');
+    });
+
+    test('an empty or missing ladder matches nothing', () => {
+        expect(findStepForCount([], 3)).toBeNull();
+        expect(findStepForCount(undefined, 3)).toBeNull();
+        expect(findStepForCount(null, 3)).toBeNull();
+    });
+
+    test('simulate is the same lookup, for previewing a ladder before saving it', () => {
+        expect(simulate(LADDER, 5)).toEqual(LADDER[1]);
+        expect(simulate(LADDER, 6)).toBeNull();
+    });
+
+    test('the reason template gets the count substituted in, everywhere it appears', () => {
+        expect(formatReason('{count} warnings ({count})', 4)).toBe('4 warnings (4)');
+        expect(formatReason(null, 4)).toBe('Automatic escalation: 4 warnings reached');
+        expect(formatReason('', 4)).toBe('Automatic escalation: 4 warnings reached');
+    });
+
+    test('warnings are counted per guild, per user, and only warnings', async () => {
+        Case.countDocuments.mockResolvedValue(3);
+
+        expect(await countWarnings('g1', 'u1')).toBe(3);
+        expect(Case.countDocuments).toHaveBeenCalledWith({ guildId: 'g1', targetUserId: 'u1', type: 'warn' });
+    });
+});
+
+describe('the gate in front of the ladder', () => {
+    test('does nothing when escalation is off', async () => {
+        Guild.findOne.mockResolvedValue({ moderation: { escalation: { enabled: false, ladder: LADDER } } });
+        expect(await apply()).toBeNull();
+        expect(createCase).not.toHaveBeenCalled();
+    });
+
+    test('does nothing for a guild with no escalation settings at all', async () => {
+        Guild.findOne.mockResolvedValue(null);
+        expect(await apply()).toBeNull();
+    });
+
+    test('does nothing on a count that matches no rung', async () => {
+        expect(await apply({ warningCount: 4 })).toBeNull();
+        expect(createCase).not.toHaveBeenCalled();
+    });
+});
+
+describe('applying a rung', () => {
+    test('mutes for the configured duration and files the case', async () => {
+        const m = member();
+        const result = await apply({ guild: fakeGuild({ theMember: m }) });
+
+        expect(m.timeout).toHaveBeenCalledWith(10 * 60 * 1000, '3 warnings');
+        expect(result).toMatchObject({ applied: true, actionTaken: 'mute', autoCase: { caseId: 42 } });
+        expect(createCase).toHaveBeenCalledWith(expect.objectContaining({
+            guildId: 'g1', type: 'mute', targetUserId: 'u1', moderatorId: 'bot1', duration: 10,
+        }));
+    });
+
+    test('clamps a mute to Discord’s 28-day ceiling instead of failing the call', async () => {
+        Guild.findOne.mockResolvedValue({ moderation: { escalation: { enabled: true, ladder: [
+            { threshold: 3, action: 'mute', durationMinutes: 60 * 24 * 365 },
+        ] } } });
+        const m = member();
+
+        await apply({ guild: fakeGuild({ theMember: m }) });
+
+        expect(m.timeout.mock.calls[0][0]).toBe(MAX_TIMEOUT_MS);
+    });
+
+    test('a mute step with no duration uses the ceiling rather than muting for zero', async () => {
+        Guild.findOne.mockResolvedValue({ moderation: { escalation: { enabled: true, ladder: [
+            { threshold: 3, action: 'mute' },
+        ] } } });
+        const m = member();
+
+        await apply({ guild: fakeGuild({ theMember: m }) });
+
+        expect(m.timeout.mock.calls[0][0]).toBe(MAX_TIMEOUT_MS);
+        expect(createCase.mock.calls[0][0].duration).toBeNull();
+    });
+
+    test('kicks with the substituted reason', async () => {
+        const m = member();
+        await apply({ guild: fakeGuild({ theMember: m }), warningCount: 5 });
+
+        expect(m.kick).toHaveBeenCalledWith('kicked at 5');
+        expect(createCase.mock.calls[0][0].type).toBe('kick');
+    });
+
+    test('bans through the guild, so it works on a user who has already left', async () => {
+        const guild = fakeGuild();
+        guild.members.fetch.mockResolvedValue(null);
+
+        const result = await apply({ guild, warningCount: 9 });
+
+        // Discord allows ban-by-id; refusing here would let leaving the server
+        // dodge the ban rung.
+        expect(guild.members.ban).toHaveBeenCalledWith('u1', { reason: expect.stringContaining('9 warnings reached') });
+        expect(result.applied).toBe(true);
+    });
+
+    test('a tempban records the expiry so the sweep can lift it', async () => {
+        const guild = fakeGuild();
+        await apply({ guild, warningCount: 7 });
+
+        const [filter, update, options] = TempBan.findOneAndUpdate.mock.calls[0];
+        expect(filter).toEqual({ guildId: 'g1', userId: 'u1' });
+        expect(update.expiresAt.getTime() - Date.now()).toBeGreaterThan(23.9 * 3600_000);
+        // Upsert, so re-banning someone who already has a record moves the
+        // expiry rather than failing on the unique index.
+        expect(options).toEqual({ upsert: true });
+        expect(guild.members.ban).toHaveBeenCalled();
+        // Filed as a ban: 'tempban' is not a case type.
+        expect(createCase.mock.calls[0][0].type).toBe('ban');
+    });
+
+    test('records the tempban before it issues the ban', async () => {
+        const order = [];
+        TempBan.findOneAndUpdate.mockImplementation(async () => { order.push('record'); return {}; });
+        const guild = fakeGuild();
+        guild.members.ban.mockImplementation(async () => { order.push('ban'); });
+
+        await apply({ guild, warningCount: 7 });
+
+        // Banning first and crashing before the record is a permanent ban that
+        // nothing will ever lift.
+        expect(order).toEqual(['record', 'ban']);
+    });
+});
+
+describe('rungs that cannot be applied', () => {
+    test.each([
+        ['a member who has left',      'mute', 3, { theMember: null }],
+        ['a member it cannot mute',    'mute', 3, { theMember: member({ moderatable: false }) }],
+        ['a member who has left',      'kick', 5, { theMember: null }],
+        ['a member it cannot kick',    'kick', 5, { theMember: member({ kickable: false }) }],
+        ['a member it cannot ban',     'ban',  9, { theMember: member({ bannable: false }) }],
+        ['a member it cannot tempban', 'ban',  7, { theMember: member({ bannable: false }) }],
+    ])('skips %s on a %s rung', async (_who, _action, warningCount, guildOpts) => {
+        const result = await apply({ guild: fakeGuild(guildOpts), warningCount });
+
+        expect(result.skipped).toBe(true);
+        expect(result.reason).toBeTruthy();
+        // No case, because nothing happened. A case here is a record of a
+        // punishment the user never received.
+        expect(createCase).not.toHaveBeenCalled();
+    });
+
+    test('skips a tempban rung configured with no duration', async () => {
+        Guild.findOne.mockResolvedValue({ moderation: { escalation: { enabled: true, ladder: [
+            { threshold: 3, action: 'tempban' },
+        ] } } });
+
+        const result = await apply();
+
+        // Without a duration there is nothing to expire, so this would be a
+        // permanent ban dressed as a temporary one.
+        expect(result).toMatchObject({ skipped: true, reason: 'tempban step missing duration.' });
+        expect(TempBan.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    test('an action that throws is reported, not swallowed and not re-thrown', async () => {
+        const m = member();
+        m.timeout.mockRejectedValue(new Error('Missing Permissions'));
+
+        const result = await apply({ guild: fakeGuild({ theMember: m }) });
+
+        expect(result).toMatchObject({ error: true, step: expect.objectContaining({ action: 'mute' }) });
+        expect(createCase).not.toHaveBeenCalled();
+        expect(errorLog).toHaveBeenCalled();
+    });
+});
+
+describe('what the guild is told', () => {
+    test('DMs the target when the rung says to, naming the action and duration', async () => {
+        const user = targetUser();
+        await apply({ targetUser: user });
+
+        expect(user.send.mock.calls[0][0]).toBe('You have been auto-muted for 10 minute(s) in **Guild One**: 3 warnings');
+    });
+
+    test('stays silent when the rung does not ask for a DM', async () => {
+        const user = targetUser();
+        await apply({ targetUser: user, warningCount: 5 });
+
+        expect(user.send).not.toHaveBeenCalled();
+    });
+
+    test('a DM the user has closed does not stop the mute', async () => {
+        const user = targetUser();
+        user.send.mockRejectedValue(new Error('Cannot send messages to this user'));
+        const m = member();
+
+        const result = await apply({ targetUser: user, guild: fakeGuild({ theMember: m }) });
+
+        expect(m.timeout).toHaveBeenCalled();
+        expect(result.applied).toBe(true);
+    });
+
+    test('posts to the moderation log with both case references', async () => {
+        const sent = [];
+        Guild.findOne.mockResolvedValue({ moderation: { logChannelId: 'log1', escalation: { enabled: true, ladder: LADDER } } });
+
+        await apply({
+            guild: fakeGuild({ channel: { send: async p => sent.push(p) } }),
+            triggeringCase: { caseId: 41, guildId: 'g1' },
+        });
+
+        const embed = sent[0].embeds[0];
+        expect(embed.title).toBe('AutoMod | MUTE | Ada');
+        expect(embed.description).toContain('threshold **3**');
+        const byName = Object.fromEntries(embed.fields.map(f => [f.name, f.value]));
+        expect(byName['Triggering Warning']).toBe('Case #41');
+        expect(byName['Auto Case']).toBe('Case #42');
+        expect(byName.Duration).toBe('10 minute(s)');
+    });
+
+    test('a guild with no log channel still applies the rung', async () => {
+        const m = member();
+        const result = await apply({ guild: fakeGuild({ theMember: m }) });
+
+        expect(m.timeout).toHaveBeenCalled();
+        expect(result.applied).toBe(true);
+    });
+
+    test('a case that failed to file does not block the log post', async () => {
+        const sent = [];
+        Guild.findOne.mockResolvedValue({ moderation: { logChannelId: 'log1', escalation: { enabled: true, ladder: LADDER } } });
+        createCase.mockResolvedValue(null);
+
+        const result = await apply({ guild: fakeGuild({ channel: { send: async p => sent.push(p) } }) });
+
+        expect(sent[0].embeds[0].fields.some(f => f.name === 'Auto Case')).toBe(false);
+        expect(result.applied).toBe(true);
+    });
+});

--- a/tests/helpers/messageCreateMessage.js
+++ b/tests/helpers/messageCreateMessage.js
@@ -37,9 +37,13 @@ function makeChannel(id = 'chan1') {
  *   bannable/kickable/moderatable — what the bot is permitted to do to the member
  */
 function makeMessage(contentOrOverrides = 'hello there', overrides = {}) {
-    const opts = typeof contentOrOverrides === 'string'
-        ? { content: contentOrOverrides, ...overrides }
+    // Both forms merge `overrides` last, so `makeMessage(spec, { isModerator: true })`
+    // means the same thing whether `spec` is a string or an object. The object
+    // form used to drop the second argument entirely, which reads as working.
+    const base = typeof contentOrOverrides === 'string'
+        ? { content: contentOrOverrides }
         : { content: 'hello there', ...contentOrOverrides };
+    const opts = { ...base, ...overrides };
 
     const {
         content, isModerator = false, roleIds = [],

--- a/tests/helpers/messageCreateMessage.js
+++ b/tests/helpers/messageCreateMessage.js
@@ -1,0 +1,111 @@
+'use strict';
+
+/**
+ * Fake `message` and guild-settings builders for the `messageCreate` handlers.
+ *
+ * Lifted out of `tests/messageCreateSharedUser.test.js` for #783: the auto-mod
+ * filters need the same fake message that test already built, plus the few
+ * fields they read that leveling never touched (mention counts, attachments,
+ * and the `bannable`/`kickable`/`moderatable` flags the escalation ladder gates
+ * on). Keeping one builder means a filter cannot pass against a message shape
+ * the real handler would never see.
+ */
+
+/** A channel that records what was sent to it and hands back a deletable message. */
+function makeChannel(id = 'chan1') {
+    const sent = [];
+    const channel = {
+        id,
+        sent,
+        send: jest.fn(async payload => {
+            sent.push(payload);
+            return { delete: jest.fn(async () => {}) };
+        }),
+    };
+    return channel;
+}
+
+/**
+ * @param {string|object} contentOrOverrides  message content, or an overrides object
+ * @param {object} [overrides]
+ *   content            — message text
+ *   isModerator        — grants ManageMessages
+ *   roleIds            — role ids the member holds, for immunity checks
+ *   mentionedUsers     — number of distinct users mentioned
+ *   mentionedRoles     — number of distinct roles mentioned
+ *   attachmentUrls     — attachment urls, which the evidence payload records
+ *   bannable/kickable/moderatable — what the bot is permitted to do to the member
+ */
+function makeMessage(contentOrOverrides = 'hello there', overrides = {}) {
+    const opts = typeof contentOrOverrides === 'string'
+        ? { content: contentOrOverrides, ...overrides }
+        : { content: 'hello there', ...contentOrOverrides };
+
+    const {
+        content, isModerator = false, roleIds = [],
+        mentionedUsers = 0, mentionedRoles = 0, attachmentUrls = [],
+        bannable = false, kickable = false, moderatable = false,
+        userId = 'author1', guildId = 'guild1', channelId = 'chan1',
+    } = opts;
+
+    const channel = makeChannel(channelId);
+    const sized = n => ({ size: n });
+
+    return {
+        id: 'msg1',
+        url: `https://discord.com/channels/${guildId}/${channelId}/msg1`,
+        content,
+        author: {
+            id: userId,
+            bot: false,
+            toString: () => `<@${userId}>`,
+            send: jest.fn(async () => {}),
+        },
+        attachments: new Map(attachmentUrls.map((url, i) => [`a${i}`, { url }])),
+        mentions: { has: () => false, users: sized(mentionedUsers), roles: sized(mentionedRoles) },
+        member: {
+            id: userId,
+            permissions: { has: perm => isModerator && perm === 'ManageMessages' },
+            roles: { cache: { some: fn => roleIds.some(id => fn({ id })) } },
+            bannable, kickable, moderatable,
+            ban: jest.fn(async () => {}),
+            kick: jest.fn(async () => {}),
+            timeout: jest.fn(async () => {}),
+        },
+        guild: { id: guildId, name: 'Guild One' },
+        channel,
+        client: { user: { id: 'bot1' } },
+        delete: jest.fn(async () => {}),
+    };
+}
+
+/** Guild settings with every handler off, so a test only turns on what it means to exercise. */
+function makeSettings(overrides = {}) {
+    return {
+        ai: { enabled: false },
+        leveling: { enabled: true, rewardsEnabled: true, xpRate: 1, noXpChannelIds: [], noXpRoleIds: [] },
+        moderation: { enabled: false },
+        suggestions: { enabled: false },
+        bibleVerse: { autoRespond: false },
+        ...overrides,
+    };
+}
+
+/**
+ * Settings with auto-moderation on and every filter off. `filters` turns on the
+ * ones under test, so a filter that fires is unambiguously the one asked for.
+ */
+function makeModerationSettings(filters = {}, rest = {}) {
+    return makeSettings({
+        leveling: { enabled: false },
+        moderation: {
+            enabled: true,
+            autoModEnabled: true,
+            immunityRoleIds: [],
+            ...filters,
+        },
+        ...rest,
+    });
+}
+
+module.exports = { makeMessage, makeSettings, makeModerationSettings, makeChannel };

--- a/tests/hourlyWinnerPayout.test.js
+++ b/tests/hourlyWinnerPayout.test.js
@@ -1,0 +1,186 @@
+'use strict';
+
+/**
+ * #784. `announceHourlyWinners` pays 500 coins per winner every hour, unwatched.
+ * The only thing standing between it and a double payout is the per-winner
+ * `rewarded: false → true` claim; the only thing standing between a winner and
+ * silence is a `HOURLY_CATEGORY_LABELS` entry, which is a separate table a new
+ * competition has to be added to. Neither was executed.
+ */
+
+jest.mock('discord.js', () => {
+    class EmbedBuilder {
+        constructor() { this.fields = []; }
+        setColor(c) { this.color = c; return this; }
+        setTitle(t) { this.title = t; return this; }
+        setDescription(d) { this.description = d; return this; }
+        setFooter() { return this; }
+        setTimestamp() { return this; }
+        addFields(...f) { this.fields.push(...f.flat()); return this; }
+    }
+    return { EmbedBuilder, AttachmentBuilder: class {} };
+});
+
+jest.mock('../src/models/Guild', () => ({ find: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), updateOne: jest.fn() }));
+jest.mock('../src/models/User',  () => ({ find: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), aggregate: jest.fn(), updateOne: jest.fn(), updateMany: jest.fn(), bulkWrite: jest.fn() }));
+jest.mock('../src/models/HourlyWinner', () => ({ find: jest.fn(), findOneAndUpdate: jest.fn(), updateMany: jest.fn() }));
+
+const Guild        = require('../src/models/Guild');
+const User         = require('../src/models/User');
+const HourlyWinner = require('../src/models/HourlyWinner');
+const { getPreviousHourKey } = require('../src/utils/hourlyWinner');
+const { announceHourlyWinners } = require('../src/services/schedulerService');
+
+const REWARD = 500;
+
+let sent;
+let errorLog;
+
+function fakeClient() {
+    sent = [];
+    return {
+        guilds: {
+            fetch: jest.fn(async guildId => ({
+                id: guildId,
+                channels: {
+                    fetch: async channelId => ({
+                        isTextBased: () => true,
+                        send: async payload => { sent.push({ guildId, channelId, payload }); },
+                    }),
+                },
+            })),
+        },
+    };
+}
+
+function winner(over = {}) {
+    return { _id: 'w1', guildId: 'g1', userId: 'u1', username: 'Ada', category: 'fish', details: 'a Coelacanth', rewarded: false, ...over };
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    HourlyWinner.find.mockReturnValue({ lean: async () => [winner()] });
+    HourlyWinner.findOneAndUpdate.mockImplementation(async filter => ({ _id: filter._id, rewarded: true }));
+    User.findOneAndUpdate.mockResolvedValue({});
+    Guild.findOne.mockReturnValue({ lean: async () => ({ guildId: 'g1', economy: { announcementChannelId: 'c1' } }) });
+    errorLog = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => errorLog.mockRestore());
+
+describe('announceHourlyWinners', () => {
+    test('reads the hour that just closed, not the one still running', async () => {
+        await announceHourlyWinners(fakeClient());
+
+        const [filter] = HourlyWinner.find.mock.calls[0];
+        expect(filter).toEqual({ hour: getPreviousHourKey(), rewarded: false });
+    });
+
+    test('claims each winner before crediting, so a second run pays nothing', async () => {
+        const order = [];
+        HourlyWinner.findOneAndUpdate.mockImplementation(async filter => { order.push('claim'); return { _id: filter._id }; });
+        User.findOneAndUpdate.mockImplementation(async () => { order.push('credit'); return {}; });
+
+        await announceHourlyWinners(fakeClient());
+
+        expect(order).toEqual(['claim', 'credit']);
+        const [filter, update] = HourlyWinner.findOneAndUpdate.mock.calls[0];
+        // `rewarded: false` in the filter is the claim: without it the update
+        // succeeds every time and every tick re-pays.
+        expect(filter).toEqual({ _id: 'w1', rewarded: false });
+        expect(update).toEqual({ $set: { rewarded: true } });
+    });
+
+    test('a winner another worker already claimed is not paid again', async () => {
+        HourlyWinner.findOneAndUpdate.mockResolvedValue(null);
+
+        await announceHourlyWinners(fakeClient());
+
+        expect(User.findOneAndUpdate).not.toHaveBeenCalled();
+        expect(sent).toEqual([]);
+    });
+
+    test('credits the flat reward to the winner in their own guild', async () => {
+        await announceHourlyWinners(fakeClient());
+
+        expect(User.findOneAndUpdate).toHaveBeenCalledWith(
+            { userId: 'u1', guildId: 'g1' },
+            { $inc: { balance: REWARD } },
+        );
+    });
+
+    test('an hour with no candidates does nothing at all', async () => {
+        HourlyWinner.find.mockReturnValue({ lean: async () => [] });
+
+        await announceHourlyWinners(fakeClient());
+
+        expect(HourlyWinner.findOneAndUpdate).not.toHaveBeenCalled();
+        expect(User.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    test('pays every winner even when the announcement has nowhere to go', async () => {
+        Guild.findOne.mockReturnValue({ lean: async () => ({ guildId: 'g1', economy: {} }) });
+
+        await announceHourlyWinners(fakeClient());
+
+        expect(User.findOneAndUpdate).toHaveBeenCalledTimes(1);
+        expect(sent).toEqual([]);
+    });
+
+    test('a failed credit does not stop the other winners being paid', async () => {
+        HourlyWinner.find.mockReturnValue({ lean: async () => [winner(), winner({ _id: 'w2', userId: 'u2', category: 'mine' })] });
+        User.findOneAndUpdate.mockImplementation(async filter => {
+            if (filter.userId === 'u1') throw new Error('mongo down');
+            return {};
+        });
+
+        await expect(announceHourlyWinners(fakeClient())).resolves.toBeUndefined();
+
+        expect(User.findOneAndUpdate).toHaveBeenCalledTimes(2);
+        expect(errorLog).toHaveBeenCalled();
+    });
+
+    test('groups the hour into one announcement per guild', async () => {
+        HourlyWinner.find.mockReturnValue({ lean: async () => [
+            winner(),
+            winner({ _id: 'w2', userId: 'u2', username: 'Grace', category: 'mine', details: '90 ore' }),
+            winner({ _id: 'w3', guildId: 'g2', userId: 'u3', username: 'Kay', category: 'hunt', details: null }),
+        ] });
+
+        await announceHourlyWinners(fakeClient());
+
+        expect(sent.map(s => s.guildId)).toEqual(['g1', 'g2']);
+        const g1 = sent[0].payload.embeds[0];
+        expect(g1.title).toBe("🏆 Last Hour's Champions");
+        expect(g1.description).toContain('<@u1> (Ada) with **a Coelacanth** — rewarded **+500 coins**');
+        expect(g1.description).toContain('<@u2> (Grace) with **90 ore**');
+        // No details recorded reads as a bare mention, not "with **undefined**".
+        expect(sent[1].payload.embeds[0].description).toContain('<@u3> (Kay) — rewarded');
+    });
+
+    test('a category missing from the label table is paid but not announced', async () => {
+        // The label table is a second place a new competition has to be added.
+        // Silence is the intended failure here — dropping the payout is not.
+        HourlyWinner.find.mockReturnValue({ lean: async () => [winner({ category: 'forage' })] });
+
+        await announceHourlyWinners(fakeClient());
+
+        expect(User.findOneAndUpdate).toHaveBeenCalledWith({ userId: 'u1', guildId: 'g1' }, { $inc: { balance: REWARD } });
+        expect(sent).toEqual([]);
+    });
+
+    test('one guild whose announcement throws does not strand the others', async () => {
+        HourlyWinner.find.mockReturnValue({ lean: async () => [winner(), winner({ _id: 'w2', guildId: 'g2', userId: 'u2' })] });
+        Guild.findOne.mockImplementation(filter => ({
+            lean: async () => {
+                if (filter.guildId === 'g1') throw new Error('mongo down');
+                return { guildId: 'g2', economy: { announcementChannelId: 'c2' } };
+            },
+        }));
+
+        await expect(announceHourlyWinners(fakeClient())).resolves.toBeUndefined();
+
+        expect(sent.map(s => s.guildId)).toEqual(['g2']);
+        expect(errorLog).toHaveBeenCalled();
+    });
+});

--- a/tests/imageRollbackTag.test.js
+++ b/tests/imageRollbackTag.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+/**
+ * #637. `docker/metadata-action` published only `main`, `latest` and semver
+ * tags on releases, and portainer-stack.yml deployed `:latest`. Every one of
+ * those names moves with the next push, so after a bad deploy there was no
+ * reference left that named the build which had been running a minute earlier
+ * — pulling `latest` again just fetches the same broken image.
+ *
+ * The fix is one immutable tag per build (`sha-<full commit>`) plus a stack
+ * that can be pointed at one. This file is here to notice either half being
+ * dropped, since either alone restores the hole.
+ */
+
+const fs   = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const ROOT = path.join(__dirname, '..');
+const read = name => fs.readFileSync(path.join(ROOT, name), 'utf8');
+
+const ci    = read('.github/workflows/ci.yml');
+const stack = yaml.load(read('portainer-stack.yml'));
+
+// The `tags:` block of the metadata step, without the surrounding job.
+const tagBlock = (() => {
+    const start = ci.indexOf('docker/metadata-action');
+    const tags  = ci.indexOf('tags: |', start);
+    const rest  = ci.slice(tags);
+    // Ends at the next step, i.e. the next line starting a `- name:` entry.
+    return rest.slice(0, rest.indexOf('\n      - name:'));
+})();
+
+describe('image tagging', () => {
+    test('every build publishes an immutable sha tag', () => {
+        // `format=long` matters: the short form is a 12-char prefix, which is
+        // not what `git rev-parse HEAD` or the Actions UI hands an operator.
+        expect(tagBlock).toMatch(/^\s*type=sha,format=long$/m);
+    });
+
+    test('the moving tags are still published alongside it', () => {
+        // The sha tag is the rollback target, not a replacement: `latest` is
+        // what a first deploy pulls, and semver is what a release is announced
+        // as.
+        for (const tag of ['type=ref,event=branch', 'type=raw,value=latest']) {
+            expect([tag, tagBlock.includes(tag)]).toEqual([tag, true]);
+        }
+    });
+});
+
+describe('production stack', () => {
+    const image = stack.services.bot.image;
+
+    test('takes its tag from an environment variable, so a rollback needs no commit', () => {
+        // Hard-coding a sha here would mean every deploy — and every rollback,
+        // at the worst possible moment — is a repo commit and a merge.
+        expect(image).toMatch(/^ghcr\.io\/theshield2594\/clawdia:\$\{CLAWDIA_IMAGE_TAG:-latest\}$/);
+    });
+
+    test('resolves to a tag CI actually publishes', () => {
+        const substitute = tag => image.replace(/\$\{CLAWDIA_IMAGE_TAG:-(\w+)\}/, (_, dflt) => tag ?? dflt);
+
+        expect(substitute(null)).toBe('ghcr.io/theshield2594/clawdia:latest');
+        expect(substitute('sha-' + 'a'.repeat(40)))
+            .toBe(`ghcr.io/theshield2594/clawdia:sha-${'a'.repeat(40)}`);
+    });
+
+    test('says how to pin it, beside the line that needs pinning', () => {
+        // The variable is useless to an operator who never learns it exists.
+        const text = read('portainer-stack.yml');
+        expect(text).toContain('CLAWDIA_IMAGE_TAG=sha-');
+    });
+});

--- a/tests/imageRollbackTag.test.js
+++ b/tests/imageRollbackTag.test.js
@@ -38,6 +38,16 @@ describe('image tagging', () => {
         expect(tagBlock).toMatch(/^\s*type=sha,format=long$/m);
     });
 
+    test('the build records its digest, which is the reference that cannot move', () => {
+        // Every tag above can be repointed by a later build — sha-<commit>
+        // included, by a re-run of this same workflow on the same commit. The
+        // digest is the only one that always names one specific build, and it
+        // is only reachable at rollback time if the run wrote it down.
+        expect(ci).toMatch(/id: build\b/);
+        expect(ci).toContain('steps.build.outputs.digest');
+        expect(ci).toMatch(/GITHUB_STEP_SUMMARY/);
+    });
+
     test('the moving tags are still published alongside it', () => {
         // The sha tag is the rollback target, not a replacement: `latest` is
         // what a first deploy pulls, and semver is what a release is announced
@@ -58,11 +68,22 @@ describe('production stack', () => {
     });
 
     test('resolves to a tag CI actually publishes', () => {
-        const substitute = tag => image.replace(/\$\{CLAWDIA_IMAGE_TAG:-(\w+)\}/, (_, dflt) => tag ?? dflt);
+        // Models Compose's `:-`, which falls back on unset *and* on empty —
+        // unlike `:-`'s cousin `-`, which would leave a trailing bare colon and
+        // an image reference that does not parse.
+        const substitute = tag =>
+            image.replace(/\$\{CLAWDIA_IMAGE_TAG:-(\w+)\}/, (_, dflt) => (tag == null || tag === '' ? dflt : tag));
 
         expect(substitute(null)).toBe('ghcr.io/theshield2594/clawdia:latest');
+        // An operator who clears the variable rather than deleting it.
+        expect(substitute('')).toBe('ghcr.io/theshield2594/clawdia:latest');
         expect(substitute('sha-' + 'a'.repeat(40)))
             .toBe(`ghcr.io/theshield2594/clawdia:sha-${'a'.repeat(40)}`);
+        // A digest pin needs no change to the stack file: Docker accepts
+        // `name:tag@sha256:…` and resolves by the digest. This is what the
+        // publish job's summary tells an operator to paste.
+        expect(substitute(`latest@sha256:${'b'.repeat(64)}`))
+            .toBe(`ghcr.io/theshield2594/clawdia:latest@sha256:${'b'.repeat(64)}`);
     });
 
     test('says how to pin it, beside the line that needs pinning', () => {

--- a/tests/marketListingReturn.test.js
+++ b/tests/marketListingReturn.test.js
@@ -1,0 +1,143 @@
+'use strict';
+
+/**
+ * #784. `returnExpiredMarketListings` is what stops items vanishing from the
+ * economy when a market listing expires: TTL-deleted documents fire no Mongoose
+ * hooks, so this job has to beat the TTL index to them.
+ *
+ * Its ordering is deliberate and inverted from what reads naturally — delete
+ * first, credit second. The listing document is the only record that the return
+ * is owed, so whoever deletes it owns the credit. Crediting first and deleting
+ * after means a failed delete leaves the listing to be found and credited again
+ * on the next tick, minting items. Nothing executed the job.
+ */
+
+jest.mock('../src/models/Guild', () => ({ find: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), updateOne: jest.fn() }));
+jest.mock('../src/models/User',  () => ({ find: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), aggregate: jest.fn(), updateOne: jest.fn(), updateMany: jest.fn(), bulkWrite: jest.fn() }));
+jest.mock('../src/models/MarketListing', () => ({ find: jest.fn(), findOneAndDelete: jest.fn() }));
+jest.mock('../src/utils/inventoryGrant', () => ({ grantInventoryItem: jest.fn() }));
+
+const MarketListing = require('../src/models/MarketListing');
+const { grantInventoryItem } = require('../src/utils/inventoryGrant');
+const { returnExpiredMarketListings } = require('../src/services/schedulerService');
+
+function listing(over = {}) {
+    return { _id: 'l1', guildId: 'g1', sellerId: 'u1', itemId: 'sword', quantity: 2, expiresAt: new Date(0), ...over };
+}
+
+/** Records the `limit` the sweep asked for alongside the docs it gets back. */
+function stubFind(docs) {
+    const seen = {};
+    MarketListing.find.mockImplementation(filter => {
+        seen.filter = filter;
+        return { limit: n => { seen.limit = n; return { lean: async () => docs }; } };
+    });
+    return seen;
+}
+
+let errorLog;
+let infoLog;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    MarketListing.findOneAndDelete.mockImplementation(async filter => ({ _id: filter._id }));
+    grantInventoryItem.mockResolvedValue({});
+    errorLog = jest.spyOn(console, 'error').mockImplementation(() => {});
+    infoLog  = jest.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => { errorLog.mockRestore(); infoLog.mockRestore(); });
+
+describe('returnExpiredMarketListings', () => {
+    test('sweeps expired listings in bounded batches', async () => {
+        const seen = stubFind([]);
+
+        await returnExpiredMarketListings();
+
+        expect(seen.filter.expiresAt.$lte).toBeInstanceOf(Date);
+        expect(seen.filter.expiresAt.$lte.getTime()).toBeLessThanOrEqual(Date.now());
+        // Unbounded, one backlog of expiries pulls the whole collection into
+        // the process at once.
+        expect(seen.limit).toBe(50);
+    });
+
+    test('claims the listing by deleting it before it credits anything', async () => {
+        stubFind([listing()]);
+        const order = [];
+        MarketListing.findOneAndDelete.mockImplementation(async filter => { order.push('claim'); return { _id: filter._id }; });
+        grantInventoryItem.mockImplementation(async () => { order.push('credit'); return {}; });
+
+        await returnExpiredMarketListings();
+
+        expect(order).toEqual(['claim', 'credit']);
+        expect(MarketListing.findOneAndDelete).toHaveBeenCalledWith({ _id: 'l1' });
+    });
+
+    test('returns the full quantity to the seller in their own guild', async () => {
+        stubFind([listing({ quantity: 7, itemId: 'potion' })]);
+
+        await returnExpiredMarketListings();
+
+        expect(grantInventoryItem).toHaveBeenCalledWith('u1', 'g1', 'potion', 7, { upsert: true });
+    });
+
+    test('a listing another worker already claimed is not credited again', async () => {
+        stubFind([listing()]);
+        MarketListing.findOneAndDelete.mockResolvedValue(null);
+
+        await returnExpiredMarketListings();
+
+        // This is the whole point of deleting first: minting a second copy of
+        // the items is unrecoverable, losing one return is not.
+        expect(grantInventoryItem).not.toHaveBeenCalled();
+    });
+
+    test('a credit that fails after the claim is logged loudly, not retried', async () => {
+        stubFind([listing()]);
+        grantInventoryItem.mockRejectedValue(new Error('mongo down'));
+
+        await expect(returnExpiredMarketListings()).resolves.toBeUndefined();
+
+        // The listing is gone, so nothing will find this again — the log is the
+        // only record that the items are owed, and it has to say so.
+        const message = errorLog.mock.calls[0].join(' ');
+        expect(message).toContain('2x sword');
+        expect(message).toContain('u1');
+        expect(message).toContain('by hand');
+    });
+
+    test('one listing that fails does not strand the rest of the batch', async () => {
+        stubFind([listing({ _id: 'bad' }), listing({ _id: 'good', sellerId: 'u2' })]);
+        grantInventoryItem.mockImplementation(async sellerId => {
+            if (sellerId === 'u1') throw new Error('mongo down');
+            return {};
+        });
+
+        await returnExpiredMarketListings();
+
+        expect(grantInventoryItem).toHaveBeenCalledTimes(2);
+        expect(infoLog.mock.calls.flat().join(' ')).toContain('1 expired listing(s)');
+    });
+
+    test('a claim that throws is caught, so the batch continues', async () => {
+        stubFind([listing({ _id: 'bad' }), listing({ _id: 'good' })]);
+        MarketListing.findOneAndDelete.mockImplementation(async filter => {
+            if (filter._id === 'bad') throw new Error('mongo down');
+            return { _id: filter._id };
+        });
+
+        await expect(returnExpiredMarketListings()).resolves.toBeUndefined();
+
+        expect(grantInventoryItem).toHaveBeenCalledTimes(1);
+        expect(errorLog).toHaveBeenCalled();
+    });
+
+    test('an empty sweep says nothing', async () => {
+        stubFind([]);
+
+        await returnExpiredMarketListings();
+
+        expect(MarketListing.findOneAndDelete).not.toHaveBeenCalled();
+        expect(infoLog).not.toHaveBeenCalled();
+    });
+});

--- a/tests/messageCreateSharedUser.test.js
+++ b/tests/messageCreateSharedUser.test.js
@@ -66,6 +66,8 @@ const { saveWithBalanceDelta } = require('../src/utils/balanceDelta');
 const { ensureQuests } = require('../src/services/questService');
 const { checkRivalry } = require('../src/services/rivalryService');
 const messageCreate = require('../src/events/messageCreate');
+// #783 lifted these out so the auto-moderation tests drive the same fake message.
+const { makeMessage, makeSettings } = require('./helpers/messageCreateMessage');
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -99,42 +101,6 @@ function makeUserDoc(overrides = {}) {
             return true;
         },
     });
-}
-
-function makeSettings(overrides = {}) {
-    return {
-        ai: { enabled: false },
-        leveling: { enabled: true, rewardsEnabled: true, xpRate: 1, noXpChannelIds: [], noXpRoleIds: [] },
-        moderation: { enabled: false },
-        suggestions: { enabled: false },
-        bibleVerse: { autoRespond: false },
-        ...overrides,
-    };
-}
-
-function makeMessage(content = 'hello there') {
-    const channel = {
-        id: 'chan1',
-        send: jest.fn().mockResolvedValue({ delete: jest.fn().mockResolvedValue(undefined) }),
-    };
-    return {
-        id: 'msg1',
-        url: 'https://discord.com/channels/guild1/chan1/msg1',
-        content,
-        author: { id: 'author1', bot: false, toString: () => '<@author1>' },
-        attachments: new Map(),
-        mentions: { has: () => false },
-        member: {
-            id: 'author1',
-            permissions: { has: () => false },
-            roles: { cache: { some: () => false } },
-            bannable: false, kickable: false, moderatable: false,
-        },
-        guild: { id: 'guild1', name: 'Guild One' },
-        channel,
-        client: { user: { id: 'bot1' } },
-        delete: jest.fn().mockResolvedValue(undefined),
-    };
 }
 
 const run = (message) => messageCreate.execute(message, { user: { id: 'bot1' } });

--- a/tests/moderationCaseRecords.test.js
+++ b/tests/moderationCaseRecords.test.js
@@ -1,0 +1,346 @@
+'use strict';
+
+/**
+ * #783. `caseService` was at 15% lines and **0% branches**, and it is what turns
+ * an auto-moderation action into the record a human later reviews or appeals
+ * against. `logModeration` is the only caller on the automod path, and the
+ * case it writes is the only surviving evidence once the message is deleted.
+ *
+ * `getNextCaseId` is the sharp part: case ids are per-guild and user-visible
+ * (`/appeal` takes one), so two concurrent actions must not be handed the same
+ * number.
+ */
+
+jest.mock('node-cron', () => ({ schedule: jest.fn() }));
+jest.mock('../src/utils/jobRunner', () => ({ runJob: jest.fn(async (_s, _j, fn) => fn()) }));
+jest.mock('discord.js', () => {
+    class EmbedBuilder {
+        constructor() { this.fields = []; }
+        setColor(c) { this.color = c; return this; }
+        setTitle(t) { this.title = t; return this; }
+        setDescription(d) { this.description = d; return this; }
+        setTimestamp() { return this; }
+        addFields(...f) { this.fields.push(...f.flat()); return this; }
+    }
+    return { EmbedBuilder };
+});
+jest.mock('../src/models/Case',  () => ({ create: jest.fn(), find: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), countDocuments: jest.fn(), updateOne: jest.fn() }));
+jest.mock('../src/models/Guild', () => ({ find: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+
+const Case  = require('../src/models/Case');
+const Guild = require('../src/models/Guild');
+const cron = require('node-cron');
+const { runJob } = require('../src/utils/jobRunner');
+const { createCase, addNote, closeCase, getCase, getCasesForUser, startSlaMonitor } = require('../src/services/caseService');
+const { logModeration } = require('../src/services/moderationLogService');
+
+const HOUR = 3600_000;
+
+let errorLog;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    Guild.findOne.mockResolvedValue({ guildId: 'g1' });
+    Guild.findOneAndUpdate.mockResolvedValue({ caseSettings: { nextCaseId: 12 } });
+    Case.create.mockImplementation(async doc => ({ ...doc }));
+    errorLog = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => errorLog.mockRestore());
+
+describe('case ids', () => {
+    test('are allocated in one atomic round trip, not read-then-write', async () => {
+        await createCase({ guildId: 'g1', type: 'warn', targetUserId: 'u1', moderatorId: 'bot', reason: 'r' });
+
+        const [filter, update, options] = Guild.findOneAndUpdate.mock.calls[0];
+        expect(filter).toEqual({ guildId: 'g1' });
+        // A pipeline update, so the increment happens server-side. Reading the
+        // counter and writing it back would hand two concurrent actions the
+        // same user-visible case number.
+        expect(Array.isArray(update)).toBe(true);
+        expect(update[0].$set['caseSettings.nextCaseId'].$ifNull).toEqual([{ $add: ['$caseSettings.nextCaseId', 1] }, 1]);
+        expect(options).toMatchObject({ upsert: true, new: true });
+    });
+
+    test('start at 1 for a guild that has never filed one', async () => {
+        // The `$ifNull` branch above: no counter yet means 1, not NaN and not 2.
+        Guild.findOneAndUpdate.mockResolvedValue({ caseSettings: { nextCaseId: 1 } });
+
+        const created = await createCase({ guildId: 'g1', type: 'warn', targetUserId: 'u1', moderatorId: 'bot', reason: 'r' });
+
+        expect(created.caseId).toBe(1);
+    });
+
+    test('are used as returned, with no off-by-one correction', async () => {
+        const created = await createCase({ guildId: 'g1', type: 'warn', targetUserId: 'u1', moderatorId: 'bot', reason: 'r' });
+        expect(created.caseId).toBe(12);
+    });
+});
+
+describe('createCase', () => {
+    test('opens the case with the evidence it was handed', async () => {
+        const evidence = { messageId: 'm1', content: 'https://example.com' };
+
+        const created = await createCase({
+            guildId: 'g1', type: 'warn', targetUserId: 'u1', moderatorId: 'bot', reason: '[AutoMod] posting a link', evidence,
+        });
+
+        expect(created).toMatchObject({
+            guildId: 'g1', type: 'warn', targetUserId: 'u1', moderatorId: 'bot', status: 'open', evidence,
+        });
+    });
+
+    test('an evidence-free case stores an empty object rather than null', async () => {
+        const created = await createCase({ guildId: 'g1', type: 'note', targetUserId: 'u1', moderatorId: 'm1', reason: 'r' });
+        expect(created.evidence).toEqual({});
+    });
+
+    test.each([['ban'], ['kick'], ['mute']])('gives a %s an SLA deadline for review', async type => {
+        Guild.findOne.mockResolvedValue({ guildId: 'g1', caseSettings: { slaHours: 6 } });
+
+        const created = await createCase({ guildId: 'g1', type, targetUserId: 'u1', moderatorId: 'bot', reason: 'r' });
+
+        expect(created.slaDeadline.getTime() - Date.now()).toBeGreaterThan(5.9 * HOUR);
+        expect(created.slaDeadline.getTime() - Date.now()).toBeLessThan(6.1 * HOUR);
+    });
+
+    test.each([['warn'], ['note'], ['unban']])('does not put a %s on the SLA clock', async type => {
+        const created = await createCase({ guildId: 'g1', type, targetUserId: 'u1', moderatorId: 'bot', reason: 'r' });
+        expect(created.slaDeadline).toBeNull();
+    });
+
+    test('falls back to a 48-hour SLA when the guild has not set one', async () => {
+        const created = await createCase({ guildId: 'g1', type: 'ban', targetUserId: 'u1', moderatorId: 'bot', reason: 'r' });
+
+        expect(created.slaDeadline.getTime() - Date.now()).toBeGreaterThan(47.9 * HOUR);
+    });
+
+    test('a write that fails returns null instead of throwing into the caller', async () => {
+        // The caller is a moderation action that has already happened. Throwing
+        // here would surface as a failed command after the user was punished.
+        Case.create.mockRejectedValue(new Error('mongo down'));
+
+        expect(await createCase({ guildId: 'g1', type: 'warn', targetUserId: 'u1', moderatorId: 'bot', reason: 'r' })).toBeNull();
+        expect(errorLog).toHaveBeenCalled();
+    });
+});
+
+describe('case lookup and mutation', () => {
+    test('notes are appended, never overwritten', async () => {
+        Case.findOneAndUpdate.mockResolvedValue({});
+
+        await addNote('g1', 12, 'mod1', 'spoke to them');
+
+        const [filter, update] = Case.findOneAndUpdate.mock.calls[0];
+        expect(filter).toEqual({ guildId: 'g1', caseId: 12 });
+        expect(update.$push.notes).toMatchObject({ moderatorId: 'mod1', content: 'spoke to them' });
+    });
+
+    test('closing a case records who closed it and when', async () => {
+        Case.findOneAndUpdate.mockResolvedValue({});
+
+        await closeCase('g1', 12, 'mod1', 'warned, no further action');
+
+        const [, update] = Case.findOneAndUpdate.mock.calls[0];
+        expect(update).toMatchObject({ status: 'closed', resolvedBy: 'mod1', resolution: 'warned, no further action' });
+        expect(update.resolvedAt).toBeInstanceOf(Date);
+    });
+
+    test('a case is looked up by guild and id together', async () => {
+        Case.findOne.mockResolvedValue(null);
+
+        await getCase('g1', 12);
+
+        // Case ids are per-guild, so an id-only lookup reads another guild's case.
+        expect(Case.findOne).toHaveBeenCalledWith({ guildId: 'g1', caseId: 12 });
+    });
+
+    test('a user’s history comes back newest first and bounded', async () => {
+        const calls = {};
+        Case.find.mockReturnValue({
+            sort(s) { calls.sort = s; return this; },
+            limit(n) { calls.limit = n; return this; },
+        });
+
+        await getCasesForUser('g1', 'u1');
+
+        expect(Case.find).toHaveBeenCalledWith({ guildId: 'g1', targetUserId: 'u1' });
+        expect(calls.sort).toEqual({ createdAt: -1 });
+        expect(calls.limit).toBe(10);
+    });
+});
+
+describe('logModeration — the automod path into all of it', () => {
+    const botUser = (channel = null) => ({
+        id: 'bot1', username: 'Clawdia',
+        client: { channels: { cache: new Map(channel ? [['log1', channel]] : []) } },
+    });
+
+    test('files a case even when the guild has no log channel', async () => {
+        const result = await logModeration('g1', 'warn', { id: 'u1', username: 'Ada' }, botUser(), '[AutoMod] posting a link');
+
+        // The case is the durable record; the channel post is a courtesy.
+        expect(Case.create).toHaveBeenCalledTimes(1);
+        expect(result).toMatchObject({ type: 'warn', targetUserId: 'u1', moderatorId: 'bot1' });
+    });
+
+    test('posts to the log channel when there is one', async () => {
+        const sent = [];
+        Guild.findOne.mockResolvedValue({ guildId: 'g1', moderation: { logChannelId: 'log1' } });
+        const channel = { send: async p => sent.push(p) };
+
+        await logModeration('g1', 'ban', { id: 'u1', username: 'Ada' }, botUser(channel), '[AutoMod] score 30');
+
+        expect(sent[0].embeds[0].title).toBe('BAN | Ada');
+        expect(sent[0].embeds[0].fields.map(f => f.name)).toEqual(['User', 'Moderator', 'Reason']);
+    });
+
+    test('adds the duration to the log entry for a timed action', async () => {
+        const sent = [];
+        Guild.findOne.mockResolvedValue({ guildId: 'g1', moderation: { logChannelId: 'log1' } });
+
+        await logModeration('g1', 'mute', { id: 'u1', username: 'Ada' }, botUser({ send: async p => sent.push(p) }), 'r', { duration: 10 });
+
+        expect(sent[0].embeds[0].fields.find(f => f.name === 'Duration').value).toBe('10 minutes');
+    });
+
+    test('a log channel that has been deleted does not cost the case', async () => {
+        Guild.findOne.mockResolvedValue({ guildId: 'g1', moderation: { logChannelId: 'log1' } });
+
+        await logModeration('g1', 'warn', { id: 'u1', username: 'Ada' }, botUser(), 'r');
+
+        expect(Case.create).toHaveBeenCalledTimes(1);
+    });
+
+    test('a failure anywhere returns null rather than throwing at the moderator', async () => {
+        Guild.findOne.mockRejectedValue(new Error('mongo down'));
+
+        expect(await logModeration('g1', 'warn', { id: 'u1' }, botUser(), 'r')).toBeNull();
+        expect(errorLog).toHaveBeenCalled();
+    });
+});
+
+describe('the SLA monitor', () => {
+    /** Runs the job body the monitor registers with cron, without a real clock. */
+    async function tick(client) {
+        cron.schedule.mockClear();
+        startSlaMonitor(client);
+        const [expression, body] = cron.schedule.mock.calls[0];
+        await body();
+        return expression;
+    }
+
+    function overdue(over = {}) {
+        return {
+            _id: 'c1', caseId: 12, guildId: 'g1', targetUserId: 'u1',
+            type: 'ban', reason: 'raid', createdAt: new Date(0), ...over,
+        };
+    }
+
+    function clientWith({ sent = [], channels = { sla1: { send: async p => sent.push(p) } } } = {}) {
+        return {
+            sent,
+            client: {
+                guilds: {
+                    cache: new Map([['g1', {
+                        channels: { cache: new Map(Object.entries(channels)) },
+                    }]]),
+                },
+            },
+        };
+    }
+
+    beforeEach(() => {
+        Case.find.mockResolvedValue([overdue()]);
+        Guild.find.mockResolvedValue([{ guildId: 'g1', caseSettings: { slaChannelId: 'sla1', slaHours: 48 } }]);
+        Case.updateOne.mockResolvedValue({});
+    });
+
+    test('runs on a half-hourly schedule under the job runner', async () => {
+        expect(await tick(clientWith().client)).toBe('*/30 * * * *');
+        // Through runJob, so an overlapping tick is skipped and a failure is
+        // recorded rather than vanishing into an unhandled rejection.
+        expect(runJob).toHaveBeenCalledWith('caseService', 'slaMonitor', expect.any(Function));
+    });
+
+    test('reads only open cases whose deadline has passed', async () => {
+        await tick(clientWith().client);
+
+        const [filter] = Case.find.mock.calls[0];
+        expect(filter.status).toBe('open');
+        expect(filter.slaDeadline.$lte).toBeInstanceOf(Date);
+    });
+
+    test('batch-fetches guild settings rather than one read per case', async () => {
+        Case.find.mockResolvedValue([overdue(), overdue({ _id: 'c2', caseId: 13 }), overdue({ _id: 'c3', guildId: 'g2' })]);
+
+        await tick(clientWith().client);
+
+        expect(Guild.find).toHaveBeenCalledTimes(1);
+        // Deduplicated: three cases, two guilds.
+        expect(Guild.find.mock.calls[0][0]).toEqual({ guildId: { $in: ['g1', 'g2'] } });
+    });
+
+    test('pings the SLA channel with the case it is chasing', async () => {
+        const ctx = clientWith();
+        await tick(ctx.client);
+
+        const embed = ctx.sent[0].embeds[0];
+        expect(embed.title).toBe('SLA Overdue — Open Case');
+        expect(embed.description).toContain('Case **#12**');
+        expect(Object.fromEntries(embed.fields.map(f => [f.name, f.value]))).toMatchObject({
+            Type: 'BAN', Target: '<@u1>', Reason: 'raid',
+        });
+    });
+
+    test('pushes the deadline forward so it does not ping every half hour', async () => {
+        await tick(clientWith().client);
+
+        const [filter, update] = Case.updateOne.mock.calls[0];
+        expect(filter).toEqual({ _id: 'c1' });
+        expect(update.slaDeadline.getTime() - Date.now()).toBeGreaterThan(47.9 * HOUR);
+    });
+
+    test('falls back to the moderation log channel when no SLA channel is set', async () => {
+        Guild.find.mockResolvedValue([{ guildId: 'g1', moderation: { logChannelId: 'log1' } }]);
+        const sent = [];
+
+        await tick(clientWith({ sent, channels: { log1: { send: async p => sent.push(p) } } }).client);
+
+        expect(sent).toHaveLength(1);
+    });
+
+    test.each([
+        ['no channel configured', { guilds: [{ guildId: 'g1' }] }],
+        ['a guild the bot has left', { guilds: [{ guildId: 'g1', caseSettings: { slaChannelId: 'sla1' } }], noGuild: true }],
+        ['a channel that was deleted', { guilds: [{ guildId: 'g1', caseSettings: { slaChannelId: 'gone' } }] }],
+    ])('skips %s without touching the deadline', async (_label, { guilds, noGuild }) => {
+        Guild.find.mockResolvedValue(guilds);
+        const client = noGuild ? { guilds: { cache: new Map() } } : clientWith().client;
+
+        await tick(client);
+
+        // Silently rescheduling a ping nobody received would let the case age
+        // out of the report without ever being chased.
+        expect(Case.updateOne).not.toHaveBeenCalled();
+    });
+
+    test('a case with no reason still reports', async () => {
+        Case.find.mockResolvedValue([overdue({ reason: null })]);
+        const ctx = clientWith();
+
+        await tick(ctx.client);
+
+        expect(ctx.sent[0].embeds[0].fields.find(f => f.name === 'Reason').value).toBe('No reason provided');
+    });
+
+    test('nothing overdue posts nothing', async () => {
+        Case.find.mockResolvedValue([]);
+        const ctx = clientWith();
+
+        await tick(ctx.client);
+
+        expect(ctx.sent).toEqual([]);
+        expect(Case.updateOne).not.toHaveBeenCalled();
+    });
+});

--- a/tests/petOfTheWeekWrites.test.js
+++ b/tests/petOfTheWeekWrites.test.js
@@ -1,0 +1,240 @@
+'use strict';
+
+/**
+ * #784. `selectPetOfTheWeek` pays a 5,000-coin prize on a cron and then wipes
+ * every `weeklyInteractions` counter in the guild. Both are one-way: the
+ * counters are what the winner was chosen from, so once they are zeroed there
+ * is nothing left to recompute a missed crowning from. Nothing executed it.
+ */
+
+jest.mock('discord.js', () => {
+    class EmbedBuilder {
+        constructor() { this.fields = []; }
+        setColor(c) { this.color = c; return this; }
+        setTitle(t) { this.title = t; return this; }
+        setDescription(d) { this.description = d; return this; }
+        setThumbnail(t) { this.thumbnail = t; return this; }
+        setFooter() { return this; }
+        setTimestamp() { return this; }
+        addFields(...f) { this.fields.push(...f.flat()); return this; }
+    }
+    class AttachmentBuilder { constructor(buf, opts) { this.buf = buf; this.name = opts?.name; } }
+    return { EmbedBuilder, AttachmentBuilder };
+});
+
+jest.mock('../src/models/Guild', () => ({ find: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), updateOne: jest.fn() }));
+jest.mock('../src/models/User', () => ({ find: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), aggregate: jest.fn(), updateOne: jest.fn(), updateMany: jest.fn(), bulkWrite: jest.fn() }));
+jest.mock('../src/utils/cardGenerator', () => ({
+    createWarVictoryBanner: jest.fn(async () => Buffer.from('banner')),
+    createSeasonRecapCard:  jest.fn(async () => Buffer.from('recap')),
+    generatePetSprite:      jest.fn(async () => Buffer.from('sprite')),
+}));
+jest.mock('../src/utils/logTransaction', () => ({ logTransaction: jest.fn() }));
+
+const Guild = require('../src/models/Guild');
+const User  = require('../src/models/User');
+const { generatePetSprite } = require('../src/utils/cardGenerator');
+const { logTransaction } = require('../src/utils/logTransaction');
+const { selectPetOfTheWeek } = require('../src/services/schedulerService');
+
+const DEFAULT_REWARD = 5_000;
+const WEEK = 7 * 24 * 3600_000;
+
+const WINNER = {
+    userId: 'u1',
+    pet: { _id: 'pet1', petId: 'cat', name: 'Mochi', weeklyInteractions: 42, adoptedAt: new Date(Date.now() - 3 * 86400000), evolutionStage: 1 },
+};
+
+let sent;
+let errorLog;
+
+function fakeClient() {
+    sent = [];
+    return {
+        guilds: {
+            fetch: jest.fn(async guildId => ({
+                id: guildId,
+                systemChannelId: 'system',
+                channels: {
+                    fetch: async channelId => ({
+                        isTextBased: () => true,
+                        send: async payload => { sent.push({ guildId, channelId, payload }); },
+                    }),
+                },
+            })),
+        },
+    };
+}
+
+function guildDoc(over = {}) {
+    return { guildId: 'g1', economy: { announcementChannelId: 'c1' }, potwLastRunAt: null, ...over };
+}
+
+/** The two counter-clearing writes, told apart by their update shape. */
+const ribbonClear  = () => User.updateMany.mock.calls.find(([, u]) => 'pets.$[old].potw' in (u.$set ?? {}));
+const counterClear = () => User.updateMany.mock.calls.find(([, u]) => 'pets.$[].weeklyInteractions' in (u.$set ?? {}));
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    Guild.find.mockReturnValue({ lean: async () => [guildDoc()] });
+    Guild.findOneAndUpdate.mockResolvedValue({ guildId: 'g1' });
+    User.aggregate.mockResolvedValue([WINNER]);
+    User.updateOne.mockResolvedValue({});
+    User.updateMany.mockResolvedValue({});
+    User.findOneAndUpdate.mockResolvedValue({ balance: 12_345 });
+    errorLog = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => errorLog.mockRestore());
+
+describe('selectPetOfTheWeek', () => {
+    test('leases each guild on a weekly cadence, so a re-run within the week pays nothing', async () => {
+        await selectPetOfTheWeek(fakeClient());
+
+        const [filter, update, options] = Guild.findOneAndUpdate.mock.calls[0];
+        expect(filter.guildId).toBe('g1');
+        // Unrun, or last run at least a week ago — nothing in between.
+        expect(filter.$or).toEqual([{ potwLastRunAt: null }, { potwLastRunAt: { $lte: expect.any(Date) } }]);
+        expect(Date.now() - filter.$or[1].potwLastRunAt.$lte.getTime()).toBeGreaterThanOrEqual(WEEK - 5_000);
+        expect(update.$set.potwLastRunAt).toBeInstanceOf(Date);
+        expect(options).toEqual({ new: false });
+    });
+
+    test('a guild another worker already ran this week is skipped entirely', async () => {
+        Guild.findOneAndUpdate.mockResolvedValue(null);
+
+        await selectPetOfTheWeek(fakeClient());
+
+        expect(User.aggregate).not.toHaveBeenCalled();
+        expect(User.findOneAndUpdate).not.toHaveBeenCalled();
+        expect(User.updateMany).not.toHaveBeenCalled();
+    });
+
+    test('picks the winner in the database rather than scanning every pet in memory', async () => {
+        await selectPetOfTheWeek(fakeClient());
+
+        const [pipeline] = User.aggregate.mock.calls[0];
+        const stages = pipeline.map(s => Object.keys(s)[0]);
+        expect(stages).toEqual(['$match', '$unwind', '$match', '$sort', '$limit', '$project']);
+        // Only pets that were actually interacted with can win.
+        expect(pipeline[2].$match).toEqual({ 'pets.weeklyInteractions': { $gt: 0 } });
+        expect(pipeline[4].$limit).toBe(1);
+    });
+
+    test('crowns the winner before it clears the counters', async () => {
+        const order = [];
+        User.updateOne.mockImplementation(async (_f, u) => {
+            if (u.$set?.['pets.$.potw'] === true) order.push('crown');
+            return {};
+        });
+        User.updateMany.mockImplementation(async (_f, u) => {
+            order.push('pets.$[].weeklyInteractions' in (u.$set ?? {}) ? 'clear-counters' : 'clear-ribbons');
+            return {};
+        });
+
+        await selectPetOfTheWeek(fakeClient());
+
+        // Reversed, a failure between the two leaves the week with no POTW and
+        // the counts already wiped.
+        expect(order).toEqual(['crown', 'clear-ribbons', 'clear-counters']);
+        expect(User.updateOne.mock.calls[0][0]).toEqual({ guildId: 'g1', userId: 'u1', 'pets._id': 'pet1' });
+    });
+
+    test('clears last week’s ribbons from every pet except the new winner', async () => {
+        await selectPetOfTheWeek(fakeClient());
+
+        const [filter, , options] = ribbonClear();
+        expect(filter).toEqual({ guildId: 'g1' });
+        expect(options.arrayFilters).toEqual([{ 'old._id': { $ne: 'pet1' } }]);
+        // Two writes, not one: `$[]` and `$[old]` over the same array in a
+        // single `$set` is a path conflict MongoDB can reject outright.
+        expect(counterClear()[0]).toEqual({ guildId: 'g1' });
+    });
+
+    test('pays the prize and files the ledger entry', async () => {
+        await selectPetOfTheWeek(fakeClient());
+
+        expect(User.findOneAndUpdate).toHaveBeenCalledWith(
+            { guildId: 'g1', userId: 'u1' },
+            { $inc: { balance: DEFAULT_REWARD } },
+            { new: true },
+        );
+        expect(logTransaction).toHaveBeenCalledWith(expect.objectContaining({
+            userId: 'u1', guildId: 'g1', type: 'potw_reward', amount: DEFAULT_REWARD, balance: 12_345,
+        }));
+    });
+
+    test('honours a guild’s configured prize, including zero', async () => {
+        Guild.find.mockReturnValue({ lean: async () => [guildDoc({ economy: { announcementChannelId: 'c1', potwReward: 250 } })] });
+        await selectPetOfTheWeek(fakeClient());
+        expect(User.findOneAndUpdate.mock.calls[0][1]).toEqual({ $inc: { balance: 250 } });
+
+        jest.clearAllMocks();
+        Guild.find.mockReturnValue({ lean: async () => [guildDoc({ economy: { announcementChannelId: 'c1', potwReward: 0 } })] });
+        Guild.findOneAndUpdate.mockResolvedValue({ guildId: 'g1' });
+        User.aggregate.mockResolvedValue([WINNER]);
+
+        await selectPetOfTheWeek(fakeClient());
+
+        expect(User.findOneAndUpdate).not.toHaveBeenCalled();
+        // And the embed must not advertise a prize nobody was paid.
+        expect(sent[0].payload.embeds[0].fields.some(f => f.name.includes('Prize'))).toBe(false);
+    });
+
+    test('a week where nobody interacted still clears the counters and crowns nobody', async () => {
+        User.aggregate.mockResolvedValue([]);
+
+        await selectPetOfTheWeek(fakeClient());
+
+        expect(User.updateOne).not.toHaveBeenCalled();
+        expect(counterClear()).toBeDefined();
+        // No winner to exempt, so every ribbon comes off.
+        expect(ribbonClear()[2].arrayFilters).toEqual([{ 'old._id': { $ne: null } }]);
+        expect(User.findOneAndUpdate).not.toHaveBeenCalled();
+        expect(sent).toEqual([]);
+    });
+
+    test('announces the winner with the interaction count and the prize', async () => {
+        await selectPetOfTheWeek(fakeClient());
+
+        const embed = sent[0].payload.embeds[0];
+        expect(embed.title).toBe('🌟 Pet of the Week!');
+        expect(embed.description).toContain('**Mochi** — owned by <@u1>');
+        expect(embed.description).toContain('42 interactions this week');
+        expect(embed.fields.find(f => f.name.includes('Prize')).value).toBe('5,000 coins');
+    });
+
+    test('a sprite that fails to render still lets the announcement go out', async () => {
+        generatePetSprite.mockRejectedValueOnce(new Error('canvas unavailable'));
+
+        await selectPetOfTheWeek(fakeClient());
+
+        expect(sent[0].payload.embeds[0].title).toBe('🌟 Pet of the Week!');
+        expect(sent[0].payload.files).toEqual([]);
+    });
+
+    test('a guild with nowhere to announce is still paid and still reset', async () => {
+        Guild.find.mockReturnValue({ lean: async () => [guildDoc({ economy: {} })] });
+        const client = fakeClient();
+        client.guilds.fetch.mockResolvedValue(null);   // bot no longer in the guild
+
+        await selectPetOfTheWeek(client);
+
+        expect(User.findOneAndUpdate).toHaveBeenCalled();
+        expect(counterClear()).toBeDefined();
+        expect(sent).toEqual([]);
+    });
+
+    test('one guild that throws does not strand the rest of the sweep', async () => {
+        Guild.find.mockReturnValue({ lean: async () => [guildDoc({ guildId: 'boom' }), guildDoc({ guildId: 'ok' })] });
+        Guild.findOneAndUpdate.mockImplementation(async filter => {
+            if (filter.guildId === 'boom') throw new Error('mongo down');
+            return { guildId: filter.guildId };
+        });
+
+        await expect(selectPetOfTheWeek(fakeClient())).resolves.toBeUndefined();
+
+        expect(User.findOneAndUpdate).toHaveBeenCalledTimes(1);
+        expect(errorLog).toHaveBeenCalled();
+    });
+});

--- a/tests/rankedSeasonRollover.test.js
+++ b/tests/rankedSeasonRollover.test.js
@@ -1,0 +1,243 @@
+'use strict';
+
+/**
+ * #784. `resolveRankedSeasons` runs on a cron, pays a 50,000-coin top prize
+ * split three ways, and soft-resets every participant's ELO. Both are one-way
+ * and both key off `currentSeasonId`, which the same job rolls forward — so a
+ * claim that is not atomic pays the podium twice and resets the ELO of a season
+ * that has already started. None of it was executed.
+ */
+
+jest.mock('discord.js', () => {
+    class EmbedBuilder {
+        constructor() { this.fields = []; }
+        setColor(c) { this.color = c; return this; }
+        setTitle(t) { this.title = t; return this; }
+        setDescription(d) { this.description = d; return this; }
+        setFooter(f) { this.footer = f; return this; }
+        setTimestamp() { return this; }
+        addFields(...f) { this.fields.push(...f.flat()); return this; }
+    }
+    return { EmbedBuilder, AttachmentBuilder: class {} };
+});
+
+jest.mock('../src/models/Guild', () => ({ find: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), updateOne: jest.fn() }));
+jest.mock('../src/models/User',  () => ({ find: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), aggregate: jest.fn(), updateOne: jest.fn(), updateMany: jest.fn(), bulkWrite: jest.fn() }));
+
+const Guild = require('../src/models/Guild');
+const User  = require('../src/models/User');
+const { softResetElo } = require('../src/utils/duelElo');
+const { resolveRankedSeasons } = require('../src/services/schedulerService');
+
+const DAY = 86_400_000;
+
+function chain(docs) {
+    const c = {
+        sort: () => c, limit: () => c, select: () => c,
+        lean: async () => docs,
+        then: (res, rej) => Promise.resolve(docs).then(res, rej),
+    };
+    return c;
+}
+
+function rankedGuild(over = {}) {
+    return {
+        guildId: 'g1',
+        economy: { currency: '💰', announcementChannelId: 'c1' },
+        rankedDuels: {
+            enabled: true,
+            currentSeasonId: 'S3',
+            seasonNumber: 3,
+            seasonDurationDays: 60,
+            seasonEndsAt: new Date(Date.now() - DAY),
+            announceChannelId: 'rank-c',
+            topReward: 50_000,
+        },
+        ...over,
+    };
+}
+
+const PODIUM = [
+    { userId: 'u1', ranked: { seasonPeakElo: 1800 } },
+    { userId: 'u2', ranked: { seasonPeakElo: 1600 } },
+    { userId: 'u3', ranked: { seasonPeakElo: 1400 } },
+];
+
+let sent;
+let errorLog;
+
+function fakeClient() {
+    sent = [];
+    return {
+        guilds: {
+            fetch: jest.fn(async guildId => ({
+                id: guildId,
+                channels: {
+                    fetch: async channelId => ({
+                        isTextBased: () => true,
+                        send: async payload => { sent.push({ guildId, channelId, payload }); },
+                    }),
+                },
+            })),
+        },
+    };
+}
+
+/** `find` is called for uninitialized guilds, expired guilds, the podium, and participants. */
+function stubFinds({ uninitialized = [], expired = [rankedGuild()], podium = PODIUM, participants = [] } = {}) {
+    Guild.find.mockImplementation(async filter =>
+        filter.$or ? uninitialized : expired);
+    User.find.mockImplementation(filter =>
+        chain(filter['ranked.currentSeasonId'] ? podium : participants));
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    Guild.findOneAndUpdate.mockResolvedValue({ guildId: 'g1' });
+    User.updateOne.mockResolvedValue({});
+    User.bulkWrite.mockResolvedValue({});
+    stubFinds();
+    errorLog = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => errorLog.mockRestore());
+
+describe('resolveRankedSeasons', () => {
+    test('gives a ranked guild with no season yet its first one', async () => {
+        const fresh = rankedGuild({
+            rankedDuels: { enabled: true, seasonNumber: 1, seasonDurationDays: 30, currentSeasonId: null, seasonEndsAt: null },
+            save: jest.fn(async () => {}),
+        });
+        stubFinds({ uninitialized: [fresh], expired: [] });
+
+        await resolveRankedSeasons(fakeClient());
+
+        expect(fresh.rankedDuels.currentSeasonId).toBe('S1');
+        expect(fresh.rankedDuels.seasonEndsAt.getTime() - fresh.rankedDuels.seasonStartedAt.getTime()).toBe(30 * DAY);
+        expect(fresh.save).toHaveBeenCalled();
+    });
+
+    test('rolls the season forward as the claim, before it pays anything', async () => {
+        const order = [];
+        Guild.findOneAndUpdate.mockImplementation(async () => { order.push('claim'); return { guildId: 'g1' }; });
+        User.updateOne.mockImplementation(async () => { order.push('pay'); return {}; });
+
+        await resolveRankedSeasons(fakeClient());
+
+        expect(order[0]).toBe('claim');
+        const [filter, update, options] = Guild.findOneAndUpdate.mock.calls[0];
+        // Matching on the *old* season id is what makes this a claim: the update
+        // replaces it, so a second sweep finds nothing to match.
+        expect(filter).toEqual({ guildId: 'g1', 'rankedDuels.currentSeasonId': 'S3' });
+        expect(update.$set['rankedDuels.currentSeasonId']).toBe('S4');
+        expect(update.$set['rankedDuels.seasonNumber']).toBe(4);
+        expect(options).toEqual({ new: false });
+    });
+
+    test('a season another worker already rolled pays nobody', async () => {
+        Guild.findOneAndUpdate.mockResolvedValue(null);
+
+        await resolveRankedSeasons(fakeClient());
+
+        expect(User.updateOne).not.toHaveBeenCalled();
+        expect(User.bulkWrite).not.toHaveBeenCalled();
+    });
+
+    test('counts only players who actually played this season', async () => {
+        await resolveRankedSeasons(fakeClient());
+
+        const [filter] = User.find.mock.calls.find(([f]) => f['ranked.currentSeasonId']);
+        // Without the season-id clause a prior-season winner's lingering
+        // seasonPeakElo reclaims a podium slot without playing a single game.
+        expect(filter['ranked.currentSeasonId']).toBe('S3');
+        expect(filter.$or).toEqual([
+            { 'ranked.seasonRankedWins':   { $gt: 0 } },
+            { 'ranked.seasonRankedLosses': { $gt: 0 } },
+        ]);
+    });
+
+    test('pays 100/60/30% of the configured top reward, in rank order', async () => {
+        await resolveRankedSeasons(fakeClient());
+
+        expect(User.updateOne.mock.calls.map(([f, u]) => [f.userId, u.$inc.balance]))
+            .toEqual([['u1', 50_000], ['u2', 30_000], ['u3', 15_000]]);
+    });
+
+    test('awards a distinct title per place and records the season it was won in', async () => {
+        await resolveRankedSeasons(fakeClient());
+
+        const titles = User.updateOne.mock.calls.map(([, u]) => u.$addToSet['ranked.seasonalTitles']);
+        expect(titles).toEqual(['S3 Champion', 'S3 Runner-Up', 'S3 Third Place']);
+        for (const [, update] of User.updateOne.mock.calls) {
+            expect(update.$set['ranked.lastSeasonId']).toBe('S3');
+        }
+    });
+
+    test('soft-resets every participant toward 1200 in one bulkWrite', async () => {
+        stubFinds({ participants: [
+            { _id: 'a', ranked: { elo: 2000 } },
+            { _id: 'b', ranked: { elo: 800 } },
+            { _id: 'c', ranked: {} },
+        ] });
+
+        await resolveRankedSeasons(fakeClient());
+
+        expect(User.bulkWrite).toHaveBeenCalledTimes(1);
+        const [ops, options] = User.bulkWrite.mock.calls[0];
+        expect(options).toEqual({ ordered: false });
+        expect(ops.map(o => o.updateOne.update.$set['ranked.elo']))
+            .toEqual([softResetElo(2000), softResetElo(800), softResetElo(1000)]);
+        // Season counters zeroed and everyone moved onto the new season id, or
+        // the next rollover finds them still tagged with the old one.
+        expect(ops[0].updateOne.update.$set).toMatchObject({
+            'ranked.seasonRankedWins': 0, 'ranked.seasonRankedLosses': 0, 'ranked.currentSeasonId': 'S4',
+        });
+    });
+
+    test('a season with no participants writes nothing and still announces', async () => {
+        stubFinds({ podium: [], participants: [] });
+
+        await resolveRankedSeasons(fakeClient());
+
+        expect(User.updateOne).not.toHaveBeenCalled();
+        expect(User.bulkWrite).not.toHaveBeenCalled();
+        expect(sent[0].payload.embeds[0].description).toBe('_No ranked games played this season._');
+    });
+
+    test('announces to the ranked channel, falling back to the economy one', async () => {
+        await resolveRankedSeasons(fakeClient());
+        expect(sent[0].channelId).toBe('rank-c');
+
+        jest.clearAllMocks();
+        stubFinds({ expired: [rankedGuild({
+            rankedDuels: { ...rankedGuild().rankedDuels, announceChannelId: null },
+        })] });
+        Guild.findOneAndUpdate.mockResolvedValue({ guildId: 'g1' });
+
+        await resolveRankedSeasons(fakeClient());
+        expect(sent[0].channelId).toBe('c1');
+    });
+
+    test('the announcement names the podium, its prizes and the new season', async () => {
+        await resolveRankedSeasons(fakeClient());
+
+        const embed = sent[0].payload.embeds[0];
+        expect(embed.title).toBe('🏆 Ranked Season Ended — S3');
+        expect(embed.description).toContain('🥇 <@u1> — 1800 ELO · earned **💰50,000**');
+        expect(embed.description).toContain('🥉 <@u3> — 1400 ELO');
+        expect(embed.footer.text).toContain('Season 4 starts now');
+    });
+
+    test('one guild that throws does not strand the rest of the sweep', async () => {
+        stubFinds({ expired: [rankedGuild({ guildId: 'boom' }), rankedGuild({ guildId: 'ok' })] });
+        Guild.findOneAndUpdate.mockImplementation(async filter => {
+            if (filter.guildId === 'boom') throw new Error('mongo down');
+            return { guildId: filter.guildId };
+        });
+
+        await expect(resolveRankedSeasons(fakeClient())).resolves.toBeUndefined();
+
+        expect(User.updateOne.mock.calls.map(([f]) => f.guildId)).toEqual(['ok', 'ok', 'ok']);
+        expect(errorLog).toHaveBeenCalled();
+    });
+});

--- a/tests/seasonResolutionWrites.test.js
+++ b/tests/seasonResolutionWrites.test.js
@@ -1,0 +1,325 @@
+'use strict';
+
+/**
+ * #784. `resolveExpiredSeasons` runs on a cron and does something irreversible:
+ * it resets `seasonCoins` to zero for every user in the guild. The frozen
+ * `SeasonRecord` is the only thing left afterwards that says who won, so the
+ * order of those two writes is the whole correctness story — freeze first, then
+ * reset. Nothing executed this job at all.
+ */
+
+jest.mock('discord.js', () => {
+    class EmbedBuilder {
+        constructor() { this.fields = []; }
+        setColor(c) { this.color = c; return this; }
+        setTitle(t) { this.title = t; return this; }
+        setDescription(d) { this.description = d; return this; }
+        setFooter() { return this; }
+        setTimestamp() { return this; }
+        addFields(...f) { this.fields.push(...f.flat()); return this; }
+    }
+    class AttachmentBuilder { constructor(buf, opts) { this.buf = buf; this.name = opts?.name; } }
+    return { EmbedBuilder, AttachmentBuilder };
+});
+
+jest.mock('../src/models/Guild', () => ({ find: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), updateOne: jest.fn() }));
+jest.mock('../src/models/User', () => ({ find: jest.fn(), findOne: jest.fn(), aggregate: jest.fn(), updateOne: jest.fn(), updateMany: jest.fn(), bulkWrite: jest.fn() }));
+jest.mock('../src/models/SeasonRecord', () => ({ create: jest.fn() }));
+jest.mock('../src/utils/cardGenerator', () => ({
+    createWarVictoryBanner: jest.fn(async () => Buffer.from('banner')),
+    createSeasonRecapCard:  jest.fn(async () => Buffer.from('recap')),
+    generatePetSprite:      jest.fn(async () => Buffer.from('sprite')),
+}));
+
+const Guild        = require('../src/models/Guild');
+const User         = require('../src/models/User');
+const SeasonRecord = require('../src/models/SeasonRecord');
+const { createSeasonRecapCard } = require('../src/utils/cardGenerator');
+const { resolveExpiredSeasons } = require('../src/services/schedulerService');
+
+/** A thenable that answers every query modifier the job chains onto `find`. */
+function chain(docs) {
+    const c = {
+        sort: () => c, limit: () => c, select: () => c,
+        lean: async () => docs,
+        then: (res, rej) => Promise.resolve(docs).then(res, rej),
+    };
+    return c;
+}
+
+function seasonGuild(over = {}) {
+    return {
+        guildId: 'g1',
+        name: 'Home',
+        economy: { announcementChannelId: 'c1', currency: '🪙' },
+        currentSeason: { id: 's1', name: 'Season One', startedAt: new Date(0), endsAt: new Date(Date.now() - 3600_000) },
+        ...over,
+    };
+}
+
+const TOP = [
+    { userId: 'u1', seasonCoins: 900 },
+    { userId: 'u2', seasonCoins: 500 },
+    { userId: 'u3', seasonCoins: 100 },
+];
+
+let errorLog;
+let sent;
+let dms;
+let missingMembers;
+
+/**
+ * `User.find` is called four times with different shapes. Route by filter so a
+ * test can change one without rewriting the others.
+ */
+function stubUserFind({ top = TOP, active = [], ranked = TOP } = {}) {
+    User.find.mockImplementation(filter => {
+        if (filter['season.xp']) return chain(active);
+        if (filter['season.seasonId']) return chain(ranked);
+        return chain(top);
+    });
+}
+
+function fakeClient() {
+    sent = [];
+    dms = [];
+    missingMembers = new Set();
+    return {
+        guilds: {
+            fetch: jest.fn(async guildId => ({
+                id: guildId,
+                systemChannelId: 'system',
+                channels: {
+                    fetch: async channelId => ({
+                        isTextBased: () => true,
+                        send: async payload => { sent.push({ guildId, channelId, payload }); },
+                    }),
+                },
+                members: {
+                    fetch: async userId => {
+                        if (missingMembers.has(userId)) return null;
+                        return {
+                            user: { username: `name-${userId}` },
+                            send: async payload => { dms.push({ userId, payload }); },
+                        };
+                    },
+                },
+            })),
+        },
+    };
+}
+
+/** The recap DMs are fire-and-forget, so they land a tick after the job returns. */
+const settle = () => new Promise(resolve => setImmediate(resolve));
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    Guild.findOneAndUpdate.mockResolvedValue({ guildId: 'g1' });
+    SeasonRecord.create.mockResolvedValue({});
+    User.updateMany.mockResolvedValue({});
+    stubUserFind();
+    errorLog = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => errorLog.mockRestore());
+
+describe('resolveExpiredSeasons', () => {
+    test('sweeps only seasons that exist and have already ended', async () => {
+        Guild.find.mockResolvedValue([]);
+
+        await resolveExpiredSeasons(fakeClient());
+
+        const [filter] = Guild.find.mock.calls[0];
+        expect(filter['currentSeason.id']).toEqual({ $ne: null });
+        expect(filter['currentSeason.endsAt'].$lte).toBeInstanceOf(Date);
+    });
+
+    test('claims the season by clearing its id, so a duplicate sweep no-ops', async () => {
+        Guild.find.mockResolvedValue([seasonGuild()]);
+
+        await resolveExpiredSeasons(fakeClient());
+
+        const [filter, update, options] = Guild.findOneAndUpdate.mock.calls[0];
+        expect(filter).toEqual({ guildId: 'g1', 'currentSeason.id': 's1' });
+        expect(update.$set.currentSeason).toEqual({ id: null, name: null, startedAt: null, endsAt: null });
+        expect(options).toEqual({ new: false });
+    });
+
+    test('a season another worker already claimed resets nobody', async () => {
+        Guild.find.mockResolvedValue([seasonGuild()]);
+        Guild.findOneAndUpdate.mockResolvedValue(null);
+
+        await resolveExpiredSeasons(fakeClient());
+
+        expect(SeasonRecord.create).not.toHaveBeenCalled();
+        expect(User.updateMany).not.toHaveBeenCalled();
+    });
+
+    test('freezes the leaderboard before it wipes the coins it was computed from', async () => {
+        Guild.find.mockResolvedValue([seasonGuild()]);
+        const order = [];
+        SeasonRecord.create.mockImplementation(async () => { order.push('freeze'); return {}; });
+        User.updateMany.mockImplementation(async (_f, update) => {
+            if (update.$set?.seasonCoins === 0) order.push('reset');
+            return {};
+        });
+
+        await resolveExpiredSeasons(fakeClient());
+
+        // Reversed, a crash between the two leaves the season with no record of
+        // who won and the counts already gone — nothing to recompute from.
+        expect(order).toEqual(['freeze', 'reset']);
+    });
+
+    test('freezes the top 10 with the season id, names resolved for the podium', async () => {
+        Guild.find.mockResolvedValue([seasonGuild()]);
+
+        await resolveExpiredSeasons(fakeClient());
+
+        const [record] = SeasonRecord.create.mock.calls[0];
+        expect(record).toMatchObject({ guildId: 'g1', seasonId: 's1', seasonName: 'Season One' });
+        expect(record.top10).toEqual([
+            { userId: 'u1', username: 'name-u1', coins: 900 },
+            { userId: 'u2', username: 'name-u2', coins: 500 },
+            { userId: 'u3', username: 'name-u3', coins: 100 },
+        ]);
+    });
+
+    test('a duplicate freeze is another worker having won, not an error', async () => {
+        Guild.find.mockResolvedValue([seasonGuild()]);
+        const dup = Object.assign(new Error('E11000'), { code: 11000 });
+        SeasonRecord.create.mockRejectedValue(dup);
+
+        await expect(resolveExpiredSeasons(fakeClient())).resolves.toBeUndefined();
+
+        // The reset still runs: the record exists, it was simply written by
+        // whoever got there first.
+        expect(User.updateMany).toHaveBeenCalled();
+    });
+
+    test('any other freeze failure aborts before the coins are wiped', async () => {
+        Guild.find.mockResolvedValue([seasonGuild()]);
+        SeasonRecord.create.mockRejectedValue(new Error('mongo down'));
+
+        await expect(resolveExpiredSeasons(fakeClient())).resolves.toBeUndefined();
+
+        expect(User.updateMany).not.toHaveBeenCalled();
+        expect(errorLog).toHaveBeenCalled();
+    });
+
+    test('resets seasonCoins for the whole guild, not just the podium', async () => {
+        Guild.find.mockResolvedValue([seasonGuild()]);
+
+        await resolveExpiredSeasons(fakeClient());
+
+        const reset = User.updateMany.mock.calls.find(([, u]) => u.$set?.seasonCoins === 0);
+        expect(reset[0]).toEqual({ guildId: 'g1' });
+    });
+
+    test('announces the final podium in the guild currency', async () => {
+        Guild.find.mockResolvedValue([seasonGuild()]);
+
+        await resolveExpiredSeasons(fakeClient());
+
+        const embed = sent[0].payload.embeds[0];
+        expect(embed.title).toBe('🏁 Season Ended: Season One');
+        expect(embed.fields[0].value).toContain('🥇 <@u1> — 900 🪙');
+        expect(embed.fields[0].value).toContain('🥉 <@u3> — 100 🪙');
+    });
+
+    test('an empty season still announces, rather than announcing a blank podium', async () => {
+        Guild.find.mockResolvedValue([seasonGuild()]);
+        stubUserFind({ top: [], ranked: [] });
+
+        await resolveExpiredSeasons(fakeClient());
+
+        expect(sent[0].payload.embeds[0].fields[0].value).toBe('*No participants*');
+    });
+
+    test('falls back to the system channel when no announcement channel is set', async () => {
+        Guild.find.mockResolvedValue([seasonGuild({ economy: {} })]);
+
+        await resolveExpiredSeasons(fakeClient());
+
+        expect(sent[0].channelId).toBe('system');
+    });
+
+    test('one guild that throws does not strand the rest of the sweep', async () => {
+        Guild.find.mockResolvedValue([seasonGuild({ guildId: 'boom' }), seasonGuild({ guildId: 'ok' })]);
+        Guild.findOneAndUpdate.mockImplementation(async filter => {
+            if (filter.guildId === 'boom') throw new Error('mongo down');
+            return { guildId: filter.guildId };
+        });
+
+        await expect(resolveExpiredSeasons(fakeClient())).resolves.toBeUndefined();
+
+        expect(SeasonRecord.create).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('resolveExpiredSeasons — recap DMs', () => {
+    const ACTIVE = [
+        { userId: 'u1', season: { xp: 500 } },
+        { userId: 'u2', season: { xp: 10 } },
+    ];
+
+    test('DMs a recap card to each active player, ranked against the field', async () => {
+        Guild.find.mockResolvedValue([seasonGuild()]);
+        stubUserFind({ active: ACTIVE, ranked: TOP });
+        const client = fakeClient();
+
+        await resolveExpiredSeasons(client);
+        await settle();
+
+        expect(dms.map(d => d.userId)).toEqual(['u1', 'u2']);
+        expect(dms[0].payload.content).toContain('Your Season One recap is here!');
+        expect(dms[0].payload.files[0].name).toBe('season_recap.png');
+
+        const [player, seasonName, rank, total] = createSeasonRecapCard.mock.calls[0];
+        expect([player.userId, seasonName, rank, total]).toEqual(['u1', 'Season One', 1, 3]);
+    });
+
+    test('a card that fails to render costs that one player their DM, nobody else', async () => {
+        Guild.find.mockResolvedValue([seasonGuild()]);
+        stubUserFind({ active: ACTIVE, ranked: TOP });
+        createSeasonRecapCard.mockRejectedValueOnce(new Error('canvas unavailable'));
+
+        await resolveExpiredSeasons(fakeClient());
+        await settle();
+
+        expect(dms.map(d => d.userId)).toEqual(['u2']);
+    });
+
+    test('a player who has left the guild is skipped rather than throwing the loop', async () => {
+        Guild.find.mockResolvedValue([seasonGuild()]);
+        stubUserFind({ active: ACTIVE, ranked: TOP });
+        const client = fakeClient();
+        missingMembers.add('u1');
+
+        await resolveExpiredSeasons(client);
+        await settle();
+
+        expect(dms.map(d => d.userId)).toEqual(['u2']);
+    });
+
+    test('points the channel at the DMs once they have gone out', async () => {
+        Guild.find.mockResolvedValue([seasonGuild()]);
+        stubUserFind({ active: ACTIVE, ranked: TOP });
+
+        await resolveExpiredSeasons(fakeClient());
+        await settle();
+
+        expect(sent.some(s => String(s.payload).includes('Check your DMs'))).toBe(true);
+    });
+
+    test('a season nobody played sends no DMs', async () => {
+        Guild.find.mockResolvedValue([seasonGuild()]);
+        stubUserFind({ active: [], ranked: TOP });
+
+        await resolveExpiredSeasons(fakeClient());
+        await settle();
+
+        expect(dms).toEqual([]);
+        expect(createSeasonRecapCard).not.toHaveBeenCalled();
+    });
+});

--- a/tests/tempBanSweep.test.js
+++ b/tests/tempBanSweep.test.js
@@ -1,0 +1,191 @@
+'use strict';
+
+/**
+ * #784. `processExpiredBans` runs on a cron with no user in the loop, and it is
+ * the only thing that lifts a temporary ban — a ban it fails to lift stays in
+ * place until the banned user complains.
+ *
+ * 8b35886 fixed a real bug in it: `guild.bans.fetch(...).catch(() => null)` read
+ * *any* failure as "there is no ban", so a missing Ban Members permission or a
+ * transient 500 deleted the TempBan record while the ban stayed on forever, and
+ * bypassed the failure count so the sweep still reported healthy. That fix
+ * shipped with no test and the file was at 0%.
+ *
+ * These pin the three behaviours it turns on: which failure retires a record,
+ * which failure keeps it, and that a sweep with failures is loud.
+ */
+
+jest.mock('../src/models/TempBan', () => ({ find: jest.fn(), deleteOne: jest.fn() }));
+jest.mock('../src/services/moderationLogService', () => ({ logModeration: jest.fn() }));
+
+const TempBan = require('../src/models/TempBan');
+const { logModeration } = require('../src/services/moderationLogService');
+const { processExpiredBans } = require('../src/services/tempBanService');
+
+const UNKNOWN_BAN = 10026;
+
+function discordError(code) {
+    const err = new Error(`DiscordAPIError[${code}]`);
+    err.code = code;
+    return err;
+}
+
+/**
+ * A client whose guild either resolves a ban, or fails the fetch with `banError`.
+ * `unbanError` fails the unban itself, which is the missing-permission case that
+ * only shows up after the fetch has succeeded.
+ */
+function fakeClient({ guildId = 'g1', ban = { user: { id: 'u1' } }, banError = null, unbanError = null } = {}) {
+    const calls = { unbanned: [], fetched: [] };
+    const guild = {
+        bans: {
+            fetch: jest.fn(async userId => {
+                calls.fetched.push(userId);
+                if (banError) throw banError;
+                return ban;
+            }),
+        },
+        members: {
+            unban: jest.fn(async (userId, reason) => {
+                if (unbanError) throw unbanError;
+                calls.unbanned.push([userId, reason]);
+            }),
+        },
+    };
+    return {
+        calls,
+        guild,
+        client: {
+            user: { id: 'bot' },
+            guilds: { cache: new Map(guildId ? [[guildId, guild]] : []) },
+        },
+    };
+}
+
+function entry(over = {}) {
+    return { _id: 'rec1', guildId: 'g1', userId: 'u1', expiresAt: new Date(0), ...over };
+}
+
+let errorLog;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    TempBan.deleteOne.mockResolvedValue({ deletedCount: 1 });
+    logModeration.mockResolvedValue(undefined);
+    errorLog = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => errorLog.mockRestore());
+
+describe('processExpiredBans', () => {
+    test('sweeps only bans whose expiry has passed', async () => {
+        TempBan.find.mockResolvedValue([]);
+
+        await processExpiredBans(fakeClient().client);
+
+        const [filter] = TempBan.find.mock.calls[0];
+        expect(Object.keys(filter)).toEqual(['expiresAt']);
+        expect(filter.expiresAt.$lte).toBeInstanceOf(Date);
+        // A `$gte` here would sweep the bans that have *not* expired yet.
+        expect(filter.expiresAt.$lte.getTime()).toBeLessThanOrEqual(Date.now());
+    });
+
+    test('lifts an expired ban, logs it, and retires the record', async () => {
+        TempBan.find.mockResolvedValue([entry()]);
+        const { client, calls } = fakeClient();
+
+        await expect(processExpiredBans(client)).resolves.toBeUndefined();
+
+        expect(calls.unbanned).toEqual([['u1', 'Temporary ban expired']]);
+        expect(logModeration).toHaveBeenCalledWith('g1', 'unban', { id: 'u1' }, client.user, 'Temporary ban expired');
+        expect(TempBan.deleteOne).toHaveBeenCalledWith({ _id: 'rec1' });
+    });
+
+    test('an Unknown Ban clears the record — the ban is already gone', async () => {
+        // Someone unbanned by hand, or a previous tick lifted it and died before
+        // the delete. Either way the record has done its job; keeping it would
+        // mean retrying a ban that does not exist, forever.
+        TempBan.find.mockResolvedValue([entry()]);
+        const { client, guild } = fakeClient({ banError: discordError(UNKNOWN_BAN) });
+
+        await expect(processExpiredBans(client)).resolves.toBeUndefined();
+
+        expect(guild.members.unban).not.toHaveBeenCalled();
+        expect(logModeration).not.toHaveBeenCalled();
+        expect(TempBan.deleteOne).toHaveBeenCalledWith({ _id: 'rec1' });
+    });
+
+    test.each([
+        ['a missing Ban Members permission', 50013],
+        ['a transient server error',         500],
+        ['a plain failure with no code',     undefined],
+    ])('%s keeps the record and fails the sweep', async (_label, code) => {
+        // This is the regression 8b35886 fixed. Deleting here strands the ban:
+        // the record is the only thing that would ever lift it again.
+        TempBan.find.mockResolvedValue([entry()]);
+        const { client, guild } = fakeClient({ banError: code === undefined ? new Error('boom') : discordError(code) });
+
+        await expect(processExpiredBans(client)).rejects.toThrow(/could not be lifted/);
+
+        expect(TempBan.deleteOne).not.toHaveBeenCalled();
+        expect(guild.members.unban).not.toHaveBeenCalled();
+    });
+
+    test('an unban that fails after a successful fetch also keeps the record', async () => {
+        TempBan.find.mockResolvedValue([entry()]);
+        const { client } = fakeClient({ unbanError: discordError(50013) });
+
+        await expect(processExpiredBans(client)).rejects.toThrow(/1 of 1/);
+
+        expect(TempBan.deleteOne).not.toHaveBeenCalled();
+    });
+
+    test('a guild the bot is no longer in retires the record instead of retrying forever', async () => {
+        TempBan.find.mockResolvedValue([entry({ guildId: 'gone' })]);
+        const { client } = fakeClient({ guildId: 'g1' });
+
+        await expect(processExpiredBans(client)).resolves.toBeUndefined();
+
+        expect(TempBan.deleteOne).toHaveBeenCalledWith({ _id: 'rec1' });
+    });
+
+    test('one ban that will not lift does not strand the rest of the sweep', async () => {
+        TempBan.find.mockResolvedValue([
+            entry({ _id: 'bad',  userId: 'u1' }),
+            entry({ _id: 'good', userId: 'u2' }),
+        ]);
+        const { client, guild } = fakeClient();
+        guild.bans.fetch.mockImplementation(async userId => {
+            if (userId === 'u1') throw discordError(50013);
+            return { user: { id: userId } };
+        });
+
+        await expect(processExpiredBans(client)).rejects.toThrow(/1 of 2/);
+
+        // The healthy entry was still lifted and retired, and only it.
+        expect(guild.members.unban).toHaveBeenCalledWith('u2', 'Temporary ban expired');
+        expect(TempBan.deleteOne.mock.calls).toEqual([[{ _id: 'good' }]]);
+    });
+
+    test('throws so runJob files a dead letter — a silent sweep is the failure mode', async () => {
+        // Returning normally here is what let every unban in a sweep fail while
+        // /health still showed a healthy run. The entries are left alone, so the
+        // next tick retries them.
+        TempBan.find.mockResolvedValue([entry({ _id: 'a' }), entry({ _id: 'b', userId: 'u2' })]);
+        const { client, guild } = fakeClient();
+        guild.bans.fetch.mockRejectedValue(discordError(50013));
+
+        await expect(processExpiredBans(client)).rejects.toThrow('2 of 2 expired ban(s) could not be lifted');
+
+        expect(TempBan.deleteOne).not.toHaveBeenCalled();
+        expect(errorLog).toHaveBeenCalledTimes(2);
+    });
+
+    test('an empty sweep is a success, not a failure', async () => {
+        TempBan.find.mockResolvedValue([]);
+
+        await expect(processExpiredBans(fakeClient().client)).resolves.toBeUndefined();
+
+        expect(TempBan.deleteOne).not.toHaveBeenCalled();
+    });
+});

--- a/tests/warResolutionWrites.test.js
+++ b/tests/warResolutionWrites.test.js
@@ -45,18 +45,18 @@ const { resolveExpiredWars } = require('../src/services/schedulerService');
 
 const HOUR = 3600_000;
 
-/** Collects everything the job posts, keyed by the guild it was posted to. */
+/**
+ * A client that resolves guilds, channels and members. Tests that care what was
+ * announced install `capture(client)` over it; the rest only need the fetches
+ * to succeed so the job runs to completion.
+ */
 function fakeClient() {
-    const posts = [];
-    const channel = { isTextBased: () => true, send: jest.fn(async () => {}) };
     return {
-        posts,
-        channel,
         client: {
             guilds: {
                 fetch: jest.fn(async guildId => ({
                     id: guildId,
-                    channels: { fetch: async channelId => { channel.lastFor = [guildId, channelId]; return channel; } },
+                    channels: { fetch: async () => ({ isTextBased: () => true, send: jest.fn(async () => {}) }) },
                     members:  { fetch: async userId => ({ user: { username: `name-${userId}` } }) },
                 })),
             },
@@ -180,6 +180,7 @@ describe('resolveExpiredWars', () => {
         expect(activeEffects.expiresAt.getTime() - Date.now()).toBeGreaterThan(23 * HOUR);
         expect(activeEffects.expiresAt.getTime() - Date.now()).toBeLessThan(25 * HOUR);
         expect(badges.expiresAt.getTime() - Date.now()).toBeGreaterThan(29 * 24 * HOUR);
+        expect(badges.expiresAt.getTime() - Date.now()).toBeLessThan(31 * 24 * HOUR);
     });
 
     test('pays the opponent when the opponent is the one that won', async () => {

--- a/tests/warResolutionWrites.test.js
+++ b/tests/warResolutionWrites.test.js
@@ -1,0 +1,258 @@
+'use strict';
+
+/**
+ * #784. `resolveExpiredWars` runs on a cron and pays out: every member of the
+ * winning guild gets a 24h 2× coin booster and a 30-day badge, pushed with an
+ * unfiltered `updateMany`. Nobody watches it run, so a wrong winner or a
+ * double payout lands in balances and stays there.
+ *
+ * The thing that keeps it from paying twice is the atomic
+ * `activeWar.status: 'active' → 'ended'` claim: whoever flips it owns the
+ * resolution. These pin that claim, and that the rewards follow the score
+ * rather than the perspective of whichever guild document the sweep happened
+ * to find first.
+ */
+
+jest.mock('discord.js', () => {
+    class EmbedBuilder {
+        constructor() { this.fields = []; }
+        setColor(c) { this.color = c; return this; }
+        setTitle(t) { this.title = t; return this; }
+        setDescription(d) { this.description = d; return this; }
+        setImage(i) { this.image = i; return this; }
+        setFooter() { return this; }
+        setTimestamp() { return this; }
+        addFields(...f) { this.fields.push(...f.flat()); return this; }
+    }
+    class AttachmentBuilder {
+        constructor(buf, opts) { this.buf = buf; this.name = opts?.name; }
+    }
+    return { EmbedBuilder, AttachmentBuilder };
+});
+
+jest.mock('../src/models/Guild', () => ({ find: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), updateOne: jest.fn() }));
+jest.mock('../src/models/User', () => ({ find: jest.fn(), findOne: jest.fn(), aggregate: jest.fn(), updateOne: jest.fn(), updateMany: jest.fn(), bulkWrite: jest.fn() }));
+jest.mock('../src/utils/cardGenerator', () => ({
+    createWarVictoryBanner: jest.fn(async () => Buffer.from('banner')),
+    createSeasonRecapCard:  jest.fn(async () => Buffer.from('recap')),
+    generatePetSprite:      jest.fn(async () => Buffer.from('sprite')),
+}));
+
+const Guild = require('../src/models/Guild');
+const User  = require('../src/models/User');
+const { createWarVictoryBanner } = require('../src/utils/cardGenerator');
+const { resolveExpiredWars } = require('../src/services/schedulerService');
+
+const HOUR = 3600_000;
+
+/** Collects everything the job posts, keyed by the guild it was posted to. */
+function fakeClient() {
+    const posts = [];
+    const channel = { isTextBased: () => true, send: jest.fn(async () => {}) };
+    return {
+        posts,
+        channel,
+        client: {
+            guilds: {
+                fetch: jest.fn(async guildId => ({
+                    id: guildId,
+                    channels: { fetch: async channelId => { channel.lastFor = [guildId, channelId]; return channel; } },
+                    members:  { fetch: async userId => ({ user: { username: `name-${userId}` } }) },
+                })),
+            },
+        },
+    };
+}
+
+function warGuild(over = {}) {
+    return {
+        guildId: 'g1',
+        name: 'Home',
+        activeWar: {
+            status: 'active',
+            myScore: 100,
+            opponentScore: 40,
+            opponentGuildId: 'g2',
+            opponentGuildName: 'Away',
+            announcementChannelId: 'c1',
+            endsAt: new Date(Date.now() - HOUR),
+        },
+        ...over,
+    };
+}
+
+/** Records the posts a fake channel receives, per guild. */
+function capture(client) {
+    const sent = [];
+    client.guilds.fetch.mockImplementation(async guildId => ({
+        id: guildId,
+        channels: {
+            fetch: async channelId => ({
+                isTextBased: () => true,
+                send: async payload => { sent.push({ guildId, channelId, payload }); },
+            }),
+        },
+        members: { fetch: async userId => ({ user: { username: `name-${userId}` } }) },
+    }));
+    return sent;
+}
+
+function chain(docs) {
+    const c = {
+        sort: () => c,
+        limit: () => c,
+        select: () => c,
+        lean: async () => docs,
+        then: (res, rej) => Promise.resolve(docs).then(res, rej),
+    };
+    return c;
+}
+
+let errorLog;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    Guild.findOneAndUpdate.mockResolvedValue({ guildId: 'g1' });   // claim won
+    Guild.findOne.mockReturnValue({ lean: async () => ({ activeWar: { announcementChannelId: 'c2' } }) });
+    User.findOne.mockReturnValue(chain(null));
+    User.updateMany.mockResolvedValue({});
+    errorLog = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => errorLog.mockRestore());
+
+describe('resolveExpiredWars', () => {
+    test('sweeps only wars that are still active and already past their end', async () => {
+        Guild.find.mockResolvedValue([]);
+
+        await resolveExpiredWars(fakeClient().client);
+
+        const [filter] = Guild.find.mock.calls[0];
+        expect(filter['activeWar.status']).toBe('active');
+        expect(filter['activeWar.endsAt'].$ne).toBeNull();
+        expect(filter['activeWar.endsAt'].$lte).toBeInstanceOf(Date);
+    });
+
+    test('claims the war by flipping active → ended before it pays anything', async () => {
+        Guild.find.mockResolvedValue([warGuild()]);
+        const order = [];
+        Guild.findOneAndUpdate.mockImplementation(async filter => {
+            order.push(filter['activeWar.status'] === 'active' ? 'claim' : 'other');
+            return { guildId: 'g1' };
+        });
+        User.updateMany.mockImplementation(async () => { order.push('pay'); return {}; });
+
+        await resolveExpiredWars(fakeClient().client);
+
+        expect(order[0]).toBe('claim');
+        expect(order).toContain('pay');
+
+        const [filter, update, options] = Guild.findOneAndUpdate.mock.calls[0];
+        expect(filter).toEqual({ guildId: 'g1', 'activeWar.status': 'active' });
+        expect(update).toEqual({ $set: { 'activeWar.status': 'ended' } });
+        // `new: false` is not cosmetic here: the pre-update document is what
+        // proves this call is the one that won the claim.
+        expect(options).toEqual({ new: false });
+    });
+
+    test('a war another worker already claimed pays nothing', async () => {
+        Guild.find.mockResolvedValue([warGuild()]);
+        Guild.findOneAndUpdate.mockResolvedValue(null);   // someone else flipped it
+
+        await resolveExpiredWars(fakeClient().client);
+
+        expect(User.updateMany).not.toHaveBeenCalled();
+    });
+
+    test('pays the booster and the badge to the winning guild, and only to it', async () => {
+        Guild.find.mockResolvedValue([warGuild()]);   // 100 – 40, this guild wins
+
+        await resolveExpiredWars(fakeClient().client);
+
+        expect(User.updateMany).toHaveBeenCalledTimes(1);
+        const [filter, update] = User.updateMany.mock.calls[0];
+        expect(filter).toEqual({ guildId: 'g1' });
+
+        const { activeEffects, badges } = update.$push;
+        expect(activeEffects).toMatchObject({ type: 'coin_booster_2x', charges: -1 });
+        expect(badges).toMatchObject({ id: 'war_victor' });
+        // 24 hours and 30 days, not the other way round.
+        expect(activeEffects.expiresAt.getTime() - Date.now()).toBeGreaterThan(23 * HOUR);
+        expect(activeEffects.expiresAt.getTime() - Date.now()).toBeLessThan(25 * HOUR);
+        expect(badges.expiresAt.getTime() - Date.now()).toBeGreaterThan(29 * 24 * HOUR);
+    });
+
+    test('pays the opponent when the opponent is the one that won', async () => {
+        Guild.find.mockResolvedValue([warGuild({ activeWar: { ...warGuild().activeWar, myScore: 10, opponentScore: 90 } })]);
+
+        await resolveExpiredWars(fakeClient().client);
+
+        // The sweep found g1's document, but g2 outscored it. Paying the guild
+        // whose document was found is the bug this guards.
+        expect(User.updateMany.mock.calls[0][0]).toEqual({ guildId: 'g2' });
+    });
+
+    test('a tie pays nobody', async () => {
+        Guild.find.mockResolvedValue([warGuild({ activeWar: { ...warGuild().activeWar, myScore: 50, opponentScore: 50 } })]);
+
+        await resolveExpiredWars(fakeClient().client);
+
+        expect(User.updateMany).not.toHaveBeenCalled();
+        expect(createWarVictoryBanner).not.toHaveBeenCalled();
+    });
+
+    test('announces the win to the winner and the loss to the opponent', async () => {
+        Guild.find.mockResolvedValue([warGuild()]);
+        const { client } = fakeClient();
+        const sent = capture(client);
+
+        await resolveExpiredWars(client);
+
+        const titles = Object.fromEntries(sent.map(s => [
+            s.guildId,
+            (s.payload.embeds?.[0] ?? s.payload).title,
+        ]));
+        expect(titles.g1).toMatch(/WINS THE WAR/);
+        expect(titles.g2).toMatch(/War Lost/);
+        // The opponent's own announcement channel, read from its own document —
+        // not the channel id off the guild that happened to be swept.
+        expect(sent.find(s => s.guildId === 'g2').channelId).toBe('c2');
+    });
+
+    test('names the MVP from the winning guild, not the guild that was swept', async () => {
+        Guild.find.mockResolvedValue([warGuild({ activeWar: { ...warGuild().activeWar, myScore: 10, opponentScore: 90 } })]);
+        const seen = [];
+        User.findOne.mockImplementation(filter => { seen.push(filter.guildId); return chain({ userId: 'mvp', duelWins: 9 }); });
+        const { client } = fakeClient();
+        capture(client);
+
+        await resolveExpiredWars(client);
+
+        expect(new Set(seen)).toEqual(new Set(['g2']));
+    });
+
+    test('a banner that fails to render still lets the announcement go out', async () => {
+        Guild.find.mockResolvedValue([warGuild()]);
+        createWarVictoryBanner.mockRejectedValueOnce(new Error('canvas unavailable'));
+        const { client } = fakeClient();
+        const sent = capture(client);
+
+        await resolveExpiredWars(client);
+
+        expect(sent.some(s => (s.payload.embeds?.[0] ?? s.payload).title?.includes('WINS'))).toBe(true);
+        expect(sent.every(s => !s.payload.files?.length)).toBe(true);
+    });
+
+    test('one war that throws does not strand the rest of the sweep', async () => {
+        Guild.find.mockResolvedValue([warGuild({ guildId: 'boom' }), warGuild({ guildId: 'ok' })]);
+        Guild.findOneAndUpdate.mockImplementation(async filter => {
+            if (filter.guildId === 'boom') throw new Error('mongo down');
+            return { guildId: filter.guildId };
+        });
+
+        await expect(resolveExpiredWars(fakeClient().client)).resolves.toBeUndefined();
+
+        expect(User.updateMany).toHaveBeenCalledTimes(1);
+        expect(errorLog).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Closes #783, closes #784, closes #637.

Three issues that share a shape: code that acts on real users or real balances with nobody in the loop, and nothing proving it acts correctly.

## #637 — no immutable image tag

`docker/metadata-action` emitted only `main`, `latest` and semver tags. All three move with the next push, so after a bad deploy there was no reference left naming the build that had been running — pulling `latest` again just fetches the same broken image.

- `type=sha,format=long` is now published for every build. `format=long` matters: the short form is a 12-char prefix, which is not what `git rev-parse HEAD` or the Actions UI hands an operator.
- `portainer-stack.yml` reads its tag from `CLAWDIA_IMAGE_TAG`, defaulting to `latest`. Pinning or rolling back is an environment change rather than a repo commit at the worst possible moment. The default stays `latest` so a first deploy still works.
- `docs/RELEASING.md` gained a rollback procedure, including the step that a schema rollback needs the pre-migration dump from `/app/backups` — migrations here are forward-only and destructive, so the image alone does not roll back.
- `tests/imageRollbackTag.test.js` guards both halves, since either one alone restores the hole.

## #784 — six of nine scheduled job bodies untested

`schedulerService` was at 22.9% lines. Six of its nine cron job bodies were never called by any test, and `tempBanService` — whose `processExpiredBans` had just had a real bug fixed in 8b35886 — was at 0%.

Eight new test files: `processExpiredBans`, `resolveExpiredWars`, `resolveExpiredSeasons`, `selectPetOfTheWeek`, `announceHourlyWinners`, `resolveRankedSeasons`, `returnExpiredMarketListings`, and `casinoJackpotService`. Each pins:

- the **atomic claim** that stops a double payout (`status: active → ended`, `currentSeason.id` cleared, `rewarded: false → true`, the season-id roll-forward),
- the **write ordering** that keeps a crash recoverable — freeze the leaderboard before wiping the coins it was computed from, crown the pet before clearing the counters it was chosen from, delete the listing before crediting it back,
- the **per-entry isolation** that stops one bad record stranding a whole sweep, and that a sweep with failures still throws so `runJob` files a dead letter.

| File | Before | After |
|---|---|---|
| `tempBanService.js` | 0% | 100% lines / 100% branches |
| `casinoJackpotService.js` | 14.6% lines, 0% branches | 100% lines / 93.9% branches |
| `schedulerService.js` | 22.9% lines, 11.0% branches | 87.2% lines / 70.2% branches |

## #783 — auto-moderation entirely unexecuted

`handleAutoModeration` was only ever *entered*, on its early-return path: 37 of 154 statements, 45 of 146 branches, all nine filter bodies unexecuted.

Per the issue's recommendation, the fake-message builder is lifted out of `tests/messageCreateSharedUser.test.js` into `tests/helpers/messageCreateMessage.js` (that test now uses it too, so a filter cannot pass against a message shape the real handler would never see). Each filter is then driven table-driven: one message that trips the threshold, one that sits just under it, one from a member with `ManageMessages`, one from a member holding an immunity role. Then the ladder at every score boundary, the warning-count fallback beneath it, and the same for `escalationService`, `caseService` and `moderationLogService`.

### A bug the boundary cases found

The three behaviour-score bands read their defaults with `||`:

```js
const banAt = mod.behaviorScoreBanAt || 30;
```

Each field is labelled **"0 = disabled"** beside its dashboard input, the schema allows `min: 0`, and the ladder guards on `banAt > 0` for exactly that reason — but `||` reads `0` as absent and hands back the default. An operator who turned auto-ban off got it silently re-armed at 30, and all three `> 0` guards were unreachable. Changed to `??`, with tests pinning both that `0` disables and that *unset* still gets the documented default.

| File | Before | After |
|---|---|---|
| `messageCreate.js:436-654` | 24% statements, 30.8% branches | fully executed |
| `escalationService.js` | 11.9% lines, 0% branches | 100% lines / 94.3% branches |
| `caseService.js` | 15% lines, 0% branches | 100% / 100% |
| `moderationLogService.js` | — | 100% / 94.7% |

Coverage floors raised 33/22/35/34 → 36/25/38/37, with the measurement recorded in the `jest.config.js` comment as that file's convention asks.

## Verification

`eslint .` is clean. 202 suites / 3,582 tests pass with the new thresholds applied.

One caveat: `npm test` also runs two integration suites that need `mongodb-memory-server` to download a mongod binary, which the sandbox proxy refuses with a 403. I confirmed the same 61 tests fail identically on a clean checkout of `main`, so it is environmental and not from this branch — but it does mean **the two integration suites were never executed against these changes**, and CI is the first run that will do so. The coverage figures the new floors were set from were measured *without* those suites, so CI's number should be that or better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bPiA32E8gNYdVqb9dVN8o

---
_Generated by [Claude Code](https://claude.ai/code/session_018bPiA32E8gNYdVqb9dVN8o)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deployments can now select a specific image version or immutable commit using `CLAWDIA_IMAGE_TAG`, while defaulting to `latest`.
  - Image builds now publish immutable commit-based tags for safer rollbacks.

- **Bug Fixes**
  - Auto-moderation thresholds set to `0` now correctly disable the corresponding action instead of reverting to defaults.

- **Documentation**
  - Updated release and rollback guidance, including image pinning and database backup considerations.

- **Tests**
  - Expanded coverage across moderation, games, seasonal systems, marketplace returns, temporary bans, and deployment tag handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->