### PR TITLE
Record and replay owed payouts, and run every migration against a real database

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "nodemon src/index.js",
     "deploy": "node src/deploy-commands.js",
     "migrate:rollback": "node scripts/rollback-migration.js",
+    "payouts:replay": "node scripts/replay-owed-payouts.js",
     "docs:commands": "node scripts/docs-commands.js",
     "docs:api": "node scripts/docs-api.js",
     "docs:panels": "node scripts/docs-panels.js",

--- a/scripts/replay-owed-payouts.js
+++ b/scripts/replay-owed-payouts.js
@@ -31,20 +31,8 @@ require('../src/config/fileSecrets').loadFileSecrets();
 
 const mongoose = require('mongoose');
 const FailedJob = require('../src/models/FailedJob');
-const { retryJob } = require('../src/utils/jobRunner');
+const { retryJob, claimableFilter } = require('../src/utils/jobRunner');
 const { replayOwedPayout, describeOwedPayout, OWED_SUFFIX } = require('../src/utils/owedPayout');
-
-// Pending and retrying only. 'exhausted' has spent its attempts and wants a
-// human; 'resolved' has been paid, and paying it twice is the failure this
-// whole mechanism exists to avoid.
-//
-// 'retrying' is in the set on purpose. It describes both a replay in flight and
-// one whose process died holding the record, and dropping it would strand the
-// second kind forever. Telling them apart is not this listing's job: retryJob
-// claims each record with a compare-and-set before it calls the handler, so a
-// record another run is actively replaying is refused there rather than here,
-// and only the abandoned ones get through.
-const REPLAYABLE = ['pending', 'retrying'];
 
 async function main() {
     const pay = process.argv.slice(2).includes('--pay');
@@ -56,9 +44,14 @@ async function main() {
 
     await mongoose.connect(process.env.MONGODB_URI);
     try {
+        // claimableFilter is retryJob's own claim condition: pending or
+        // retrying, and not under a live lease. Selecting on anything looser
+        // would list records the replay below is about to refuse — 'exhausted'
+        // has spent its attempts and wants a human, 'resolved' has been paid,
+        // and a record another run is replaying right now is that run's.
         const owed = await FailedJob.find({
             jobName: { $regex: `\\${OWED_SUFFIX}$` },
-            status: { $in: REPLAYABLE },
+            ...claimableFilter(),
         }).sort({ createdAt: 1 });
 
         if (owed.length === 0) {

--- a/scripts/replay-owed-payouts.js
+++ b/scripts/replay-owed-payouts.js
@@ -37,6 +37,13 @@ const { replayOwedPayout, describeOwedPayout, OWED_SUFFIX } = require('../src/ut
 // Pending and retrying only. 'exhausted' has spent its attempts and wants a
 // human; 'resolved' has been paid, and paying it twice is the failure this
 // whole mechanism exists to avoid.
+//
+// 'retrying' is in the set on purpose. It describes both a replay in flight and
+// one whose process died holding the record, and dropping it would strand the
+// second kind forever. Telling them apart is not this listing's job: retryJob
+// claims each record with a compare-and-set before it calls the handler, so a
+// record another run is actively replaying is refused there rather than here,
+// and only the abandoned ones get through.
 const REPLAYABLE = ['pending', 'retrying'];
 
 async function main() {

--- a/scripts/replay-owed-payouts.js
+++ b/scripts/replay-owed-payouts.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+'use strict';
+
+// Lists and replays payouts a scheduled job claimed but never delivered (#804).
+//
+//   npm run payouts:replay             # list what is owed, pay nothing
+//   npm run payouts:replay -- --pay    # attempt every pending owed payout
+//
+// `announceHourlyWinners` and `returnExpiredMarketListings` both claim a record
+// before paying out — the winner is flipped to `rewarded`, the listing is
+// deleted — so a credit that fails afterwards cannot be retried by re-running
+// the job: the next tick finds nothing. Instead each one is written down as a
+// FailedJob whose payload names who is owed what (src/utils/owedPayout.js), and
+// this is what pays them.
+//
+// It is deliberately an operator command rather than an automatic retry. These
+// records exist because a write did not land, and the failure that stopped it —
+// a database that was down, a user document that no longer exists — is usually
+// still true a minute later; a loop that kept trying would spend its attempts
+// before anyone could look. Shell access to the host is the same bar as
+// `npm run migrate:rollback`, and the same reasoning: a hand on the wheel for
+// the operations that move data no other path can put back.
+//
+// Every attempt goes through retryJob, so the DLQ record carries its own audit
+// trail: attempts, last error, and `resolved`/`exhausted` at the end of it. A
+// record that exhausts its attempts is left for a human — nothing here deletes
+// one.
+
+require('dotenv').config();
+require('../src/config/fileSecrets').loadFileSecrets();
+
+const mongoose = require('mongoose');
+const FailedJob = require('../src/models/FailedJob');
+const { retryJob } = require('../src/utils/jobRunner');
+const { replayOwedPayout, describeOwedPayout, OWED_SUFFIX } = require('../src/utils/owedPayout');
+
+// Pending and retrying only. 'exhausted' has spent its attempts and wants a
+// human; 'resolved' has been paid, and paying it twice is the failure this
+// whole mechanism exists to avoid.
+const REPLAYABLE = ['pending', 'retrying'];
+
+async function main() {
+    const pay = process.argv.slice(2).includes('--pay');
+
+    if (!process.env.MONGODB_URI) {
+        console.error('MONGODB_URI is not set (put it in .env or the environment).');
+        process.exit(1);
+    }
+
+    await mongoose.connect(process.env.MONGODB_URI);
+    try {
+        const owed = await FailedJob.find({
+            jobName: { $regex: `\\${OWED_SUFFIX}$` },
+            status: { $in: REPLAYABLE },
+        }).sort({ createdAt: 1 });
+
+        if (owed.length === 0) {
+            console.log('Nothing owed.');
+            return;
+        }
+
+        console.log(`${owed.length} owed payout(s):\n`);
+        for (const record of owed) {
+            console.log(
+                `  ${record._id}  ${record.jobName}  ${describeOwedPayout(record.payload)}  ` +
+                `(attempt ${record.attempts}/${record.maxAttempts}, last error: ${record.errorMessage})`
+            );
+        }
+
+        if (!pay) {
+            console.log('\nNothing was paid. Re-run with --pay to attempt these.');
+            return;
+        }
+
+        console.log('');
+        let paid = 0;
+        let stillOwed = 0;
+        for (const record of owed) {
+            const what = describeOwedPayout(record.payload);
+            try {
+                const after = await retryJob(record._id, replayOwedPayout, 'replay-owed-payouts');
+                if (after.status === 'resolved') {
+                    paid++;
+                    console.log(`  paid    ${what}`);
+                } else {
+                    stillOwed++;
+                    console.error(`  FAILED  ${what} — ${after.errorMessage} [${after.status}]`);
+                }
+            } catch (err) {
+                // retryJob refuses a record another run resolved or exhausted
+                // between the listing above and here.
+                stillOwed++;
+                console.error(`  SKIPPED ${what} — ${err.message}`);
+            }
+        }
+
+        console.log(`\nPaid ${paid}, still owed ${stillOwed}.`);
+        if (stillOwed > 0) process.exitCode = 1;
+    } finally {
+        await mongoose.disconnect();
+    }
+}
+
+main().catch(err => {
+    console.error(err.message || err);
+    process.exitCode = 1;
+});

--- a/src/models/FailedJob.js
+++ b/src/models/FailedJob.js
@@ -18,6 +18,17 @@ const FailedJobSchema = new Schema({
     resolvedAt: { type: Date, default: null },
     resolvedBy: { type: String, default: null },
     lastAttemptAt: { type: Date, default: Date.now },
+
+    // Lease held by an in-flight retry, and who holds it. `status: 'retrying'`
+    // alone cannot say whether a replay is running or whether the process
+    // running it died, and retrying a live one runs its handler twice — for an
+    // owed payout, a second credit. Null means nobody holds it; a timestamp
+    // older than RETRY_LEASE_MS in src/utils/jobRunner.js means the holder is
+    // gone and the record can be taken. Absent on records written before this
+    // field existed, which `{ claimedAt: null }` matches, so they are claimable
+    // without a migration.
+    claimedAt: { type: Date, default: null },
+    claimedBy: { type: String, default: null },
 }, { timestamps: true });
 
 // Auto-expire resolved/exhausted records after 30 days

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -7,6 +7,7 @@ const { ensurePricingFields, nextPrice, decayDemand, demandDecayFactor, trendBuc
 const { softResetElo, tierFor, makeSeasonId } = require('../utils/duelElo');
 const { topByNetWorth } = require('../utils/netWorth');
 const { grantInventoryItem } = require('../utils/inventoryGrant');
+const { recordOwedPayout } = require('../utils/owedPayout');
 const COLORS = require('../utils/embedColors');
 
 const WAR_BOOSTER_DURATION_MS = 24 * 60 * 60 * 1000;
@@ -603,18 +604,66 @@ async function announceHourlyWinners(client) {
     }
     if (!actualWinners.length) return;
 
-    // Grant coin rewards first, decoupled from announcement availability
+    // Grant coin rewards first, decoupled from announcement availability.
+    //
+    // The claim above is one-way: this winner is `rewarded: true` now, so the
+    // next tick will not find them again whatever happens here. That makes a
+    // failed credit unrepeatable rather than merely unreported, so it is
+    // written down as owed (#804) and counted, and the sweep fails at the end.
+    //
+    // A `null` return counts as a failure too. `findOneAndUpdate` without
+    // `upsert` resolves to `null` when the user has no document in that guild —
+    // it does not throw, so the old `.catch` never fired and a winner whose
+    // record had been pruned was silently not paid while the announcement went
+    // on naming them as rewarded.
     const rewardAmount = 500;
+    const paidWinners = [];
+    let failedCredits = 0;
+
     for (const winner of actualWinners) {
-        await User.findOneAndUpdate(
-            { userId: winner.userId, guildId: winner.guildId },
-            { $inc: { balance: rewardAmount } }
-        ).catch(err => console.error(`[scheduler] reward credit failed for ${winner.userId}:`, err.message));
+        let credited = null;
+        let creditErr = null;
+        try {
+            credited = await User.findOneAndUpdate(
+                { userId: winner.userId, guildId: winner.guildId },
+                { $inc: { balance: rewardAmount } }
+            );
+        } catch (err) {
+            creditErr = err;
+        }
+
+        if (credited) {
+            paidWinners.push(winner);
+            continue;
+        }
+
+        failedCredits += 1;
+        const reason = creditErr?.message ?? `no user document for ${winner.userId} in ${winner.guildId}`;
+        console.error(
+            `[scheduler] hourly reward credit failed for ${winner.userId} in ${winner.guildId} ` +
+            `(${winner.category}, ${rewardAmount} coins) — recorded as owed:`, reason,
+        );
+        await recordOwedPayout({
+            service: 'schedulerService',
+            jobName: 'announceHourlyWinners',
+            guildId: winner.guildId,
+            payload: {
+                kind:     'coins',
+                userId:   winner.userId,
+                guildId:  winner.guildId,
+                amount:   rewardAmount,
+                hour:     prevHour,
+                category: winner.category,
+            },
+            error: creditErr ?? new Error(reason),
+        });
     }
 
-    // Announce per guild (best-effort — reward already granted above)
+    // Announce per guild (best-effort — reward already granted above).
+    // Only winners actually paid: the embed says "rewarded +500 coins", and a
+    // winner whose credit is sitting in the owed queue has not been.
     const byGuild = new Map();
-    for (const w of actualWinners) {
+    for (const w of paidWinners) {
         if (!byGuild.has(w.guildId)) byGuild.set(w.guildId, []);
         byGuild.get(w.guildId).push(w);
     }
@@ -646,6 +695,19 @@ async function announceHourlyWinners(client) {
         } catch (err) {
             console.error(`[scheduler] announceHourlyWinners failed for guild ${guildId}:`, err.message);
         }
+    }
+
+    // Last, so the winners who *were* paid are still announced. The per-winner
+    // catch above is what stops one bad credit stranding the rest of the hour;
+    // on its own it also meant an hour in which every credit failed returned
+    // normally and runJob recorded a healthy run. Throwing here is what puts it
+    // on /health and files the run-level dead-letter entry — the owed records
+    // above are what make it recoverable.
+    if (failedCredits) {
+        throw new Error(
+            `${failedCredits} of ${actualWinners.length} hourly reward(s) could not be credited ` +
+            '— recorded as owed, replay with `npm run payouts:replay`'
+        );
     }
 }
 
@@ -1058,6 +1120,7 @@ async function returnExpiredMarketListings() {
     const MarketListing = require('../models/MarketListing');
     const now = new Date();
     let processed = 0;
+    let failed = 0;
 
     // Process in batches of 50 to avoid large memory spikes
     const expired = await MarketListing.find({ expiresAt: { $lte: now } }).limit(50).lean();
@@ -1082,21 +1145,53 @@ async function returnExpiredMarketListings() {
             try {
                 await grantInventoryItem(listing.sellerId, listing.guildId, listing.itemId, listing.quantity, { upsert: true });
             } catch (creditErr) {
+                // The listing is already deleted, so nothing will find this
+                // again — which is why the credit is written down as owed
+                // rather than left to a retry that will never come (#804).
+                failed++;
                 console.error(
                     `[scheduler] listing ${listing._id} was claimed but crediting ` +
                     `${listing.quantity}x ${listing.itemId} to ${listing.sellerId} failed — ` +
-                    'items owed and must be returned by hand:', creditErr.message,
+                    'items owed, recorded for replay:', creditErr.message,
                 );
+                await recordOwedPayout({
+                    service: 'schedulerService',
+                    jobName: 'returnExpiredMarketListings',
+                    guildId: listing.guildId,
+                    payload: {
+                        kind:      'items',
+                        userId:    listing.sellerId,
+                        guildId:   listing.guildId,
+                        itemId:    listing.itemId,
+                        quantity:  listing.quantity,
+                        listingId: String(listing._id),
+                    },
+                    error: creditErr,
+                });
                 continue;
             }
             processed++;
         } catch (err) {
+            // A failure before the claim — the listing is untouched, so the
+            // next tick finds it again. Counted all the same: a sweep that
+            // returned nothing must not report a healthy run.
+            failed++;
             console.error(`[scheduler] returnExpiredMarketListings failed for listing ${listing._id}:`, err.message);
         }
     }
 
     if (processed > 0) {
         console.log(`[scheduler] returnExpiredMarketListings: returned items from ${processed} expired listing(s).`);
+    }
+
+    // Same reasoning as announceHourlyWinners: the per-listing catches keep one
+    // bad listing from stranding the batch, and would otherwise also keep the
+    // whole batch failing off /health and out of the dead-letter queue.
+    if (failed) {
+        throw new Error(
+            `${failed} of ${expired.length} expired listing(s) could not be returned` +
+            (processed ? ` (${processed} were)` : '')
+        );
     }
 }
 

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -657,10 +657,6 @@ async function announceHourlyWinners(client) {
 
         failedCredits += 1;
         const reason = creditErr?.message ?? `no user document for ${winner.userId} in ${winner.guildId}`;
-        console.error(
-            `[scheduler] hourly reward credit failed for ${winner.userId} in ${winner.guildId} ` +
-            `(${winner.category}, ${rewardAmount} coins) — recorded as owed:`, reason,
-        );
         const recorded = await recordOwedPayout({
             service: 'schedulerService',
             jobName: 'announceHourlyWinners',
@@ -676,6 +672,15 @@ async function announceHourlyWinners(client) {
             error: creditErr ?? new Error(reason),
         });
         if (!recorded) unrecordedCredits += 1;
+
+        // Logged after the record write, not before it: this line is the only
+        // trace of an unrecorded payout, so it has to say which of the two
+        // happened rather than assume the queue write it has not made yet.
+        console.error(
+            `[scheduler] hourly reward credit failed for ${winner.userId} in ${winner.guildId} ` +
+            `(${winner.category}, ${rewardAmount} coins) — ` +
+            `${recorded ? 'recorded as owed' : 'NOT recorded, must be paid by hand'}:`, reason,
+        );
     }
 
     // Announce per guild (best-effort — reward already granted above).
@@ -1169,11 +1174,6 @@ async function returnExpiredMarketListings() {
                 // again — which is why the credit is written down as owed
                 // rather than left to a retry that will never come (#804).
                 failed++;
-                console.error(
-                    `[scheduler] listing ${listing._id} was claimed but crediting ` +
-                    `${listing.quantity}x ${listing.itemId} to ${listing.sellerId} failed — ` +
-                    'items owed, recorded for replay:', creditErr.message,
-                );
                 const recorded = await recordOwedPayout({
                     service: 'schedulerService',
                     jobName: 'returnExpiredMarketListings',
@@ -1189,6 +1189,15 @@ async function returnExpiredMarketListings() {
                     error: creditErr,
                 });
                 if (!recorded) unrecordedReturns += 1;
+
+                // After the record write, for the same reason as the hourly
+                // credit above.
+                console.error(
+                    `[scheduler] listing ${listing._id} was claimed but crediting ` +
+                    `${listing.quantity}x ${listing.itemId} to ${listing.sellerId} failed — ` +
+                    `${recorded ? 'items owed, recorded for replay' : 'items owed and NOT recorded, must be returned by hand'}:`,
+                    creditErr.message,
+                );
                 continue;
             }
             processed++;

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -570,6 +570,23 @@ async function selectPetOfTheWeek(client) {
     }
 }
 
+// What a sweep says about the payouts it could not deliver.
+//
+// The distinction matters to whoever reads the failure: a payout recorded as
+// owed is one command away from being paid, and one that could not even be
+// recorded is not — the claim is still spent, so nothing will find it again and
+// the log line is all that is left of it. Reporting both as "recorded as owed"
+// would send an operator to `payouts:replay` for a record that is not there.
+function owedSummary(failed, unrecorded) {
+    const recorded = failed - unrecorded;
+    if (!unrecorded) return 'recorded as owed, replay with `npm run payouts:replay`';
+    if (!recorded) return 'none could be recorded as owed; they must be paid by hand, see the log above';
+    return (
+        `${recorded} recorded as owed (replay with \`npm run payouts:replay\`); ` +
+        `${unrecorded} could not be recorded and must be paid by hand, see the log above`
+    );
+}
+
 // ── Hourly Micro-Competition Announcements ────────────────────────────────────
 
 const HOURLY_CATEGORY_LABELS = {
@@ -619,6 +636,7 @@ async function announceHourlyWinners(client) {
     const rewardAmount = 500;
     const paidWinners = [];
     let failedCredits = 0;
+    let unrecordedCredits = 0;
 
     for (const winner of actualWinners) {
         let credited = null;
@@ -643,7 +661,7 @@ async function announceHourlyWinners(client) {
             `[scheduler] hourly reward credit failed for ${winner.userId} in ${winner.guildId} ` +
             `(${winner.category}, ${rewardAmount} coins) — recorded as owed:`, reason,
         );
-        await recordOwedPayout({
+        const recorded = await recordOwedPayout({
             service: 'schedulerService',
             jobName: 'announceHourlyWinners',
             guildId: winner.guildId,
@@ -657,6 +675,7 @@ async function announceHourlyWinners(client) {
             },
             error: creditErr ?? new Error(reason),
         });
+        if (!recorded) unrecordedCredits += 1;
     }
 
     // Announce per guild (best-effort — reward already granted above).
@@ -705,8 +724,8 @@ async function announceHourlyWinners(client) {
     // above are what make it recoverable.
     if (failedCredits) {
         throw new Error(
-            `${failedCredits} of ${actualWinners.length} hourly reward(s) could not be credited ` +
-            '— recorded as owed, replay with `npm run payouts:replay`'
+            `${failedCredits} of ${actualWinners.length} hourly reward(s) could not be credited — ` +
+            owedSummary(failedCredits, unrecordedCredits)
         );
     }
 }
@@ -1121,6 +1140,7 @@ async function returnExpiredMarketListings() {
     const now = new Date();
     let processed = 0;
     let failed = 0;
+    let unrecordedReturns = 0;
 
     // Process in batches of 50 to avoid large memory spikes
     const expired = await MarketListing.find({ expiresAt: { $lte: now } }).limit(50).lean();
@@ -1154,7 +1174,7 @@ async function returnExpiredMarketListings() {
                     `${listing.quantity}x ${listing.itemId} to ${listing.sellerId} failed — ` +
                     'items owed, recorded for replay:', creditErr.message,
                 );
-                await recordOwedPayout({
+                const recorded = await recordOwedPayout({
                     service: 'schedulerService',
                     jobName: 'returnExpiredMarketListings',
                     guildId: listing.guildId,
@@ -1168,6 +1188,7 @@ async function returnExpiredMarketListings() {
                     },
                     error: creditErr,
                 });
+                if (!recorded) unrecordedReturns += 1;
                 continue;
             }
             processed++;
@@ -1190,7 +1211,8 @@ async function returnExpiredMarketListings() {
     if (failed) {
         throw new Error(
             `${failed} of ${expired.length} expired listing(s) could not be returned` +
-            (processed ? ` (${processed} were)` : '')
+            (processed ? ` (${processed} were)` : '') +
+            (unrecordedReturns ? ` — ${owedSummary(failed, unrecordedReturns)}` : '')
         );
     }
 }

--- a/src/utils/jobRunner.js
+++ b/src/utils/jobRunner.js
@@ -78,20 +78,41 @@ async function runJob(service, jobName, fn, { guildId = null, scope = null, payl
  * Retry a pending FailedJob by its _id.
  * Runs the supplied handler with the stored payload and updates the DLQ record.
  *
+ * The attempt is *claimed* rather than merely marked. Reading the record,
+ * deciding it is retriable and then saving `retrying` is a check-then-act with a
+ * window in it: two operators running the replay script at once both read a
+ * pending record, both pass the guard, and both call the handler — which for an
+ * owed payout is a second `$inc` or a second inventory grant. Since the handler
+ * is what moves the money, that window has to be closed before it runs, not
+ * after.
+ *
+ * The claim is a compare-and-set on `attempts`, which only ever increases: both
+ * runs read the same value, both try to advance it, and the loser's filter no
+ * longer matches. No extra field, and no lease to expire.
+ *
+ * A record left `retrying` by a run that died is still claimable — its
+ * `attempts` is whatever that run left behind, so the next CAS against it
+ * succeeds. Excluding `retrying` outright would close the race by stranding
+ * those forever instead.
+ *
  * @param {string}   failedJobId  - FailedJob._id
  * @param {Function} handler      - async fn(payload) to call
  * @param {string}   resolvedBy   - userId or label for audit trail
  */
 async function retryJob(failedJobId, handler, resolvedBy = 'system') {
-    const record = await FailedJob.findById(failedJobId);
-    if (!record) throw new Error('FailedJob not found');
-    if (record.status === 'resolved') throw new Error('Job already resolved');
-    if (record.status === 'exhausted') throw new Error('Job exhausted');
+    const found = await FailedJob.findById(failedJobId);
+    if (!found) throw new Error('FailedJob not found');
+    if (found.status === 'resolved') throw new Error('Job already resolved');
+    if (found.status === 'exhausted') throw new Error('Job exhausted');
 
-    record.attempts += 1;
-    record.lastAttemptAt = new Date();
-    record.status = 'retrying';
-    await record.save();
+    const record = await FailedJob.findOneAndUpdate(
+        { _id: failedJobId, status: { $in: ['pending', 'retrying'] }, attempts: found.attempts },
+        { $inc: { attempts: 1 }, $set: { status: 'retrying', lastAttemptAt: new Date() } },
+        { new: true },
+    );
+    // Someone else advanced this record between the read above and the claim:
+    // another replay run has it, or resolved it. Either way it is not ours.
+    if (!record) throw new Error('Job is already being retried by another run');
 
     try {
         await handler(record.payload);

--- a/src/utils/jobRunner.js
+++ b/src/utils/jobRunner.js
@@ -74,45 +74,85 @@ async function runJob(service, jobName, fn, { guildId = null, scope = null, payl
     return true;
 }
 
+// How long an in-flight retry's claim on a dead-letter record is honoured.
+//
+// A lease rather than a flag, because `status: 'retrying'` cannot distinguish a
+// replay that is running from one whose process died holding the record. Reading
+// it as "running" strands the record forever; reading it as "dead" runs the
+// handler a second time, which for an owed payout is a second credit. The
+// timestamp is what tells them apart.
+//
+// Five minutes is far longer than any handler here takes — a replayed payout is
+// a single write — so a live claim is never mistaken for a dead one in practice,
+// and a genuinely dead one is recoverable within the window.
+const RETRY_LEASE_MS = 5 * 60 * 1000;
+
+/**
+ * Filter fragment matching dead-letter records that are free to claim: retriable
+ * status, and no lease or an expired one.
+ *
+ * Exported so a caller listing work to retry selects on the same terms the claim
+ * in `retryJob` enforces. Listing records it will then be refused only produces
+ * noise an operator has to learn to ignore.
+ *
+ * `{ claimedAt: null }` also matches documents with no `claimedAt` at all, which
+ * is every record written before the field existed.
+ */
+function claimableFilter(now = new Date()) {
+    return {
+        status: { $in: ['pending', 'retrying'] },
+        $or: [
+            { claimedAt: null },
+            { claimedAt: { $lte: new Date(now.getTime() - RETRY_LEASE_MS) } },
+        ],
+    };
+}
+
 /**
  * Retry a pending FailedJob by its _id.
  * Runs the supplied handler with the stored payload and updates the DLQ record.
  *
- * The attempt is *claimed* rather than merely marked. Reading the record,
- * deciding it is retriable and then saving `retrying` is a check-then-act with a
- * window in it: two operators running the replay script at once both read a
- * pending record, both pass the guard, and both call the handler — which for an
- * owed payout is a second `$inc` or a second inventory grant. Since the handler
- * is what moves the money, that window has to be closed before it runs, not
- * after.
+ * The record is claimed by the same update that marks it retrying — one
+ * conditional write, before the handler runs. Reading the record, deciding it is
+ * retriable and then saving `retrying` would be a check-then-act, and the window
+ * is wide enough for two operators running the replay script to both reach the
+ * handler: a second `$inc`, or a second inventory grant.
  *
- * The claim is a compare-and-set on `attempts`, which only ever increases: both
- * runs read the same value, both try to advance it, and the loser's filter no
- * longer matches. No extra field, and no lease to expire.
+ * A compare-and-set on `attempts` is not enough on its own. It stops two runs
+ * that read the same pre-claim state, but not a run that reads *after* the
+ * other's claim has landed — that one sees the incremented value and matches on
+ * it. Only a lease with a clock can tell an in-flight replay from an abandoned
+ * one, which is what `claimedAt` is.
  *
- * A record left `retrying` by a run that died is still claimable — its
- * `attempts` is whatever that run left behind, so the next CAS against it
- * succeeds. Excluding `retrying` outright would close the race by stranding
- * those forever instead.
+ * The lease is released whichever way the handler ends, so a record that goes
+ * back to `pending` is immediately available rather than waiting out its window.
  *
  * @param {string}   failedJobId  - FailedJob._id
  * @param {Function} handler      - async fn(payload) to call
  * @param {string}   resolvedBy   - userId or label for audit trail
  */
 async function retryJob(failedJobId, handler, resolvedBy = 'system') {
-    const found = await FailedJob.findById(failedJobId);
-    if (!found) throw new Error('FailedJob not found');
-    if (found.status === 'resolved') throw new Error('Job already resolved');
-    if (found.status === 'exhausted') throw new Error('Job exhausted');
+    const now = new Date();
 
     const record = await FailedJob.findOneAndUpdate(
-        { _id: failedJobId, status: { $in: ['pending', 'retrying'] }, attempts: found.attempts },
-        { $inc: { attempts: 1 }, $set: { status: 'retrying', lastAttemptAt: new Date() } },
+        { _id: failedJobId, ...claimableFilter(now) },
+        {
+            $inc: { attempts: 1 },
+            $set: { status: 'retrying', claimedAt: now, claimedBy: resolvedBy, lastAttemptAt: now },
+        },
         { new: true },
     );
-    // Someone else advanced this record between the read above and the claim:
-    // another replay run has it, or resolved it. Either way it is not ours.
-    if (!record) throw new Error('Job is already being retried by another run');
+
+    // Nothing was claimed. Read the record back to say which of the several
+    // reasons it was — the caller is an operator who needs to know whether to
+    // wait, look elsewhere, or stop.
+    if (!record) {
+        const existing = await FailedJob.findById(failedJobId);
+        if (!existing) throw new Error('FailedJob not found');
+        if (existing.status === 'resolved') throw new Error('Job already resolved');
+        if (existing.status === 'exhausted') throw new Error('Job exhausted');
+        throw new Error('Job is already being retried by another run');
+    }
 
     try {
         await handler(record.payload);
@@ -125,8 +165,10 @@ async function retryJob(failedJobId, handler, resolvedBy = 'system') {
         record.status = record.attempts >= record.maxAttempts ? 'exhausted' : 'pending';
     }
 
+    record.claimedAt = null;
+    record.claimedBy = null;
     await record.save();
     return record;
 }
 
-module.exports = { runJob, retryJob };
+module.exports = { runJob, retryJob, claimableFilter, RETRY_LEASE_MS };

--- a/src/utils/owedPayout.js
+++ b/src/utils/owedPayout.js
@@ -1,0 +1,138 @@
+'use strict';
+
+/**
+ * A durable record of a payout that was claimed but never delivered (#804).
+ *
+ * Two scheduled jobs claim a record before paying out — `announceHourlyWinners`
+ * flips a winner to `rewarded: true`, `returnExpiredMarketListings` deletes the
+ * listing — and the claim is what makes them safe to run twice. It is also
+ * one-way: once it is spent, the job's next tick finds nothing, so a credit that
+ * fails after the claim is not merely unreported, it is unrepeatable. Throwing
+ * gets the sweep onto /health and into the dead-letter queue, but the entry it
+ * files names a *run*, and re-running the run pays nobody.
+ *
+ * So the thing owed is written down separately, per entry, with everything the
+ * credit needs to be attempted again: who, where, and how much of what. That is
+ * the shape `retryJob` in src/utils/jobRunner.js already replays — it calls
+ * `handler(record.payload)` and marks the record resolved when the handler
+ * returns — so the record is a `FailedJob` and the handler is `replayOwedPayout`
+ * below. `scripts/replay-owed-payouts.js` is the operator-facing end of it.
+ *
+ * The precedent is src/utils/balanceDelta.js, which does the same thing for a
+ * credit that fails in the middle of a command: retry, and if it still will not
+ * land, record it as owed rather than lose it.
+ */
+
+const FailedJob = require('../models/FailedJob');
+
+// `jobName` on these records is the job that owed the payout, suffixed. runJob
+// files its own entry under the bare job name when the sweep throws, and the two
+// are different things: that one says "this run failed", this one says "this
+// player is owed 500 coins". The suffix is what lets the replay script pick out
+// the ones it knows how to pay without touching the rest of the queue.
+const OWED_SUFFIX = '.owed';
+
+/** True for a FailedJob written by `recordOwedPayout`. */
+function isOwedPayout(record) {
+    return typeof record?.jobName === 'string' && record.jobName.endsWith(OWED_SUFFIX);
+}
+
+/**
+ * Writes down one undelivered payout.
+ *
+ * Never throws. The reason a payout failed is usually that the database is
+ * unreachable, which is also the reason writing this down can fail — and a
+ * caller that has already lost the credit must not then lose the rest of its
+ * sweep to the bookkeeping. The caller still counts the failure and still fails
+ * its job, so a queue write that does not land is at worst a failure recorded
+ * one level coarser rather than a silent one.
+ *
+ * @param {object}  entry
+ * @param {string}  entry.service  service the job belongs to, e.g. 'schedulerService'
+ * @param {string}  entry.jobName  bare job name; the suffix is added here
+ * @param {?string} entry.guildId  guild the payout belongs to
+ * @param {object}  entry.payload  a `replayOwedPayout` payload — see below
+ * @param {?Error}  entry.error    what went wrong, for the queue entry
+ * @returns {Promise<boolean>} whether the record was written
+ */
+async function recordOwedPayout({ service, jobName, guildId = null, payload, error }) {
+    try {
+        await FailedJob.create({
+            service,
+            jobName: `${jobName}${OWED_SUFFIX}`,
+            guildId,
+            payload,
+            errorMessage: error?.message ?? 'unknown error',
+            errorStack: error?.stack ?? null,
+            lastAttemptAt: new Date(),
+        });
+        return true;
+    } catch (err) {
+        console.error(
+            `[${service}] ${jobName} could not record an owed payout ` +
+            `(${JSON.stringify(payload)}):`, err.message,
+        );
+        return false;
+    }
+}
+
+/**
+ * Pays one owed payout, from the payload `recordOwedPayout` stored.
+ *
+ * Written to be handed straight to `retryJob`, which treats a return as paid and
+ * a throw as still owed — so everything that means "not paid" has to throw,
+ * including the quiet one: `findOneAndUpdate` without `upsert` resolves to
+ * `null` when no document matches, which is exactly the case that made the
+ * hourly credit lose a winner in silence to begin with.
+ *
+ * Two kinds, one per claim site:
+ *
+ *   coins  { kind: 'coins', userId, guildId, amount }
+ *   items  { kind: 'items', userId, guildId, itemId, quantity }
+ */
+async function replayOwedPayout(payload) {
+    const kind = payload?.kind;
+
+    if (kind === 'coins') {
+        const { userId, guildId, amount } = payload;
+        if (!userId || !guildId || !(amount > 0)) {
+            throw new Error(`owed coins payload is incomplete: ${JSON.stringify(payload)}`);
+        }
+
+        const User = require('../models/User');
+        const credited = await User.findOneAndUpdate(
+            { userId, guildId },
+            { $inc: { balance: amount } },
+        );
+        if (!credited) {
+            throw new Error(`no user document for ${userId} in ${guildId} — nothing to credit`);
+        }
+        return;
+    }
+
+    if (kind === 'items') {
+        const { userId, guildId, itemId, quantity } = payload;
+        if (!userId || !guildId || !itemId || !(quantity > 0)) {
+            throw new Error(`owed items payload is incomplete: ${JSON.stringify(payload)}`);
+        }
+
+        const { grantInventoryItem } = require('./inventoryGrant');
+        await grantInventoryItem(userId, guildId, itemId, quantity, { upsert: true });
+        return;
+    }
+
+    throw new Error(`unknown owed payout kind: ${JSON.stringify(kind)}`);
+}
+
+/** Human-readable one-liner for a payload, for logs and the replay script. */
+function describeOwedPayout(payload) {
+    if (payload?.kind === 'coins') {
+        return `${payload.amount} coins to ${payload.userId} in ${payload.guildId}`;
+    }
+    if (payload?.kind === 'items') {
+        return `${payload.quantity}x ${payload.itemId} to ${payload.userId} in ${payload.guildId}`;
+    }
+    return JSON.stringify(payload);
+}
+
+module.exports = { recordOwedPayout, replayOwedPayout, describeOwedPayout, isOwedPayout, OWED_SUFFIX };

--- a/tests/hourlyWinnerPayout.test.js
+++ b/tests/hourlyWinnerPayout.test.js
@@ -24,10 +24,12 @@ jest.mock('discord.js', () => {
 jest.mock('../src/models/Guild', () => ({ find: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), updateOne: jest.fn() }));
 jest.mock('../src/models/User',  () => ({ find: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), aggregate: jest.fn(), updateOne: jest.fn(), updateMany: jest.fn(), bulkWrite: jest.fn() }));
 jest.mock('../src/models/HourlyWinner', () => ({ find: jest.fn(), findOneAndUpdate: jest.fn(), updateMany: jest.fn() }));
+jest.mock('../src/utils/owedPayout', () => ({ recordOwedPayout: jest.fn() }));
 
 const Guild        = require('../src/models/Guild');
 const User         = require('../src/models/User');
 const HourlyWinner = require('../src/models/HourlyWinner');
+const { recordOwedPayout } = require('../src/utils/owedPayout');
 const { getPreviousHourKey } = require('../src/utils/hourlyWinner');
 const { announceHourlyWinners } = require('../src/services/schedulerService');
 
@@ -62,6 +64,7 @@ beforeEach(() => {
     HourlyWinner.find.mockReturnValue({ lean: async () => [winner()] });
     HourlyWinner.findOneAndUpdate.mockImplementation(async filter => ({ _id: filter._id, rewarded: true }));
     User.findOneAndUpdate.mockResolvedValue({});
+    recordOwedPayout.mockResolvedValue(true);
     Guild.findOne.mockReturnValue({ lean: async () => ({ guildId: 'g1', economy: { announcementChannelId: 'c1' } }) });
     errorLog = jest.spyOn(console, 'error').mockImplementation(() => {});
 });
@@ -127,17 +130,65 @@ describe('announceHourlyWinners', () => {
         expect(sent).toEqual([]);
     });
 
-    test('a failed credit does not stop the other winners being paid', async () => {
+    // #804. The claim is spent — the winner is `rewarded: true` — so no later
+    // tick will find them again. The failure has to be both recorded per winner
+    // (so someone can pay it) and raised (so the run is not reported healthy).
+    test('a failed credit does not stop the other winners being paid, and is written down as owed', async () => {
         HourlyWinner.find.mockReturnValue({ lean: async () => [winner(), winner({ _id: 'w2', userId: 'u2', category: 'mine' })] });
         User.findOneAndUpdate.mockImplementation(async filter => {
             if (filter.userId === 'u1') throw new Error('mongo down');
             return {};
         });
 
-        await expect(announceHourlyWinners(fakeClient())).resolves.toBeUndefined();
+        await expect(announceHourlyWinners(fakeClient())).rejects.toThrow('1 of 2 hourly reward(s) could not be credited');
 
         expect(User.findOneAndUpdate).toHaveBeenCalledTimes(2);
+        expect(recordOwedPayout).toHaveBeenCalledTimes(1);
+        expect(recordOwedPayout).toHaveBeenCalledWith(expect.objectContaining({
+            service: 'schedulerService',
+            jobName: 'announceHourlyWinners',
+            guildId: 'g1',
+            payload: expect.objectContaining({
+                kind: 'coins', userId: 'u1', guildId: 'g1', amount: REWARD, category: 'fish',
+            }),
+        }));
         expect(errorLog).toHaveBeenCalled();
+    });
+
+    // The quiet one. `findOneAndUpdate` with no `upsert` resolves to `null`
+    // rather than throwing when the user has no document in that guild, so the
+    // old `.catch` never fired: the winner was marked rewarded, paid nothing,
+    // and still named in the announcement as "rewarded +500 coins".
+    test('a winner with no user document is owed, not silently skipped', async () => {
+        User.findOneAndUpdate.mockResolvedValue(null);
+
+        await expect(announceHourlyWinners(fakeClient())).rejects.toThrow('1 of 1 hourly reward(s) could not be credited');
+
+        expect(recordOwedPayout).toHaveBeenCalledWith(expect.objectContaining({
+            payload: expect.objectContaining({ kind: 'coins', userId: 'u1', amount: REWARD }),
+        }));
+        expect(sent).toEqual([]);
+    });
+
+    test('an unpaid winner is left out of the announcement the paid ones still get', async () => {
+        HourlyWinner.find.mockReturnValue({ lean: async () => [winner(), winner({ _id: 'w2', userId: 'u2', username: 'Grace', category: 'mine', details: '90 ore' })] });
+        User.findOneAndUpdate.mockImplementation(async filter => (filter.userId === 'u1' ? null : {}));
+
+        await expect(announceHourlyWinners(fakeClient())).rejects.toThrow(/1 of 2/);
+
+        expect(sent).toHaveLength(1);
+        const description = sent[0].payload.embeds[0].description;
+        expect(description).toContain('<@u2> (Grace)');
+        expect(description).not.toContain('<@u1>');
+    });
+
+    // The owed-queue write fails for the same reason the credit did, often
+    // enough. Neither the rest of the hour nor the raised failure depends on it.
+    test('a failed owed-queue write still leaves the sweep failing', async () => {
+        recordOwedPayout.mockResolvedValue(false);
+        User.findOneAndUpdate.mockResolvedValue(null);
+
+        await expect(announceHourlyWinners(fakeClient())).rejects.toThrow(/1 of 1/);
     });
 
     test('groups the hour into one announcement per guild', async () => {

--- a/tests/hourlyWinnerPayout.test.js
+++ b/tests/hourlyWinnerPayout.test.js
@@ -191,6 +191,36 @@ describe('announceHourlyWinners', () => {
         await expect(announceHourlyWinners(fakeClient())).rejects.toThrow(/1 of 1/);
     });
 
+    // What the failure *says* has to match what an operator will find. A payout
+    // in the owed queue is one command away from being paid; one that could not
+    // be recorded is not there at all, and sending someone to payouts:replay for
+    // it wastes the only chance anyone has of noticing.
+    test('says a payout is replayable only when it was really recorded', async () => {
+        User.findOneAndUpdate.mockResolvedValue(null);
+
+        await expect(announceHourlyWinners(fakeClient())).rejects.toThrow(/recorded as owed, replay with/);
+    });
+
+    test('says so plainly when nothing could be recorded', async () => {
+        User.findOneAndUpdate.mockResolvedValue(null);
+        recordOwedPayout.mockResolvedValue(false);
+
+        await expect(announceHourlyWinners(fakeClient()))
+            .rejects.toThrow(/none could be recorded as owed; they must be paid by hand/);
+    });
+
+    test('separates the recorded from the unrecorded when the hour has both', async () => {
+        HourlyWinner.find.mockReturnValue({ lean: async () => [winner(), winner({ _id: 'w2', userId: 'u2', category: 'mine' })] });
+        User.findOneAndUpdate.mockResolvedValue(null);
+        recordOwedPayout.mockImplementation(async ({ payload }) => payload.userId !== 'u1');
+
+        await expect(announceHourlyWinners(fakeClient())).rejects.toThrow(
+            '2 of 2 hourly reward(s) could not be credited — 1 recorded as owed ' +
+            '(replay with `npm run payouts:replay`); 1 could not be recorded and ' +
+            'must be paid by hand, see the log above',
+        );
+    });
+
     test('groups the hour into one announcement per guild', async () => {
         HourlyWinner.find.mockReturnValue({ lean: async () => [
             winner(),

--- a/tests/integration/migrations.test.js
+++ b/tests/integration/migrations.test.js
@@ -1,0 +1,632 @@
+'use strict';
+
+/**
+ * #629. Migrations executed, rather than described.
+ *
+ * `tests/migrationIndexes.test.js` greps the migration sources with a regex and
+ * `tests/migrationRunner.test.js` drives the runner against a mocked
+ * `MigrationRecord`. Between them they check that the files say what they are
+ * supposed to say and that the runner's control flow branches where it should —
+ * neither of which is the thing that goes wrong with a migration. What goes
+ * wrong is a server decision: a `partialFilterExpression` MongoDB refuses, an
+ * index it will not build, an aggregation `$merge` that needs a unique key that
+ * is not there yet, a pipeline `updateMany` the deployed server is too old for.
+ * A mock says yes to all of them.
+ *
+ * `tests/integration/guildIndexMigration.test.js` was the first file to run any
+ * migration against a real mongod — two of them, 001 and 015. This runs the
+ * whole sequence, in order, against real documents, and then goes back over the
+ * runner's own contract — ordering, idempotency, partial failure, rollback —
+ * with fixture migrations on disk, because those cases cannot be provoked with
+ * the shipped ones.
+ *
+ * Migrations auto-run at boot and have no rollback path beyond `down()` and the
+ * pre-migration backup, so "it applied cleanly against a server" is not a
+ * detail these tests could reasonably leave to production.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const mongoose = require('mongoose');
+
+const { useMongo } = require('../helpers/mongo');
+
+useMongo();
+
+const {
+    runMigrations, rollbackMigration, pendingMigrationNames, waitForMigrations,
+} = require('../../src/migrations/runner');
+const MigrationRecord = require('../../src/models/MigrationRecord');
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '..', '..', 'src', 'migrations');
+
+/** Shipped migrations, in the order the runner will apply them. */
+function shippedMigrations() {
+    return fs.readdirSync(MIGRATIONS_DIR)
+        .filter(f => f.endsWith('.js') && f !== 'runner.js')
+        .sort()
+        .map(file => require(path.join(MIGRATIONS_DIR, file)));
+}
+
+/** Recorded migration names, oldest first. ObjectIds order by creation. */
+async function appliedInOrder() {
+    return (await MigrationRecord.find({}).sort({ _id: 1 }).lean()).map(r => r.name);
+}
+
+const db = () => mongoose.connection.db;
+const indexNames = async collection => (await db().collection(collection).indexes()).map(i => i.name).sort();
+
+// ── Fixture migrations on disk ───────────────────────────────────────────────
+//
+// The runner discovers migrations with readdirSync + require, so provoking a
+// failure, an ordering question or a rollback needs real files. They report
+// what they did through a global the test reads back, which is the only way to
+// see the *order* the runner chose rather than the order it recorded.
+
+const tmpDirs = [];
+
+function migrationSource({ name, body = '', extra = '', down = true }) {
+    return `'use strict';
+module.exports = {
+    name: ${JSON.stringify(name)},
+${extra}    async up(options) {
+        globalThis.__migrationRuns.push(${JSON.stringify(name)});
+        globalThis.__migrationBudgets[${JSON.stringify(name)}] = options?.timeoutMs ?? null;
+        ${body}
+    },
+${down ? `    async down() { globalThis.__migrationRuns.push(${JSON.stringify(name)} + ':down'); },\n` : ''}};
+`;
+}
+
+/** Writes migration files into a throwaway directory and returns its path. */
+function migrationsDir(files) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawdia-migrations-'));
+    tmpDirs.push(dir);
+    for (const [file, source] of Object.entries(files)) {
+        fs.writeFileSync(path.join(dir, file), source);
+    }
+    return dir;
+}
+
+const savedEnv = {};
+
+beforeAll(() => {
+    for (const key of ['MIGRATION_BACKUP', 'MIGRATION_TIMEOUT_MS']) savedEnv[key] = process.env[key];
+    // Five of the shipped migrations are irreversible, which is what triggers
+    // the pre-migration mongodump. A test run must neither spawn one nor depend
+    // on whether this machine has the tool.
+    process.env.MIGRATION_BACKUP = 'skip';
+    delete process.env.MIGRATION_TIMEOUT_MS;
+});
+
+afterAll(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+    }
+    for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+    globalThis.__migrationRuns = [];
+    globalThis.__migrationBudgets = {};
+    globalThis.__migrationFails = new Set();
+    // The runner narrates every migration it applies, skips and defers. Useful
+    // at boot, noise here — and console.error is asserted on where it matters.
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(async () => {
+    jest.restoreAllMocks();
+    // useMongo clears the collections its models know about; migrations create
+    // theirs through the driver, so those are not among them.
+    await mongoose.connection.db.dropDatabase();
+});
+
+// ── The shipped sequence, end to end ─────────────────────────────────────────
+
+describe('every shipped migration, against a real server', () => {
+    test('the whole sequence applies cleanly and records what it applied', async () => {
+        const expected = shippedMigrations().map(m => m.name);
+
+        await runMigrations({ dir: MIGRATIONS_DIR });
+
+        // Not a subset and not a set: the order recorded is the order applied,
+        // and later migrations undo what earlier ones built.
+        expect(await appliedInOrder()).toEqual(expected);
+        // An optional migration that fails is deliberately left unrecorded, so
+        // a missing name here is a migration a real mongod refused.
+        expect(console.error).not.toHaveBeenCalled();
+    }, 60_000);
+
+    test('running the sequence twice applies nothing the second time', async () => {
+        await runMigrations({ dir: MIGRATIONS_DIR });
+        const first = await MigrationRecord.find({}).sort({ _id: 1 }).lean();
+
+        await runMigrations({ dir: MIGRATIONS_DIR });
+        const second = await MigrationRecord.find({}).sort({ _id: 1 }).lean();
+
+        // Same documents, not merely the same names: a re-applied migration
+        // would write a new record with a new _id and a new appliedAt.
+        expect(second.map(r => String(r._id))).toEqual(first.map(r => String(r._id)));
+        expect(second.map(r => r.appliedAt.getTime())).toEqual(first.map(r => r.appliedAt.getTime()));
+    }, 60_000);
+
+    // Ordering, observed from the outside. 002 and 003 build seven indexes on
+    // `users` and 009 drops them; 001 builds `idx_giveaways_active` on `guilds`
+    // and 015 drops it. Run in the wrong order every one of those would survive,
+    // because the drops would find nothing and the builds would come after.
+    test('later migrations undo the earlier ones, which only works in order', async () => {
+        await db().collection('users').insertOne({ userId: 'u1', guildId: 'g1' });
+        await db().collection('guilds').insertOne({ guildId: 'g1' });
+
+        await runMigrations({ dir: MIGRATIONS_DIR });
+
+        const users = await indexNames('users');
+        for (const stale of [
+            'idx_hunt_stamina_regen', 'idx_hunt_leaderboard_earned', 'idx_hunt_leaderboard_legendary',
+            'idx_fishing_stamina_regen', 'idx_fishing_leaderboard_earned',
+            'idx_fishing_leaderboard_legendary', 'idx_fishing_last_cast',
+        ]) {
+            expect(users).not.toContain(stale);
+        }
+        expect(await indexNames('guilds')).not.toContain('idx_giveaways_active');
+    }, 60_000);
+
+    // The one index a correctness argument rests on: the action lock's
+    // "already held" signal is the server rejecting a duplicate insert.
+    test('012 leaves an activelocks key index the server will actually enforce', async () => {
+        await runMigrations({ dir: MIGRATIONS_DIR });
+
+        await db().collection('activelocks').insertOne({ key: 'g1:u1:fish', expiresAt: new Date(Date.now() + 60_000) });
+
+        await expect(
+            db().collection('activelocks').insertOne({ key: 'g1:u1:fish', expiresAt: new Date(Date.now() + 60_000) }),
+        ).rejects.toMatchObject({ code: 11000 });
+    }, 60_000);
+
+    test('014 leaves itemimages keyed per guild, so two guilds can hold the same item', async () => {
+        await runMigrations({ dir: MIGRATIONS_DIR });
+        const images = db().collection('itemimages');
+
+        await images.insertOne({ guildId: 'g1', itemId: 'sword', imageData: Buffer.from('a') });
+        await images.insertOne({ guildId: 'g2', itemId: 'sword', imageData: Buffer.from('b') });
+
+        await expect(
+            images.insertOne({ guildId: 'g1', itemId: 'sword', imageData: Buffer.from('c') }),
+        ).rejects.toMatchObject({ code: 11000 });
+    }, 60_000);
+});
+
+// ── The shipped sequence, over documents that predate it ─────────────────────
+
+describe('the data migrations, over pre-migration documents', () => {
+    // Seeded through the driver rather than the models on purpose: these are
+    // shapes the current schemas no longer describe, so Mongoose would strip
+    // exactly the fields the migration exists to deal with.
+    async function seed() {
+        await db().collection('users').insertMany([
+            {
+                userId: 'u1', guildId: 'g1', balance: -50, bank: -10,
+                lastWheelSpin: new Date('2024-01-01T00:00:00Z'),
+                fishing: { xp: 10, totalEarned: 500, gear: ['rod'] },
+                hunt:    { xp: 3, totalEarned: 20 },
+                pets: [{ petId: 'cat', lastFed: new Date('2024-01-01T00:00:00Z'), starvingStartAt: new Date('2024-01-02T00:00:00Z') }],
+                inventory: [
+                    { itemId: 'sword', quantity: 1 },
+                    { itemId: 'shield', quantity: 4 },
+                    { itemId: 'sword', quantity: 2 },
+                ],
+            },
+            { userId: 'u2', guildId: 'g1', balance: 25, bank: 0, inventory: [{ itemId: 'potion', quantity: 1 }] },
+        ]);
+
+        await db().collection('guilds').insertOne({
+            guildId: 'g1',
+            economy: { wheelEnabled: true, wheelCooldownHours: 6, wheelExtraSpinCost: 100, currency: '💰' },
+            analytics: {
+                memberEvents: [{ date: '2024-01-01', joins: 2, leaves: 1 }],
+                commandUsage: [{ command: 'fish', hour: 3, success: true }],
+            },
+        });
+
+        // The pre-#561 shape: no guildId, and the single-field unique index
+        // Mongoose built from `unique: true` on itemId.
+        await db().collection('itemimages').insertOne({ itemId: 'sword', imageData: Buffer.from('a') });
+        await db().collection('itemimages').createIndex({ itemId: 1 }, { name: 'itemId_1', unique: true });
+
+        // The single-field index 016 exists to drop.
+        await db().collection('fishingtournaments').insertOne({ guildId: 'g1', status: 'ended' });
+        await db().collection('fishingtournaments').createIndex({ guildId: 1 }, { name: 'guildId_1' });
+    }
+
+    const user = id => db().collection('users').findOne({ userId: id });
+
+    test('005 moves grind state into its own collection and clears the source', async () => {
+        await seed();
+
+        await runMigrations({ dir: MIGRATIONS_DIR });
+
+        const moved = await user('u1');
+        expect(moved.fishing).toBeUndefined();
+        expect(moved.hunt).toBeUndefined();
+
+        const profiles = await db().collection('grindprofiles')
+            .find({ userId: 'u1' }).sort({ system: 1 }).toArray();
+        expect(profiles.map(p => p.system)).toEqual(['fishing', 'hunt']);
+        expect(profiles[0].data).toEqual({ xp: 10, totalEarned: 500, gear: ['rod'] });
+        expect(profiles[0].guildId).toBe('g1');
+    }, 60_000);
+
+    // $merge with whenMatched: 'keepExisting' is the whole idempotency claim,
+    // and it needs the unique index the migration builds first.
+    test('005 leaves a profile written since the move alone on a re-run', async () => {
+        await seed();
+        await runMigrations({ dir: MIGRATIONS_DIR });
+
+        await db().collection('grindprofiles').updateOne(
+            { userId: 'u1', system: 'fishing' },
+            { $set: { 'data.xp': 999 } },
+        );
+        await db().collection('users').updateOne({ userId: 'u1' }, { $set: { fishing: { xp: 1 } } });
+        await require('../../src/migrations/005_grind_profiles').up({ timeoutMs: 30_000 });
+
+        const profile = await db().collection('grindprofiles').findOne({ userId: 'u1', system: 'fishing' });
+        expect(profile.data.xp).toBe(999);
+        expect((await user('u1')).fishing).toBeUndefined();
+    }, 60_000);
+
+    test('006 drops the wheel fields from both collections', async () => {
+        await seed();
+
+        await runMigrations({ dir: MIGRATIONS_DIR });
+
+        expect((await user('u1')).lastWheelSpin).toBeUndefined();
+        const guild = await db().collection('guilds').findOne({ guildId: 'g1' });
+        expect(guild.economy.wheelEnabled).toBeUndefined();
+        expect(guild.economy.wheelCooldownHours).toBeUndefined();
+        expect(guild.economy.wheelExtraSpinCost).toBeUndefined();
+        // Only the wheel fields: the rest of the economy settings stay.
+        expect(guild.economy.currency).toBe('💰');
+    }, 60_000);
+
+    test('008 gives every existing pet a decay cursor and clears its starvation clock', async () => {
+        await seed();
+        const before = Date.now();
+
+        await runMigrations({ dir: MIGRATIONS_DIR });
+
+        const [pet] = (await user('u1')).pets;
+        expect(pet.lastDecayAt).toBeInstanceOf(Date);
+        expect(pet.lastDecayAt.getTime()).toBeGreaterThanOrEqual(before);
+        expect(pet.starvingStartAt).toBeNull();
+    }, 60_000);
+
+    test('010 folds duplicate inventory slots together without losing quantity', async () => {
+        await seed();
+
+        await runMigrations({ dir: MIGRATIONS_DIR });
+
+        const { inventory } = await user('u1');
+        // One slot per itemId, in the order the slots first appeared, carrying
+        // the summed quantity — the second sword slot was unspendable, since
+        // every reader takes the first match.
+        expect(inventory.map(i => [i.itemId, i.quantity])).toEqual([['sword', 3], ['shield', 4]]);
+        // A document with no duplicates is not rewritten at all.
+        expect((await user('u2')).inventory).toEqual([{ itemId: 'potion', quantity: 1 }]);
+    }, 60_000);
+
+    test('011 raises negative balances to zero and leaves healthy ones alone', async () => {
+        await seed();
+
+        await runMigrations({ dir: MIGRATIONS_DIR });
+
+        expect(await user('u1')).toMatchObject({ balance: 0, bank: 0 });
+        expect(await user('u2')).toMatchObject({ balance: 25, bank: 0 });
+    }, 60_000);
+
+    test('013 moves guild analytics into their own collection', async () => {
+        await seed();
+
+        await runMigrations({ dir: MIGRATIONS_DIR });
+
+        expect((await db().collection('guilds').findOne({ guildId: 'g1' })).analytics).toBeUndefined();
+        const analytics = await db().collection('guildanalytics').findOne({ guildId: 'g1' });
+        expect(analytics.memberEvents).toEqual([{ date: '2024-01-01', joins: 2, leaves: 1 }]);
+        expect(analytics.commandUsage).toEqual([{ command: 'fish', hour: 3, success: true }]);
+    }, 60_000);
+
+    test('014 re-keys the shared item images and drops the index that blocked it', async () => {
+        await seed();
+
+        await runMigrations({ dir: MIGRATIONS_DIR });
+
+        // Left as the shared fallback rather than assigned to a guild: nothing
+        // records who uploaded it.
+        expect(await db().collection('itemimages').findOne({ itemId: 'sword' })).toMatchObject({ guildId: null });
+        const names = await indexNames('itemimages');
+        expect(names).not.toContain('itemId_1');
+        expect(names).toContain('idx_itemimage_guild_item');
+    }, 60_000);
+
+    test('016 swaps the tournament index for the compound one', async () => {
+        await seed();
+
+        await runMigrations({ dir: MIGRATIONS_DIR });
+
+        const names = await indexNames('fishingtournaments');
+        expect(names).not.toContain('guildId_1');
+        expect(names).toContain('idx_tournament_guild_status');
+    }, 60_000);
+
+    // The claim every one of the above rests on: applying twice is applying
+    // once. Here the second pass is forced past the MigrationRecord skip, so
+    // the migrations themselves have to be idempotent rather than merely
+    // unreachable.
+    test('re-applying every migration over its own output changes nothing', async () => {
+        await seed();
+        await runMigrations({ dir: MIGRATIONS_DIR });
+
+        const snapshot = async () => ({
+            // 008 stamps every pet's `lastDecayAt` with the time it runs, on
+            // purpose — a pet last fed six months ago must not be retroactively
+            // starved — so that one field is expected to move under a forced
+            // second pass. Its MigrationRecord is what stops that happening for
+            // real; everything else here has to be idempotent on its own.
+            users: (await db().collection('users').find({}).sort({ userId: 1 }).toArray())
+                .map(u => ({ ...u, pets: (u.pets ?? []).map(({ lastDecayAt, ...pet }) => pet) })),
+            guilds: await db().collection('guilds').find({}).toArray(),
+            profiles: await db().collection('grindprofiles').find({}).sort({ system: 1 }).toArray(),
+            analytics: await db().collection('guildanalytics').find({}).toArray(),
+            images: await db().collection('itemimages').find({}).toArray(),
+        });
+
+        const before = await snapshot();
+        await MigrationRecord.deleteMany({});
+        await runMigrations({ dir: MIGRATIONS_DIR });
+
+        expect(await snapshot()).toEqual(before);
+        expect(console.error).not.toHaveBeenCalled();
+    }, 60_000);
+});
+
+// ── The runner's own contract ────────────────────────────────────────────────
+
+describe('ordering', () => {
+    test('applies by filename, not by directory order', async () => {
+        // Written out of order, and readdirSync is free to hand them back in
+        // this order — the sort in loadMigrations is the only thing that makes
+        // 002 a promise about what has already run.
+        const dir = migrationsDir({
+            '030_c.js': migrationSource({ name: 'c' }),
+            '002_a.js': migrationSource({ name: 'a' }),
+            '010_b.js': migrationSource({ name: 'b' }),
+        });
+
+        await runMigrations({ dir });
+
+        expect(globalThis.__migrationRuns).toEqual(['a', 'b', 'c']);
+        expect(await appliedInOrder()).toEqual(['a', 'b', 'c']);
+    });
+
+    test('a migration already recorded is not run again', async () => {
+        const dir = migrationsDir({
+            '001_a.js': migrationSource({ name: 'a' }),
+            '002_b.js': migrationSource({ name: 'b' }),
+        });
+        await MigrationRecord.create({ name: 'a' });
+
+        await runMigrations({ dir });
+
+        expect(globalThis.__migrationRuns).toEqual(['b']);
+    });
+
+    test('a file that does not export { name, up } is skipped, not recorded', async () => {
+        const dir = migrationsDir({
+            '001_a.js': migrationSource({ name: 'a' }),
+            '002_junk.js': "'use strict';\nmodule.exports = { name: 'junk' };\n",
+        });
+
+        await runMigrations({ dir });
+
+        expect(await appliedInOrder()).toEqual(['a']);
+        // And pendingMigrationNames has to agree, or every non-primary shard
+        // waits for a migration that will never be recorded.
+        expect(await pendingMigrationNames({ dir })).toEqual([]);
+    });
+
+    test('an empty directory is not an error', async () => {
+        await expect(runMigrations({ dir: migrationsDir({}) })).resolves.toBeUndefined();
+        expect(await appliedInOrder()).toEqual([]);
+    });
+});
+
+describe('failure recovery', () => {
+    test('a failed migration aborts the run, keeps what applied, and resumes next time', async () => {
+        const dir = migrationsDir({
+            '001_a.js': migrationSource({ name: 'a' }),
+            '002_b.js': migrationSource({ name: 'b', body: "if (globalThis.__migrationFails.has('b')) throw new Error('boom');" }),
+            '003_c.js': migrationSource({ name: 'c' }),
+        });
+        globalThis.__migrationFails.add('b');
+
+        await expect(runMigrations({ dir })).rejects.toThrow('boom');
+
+        // c never ran: booting on a half-applied schema is the thing the throw
+        // is protecting against, so nothing after the failure is attempted.
+        expect(globalThis.__migrationRuns).toEqual(['a', 'b']);
+        expect(await appliedInOrder()).toEqual(['a']);
+        expect(await pendingMigrationNames({ dir })).toEqual(['b', 'c']);
+
+        globalThis.__migrationFails.delete('b');
+        globalThis.__migrationRuns = [];
+
+        await runMigrations({ dir });
+
+        // a is not re-run — the record is what makes a resumed boot safe.
+        expect(globalThis.__migrationRuns).toEqual(['b', 'c']);
+        expect(await appliedInOrder()).toEqual(['a', 'b', 'c']);
+    });
+
+    test('an optional migration that fails is left unrecorded and retried on the next run', async () => {
+        const dir = migrationsDir({
+            '001_a.js': migrationSource({ name: 'a' }),
+            '002_b.js': migrationSource({
+                name: 'b', extra: '    optional: true,\n',
+                body: "if (globalThis.__migrationFails.has('b')) throw new Error('index build refused');",
+            }),
+            '003_c.js': migrationSource({ name: 'c' }),
+        });
+        globalThis.__migrationFails.add('b');
+
+        // A performance index is not worth refusing to boot over.
+        await expect(runMigrations({ dir })).resolves.toBeUndefined();
+
+        expect(globalThis.__migrationRuns).toEqual(['a', 'b', 'c']);
+        expect(await appliedInOrder()).toEqual(['a', 'c']);
+        // Not pending, though: another shard must not refuse to start over an
+        // index the bot is merely faster with.
+        expect(await pendingMigrationNames({ dir })).toEqual([]);
+
+        globalThis.__migrationRuns = [];
+        await runMigrations({ dir });
+
+        expect(globalThis.__migrationRuns).toEqual(['b']);
+        expect(await appliedInOrder()).toEqual(['a', 'c']);
+
+        globalThis.__migrationFails.delete('b');
+        globalThis.__migrationRuns = [];
+        await runMigrations({ dir });
+
+        expect(await appliedInOrder()).toEqual(['a', 'c', 'b']);
+    });
+
+    test('a migration that hangs past its budget fails rather than holding the boot open', async () => {
+        const dir = migrationsDir({
+            '001_a.js': migrationSource({ name: 'a' }),
+            '002_slow.js': migrationSource({ name: 'slow', body: 'await new Promise(() => {});' }),
+        });
+        process.env.MIGRATION_TIMEOUT_MS = '60';
+
+        try {
+            await expect(runMigrations({ dir })).rejects.toThrow(/Timed out after 60ms: slow/);
+        } finally {
+            delete process.env.MIGRATION_TIMEOUT_MS;
+        }
+
+        expect(await appliedInOrder()).toEqual(['a']);
+    });
+
+    test('the budget in force is handed to the migration, so it can bound its own queries', async () => {
+        const dir = migrationsDir({
+            '001_a.js': migrationSource({ name: 'a' }),
+            // Declares more than the operator asked for; the larger wins, or
+            // raising the env var would be powerless against the migration
+            // that is timing out.
+            '002_heavy.js': migrationSource({ name: 'heavy', extra: '    timeoutMs: 90_000,\n' }),
+        });
+        process.env.MIGRATION_TIMEOUT_MS = '45000';
+
+        try {
+            await runMigrations({ dir });
+        } finally {
+            delete process.env.MIGRATION_TIMEOUT_MS;
+        }
+
+        expect(globalThis.__migrationBudgets).toEqual({ a: 45_000, heavy: 90_000 });
+    });
+});
+
+describe('rollback, against a real server', () => {
+    const reversiblePair = () => migrationsDir({
+        '001_a.js': migrationSource({ name: 'a' }),
+        '002_b.js': migrationSource({ name: 'b' }),
+    });
+
+    test('unwinds the most recent migration and forgets it', async () => {
+        const dir = reversiblePair();
+        await runMigrations({ dir });
+        globalThis.__migrationRuns = [];
+
+        await rollbackMigration('b', { dir });
+
+        expect(globalThis.__migrationRuns).toEqual(['b:down']);
+        expect(await appliedInOrder()).toEqual(['a']);
+    });
+
+    test('the next run re-applies what was rolled back', async () => {
+        const dir = reversiblePair();
+        await runMigrations({ dir });
+        await rollbackMigration('b', { dir });
+        globalThis.__migrationRuns = [];
+
+        await runMigrations({ dir });
+
+        expect(globalThis.__migrationRuns).toEqual(['b']);
+        expect(await appliedInOrder()).toEqual(['a', 'b']);
+    });
+
+    // Later migrations may build on what an earlier one wrote, so the chain
+    // unwinds in reverse, one invocation at a time.
+    test('refuses anything but the most recent', async () => {
+        const dir = reversiblePair();
+        await runMigrations({ dir });
+
+        await expect(rollbackMigration('a', { dir })).rejects.toThrow(/roll back b first/);
+        expect(await appliedInOrder()).toEqual(['a', 'b']);
+    });
+
+    test('refuses a migration that was never applied', async () => {
+        const dir = reversiblePair();
+
+        await expect(rollbackMigration('a', { dir })).rejects.toThrow(/not recorded as applied/);
+    });
+
+    test('refuses a name no file declares', async () => {
+        await expect(rollbackMigration('nope', { dir: reversiblePair() })).rejects.toThrow(/No migration named/);
+    });
+
+    // The way back from one of these is the pre-migration backup, which is why
+    // declaring it is what makes the runner take one.
+    test('refuses an irreversible migration and leaves it applied', async () => {
+        const dir = migrationsDir({
+            '001_a.js': migrationSource({ name: 'a' }),
+            '002_gone.js': migrationSource({ name: 'gone', extra: '    irreversible: true,\n', down: false }),
+        });
+        await runMigrations({ dir });
+
+        await expect(rollbackMigration('gone', { dir })).rejects.toThrow(/irreversible/);
+        expect(await appliedInOrder()).toEqual(['a', 'gone']);
+    });
+});
+
+describe('waiting for another process to migrate', () => {
+    test('reports the shipped migrations as pending until they are applied', async () => {
+        // Optional ones are excluded by design: they are left unrecorded when
+        // they fail, so a shard waiting on one would wait forever.
+        const expected = shippedMigrations().filter(m => !m.optional).map(m => m.name);
+
+        expect(await pendingMigrationNames({ dir: MIGRATIONS_DIR })).toEqual(expected);
+
+        await runMigrations({ dir: MIGRATIONS_DIR });
+
+        expect(await pendingMigrationNames({ dir: MIGRATIONS_DIR })).toEqual([]);
+    }, 60_000);
+
+    test('returns as soon as everything is recorded', async () => {
+        const dir = migrationsDir({ '001_a.js': migrationSource({ name: 'a' }) });
+        await runMigrations({ dir });
+
+        await expect(waitForMigrations({ dir, timeoutMs: 5_000, pollMs: 10 })).resolves.toBe(true);
+    });
+
+    test('gives up rather than blocking a boot forever', async () => {
+        const dir = migrationsDir({ '001_a.js': migrationSource({ name: 'a' }) });
+
+        await expect(waitForMigrations({ dir, timeoutMs: 50, pollMs: 10 })).resolves.toBe(false);
+        expect(console.error.mock.calls.flat().join(' ')).toContain('Gave up');
+    });
+});

--- a/tests/integration/migrations.test.js
+++ b/tests/integration/migrations.test.js
@@ -134,12 +134,11 @@ describe('every shipped migration, against a real server', () => {
 
         await runMigrations({ dir: MIGRATIONS_DIR });
 
-        // Not a subset and not a set: the order recorded is the order applied,
-        // and later migrations undo what earlier ones built.
-        expect(await appliedInOrder()).toEqual(expected);
         // An optional migration that fails is deliberately left unrecorded, so
-        // a missing name here is a migration a real mongod refused.
-        expect(console.error).not.toHaveBeenCalled();
+        // this is not a subset and not a set: a missing name is a migration a
+        // real mongod refused, and the order recorded is the order applied —
+        // which matters because later migrations undo what earlier ones built.
+        expect(await appliedInOrder()).toEqual(expected);
     }, 60_000);
 
     test('running the sequence twice applies nothing the second time', async () => {
@@ -389,7 +388,9 @@ describe('the data migrations, over pre-migration documents', () => {
         await runMigrations({ dir: MIGRATIONS_DIR });
 
         expect(await snapshot()).toEqual(before);
-        expect(console.error).not.toHaveBeenCalled();
+        // And every one of them applied again, rather than an optional one
+        // being quietly deferred over its own output.
+        expect(await appliedInOrder()).toEqual(shippedMigrations().map(m => m.name));
     }, 60_000);
 });
 

--- a/tests/jobRunnerRetry.test.js
+++ b/tests/jobRunnerRetry.test.js
@@ -8,46 +8,76 @@
  * `npm run payouts:replay -- --pay` at once must not both reach it for the same
  * record: that is a second `$inc`, or a second inventory grant, which is the
  * exact failure the owed queue exists to avoid.
+ *
+ * The first attempt at this used a compare-and-set on `attempts`, which is not
+ * enough: it stops two runs that read the same pre-claim state, but a run that
+ * reads *after* the other's claim sees the incremented value and matches on it.
+ * Hence the lease, and hence the sequential test below — the one the CAS passed
+ * and should not have.
  */
 
 jest.mock('../src/models/FailedJob', () => ({ findById: jest.fn(), findOneAndUpdate: jest.fn() }));
 
 const FailedJob = require('../src/models/FailedJob');
-const { retryJob } = require('../src/utils/jobRunner');
+const { retryJob, claimableFilter, RETRY_LEASE_MS } = require('../src/utils/jobRunner');
 
 /**
- * A stand-in for one FailedJob document, with `findOneAndUpdate` behaving the
- * way the server does: the compare-and-set on `attempts` matches at most once.
+ * One FailedJob document, with `findOneAndUpdate` evaluating the claim filter
+ * the way the server does — including the `$or` over the lease, which is the
+ * whole point of the exercise.
  */
 function stubRecord(over = {}) {
     const doc = {
         _id: 'f1', payload: { kind: 'coins', userId: 'u1', guildId: 'g1', amount: 500 },
         attempts: 0, maxAttempts: 3, status: 'pending',
         errorMessage: 'mongo down', errorStack: null,
+        claimedAt: null, claimedBy: null,
         resolvedAt: null, resolvedBy: null, lastAttemptAt: new Date(0),
         save: jest.fn(async () => doc),
         ...over,
     };
 
     // A snapshot, the way the driver hands one back — not a live reference to
-    // the document the claim below mutates. Returning the live object would let
-    // a racing caller read the winner's post-claim `attempts` and match on it,
-    // which is a property of the stub and not of any real database.
+    // the document a claim mutates.
     FailedJob.findById.mockImplementation(async () => ({ ...doc }));
+
     FailedJob.findOneAndUpdate.mockImplementation(async (filter, update) => {
         if (filter._id !== doc._id) return null;
         if (!filter.status.$in.includes(doc.status)) return null;
-        // The CAS. A run whose read is stale no longer matches.
-        if (filter.attempts !== doc.attempts) return null;
+
+        const [free, expired] = filter.$or;
+        const leaseIsFree = doc.claimedAt === null || doc.claimedAt === undefined;
+        const leaseIsStale = doc.claimedAt != null && doc.claimedAt <= expired.claimedAt.$lte;
+        if (!(free.claimedAt === null && leaseIsFree) && !leaseIsStale) return null;
+
         doc.attempts += update.$inc.attempts;
-        doc.status = update.$set.status;
-        doc.lastAttemptAt = update.$set.lastAttemptAt;
+        Object.assign(doc, update.$set);
         return doc;
     });
     return doc;
 }
 
+/** Resolves once `release()` is called. */
+function gate() {
+    let release;
+    const promise = new Promise(resolve => { release = resolve; });
+    return { promise, release };
+}
+
 beforeEach(() => jest.clearAllMocks());
+
+describe('claimableFilter', () => {
+    test('matches a free lease and one older than the window, not a live one', () => {
+        const now = new Date('2026-08-27T00:10:00Z');
+        const filter = claimableFilter(now);
+
+        expect(filter.status).toEqual({ $in: ['pending', 'retrying'] });
+        // `{ claimedAt: null }` also matches a document that has no claimedAt at
+        // all, which is every record written before the field existed.
+        expect(filter.$or[0]).toEqual({ claimedAt: null });
+        expect(filter.$or[1].claimedAt.$lte).toEqual(new Date(now.getTime() - RETRY_LEASE_MS));
+    });
+});
 
 describe('retryJob', () => {
     test('runs the handler with the stored payload and resolves the record', async () => {
@@ -59,7 +89,6 @@ describe('retryJob', () => {
         expect(handler).toHaveBeenCalledWith(doc.payload);
         expect(after.status).toBe('resolved');
         expect(after.resolvedBy).toBe('an-operator');
-        expect(after.resolvedAt).toBeInstanceOf(Date);
         expect(after.attempts).toBe(1);
     });
 
@@ -73,54 +102,86 @@ describe('retryJob', () => {
 
         await retryJob('f1', async () => { order.push('handler'); });
 
-        // The other way round is the whole bug: the window between deciding a
-        // record is retriable and marking it is a window two runs fit through.
         expect(order).toEqual(['claim', 'handler']);
     });
 
-    // The race, played out. Both runs read the record while it is pending;
-    // only one may reach the handler.
-    test('a second run racing the same record never reaches the handler', async () => {
+    test('releases the lease whichever way the handler ends', async () => {
+        stubRecord();
+
+        const resolved = await retryJob('f1', async () => {});
+        expect(resolved.claimedAt).toBeNull();
+        expect(resolved.claimedBy).toBeNull();
+
+        stubRecord();
+        const failed = await retryJob('f1', async () => { throw new Error('still down'); });
+        // Back to pending with no lease, so the next run can take it straight
+        // away rather than waiting out a window nobody is holding.
+        expect(failed.status).toBe('pending');
+        expect(failed.claimedAt).toBeNull();
+    });
+
+    // Two runs that read the same pre-claim state.
+    test('two runs starting together: only one reaches the handler', async () => {
         stubRecord();
         const handler = jest.fn().mockResolvedValue(undefined);
 
-        const [first, second] = await Promise.allSettled([
-            retryJob('f1', handler),
-            retryJob('f1', handler),
-        ]);
+        const results = await Promise.allSettled([retryJob('f1', handler), retryJob('f1', handler)]);
 
         expect(handler).toHaveBeenCalledTimes(1);
-        const outcomes = [first.status, second.status].sort();
-        expect(outcomes).toEqual(['fulfilled', 'rejected']);
-        const loser = first.status === 'rejected' ? first : second;
-        expect(loser.reason.message).toMatch(/already being retried/);
+        expect(results.map(r => r.status).sort()).toEqual(['fulfilled', 'rejected']);
+        expect(results.find(r => r.status === 'rejected').reason.message)
+            .toMatch(/already being retried/);
     });
 
-    test('a record another run advanced between the read and the claim is refused', async () => {
-        const doc = stubRecord();
-        FailedJob.findById.mockImplementation(async () => {
-            // Hand back the state as it was before the other run claimed it.
-            const stale = { ...doc, attempts: doc.attempts };
-            doc.attempts += 1;
-            return stale;
-        });
-        const handler = jest.fn();
+    // The one a compare-and-set on `attempts` alone gets wrong: the second run
+    // reads *after* the first has claimed, so it sees the incremented value and
+    // matches on it. Only the lease refuses it.
+    test('a run arriving while another holds the record never reaches the handler', async () => {
+        stubRecord();
+        const held = gate();
+        const handler = jest.fn()
+            .mockImplementationOnce(() => held.promise)
+            .mockImplementation(async () => {});
+
+        const first = retryJob('f1', handler);
+        // Let the first run claim and enter its handler before the second reads.
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
 
         await expect(retryJob('f1', handler)).rejects.toThrow(/already being retried/);
-        expect(handler).not.toHaveBeenCalled();
+
+        held.release();
+        await first;
+        expect(handler).toHaveBeenCalledTimes(1);
     });
 
-    // A run that died mid-replay leaves the record `retrying`. Refusing those
-    // outright would close the race by stranding them forever instead.
-    test('a record stranded in retrying by a dead run can still be claimed', async () => {
-        stubRecord({ status: 'retrying', attempts: 1 });
+    // A run that died holding the record. Refusing these outright would close
+    // the race by stranding them forever instead.
+    test('a lease older than the window is reclaimable', async () => {
+        stubRecord({
+            status: 'retrying',
+            attempts: 1,
+            claimedAt: new Date(Date.now() - RETRY_LEASE_MS - 1000),
+            claimedBy: 'a-run-that-died',
+        });
         const handler = jest.fn().mockResolvedValue(undefined);
 
-        const after = await retryJob('f1', handler);
+        const after = await retryJob('f1', handler, 'the-next-operator');
 
         expect(handler).toHaveBeenCalled();
         expect(after.status).toBe('resolved');
         expect(after.attempts).toBe(2);
+    });
+
+    test('a record written before the lease field existed is claimable', async () => {
+        const doc = stubRecord();
+        delete doc.claimedAt;
+        const handler = jest.fn().mockResolvedValue(undefined);
+
+        await retryJob('f1', handler);
+
+        expect(handler).toHaveBeenCalled();
     });
 
     test('a handler that throws leaves the record pending for another attempt', async () => {
@@ -151,10 +212,10 @@ describe('retryJob', () => {
 
         await expect(retryJob('f1', handler)).rejects.toThrow(message);
         expect(handler).not.toHaveBeenCalled();
-        expect(FailedJob.findOneAndUpdate).not.toHaveBeenCalled();
     });
 
     test('refuses an id no record has', async () => {
+        FailedJob.findOneAndUpdate.mockResolvedValue(null);
         FailedJob.findById.mockResolvedValue(null);
 
         await expect(retryJob('nope', jest.fn())).rejects.toThrow('FailedJob not found');

--- a/tests/jobRunnerRetry.test.js
+++ b/tests/jobRunnerRetry.test.js
@@ -1,0 +1,162 @@
+'use strict';
+
+/**
+ * `retryJob` is what replays a dead-letter entry, and until #804 gave it the
+ * owed-payout script nothing called it — so nothing had ever executed it.
+ *
+ * The handler is what moves the money. Two operators running
+ * `npm run payouts:replay -- --pay` at once must not both reach it for the same
+ * record: that is a second `$inc`, or a second inventory grant, which is the
+ * exact failure the owed queue exists to avoid.
+ */
+
+jest.mock('../src/models/FailedJob', () => ({ findById: jest.fn(), findOneAndUpdate: jest.fn() }));
+
+const FailedJob = require('../src/models/FailedJob');
+const { retryJob } = require('../src/utils/jobRunner');
+
+/**
+ * A stand-in for one FailedJob document, with `findOneAndUpdate` behaving the
+ * way the server does: the compare-and-set on `attempts` matches at most once.
+ */
+function stubRecord(over = {}) {
+    const doc = {
+        _id: 'f1', payload: { kind: 'coins', userId: 'u1', guildId: 'g1', amount: 500 },
+        attempts: 0, maxAttempts: 3, status: 'pending',
+        errorMessage: 'mongo down', errorStack: null,
+        resolvedAt: null, resolvedBy: null, lastAttemptAt: new Date(0),
+        save: jest.fn(async () => doc),
+        ...over,
+    };
+
+    // A snapshot, the way the driver hands one back — not a live reference to
+    // the document the claim below mutates. Returning the live object would let
+    // a racing caller read the winner's post-claim `attempts` and match on it,
+    // which is a property of the stub and not of any real database.
+    FailedJob.findById.mockImplementation(async () => ({ ...doc }));
+    FailedJob.findOneAndUpdate.mockImplementation(async (filter, update) => {
+        if (filter._id !== doc._id) return null;
+        if (!filter.status.$in.includes(doc.status)) return null;
+        // The CAS. A run whose read is stale no longer matches.
+        if (filter.attempts !== doc.attempts) return null;
+        doc.attempts += update.$inc.attempts;
+        doc.status = update.$set.status;
+        doc.lastAttemptAt = update.$set.lastAttemptAt;
+        return doc;
+    });
+    return doc;
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('retryJob', () => {
+    test('runs the handler with the stored payload and resolves the record', async () => {
+        const doc = stubRecord();
+        const handler = jest.fn().mockResolvedValue(undefined);
+
+        const after = await retryJob('f1', handler, 'an-operator');
+
+        expect(handler).toHaveBeenCalledWith(doc.payload);
+        expect(after.status).toBe('resolved');
+        expect(after.resolvedBy).toBe('an-operator');
+        expect(after.resolvedAt).toBeInstanceOf(Date);
+        expect(after.attempts).toBe(1);
+    });
+
+    test('claims the record before the handler runs, not after', async () => {
+        stubRecord();
+        const order = [];
+        FailedJob.findOneAndUpdate.mockImplementation(async () => {
+            order.push('claim');
+            return { attempts: 1, maxAttempts: 3, payload: {}, save: jest.fn() };
+        });
+
+        await retryJob('f1', async () => { order.push('handler'); });
+
+        // The other way round is the whole bug: the window between deciding a
+        // record is retriable and marking it is a window two runs fit through.
+        expect(order).toEqual(['claim', 'handler']);
+    });
+
+    // The race, played out. Both runs read the record while it is pending;
+    // only one may reach the handler.
+    test('a second run racing the same record never reaches the handler', async () => {
+        stubRecord();
+        const handler = jest.fn().mockResolvedValue(undefined);
+
+        const [first, second] = await Promise.allSettled([
+            retryJob('f1', handler),
+            retryJob('f1', handler),
+        ]);
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        const outcomes = [first.status, second.status].sort();
+        expect(outcomes).toEqual(['fulfilled', 'rejected']);
+        const loser = first.status === 'rejected' ? first : second;
+        expect(loser.reason.message).toMatch(/already being retried/);
+    });
+
+    test('a record another run advanced between the read and the claim is refused', async () => {
+        const doc = stubRecord();
+        FailedJob.findById.mockImplementation(async () => {
+            // Hand back the state as it was before the other run claimed it.
+            const stale = { ...doc, attempts: doc.attempts };
+            doc.attempts += 1;
+            return stale;
+        });
+        const handler = jest.fn();
+
+        await expect(retryJob('f1', handler)).rejects.toThrow(/already being retried/);
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    // A run that died mid-replay leaves the record `retrying`. Refusing those
+    // outright would close the race by stranding them forever instead.
+    test('a record stranded in retrying by a dead run can still be claimed', async () => {
+        stubRecord({ status: 'retrying', attempts: 1 });
+        const handler = jest.fn().mockResolvedValue(undefined);
+
+        const after = await retryJob('f1', handler);
+
+        expect(handler).toHaveBeenCalled();
+        expect(after.status).toBe('resolved');
+        expect(after.attempts).toBe(2);
+    });
+
+    test('a handler that throws leaves the record pending for another attempt', async () => {
+        stubRecord();
+
+        const after = await retryJob('f1', async () => { throw new Error('still down'); });
+
+        expect(after.status).toBe('pending');
+        expect(after.errorMessage).toBe('still down');
+        expect(after.attempts).toBe(1);
+    });
+
+    test('the last permitted attempt exhausts the record rather than looping', async () => {
+        stubRecord({ attempts: 2, maxAttempts: 3 });
+
+        const after = await retryJob('f1', async () => { throw new Error('still down'); });
+
+        expect(after.attempts).toBe(3);
+        expect(after.status).toBe('exhausted');
+    });
+
+    test.each([
+        ['resolved',  'Job already resolved'],
+        ['exhausted', 'Job exhausted'],
+    ])('refuses a %s record without touching the handler', async (status, message) => {
+        stubRecord({ status });
+        const handler = jest.fn();
+
+        await expect(retryJob('f1', handler)).rejects.toThrow(message);
+        expect(handler).not.toHaveBeenCalled();
+        expect(FailedJob.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    test('refuses an id no record has', async () => {
+        FailedJob.findById.mockResolvedValue(null);
+
+        await expect(retryJob('nope', jest.fn())).rejects.toThrow('FailedJob not found');
+    });
+});

--- a/tests/marketListingReturn.test.js
+++ b/tests/marketListingReturn.test.js
@@ -16,9 +16,11 @@ jest.mock('../src/models/Guild', () => ({ find: jest.fn(), findOne: jest.fn(), f
 jest.mock('../src/models/User',  () => ({ find: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), aggregate: jest.fn(), updateOne: jest.fn(), updateMany: jest.fn(), bulkWrite: jest.fn() }));
 jest.mock('../src/models/MarketListing', () => ({ find: jest.fn(), findOneAndDelete: jest.fn() }));
 jest.mock('../src/utils/inventoryGrant', () => ({ grantInventoryItem: jest.fn() }));
+jest.mock('../src/utils/owedPayout', () => ({ recordOwedPayout: jest.fn() }));
 
 const MarketListing = require('../src/models/MarketListing');
 const { grantInventoryItem } = require('../src/utils/inventoryGrant');
+const { recordOwedPayout } = require('../src/utils/owedPayout');
 const { returnExpiredMarketListings } = require('../src/services/schedulerService');
 
 function listing(over = {}) {
@@ -42,6 +44,7 @@ beforeEach(() => {
     jest.clearAllMocks();
     MarketListing.findOneAndDelete.mockImplementation(async filter => ({ _id: filter._id }));
     grantInventoryItem.mockResolvedValue({});
+    recordOwedPayout.mockResolvedValue(true);
     errorLog = jest.spyOn(console, 'error').mockImplementation(() => {});
     infoLog  = jest.spyOn(console, 'log').mockImplementation(() => {});
 });
@@ -92,18 +95,44 @@ describe('returnExpiredMarketListings', () => {
         expect(grantInventoryItem).not.toHaveBeenCalled();
     });
 
-    test('a credit that fails after the claim is logged loudly, not retried', async () => {
+    // #804. The claim is spent — the listing is deleted — so the next tick will
+    // never find this return again. A log is not a record; the owed queue is.
+    test('a credit that fails after the claim is written down as owed', async () => {
         stubFind([listing()]);
         grantInventoryItem.mockRejectedValue(new Error('mongo down'));
 
-        await expect(returnExpiredMarketListings()).resolves.toBeUndefined();
+        await expect(returnExpiredMarketListings()).rejects.toThrow(/1 of 1/);
 
-        // The listing is gone, so nothing will find this again — the log is the
-        // only record that the items are owed, and it has to say so.
+        expect(recordOwedPayout).toHaveBeenCalledWith(expect.objectContaining({
+            service: 'schedulerService',
+            jobName: 'returnExpiredMarketListings',
+            guildId: 'g1',
+            payload: {
+                kind: 'items', userId: 'u1', guildId: 'g1',
+                itemId: 'sword', quantity: 2, listingId: 'l1',
+            },
+        }));
+
         const message = errorLog.mock.calls[0].join(' ');
         expect(message).toContain('2x sword');
         expect(message).toContain('u1');
-        expect(message).toContain('by hand');
+        expect(message).toContain('recorded for replay');
+    });
+
+    // The queue write fails for the same reason the credit did, often enough.
+    // It must not take the rest of the sweep with it, and the job must still
+    // fail so the run itself is on /health.
+    test('a failed owed-queue write does not stop the sweep or hide the failure', async () => {
+        stubFind([listing({ _id: 'bad' }), listing({ _id: 'good', sellerId: 'u2' })]);
+        grantInventoryItem.mockImplementation(async sellerId => {
+            if (sellerId === 'u1') throw new Error('mongo down');
+            return {};
+        });
+        recordOwedPayout.mockResolvedValue(false);
+
+        await expect(returnExpiredMarketListings()).rejects.toThrow(/1 of 2/);
+
+        expect(grantInventoryItem).toHaveBeenCalledTimes(2);
     });
 
     test('one listing that fails does not strand the rest of the batch', async () => {
@@ -113,23 +142,26 @@ describe('returnExpiredMarketListings', () => {
             return {};
         });
 
-        await returnExpiredMarketListings();
+        // The throw comes last, after every listing has had its turn.
+        await expect(returnExpiredMarketListings()).rejects.toThrow('1 of 2 expired listing(s) could not be returned (1 were)');
 
         expect(grantInventoryItem).toHaveBeenCalledTimes(2);
         expect(infoLog.mock.calls.flat().join(' ')).toContain('1 expired listing(s)');
     });
 
-    test('a claim that throws is caught, so the batch continues', async () => {
+    test('a claim that throws is counted, but the batch continues', async () => {
         stubFind([listing({ _id: 'bad' }), listing({ _id: 'good' })]);
         MarketListing.findOneAndDelete.mockImplementation(async filter => {
             if (filter._id === 'bad') throw new Error('mongo down');
             return { _id: filter._id };
         });
 
-        await expect(returnExpiredMarketListings()).resolves.toBeUndefined();
+        await expect(returnExpiredMarketListings()).rejects.toThrow(/1 of 2/);
 
         expect(grantInventoryItem).toHaveBeenCalledTimes(1);
-        expect(errorLog).toHaveBeenCalled();
+        // Nothing was claimed for the failing listing, so the next tick finds
+        // it again — there is nothing owed to write down.
+        expect(recordOwedPayout).not.toHaveBeenCalled();
     });
 
     test('an empty sweep says nothing', async () => {

--- a/tests/marketListingReturn.test.js
+++ b/tests/marketListingReturn.test.js
@@ -130,7 +130,10 @@ describe('returnExpiredMarketListings', () => {
         });
         recordOwedPayout.mockResolvedValue(false);
 
-        await expect(returnExpiredMarketListings()).rejects.toThrow(/1 of 2/);
+        await expect(returnExpiredMarketListings()).rejects.toThrow(
+            '1 of 2 expired listing(s) could not be returned (1 were) — none could be ' +
+            'recorded as owed; they must be paid by hand, see the log above',
+        );
 
         expect(grantInventoryItem).toHaveBeenCalledTimes(2);
     });

--- a/tests/migrationIndexes.test.js
+++ b/tests/migrationIndexes.test.js
@@ -1,5 +1,19 @@
 'use strict';
 
+/**
+ * A drift check over the migration sources, not a substitute for running them.
+ *
+ * `indexNamesIn` below is a regex over the file text, which #629 rightly called
+ * out as a "migration test" that executes no migration. It stays because the
+ * question it answers is a textual one — do 009's drop list and 002/003's
+ * create lists still name the same indexes — and a mismatch there is a silent
+ * no-op rather than a failure any execution would surface.
+ *
+ * What it is no longer standing in for lives in tests/integration/migrations.test.js:
+ * every shipped migration applied in order against a real mongod, over real
+ * documents, twice.
+ */
+
 const fs   = require('fs');
 const path = require('path');
 

--- a/tests/owedPayout.test.js
+++ b/tests/owedPayout.test.js
@@ -1,0 +1,160 @@
+'use strict';
+
+/**
+ * #804. Two scheduled jobs claim a record before paying out, and the claim is
+ * one-way: once it is spent, re-running the job finds nothing. So a credit that
+ * fails afterwards has to be written down per entry, with enough in the payload
+ * to pay it later — that is what this module is, and what `retryJob` replays.
+ */
+
+jest.mock('../src/models/FailedJob', () => ({ create: jest.fn() }));
+jest.mock('../src/models/User', () => ({ findOneAndUpdate: jest.fn() }));
+jest.mock('../src/utils/inventoryGrant', () => ({ grantInventoryItem: jest.fn() }));
+
+const FailedJob = require('../src/models/FailedJob');
+const User = require('../src/models/User');
+const { grantInventoryItem } = require('../src/utils/inventoryGrant');
+const {
+    recordOwedPayout, replayOwedPayout, describeOwedPayout, isOwedPayout, OWED_SUFFIX,
+} = require('../src/utils/owedPayout');
+
+let errorLog;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    FailedJob.create.mockResolvedValue({});
+    User.findOneAndUpdate.mockResolvedValue({});
+    grantInventoryItem.mockResolvedValue({});
+    errorLog = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => errorLog.mockRestore());
+
+describe('recordOwedPayout', () => {
+    test('files a dead-letter entry carrying everything the credit needs', async () => {
+        const error = new Error('mongo down');
+
+        await expect(recordOwedPayout({
+            service: 'schedulerService',
+            jobName: 'announceHourlyWinners',
+            guildId: 'g1',
+            payload: { kind: 'coins', userId: 'u1', guildId: 'g1', amount: 500 },
+            error,
+        })).resolves.toBe(true);
+
+        expect(FailedJob.create).toHaveBeenCalledWith(expect.objectContaining({
+            service: 'schedulerService',
+            guildId: 'g1',
+            payload: { kind: 'coins', userId: 'u1', guildId: 'g1', amount: 500 },
+            errorMessage: 'mongo down',
+            errorStack: error.stack,
+        }));
+    });
+
+    // runJob files its own entry under the bare job name when the sweep throws.
+    // That one says "this run failed"; this one says "this player is owed 500
+    // coins", and the replay script has to be able to tell them apart.
+    test('suffixes the job name so the run-level entry is distinguishable', async () => {
+        await recordOwedPayout({
+            service: 'schedulerService', jobName: 'returnExpiredMarketListings',
+            payload: { kind: 'items' }, error: new Error('x'),
+        });
+
+        const [{ jobName }] = FailedJob.create.mock.calls[0];
+        expect(jobName).toBe(`returnExpiredMarketListings${OWED_SUFFIX}`);
+        expect(isOwedPayout({ jobName })).toBe(true);
+        expect(isOwedPayout({ jobName: 'returnExpiredMarketListings' })).toBe(false);
+    });
+
+    // The database being unreachable is the usual reason a payout failed, and
+    // the same reason writing it down can fail. The caller has already lost the
+    // credit; it must not also lose the rest of its sweep to the bookkeeping.
+    test('a queue write that itself fails is reported, not thrown', async () => {
+        FailedJob.create.mockRejectedValue(new Error('also down'));
+
+        await expect(recordOwedPayout({
+            service: 'schedulerService', jobName: 'announceHourlyWinners',
+            payload: { kind: 'coins', userId: 'u1', guildId: 'g1', amount: 500 },
+            error: new Error('mongo down'),
+        })).resolves.toBe(false);
+
+        expect(errorLog.mock.calls.flat().join(' ')).toContain('also down');
+    });
+
+    test('an error with no message still files a usable entry', async () => {
+        await recordOwedPayout({ service: 's', jobName: 'j', payload: {}, error: null });
+
+        expect(FailedJob.create).toHaveBeenCalledWith(expect.objectContaining({
+            errorMessage: 'unknown error', errorStack: null, guildId: null,
+        }));
+    });
+});
+
+describe('replayOwedPayout', () => {
+    test('credits the coins a winner was owed', async () => {
+        await replayOwedPayout({ kind: 'coins', userId: 'u1', guildId: 'g1', amount: 500 });
+
+        expect(User.findOneAndUpdate).toHaveBeenCalledWith(
+            { userId: 'u1', guildId: 'g1' },
+            { $inc: { balance: 500 } },
+        );
+    });
+
+    // retryJob reads a return as "paid". `findOneAndUpdate` without `upsert`
+    // resolves to null rather than throwing when nothing matches — which is the
+    // exact silence this whole mechanism exists to end, so it has to throw here.
+    test('a credit that matches no user document throws rather than reporting success', async () => {
+        User.findOneAndUpdate.mockResolvedValue(null);
+
+        await expect(replayOwedPayout({ kind: 'coins', userId: 'u1', guildId: 'g1', amount: 500 }))
+            .rejects.toThrow('no user document for u1 in g1');
+    });
+
+    test('returns the items a seller was owed', async () => {
+        await replayOwedPayout({ kind: 'items', userId: 'u1', guildId: 'g1', itemId: 'sword', quantity: 2 });
+
+        expect(grantInventoryItem).toHaveBeenCalledWith('u1', 'g1', 'sword', 2, { upsert: true });
+    });
+
+    test('an item grant that fails leaves the record owed', async () => {
+        grantInventoryItem.mockRejectedValue(new Error('still down'));
+
+        await expect(replayOwedPayout({ kind: 'items', userId: 'u1', guildId: 'g1', itemId: 'sword', quantity: 2 }))
+            .rejects.toThrow('still down');
+    });
+
+    // A payload written by an older build, or hand-edited in the queue. Paying
+    // out from an incomplete one would credit the wrong amount to nobody.
+    test.each([
+        ['coins with no user',    { kind: 'coins', guildId: 'g1', amount: 500 }],
+        ['coins with no amount',  { kind: 'coins', userId: 'u1', guildId: 'g1' }],
+        ['coins with a zero amount', { kind: 'coins', userId: 'u1', guildId: 'g1', amount: 0 }],
+        ['items with no itemId',  { kind: 'items', userId: 'u1', guildId: 'g1', quantity: 2 }],
+        ['items with no quantity', { kind: 'items', userId: 'u1', guildId: 'g1', itemId: 'sword' }],
+    ])('refuses to pay from an incomplete payload: %s', async (_label, payload) => {
+        await expect(replayOwedPayout(payload)).rejects.toThrow('incomplete');
+        expect(User.findOneAndUpdate).not.toHaveBeenCalled();
+        expect(grantInventoryItem).not.toHaveBeenCalled();
+    });
+
+    test.each([
+        ['an unknown kind', { kind: 'gems', userId: 'u1' }],
+        ['no kind at all',  { userId: 'u1' }],
+        ['nothing',         undefined],
+    ])('refuses %s', async (_label, payload) => {
+        await expect(replayOwedPayout(payload)).rejects.toThrow('unknown owed payout kind');
+    });
+});
+
+describe('describeOwedPayout', () => {
+    test('names who is owed what', () => {
+        expect(describeOwedPayout({ kind: 'coins', userId: 'u1', guildId: 'g1', amount: 500 }))
+            .toBe('500 coins to u1 in g1');
+        expect(describeOwedPayout({ kind: 'items', userId: 'u1', guildId: 'g1', itemId: 'sword', quantity: 2 }))
+            .toBe('2x sword to u1 in g1');
+    });
+
+    test('falls back to the raw payload rather than saying nothing', () => {
+        expect(describeOwedPayout({ kind: 'gems', n: 1 })).toBe('{"kind":"gems","n":1}');
+    });
+});


### PR DESCRIPTION
Closes #804. Closes #629. Re-measures #625 (no code — see below).

## #804 — a failed payout in two scheduled jobs is unrecoverable

`announceHourlyWinners` and `returnExpiredMarketListings` both claim a record before paying out — the winner is flipped to `rewarded: true`, the listing is deleted — and then swallowed the payout failure. The claim is what makes them safe to run twice; it is also one-way, so once it is spent nothing will ever find that record again. A sweep in which every payout failed returned normally and `/health` showed green.

Two halves, because either alone is not enough:

**Visible.** Per-entry failures are counted and the sweep throws at the end, the way `tempBanService.processExpiredBans` already does, so `runJob` files a dead-letter entry and marks the run failed. The throw comes last, so entries that did succeed are still announced. A `null` return from the hourly credit counts as a failure too: `findOneAndUpdate` without `upsert` resolves to `null` when the user has no document in that guild, so the old `.catch` never fired and a winner whose record had been pruned was silently not paid — while the announcement went on naming them as "rewarded **+500 coins**". They are now left out of the announcement as well.

**Recoverable.** A dead-letter entry naming the *run* is not enough, because re-running the run is a no-op. So each undelivered payout is written down separately, with everything the credit needs to be attempted again. `src/utils/owedPayout.js` files it as a `FailedJob` whose payload names who is owed what — the shape `retryJob` already replays via `handler(payload)`. The precedent is `src/utils/balanceDelta.js`, which does the same for a credit that fails mid-command.

That answers the open question in the issue — where the owed-payout record lives, and who may trigger the replay. It lives in the existing dead-letter queue, under a `.owed` job-name suffix so it is distinguishable from the run-level entry; and `scripts/replay-owed-payouts.js` is the operator end of it:

```
npm run payouts:replay            # list what is owed, pay nothing
npm run payouts:replay -- --pay   # attempt every pending owed payout
```

Deliberately a command rather than an automatic retry: these records exist because a write did not land, and the failure that stopped it is usually still true a minute later, so a loop would spend its attempts before anyone could look. Shell access to the host is the same bar as `npm run migrate:rollback`.

The two tests that pinned the swallow-and-log behaviour (named in the issue) are updated to the new expectations, plus `tests/owedPayout.test.js` for the helper.

### What the review round changed

`retryJob` had no caller and no test before this branch, so giving it one exposed a race it had always carried: it read a record, checked it was retriable, and only then saved `retrying`. Two operators running `--pay` at once both passed that check and both reached the handler — a second `$inc`, or a second inventory grant.

The first fix, a compare-and-set on `attempts`, was **wrong** and review was right to reject it: it stops two runs that read the same pre-claim state, but a run that reads *after* the other's claim sees the incremented value and matches on it. `attempts` says how many attempts have been made, not whether one is happening now. Reproduced by blocking the first run inside its handler and starting a second — the handler ran twice.

So `claimedAt`/`claimedBy` on `FailedJob`, and the claim is one conditional write: retriable status, and either no lease or one older than `RETRY_LEASE_MS`. A live claim is refused; a claim abandoned by a dead process is reclaimable once its window passes. The lease is released whichever way the handler ends. No migration — `{ claimedAt: null }` matches records written before the field existed. `claimableFilter` is exported so the replay script's listing and the claim itself cannot drift apart. `tests/jobRunnerRetry.test.js` executes `retryJob` for the first time, 13 tests, the decisive one being the sequential interleaving the CAS passed and should not have.

Also from review: both sweeps logged "recorded as owed" *before* `recordOwedPayout` returned, so the line could contradict the summary thrown at the end of the same run — and when the queue write fails that line is the only trace of the payout. Both now log after the write and say which of the two happened.

**Not addressed, deliberately:** making replay idempotent against a credit that commits but whose response is lost. That needs a durable payout key written with the credit itself, which a standalone mongod cannot do atomically (transactions were removed in PR #520), and it applies equally to the existing `balanceDelta` path — so it is a shared design change rather than a fix to this one. Discussed on the thread with a proposed shape; left for a follow-up decision.

## #629 — migrations are never executed by any test

The suite proved migrations two ways and neither ran one. `tests/migrationIndexes.test.js` greps the sources with a regex; `tests/migrationRunner.test.js` drives the runner against a mocked `MigrationRecord`. Between them they check that the files say what they should and that the runner branches where it should — neither of which is what goes wrong with a migration. What goes wrong is a server decision: a `partialFilterExpression` MongoDB refuses, an index it will not build, a `$merge` that needs a unique key which is not there yet, a pipeline `updateMany` the deployed server is too old for. A mock says yes to all of them. Only 001 and 015 had ever been executed, by `tests/integration/guildIndexMigration.test.js`.

`tests/integration/migrations.test.js` runs all sixteen, in order, against `mongodb-memory-server`:

- the whole sequence applies cleanly and records what it applied, and a second run applies nothing — same records, same `_id`s, same `appliedAt`
- the drops land after the builds they undo (002/003 then 009, 001 then 015), which is only true if the order held
- 012 and 014 leave index constraints the server actually enforces, shown by the duplicate inserts they now reject
- the data migrations (005, 006, 008, 010, 011, 013, 014, 016) run over documents seeded through the driver in the pre-migration shapes the current schemas no longer describe, and re-applying the whole sequence over its own output changes nothing

Then the runner's own contract, with fixture migrations written to a temporary directory, because these cases cannot be provoked with the shipped ones: apply order is filename order; a failed mandatory migration aborts the run, keeps what applied and resumes from there; a failed optional one is left unrecorded, does not block the boot, and is retried; a migration that hangs is cut off at its budget, and the budget in force is the one handed to it; rollback unwinds only the most recent, refuses an unapplied or irreversible one, and lets the next run re-apply.

`tests/migrationIndexes.test.js` keeps its regex — the drift question it answers is a textual one — with a header saying what it is no longer standing in for.

## #625 — overall test coverage

No code. Its one recommendation, the `coverageThreshold` ratchet, already landed via #635 and CI applies it. Re-measured and [commented on the issue](https://github.com/TheShield2594/clawdia/issues/625#issuecomment-5428520773) with current numbers and per-hole status, recommending it be closed in favour of the sub-issues that now cover the same ground. The floors stay at 36/25/38/37 — still the whole percent below each measurement, which is the policy `jest.config.js` documents.

## Verification

Locally, with `tests/integration/` excluded: **205 suites / 3,630 tests** and `npm run lint` pass. The exclusion is environmental — `mongodb-memory-server` gets a 403 fetching `fastdl.mongodb.org` through this sandbox's egress proxy — so the integration half could not be run here.

CI ran it. On `9d78657` the run is green at **208 suites / 3,723 tests**: exactly three suites and 93 tests more than the local figure, which is the three files under `tests/integration/` — the new one's 32 tests plus the 61 in the two that already existed. So every migration really was executed against a real mongod, rather than the file being skipped.

Coverage on that run: **37.50 / 26.51 / 39.59 / 38.64**, against floors of 36/25/38/37.