### PR TITLE
Validate config before the database, drive the moderation commands, floor each subsystem's coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,17 @@ jobs:
       - name: Run tests
         run: npm test -- --ci --coverage
 
+      # The global ratchet is one number over the whole of src, so it cannot
+      # see *where* the coverage is: src/services/ai is at 80% and
+      # src/commands/economy at 20%, and deleting every AI test would cost
+      # about four points of a 37% total and stay green. This applies a floor
+      # per directory, and fails on a file that stops being executed at all
+      # (#625). `always()` so it still runs when the global threshold failed —
+      # the two answers together say what actually moved.
+      - name: Check per-subsystem coverage floors
+        if: always()
+        run: npm run coverage:check
+
       # The four numbers, on the run's summary page rather than buried in the
       # log. `always()` because the interesting case is the run where the
       # ratchet just failed and you want to see by how much.

--- a/coverage-floors.json
+++ b/coverage-floors.json
@@ -199,8 +199,10 @@
         "src/events/webhooksUpdate.js",
         "src/index.js",
         "src/models/AuditLog.js",
-        "src/models/MigrationRecord.js",
         "src/services/summaryService.js",
         "src/shard.js"
+    ],
+    "coveredOnlyByIntegration": [
+        "src/models/MigrationRecord.js"
     ]
 }

--- a/coverage-floors.json
+++ b/coverage-floors.json
@@ -1,0 +1,206 @@
+{
+    "directories": {
+        "src": {
+            "statements": 10,
+            "branches": 42,
+            "functions": 13,
+            "lines": 10
+        },
+        "src/bot": {
+            "statements": 86,
+            "branches": 84,
+            "functions": 82,
+            "lines": 89
+        },
+        "src/commands/admin": {
+            "statements": 18,
+            "branches": 0,
+            "functions": 77,
+            "lines": 21
+        },
+        "src/commands/ai": {
+            "statements": 44,
+            "branches": 26,
+            "functions": 75,
+            "lines": 45
+        },
+        "src/commands/community": {
+            "statements": 9,
+            "branches": 0,
+            "functions": 13,
+            "lines": 10
+        },
+        "src/commands/economy": {
+            "statements": 15,
+            "branches": 2,
+            "functions": 21,
+            "lines": 15
+        },
+        "src/commands/economy/fish": {
+            "statements": 11,
+            "branches": 0,
+            "functions": 24,
+            "lines": 11
+        },
+        "src/commands/economy/hunt": {
+            "statements": 32,
+            "branches": 15,
+            "functions": 42,
+            "lines": 32
+        },
+        "src/commands/economy/mine": {
+            "statements": 16,
+            "branches": 0,
+            "functions": 25,
+            "lines": 17
+        },
+        "src/commands/fun": {
+            "statements": 29,
+            "branches": 16,
+            "functions": 37,
+            "lines": 28
+        },
+        "src/commands/leveling": {
+            "statements": 20,
+            "branches": 7,
+            "functions": 20,
+            "lines": 21
+        },
+        "src/commands/moderation": {
+            "statements": 71,
+            "branches": 62,
+            "functions": 74,
+            "lines": 73
+        },
+        "src/commands/utility": {
+            "statements": 20,
+            "branches": 0,
+            "functions": 49,
+            "lines": 21
+        },
+        "src/config": {
+            "statements": 94,
+            "branches": 89,
+            "functions": 94,
+            "lines": 94
+        },
+        "src/dashboard": {
+            "statements": 70,
+            "branches": 33,
+            "functions": 32,
+            "lines": 72
+        },
+        "src/dashboard/lib": {
+            "statements": 84,
+            "branches": 71,
+            "functions": 85,
+            "lines": 86
+        },
+        "src/dashboard/public": {
+            "statements": 0,
+            "branches": 0,
+            "functions": 0,
+            "lines": 0
+        },
+        "src/dashboard/routes": {
+            "statements": 77,
+            "branches": 53,
+            "functions": 63,
+            "lines": 79
+        },
+        "src/dashboard/routes/api": {
+            "statements": 35,
+            "branches": 26,
+            "functions": 31,
+            "lines": 38
+        },
+        "src/data": {
+            "statements": 57,
+            "branches": 23,
+            "functions": 32,
+            "lines": 58
+        },
+        "src/events": {
+            "statements": 49,
+            "branches": 41,
+            "functions": 35,
+            "lines": 51
+        },
+        "src/games/casino": {
+            "statements": 22,
+            "branches": 14,
+            "functions": 21,
+            "lines": 23
+        },
+        "src/migrations": {
+            "statements": 42,
+            "branches": 35,
+            "functions": 38,
+            "lines": 45
+        },
+        "src/models": {
+            "statements": 67,
+            "branches": 0,
+            "functions": 38,
+            "lines": 72
+        },
+        "src/services": {
+            "statements": 53,
+            "branches": 45,
+            "functions": 47,
+            "lines": 56
+        },
+        "src/services/ai": {
+            "statements": 45,
+            "branches": 41,
+            "functions": 37,
+            "lines": 48
+        },
+        "src/services/ai/mcp": {
+            "statements": 91,
+            "branches": 84,
+            "functions": 89,
+            "lines": 93
+        },
+        "src/services/ai/providers": {
+            "statements": 92,
+            "branches": 80,
+            "functions": 89,
+            "lines": 93
+        },
+        "src/services/scheduler": {
+            "statements": 13,
+            "branches": 0,
+            "functions": 0,
+            "lines": 14
+        },
+        "src/utils": {
+            "statements": 56,
+            "branches": 57,
+            "functions": 63,
+            "lines": 57
+        },
+        "src/views": {
+            "statements": 58,
+            "branches": 49,
+            "functions": 40,
+            "lines": 61
+        }
+    },
+    "neverExecuted": [
+        "src/dashboard/public/guild-settings.js",
+        "src/deploy-commands.js",
+        "src/events/guildBanAdd.js",
+        "src/events/guildCreate.js",
+        "src/events/ready.js",
+        "src/events/roleCreate.js",
+        "src/events/roleDelete.js",
+        "src/events/voiceStateUpdate.js",
+        "src/events/webhooksUpdate.js",
+        "src/index.js",
+        "src/models/AuditLog.js",
+        "src/models/MigrationRecord.js",
+        "src/services/summaryService.js",
+        "src/shard.js"
+    ]
+}

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -805,9 +805,19 @@ already tested. Raise the floors when coverage rises; nothing may lower them.
 coverage is: `src/services/ai/mcp` is at 94% and `src/commands/economy` at 18%,
 so deleting every MCP test would cost about four points of a 37% total and the
 global ratchet would stay green. A floor per directory is what notices. The same
-file records the fourteen files with no executed line at all — that list may
-shrink and must not grow, and an entry that has since been covered is an error
-too, since a stale one is standing permission to un-cover the file.
+file records the files with no executed line at all — that list may shrink and
+must not grow, and an entry that has since been covered is an error too, since a
+stale one is standing permission to un-cover the file.
+
+`coveredOnlyByIntegration` is the second list in that file, and it is there
+because the check runs against whichever suites the run included. `tests/integration/`
+needs a real mongod, so a contributor whose machine cannot fetch one runs
+without it while CI runs with it — and a file only those suites reach reads as
+zero-coverage in the first run and covered in the second. Listing it separately
+is what makes both runs agree. `src/models/MigrationRecord.js` is the current
+example. For the same reason the directory floors are recorded from the
+integration-excluded run, matching what `jest.config.js` does, so the number CI
+sees is that or better: `src/migrations` measures 45.8% locally and 81.8% in CI.
 
 Both are ratchets, not targets. When coverage genuinely rises:
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -695,8 +695,8 @@ after the last assertion has already passed.
 ### How the suite is laid out
 
 - One file per subject, named after it: `tests/huntRepair.test.js`,
-  `tests/rollPayout.test.js`. There is no `jest.config.js` — the defaults apply,
-  so anything matching `*.test.js` is collected.
+  `tests/rollPayout.test.js`. `jest.config.js` sets only coverage options, so
+  the defaults still apply to collection: anything matching `*.test.js` runs.
 - Shared fixtures live in `tests/helpers/`. They are not test files and are not
   collected; require them from a test the way you would any module.
 - `tests/integration/` holds the suites that run against a real MongoDB rather
@@ -789,6 +789,36 @@ Two things to know before writing one:
 caches it per machine. If that host is unreachable the suite fails rather than
 skipping — a green run has to mean the tests ran — and the failure names the two
 ways out, `MONGOMS_SYSTEM_BINARY` and `MONGOMS_DOWNLOAD_URL`.
+
+### Coverage, and the two ratchets on it
+
+`npm run test:coverage` measures; CI runs the same thing with `--ci`. Two
+separate guards then apply, and they answer different questions.
+
+**The global floor** lives in `jest.config.js` as `coverageThreshold.global`. It
+is measured over all of `src/` — not Jest's default, which counts a file only
+once some test requires it and so reports a percentage of the code that is
+already tested. Raise the floors when coverage rises; nothing may lower them.
+
+**The per-subsystem floors** live in `coverage-floors.json` and are applied by
+`npm run coverage:check`. One number over the whole tree cannot say *where* the
+coverage is: `src/services/ai/mcp` is at 94% and `src/commands/economy` at 18%,
+so deleting every MCP test would cost about four points of a 37% total and the
+global ratchet would stay green. A floor per directory is what notices. The same
+file records the fourteen files with no executed line at all — that list may
+shrink and must not grow, and an entry that has since been covered is an error
+too, since a stale one is standing permission to un-cover the file.
+
+Both are ratchets, not targets. When coverage genuinely rises:
+
+```bash
+npm run test:coverage
+npm run coverage:check -- --update   # never lowers a floor
+```
+
+`--update` will not write a number below one already recorded, so it cannot be
+used to make a failure go away — a directory that dropped has to be fixed or
+explained.
 
 ### Logging
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write",
     "test": "jest --forceExit",
-    "test:coverage": "jest --forceExit --coverage"
+    "test:coverage": "jest --forceExit --coverage",
+    "coverage:check": "node scripts/check-coverage.js"
   },
   "keywords": [
     "discord",

--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Per-subsystem coverage floors, and a list of the files no test has ever
+ * loaded (#625).
+ *
+ * jest.config.js already holds a global ratchet, and that was #625's own
+ * recommendation — it is what stops the total sliding. What it cannot express
+ * is where the coverage is. `src/services/ai` is at 80% and
+ * `src/commands/economy` at 20%; the global number is a weighted average of the
+ * two, so deleting every AI test would cost about four points of a 37% total
+ * and the run would stay green. A whole subsystem can go to zero without the
+ * one number that guards it moving far enough to notice.
+ *
+ * So this checks two more things, from the same coverage-summary.json the CI
+ * step already reads:
+ *
+ *   1. A floor per directory. Each one sits a few points under what the suite
+ *      measured when it was recorded, which is enough slack for a refactor and
+ *      nowhere near enough for a deleted suite.
+ *
+ *   2. A list of the files with no executed statement at all. Fourteen of them
+ *      exist; the point is that the list may shrink and must not grow. A file
+ *      on it that has since been covered is also an error — a stale entry is
+ *      permission to un-cover it again.
+ *
+ * The numbers live in coverage-floors.json rather than here, so raising them is
+ * a reviewable diff rather than an edit buried in a script. `--update` rewrites
+ * that file from the current run: use it when coverage has gone up, never to
+ * make a failure go away.
+ *
+ *   npm run coverage:check
+ *   npm run coverage:check -- --update
+ *
+ * These floors are not Jest `coverageThreshold` path keys deliberately. Jest
+ * subtracts every path-keyed group from the global group, so adding directory
+ * keys there would quietly redefine the global ratchet to mean "everything
+ * except the directories listed" — the opposite of what both are for.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const SUMMARY_PATH = path.join(ROOT, 'coverage', 'coverage-summary.json');
+const FLOORS_PATH = path.join(ROOT, 'coverage-floors.json');
+
+const METRICS = ['statements', 'branches', 'functions', 'lines'];
+
+/** How far under the measurement a newly recorded floor sits, in points. */
+const SLACK = 3;
+
+/** Coverage of a directory is the coverage of the files under it, added up. */
+function aggregate(files) {
+    const totals = Object.fromEntries(METRICS.map(m => [m, { covered: 0, total: 0 }]));
+    for (const entry of files) {
+        for (const metric of METRICS) {
+            totals[metric].covered += entry[metric].covered;
+            totals[metric].total += entry[metric].total;
+        }
+    }
+    return Object.fromEntries(METRICS.map(m => [
+        m,
+        totals[m].total === 0 ? 100 : (totals[m].covered * 100) / totals[m].total,
+    ]));
+}
+
+/** Every measured file, keyed by its repo-relative path. */
+function readSummary() {
+    if (!fs.existsSync(SUMMARY_PATH)) return null;
+    const raw = JSON.parse(fs.readFileSync(SUMMARY_PATH, 'utf8'));
+    const files = new Map();
+    for (const [absolute, entry] of Object.entries(raw)) {
+        if (absolute === 'total') continue;
+        files.set(path.relative(ROOT, absolute).split(path.sep).join('/'), entry);
+    }
+    return files;
+}
+
+// A file belongs to exactly one bucket: the directory it sits in. Not a prefix
+// match — `src/services` would then swallow `src/services/ai`, and a bucket that
+// contains a much larger sibling is a bucket whose floor says nothing about it.
+const dirOf = file => file.split('/').slice(0, -1).join('/');
+
+/** Every directory the run measured a file in. */
+function directoriesIn(files) {
+    return [...new Set([...files.keys()].map(dirOf))].sort();
+}
+
+/** Files with something to execute, none of which any test executed. */
+function zeroCoverageFiles(files) {
+    return [...files.entries()]
+        .filter(([, entry]) => entry.statements.total > 0 && entry.statements.covered === 0)
+        .map(([file]) => file)
+        .sort();
+}
+
+function measure(files, directories) {
+    return Object.fromEntries(directories.map(dir => [
+        dir,
+        aggregate([...files.entries()].filter(([file]) => dirOf(file) === dir).map(([, entry]) => entry)),
+    ]));
+}
+
+function update(files, floors) {
+    // A directory that appeared since the floors were recorded gets one now,
+    // rather than being a subsystem with no floor at all.
+    const measured = measure(files, directoriesIn(files));
+    const directories = {};
+    for (const [dir, pcts] of Object.entries(measured)) {
+        directories[dir] = Object.fromEntries(METRICS.map(m => [
+            m,
+            // Never lower a floor on an update: coverage that dropped since the
+            // floor was set is the failure this exists to report, not a new
+            // baseline to write down.
+            Math.max(floors.directories[dir]?.[m] ?? 0, Math.max(0, Math.floor(pcts[m]) - SLACK)),
+        ]));
+    }
+    const next = { ...floors, directories, neverExecuted: zeroCoverageFiles(files) };
+    fs.writeFileSync(FLOORS_PATH, `${JSON.stringify(next, null, 4)}\n`);
+    return next;
+}
+
+function check(files, floors) {
+    const failures = [];
+    const measured = measure(files, directoriesIn(files));
+
+    // A new directory with no floor is a subsystem outside the ratchet, which is
+    // the hole this whole file exists to close.
+    for (const dir of directoriesIn(files)) {
+        if (!floors.directories[dir]) {
+            failures.push(`${dir} is new and has no recorded floor — rerun with --update`);
+        }
+    }
+
+    for (const [dir, required] of Object.entries(floors.directories)) {
+        if (!measured[dir]) {
+            failures.push(`${dir} has a floor but no measured file — drop it from coverage-floors.json`);
+            continue;
+        }
+        for (const metric of METRICS) {
+            const actual = measured[dir][metric];
+            if (actual + 1e-9 < required[metric]) {
+                failures.push(
+                    `${dir} ${metric} ${actual.toFixed(2)}% is below its floor of ${required[metric]}%`
+                );
+            }
+        }
+    }
+
+    const recorded = new Set(floors.neverExecuted);
+    const zero = zeroCoverageFiles(files);
+
+    for (const file of zero) {
+        if (!recorded.has(file)) {
+            failures.push(`${file} has no executed line and is not on the recorded list`);
+        }
+    }
+    // A file that is covered now but still listed is permission to un-cover it.
+    for (const file of floors.neverExecuted) {
+        if (files.has(file) && !zero.includes(file)) {
+            failures.push(`${file} is covered now — drop it from coverage-floors.json`);
+        }
+    }
+
+    return { failures, measured, zero };
+}
+
+function main() {
+    const wantsUpdate = process.argv.includes('--update');
+    const files = readSummary();
+
+    if (!files) {
+        console.error('[coverage] coverage/coverage-summary.json not found — run `npm run test:coverage` first.');
+        process.exit(1);
+    }
+
+    const floors = JSON.parse(fs.readFileSync(FLOORS_PATH, 'utf8'));
+
+    if (wantsUpdate) {
+        const next = update(files, floors);
+        console.log(`[coverage] floors updated for ${Object.keys(next.directories).length} director(ies); ` +
+            `${next.neverExecuted.length} file(s) with no executed line.`);
+        return;
+    }
+
+    const { failures, measured, zero } = check(files, floors);
+
+    for (const [dir, pcts] of Object.entries(measured)) {
+        const shown = METRICS.map(m => `${m[0]}${pcts[m].toFixed(1)}`).join(' ');
+        console.log(`[coverage] ${dir.padEnd(28)} ${shown}`);
+    }
+    console.log(`[coverage] ${zero.length} file(s) with no executed line.`);
+
+    if (failures.length) {
+        console.error('\n[coverage] the per-subsystem ratchet failed:');
+        for (const failure of failures) console.error(`  - ${failure}`);
+        console.error('\nAdd tests, or — only if coverage genuinely moved for a good reason —');
+        console.error('rerun with `npm run coverage:check -- --update` and explain it in the commit.');
+        process.exit(1);
+    }
+}
+
+if (require.main === module) main();
+
+module.exports = {
+    aggregate, check, update, zeroCoverageFiles, measure, directoriesIn, dirOf,
+    METRICS, SLACK, FLOORS_PATH,
+};

--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -20,10 +20,24 @@
  *      measured when it was recorded, which is enough slack for a refactor and
  *      nowhere near enough for a deleted suite.
  *
- *   2. A list of the files with no executed statement at all. Fourteen of them
- *      exist; the point is that the list may shrink and must not grow. A file
- *      on it that has since been covered is also an error — a stale entry is
- *      permission to un-cover it again.
+ *   2. A list of the files with no executed statement at all; the point is that
+ *      the list may shrink and must not grow. A file on it that has since been
+ *      covered is also an error — a stale entry is permission to un-cover it
+ *      again.
+ *
+ *      `coveredOnlyByIntegration` is the second list, and it exists because
+ *      this runs against whichever suites the run included. tests/integration/
+ *      needs a real mongod, so a contributor whose machine cannot fetch one
+ *      runs without it while CI runs with it — and a file only those suites
+ *      reach is zero-coverage in the first run and covered in the second.
+ *      Listing it separately makes both runs agree instead of one of them
+ *      being wrong.
+ *
+ * One consequence worth naming: the directory floors are recorded from the
+ * integration-excluded run, the same baseline jest.config.js uses, so the
+ * number CI sees is that or better — `src/migrations` measures 45.8% here and
+ * 81.8% in CI. That keeps a local run honest, and it does mean the floor for a
+ * directory the integration suites cover is looser than CI's own measurement.
  *
  * The numbers live in coverage-floors.json rather than here, so raising them is
  * a reviewable diff rather than an edit buried in a script. `--update` rewrites
@@ -117,7 +131,16 @@ function update(files, floors) {
             Math.max(floors.directories[dir]?.[m] ?? 0, Math.max(0, Math.floor(pcts[m]) - SLACK)),
         ]));
     }
-    const next = { ...floors, directories, neverExecuted: zeroCoverageFiles(files) };
+    // An integration-only file reads as zero in an integration-excluded run, so
+    // re-recording from one would move it onto `neverExecuted` and lose the
+    // distinction. Keep it where it is.
+    const integrationOnly = new Set(floors.coveredOnlyByIntegration ?? []);
+    const next = {
+        ...floors,
+        directories,
+        neverExecuted: zeroCoverageFiles(files).filter(file => !integrationOnly.has(file)),
+        coveredOnlyByIntegration: [...integrationOnly].sort(),
+    };
     fs.writeFileSync(FLOORS_PATH, `${JSON.stringify(next, null, 4)}\n`);
     return next;
 }
@@ -149,18 +172,37 @@ function check(files, floors) {
         }
     }
 
+    // Two lists, because the run this is checking may or may not have included
+    // tests/integration/. Those suites need a real mongod, so a contributor
+    // whose machine cannot fetch one runs without them — and CI does run them.
+    // A file covered only by an integration suite therefore reads as
+    // zero-coverage in one run and covered in the other, and neither is wrong.
+    const integrationOnly = new Set(floors.coveredOnlyByIntegration ?? []);
     const recorded = new Set(floors.neverExecuted);
     const zero = zeroCoverageFiles(files);
 
     for (const file of zero) {
-        if (!recorded.has(file)) {
+        if (!recorded.has(file) && !integrationOnly.has(file)) {
             failures.push(`${file} has no executed line and is not on the recorded list`);
         }
     }
-    // A file that is covered now but still listed is permission to un-cover it.
+    // A file that is covered now but still listed as never executed is standing
+    // permission to un-cover it. Not applied to the integration-only list: being
+    // covered is exactly what that list predicts of a run that included them.
     for (const file of floors.neverExecuted) {
         if (files.has(file) && !zero.includes(file)) {
-            failures.push(`${file} is covered now — drop it from coverage-floors.json`);
+            failures.push(
+                `${file} is covered now — move it to coveredOnlyByIntegration ` +
+                'if only tests/integration/ reaches it, or drop it'
+            );
+        }
+    }
+    // The integration list has to stay honest in the other direction: an entry
+    // that no longer exists is noise, and one that is covered by the ordinary
+    // suite belongs nowhere on either list.
+    for (const file of integrationOnly) {
+        if (!files.has(file)) {
+            failures.push(`${file} is listed as integration-covered but was not measured — drop it`);
         }
     }
 

--- a/src/commands/moderation/warn.js
+++ b/src/commands/moderation/warn.js
@@ -66,7 +66,14 @@ module.exports = {
                 const bypassEscalation = bypassRequested && canBypass;
 
                 const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
-                const matchedStep = !bypassEscalation
+                // Only ever read by the bypass branches below, to say what the
+                // bypass suppressed — when escalation is going to run,
+                // applyEscalation looks the step up itself. The condition used
+                // to be `!bypassEscalation`, which computed it in exactly the
+                // case nothing reads it and left it null in the case that does:
+                // "would have triggered MUTE at 3 warnings" was unreachable,
+                // and every honoured bypass claimed there was no step anyway.
+                const matchedStep = bypassEscalation
                     ? findStepForCount(guildSettings?.moderation?.escalation?.ladder, warningCount)
                     : null;
 

--- a/src/config/validateEnv.js
+++ b/src/config/validateEnv.js
@@ -1,0 +1,198 @@
+'use strict';
+
+/**
+ * The one place that decides whether this process is configured well enough to
+ * run (#639).
+ *
+ * There used to be two places. `src/index.js` checked that five variables were
+ * present; `src/dashboard/server.js` enforced the rest — that `DASHBOARD_URL`
+ * parses, carries no path, and is HTTPS in production, and that
+ * `SESSION_SECRET` is at least 32 characters. The dashboard starts *after*
+ * `connectDatabase()` and `runMigrations()`, so a deploy with a http://
+ * DASHBOARD_URL and NODE_ENV=production would connect, migrate the database,
+ * and only then throw. The crash-loop that follows is not the problem — the
+ * problem is that it had already written to the database on the way there, and
+ * migrations have no rollback path.
+ *
+ * So every rule lives here, and both entry points call `assertEnv()` before
+ * they touch anything: src/index.js as its first statement after the secrets
+ * are loaded, src/shard.js likewise, so a bad config is caught by the manager
+ * rather than N times over by its children.
+ *
+ * The dashboard still applies the same rules at the point it needs their
+ * answers — `resolveDashboardUrl()` below is the function it calls — but it is
+ * no longer where they are *defined*, and by the time it runs they have already
+ * passed. That matters for the second entry point into the dashboard,
+ * `createApp()` under test: it can still be handed a bad environment directly,
+ * and it still refuses.
+ *
+ * Everything is reported at once. A validator that stops at the first problem
+ * turns a misconfigured deploy into one round trip per missing variable.
+ */
+
+// Without these there is no bot: the gateway will not connect, OAuth cannot
+// complete, and there is nowhere to write. All five are also `*_FILE`-capable —
+// see config/fileSecrets.js, which must run first so the values are in place.
+const REQUIRED_ENV = ['DISCORD_TOKEN', 'CLIENT_ID', 'MONGODB_URI', 'SESSION_SECRET', 'CLIENT_SECRET'];
+
+// express-session will happily sign cookies with "hunter2". The floor is the
+// one openssl invocation in .env.example: `openssl rand -hex 32`.
+const SESSION_SECRET_MIN_LENGTH = 32;
+
+/** What DASHBOARD_URL falls back to when it is not set — local development. */
+function defaultDashboardUrl(env) {
+    return `http://localhost:${env.DASHBOARD_PORT || 3000}`;
+}
+
+/**
+ * Checks DASHBOARD_URL and works out the base URL the OAuth callback hangs off.
+ *
+ * Returns the problems rather than throwing them, so the same code can serve
+ * the startup validator (which wants all of them at once) and the dashboard
+ * (which wants the value, and throws on the first).
+ *
+ * @returns {{ baseUrl: ?string, errors: string[], warnings: string[] }}
+ */
+function checkDashboardUrl(env = process.env) {
+    const errors = [];
+    const warnings = [];
+    const raw = (env.DASHBOARD_URL || defaultDashboardUrl(env)).trim();
+
+    let parsed;
+    try {
+        parsed = new URL(raw);
+    } catch {
+        errors.push(`DASHBOARD_URL is not a valid URL: "${raw}"`);
+        return { baseUrl: null, errors, warnings };
+    }
+
+    // M5: HTTPS is required in production unconditionally — localhost is not
+    // exempt, because a production deployment should never be reached that way.
+    if (parsed.protocol !== 'https:') {
+        if (env.NODE_ENV === 'production') {
+            errors.push(
+                `DASHBOARD_URL must use HTTPS in production. Got: "${raw}". ` +
+                'Set NODE_ENV=development for local testing.'
+            );
+        } else {
+            warnings.push(
+                `DASHBOARD_URL "${raw}" is not HTTPS. ` +
+                'Discord OAuth will reject non-HTTPS redirect URIs in production.'
+            );
+        }
+    }
+
+    // The callback URL is built by appending "/auth/callback", and it has to
+    // match what is registered in the Discord Developer Portal character for
+    // character. A path here silently produces a URL that never matches.
+    if (parsed.pathname && parsed.pathname !== '/' && parsed.pathname !== '') {
+        errors.push(
+            'DASHBOARD_URL must be just a scheme + host (e.g. https://bot.example.com), ' +
+            `with no path. Got: "${raw}"`
+        );
+    }
+
+    return { baseUrl: `${parsed.protocol}//${parsed.host}`, errors, warnings };
+}
+
+/**
+ * The dashboard's base URL, or a throw. This is the call site that wants an
+ * answer rather than a report — it runs while passport is being configured, at
+ * which point there is nothing useful to do with a URL that does not parse.
+ */
+function resolveDashboardUrl(env = process.env) {
+    const { baseUrl, errors, warnings } = checkDashboardUrl(env);
+    if (errors.length) throw new Error(`[DASHBOARD] ${errors[0]}`);
+    for (const warning of warnings) console.warn(`[DASHBOARD] WARNING: ${warning}`);
+    return baseUrl;
+}
+
+/** M1: SESSION_SECRET has to exist and be long enough to be worth having. */
+function checkSessionSecret(env = process.env) {
+    if (!env.SESSION_SECRET) {
+        return ['SESSION_SECRET is not set. Add a strong random value to your .env file.'];
+    }
+    if (env.SESSION_SECRET.length < SESSION_SECRET_MIN_LENGTH) {
+        return [
+            `SESSION_SECRET must be at least ${SESSION_SECRET_MIN_LENGTH} characters. ` +
+            'Generate one with: openssl rand -hex 32',
+        ];
+    }
+    return [];
+}
+
+/**
+ * Every configuration problem this process can be told about before it starts.
+ *
+ * @param {object} env
+ * @returns {{ errors: string[], warnings: string[] }}
+ */
+function collectEnvProblems(env = process.env) {
+    const errors = [];
+    const warnings = [];
+
+    const missing = REQUIRED_ENV.filter(key => !env[key]);
+    if (missing.length) {
+        errors.push(`Missing required environment variables: ${missing.join(', ')}`);
+    }
+
+    // Only worth saying when the variable is there at all; "not set" is already
+    // covered by the line above, and saying it twice reads like two faults.
+    if (env.SESSION_SECRET) errors.push(...checkSessionSecret(env));
+
+    if (env.MONGODB_URI && !/^mongodb(\+srv)?:\/\//.test(env.MONGODB_URI)) {
+        errors.push(
+            'MONGODB_URI must start with mongodb:// or mongodb+srv:// ' +
+            `(got "${env.MONGODB_URI.split(':')[0]}:...")`
+        );
+    }
+
+    if (env.DASHBOARD_PORT !== undefined && env.DASHBOARD_PORT !== '') {
+        const port = Number(env.DASHBOARD_PORT);
+        if (!Number.isInteger(port) || port < 1 || port > 65535) {
+            errors.push(`DASHBOARD_PORT must be a port number between 1 and 65535. Got: "${env.DASHBOARD_PORT}"`);
+        }
+    }
+
+    const dashboardUrl = checkDashboardUrl(env);
+    errors.push(...dashboardUrl.errors);
+    warnings.push(...dashboardUrl.warnings);
+
+    return { errors, warnings };
+}
+
+/**
+ * Validates, or exits.
+ *
+ * Called before `connectDatabase()`, which is the whole point: a process that
+ * is going to refuse to serve should refuse before it has written anything.
+ * Warnings are printed and do not stop the boot.
+ *
+ * @param {object}   [options]
+ * @param {object}   [options.env]    environment to read, for tests
+ * @param {string}   [options.label]  log prefix — 'STARTUP' or 'SHARD'
+ * @param {Function} [options.onFail] what to do when it fails; exits by default
+ */
+function assertEnv({ env = process.env, label = 'STARTUP', onFail } = {}) {
+    const { errors, warnings } = collectEnvProblems(env);
+
+    for (const warning of warnings) console.warn(`[${label}] WARNING: ${warning}`);
+    if (!errors.length) return true;
+
+    for (const error of errors) console.error(`[${label}] ${error}`);
+    console.error(`[${label}] Copy .env.example to .env and fill in all required values.`);
+
+    if (onFail) return onFail(errors);
+    process.exit(1);
+    return false;
+}
+
+module.exports = {
+    assertEnv,
+    collectEnvProblems,
+    checkDashboardUrl,
+    checkSessionSecret,
+    resolveDashboardUrl,
+    REQUIRED_ENV,
+    SESSION_SECRET_MIN_LENGTH,
+};

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -12,32 +12,18 @@ const { jsonForScript } = require('./lib/jsonForScript');
 const { asset } = require('./lib/assets');
 const { createBotGateway } = require('../bot/gateway');
 const { instanceStats } = require('./lib/instanceStats');
+// The DASHBOARD_URL and SESSION_SECRET rules used to be defined here, which is
+// after connectDatabase() and runMigrations() in the boot order — so a config
+// they rejected was rejected only once the database had been migrated (#639).
+// They live in config/validateEnv.js now and both entry points check them before
+// anything is connected. They are still applied at the two points below that
+// need their answers, because createApp() can be handed an environment directly
+// by a test, and because a rule enforced only at the edge is a rule that quietly
+// stops being enforced when a second caller appears.
+const { resolveDashboardUrl, checkSessionSecret } = require('../config/validateEnv');
 
 passport.serializeUser((user, done) => done(null, user));
 passport.deserializeUser((obj, done) => done(null, obj));
-
-function resolveDashboardUrl() {
-    const raw = (process.env.DASHBOARD_URL || `http://localhost:${process.env.DASHBOARD_PORT || 3000}`).trim();
-    let parsed;
-    try {
-        parsed = new URL(raw);
-    } catch {
-        throw new Error(`[DASHBOARD] DASHBOARD_URL is not a valid URL: "${raw}"`);
-    }
-    // M5: Enforce HTTPS in production unconditionally — localhost is not exempt
-    // because production deployments should never be reached via localhost.
-    const isProduction = process.env.NODE_ENV === 'production';
-    if (parsed.protocol !== 'https:') {
-        if (isProduction) {
-            throw new Error(`[DASHBOARD] DASHBOARD_URL must use HTTPS in production. Got: "${raw}". Set NODE_ENV=development for local testing.`);
-        }
-        console.warn(`[DASHBOARD] WARNING: DASHBOARD_URL "${raw}" is not HTTPS. Discord OAuth will reject non-HTTPS redirect URIs in production.`);
-    }
-    if (parsed.pathname && parsed.pathname !== '/' && parsed.pathname !== '') {
-        throw new Error(`[DASHBOARD] DASHBOARD_URL must be just a scheme + host (e.g. https://bot.example.com), with no path. Got: "${raw}"`);
-    }
-    return `${parsed.protocol}//${parsed.host}`;
-}
 
 // Options for the Discord OAuth2 strategy, split out from the passport.use()
 // call so the login CSRF defence below is assertable without booting the app.
@@ -196,13 +182,10 @@ function createApp({ client = null, bot: injectedBot, sessionStore, configurePas
     app.use(express.json());
     app.use(express.urlencoded({ extended: true }));
 
-    // M1: Validate SESSION_SECRET exists and meets minimum strength requirements.
-    if (!process.env.SESSION_SECRET) {
-        throw new Error('[DASHBOARD] SESSION_SECRET is not set. Add a strong random value to your .env file.');
-    }
-    if (process.env.SESSION_SECRET.length < 32) {
-        throw new Error('[DASHBOARD] SESSION_SECRET must be at least 32 characters. Generate one with: openssl rand -hex 32');
-    }
+    // M1: SESSION_SECRET has to exist and be long enough to be worth having.
+    // The rule itself is in config/validateEnv.js, where startup checks it too.
+    const [secretProblem] = checkSessionSecret(process.env);
+    if (secretProblem) throw new Error(`[DASHBOARD] ${secretProblem}`);
 
     // Trust the first hop from a reverse proxy (nginx, Caddy, etc.) so that
     // req.protocol reflects the original HTTPS scheme and the secure: true

--- a/src/index.js
+++ b/src/index.js
@@ -9,21 +9,22 @@ require('dotenv').config();
 // anything reads process.env.
 require('./config/fileSecrets').loadFileSecrets();
 
+// Validate the whole configuration before doing anything else — in particular
+// before connectDatabase() and runMigrations(), which is the ordering #639 was
+// about. The DASHBOARD_URL and SESSION_SECRET rules used to live in
+// dashboard/server.js, which starts *after* the database has been connected and
+// migrated, so a deploy that was going to be rejected for a http:// callback URL
+// was rejected only once it had already written to the database. Migrations have
+// no rollback path, so "crash-loop before touching anything" is the only safe
+// order. Every rule now lives in config/validateEnv.js; this exits on the first
+// call if any of them fail.
+require('./config/validateEnv').assertEnv({ label: 'STARTUP' });
+
 const health = require('./health');
 const { makeCache, sweepers } = require('./utils/cacheOptions');
 const { isPrimaryShard, shardTag } = require('./utils/sharding');
 const { loadCommandModules } = require('./utils/commandLoader');
 const { startCooldownSweeper } = require('./utils/commandCooldowns');
-
-// Validate required environment variables before doing anything else.
-// Fail loudly at startup rather than silently misbehaving at runtime.
-const REQUIRED_ENV = ['DISCORD_TOKEN', 'CLIENT_ID', 'MONGODB_URI', 'SESSION_SECRET', 'CLIENT_SECRET'];
-const missingEnv = REQUIRED_ENV.filter(k => !process.env[k]);
-if (missingEnv.length) {
-    console.error(`[STARTUP] Missing required environment variables: ${missingEnv.join(', ')}`);
-    console.error('[STARTUP] Copy .env.example to .env and fill in all required values.');
-    process.exit(1);
-}
 
 const client = new Client({
     intents: [

--- a/src/shard.js
+++ b/src/shard.js
@@ -31,12 +31,12 @@ require('./config/fileSecrets').loadFileSecrets();
 const path = require('path');
 const { ShardingManager } = require('discord.js');
 
-const REQUIRED_ENV = ['DISCORD_TOKEN', 'CLIENT_ID', 'MONGODB_URI', 'SESSION_SECRET', 'CLIENT_SECRET'];
-const missingEnv = REQUIRED_ENV.filter(k => !process.env[k]);
-if (missingEnv.length) {
-    console.error(`[SHARD] Missing required environment variables: ${missingEnv.join(', ')}`);
-    process.exit(1);
-}
+// The same rules the children apply, applied once here first (#639). A shard
+// manager that spawns N processes to watch each of them exit on the same missing
+// variable is N times the log for one fact, and `respawn: true` means it does it
+// again. Shard 0 also runs the dashboard, so its DASHBOARD_URL rules belong to
+// this process too.
+require('./config/validateEnv').assertEnv({ label: 'SHARD' });
 
 function resolveShardCount() {
     const pinned = Number(process.env.SHARD_COUNT);

--- a/tests/coverageRatchet.test.js
+++ b/tests/coverageRatchet.test.js
@@ -67,3 +67,157 @@ describe('coverage ratchet', () => {
         expect(pkg.scripts['test:coverage']).toMatch(/--coverage\b/);
     });
 });
+
+// The half the global number cannot express (#625). One percentage over all of
+// src says nothing about where the coverage is: src/services/ai/mcp is at 94%
+// and src/commands/economy at 18%, so deleting every MCP test costs about four
+// points of a 37% total and the run stays green. A whole subsystem can go to
+// zero without the number that guards it moving far enough to notice.
+describe('per-subsystem floors', () => {
+    const floors = JSON.parse(read('coverage-floors.json'));
+    const {
+        aggregate, check, dirOf, METRICS,
+    } = require('../scripts/check-coverage.js');
+
+    const file = (covered, total) => Object.fromEntries(
+        METRICS.map(m => [m, { covered, total }]),
+    );
+
+    test('every directory that holds a measured file has a floor', () => {
+        // Not asserted against a live coverage run — the run that produced the
+        // file may not have happened. The script itself fails on a directory
+        // with no floor; this holds the recorded list against the tree.
+        const recorded = Object.keys(floors.directories);
+        expect(recorded.length).toBeGreaterThan(20);
+        for (const dir of recorded) {
+            expect([dir, fs.existsSync(path.join(root, dir))]).toEqual([dir, true]);
+        }
+    });
+
+    test('the moderation and casino directories the issue named are floored', () => {
+        for (const dir of ['src/commands/moderation', 'src/games/casino', 'src/migrations', 'src/events']) {
+            expect(Object.keys(floors.directories)).toContain(dir);
+            expect(floors.directories[dir].statements).toBeGreaterThan(0);
+        }
+    });
+
+    // #628 raised this directory from 1.6% branches; the floor is what stops it
+    // going back, and a floor of zero would not.
+    test('the moderation floor reflects the tests that now drive those commands', () => {
+        expect(floors.directories['src/commands/moderation'].branches).toBeGreaterThanOrEqual(60);
+    });
+
+    test('a file belongs to its own directory, not to every parent of it', () => {
+        // src/services would otherwise swallow src/services/ai, and a bucket
+        // that contains a much larger sibling says nothing about it.
+        expect(dirOf('src/services/ai/mcp/client.js')).toBe('src/services/ai/mcp');
+        expect(dirOf('src/index.js')).toBe('src');
+    });
+
+    test('a directory below its floor fails', () => {
+        const files = new Map([['src/thing/a.js', file(1, 100)]]);
+        const { failures } = check(files, {
+            directories: { 'src/thing': { statements: 50, branches: 50, functions: 50, lines: 50 } },
+            neverExecuted: [],
+        });
+        expect(failures.join('\n')).toMatch(/src\/thing statements 1.00% is below its floor of 50%/);
+    });
+
+    test('a directory at or above its floor passes', () => {
+        const files = new Map([['src/thing/a.js', file(60, 100)]]);
+        const { failures } = check(files, {
+            directories: { 'src/thing': { statements: 60, branches: 60, functions: 60, lines: 60 } },
+            neverExecuted: [],
+        });
+        expect(failures).toEqual([]);
+    });
+
+    // The hole a new subsystem would otherwise walk straight through.
+    test('a directory with no recorded floor fails', () => {
+        const files = new Map([['src/brand-new/a.js', file(100, 100)]]);
+        const { failures } = check(files, { directories: {}, neverExecuted: [] });
+        expect(failures.join('\n')).toMatch(/src\/brand-new is new and has no recorded floor/);
+    });
+
+    test('a floor for a directory that no longer exists fails', () => {
+        const files = new Map([['src/thing/a.js', file(100, 100)]]);
+        const { failures } = check(files, {
+            directories: {
+                'src/thing': { statements: 0, branches: 0, functions: 0, lines: 0 },
+                'src/deleted': { statements: 10, branches: 10, functions: 10, lines: 10 },
+            },
+            neverExecuted: [],
+        });
+        expect(failures.join('\n')).toMatch(/src\/deleted has a floor but no measured file/);
+    });
+
+    test('an empty directory is 100%, not a division by zero', () => {
+        expect(aggregate([file(0, 0)]).statements).toBe(100);
+    });
+});
+
+// The other thing one number hides: a file no test has ever loaded contributes
+// its whole size to the denominator and nothing to the numerator, which is
+// indistinguishable from a file that is merely badly covered. Fourteen of them
+// exist. The list may shrink; it must not grow.
+describe('the files with no executed line', () => {
+    const floors = JSON.parse(read('coverage-floors.json'));
+    const { check, zeroCoverageFiles, METRICS } = require('../scripts/check-coverage.js');
+
+    const file = (covered, total) => Object.fromEntries(
+        METRICS.map(m => [m, { covered, total }]),
+    );
+
+    test('the recorded list names real files', () => {
+        expect(floors.neverExecuted.length).toBeGreaterThan(0);
+        for (const name of floors.neverExecuted) {
+            expect([name, fs.existsSync(path.join(root, name))]).toEqual([name, true]);
+        }
+    });
+
+    // The two entry points are on it for a reason worth keeping visible: both
+    // call process.exit, and index.js opens a gateway connection on the way.
+    test('it still contains the entry points, which cannot be required in a test', () => {
+        expect(floors.neverExecuted).toEqual(expect.arrayContaining(['src/index.js', 'src/shard.js']));
+    });
+
+    test('a file with nothing executed is one with statements and no covered statement', () => {
+        const files = new Map([
+            ['src/a.js', file(0, 12)],
+            ['src/b.js', file(3, 12)],
+            // A file with nothing in it to execute is not an uncovered file.
+            ['src/c.js', file(0, 0)],
+        ]);
+        expect(zeroCoverageFiles(files)).toEqual(['src/a.js']);
+    });
+
+    test('a newly unexecuted file fails', () => {
+        const files = new Map([['src/fresh.js', file(0, 12)]]);
+        const { failures } = check(files, {
+            directories: { src: { statements: 0, branches: 0, functions: 0, lines: 0 } },
+            neverExecuted: [],
+        });
+        expect(failures.join('\n')).toMatch(/src\/fresh.js has no executed line/);
+    });
+
+    // A stale entry is standing permission to un-cover the file again.
+    test('a listed file that is covered now fails, so the list cannot rot', () => {
+        const files = new Map([['src/covered.js', file(12, 12)]]);
+        const { failures } = check(files, {
+            directories: { src: { statements: 0, branches: 0, functions: 0, lines: 0 } },
+            neverExecuted: ['src/covered.js'],
+        });
+        expect(failures.join('\n')).toMatch(/src\/covered.js is covered now/);
+    });
+});
+
+describe('the per-subsystem ratchet is wired up', () => {
+    test('CI checks the floors as well as the global thresholds', () => {
+        const testJob = ci.slice(ci.indexOf('\n  test:'), ci.indexOf('\n  publish:'));
+        expect(testJob).toMatch(/run: npm run coverage:check/);
+    });
+
+    test('the same check is one command locally', () => {
+        expect(pkg.scripts['coverage:check']).toMatch(/check-coverage\.js/);
+    });
+});

--- a/tests/coverageRatchet.test.js
+++ b/tests/coverageRatchet.test.js
@@ -211,6 +211,111 @@ describe('the files with no executed line', () => {
     });
 });
 
+// The check runs against whichever suites the run included, and that is not one
+// fixed set: tests/integration/ needs a real mongod, so a contributor whose
+// machine cannot fetch one runs without it while CI runs with it. A file only
+// those suites reach is zero-coverage in the first run and covered in the
+// second, and neither reading is wrong — which is what sent CI red the first
+// time this landed, on src/models/MigrationRecord.js.
+describe('files only the integration suites reach', () => {
+    const floors = JSON.parse(read('coverage-floors.json'));
+    const { check, METRICS } = require('../scripts/check-coverage.js');
+
+    const file = (covered, total) => Object.fromEntries(
+        METRICS.map(m => [m, { covered, total }]),
+    );
+
+    const dirs = { src: { statements: 0, branches: 0, functions: 0, lines: 0 } };
+
+    test('the recorded entries are real files, and are not on the other list', () => {
+        for (const name of floors.coveredOnlyByIntegration) {
+            expect([name, fs.existsSync(path.join(root, name))]).toEqual([name, true]);
+            expect(floors.neverExecuted).not.toContain(name);
+        }
+    });
+
+    test('one reading zero passes — that is the run without integration', () => {
+        const files = new Map([['src/only.js', file(0, 10)]]);
+        const { failures } = check(files, {
+            directories: dirs, neverExecuted: [], coveredOnlyByIntegration: ['src/only.js'],
+        });
+        expect(failures).toEqual([]);
+    });
+
+    test('the same one reading covered passes too — that is CI', () => {
+        const files = new Map([['src/only.js', file(10, 10)]]);
+        const { failures } = check(files, {
+            directories: dirs, neverExecuted: [], coveredOnlyByIntegration: ['src/only.js'],
+        });
+        expect(failures).toEqual([]);
+    });
+
+    // Without this the list is a place to hide a file that no longer exists.
+    test('an entry that was not measured at all fails', () => {
+        const files = new Map([['src/other.js', file(10, 10)]]);
+        const { failures } = check(files, {
+            directories: dirs, neverExecuted: [], coveredOnlyByIntegration: ['src/gone.js'],
+        });
+        expect(failures.join('\n')).toMatch(/src\/gone.js is listed as integration-covered/);
+    });
+
+    // The failure CI actually hit: an integration-covered file left on the
+    // never-executed list fails in CI and passes locally, which is the worst of
+    // both. The message has to say where it belongs.
+    test('a never-executed entry that CI covers is told where to go', () => {
+        const files = new Map([['src/only.js', file(10, 10)]]);
+        const { failures } = check(files, {
+            directories: dirs, neverExecuted: ['src/only.js'], coveredOnlyByIntegration: [],
+        });
+        expect(failures.join('\n')).toMatch(/move it to coveredOnlyByIntegration/);
+    });
+
+    test('the list is optional — a floors file without one still checks', () => {
+        const files = new Map([['src/a.js', file(0, 10)]]);
+        const { failures } = check(files, { directories: dirs, neverExecuted: ['src/a.js'] });
+        expect(failures).toEqual([]);
+    });
+});
+
+describe('re-recording the floors', () => {
+    const { update, METRICS } = require('../scripts/check-coverage.js');
+
+    const file = (covered, total) => Object.fromEntries(
+        METRICS.map(m => [m, { covered, total }]),
+    );
+
+    // An integration-only file reads as zero in an integration-excluded run, so
+    // re-recording from one would quietly move it onto `neverExecuted` and put
+    // the CI failure straight back.
+    test('an integration-only entry survives an update run that sees it as zero', () => {
+        const written = [];
+        const spy = jest.spyOn(fs, 'writeFileSync').mockImplementation((_p, body) => written.push(body));
+
+        const files = new Map([['src/only.js', file(0, 10)], ['src/b.js', file(5, 10)]]);
+        const next = update(files, {
+            directories: { src: { statements: 0, branches: 0, functions: 0, lines: 0 } },
+            neverExecuted: [],
+            coveredOnlyByIntegration: ['src/only.js'],
+        });
+
+        expect(next.coveredOnlyByIntegration).toEqual(['src/only.js']);
+        expect(next.neverExecuted).not.toContain('src/only.js');
+        expect(written).toHaveLength(1);
+        spy.mockRestore();
+    });
+
+    test('a floor is never lowered by an update', () => {
+        const spy = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+        const files = new Map([['src/a.js', file(1, 100)]]);
+        const next = update(files, {
+            directories: { src: { statements: 40, branches: 40, functions: 40, lines: 40 } },
+            neverExecuted: [],
+        });
+        expect(next.directories.src.statements).toBe(40);
+        spy.mockRestore();
+    });
+});
+
 describe('the per-subsystem ratchet is wired up', () => {
     test('CI checks the floors as well as the global thresholds', () => {
         const testJob = ci.slice(ci.indexOf('\n  test:'), ci.indexOf('\n  publish:'));

--- a/tests/envValidation.test.js
+++ b/tests/envValidation.test.js
@@ -1,0 +1,246 @@
+'use strict';
+
+// #639: config validation was split across two files that run at very different
+// points in the boot. src/index.js checked that five variables were present;
+// dashboard/server.js enforced the DASHBOARD_URL and SESSION_SECRET rules — and
+// it starts after connectDatabase() and runMigrations(). So a deploy that was
+// always going to be rejected got as far as migrating the database first, and
+// migrations have no rollback path.
+//
+// These tests hold both halves of the fix: every rule is in one module, and the
+// entry points run it before they connect to anything.
+
+const fs = require('fs');
+const path = require('path');
+
+const {
+    assertEnv,
+    collectEnvProblems,
+    checkDashboardUrl,
+    checkSessionSecret,
+    resolveDashboardUrl,
+    REQUIRED_ENV,
+    SESSION_SECRET_MIN_LENGTH,
+} = require('../src/config/validateEnv');
+
+/** A configuration with nothing wrong with it. */
+function goodEnv(overrides = {}) {
+    return {
+        DISCORD_TOKEN: 'token',
+        CLIENT_ID: '123',
+        CLIENT_SECRET: 'secret',
+        MONGODB_URI: 'mongodb://mongodb:27017/ultrabot',
+        SESSION_SECRET: 'x'.repeat(SESSION_SECRET_MIN_LENGTH),
+        DASHBOARD_URL: 'https://bot.example.com',
+        NODE_ENV: 'production',
+        ...overrides,
+    };
+}
+
+const errorsFor = env => collectEnvProblems(env).errors;
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('a configuration with nothing wrong with it', () => {
+    test('produces no errors and no warnings', () => {
+        expect(collectEnvProblems(goodEnv())).toEqual({ errors: [], warnings: [] });
+    });
+
+    test('development over http is a warning, not a refusal', () => {
+        const { errors, warnings } = collectEnvProblems(goodEnv({
+            NODE_ENV: 'development',
+            DASHBOARD_URL: 'http://localhost:3000',
+        }));
+        expect(errors).toEqual([]);
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toMatch(/not HTTPS/);
+    });
+
+    test('an unset DASHBOARD_URL falls back to localhost on the configured port', () => {
+        const { baseUrl } = checkDashboardUrl({ DASHBOARD_PORT: '8080' });
+        expect(baseUrl).toBe('http://localhost:8080');
+    });
+});
+
+describe('required variables', () => {
+    test.each(REQUIRED_ENV)('a missing %s is an error', key => {
+        const env = goodEnv();
+        delete env[key];
+        expect(errorsFor(env).join('\n')).toContain(key);
+    });
+
+    // A validator that stops at the first problem turns a misconfigured deploy
+    // into one round trip per missing variable.
+    test('every missing variable is named at once, in one message', () => {
+        const env = goodEnv();
+        delete env.DISCORD_TOKEN;
+        delete env.CLIENT_SECRET;
+
+        const missing = errorsFor(env).filter(e => e.startsWith('Missing required'));
+        expect(missing).toHaveLength(1);
+        expect(missing[0]).toContain('DISCORD_TOKEN');
+        expect(missing[0]).toContain('CLIENT_SECRET');
+    });
+
+    // "SESSION_SECRET is not set" and "SESSION_SECRET must be 32 characters"
+    // are the same fault; reporting both reads like two.
+    test('an unset SESSION_SECRET is reported once, not also as too short', () => {
+        const env = goodEnv();
+        delete env.SESSION_SECRET;
+        const errors = errorsFor(env);
+        expect(errors.filter(e => e.includes('SESSION_SECRET'))).toEqual([
+            'Missing required environment variables: SESSION_SECRET',
+        ]);
+    });
+});
+
+describe('SESSION_SECRET strength', () => {
+    test('a secret one character short is rejected', () => {
+        const short = 'x'.repeat(SESSION_SECRET_MIN_LENGTH - 1);
+        expect(checkSessionSecret({ SESSION_SECRET: short })).toHaveLength(1);
+        expect(checkSessionSecret({ SESSION_SECRET: short })[0]).toMatch(/at least 32 characters/);
+    });
+
+    test('a secret at exactly the floor is accepted', () => {
+        expect(checkSessionSecret({ SESSION_SECRET: 'x'.repeat(SESSION_SECRET_MIN_LENGTH) })).toEqual([]);
+    });
+
+    test('the rule reaches collectEnvProblems too', () => {
+        expect(errorsFor(goodEnv({ SESSION_SECRET: 'too-short' })).join('\n'))
+            .toMatch(/SESSION_SECRET must be at least/);
+    });
+});
+
+describe('DASHBOARD_URL', () => {
+    // The rule this issue was named for: it was enforced only from
+    // dashboard/server.js, four steps into the boot.
+    test('http in production is an error', () => {
+        const errors = errorsFor(goodEnv({ DASHBOARD_URL: 'http://bot.example.com' }));
+        expect(errors.join('\n')).toMatch(/must use HTTPS in production/);
+    });
+
+    test('a URL that does not parse is an error', () => {
+        expect(errorsFor(goodEnv({ DASHBOARD_URL: 'not a url' })).join('\n'))
+            .toMatch(/not a valid URL/);
+    });
+
+    // The callback URL is this value plus "/auth/callback", and it has to match
+    // the Discord Developer Portal entry character for character.
+    test('a path is an error', () => {
+        expect(errorsFor(goodEnv({ DASHBOARD_URL: 'https://bot.example.com/dashboard' })).join('\n'))
+            .toMatch(/no path/);
+    });
+
+    test('a bare trailing slash is not a path', () => {
+        expect(errorsFor(goodEnv({ DASHBOARD_URL: 'https://bot.example.com/' }))).toEqual([]);
+    });
+
+    test('surrounding whitespace is trimmed rather than failing the parse', () => {
+        expect(checkDashboardUrl({ DASHBOARD_URL: '  https://bot.example.com  ' }))
+            .toMatchObject({ baseUrl: 'https://bot.example.com', errors: [] });
+    });
+
+    test('resolveDashboardUrl throws the first error with the dashboard prefix', () => {
+        expect(() => resolveDashboardUrl({ DASHBOARD_URL: 'not a url' }))
+            .toThrow(/^\[DASHBOARD\] DASHBOARD_URL is not a valid URL/);
+    });
+
+    test('resolveDashboardUrl returns scheme and host only', () => {
+        expect(resolveDashboardUrl({ DASHBOARD_URL: 'https://bot.example.com:8443' }))
+            .toBe('https://bot.example.com:8443');
+    });
+});
+
+describe('the values that are read as numbers', () => {
+    test('a DASHBOARD_PORT that is not a port is an error', () => {
+        expect(errorsFor(goodEnv({ DASHBOARD_PORT: 'three thousand' })).join('\n'))
+            .toMatch(/DASHBOARD_PORT must be a port number/);
+        expect(errorsFor(goodEnv({ DASHBOARD_PORT: '70000' })).join('\n'))
+            .toMatch(/DASHBOARD_PORT must be a port number/);
+    });
+
+    test('an unset or empty DASHBOARD_PORT is fine — it has a default', () => {
+        expect(errorsFor(goodEnv({ DASHBOARD_PORT: '' }))).toEqual([]);
+    });
+
+    test('a MONGODB_URI with the wrong scheme is an error', () => {
+        expect(errorsFor(goodEnv({ MONGODB_URI: 'postgres://localhost/db' })).join('\n'))
+            .toMatch(/must start with mongodb/);
+    });
+
+    test('mongodb+srv is accepted', () => {
+        expect(errorsFor(goodEnv({ MONGODB_URI: 'mongodb+srv://cluster/db' }))).toEqual([]);
+    });
+});
+
+describe('assertEnv', () => {
+    test('returns true and prints nothing when the config is good', () => {
+        const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+        expect(assertEnv({ env: goodEnv(), onFail: () => 'failed' })).toBe(true);
+        expect(error).not.toHaveBeenCalled();
+    });
+
+    test('prints every error under the given label, then fails', () => {
+        const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const env = goodEnv({ SESSION_SECRET: 'short', DASHBOARD_URL: 'http://bot.example.com' });
+
+        const failed = jest.fn(() => 'failed');
+        expect(assertEnv({ env, label: 'SHARD', onFail: failed })).toBe('failed');
+        expect(failed).toHaveBeenCalledTimes(1);
+        expect(failed.mock.calls[0][0]).toHaveLength(2);
+
+        const printed = error.mock.calls.map(c => c.join(' ')).join('\n');
+        expect(printed).toMatch(/\[SHARD\] SESSION_SECRET must be at least/);
+        expect(printed).toMatch(/\[SHARD\] DASHBOARD_URL must use HTTPS/);
+        expect(printed).toMatch(/Copy \.env\.example/);
+    });
+
+    test('warnings are printed but do not stop the boot', () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const failed = jest.fn();
+
+        expect(assertEnv({
+            env: goodEnv({ NODE_ENV: 'development', DASHBOARD_URL: 'http://localhost:3000' }),
+            onFail: failed,
+        })).toBe(true);
+        expect(failed).not.toHaveBeenCalled();
+        expect(warn.mock.calls.map(c => c.join(' ')).join('\n')).toMatch(/not HTTPS/);
+    });
+});
+
+// The half of #639 that is about ordering rather than rules. Asserted against
+// the source, because the alternative is booting a real bot: both entry points
+// exit the process, and index.js opens a gateway connection on the way.
+describe('the entry points validate before they connect', () => {
+    const sourceOf = file => fs.readFileSync(path.join(__dirname, '..', 'src', file), 'utf8');
+
+    test.each(['index.js', 'shard.js'])('%s validates the environment', file => {
+        expect(sourceOf(file)).toMatch(/require\('\.\/config\/validateEnv'\)\.assertEnv\(/);
+    });
+
+    // The point of the issue: this ordering is what stops a misconfigured deploy
+    // migrating the database on its way to the crash it was always going to hit.
+    test('index.js validates before it connects or migrates', () => {
+        const source = sourceOf('index.js');
+        const validate = source.indexOf("require('./config/validateEnv')");
+        const connect = source.indexOf('async function connectDatabase');
+        const startBot = source.indexOf('async function startBot');
+
+        expect(validate).toBeGreaterThan(-1);
+        expect(validate).toBeLessThan(connect);
+        expect(validate).toBeLessThan(startBot);
+    });
+
+    // A second copy of the required-variable list is a second copy that drifts.
+    test.each(['index.js', 'shard.js'])('%s no longer keeps its own copy of the rules', file => {
+        expect(sourceOf(file)).not.toMatch(/REQUIRED_ENV\s*=\s*\[/);
+    });
+
+    test('the dashboard applies the shared rules rather than redefining them', () => {
+        const source = sourceOf('dashboard/server.js');
+        expect(source).toMatch(/require\('\.\.\/config\/validateEnv'\)/);
+        expect(source).not.toMatch(/must use HTTPS in production/);
+        expect(source).not.toMatch(/SESSION_SECRET\.length < 32/);
+    });
+});

--- a/tests/helpers/moderationInteraction.js
+++ b/tests/helpers/moderationInteraction.js
@@ -1,0 +1,226 @@
+'use strict';
+
+/**
+ * A stand-in ChatInputCommandInteraction for driving `src/commands/moderation/*`.
+ *
+ * #628: those sixteen files are the destructive surface — ban, kick, mute,
+ * massban, lockdown, clear — and no test had ever invoked one of their
+ * `execute()` functions. The directory reported non-zero line coverage, which
+ * was module-level `SlashCommandBuilder` constants evaluating at import;
+ * branches sat at zero. The role-hierarchy guard added in #588 was proven in
+ * isolation and tied to its call sites by a source-text grep, which is exactly
+ * the "fix that silently regresses" shape the issue warned about — a rename of
+ * the helper keeps the grep passing.
+ *
+ * So this builds enough of a guild for the commands to run against: members
+ * with role positions the hierarchy guard can compare, a member cache that
+ * misses the way the real one does, and a ban/kick/timeout surface that records
+ * what was called rather than performing it. `interaction.replies` is what
+ * assertions about "what did the moderator actually see" read; `guild.actions`
+ * is what "and what was actually done to the target" reads.
+ */
+
+const { PermissionFlagsBits, PermissionsBitField } = require('discord.js');
+
+const GUILD_ID = 'guild-1';
+const OWNER_ID = 'owner-1';
+const BOT_ID   = 'bot-1';
+const MOD_ID   = 'mod-1';
+
+/** Discord's "no such member here" code, which resolveMember treats as absent. */
+const UNKNOWN_MEMBER = 10007;
+
+/**
+ * A user, as the options resolver hands one over. `send` is the warning DM;
+ * every command that sends one already swallows a rejection.
+ */
+function makeUser(id, { username = `user-${id}`, globalName = null, bot = false } = {}) {
+    return { id, username, globalName, bot, send: jest.fn().mockResolvedValue(undefined) };
+}
+
+/**
+ * A guild member with a role position the hierarchy guard can compare.
+ *
+ * `bannable` / `kickable` / `moderatable` are the *bot's* power over this
+ * member and default to true, so a test that does not mention them is testing
+ * the moderator's rank rather than the bot's.
+ */
+function makeMember(id, {
+    position = 1,
+    ownerId = OWNER_ID,
+    bannable = true,
+    kickable = true,
+    moderatable = true,
+    user = null,
+} = {}) {
+    const member = {
+        id,
+        user: user ?? makeUser(id),
+        guild: { id: GUILD_ID, ownerId },
+        bannable,
+        kickable,
+        moderatable,
+        roles: { highest: { position, comparePositionTo: other => position - other.position } },
+        kick: jest.fn().mockResolvedValue(undefined),
+        timeout: jest.fn().mockResolvedValue(undefined),
+    };
+    return member;
+}
+
+/**
+ * The guild the command acts on.
+ *
+ * `members.cache` holds only what a test puts in `cached`; everything else has
+ * to come through `fetch`, which is the distinction resolveMember exists for.
+ * `fetchable` is who the fetch can find, `fetchError` is what it throws instead
+ * — the indeterminate case, which every ban-shaped command must refuse on.
+ */
+function makeGuild({
+    ownerId = OWNER_ID,
+    cached = [],
+    fetchable = [],
+    fetchError = null,
+    bans = new Map(),
+    banError = null,
+} = {}) {
+    const cache = new Map(cached.map(m => [m.id, m]));
+    const fetchableById = new Map(fetchable.map(m => [m.id, m]));
+    const actions = { banned: [], unbanned: [] };
+
+    const fetchOne = async id => {
+        if (fetchError) throw fetchError;
+        const found = fetchableById.get(id);
+        if (found) return found;
+        const err = new Error('Unknown Member');
+        err.code = UNKNOWN_MEMBER;
+        throw err;
+    };
+
+    return {
+        id: GUILD_ID,
+        name: 'Guild',
+        ownerId,
+        actions,
+        members: {
+            cache,
+            // discord.js overloads this: an id resolves one member, an object
+            // with `user` resolves a batch and simply omits the ids it cannot
+            // find — which is why a throw here says nothing about any of them.
+            fetch: jest.fn(async query => {
+                if (query && typeof query === 'object' && Array.isArray(query.user)) {
+                    if (fetchError) throw fetchError;
+                    return new Map(query.user
+                        .filter(id => fetchableById.has(id))
+                        .map(id => [id, fetchableById.get(id)]));
+                }
+                return fetchOne(query);
+            }),
+            ban: jest.fn(async (userOrId, options) => {
+                if (banError) throw banError;
+                actions.banned.push({ id: userOrId?.id ?? userOrId, options });
+            }),
+            unban: jest.fn(async (userId, reason) => {
+                actions.unbanned.push({ id: userId, reason });
+            }),
+        },
+        bans: {
+            fetch: jest.fn(async id => {
+                const found = bans.get(id);
+                if (!found) throw new Error('Unknown Ban');
+                return found;
+            }),
+        },
+        channels: { cache: new Map() },
+    };
+}
+
+/**
+ * The interaction itself.
+ *
+ * Options are a flat bag read by name — the commands only ever ask for a value,
+ * never for the option's metadata — plus `subcommand` for the three commands
+ * built out of subcommands.
+ */
+function makeInteraction({
+    options = {},
+    subcommand = null,
+    guild = makeGuild(),
+    invoker = makeMember(MOD_ID, { position: 10 }),
+    userId = MOD_ID,
+    permissions = [PermissionFlagsBits.Administrator],
+    channel = null,
+    users = new Map(),
+} = {}) {
+    const replies = [];
+    const record = payload => { replies.push(payload); return Promise.resolve(payload); };
+
+    const interaction = {
+        replies,
+        replied: false,
+        deferred: false,
+        guild,
+        member: invoker,
+        user: makeUser(userId, { username: 'moderator' }),
+        memberPermissions: new PermissionsBitField(permissions),
+        channel: channel ?? {
+            id: 'channel-1',
+            isTextBased: () => true,
+            bulkDelete: jest.fn().mockResolvedValue(new Map()),
+            setRateLimitPerUser: jest.fn().mockResolvedValue(undefined),
+        },
+        client: {
+            user: { id: BOT_ID },
+            users: {
+                fetch: jest.fn(async id => {
+                    const found = users.get(id);
+                    if (found) return found;
+                    throw new Error('Unknown User');
+                }),
+            },
+        },
+        options: {
+            getUser:       name => options[name] ?? null,
+            getString:     name => options[name] ?? null,
+            getInteger:    name => (options[name] === undefined ? null : options[name]),
+            getBoolean:    name => (options[name] === undefined ? null : options[name]),
+            getChannel:    name => options[name] ?? null,
+            getSubcommand: () => subcommand,
+        },
+    };
+
+    interaction.reply     = jest.fn(p => { interaction.replied = true; return record(p); });
+    interaction.editReply = jest.fn(p => { interaction.replied = true; return record(p); });
+    interaction.followUp  = jest.fn(record);
+    interaction.deferReply = jest.fn(async () => { interaction.deferred = true; });
+
+    return interaction;
+}
+
+/** The text of the last thing the moderator was shown, embed titles included. */
+function lastReply(interaction) {
+    const payload = interaction.replies[interaction.replies.length - 1];
+    if (payload === undefined) return '';
+    if (typeof payload === 'string') return payload;
+    if (payload.content) return payload.content;
+    const embed = payload.embeds?.[0];
+    const data = embed?.data ?? embed ?? {};
+    return [data.title, data.description, ...(data.fields ?? []).map(f => `${f.name}: ${f.value}`)]
+        .filter(Boolean)
+        .join('\n');
+}
+
+const command = name => require(`../../src/commands/moderation/${name}`);
+
+module.exports = {
+    makeUser,
+    makeMember,
+    makeGuild,
+    makeInteraction,
+    lastReply,
+    command,
+    GUILD_ID,
+    OWNER_ID,
+    BOT_ID,
+    MOD_ID,
+    UNKNOWN_MEMBER,
+};

--- a/tests/moderationCommands.test.js
+++ b/tests/moderationCommands.test.js
@@ -1,0 +1,940 @@
+'use strict';
+
+// #628: `src/commands/moderation/*` is 16 files and the whole destructive
+// surface — ban, kick, mute, massban, lockdown, clear — and not one of their
+// `execute()` functions had ever been invoked by a test. The directory's
+// reported line coverage was module-level `SlashCommandBuilder` constants
+// evaluating at import; branches were at zero, and 49 `PermissionFlagsBits` /
+// `memberPermissions` references sat unexecuted.
+//
+// The gap that matters most is the role-hierarchy guard. `src/utils/
+// moderationHierarchy.js` is at 100% and tests/moderationHierarchy.test.js
+// proves the rule — but it ties the rule to its *call sites* with a grep over
+// file source, so renaming the helper, or moving the call below the action it
+// guards, keeps that suite green. These tests drive the commands instead: a
+// trial moderator aims at the head moderator and the ban has to not happen.
+
+const { PermissionFlagsBits } = require('discord.js');
+
+jest.mock('../src/services/moderationLogService', () => ({
+    logModeration: jest.fn().mockResolvedValue({ caseId: 1 }),
+}));
+jest.mock('../src/services/antiNukeService', () => ({
+    startLockdown: jest.fn().mockResolvedValue({ ok: true, locked: 4 }),
+    endLockdown:   jest.fn().mockResolvedValue({ ok: true, restored: 4 }),
+}));
+jest.mock('../src/models/TempBan', () => ({ findOneAndUpdate: jest.fn().mockResolvedValue({}) }));
+jest.mock('../src/models/Case', () => ({
+    countDocuments: jest.fn().mockResolvedValue(0),
+    find:           jest.fn(),
+    findOne:        jest.fn().mockResolvedValue(null),
+    deleteOne:      jest.fn().mockResolvedValue({ deletedCount: 1 }),
+}));
+jest.mock('../src/models/Guild', () => ({ findOne: jest.fn().mockResolvedValue(null) }));
+jest.mock('../src/models/User', () => ({ findOneAndUpdate: jest.fn().mockResolvedValue({}) }));
+// findStepForCount is a pure function over the configured ladder and is worth
+// running for real; only the half that touches Discord is stubbed.
+jest.mock('../src/services/escalationService', () => ({
+    ...jest.requireActual('../src/services/escalationService'),
+    applyEscalation: jest.fn().mockResolvedValue({ applied: false }),
+}));
+
+const { logModeration } = require('../src/services/moderationLogService');
+const Case = require('../src/models/Case');
+const Guild = require('../src/models/Guild');
+const User = require('../src/models/User');
+const { applyEscalation } = require('../src/services/escalationService');
+const { startLockdown, endLockdown } = require('../src/services/antiNukeService');
+const TempBan = require('../src/models/TempBan');
+
+const {
+    makeUser, makeMember, makeGuild, makeInteraction, lastReply, command,
+    GUILD_ID, OWNER_ID, BOT_ID, MOD_ID,
+} = require('./helpers/moderationInteraction');
+
+// The moderator is deliberately mid-table: high enough to act on an ordinary
+// member, low enough that the head moderator and the owner are out of reach.
+const MOD_POSITION = 10;
+const modMember = () => makeMember(MOD_ID, { position: MOD_POSITION });
+
+const target = (id = 'target-1', position = 1) => makeMember(id, { position });
+const headMod = (id = 'head-mod') => makeMember(id, { position: MOD_POSITION + 5 });
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => jest.restoreAllMocks());
+
+// ── The guard, at every call site that has one ──────────────────────────────
+//
+// One table rather than one test per command, because the point is that the
+// answer is the same everywhere: the rule is not a thing each handler
+// re-implements slightly differently.
+describe('a moderator cannot act on someone who outranks them', () => {
+    const CASES = [
+        {
+            name: 'ban',
+            run: async member => {
+                const guild = makeGuild({ cached: [member] });
+                const interaction = makeInteraction({
+                    guild, options: { user: makeUser(member.id) }, invoker: modMember(),
+                });
+                await command('ban').execute(interaction);
+                return { interaction, done: guild.actions.banned.length > 0 };
+            },
+        },
+        {
+            name: 'softban',
+            run: async member => {
+                const guild = makeGuild({ cached: [member] });
+                const interaction = makeInteraction({
+                    guild, options: { user: makeUser(member.id) }, invoker: modMember(),
+                });
+                await command('softban').execute(interaction);
+                return { interaction, done: guild.actions.banned.length > 0 };
+            },
+        },
+        {
+            name: 'kick',
+            run: async member => {
+                const guild = makeGuild({ cached: [member] });
+                const interaction = makeInteraction({
+                    guild, options: { user: makeUser(member.id) }, invoker: modMember(),
+                });
+                await command('kick').execute(interaction);
+                return { interaction, done: member.kick.mock.calls.length > 0 };
+            },
+        },
+        {
+            name: 'mute',
+            run: async member => {
+                const guild = makeGuild({ cached: [member] });
+                const interaction = makeInteraction({
+                    guild, options: { user: makeUser(member.id), duration: 10 }, invoker: modMember(),
+                });
+                await command('mute').execute(interaction);
+                return { interaction, done: member.timeout.mock.calls.length > 0 };
+            },
+        },
+    ];
+
+    test.each(CASES)('$name refuses a target with a higher role', async ({ run }) => {
+        const { interaction, done } = await run(headMod());
+        expect(done).toBe(false);
+        expect(lastReply(interaction)).toMatch(/above or equal to yours/i);
+    });
+
+    // The realistic case: two moderators handed the same role. Discord treats
+    // equal as "no".
+    test.each(CASES)('$name refuses an equal', async ({ run }) => {
+        const { interaction, done } = await run(makeMember('peer', { position: MOD_POSITION }));
+        expect(done).toBe(false);
+        expect(lastReply(interaction)).toMatch(/above or equal to yours/i);
+    });
+
+    test.each(CASES)('$name refuses the server owner', async ({ run }) => {
+        const { interaction, done } = await run(makeMember(OWNER_ID, { position: 1 }));
+        expect(done).toBe(false);
+        expect(lastReply(interaction)).toMatch(/server owner/i);
+    });
+
+    test.each(CASES)('$name allows an ordinary member below them', async ({ run }) => {
+        const { done } = await run(target());
+        expect(done).toBe(true);
+    });
+});
+
+// ── ban ─────────────────────────────────────────────────────────────────────
+describe('/ban', () => {
+    const banInteraction = (overrides = {}) => {
+        const member = overrides.member ?? target();
+        const guild = overrides.guild ?? makeGuild({ cached: [member] });
+        return {
+            member,
+            guild,
+            interaction: makeInteraction({
+                guild,
+                invoker: modMember(),
+                options: { user: makeUser(member.id), ...overrides.options },
+            }),
+        };
+    };
+
+    test('bans a member below the moderator and logs the case', async () => {
+        const { guild, interaction } = banInteraction({ options: { reason: 'spam' } });
+        await command('ban').execute(interaction);
+
+        expect(guild.actions.banned).toHaveLength(1);
+        expect(guild.actions.banned[0].options.reason).toBe('spam');
+        expect(logModeration).toHaveBeenCalledWith(
+            GUILD_ID, 'ban', expect.anything(), expect.anything(), 'spam', {},
+        );
+        expect(lastReply(interaction)).toMatch(/User Banned/);
+    });
+
+    test('refuses to ban the moderator themselves', async () => {
+        const guild = makeGuild();
+        const interaction = makeInteraction({ guild, options: { user: makeUser(MOD_ID) } });
+        await command('ban').execute(interaction);
+
+        expect(guild.actions.banned).toHaveLength(0);
+        expect(lastReply(interaction)).toMatch(/cannot ban yourself/i);
+    });
+
+    test('refuses to ban the bot', async () => {
+        const guild = makeGuild();
+        const interaction = makeInteraction({ guild, options: { user: makeUser(BOT_ID) } });
+        await command('ban').execute(interaction);
+
+        expect(guild.actions.banned).toHaveLength(0);
+        expect(lastReply(interaction)).toMatch(/cannot ban myself/i);
+    });
+
+    test('refuses a target the bot itself cannot ban', async () => {
+        const { guild, interaction } = banInteraction({
+            member: makeMember('immune', { position: 1, bannable: false }),
+        });
+        await command('ban').execute(interaction);
+
+        expect(guild.actions.banned).toHaveLength(0);
+        expect(lastReply(interaction)).toMatch(/higher permissions/i);
+    });
+
+    // The member cache holds at most 200 per guild, so a target who has been
+    // quiet is a cache miss rather than a non-member. A miss must be fetched.
+    test('fetches a target the cache does not hold, and still checks their rank', async () => {
+        const boss = headMod();
+        const guild = makeGuild({ cached: [], fetchable: [boss] });
+        const interaction = makeInteraction({
+            guild, invoker: modMember(), options: { user: makeUser(boss.id) },
+        });
+        await command('ban').execute(interaction);
+
+        expect(guild.members.fetch).toHaveBeenCalledWith(boss.id);
+        expect(guild.actions.banned).toHaveLength(0);
+        expect(lastReply(interaction)).toMatch(/above or equal to yours/i);
+    });
+
+    // A ban by ID of someone who was never here is the whole point of the
+    // command's "no member" path — it must still work.
+    test('bans a user who is confirmed not in the guild', async () => {
+        const guild = makeGuild({ cached: [], fetchable: [] });
+        const interaction = makeInteraction({
+            guild, invoker: modMember(), options: { user: makeUser('outsider') },
+        });
+        await command('ban').execute(interaction);
+
+        expect(guild.actions.banned).toHaveLength(1);
+    });
+
+    // The failure a caller can provoke: a 429 on the fetch is not "not a
+    // member", and treating it as one would skip both the bot's bannable check
+    // and the moderator's rank check.
+    test('refuses when the lookup could not be settled', async () => {
+        const rateLimited = Object.assign(new Error('rate limited'), { code: 0, status: 429 });
+        const guild = makeGuild({ cached: [], fetchError: rateLimited });
+        const interaction = makeInteraction({
+            guild, invoker: modMember(), options: { user: makeUser('unknown') },
+        });
+        await command('ban').execute(interaction);
+
+        expect(guild.actions.banned).toHaveLength(0);
+        expect(lastReply(interaction)).toMatch(/could not look this user up/i);
+    });
+
+    test('a temporary ban records an expiry and says when it lifts', async () => {
+        const { interaction } = banInteraction({ options: { duration: '2h', reason: 'cooling off' } });
+        await command('ban').execute(interaction);
+
+        expect(TempBan.findOneAndUpdate).toHaveBeenCalledTimes(1);
+        const [filter, update, opts] = TempBan.findOneAndUpdate.mock.calls[0];
+        expect(filter).toEqual({ guildId: GUILD_ID, userId: 'target-1' });
+        expect(update.expiresAt.getTime()).toBeGreaterThan(Date.now());
+        expect(opts).toEqual({ upsert: true });
+        expect(lastReply(interaction)).toMatch(/User Temporarily Banned/);
+        expect(lastReply(interaction)).toMatch(/2h/);
+    });
+
+    test.each(['2 hours', '2', 'h', '-1h', '2w'])('rejects the duration %p without banning', async duration => {
+        const { guild, interaction } = banInteraction({ options: { duration } });
+        await command('ban').execute(interaction);
+
+        expect(guild.actions.banned).toHaveLength(0);
+        expect(TempBan.findOneAndUpdate).not.toHaveBeenCalled();
+        expect(lastReply(interaction)).toMatch(/Invalid duration/i);
+    });
+
+    test('a permanent ban writes no TempBan record', async () => {
+        const { interaction } = banInteraction();
+        await command('ban').execute(interaction);
+        expect(TempBan.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    test('delete_days is sent to Discord as seconds', async () => {
+        const { guild, interaction } = banInteraction({ options: { delete_days: 7 } });
+        await command('ban').execute(interaction);
+        expect(guild.actions.banned[0].options.deleteMessageSeconds).toBe(7 * 86400);
+    });
+
+    // The reply is the only place a moderator finds out; swallowing the error
+    // and saying nothing is what this branch exists to prevent.
+    test('reports a ban that Discord rejects', async () => {
+        const member = target();
+        const guild = makeGuild({ cached: [member], banError: new Error('Missing Permissions') });
+        const interaction = makeInteraction({
+            guild, invoker: modMember(), options: { user: makeUser(member.id) },
+        });
+        await command('ban').execute(interaction);
+
+        expect(lastReply(interaction)).toMatch(/Failed to ban/i);
+    });
+});
+
+// ── softban ─────────────────────────────────────────────────────────────────
+describe('/softban', () => {
+    test('bans and then unbans, so the messages go but the member may return', async () => {
+        const member = target();
+        const guild = makeGuild({ cached: [member] });
+        const interaction = makeInteraction({
+            guild, invoker: modMember(), options: { user: makeUser(member.id), reason: 'raid' },
+        });
+        await command('softban').execute(interaction);
+
+        expect(guild.actions.banned).toHaveLength(1);
+        expect(guild.actions.unbanned).toHaveLength(1);
+        expect(guild.actions.banned[0].options.reason).toBe('[Softban] raid');
+        expect(lastReply(interaction)).toMatch(/User Softbanned/);
+    });
+
+    test('deletes one day of messages by default', async () => {
+        const member = target();
+        const guild = makeGuild({ cached: [member] });
+        const interaction = makeInteraction({
+            guild, invoker: modMember(), options: { user: makeUser(member.id) },
+        });
+        await command('softban').execute(interaction);
+        expect(guild.actions.banned[0].options.deleteMessageSeconds).toBe(86400);
+    });
+
+    // The unban is the half that makes it a softban rather than a ban, but it
+    // is also the half that has already achieved its purpose if it fails.
+    test('does not unban when the ban step failed', async () => {
+        const member = target();
+        const guild = makeGuild({ cached: [member], banError: new Error('Missing Permissions') });
+        const interaction = makeInteraction({
+            guild, invoker: modMember(), options: { user: makeUser(member.id) },
+        });
+        await command('softban').execute(interaction);
+
+        expect(guild.actions.unbanned).toHaveLength(0);
+        expect(lastReply(interaction)).toMatch(/Failed to ban/i);
+    });
+
+    test('refuses when the lookup could not be settled', async () => {
+        const guild = makeGuild({ fetchError: new Error('rate limited') });
+        const interaction = makeInteraction({
+            guild, invoker: modMember(), options: { user: makeUser('unknown') },
+        });
+        await command('softban').execute(interaction);
+
+        expect(guild.actions.banned).toHaveLength(0);
+        expect(lastReply(interaction)).toMatch(/could not look this user up/i);
+    });
+
+    test.each([[MOD_ID, /cannot softban yourself/i], [BOT_ID, /cannot softban myself/i]])(
+        'refuses %s', async (id, expected) => {
+            const guild = makeGuild();
+            const interaction = makeInteraction({ guild, options: { user: makeUser(id) } });
+            await command('softban').execute(interaction);
+
+            expect(guild.actions.banned).toHaveLength(0);
+            expect(lastReply(interaction)).toMatch(expected);
+        });
+});
+
+// ── kick / mute / unmute ────────────────────────────────────────────────────
+describe('/kick', () => {
+    test('kicks a member below the moderator', async () => {
+        const member = target();
+        const guild = makeGuild({ cached: [member] });
+        const interaction = makeInteraction({
+            guild, invoker: modMember(), options: { user: makeUser(member.id), reason: 'rules' },
+        });
+        await command('kick').execute(interaction);
+
+        expect(member.kick).toHaveBeenCalledWith('rules');
+        expect(logModeration).toHaveBeenCalledWith(GUILD_ID, 'kick', expect.anything(), expect.anything(), 'rules');
+    });
+
+    test('refuses a target the bot cannot kick', async () => {
+        const member = makeMember('immune', { position: 1, kickable: false });
+        const guild = makeGuild({ cached: [member] });
+        const interaction = makeInteraction({
+            guild, invoker: modMember(), options: { user: makeUser(member.id) },
+        });
+        await command('kick').execute(interaction);
+
+        expect(member.kick).not.toHaveBeenCalled();
+        expect(lastReply(interaction)).toMatch(/higher permissions/i);
+    });
+
+    test('refuses a user who is not in the guild', async () => {
+        const interaction = makeInteraction({
+            guild: makeGuild(), invoker: modMember(), options: { user: makeUser('outsider') },
+        });
+        await command('kick').execute(interaction);
+        expect(lastReply(interaction)).toMatch(/not found in this server/i);
+    });
+
+    test('refuses to kick the moderator themselves', async () => {
+        const self = modMember();
+        const guild = makeGuild({ cached: [self] });
+        const interaction = makeInteraction({ guild, invoker: self, options: { user: makeUser(MOD_ID) } });
+        await command('kick').execute(interaction);
+
+        expect(self.kick).not.toHaveBeenCalled();
+        expect(lastReply(interaction)).toMatch(/cannot kick yourself/i);
+    });
+
+    test('reports a kick that Discord rejects', async () => {
+        const member = target();
+        member.kick.mockRejectedValue(new Error('Missing Permissions'));
+        const guild = makeGuild({ cached: [member] });
+        const interaction = makeInteraction({
+            guild, invoker: modMember(), options: { user: makeUser(member.id) },
+        });
+        await command('kick').execute(interaction);
+        expect(lastReply(interaction)).toMatch(/Failed to kick/i);
+    });
+});
+
+describe('/mute and /unmute', () => {
+    test('mute times the member out for the requested minutes', async () => {
+        const member = target();
+        const guild = makeGuild({ cached: [member] });
+        const interaction = makeInteraction({
+            guild, invoker: modMember(), options: { user: makeUser(member.id), duration: 45, reason: 'cooldown' },
+        });
+        await command('mute').execute(interaction);
+
+        expect(member.timeout).toHaveBeenCalledWith(45 * 60 * 1000, 'cooldown');
+        expect(lastReply(interaction)).toMatch(/45 minutes/);
+    });
+
+    test('mute refuses a target the bot cannot moderate', async () => {
+        const member = makeMember('immune', { position: 1, moderatable: false });
+        const guild = makeGuild({ cached: [member] });
+        const interaction = makeInteraction({
+            guild, invoker: modMember(), options: { user: makeUser(member.id), duration: 5 },
+        });
+        await command('mute').execute(interaction);
+
+        expect(member.timeout).not.toHaveBeenCalled();
+        expect(lastReply(interaction)).toMatch(/cannot mute/i);
+    });
+
+    test('unmute clears the timeout', async () => {
+        const member = target();
+        const guild = makeGuild({ cached: [member] });
+        const interaction = makeInteraction({
+            guild, invoker: modMember(), options: { user: makeUser(member.id) },
+        });
+        await command('unmute').execute(interaction);
+
+        expect(member.timeout).toHaveBeenCalledWith(null);
+        expect(lastReply(interaction)).toMatch(/User Unmuted/);
+    });
+
+    test('unmute refuses a user who is not in the guild', async () => {
+        const interaction = makeInteraction({
+            guild: makeGuild(), invoker: modMember(), options: { user: makeUser('outsider') },
+        });
+        await command('unmute').execute(interaction);
+        expect(lastReply(interaction)).toMatch(/not found/i);
+    });
+});
+
+// ── unban ───────────────────────────────────────────────────────────────────
+describe('/unban', () => {
+    const BANNED_ID = '123456789012345678';
+    const banRecord = { user: makeUser(BANNED_ID, { username: 'returner' }) };
+
+    test('unbans an id that is actually banned', async () => {
+        const guild = makeGuild({ bans: new Map([[BANNED_ID, banRecord]]) });
+        const interaction = makeInteraction({ guild, options: { user_id: BANNED_ID, reason: 'appeal upheld' } });
+        await command('unban').execute(interaction);
+
+        expect(guild.actions.unbanned).toEqual([{ id: BANNED_ID, reason: 'appeal upheld' }]);
+        expect(logModeration).toHaveBeenCalledWith(
+            GUILD_ID, 'unban', banRecord.user, expect.anything(), 'appeal upheld',
+        );
+    });
+
+    test('says so when the id is not banned, without calling unban', async () => {
+        const guild = makeGuild();
+        const interaction = makeInteraction({ guild, options: { user_id: BANNED_ID } });
+        await command('unban').execute(interaction);
+
+        expect(guild.actions.unbanned).toHaveLength(0);
+        expect(lastReply(interaction)).toMatch(/not banned/i);
+    });
+
+    test.each(['not-an-id', '123', '1'.repeat(21), ''])('rejects %p as a user id', async userId => {
+        const guild = makeGuild();
+        const interaction = makeInteraction({ guild, options: { user_id: userId } });
+        await command('unban').execute(interaction);
+
+        expect(guild.bans.fetch).not.toHaveBeenCalled();
+        expect(lastReply(interaction)).toMatch(/Invalid user ID/i);
+    });
+
+    // The unban itself succeeded; the moderator is told the log did not, rather
+    // than being told the unban failed.
+    test('an audit-log failure does not read as a failed unban', async () => {
+        logModeration.mockRejectedValueOnce(new Error('mongo down'));
+        const guild = makeGuild({ bans: new Map([[BANNED_ID, banRecord]]) });
+        const interaction = makeInteraction({ guild, options: { user_id: BANNED_ID } });
+        await command('unban').execute(interaction);
+
+        expect(guild.actions.unbanned).toHaveLength(1);
+        expect(interaction.followUp).toHaveBeenCalledWith(
+            expect.objectContaining({ content: expect.stringMatching(/failed to log/i) }),
+        );
+    });
+});
+
+// ── massban ─────────────────────────────────────────────────────────────────
+//
+// The command that used to be the way around the hierarchy rule: it looped
+// guild.members.ban() over raw IDs with neither the bannable check nor the rank
+// check the single-target commands run.
+describe('/massban', () => {
+    const id = n => `10000000000000000${n}`;
+
+    const run = async ({ ids, cached = [], fetchable = [], fetchError = null, invoker = modMember() }) => {
+        const guild = makeGuild({ cached, fetchable, fetchError });
+        const interaction = makeInteraction({
+            guild, invoker, options: { user_ids: ids.join(' '), reason: 'raid' },
+        });
+        await command('massban').execute(interaction);
+        return { guild, interaction };
+    };
+
+    test('bans the ids nobody in the guild answers to — the raid case', async () => {
+        const { guild, interaction } = await run({ ids: [id(1), id(2), id(3)] });
+        expect(guild.actions.banned.map(b => b.id)).toEqual([id(1), id(2), id(3)]);
+        expect(lastReply(interaction)).toMatch(/Banned: 3 user\(s\)/);
+    });
+
+    test('skips a member who outranks the moderator, and says why', async () => {
+        const boss = makeMember(id(2), { position: MOD_POSITION + 5 });
+        const { guild, interaction } = await run({ ids: [id(1), id(2)], cached: [boss] });
+
+        expect(guild.actions.banned.map(b => b.id)).toEqual([id(1)]);
+        expect(lastReply(interaction)).toMatch(/outranks you or the bot/i);
+    });
+
+    test('skips a member the bot cannot ban', async () => {
+        const immune = makeMember(id(2), { position: 1, bannable: false });
+        const { guild } = await run({ ids: [id(1), id(2)], cached: [immune] });
+        expect(guild.actions.banned.map(b => b.id)).toEqual([id(1)]);
+    });
+
+    // The distinction a moderator needs in order to know what to retry.
+    test('reports ids it could not look up apart from ids it refused', async () => {
+        const { guild, interaction } = await run({
+            ids: [id(1), id(2)], fetchError: new Error('rate limited'),
+        });
+        expect(guild.actions.banned).toHaveLength(0);
+        expect(lastReply(interaction)).toMatch(/could not be looked up, try again/i);
+    });
+
+    test('never bans the moderator or the bot, whatever the list says', async () => {
+        const guild = makeGuild();
+        const interaction = makeInteraction({
+            guild, invoker: modMember(),
+            options: { user_ids: [MOD_ID, BOT_ID, id(1)].join(','), reason: 'raid' },
+        });
+        await command('massban').execute(interaction);
+        // MOD_ID and BOT_ID are not 17–20 digits, so they are filtered as
+        // malformed first; the assertion that matters is that neither is banned.
+        expect(guild.actions.banned.map(b => b.id)).toEqual([id(1)]);
+    });
+
+    test('deduplicates a repeated id', async () => {
+        const { guild } = await run({ ids: [id(1), id(1), id(1)] });
+        expect(guild.actions.banned).toHaveLength(1);
+    });
+
+    test('refuses a list with no valid ids', async () => {
+        const guild = makeGuild();
+        const interaction = makeInteraction({ guild, options: { user_ids: 'nobody, at, all' } });
+        await command('massban').execute(interaction);
+
+        expect(guild.actions.banned).toHaveLength(0);
+        expect(lastReply(interaction)).toMatch(/No valid user IDs/i);
+    });
+
+    test('refuses more than fifty at once', async () => {
+        const many = Array.from({ length: 51 }, (_, i) => `1000000000000000${String(i).padStart(3, '0')}`);
+        const guild = makeGuild();
+        const interaction = makeInteraction({ guild, options: { user_ids: many.join(' ') } });
+        await command('massban').execute(interaction);
+
+        expect(guild.actions.banned).toHaveLength(0);
+        expect(lastReply(interaction)).toMatch(/Maximum 50/i);
+    });
+
+    // One batch fetch for the whole list, not one per id: the member cache holds
+    // 200 per guild, so reading it alone would make most of a raid list look
+    // like non-members and skip both checks.
+    test('resolves the whole batch in one round trip', async () => {
+        const guild = makeGuild({ fetchable: [] });
+        const interaction = makeInteraction({
+            guild, invoker: modMember(), options: { user_ids: [id(1), id(2), id(3)].join(' ') },
+        });
+        await command('massban').execute(interaction);
+
+        expect(guild.members.fetch).toHaveBeenCalledTimes(1);
+        expect(guild.members.fetch).toHaveBeenCalledWith({ user: [id(1), id(2), id(3)] });
+    });
+});
+
+// ── clear / slowmode / lockdown ─────────────────────────────────────────────
+describe('/clear', () => {
+    test('bulk-deletes the requested number of messages', async () => {
+        const interaction = makeInteraction({ options: { amount: 42 } });
+        await command('clear').execute(interaction);
+
+        expect(interaction.channel.bulkDelete).toHaveBeenCalledWith(42, true);
+        expect(lastReply(interaction)).toMatch(/deleted 42 messages/i);
+    });
+
+    // Discord refuses to bulk-delete anything older than 14 days, and the reply
+    // is the only place a moderator learns that is what happened.
+    test('explains a failure rather than reporting a deletion that did not happen', async () => {
+        const interaction = makeInteraction({ options: { amount: 10 } });
+        interaction.channel.bulkDelete.mockRejectedValue(new Error('too old'));
+        await command('clear').execute(interaction);
+
+        expect(lastReply(interaction)).toMatch(/14\+ days/);
+    });
+});
+
+describe('/slowmode', () => {
+    test('applies the cooldown to the current channel by default', async () => {
+        const interaction = makeInteraction({ options: { seconds: 30 } });
+        await command('slowmode').execute(interaction);
+
+        expect(interaction.channel.setRateLimitPerUser).toHaveBeenCalledWith(30, expect.any(String));
+        expect(lastReply(interaction)).toMatch(/Slowmode Enabled/);
+    });
+
+    test('zero seconds reads as disabling it', async () => {
+        const interaction = makeInteraction({ options: { seconds: 0 } });
+        await command('slowmode').execute(interaction);
+
+        expect(interaction.channel.setRateLimitPerUser).toHaveBeenCalledWith(0, expect.any(String));
+        expect(lastReply(interaction)).toMatch(/Slowmode Disabled/);
+    });
+
+    test('applies to the named channel when one is given', async () => {
+        const other = {
+            id: 'channel-2',
+            isTextBased: () => true,
+            setRateLimitPerUser: jest.fn().mockResolvedValue(undefined),
+            toString: () => '<#channel-2>',
+        };
+        const interaction = makeInteraction({ options: { seconds: 5, channel: other } });
+        await command('slowmode').execute(interaction);
+
+        expect(other.setRateLimitPerUser).toHaveBeenCalledWith(5, expect.any(String));
+        expect(interaction.channel.setRateLimitPerUser).not.toHaveBeenCalled();
+    });
+
+    test('refuses a channel that is not text-based', async () => {
+        const voice = { id: 'voice-1', isTextBased: () => false, setRateLimitPerUser: jest.fn() };
+        const interaction = makeInteraction({ options: { seconds: 5, channel: voice } });
+        await command('slowmode').execute(interaction);
+
+        expect(voice.setRateLimitPerUser).not.toHaveBeenCalled();
+        expect(lastReply(interaction)).toMatch(/only be set on text channels/i);
+    });
+});
+
+describe('/lockdown', () => {
+    test('start locks the server and reports the count', async () => {
+        const interaction = makeInteraction({ subcommand: 'start', options: { reason: 'raid' } });
+        await command('lockdown').execute(interaction);
+
+        expect(startLockdown).toHaveBeenCalledWith(
+            interaction.guild, interaction.client,
+            { startedBy: MOD_ID, reason: 'raid' },
+        );
+        expect(lastReply(interaction)).toMatch(/Locked \*\*4\*\* channels/);
+    });
+
+    test('start defaults the reason rather than recording an empty one', async () => {
+        const interaction = makeInteraction({ subcommand: 'start' });
+        await command('lockdown').execute(interaction);
+        expect(startLockdown.mock.calls[0][2].reason).toBe('Manual lockdown');
+    });
+
+    test('end lifts it and reports what was restored', async () => {
+        const interaction = makeInteraction({ subcommand: 'end' });
+        await command('lockdown').execute(interaction);
+
+        expect(endLockdown).toHaveBeenCalledWith(interaction.guild, { endedBy: MOD_ID });
+        expect(lastReply(interaction)).toMatch(/Restored \*\*4\*\* channels/);
+    });
+
+    test.each(['start', 'end'])('%s surfaces a refusal from the service', async sub => {
+        startLockdown.mockResolvedValueOnce({ ok: false, error: 'already active' });
+        endLockdown.mockResolvedValueOnce({ ok: false, error: 'nothing to lift' });
+        const interaction = makeInteraction({ subcommand: sub });
+        await command('lockdown').execute(interaction);
+
+        expect(lastReply(interaction)).toMatch(/Could not (start|end) lockdown:/);
+    });
+
+    // Server-wide channel edits are slow enough to blow the three-second
+    // interaction window; without the defer the reply lands on a dead token.
+    test.each(['start', 'end'])('%s defers before doing the work', async sub => {
+        const interaction = makeInteraction({ subcommand: sub });
+        await command('lockdown').execute(interaction);
+        expect(interaction.deferReply).toHaveBeenCalled();
+    });
+});
+
+// ── warn ────────────────────────────────────────────────────────────────────
+//
+// The largest file in the directory, and the one whose `memberPermissions`
+// reference decides something: `bypass_escalation` is offered to anyone who can
+// run /warn, and honoured only for someone who also holds Manage Messages.
+describe('/warn', () => {
+    const TARGET = makeUser('target-1', { username: 'offender' });
+
+    const ladder = (...steps) => ({ moderation: { escalation: { enabled: true, ladder: steps } } });
+
+    beforeEach(() => {
+        Case.countDocuments.mockResolvedValue(3);
+        Case.findOne.mockResolvedValue(null);
+        Guild.findOne.mockResolvedValue(null);
+    });
+
+    const warnAdd = (options = {}, permissions) => makeInteraction({
+        subcommand: 'add',
+        options: { user: TARGET, reason: 'being unpleasant', ...options },
+        ...(permissions ? { permissions } : {}),
+    });
+
+    test('records the warning, counts it, and tells the member', async () => {
+        const interaction = warnAdd();
+        await command('warn').execute(interaction);
+
+        expect(logModeration).toHaveBeenCalledWith(
+            GUILD_ID, 'warn', TARGET, expect.anything(), 'being unpleasant',
+        );
+        expect(User.findOneAndUpdate).toHaveBeenCalledWith(
+            { userId: TARGET.id, guildId: GUILD_ID },
+            { $set: { lastWarnedAt: expect.any(Date) } },
+            { upsert: true },
+        );
+        expect(TARGET.send).toHaveBeenCalledWith(expect.stringContaining('being unpleasant'));
+        expect(lastReply(interaction)).toMatch(/Total Warnings: 3/);
+    });
+
+    test('refuses to warn a bot', async () => {
+        const bot = makeUser('bot-9', { bot: true });
+        const interaction = makeInteraction({ subcommand: 'add', options: { user: bot, reason: 'x' } });
+        await command('warn').execute(interaction);
+
+        expect(logModeration).not.toHaveBeenCalled();
+        expect(lastReply(interaction)).toMatch(/cannot warn bots/i);
+    });
+
+    // A member who cannot bypass asking to bypass must not silently bypass.
+    test('ignores a bypass from a moderator without Manage Messages, and says so', async () => {
+        Guild.findOne.mockResolvedValue(ladder({ threshold: 3, action: 'mute', durationMinutes: 10 }));
+        const interaction = warnAdd({ bypass_escalation: true }, [PermissionFlagsBits.ModerateMembers]);
+        await command('warn').execute(interaction);
+
+        expect(lastReply(interaction)).toMatch(/Requested but ignored/);
+        expect(applyEscalation).toHaveBeenCalledTimes(1);
+    });
+
+    test('honours a bypass from a moderator who holds Manage Messages', async () => {
+        Guild.findOne.mockResolvedValue(ladder({ threshold: 3, action: 'mute', durationMinutes: 10 }));
+        const interaction = warnAdd({ bypass_escalation: true },
+            [PermissionFlagsBits.ModerateMembers, PermissionFlagsBits.ManageMessages]);
+        await command('warn').execute(interaction);
+
+        expect(applyEscalation).not.toHaveBeenCalled();
+        expect(lastReply(interaction)).toMatch(/Bypassed — would have triggered MUTE at 3 warnings/);
+    });
+
+    test('a bypass at a count with no step says there was nothing to bypass', async () => {
+        Guild.findOne.mockResolvedValue(ladder({ threshold: 10, action: 'ban' }));
+        const interaction = warnAdd({ bypass_escalation: true });
+        await command('warn').execute(interaction);
+
+        expect(lastReply(interaction)).toMatch(/no matching step at this count/i);
+    });
+
+    test('announces an escalation that fired', async () => {
+        Guild.findOne.mockResolvedValue(ladder({ threshold: 3, action: 'mute', durationMinutes: 30 }));
+        applyEscalation.mockResolvedValueOnce({
+            applied: true, step: { threshold: 3, action: 'mute', durationMinutes: 30 },
+        });
+        const interaction = warnAdd();
+        await command('warn').execute(interaction);
+
+        expect(interaction.followUp).toHaveBeenCalledTimes(1);
+        expect(lastReply(interaction)).toMatch(/Auto-Escalation Triggered/);
+    });
+
+    test.each([
+        ['skipped', { skipped: true, reason: 'target outranks the bot', step: { threshold: 3, action: 'ban' } }, /skipped: target outranks the bot/],
+        ['failed',  { error: new Error('boom'), step: { threshold: 3, action: 'ban' } },                          /failed — see logs/],
+    ])('reports an escalation that %s', async (_label, result, expected) => {
+        Guild.findOne.mockResolvedValue(ladder({ threshold: 3, action: 'ban' }));
+        applyEscalation.mockResolvedValueOnce(result);
+        const interaction = warnAdd();
+        await command('warn').execute(interaction);
+
+        expect(interaction.followUp).toHaveBeenCalledWith(
+            expect.objectContaining({ content: expect.stringMatching(expected) }),
+        );
+    });
+
+    test('does not escalate when the guild has the ladder switched off', async () => {
+        Guild.findOne.mockResolvedValue({ moderation: { escalation: { enabled: false, ladder: [{ threshold: 3, action: 'ban' }] } } });
+        await command('warn').execute(warnAdd());
+        expect(applyEscalation).not.toHaveBeenCalled();
+    });
+
+    // The warning itself succeeded; losing the achievement timestamp must not
+    // turn into a failed warning.
+    test('a failed lastWarnedAt write does not fail the warning', async () => {
+        User.findOneAndUpdate.mockRejectedValueOnce(new Error('mongo down'));
+        const interaction = warnAdd();
+        await command('warn').execute(interaction);
+
+        expect(lastReply(interaction)).toMatch(/User Warned/);
+    });
+
+    test('reports a warning that could not be recorded at all', async () => {
+        logModeration.mockRejectedValueOnce(new Error('mongo down'));
+        const interaction = warnAdd();
+        await command('warn').execute(interaction);
+
+        expect(lastReply(interaction)).toMatch(/Failed to warn/i);
+    });
+
+    describe('list', () => {
+        const listOf = warnings => {
+            Case.find.mockReturnValue({
+                sort: () => ({ limit: () => Promise.resolve(warnings) }),
+            });
+        };
+
+        test('says so when there are none', async () => {
+            listOf([]);
+            const interaction = makeInteraction({ subcommand: 'list', options: { user: TARGET } });
+            await command('warn').execute(interaction);
+            expect(lastReply(interaction)).toMatch(/has no warnings/i);
+        });
+
+        test('lists them newest first with their case ids', async () => {
+            listOf([
+                { caseId: 7, reason: 'flooding',  createdAt: new Date('2026-02-01T00:00:00Z') },
+                { caseId: 4, reason: 'name-calling', createdAt: new Date('2026-01-01T00:00:00Z') },
+            ]);
+            const interaction = makeInteraction({ subcommand: 'list', options: { user: TARGET } });
+            await command('warn').execute(interaction);
+
+            const shown = lastReply(interaction);
+            expect(shown).toMatch(/#7/);
+            expect(shown).toMatch(/2026-02-01/);
+            expect(shown).toMatch(/flooding/);
+        });
+
+        // `reason` is a required string with no length cap, so it arrives at up
+        // to Discord's own 6,000-character ceiling — and an embed description
+        // allows 4,096. discord.js throws rather than truncating.
+        test('drops whole lines rather than throwing on an over-long list', async () => {
+            listOf(Array.from({ length: 20 }, (_, i) => ({
+                caseId: i + 1,
+                reason: 'x'.repeat(400),
+                createdAt: new Date('2026-01-01T00:00:00Z'),
+            })));
+            const interaction = makeInteraction({ subcommand: 'list', options: { user: TARGET } });
+            await command('warn').execute(interaction);
+
+            const payload = interaction.replies[interaction.replies.length - 1];
+            const data = payload.embeds[0].data;
+            expect(data.description.length).toBeLessThanOrEqual(4096);
+            expect(data.footer.text).toMatch(/of 20 warning\(s\) shown/);
+        });
+    });
+
+    describe('remove', () => {
+        test('deletes the case and quotes what it said', async () => {
+            Case.findOne.mockResolvedValue({ _id: 'case-oid', caseId: 12, reason: 'flooding' });
+            const interaction = makeInteraction({ subcommand: 'remove', options: { case_id: 12 } });
+            await command('warn').execute(interaction);
+
+            expect(Case.deleteOne).toHaveBeenCalledWith({ _id: 'case-oid' });
+            expect(lastReply(interaction)).toMatch(/Warning Removed/);
+            expect(lastReply(interaction)).toMatch(/flooding/);
+        });
+
+        // Scoped to this guild: a case id from another server is not this
+        // moderator's to delete.
+        test('refuses an id that is not a warning in this guild', async () => {
+            Case.findOne.mockResolvedValue(null);
+            const interaction = makeInteraction({ subcommand: 'remove', options: { case_id: 99 } });
+            await command('warn').execute(interaction);
+
+            expect(Case.findOne).toHaveBeenCalledWith({ guildId: GUILD_ID, caseId: 99, type: 'warn' });
+            expect(Case.deleteOne).not.toHaveBeenCalled();
+            expect(lastReply(interaction)).toMatch(/not found in this server/i);
+        });
+    });
+});
+
+// ── the permission surface, as declared ─────────────────────────────────────
+//
+// The gate in events/interactionCreate is what enforces these, and
+// tests/commandPermissionGate.test.js proves the gate. What is left is that
+// each command declares the bits it means — a command that forgets is a command
+// the gate waves through.
+describe('what the moderation commands require', () => {
+    const EXPECTED = {
+        ban:       [PermissionFlagsBits.BanMembers],
+        softban:   [PermissionFlagsBits.BanMembers],
+        unban:     [PermissionFlagsBits.BanMembers],
+        massban:   [PermissionFlagsBits.BanMembers, PermissionFlagsBits.ManageGuild],
+        kick:      [PermissionFlagsBits.KickMembers],
+        mute:      [PermissionFlagsBits.ModerateMembers],
+        unmute:    [PermissionFlagsBits.ModerateMembers],
+        warn:      [PermissionFlagsBits.ModerateMembers],
+        clear:     [PermissionFlagsBits.ManageMessages],
+        slowmode:  [PermissionFlagsBits.ManageChannels],
+        lockdown:  [PermissionFlagsBits.ManageGuild],
+    };
+
+    test.each(Object.entries(EXPECTED))('/%s requires exactly what it should', (name, bits) => {
+        expect(command(name).requiredPermissions).toEqual(bits);
+    });
+
+    // massban is the one command that wants two bits, and the builder default
+    // has to be the same pair — a default of one bit and a gate of two is a
+    // command Discord offers to people it then refuses.
+    test('massban declares both bits in its Discord default too', () => {
+        const asDefault = BigInt(command('massban').data.default_member_permissions);
+        expect(asDefault & PermissionFlagsBits.BanMembers).toBe(PermissionFlagsBits.BanMembers);
+        expect(asDefault & PermissionFlagsBits.ManageGuild).toBe(PermissionFlagsBits.ManageGuild);
+    });
+});

--- a/tests/requirePathsResolve.test.js
+++ b/tests/requirePathsResolve.test.js
@@ -32,13 +32,27 @@ function walk(dir) {
 // Browser-side scripts are served to the page, not required by node.
 const BROWSER_SCRIPTS = /^dashboard\/public\//;
 
+// A file that is gone by the time it is read is not a source file. Jest runs
+// suites in parallel workers, and tests/apiDocs.test.js writes a throwaway
+// router into src/dashboard/routes/api/ and deletes it again — so this walk can
+// list a name that no longer exists a moment later, and the whole suite failed
+// to load on the timing rather than on anything in src/.
+const readOrSkip = full => {
+    try {
+        return fs.readFileSync(full, 'utf8');
+    } catch (err) {
+        if (err.code === 'ENOENT') return null;
+        throw err;
+    }
+};
+
 const sourceFiles = walk(SRC)
     .map(full => ({
         full,
         rel: path.relative(SRC, full).split(path.sep).join('/'),
-        text: fs.readFileSync(full, 'utf8'),
+        text: readOrSkip(full),
     }))
-    .filter(f => !BROWSER_SCRIPTS.test(f.rel));
+    .filter(f => f.text !== null && !BROWSER_SCRIPTS.test(f.rel));
 
 describe('every relative require in src resolves', () => {
     test('no module requires a path that is not there', () => {


### PR DESCRIPTION
Closes #639, closes #628, closes #625.

#804 and #629 were on the original list and are not here — #806 landed them both while this branch was in progress.

## #639 — validation ran after the database had already been written to

`src/index.js` checked that five variables were present. The rest — `DASHBOARD_URL` parses, carries no path, and is HTTPS in production; `SESSION_SECRET` is at least 32 characters — was enforced inside `dashboard/server.js`, which starts *after* `connectDatabase()` and `runMigrations()`. So a deploy with `NODE_ENV=production` and a `http://` dashboard URL was always going to be rejected, and got as far as migrating the database before it was. The crash-loop is fine; having already written to the database on the way there is not, because migrations are forward-only.

Every rule now lives in `src/config/validateEnv.js`, and both entry points call `assertEnv()` as their first statement after the secrets are loaded. `src/shard.js` gets it too, so a bad config is one message from the manager rather than N from the children it respawns. The dashboard still applies the same rules where it needs their answers — `createApp()` can be handed an environment directly by a test — but no longer defines them.

Three checks that had nowhere to live came along with the move: `DASHBOARD_PORT` has to be a port number, `MONGODB_URI` has to carry a `mongodb` scheme, and everything wrong is reported at once rather than one deploy round trip per missing variable.

## #628 — 16 moderation commands, no `execute()` ever run

The directory reported 26% lines, which was module-level `SlashCommandBuilder` constants evaluating at import. Branches were at 1.6% and 49 `PermissionFlagsBits` / `memberPermissions` references sat unexecuted.

The gap that mattered was the role-hierarchy guard. The rule in `utils/moderationHierarchy.js` is at 100%, but it was tied to its *call sites* by a grep over file source — so renaming the helper, or moving a call below the action it guards, kept that suite green. These tests drive the commands instead: a trial moderator aims at the head moderator, and the ban has to not happen. Deleting the guard from `ban.js` now fails four assertions here as well as the grep (checked by mutation).

`tests/helpers/moderationInteraction.js` is the harness — a guild with role positions the guard can compare, a member cache that misses the way the real one does at 200 entries per guild, and a ban/kick/timeout surface that records rather than performs. Covered: every hierarchy call site against a senior, an equal and the owner; the indeterminate-lookup refusal a 429 can provoke; ban durations and `delete_days`; softban's two halves; massban's per-id refusal, unverified and dedup paths; unban's id validation and its log-failed-but-unban-succeeded reply; clear, slowmode, lockdown and warn.

Branches over the directory go from **1.6% to 65%**.

### One live bug, found by running the code

`/warn`'s `matchedStep` is read only by the two escalation-bypass branches, and was computed under `!bypassEscalation` — so it was worked out in exactly the case nothing reads it and left `null` in the case that does. "Bypassed — would have triggered MUTE at 3 warnings" was unreachable, and a moderator who bypassed an escalation at its exact threshold was told there was no step to bypass. The ternary is inverted.

## #625 — a floor under each subsystem, not just under the total

The global ratchet in `jest.config.js` is what stops the total sliding, and it was this issue's own recommendation — it landed in #635. What one number cannot express is *where* the coverage is. `src/services/ai/mcp` is at 94% and `src/commands/economy` at 18%; the total is a weighted average, so deleting every MCP test costs about four points of a 37% total and the run stays green. A whole subsystem can go to zero without the number guarding it moving far enough to notice.

`coverage-floors.json` + `scripts/check-coverage.js` (`npm run coverage:check`, wired into CI) add three checks over the same `coverage-summary.json` the existing CI step already reads:

- **A floor per directory** — 31 of them, each recorded three points under measurement, which is slack enough for a refactor and nowhere near enough for a deleted suite. A directory that appears with no floor fails too, so a new subsystem cannot arrive outside the ratchet.
- **`neverExecuted`** — the 13 files no suite reaches. It may shrink and must not grow, and a listed file that is covered now is also an error, since a stale entry is standing permission to un-cover it.
- **`coveredOnlyByIntegration`** — currently one file, `src/models/MigrationRecord.js`. See below; this list is why.

Deliberately not Jest `coverageThreshold` path keys: Jest subtracts every path-keyed group from the global group, so directory keys there would quietly redefine the global ratchet to mean "everything except the directories listed".

`npm run coverage:check -- --update` re-records the floors when coverage rises. It will not write a number below one already recorded, so it cannot be used to make a failure go away. Documented in `docs/EXTENDING.md`.

### Why there are two lists, not one

The first push of this went red, on the ratchet it was adding — worth keeping in the record, because the same tension applies to anyone re-recording the floors later.

The floors were recorded from an integration-excluded run, because this sandbox gets a 403 fetching `fastdl.mongodb.org` and cannot start `mongodb-memory-server`. CI has no such problem and runs `tests/integration/` too, where `migrations.test.js` executes every migration against a real mongod — which covers `src/models/MigrationRecord.js`. So the stale-entry check fired on a file that is genuinely covered in CI and genuinely uncovered locally. Neither reading is wrong, and one list could not hold both.

Hence `coveredOnlyByIntegration`: entries there pass whether they read as zero or covered, so both shapes of the run agree. It has its own guard — an entry that was not measured at all fails, so it cannot become somewhere to hide a deleted file — and `--update` no longer folds those entries back onto `neverExecuted` when run without integration.

The same asymmetry is why the **directory floors stay recorded from the integration-excluded run**, matching what `jest.config.js` already does so the number CI sees is that or better. It does mean a floor for a directory the integration suites cover is looser than CI's own measurement: `src/migrations` measures 45.8% locally and 81.8% in CI. That is now written down in the script and in `docs/EXTENDING.md` rather than left implied.

## One unrelated fix

`tests/requirePathsResolve.test.js` walks `src/` and reads every file at module load. `tests/apiDocs.test.js` writes a throwaway router into `src/dashboard/routes/api/` and deletes it again, and Jest runs suites in parallel workers — so the walk could list a name that was gone by the time it read it, and the whole suite failed to load on the timing rather than on anything in `src/`. It hit once during this work. A file that vanishes between the listing and the read is not a source file; it is skipped.

## Verification

- 207 suites / 3,791 tests pass locally (integration excluded, per the 403 above).
- `npx eslint .` clean.
- `npm run coverage:check` verified against **both** shapes of the run, since only one can be produced here: the real local summary, and the same summary patched to cover `MigrationRecord.js` the way CI does. Both exit 0.
- Global thresholds unchanged at 36/25/38/37 against a measured 37.76/27.22/39.30/38.95 locally, 38.28/27.41/40.01/39.48 in CI.
- The hierarchy and massban guards were mutation-checked: removing each one fails the new tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_013sn4YNpaL5rWo34RbbBEnz)_