### PR TITLE
Let the rare companions announce all four of themselves

### DIFF
--- a/src/commands/economy/pet.js
+++ b/src/commands/economy/pet.js
@@ -1278,6 +1278,21 @@ async function pvpBattle(interaction, ctx) {
     });
 }
 
+// The rare companions and where they turn up, read off PET_DEFINITIONS rather
+// than spelled out: the footer named three pets and three grinds for as long as
+// there were three, and stayed that way when the Lantern Owl was added (#753) —
+// leaving the only in-game mention of a pet nobody can buy pointing at the
+// wrong set. Deriving it means the next one added lists itself.
+function rareCompanionFooter() {
+    const rare    = Object.values(PET_DEFINITIONS).filter(d => !d.purchasable);
+    const names   = rare.map(d => d.name);
+    const sources = [...new Set(rare.map(d => d.materialSource))];
+    const nameList = names.length > 1
+        ? `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`
+        : names[0];
+    return `${nameList} aren't sold — each has a ${Math.round(RARE_PET_DROP_CHANCE * 100)}% chance to appear on a legendary ${sources.join(' / ')}`;
+}
+
 async function executeList(interaction) {
     const lines = Object.values(PET_DEFINITIONS)
         .filter(d => d.purchasable)
@@ -1288,7 +1303,7 @@ async function executeList(interaction) {
         .setColor(COLORS.WARN)
         .setTitle('🐾 Pet Shop')
         .setDescription(`Pets level up from feeding and battling, and their passive grows with them.\n\n${lines.join('\n\n')}`)
-        .setFooter({ text: `Eagle, Shark and Crystal Fox aren't sold — each has a ${Math.round(RARE_PET_DROP_CHANCE * 100)}% chance to appear on a legendary hunt / fish / mine` })
+        .setFooter({ text: rareCompanionFooter() })
         .setTimestamp();
 
     return interaction.reply({ embeds: [embed] });
@@ -1468,3 +1483,5 @@ module.exports = {
         }
     }
 };
+
+module.exports.__test__ = { rareCompanionFooter };

--- a/src/data/achievements.js
+++ b/src/data/achievements.js
@@ -8,6 +8,16 @@ const { CORE_REGION_IDS, TOTAL_CORE_SECRETS } = require('./exploreData');
 // `check(user, guildSettings)` returns true when the achievement is earned.
 // `secret: true` hides name/description/progress until the achievement is earned.
 
+// Every unpurchasable pet, in the order petService defines them. Kept here as a
+// literal because src/data must not depend on a service; tests/petAchievements
+// asserts it still matches the unpurchasable set in PET_DEFINITIONS, so adding a
+// rare companion without widening Menagerie fails there rather than silently
+// leaving an achievement that claims to want all of them but checks a subset.
+// Widening it is safe for players who already earned it: achievementService
+// skips any achievement already in user.achievements, so an earned Menagerie is
+// never re-checked and never taken back.
+const RARE_COMPANION_IDS = ['eagle', 'shark', 'crystal_fox', 'lantern_owl'];
+
 const ACHIEVEMENTS = [
     // ── Economy ──────────────────────────────────────────────────────────────
     {
@@ -548,18 +558,18 @@ const ACHIEVEMENTS = [
     {
         id: 'menagerie',
         name: 'Menagerie',
-        description: 'Find all three rare companions: Eagle, Shark and Crystal Fox',
+        description: 'Find all four rare companions: Eagle, Shark, Crystal Fox and Lantern Owl',
         emoji: '💎',
         category: 'pets',
         xpReward: 1_000,
         coinReward: 15_000,
         check: (user) => {
             const owned = new Set((user.pets || []).map(p => p.petId));
-            return ['eagle', 'shark', 'crystal_fox'].every(id => owned.has(id));
+            return RARE_COMPANION_IDS.every(id => owned.has(id));
         },
         progress: (user) => {
             const owned = new Set((user.pets || []).map(p => p.petId));
-            return [['eagle', 'shark', 'crystal_fox'].filter(id => owned.has(id)).length, 3];
+            return [RARE_COMPANION_IDS.filter(id => owned.has(id)).length, RARE_COMPANION_IDS.length];
         }
     },
 
@@ -916,4 +926,4 @@ const CATEGORY_EMOJIS = {
     custom: '⚙️'
 };
 
-module.exports = { ACHIEVEMENTS, CATEGORY_LABELS, CATEGORY_EMOJIS };
+module.exports = { ACHIEVEMENTS, CATEGORY_LABELS, CATEGORY_EMOJIS, RARE_COMPANION_IDS };

--- a/tests/petAchievements.test.js
+++ b/tests/petAchievements.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { ACHIEVEMENTS, CATEGORY_LABELS, CATEGORY_EMOJIS } = require('../src/data/achievements');
+const { ACHIEVEMENTS, CATEGORY_LABELS, CATEGORY_EMOJIS, RARE_COMPANION_IDS } = require('../src/data/achievements');
 
 const petAchievements = ACHIEVEMENTS.filter(a => a.category === 'pets');
 const byId = id => petAchievements.find(a => a.id === id);
@@ -74,18 +74,42 @@ describe('pet achievements', () => {
         expect(byId('inseparable').check({ pets: [pet({ adoptedAt: new Date(Date.now() - 31 * DAY) })] })).toBe(true);
     });
 
-    test('Menagerie needs all three rare companions', () => {
+    test('Menagerie needs every rare companion', () => {
         const owned = ids => ({ pets: ids.map(petId => pet({ petId })) });
-        expect(byId('menagerie').check(owned(['eagle', 'shark']))).toBe(false);
-        expect(byId('menagerie').progress(owned(['eagle', 'shark']))).toEqual([2, 3]);
-        expect(byId('menagerie').check(owned(['eagle', 'shark', 'crystal_fox']))).toBe(true);
+        const all   = RARE_COMPANION_IDS;
+        const short = all.slice(0, -1);
+
+        expect(byId('menagerie').check(owned(short))).toBe(false);
+        expect(byId('menagerie').progress(owned(short))).toEqual([short.length, all.length]);
+        expect(byId('menagerie').check(owned(all))).toBe(true);
+        expect(byId('menagerie').progress(owned(all))).toEqual([all.length, all.length]);
+    });
+
+    // The Lantern Owl shipped (#753) while Menagerie still asked for three pets,
+    // so an achievement that says "every rare companion" checked a subset of
+    // them. Pinning the list to PET_DEFINITIONS makes the next one added fail
+    // here instead of quietly repeating that.
+    test('Menagerie tracks exactly the pets that cannot be bought', () => {
+        const { PET_DEFINITIONS } = require('../src/services/petService');
+        const unpurchasable = Object.values(PET_DEFINITIONS)
+            .filter(d => !d.purchasable)
+            .map(d => d.petId);
+        expect([...RARE_COMPANION_IDS].sort()).toEqual([...unpurchasable].sort());
     });
 
     test('Menagerie is reachable — every rare pet can actually drop', () => {
-        const { rarePetForSource } = require('../src/services/petService');
-        for (const petId of ['eagle', 'shark', 'crystal_fox']) {
-            const source = require('../src/services/petService').PET_DEFINITIONS[petId].materialSource;
+        const { rarePetForSource, PET_DEFINITIONS } = require('../src/services/petService');
+        for (const petId of RARE_COMPANION_IDS) {
+            const source = PET_DEFINITIONS[petId].materialSource;
             expect(rarePetForSource(source).petId).toBe(petId);
+        }
+    });
+
+    test('the Menagerie description names the companions it checks', () => {
+        const { PET_DEFINITIONS } = require('../src/services/petService');
+        const { description } = byId('menagerie');
+        for (const petId of RARE_COMPANION_IDS) {
+            expect(description).toContain(PET_DEFINITIONS[petId].name);
         }
     });
 });

--- a/tests/petShopFooter.test.js
+++ b/tests/petShopFooter.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+// The Pet Shop footer is the only place in-game that says the rare companions
+// exist and where to look for them. It named three pets and three grinds, and
+// stayed that way when the Lantern Owl was added (#753) — so the owl, and
+// exploration as a place a pet can turn up, went unmentioned everywhere a
+// player could see. It is derived from PET_DEFINITIONS now; these lock that in.
+const { __test__: { rareCompanionFooter } } = require('../src/commands/economy/pet');
+const { PET_DEFINITIONS, RARE_PET_DROP_CHANCE } = require('../src/services/petService');
+
+const rare = Object.values(PET_DEFINITIONS).filter(d => !d.purchasable);
+
+describe('the Pet Shop rare-companion footer', () => {
+    test('names every pet that cannot be bought', () => {
+        const footer = rareCompanionFooter();
+        for (const def of rare) expect(footer).toContain(def.name);
+    });
+
+    test('names every grind one can drop from', () => {
+        const footer = rareCompanionFooter();
+        for (const source of new Set(rare.map(d => d.materialSource))) {
+            expect(footer).toContain(source);
+        }
+    });
+
+    // Substring checks can't do this one — the purchasable Fox lives inside
+    // "Crystal Fox" — so read the list back out of the sentence and compare it
+    // as a set.
+    test('lists the rare companions and nothing else', () => {
+        const listed = rareCompanionFooter()
+            .replace(/ aren't sold —.*$/, '')
+            .split(/, | and /);
+        expect(listed.sort()).toEqual(rare.map(d => d.name).sort());
+    });
+
+    test('quotes the drop chance from the service', () => {
+        expect(rareCompanionFooter()).toContain(`${Math.round(RARE_PET_DROP_CHANCE * 100)}%`);
+    });
+
+    test('reads as a sentence, not a bare list', () => {
+        expect(rareCompanionFooter()).toMatch(/^Eagle, Shark, Crystal Fox and Lantern Owl aren't sold — /);
+    });
+});


### PR DESCRIPTION
The Lantern Owl shipped in #753 as the fourth pet nobody can buy, but the
two places that name that set were written when there were three and stayed
that way: the Pet Shop footer offered "Eagle, Shark and Crystal Fox ... on a
legendary hunt / fish / mine", and Menagerie asked for "all three rare
companions". The footer is the only in-game mention that unpurchasable pets
exist at all, so the owl — and exploration as somewhere a pet can turn up —
was invisible to players, and an achievement claiming to want every rare
companion could be earned while one was still missing.

The footer now reads its names and its grinds off PET_DEFINITIONS, so a
fifth companion lists itself. Menagerie keeps a literal id list, since
src/data must not depend on a service, and a test pins that list to the
unpurchasable set in PET_DEFINITIONS — adding a rare pet without widening
the achievement fails there rather than repeating this quietly.

Widening Menagerie takes nothing back from anyone: achievementService skips
any achievement already in user.achievements, so an earned one is never
re-checked. Players who completed the three-pet version keep it; players
partway through now see a fourth step.