### PR TITLE
Stop the AI transport pinging anybody on somebody else's say-so

### DIFF
--- a/src/services/ai/discordChat.js
+++ b/src/services/ai/discordChat.js
@@ -33,6 +33,40 @@ const PAINT_LOCK_TICK_MS = 25;
 function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
 
 /**
+ * Nothing this transport sends is allowed to ping anybody.
+ *
+ * Every message it posts is assembled from text the bot did not write: the
+ * model's own output, an MCP server's progress note, a tool result, the title
+ * of a knowledge entry. A model can be talked into typing `@everyone`, and a
+ * server can call a tool it — and either one arriving in Discord as a live
+ * mention is this bot pinging a server on a stranger's say-so.
+ *
+ * `utils/toolLabel.js` strips what it can from the names it handles, and says
+ * in as many words that it is belt rather than braces. This is the braces, and
+ * it belongs on the send: it is the one place that covers the model's text as
+ * well, which is the larger surface and was never covered at all.
+ *
+ * `repliedUser` keeps the single mention this transport actually means — a
+ * reply notifies the person who asked, the way it always has. Specifying
+ * `allowedMentions` at all turns that default off, so it is asked for back.
+ */
+const NO_MENTIONS = { parse: [] };
+const REPLY_MENTIONS = { parse: [], repliedUser: true };
+
+// Discord takes a bare string or a payload object. These take either and always
+// hand back a payload carrying the policy, so a call site cannot post without
+// one by writing the shorter form.
+function withMentionPolicy(content, allowedMentions) {
+    return typeof content === 'string'
+        ? { content, allowedMentions }
+        : { allowedMentions, ...content };
+}
+
+const reply = (message, content) => message.reply(withMentionPolicy(content, REPLY_MENTIONS));
+const send = (channel, content) => channel.send(withMentionPolicy(content, NO_MENTIONS));
+const edit = (msg, content) => msg.edit(withMentionPolicy(content, NO_MENTIONS));
+
+/**
  * Run `fn`, retrying it for the failures that a second attempt can fix.
  *
  * `canRetry` is asked after each failure and before each retry, for the
@@ -73,10 +107,10 @@ async function attachToolFooter(msg, text, footer, channel) {
     if (!footer) return;
     const body = (text || '').trimEnd();
     if (msg && body.length + footer.length + 1 <= DISCORD_MAX_LEN) {
-        const edited = await msg.edit(body ? `${body}\n${footer}` : footer).then(() => true).catch(() => false);
+        const edited = await edit(msg, body ? `${body}\n${footer}` : footer).then(() => true).catch(() => false);
         if (edited) return;
     }
-    await channel.send(footer).catch(() => {});
+    await send(channel, footer).catch(() => {});
 }
 
 function chunkText(text, size = DISCORD_MAX_LEN) {
@@ -100,18 +134,18 @@ async function handleAIChat(message, aiSettings) {
     const providerLabel = providerDef?.label || provider;
 
     if (provider !== 'ollama' && !apiKey) {
-        return message.reply(`${providerLabel} is not configured. Add an API key in the dashboard.`);
+        return reply(message, `${providerLabel} is not configured. Add an API key in the dashboard.`);
     }
 
     const modelError = providerDef?.validateModel?.(model);
     if (modelError) {
-        return message.reply(modelError);
+        return reply(message, modelError);
     }
 
     const content = message.content.trim();
     if (content.toLowerCase() === '!reset') {
         await clearHistory(message.guild.id, message.channel.id, message.author.id);
-        return message.reply('Conversation history cleared.');
+        return reply(message, 'Conversation history cleared.');
     }
 
     // A peek, not a consuming check: the slot is spent inside getCompletion /
@@ -120,11 +154,11 @@ async function handleAIChat(message, aiSettings) {
     // prompt assembly below, and to say so in the channel where the user asked.
     // The same key enforcement will consume, so the peek and the spend agree.
     if (!peekRateLimit(userRateLimitKey(message.guild.id, message.author.id), rateLimit.perUser, rateLimit.windowMin)) {
-        return message.reply(`Rate limit reached (${rateLimit.perUser} per ${rateLimit.windowMin}m). Please slow down.`);
+        return reply(message, `Rate limit reached (${rateLimit.perUser} per ${rateLimit.windowMin}m). Please slow down.`);
     }
 
     if (!peekChannelRateLimit(message.channel.id, rateLimit.perChannel, rateLimit.windowMin)) {
-        return message.reply(`This channel has reached the AI request limit. Please wait before sending more AI requests here.`);
+        return reply(message, `This channel has reached the AI request limit. Please wait before sending more AI requests here.`);
     }
 
     const maxHistory = aiSettings.maxHistory ?? 20;
@@ -213,7 +247,7 @@ async function handleAIChat(message, aiSettings) {
         let fullResponse = '';
 
         if (useStreaming) {
-            placeholder = await message.reply('…');
+            placeholder = await reply(message, '…');
             let lastEdit = 0;
             let currentMsg = placeholder;
             let currentBuf = '';
@@ -240,7 +274,7 @@ async function handleAIChat(message, aiSettings) {
                 painting = true;
                 painted = text;
                 try {
-                    await currentMsg.edit(text);
+                    await edit(currentMsg, text);
                 } catch {
                     // Let the next paint try again rather than believing this landed.
                     painted = null;
@@ -301,9 +335,9 @@ async function handleAIChat(message, aiSettings) {
                             await untilPaintIdle();
                             painting = true;
                             try {
-                                await currentMsg.edit(currentBuf.slice(0, DISCORD_MAX_LEN));
+                                await edit(currentMsg, currentBuf.slice(0, DISCORD_MAX_LEN));
                                 const overflow = currentBuf.slice(DISCORD_MAX_LEN);
-                                currentMsg = await message.channel.send(overflow || '…');
+                                currentMsg = await send(message.channel, overflow || '…');
                                 sentMessages.push(currentMsg);
                                 currentBuf = overflow;
                                 painted = null;
@@ -328,7 +362,7 @@ async function handleAIChat(message, aiSettings) {
                         painting = true;
                         painted = currentBuf;
                         try {
-                            await currentMsg.edit(currentBuf);
+                            await edit(currentMsg, currentBuf);
                         } catch {
                             painted = null;
                         } finally {
@@ -354,7 +388,7 @@ async function handleAIChat(message, aiSettings) {
                     const canonicalChunks = cleanText.trim() ? chunkText(cleanText) : [];
                     for (let i = 0; i < sentMessages.length; i++) {
                         if (i < canonicalChunks.length) {
-                            await sentMessages[i].edit(canonicalChunks[i]).catch(() => {});
+                            await edit(sentMessages[i], canonicalChunks[i]).catch(() => {});
                         } else {
                             // Extra messages that existed only to hold overflow or ACTION text
                             await sentMessages[i].delete().catch(() => {});
@@ -392,10 +426,10 @@ async function handleAIChat(message, aiSettings) {
             let tailText = '';
             if (fullResponse.trim()) {
                 const chunks = chunkText(fullResponse);
-                tailMsg = await message.reply(chunks[0]);
+                tailMsg = await reply(message, chunks[0]);
                 tailText = chunks[0];
                 for (let i = 1; i < chunks.length; i++) {
-                    tailMsg = await message.channel.send(chunks[i]);
+                    tailMsg = await send(message.channel, chunks[i]);
                     tailText = chunks[i];
                 }
             }
@@ -406,7 +440,7 @@ async function handleAIChat(message, aiSettings) {
         // could not use — a chart, a screenshot. Its own message, after the
         // text, so a failed send costs the pictures and not the answer.
         if (activity.attachments.length) {
-            await message.channel.send({ files: activity.attachments }).catch(err =>
+            await send(message.channel, { files: activity.attachments }).catch(err =>
                 console.error('[MCP] tool attachments send failed:', err?.message || err)
             );
         }
@@ -434,7 +468,7 @@ async function handleAIChat(message, aiSettings) {
                     body += part;
                 }
                 if (omitted) body += ` (+${omitted} more)`;
-                await message.channel.send(prefix + body).catch(err =>
+                await send(message.channel, prefix + body).catch(err =>
                     console.error('[AI] citations footer send failed:', err?.message || err)
                 );
             }
@@ -444,10 +478,10 @@ async function handleAIChat(message, aiSettings) {
         // failure replaces the "…" instead of leaving it dangling beside it.
         const report = async text => {
             if (placeholder) {
-                const edited = await placeholder.edit(text).then(() => true).catch(() => false);
+                const edited = await edit(placeholder, text).then(() => true).catch(() => false);
                 if (edited) return;
             }
-            await message.reply(text).catch(() => {});
+            await reply(message, text).catch(() => {});
         };
 
         // The peek above passed but somebody else took the last slot in between.

--- a/tests/aiChatMentionPolicy.test.js
+++ b/tests/aiChatMentionPolicy.test.js
@@ -1,0 +1,241 @@
+'use strict';
+
+// Nothing the AI transport posts may ping anybody.
+//
+// Every message it sends is assembled from text the bot did not write — the
+// model's own output, an MCP server's progress note or tool result, the title
+// of a knowledge entry — and none of it went out with an `allowedMentions` of
+// any kind. A model talked into typing `@everyone`, or a server that names a
+// tool it, was a live mention in a channel with this bot's name on it.
+//
+// The reply ping is the one mention the transport does mean, and it survives:
+// specifying allowedMentions at all turns Discord's `replied_user` default off,
+// so it has to be asked for back.
+
+jest.mock('../src/models/User', () => ({
+    findOne: jest.fn(() => ({ lean: async () => null }))
+}));
+
+jest.mock('../src/services/ai/knowledge', () => ({
+    retrieveKnowledge: jest.fn(async () => ({ entries: [], isBackground: false })),
+    buildKnowledgeContext: jest.fn(() => '')
+}));
+
+jest.mock('../src/services/ai/history', () => ({
+    loadHistory: jest.fn(async () => ({ messages: [] })),
+    appendHistory: jest.fn(async () => {}),
+    clearHistory: jest.fn(async () => {})
+}));
+
+jest.mock('../src/services/ai/mcp/resources', () => ({
+    retrieveMcpKnowledge: jest.fn(async () => null)
+}));
+
+jest.mock('../src/services/ai/mcp/usage', () => ({
+    recordToolCalls: jest.fn(async () => {})
+}));
+
+jest.mock('../src/services/ai/providers', () => ({
+    providers: new Map([['mock', { name: 'mock', label: 'Mock' }]]),
+    mcpMode: () => 'client'
+}));
+
+const mockStream = jest.fn();
+const mockComplete = jest.fn();
+jest.mock('../src/services/ai', () => ({
+    resolveProviderConfig: aiSettings => ({
+        provider: 'mock', model: 'mock-1', temperature: 0.7, maxTokens: 512,
+        apiKey: aiSettings.apiKey === null ? null : 'k', baseUrl: null,
+        mcpServers: [],
+        rateLimit: { perUser: 0, perChannel: 0, windowMin: 10 }
+    }),
+    streamCompletion: (...args) => mockStream(...args),
+    getCompletion: (...args) => mockComplete(...args),
+    DEFAULT_MODELS: { mock: 'mock-1' }
+}));
+
+const { handleAIChat } = require('../src/services/ai/discordChat');
+
+const SETTINGS = { provider: 'mock', streaming: true, actionsEnabled: false, maxHistory: 20 };
+
+function fakeMessage(content = 'hello') {
+    const sent = [];
+    const emit = payload => {
+        const msg = {
+            payload,
+            content: typeof payload === 'string' ? payload : payload?.content ?? '',
+            edit: jest.fn(async next => { msg.edited = next; return msg; }),
+            delete: jest.fn(async () => msg)
+        };
+        sent.push(msg);
+        return msg;
+    };
+
+    const message = {
+        content,
+        author: { id: 'u1' },
+        guild: { id: 'g1' },
+        channel: {
+            id: 'c1',
+            send: jest.fn(async payload => emit(payload)),
+            sendTyping: jest.fn(async () => {})
+        },
+        reply: jest.fn(async payload => emit(payload))
+    };
+    return { message, sent };
+}
+
+// Every payload the transport handed to Discord, by whichever route: the
+// first post of a message, and every edit made to it afterwards.
+function everyPayload(message, sent) {
+    const posts = [
+        ...message.reply.mock.calls,
+        ...message.channel.send.mock.calls
+    ].map(call => call[0]);
+
+    const edits = sent.flatMap(msg => msg.edit.mock.calls).map(call => call[0]);
+
+    return [...posts, ...edits];
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockStream.mockImplementation(async function* () { yield 'an answer'; });
+    mockComplete.mockResolvedValue('an answer');
+});
+
+describe('what reaches Discord', () => {
+    test('every message carries a mention policy, none of them parse anything', async () => {
+        const { message, sent } = fakeMessage();
+        await handleAIChat(message, SETTINGS);
+
+        const payloads = everyPayload(message, sent);
+        expect(payloads.length).toBeGreaterThan(0);
+        for (const payload of payloads) {
+            expect(typeof payload).toBe('object');
+            expect(payload.allowedMentions).toBeDefined();
+            expect(payload.allowedMentions.parse).toEqual([]);
+        }
+    });
+
+    test('the reply still notifies the person who asked', async () => {
+        // The one mention the transport means. Specifying allowedMentions at
+        // all turns Discord's replied_user default off, so it is set back on.
+        const { message } = fakeMessage();
+        await handleAIChat(message, SETTINGS);
+
+        expect(message.reply).toHaveBeenCalledWith(
+            expect.objectContaining({ allowedMentions: { parse: [], repliedUser: true } })
+        );
+    });
+
+    test('a channel send is not a reply and pings nobody at all', async () => {
+        const { message } = fakeMessage();
+        await handleAIChat(message, SETTINGS);
+
+        for (const [payload] of message.channel.send.mock.calls) {
+            expect(payload.allowedMentions).toEqual({ parse: [] });
+        }
+    });
+
+    test('a model that types @everyone does not get to say it', async () => {
+        mockStream.mockImplementation(async function* () {
+            yield '@everyone the deploy is broken';
+        });
+
+        const { message, sent } = fakeMessage();
+        await handleAIChat(message, SETTINGS);
+
+        // The text is posted as written — it is the model's answer, and
+        // rewriting it would be lying about what the model said — but Discord
+        // is told to parse no mentions out of it.
+        const carried = everyPayload(message, sent).filter(p => (p.content || '').includes('@everyone'));
+        expect(carried.length).toBeGreaterThan(0);
+        for (const payload of carried) expect(payload.allowedMentions.parse).toEqual([]);
+    });
+
+    test('the non-streaming path is covered too', async () => {
+        const { message, sent } = fakeMessage();
+        await handleAIChat(message, { ...SETTINGS, streaming: false });
+
+        const payloads = everyPayload(message, sent);
+        expect(payloads.length).toBeGreaterThan(0);
+        for (const payload of payloads) expect(payload.allowedMentions.parse).toEqual([]);
+    });
+
+    test('a refusal before the provider is reached carries it as well', async () => {
+        // The early exits — no API key, !reset, a spent rate limit — are the
+        // paths most likely to be added to later without thinking about this.
+        const { message } = fakeMessage('!reset');
+        await handleAIChat(message, SETTINGS);
+
+        expect(message.reply).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: 'Conversation history cleared.',
+                allowedMentions: { parse: [], repliedUser: true }
+            })
+        );
+    });
+
+    test('an error report replaces the placeholder without pinging', async () => {
+        // Part of an answer, then the provider falls over — which is the
+        // shape a stream actually fails in. 400 is not retryable, so the
+        // report below is what the channel is left with.
+        mockStream.mockImplementation(async function* () {
+            yield 'starting to answ';
+            throw Object.assign(new Error('nope'), { status: 400 });
+        });
+
+        const { message, sent } = fakeMessage();
+        await handleAIChat(message, SETTINGS);
+
+        const placeholder = sent[0];
+        expect(placeholder.edited).toEqual(
+            expect.objectContaining({ allowedMentions: { parse: [] } })
+        );
+    });
+
+    test('a file-only message keeps its files and gains the policy', async () => {
+        mockStream.mockImplementation(async function* (args) {
+            args.onToolEvent({ type: 'start', id: 1, server: 'github', tool: 'chart' });
+            args.onToolEvent({
+                type: 'attachment', id: 1, server: 'github', tool: 'chart',
+                buffer: Buffer.from('png'), name: 'chart-1.png'
+            });
+            args.onToolEvent({ type: 'end', id: 1, server: 'github', tool: 'chart', durationMs: 10, ok: true });
+            yield 'here it is';
+        });
+
+        const { message } = fakeMessage();
+        await handleAIChat(message, SETTINGS);
+
+        const withFiles = message.channel.send.mock.calls
+            .map(call => call[0])
+            .find(payload => payload.files);
+
+        expect(withFiles.files).toHaveLength(1);
+        expect(withFiles.allowedMentions).toEqual({ parse: [] });
+    });
+});
+
+describe('the policy cannot be skipped by writing the shorter form', () => {
+    test('no outbound call in the transport bypasses the helpers', () => {
+        // The helpers are only a guarantee for as long as everything goes
+        // through them, and the shorter form is the one a new call site
+        // reaches for.
+        const fs = require('fs');
+        const path = require('path');
+        const source = fs.readFileSync(
+            path.join(__dirname, '..', 'src', 'services', 'ai', 'discordChat.js'), 'utf8'
+        );
+
+        const direct = source.split('\n')
+            .map((line, index) => ({ line: line.trim(), number: index + 1 }))
+            .filter(({ line }) => /\.(reply|send|edit|followUp)\(/.test(line))
+            // The three helper definitions are the calls; everything else is a
+            // call site that should be going through them.
+            .filter(({ line }) => !/^const (reply|send|edit) = \(/.test(line));
+
+        expect(direct.map(entry => `${entry.number}: ${entry.line}`)).toEqual([]);
+    });
+});

--- a/tests/aiToolActivityTransport.test.js
+++ b/tests/aiToolActivityTransport.test.js
@@ -60,12 +60,16 @@ const { handleAIChat } = require('../src/services/ai/discordChat');
 
 const SETTINGS = { provider: 'mock', streaming: true, actionsEnabled: false, maxHistory: 20 };
 
+// The transport posts payload objects now, never bare strings — that is what
+// carries the mention policy — so the fake reads the text back out of one.
+const textOf = payload => (typeof payload === 'string' ? payload : payload?.content ?? '');
+
 function fakeMessage(content = 'what changed in the repo?') {
     const sent = [];
-    const emit = text => {
+    const emit = payload => {
         const msg = {
-            content: typeof text === 'string' ? text : '',
-            edit: jest.fn(async next => { msg.content = next; return msg; }),
+            content: textOf(payload),
+            edit: jest.fn(async next => { msg.content = textOf(next); return msg; }),
             delete: jest.fn(async () => { msg.deleted = true; return msg; })
         };
         sent.push(msg);
@@ -78,10 +82,10 @@ function fakeMessage(content = 'what changed in the repo?') {
         guild: { id: 'g1' },
         channel: {
             id: 'c1',
-            send: jest.fn(async text => emit(text)),
+            send: jest.fn(async payload => emit(payload)),
             sendTyping: jest.fn(async () => {})
         },
-        reply: jest.fn(async text => emit(text))
+        reply: jest.fn(async payload => emit(payload))
     };
     return { message, sent };
 }
@@ -93,7 +97,7 @@ const end = args => args.onToolEvent({
 
 // Everything the message was edited to over the course of the reply, so a
 // transient state — the status line — can be asserted on as well as the last.
-const edits = msg => msg.edit.mock.calls.map(call => call[0]);
+const edits = msg => msg.edit.mock.calls.map(call => textOf(call[0]));
 
 beforeEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION
Every message src/services/ai/discordChat.js posts is assembled from text the
bot did not write — the model's own output, an MCP server's progress note or
tool result, the title of a knowledge entry — and not one of its nineteen
sends, replies and edits set `allowedMentions`. A model talked into typing
`@everyone`, or a server that names a tool it, was a live mention in a channel
with this bot's name on it.

utils/toolLabel.js already strips what it can from the names it handles, and
says in as many words that it is belt rather than braces. This is the braces,
and it belongs on the send: that is the one place that also covers the model's
own text, which is the larger surface and was never covered at all.

Three helpers now wrap the whole outbound surface and every call site goes
through them. The text is still posted exactly as written — rewriting a model's
answer would be lying about what it said — Discord is simply told to parse no
mentions out of it.

The reply ping survives. It is the one mention this transport means, and
specifying allowedMentions at all turns Discord's replied_user default off, so
it is asked for back explicitly: a reply still notifies the person who asked.

A source-level test holds the line, because the helpers are a guarantee only
for as long as everything goes through them and the bare form is the one a new
call site reaches for. It fails naming the file and line of any `.send(`,
`.reply(`, `.edit(` or `.followUp(` that bypasses them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented AI-generated content from unintentionally pinging users through Discord mentions.
  * Preserved notifications for users who explicitly requested an AI response.
  * Applied consistent mention controls to standard replies, edits, attachments, errors, and streaming responses.

* **Tests**
  * Added coverage for streaming, non-streaming, errors, attachments, and early-exit responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->