### PR TITLE
Pin the clock in the date-dependent tests

### DIFF
--- a/tests/analytics.test.js
+++ b/tests/analytics.test.js
@@ -75,6 +75,7 @@ const { computeRetention } = require('../src/dashboard/routes/api');
 const guildMemberAdd = require('../src/events/guildMemberAdd');
 const guildMemberRemove = require('../src/events/guildMemberRemove');
 const interactionCreate = require('../src/events/interactionCreate');
+const { useFixedClock, advanceClock, HOUR } = require('./helpers/fixedClock');
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -123,7 +124,13 @@ function makeMember(overrides = {}) {
 // ---------------------------------------------------------------------------
 
 describe('trackMemberEvent (guildMemberAdd)', () => {
-    const TODAY = new Date().toISOString().slice(0, 10);
+    // `TODAY` is read once when this describe body runs; the handler reads its
+    // own `new Date().toISOString().slice(0, 10)` when the event arrives
+    // (guildMemberAdd.js:65). Unpinned those are two clock reads with the whole
+    // suite between them, and a run that crosses midnight UTC compares one day
+    // against the next (#632).
+    useFixedClock();
+    const TODAY = '2026-03-29';
 
     beforeEach(() => {
         jest.clearAllMocks();
@@ -159,6 +166,22 @@ describe('trackMemberEvent (guildMemberAdd)', () => {
         expect(secondCall[1].$push.memberEvents.$slice).toBe(-120);
     });
 
+    it('a join either side of midnight UTC is counted against its own day', async () => {
+        // The pinned clock sits half an hour before midnight, so one hour of
+        // elapsed time is a date change, a month rollover and — in the EU — a
+        // DST change. The day key must follow the clock rather than whatever
+        // the suite captured when it started.
+        mockGuildAnalytics.updateOne.mockResolvedValue({ matchedCount: 1 });
+
+        await guildMemberAdd.execute(makeMember(), {});
+        advanceClock(HOUR);
+        await guildMemberAdd.execute(makeMember(), {});
+
+        const [before, after] = mockGuildAnalytics.updateOne.mock.calls;
+        expect(before[0]).toMatchObject({ 'memberEvents.date': '2026-03-29' });
+        expect(after[0]).toMatchObject({ 'memberEvents.date': '2026-03-30' });
+    });
+
     it('does not throw if guild not found', async () => {
         mockGuild.findOne.mockResolvedValue(null);
         const member = makeMember();
@@ -178,7 +201,9 @@ describe('trackMemberEvent (guildMemberAdd)', () => {
 // ---------------------------------------------------------------------------
 
 describe('trackMemberEvent (guildMemberRemove)', () => {
-    const TODAY = new Date().toISOString().slice(0, 10);
+    // Same clock race as the join side above (#632).
+    useFixedClock();
+    const TODAY = '2026-03-29';
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/tests/birthday.test.js
+++ b/tests/birthday.test.js
@@ -10,6 +10,22 @@ jest.mock('../src/models/User', () => ({ find: jest.fn() }));
 const { checkBirthdays } = require('../src/services/birthdayService');
 const Guild = require('../src/models/Guild');
 const User = require('../src/models/User');
+const { useFixedClock, setClock, advanceClock, HOUR } = require('./helpers/fixedClock');
+
+// Every assertion in this file depends on what the clock says: birthdayService
+// derives the month, the day, the UTC hour it queries guilds by, and the year it
+// stamps into `lastCelebratedYear` from a single `new Date()` (#632).
+//
+// This used to be seven copies of `jest.spyOn(global, 'Date').mockImplementation(...)`
+// with the matching `mockRestore()` as the last statement of each test body.
+// That worked, narrowly: it replaced the constructor but not `Date.now()`, so
+// the first line of service code to ask for a timestamp that way would have
+// gotten `undefined` off a mock function that carries no statics — and a test
+// that failed an assertion never reached its `mockRestore()`, leaving the global
+// `Date` replaced for every test after it in the file. `setSystemTime` moves the
+// whole clock, statics included, and the helper's `afterEach` puts it back
+// however the test ends.
+const WISHING_HOUR = '2026-05-15T09:00:00Z'; // the hour makeGuildSettings() wishes at
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -72,12 +88,10 @@ function makeClient(channel) {
 // ---------------------------------------------------------------------------
 
 describe('birthday message age substitution', () => {
+    useFixedClock(WISHING_HOUR);
     afterEach(() => jest.clearAllMocks());
 
     test('shows numeric age when birth year is provided', async () => {
-        const now = new Date('2026-05-15T09:00:00Z');
-        jest.spyOn(global, 'Date').mockImplementation((arg) => arg !== undefined ? new (jest.requireActual('Date'))(arg) : now);
-
         const channel = makeChannel();
         const client = makeClient(channel);
         Guild.find.mockResolvedValue([makeGuildSettings()]);
@@ -88,14 +102,9 @@ describe('birthday message age substitution', () => {
         expect(channel.send).toHaveBeenCalledWith(
             expect.objectContaining({ content: expect.stringContaining('36') })
         );
-
-        global.Date.mockRestore();
     });
 
     test('shows ? when no birth year is provided', async () => {
-        const now = new Date('2026-05-15T09:00:00Z');
-        jest.spyOn(global, 'Date').mockImplementation((arg) => arg !== undefined ? new (jest.requireActual('Date'))(arg) : now);
-
         const channel = makeChannel();
         const client = makeClient(channel);
         Guild.find.mockResolvedValue([makeGuildSettings()]);
@@ -106,8 +115,6 @@ describe('birthday message age substitution', () => {
         expect(channel.send).toHaveBeenCalledWith(
             expect.objectContaining({ content: expect.stringContaining('?') })
         );
-
-        global.Date.mockRestore();
     });
 });
 
@@ -116,12 +123,10 @@ describe('birthday message age substitution', () => {
 // ---------------------------------------------------------------------------
 
 describe('birthday permission check', () => {
+    useFixedClock(WISHING_HOUR);
     afterEach(() => jest.clearAllMocks());
 
     test('does not send when bot lacks SendMessages permission', async () => {
-        const now = new Date('2026-05-15T09:00:00Z');
-        jest.spyOn(global, 'Date').mockImplementation((arg) => arg !== undefined ? new (jest.requireActual('Date'))(arg) : now);
-
         const channel = makeChannel(false); // no permission
         const client = makeClient(channel);
         Guild.find.mockResolvedValue([makeGuildSettings()]);
@@ -130,14 +135,30 @@ describe('birthday permission check', () => {
         await checkBirthdays(client);
 
         expect(channel.send).not.toHaveBeenCalled();
+    });
 
-        global.Date.mockRestore();
+    test('the guild query follows the clock across the wishing hour', async () => {
+        // `wishingHourUtc` is matched against `now.getUTCHours()`, so which
+        // guilds are even considered turns over on the hour. Pinned at 09:00
+        // the query asks for hour 9; an hour later it must ask for 10, not for
+        // whatever hour the suite started in.
+        const client = makeClient(makeChannel());
+        Guild.find.mockResolvedValue([]);
+        User.find.mockResolvedValue([]);
+
+        await checkBirthdays(client);
+        expect(Guild.find).toHaveBeenLastCalledWith(
+            expect.objectContaining({ 'birthdays.wishingHourUtc': 9 })
+        );
+
+        advanceClock(HOUR);
+        await checkBirthdays(client);
+        expect(Guild.find).toHaveBeenLastCalledWith(
+            expect.objectContaining({ 'birthdays.wishingHourUtc': 10 })
+        );
     });
 
     test('sends when bot has SendMessages permission', async () => {
-        const now = new Date('2026-05-15T09:00:00Z');
-        jest.spyOn(global, 'Date').mockImplementation((arg) => arg !== undefined ? new (jest.requireActual('Date'))(arg) : now);
-
         const channel = makeChannel(true);
         const client = makeClient(channel);
         Guild.find.mockResolvedValue([makeGuildSettings()]);
@@ -146,8 +167,6 @@ describe('birthday permission check', () => {
         await checkBirthdays(client);
 
         expect(channel.send).toHaveBeenCalledTimes(1);
-
-        global.Date.mockRestore();
     });
 });
 
@@ -156,12 +175,12 @@ describe('birthday permission check', () => {
 // ---------------------------------------------------------------------------
 
 describe('leap day birthday handling', () => {
+    useFixedClock(WISHING_HOUR); // each test sets its own February
     afterEach(() => jest.clearAllMocks());
 
     test('celebrates Feb 29 birthdays on Feb 28 of non-leap years', async () => {
         // 2025 is not a leap year; Feb 28 should also include Feb 29 users
-        const now = new Date('2025-02-28T09:00:00Z');
-        jest.spyOn(global, 'Date').mockImplementation((arg) => arg !== undefined ? new (jest.requireActual('Date'))(arg) : now);
+        setClock('2025-02-28T09:00:00Z');
 
         const channel = makeChannel();
         const client = makeClient(channel);
@@ -171,14 +190,11 @@ describe('leap day birthday handling', () => {
         await checkBirthdays(client);
 
         expect(channel.send).toHaveBeenCalledTimes(1);
-
-        global.Date.mockRestore();
     });
 
     test('does not double-celebrate Feb 29 on actual leap years', async () => {
         // 2028 is a leap year; Feb 29 should only fire on Feb 29
-        const now = new Date('2028-02-28T09:00:00Z');
-        jest.spyOn(global, 'Date').mockImplementation((arg) => arg !== undefined ? new (jest.requireActual('Date'))(arg) : now);
+        setClock('2028-02-28T09:00:00Z');
 
         const channel = makeChannel();
         const client = makeClient(channel);
@@ -189,8 +205,6 @@ describe('leap day birthday handling', () => {
         await checkBirthdays(client);
 
         expect(channel.send).not.toHaveBeenCalled();
-
-        global.Date.mockRestore();
     });
 });
 
@@ -199,12 +213,10 @@ describe('leap day birthday handling', () => {
 // ---------------------------------------------------------------------------
 
 describe('lastCelebratedYear tracking', () => {
+    useFixedClock(WISHING_HOUR);
     afterEach(() => jest.clearAllMocks());
 
     test('sets lastCelebratedYear to current year after celebrating', async () => {
-        const now = new Date('2026-05-15T09:00:00Z');
-        jest.spyOn(global, 'Date').mockImplementation((arg) => arg !== undefined ? new (jest.requireActual('Date'))(arg) : now);
-
         const channel = makeChannel();
         const client = makeClient(channel);
         Guild.find.mockResolvedValue([makeGuildSettings()]);
@@ -215,7 +227,5 @@ describe('lastCelebratedYear tracking', () => {
 
         expect(u.birthday.lastCelebratedYear).toBe(2026);
         expect(u.save).toHaveBeenCalled();
-
-        global.Date.mockRestore();
     });
 });

--- a/tests/fishService.test.js
+++ b/tests/fishService.test.js
@@ -15,6 +15,7 @@ const {
 } = require('../src/services/fishService');
 const { addEffect, consumeEffect, refundEffectCharge, getEffect, EFFECT_CONFIGS } = require('../src/services/effectsService');
 const { LOCATIONS, LIMITS, ROD_TIERS } = require('../src/data/fishData');
+const { useFixedClock, advanceClock, DAY, WEEK } = require('./helpers/fixedClock');
 
 const pond = LOCATIONS.pond;
 
@@ -296,7 +297,14 @@ describe('refundEffectCharge', () => {
 // ─── Weekly record ───────────────────────────────────────────────────────────
 
 describe('weeklyRecord', () => {
-    const DAY = 24 * 3_600_000;
+    // fishService stamps and compares `weekStart` with its own `new Date()` /
+    // `Date.now()` (fishService.js:779-790), so a fixture built from the real
+    // clock races the service's read of it across any day boundary the run
+    // happens to straddle (#632). Pinned to the last Sunday in March, half an
+    // hour before midnight UTC: the fixtures below reach back into the previous
+    // month and forward through a DST change without any of it depending on
+    // when CI runs.
+    useFixedClock();
 
     test('a stale week is cleared so a lighter fish can take the record', () => {
         const user = makeUser({
@@ -328,6 +336,41 @@ describe('weeklyRecord', () => {
 
         expect(user.fishing.weeklyRecord.fish).toBe('Ancient Leviathan');
         expect(user.fishing.weeklyRecord.weight).toBe(9999);
+    });
+
+    test('a record set just under a week ago still stands', () => {
+        const user = makeUser({
+            weeklyRecord: {
+                fish: 'Ancient Leviathan', weight: 9999,
+                userId: 'u1', username: 'angler',
+                weekStart: new Date(Date.now() - (WEEK - 1)),
+            },
+        });
+
+        castUntil(user, isWeighedFish);
+
+        expect(user.fishing.weeklyRecord.weight).toBe(9999);
+    });
+
+    test('a week expires on elapsed time, not on the calendar turning over', () => {
+        // The record is set now; the clock then crosses midnight UTC, a month
+        // end and the EU spring-forward. None of those is seven days, so the
+        // week has not expired and a lighter fish must not take the record.
+        const user = makeUser();
+        const first = castUntil(user, isWeighedFish);
+        expect(first).not.toBeNull();
+        user.fishing.weeklyRecord.weight = 9999;
+
+        advanceClock(2 * DAY);
+        castUntil(user, isWeighedFish);
+        expect(user.fishing.weeklyRecord.weight).toBe(9999);
+
+        // Past seven days from the original stamp, the week is stale and the
+        // next weighed fish takes it.
+        advanceClock(6 * DAY);
+        const later = castUntil(user, isWeighedFish);
+        expect(later).not.toBeNull();
+        expect(user.fishing.weeklyRecord.weight).toBe(later.weightLbs);
     });
 
     test('a new record records who set it', () => {

--- a/tests/helpers/fixedClock.js
+++ b/tests/helpers/fixedClock.js
@@ -1,0 +1,127 @@
+'use strict';
+
+/**
+ * Pins the wall clock for a test file (#632).
+ *
+ * `Date.now()` is read in 116 source files — daily resets keyed on the UTC date
+ * string, streaks, cooldowns, weekly-record rollover, seasonal and birthday
+ * logic — and until this helper no test stubbed it. Every date-dependent test
+ * built its fixtures against whatever the clock happened to say at the moment
+ * the suite ran, which works right up until a run straddles a boundary: a
+ * fixture captured at 23:59:59.9 UTC and a source read taken a tick later are
+ * on different days, and the assertion between them fails. Midnight, the month
+ * rollover and a DST transition are the three that will find these, and they
+ * find them on someone else's schedule.
+ *
+ * The pinned clock removes the race: the fixture and the code under test read
+ * the same instant, whenever CI happens to run.
+ *
+ * ## Only Date is faked
+ *
+ * `jest.useFakeTimers()` with no arguments also takes over setTimeout and
+ * friends, which is a much larger change than these suites want — anything
+ * awaiting a real timer stops making progress unless the test also drives the
+ * scheduler. `doNotFake` leaves every timer API alone, so the only thing that
+ * changes is what `Date.now()` and `new Date()` answer. Suites that do want to
+ * drive the scheduler should keep calling `jest.useFakeTimers()` directly.
+ *
+ * ## Usage
+ *
+ *     const { useFixedClock, advanceClock } = require('./helpers/fixedClock');
+ *
+ *     describe('weekly rollover', () => {
+ *         useFixedClock('2026-03-29T23:30:00Z');
+ *         ...
+ *         test('rolls over at the boundary', () => {
+ *             advanceClock(DAY);   // move the clock, deterministically
+ *         });
+ *     });
+ *
+ * Call `useFixedClock` in a `describe` body (or at file top level). It installs
+ * the clock in `beforeEach` and restores the real one in `afterEach`, so a
+ * clock a test moved with `advanceClock` is back at the pinned instant for the
+ * next one.
+ */
+
+// Everything except 'Date'. Jest fakes the listed APIs unless they appear here,
+// so naming the rest is how you say "fake the clock and nothing else".
+const LEAVE_REAL = [
+    'hrtime',
+    'nextTick',
+    'performance',
+    'queueMicrotask',
+    'requestAnimationFrame',
+    'cancelAnimationFrame',
+    'requestIdleCallback',
+    'cancelIdleCallback',
+    'setImmediate',
+    'clearImmediate',
+    'setInterval',
+    'clearInterval',
+    'setTimeout',
+    'clearTimeout',
+];
+
+/**
+ * A default instant for suites with no reason to prefer another.
+ *
+ * Deliberately awkward: 23:30 UTC is inside the last half hour of a UTC day, so
+ * a fixture built by subtracting a few hours lands on the previous date; it is
+ * the last Sunday in March, the day the EU clocks go forward; and the next day
+ * is a month rollover. A suite pinned here is pinned somewhere the three
+ * boundaries this issue names are all within a day.
+ */
+const DEFAULT_CLOCK = '2026-03-29T23:30:00Z';
+
+function toDate(when) {
+    const at = when instanceof Date ? new Date(when.getTime()) : new Date(when);
+    if (Number.isNaN(at.getTime())) {
+        throw new TypeError(`fixedClock: not a usable instant: ${String(when)}`);
+    }
+    return at;
+}
+
+/**
+ * Pins the clock for every test in the enclosing describe.
+ *
+ * @param {string|number|Date} when The instant to pin to. Defaults to
+ *   DEFAULT_CLOCK.
+ * @returns {Date} The pinned instant, for building fixtures relative to it.
+ */
+function useFixedClock(when = DEFAULT_CLOCK) {
+    const at = toDate(when);
+
+    beforeEach(() => {
+        jest.useFakeTimers({ now: at, doNotFake: LEAVE_REAL });
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    return at;
+}
+
+/** Moves the pinned clock forward (or back, with a negative delta). */
+function advanceClock(ms) {
+    jest.setSystemTime(Date.now() + ms);
+}
+
+/** Moves the pinned clock to a specific instant. */
+function setClock(when) {
+    jest.setSystemTime(toDate(when));
+}
+
+const SECOND = 1_000;
+const MINUTE = 60 * SECOND;
+const HOUR   = 60 * MINUTE;
+const DAY    = 24 * HOUR;
+const WEEK   = 7 * DAY;
+
+module.exports = {
+    useFixedClock,
+    advanceClock,
+    setClock,
+    DEFAULT_CLOCK,
+    SECOND, MINUTE, HOUR, DAY, WEEK,
+};

--- a/tests/messageCreateConcurrency.test.js
+++ b/tests/messageCreateConcurrency.test.js
@@ -61,6 +61,7 @@ const User  = require('../src/models/User');
 const { getGuildSettings } = require('../src/utils/guildSettingsCache');
 const { saveWithBalanceDelta } = require('../src/utils/balanceDelta');
 const messageCreate = require('../src/events/messageCreate');
+const { useFixedClock } = require('./helpers/fixedClock');
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -144,6 +145,14 @@ beforeEach(() => {
 });
 
 describe('two messages from the same user', () => {
+    // The daily counter resets when the stored `lastDailyReset` is not today's
+    // UTC date (messageCreate.js:291-296), and the fixture below stamps it with
+    // its own `new Date()`. Unpinned, a run that crosses midnight UTC between
+    // the fixture and the handler's read triggers the reset, and the counter
+    // this suite asserts on comes back 1 instead of 2 — a lost-update failure
+    // reported for a clock, once a year, at midnight (#632).
+    useFixedClock();
+
     test('the second flow does not read the document until the first has written it', async () => {
         const order = [];
 

--- a/tests/questExpiryWindows.test.js
+++ b/tests/questExpiryWindows.test.js
@@ -1,0 +1,170 @@
+'use strict';
+
+// ensureQuests hands out daily and weekly quests and decides how many are still
+// live entirely from the clock: expiry is the next UTC midnight for a daily and
+// the next Sunday 00:00 UTC for a weekly, and a quest counts toward a limit only
+// when its `expiresAt` matches one of those to the millisecond
+// (questService.js:145-193).
+//
+// Every one of those is a boundary, and none of them could be asserted before
+// the clock could be pinned (#632): a suite run on a Tuesday cannot check what
+// happens on Saturday, and one run at 23:59 gets a "next midnight" a minute away
+// rather than the day the fixtures assume. The Saturday case is the one that
+// matters most — the code carries a comment about it, because that is the day
+// the daily and weekly expiries are the same instant and an earlier version
+// handed out extra quests for it.
+
+const { ensureQuests } = require('../src/services/questService');
+const { useFixedClock, setClock, HOUR, DAY } = require('./helpers/fixedClock');
+
+const settings = (overrides = {}) => ({
+    quests: { enabled: true, questsPerDay: 3, questsPerWeek: 2, ...overrides },
+});
+
+const makeUser = (quests = []) => ({ level: 5, quests });
+
+const nextMidnightUtc = () => {
+    const d = new Date();
+    d.setUTCHours(24, 0, 0, 0);
+    return d;
+};
+
+describe('ensureQuests expiry windows', () => {
+    // A Thursday, mid-morning: far from both boundaries, so the plain cases
+    // below are not accidentally sitting on one.
+    useFixedClock('2026-04-16T10:00:00Z');
+
+    test('assigns the configured daily and weekly counts to an empty user', async () => {
+        const user = makeUser();
+        const { assignedNewDaily } = await ensureQuests(user, settings());
+
+        expect(assignedNewDaily).toBe(true);
+        expect(user.quests).toHaveLength(5);
+
+        const dailies = user.quests.filter(q => q.expiresAt.getTime() === Date.parse('2026-04-17T00:00:00Z'));
+        const weeklies = user.quests.filter(q => q.expiresAt.getTime() === Date.parse('2026-04-19T00:00:00Z'));
+        expect(dailies).toHaveLength(3);
+        expect(weeklies).toHaveLength(2);
+    });
+
+    test('a second call the same day assigns nothing', async () => {
+        const user = makeUser();
+        await ensureQuests(user, settings());
+        const before = user.quests.map(q => q.questId).sort();
+
+        const { assignedNewDaily } = await ensureQuests(user, settings());
+
+        expect(assignedNewDaily).toBe(false);
+        expect(user.quests.map(q => q.questId).sort()).toEqual(before);
+    });
+
+    test('dailies expire at midnight UTC and are replaced, weeklies survive', async () => {
+        const user = makeUser();
+        await ensureQuests(user, settings());
+        const weeklyIds = user.quests
+            .filter(q => q.expiresAt.getTime() === Date.parse('2026-04-19T00:00:00Z'))
+            .map(q => q.questId)
+            .sort();
+
+        // A minute past midnight the dailies are gone; the weeklies are not.
+        setClock('2026-04-17T00:01:00Z');
+        const { assignedNewDaily } = await ensureQuests(user, settings());
+
+        expect(assignedNewDaily).toBe(true);
+        expect(user.quests).toHaveLength(5);
+        expect(user.quests
+            .filter(q => q.expiresAt.getTime() === Date.parse('2026-04-19T00:00:00Z'))
+            .map(q => q.questId)
+            .sort()).toEqual(weeklyIds);
+        expect(user.quests.filter(q => q.expiresAt.getTime() === Date.parse('2026-04-18T00:00:00Z'))).toHaveLength(3);
+    });
+
+    test('a minute before midnight the dailies are still live', async () => {
+        const user = makeUser();
+        await ensureQuests(user, settings());
+
+        setClock('2026-04-16T23:59:00Z');
+        const { assignedNewDaily } = await ensureQuests(user, settings());
+
+        expect(assignedNewDaily).toBe(false);
+        expect(user.quests).toHaveLength(5);
+    });
+});
+
+describe('ensureQuests on the Saturday boundary', () => {
+    // 2026-04-18 is a Saturday. The next UTC midnight and the next Sunday 00:00
+    // are the same instant, so a daily and a weekly quest are indistinguishable
+    // by expiry — which is exactly what the classification in ensureQuests is
+    // written to survive.
+    useFixedClock('2026-04-18T10:00:00Z');
+
+    test('the daily and weekly expiries coincide', async () => {
+        const user = makeUser();
+        await ensureQuests(user, settings());
+
+        const expiries = new Set(user.quests.map(q => q.expiresAt.getTime()));
+        expect([...expiries]).toEqual([Date.parse('2026-04-19T00:00:00Z')]);
+        expect(nextMidnightUtc().getTime()).toBe(Date.parse('2026-04-19T00:00:00Z'));
+    });
+
+    test('no extra quests are handed out on the boundary day', async () => {
+        const user = makeUser();
+        await ensureQuests(user, settings());
+        expect(user.quests).toHaveLength(5);
+
+        // Counting a quest toward both limits is the safe direction: calling
+        // again must not top either list back up to its full count.
+        await ensureQuests(user, settings());
+        expect(user.quests).toHaveLength(5);
+    });
+
+    test('Sunday starts a fresh week rather than expiring into the same one', async () => {
+        const user = makeUser();
+        await ensureQuests(user, settings());
+
+        // Everything expired at Sunday 00:00; an hour later the whole set is
+        // reissued, and the new weeklies run to the *following* Sunday.
+        setClock(new Date(Date.parse('2026-04-19T00:00:00Z') + HOUR));
+        await ensureQuests(user, settings());
+
+        expect(user.quests).toHaveLength(5);
+        expect(user.quests.filter(q => q.expiresAt.getTime() === Date.parse('2026-04-26T00:00:00Z'))).toHaveLength(2);
+        expect(user.quests.filter(q => q.expiresAt.getTime() === Date.parse('2026-04-20T00:00:00Z'))).toHaveLength(3);
+    });
+});
+
+describe('ensureQuests across a DST transition', () => {
+    // The last Sunday in March, when European clocks go forward. The service
+    // works in UTC throughout, so nothing here should shift by an hour — the
+    // point of the test is that it does not.
+    useFixedClock('2026-03-29T01:30:00Z');
+
+    test('the daily window is still 24 hours long across the change', async () => {
+        const user = makeUser();
+        await ensureQuests(user, settings());
+
+        const daily = user.quests.find(q => q.expiresAt.getTime() === Date.parse('2026-03-30T00:00:00Z'));
+        expect(daily).toBeDefined();
+        expect(daily.expiresAt.getTime() - Date.parse('2026-03-29T00:00:00Z')).toBe(DAY);
+    });
+
+    test('a Sunday assigns weeklies that run a full seven days', async () => {
+        const user = makeUser();
+        await ensureQuests(user, settings());
+
+        const weekly = user.quests.find(q => q.expiresAt.getTime() === Date.parse('2026-04-05T00:00:00Z'));
+        expect(weekly).toBeDefined();
+        expect(weekly.expiresAt.getTime() - Date.parse('2026-03-29T00:00:00Z')).toBe(7 * DAY);
+    });
+});
+
+describe('ensureQuests when the feature is off', () => {
+    useFixedClock('2026-04-16T10:00:00Z');
+
+    test('assigns nothing and leaves the user untouched', async () => {
+        const user = makeUser();
+        const result = await ensureQuests(user, { quests: { enabled: false } });
+        expect(result).toEqual({ assignedNewDaily: false });
+        expect(user.quests).toEqual([]);
+    });
+});

--- a/tests/seasonPass.test.js
+++ b/tests/seasonPass.test.js
@@ -2,6 +2,7 @@
 
 const { TIER_COUNT, TIER_TABLE, loreForTier } = require('../src/data/seasonPass');
 const { awardSeasonXp } = require('../src/services/questService');
+const { useFixedClock, advanceClock, DAY, WEEK } = require('./helpers/fixedClock');
 
 describe('season pass tier table', () => {
     test('has 50 sequential tiers with both tracks labeled', () => {
@@ -48,6 +49,16 @@ describe('season pass tier table', () => {
 });
 
 describe('awardSeasonXp weekly cap', () => {
+    // The weekly window is `now - weekStart >= 7 days` against a `weekStart` the
+    // service stamps with `new Date()` (questService.js:280-283), so a fixture
+    // built from the real clock and the service's own read of it are two
+    // different instants (#632). Pinned, they are one. The instant is the last
+    // Sunday in March, half an hour before midnight UTC — the day the EU clocks
+    // go forward and the day before a month rollover, which is where a window
+    // that quietly counted local days rather than elapsed milliseconds would
+    // come apart.
+    useFixedClock();
+
     const guildSettings = (overrides = {}) => ({
         season: { enabled: true, seasonId: 's1', xpPerTier: 100, maxTiers: 50, weeklyXpCap: 1500, ...overrides },
     });
@@ -79,7 +90,36 @@ describe('awardSeasonXp weekly cap', () => {
     test('rolls the window over after 7 days', async () => {
         const user = freshUser();
         user.season.weekXp = 1500;
-        user.season.weekStart = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
+        user.season.weekStart = new Date(Date.now() - 8 * DAY);
+        await awardSeasonXp(user, 100, guildSettings());
+        expect(user.season.xp).toBe(100);
+        expect(user.season.weekXp).toBe(100);
+    });
+
+    test('the window does not roll over a moment before seven days', async () => {
+        const user = freshUser();
+        user.season.weekXp = 1500;
+        user.season.weekStart = new Date(Date.now() - (WEEK - 1));
+        await awardSeasonXp(user, 100, guildSettings());
+        expect(user.season.xp).toBe(0);
+        expect(user.season.weekXp).toBe(1500);
+    });
+
+    test('crossing midnight, a month end and a DST change does not roll the window', async () => {
+        // Elapsed time is what the window measures, so a fixture stamped now and
+        // read again after the calendar has moved on — past midnight UTC, into
+        // April, and through the EU spring-forward — is still inside the same
+        // week. This is the assertion a wall-clock run could only make by
+        // accident, and only on one night of the year.
+        const user = freshUser();
+        user.season.weekXp = 1500;
+        advanceClock(2 * DAY);
+        await awardSeasonXp(user, 100, guildSettings());
+        expect(user.season.xp).toBe(0);
+        expect(user.season.weekXp).toBe(1500);
+
+        // ...and five days later it is a new week, DST notwithstanding.
+        advanceClock(5 * DAY);
         await awardSeasonXp(user, 100, guildSettings());
         expect(user.season.xp).toBe(100);
         expect(user.season.weekXp).toBe(100);

--- a/tests/seasonalEventWindows.test.js
+++ b/tests/seasonalEventWindows.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+// getActiveSeasonalEvent() is calendar logic and nothing else: it reads
+// `new Date()`, reduces it to a UTC month and day, and answers with whichever
+// event's window contains them (data/seasonalEvents.js:216-229). Untested until
+// now, and untestable in any useful way without stubbing the clock — a test
+// written against the real one asserts a different answer every month, so the
+// only assertions that could survive were the ones that said nothing (#632).
+//
+// With the clock pinned each window can be walked at both of its edges, which
+// is where an off-by-one in a `>= dayStart && <= dayEnd` lives.
+
+const { getActiveSeasonalEvent, SEASONAL_EVENTS } = require('../src/data/seasonalEvents');
+const { useFixedClock, setClock, advanceClock, DAY } = require('./helpers/fixedClock');
+
+const idAt = (when) => {
+    setClock(when);
+    return getActiveSeasonalEvent()?.id ?? null;
+};
+
+describe('getActiveSeasonalEvent', () => {
+    useFixedClock();
+
+    test('every configured window is claimed by its own event on its first and last day', () => {
+        for (const event of Object.values(SEASONAL_EVENTS)) {
+            const { month, dayStart, dayEnd } = event.autoStart;
+            const mm = String(month).padStart(2, '0');
+            for (const day of [dayStart, dayEnd]) {
+                const dd = String(day).padStart(2, '0');
+                expect(idAt(`2026-${mm}-${dd}T12:00:00Z`)).toBe(event.id);
+            }
+        }
+    });
+
+    test('no two windows overlap', () => {
+        // Two events claiming the same day would make the answer depend on
+        // object key order, which is not something the data file states.
+        const claimed = new Map();
+        for (const event of Object.values(SEASONAL_EVENTS)) {
+            const { month, dayStart, dayEnd } = event.autoStart;
+            for (let day = dayStart; day <= dayEnd; day++) {
+                const key = `${month}-${day}`;
+                expect(claimed.get(key) ?? event.id).toBe(event.id);
+                claimed.set(key, event.id);
+            }
+        }
+    });
+
+    test('the day before a window opens is outside it', () => {
+        // Valentine's runs Feb 7-14, so the 6th and the 15th are quiet days —
+        // and quiet is the answer no other window claims either.
+        expect(idAt('2026-02-06T12:00:00Z')).toBeNull();
+        expect(idAt('2026-02-07T00:00:00Z')).toBe('valentines_day');
+        expect(idAt('2026-02-14T23:59:59Z')).toBe('valentines_day');
+        expect(idAt('2026-02-15T12:00:00Z')).toBeNull();
+    });
+
+    test('the winter hunt ends on the 14th of January and December is a different event', () => {
+        expect(idAt('2026-01-14T23:00:00Z')).toBe('winter_hunt');
+        expect(idAt('2026-01-15T01:00:00Z')).toBeNull();
+        expect(idAt('2026-12-25T12:00:00Z')).toBe('winter_wonderland');
+    });
+
+    test('a month rollover past midnight UTC changes the answer', () => {
+        // 23:30 UTC on the last day of October is still Spooky Season; an hour
+        // later it is November and nothing is running. The window is read from
+        // the clock at call time, not from whenever the process started.
+        setClock('2026-10-31T23:30:00Z');
+        expect(getActiveSeasonalEvent()?.id).toBe('spooky_season');
+
+        advanceClock(60 * 60 * 1000);
+        expect(getActiveSeasonalEvent()).toBeNull();
+    });
+
+    test('a leap day falls outside every window', () => {
+        // Feb 29 exists only in leap years and sits past Valentine's dayEnd, so
+        // it must not resolve to an event by accident.
+        expect(idAt('2028-02-29T12:00:00Z')).toBeNull();
+    });
+
+    test('walking a full year visits each event and never throws', () => {
+        const seen = new Set();
+        setClock('2026-01-01T12:00:00Z');
+        for (let i = 0; i < 365; i++) {
+            const event = getActiveSeasonalEvent();
+            if (event) seen.add(event.id);
+            advanceClock(DAY);
+        }
+        expect([...seen].sort()).toEqual(Object.keys(SEASONAL_EVENTS).sort());
+    });
+});


### PR DESCRIPTION
`Date.now()` is read in 116 source files and no test stubbed it (#632). Every date-dependent test built its fixtures from whatever the clock said when the suite started and then asserted against a source read taken some milliseconds later. That is a race with a very long fuse: it only fails when a run straddles a boundary, and the three that will find it — midnight UTC, a month rollover, a DST change — arrive on their own schedule rather than on a contributor's.

`tests/helpers/fixedClock.js` pins the clock for a describe. `jest.useFakeTimers()` with no arguments would also take over `setTimeout` and friends, which is a much larger change than these suites want — several of them await real timers — so `doNotFake` names every timer API and leaves `Date` as the only thing faked. `advanceClock` and `setClock` move the pinned clock, and the helper's `afterEach` restores the real one however a test ends.

The four call sites the issue names are pinned: the season pass weekly window (`tests/seasonPass.test.js`) and the fishing weekly record (`tests/fishService.test.js`). Three more were the same race. `analytics.test.js` captured `TODAY` in a describe body and compared it against a day key the join and leave handlers recompute per event, so a run crossing midnight compared one day against the next. `messageCreateConcurrency.test.js` stamps `lastDailyReset` with `new Date()`, and a reset firing between the fixture and the handler's read drops the counter this suite asserts on from 2 to 1 — a lost-update failure reported for a clock.

`birthday.test.js` was seven copies of `jest.spyOn(global, 'Date')` with the matching `mockRestore()` as the last statement of each test body. It replaced the constructor but not `Date.now()`, which comes back `undefined` off a mock function that carries no statics, and a test that failed an assertion never reached its `mockRestore()` and left the global `Date` replaced for every test after it. That is now one `useFixedClock` per describe.

Pinning also makes assertions possible that could not be written before, so each of these suites gains the boundary case it was avoiding: a week that expires on elapsed time rather than on the calendar turning over, a join either side of midnight counted against its own day, a wishing hour that follows the clock.

Two behaviours were pure calendar logic with no coverage at all, because without a stubbed clock a test could only assert what today happens to be. `getActiveSeasonalEvent()` now has `tests/seasonalEventWindows.test.js`, which walks every window at both edges, checks that no two overlap, and walks a full year a day at a time. `ensureQuests()` now has `tests/questExpiryWindows.test.js`, which covers the daily expiry at midnight UTC, the weekly at Sunday 00:00, and the Saturday case the service carries a comment about — the day the two are the same instant, which is only reachable at all with the clock pinned to it.

Tests only; no source and no schema change.