### PR TITLE
Fix mention parsing, delivery retries, and MCP timeouts

### DIFF
--- a/src/models/Reminder.js
+++ b/src/models/Reminder.js
@@ -8,6 +8,10 @@ const reminderSchema = new Schema({
     remindAt: { type: Date, required: true },
     createdAt: { type: Date, default: Date.now },
     completed: { type: Boolean, default: false },
+    // Consecutive failed deliveries (channel and DM both refused). Reset to 0
+    // on success; checkReminders gives up on the reminder once it reaches
+    // MAX_DELIVERY_ATTEMPTS so a dead destination doesn't retry forever.
+    deliveryAttempts: { type: Number, default: 0 },
     // Recurring cadence — null means one-time. When set, checkReminders reschedules
     // remindAt to the next occurrence instead of marking the reminder completed.
     repeatInterval: { type: String, enum: ['daily', 'weekly', null], default: null },

--- a/src/services/ai/actions.js
+++ b/src/services/ai/actions.js
@@ -123,14 +123,33 @@ async function executeAction(action, message) {
                 if (!logId) break;
                 const logCh = message.guild.channels.cache.get(logId);
                 if (!logCh) break;
-                await logCh.send(
-                    `**[AI Mod Suggestion]** in <#${message.channel.id}>:\n${action.suggestion}`
-                );
+                // The suggestion is model-authored text, and the mod-log send
+                // is the one place it leaves this module without going through
+                // the transport's guarded helpers — so the NO_MENTIONS policy
+                // (discordChat.js) has to be restated here, or a user who talks
+                // the model into typing `@everyone` pings the mod-log channel.
+                await logCh.send({
+                    content: `**[AI Mod Suggestion]** in <#${message.channel.id}>:\n${action.suggestion}`,
+                    allowedMentions: { parse: [] }
+                });
                 break;
             }
         }
     } catch (err) {
         console.error('[AI Action] execution error:', err.message);
+        // The reply already told the user the action was taken, so a silent
+        // failure here leaves them believing a poll or reminder exists that
+        // does not. Best-effort: reporting the failure must not throw over
+        // the same broken channel that likely caused it.
+        const labels = {
+            create_poll: 'create the poll',
+            create_reminder: 'set the reminder',
+            suggest_mod_action: 'deliver the mod suggestion'
+        };
+        await message.channel.send({
+            content: `⚠️ I couldn't ${labels[action.type] || 'complete that action'} — something went wrong.`,
+            allowedMentions: { parse: [] }
+        }).catch(() => {});
     }
 }
 

--- a/src/services/ai/mcp/client.js
+++ b/src/services/ai/mcp/client.js
@@ -252,6 +252,42 @@ function progressReader(token, onProgress) {
     };
 }
 
+/**
+ * `read`, bounded by what is left of the call's deadline.
+ *
+ * axios's `timeout` only covers the wait for response *headers*. With
+ * `responseType: 'stream'` a server could return `200 text/event-stream` and
+ * then never answer the request id, which left the event-stream reader
+ * iterating forever — a Discord reply that never finishes, holding one of the
+ * per-server slots in connections.js the whole time (#816). The timer destroys
+ * the stream as well as rejecting, so the socket is released rather than left
+ * open behind a promise nobody is waiting on any more.
+ */
+async function readWithDeadline(read, stream, deadline) {
+    let timer;
+    try {
+        return await Promise.race([
+            read,
+            new Promise((_, reject) => {
+                timer = setTimeout(() => {
+                    // The read is about to lose the race; whatever destroying
+                    // the stream makes it throw has nowhere to go and must not
+                    // surface as an unhandled rejection.
+                    read.catch(() => {});
+                    stream?.destroy?.();
+                    reject(new McpError(
+                        'the server sent response headers but no answer before the deadline',
+                        { code: 'ETIMEDOUT' }
+                    ));
+                }, Math.max(1, deadline - Date.now()));
+                timer.unref?.();
+            })
+        ]);
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
 // HTTP failures are what an admin actually sees when a URL or token is wrong,
 // so they say which of the two it probably is.
 //
@@ -360,6 +396,10 @@ class McpHttpClient {
     async post(payload, { id = null, timeout = CONNECT_TIMEOUT_MS, retryable = true, authRetried = false, onNotification = null } = {}) {
         await this.authorize();
 
+        // One deadline for the whole exchange, headers and body alike. The
+        // axios timeout below only bounds the wait for headers; every body
+        // read after it gets whatever is left of the same budget.
+        const deadline = Date.now() + timeout;
         let response;
         try {
             response = await axios.post(this.url, payload, {
@@ -391,7 +431,7 @@ class McpHttpClient {
         if (response.status >= 400) {
             // Read before anything decides what to do with it: the body is the
             // server's own explanation and the stream can only be consumed once.
-            const body = await collectText(response.data);
+            const body = await readWithDeadline(collectText(response.data), response.data, deadline);
             const challenge = response.headers['www-authenticate'] ?? null;
 
             // A 401 on an OAuth connection is the ordinary end of an access
@@ -418,9 +458,10 @@ class McpHttpClient {
         }
 
         const contentType = String(response.headers['content-type'] || '');
-        return contentType.includes('text/event-stream')
+        const read = contentType.includes('text/event-stream')
             ? readEventStream(response.data, id, onNotification)
-            : parseJsonBody(await collectText(response.data), id);
+            : collectText(response.data).then(text => parseJsonBody(text, id));
+        return readWithDeadline(read, response.data, deadline);
     }
 
     /**

--- a/src/services/ai/mcp/connections.js
+++ b/src/services/ai/mcp/connections.js
@@ -42,6 +42,13 @@ const STALE_TTL_MS = 30 * 60 * 1000;
 // queue.
 const MAX_PARALLEL_PER_SERVER = 3;
 
+// How long a caller may wait for one of those slots. The calls holding them
+// are bounded — client.js enforces its deadline on the body as well as the
+// headers now (#816) — so a wait this long means the queue is deep enough that
+// the turn behind it is already lost, and refusing the call beats holding the
+// reply open on a slot that may never come.
+const SLOT_WAIT_TIMEOUT_MS = 60 * 1000;
+
 // Sessions cost the server memory. An idle one is closed rather than held open
 // for a guild that used a tool once this afternoon.
 const SESSION_IDLE_MS = 10 * 60 * 1000;
@@ -172,7 +179,19 @@ async function withSession(entry, server, fn) {
  */
 async function withServerLimit(entry, fn) {
     if (entry.inFlight >= MAX_PARALLEL_PER_SERVER) {
-        await new Promise(resolve => entry.waiters.push(resolve));
+        await new Promise((resolve, reject) => {
+            const waiter = { resolve, timer: null };
+            waiter.timer = setTimeout(() => {
+                const index = entry.waiters.indexOf(waiter);
+                // Already gone means a finishing call handed this waiter its
+                // slot in the same tick; the resolution wins over the timeout.
+                if (index < 0) return;
+                entry.waiters.splice(index, 1);
+                reject(new McpError('timed out waiting for a free connection slot on this server'));
+            }, SLOT_WAIT_TIMEOUT_MS);
+            waiter.timer.unref?.();
+            entry.waiters.push(waiter);
+        });
     } else {
         entry.inFlight++;
     }
@@ -180,8 +199,12 @@ async function withServerLimit(entry, fn) {
         return await fn();
     } finally {
         const next = entry.waiters.shift();
-        if (next) next();
-        else entry.inFlight--;
+        if (next) {
+            clearTimeout(next.timer);
+            next.resolve();
+        } else {
+            entry.inFlight--;
+        }
     }
 }
 
@@ -308,5 +331,6 @@ module.exports = {
     STALE_TTL_MS,
     FAILURE_TTL_MS,
     SESSION_IDLE_MS,
-    MAX_PARALLEL_PER_SERVER
+    MAX_PARALLEL_PER_SERVER,
+    SLOT_WAIT_TIMEOUT_MS
 };

--- a/src/services/dmService.js
+++ b/src/services/dmService.js
@@ -163,6 +163,8 @@ async function beginSession(interaction) {
         const story = await getCompletion({
             provider, model, apiKey, baseUrl, mcpServers, rateLimit,
             guildId: guild.id, userId: interaction.user.id, channelId: interaction.channelId,
+            // A narrator has no business making tool calls mid-story.
+            mcp: false,
             systemPrompt, history: [], prompt: openingPrompt, temperature: 0.9, maxTokens: 600
         });
 
@@ -240,6 +242,8 @@ async function takeAction(interaction) {
         const narrative = await getCompletion({
             provider, model, apiKey, baseUrl, mcpServers, rateLimit,
             guildId: guild.id, userId: user.id, channelId: interaction.channelId,
+            // A narrator has no business making tool calls mid-story.
+            mcp: false,
             systemPrompt, history, prompt, temperature: 0.9, maxTokens: 500
         });
 
@@ -446,6 +450,8 @@ async function handleDmButton(interaction, _client) {
         const recap = await getCompletion({
             provider, model, apiKey, baseUrl, mcpServers, rateLimit,
             guildId: session.guildId, userId: interaction.user.id, channelId: interaction.channelId,
+            // A narrator has no business making tool calls mid-story.
+            mcp: false,
             systemPrompt: 'You are a dramatic fantasy narrator. Summarize the story concisely.',
             history: [],
             prompt: `Summarize the following campaign story so far as a dramatic narrator in 3-5 sentences:\n\n${logSnippet}`,

--- a/src/services/newspaperService.js
+++ b/src/services/newspaperService.js
@@ -174,6 +174,11 @@ async function generateNewspaper(client, guildDoc, preloadedGuild, requester) {
                     : '';
                 narrativeText = await getCompletion({
                     provider, model, apiKey, baseUrl, mcpServers, rateLimit,
+                    // A scheduled run has no userId, and the tool budget is
+                    // keyed on one — leaving MCP on would be the only
+                    // unbounded tool path in the codebase. The stats are all
+                    // in the prompt; there is nothing to look up anyway.
+                    mcp: false,
                     userId: requester?.userId,
                     channelId: requester?.channelId,
                     temperature: 0.85,

--- a/src/services/reminderService.js
+++ b/src/services/reminderService.js
@@ -6,6 +6,30 @@ const REPEAT_INTERVAL_DAYS = {
     weekly: 7
 };
 
+// How many failed deliveries a reminder survives before it is given up on.
+// The scheduler ticks every minute, so this is about five minutes of retrying
+// a channel and DM that both refuse the message — long enough to ride out a
+// Discord hiccup, short enough that a permanently dead destination does not
+// keep a reminder due forever.
+const MAX_DELIVERY_ATTEMPTS = 5;
+
+/**
+ * The next occurrence strictly after `now`.
+ *
+ * After downtime a repeating reminder can be several intervals behind, and
+ * advancing one interval per delivery replays every missed occurrence — a
+ * daily reminder that missed three days fires three times in three consecutive
+ * ticks (#817). The missed occurrences are skipped instead: one delivery, then
+ * straight to the next future one.
+ */
+function nextOccurrence(from, intervalDays, timezone, now) {
+    let next = addCalendarDays(from, intervalDays, timezone);
+    while (next.getTime() <= now.getTime()) {
+        next = addCalendarDays(next, intervalDays, timezone);
+    }
+    return next;
+}
+
 async function getChannel(client, channelId) {
     const cached = client.channels.cache.get(channelId);
     if (cached) return cached;
@@ -49,11 +73,25 @@ async function checkReminders(client) {
 
         for (const reminder of dueReminders) {
             try {
-                await deliver(client, reminder);
+                const delivered = await deliver(client, reminder);
 
+                if (!delivered) {
+                    // Both the channel and the DM refused it. Leave the
+                    // reminder due so the next tick retries, but count the
+                    // attempt: a destination that is dead rather than
+                    // hiccuping is given up on below, not retried forever.
+                    reminder.deliveryAttempts = (reminder.deliveryAttempts || 0) + 1;
+                    if (reminder.deliveryAttempts < MAX_DELIVERY_ATTEMPTS) {
+                        await reminder.save();
+                        continue;
+                    }
+                    console.error(`Giving up on reminder ${reminder._id} after ${MAX_DELIVERY_ATTEMPTS} failed delivery attempts`);
+                }
+
+                reminder.deliveryAttempts = 0;
                 const intervalDays = REPEAT_INTERVAL_DAYS[reminder.repeatInterval];
                 if (intervalDays) {
-                    reminder.remindAt = addCalendarDays(reminder.remindAt, intervalDays, reminder.timezone || 'Etc/UTC');
+                    reminder.remindAt = nextOccurrence(reminder.remindAt, intervalDays, reminder.timezone || 'Etc/UTC', now);
                 } else {
                     reminder.completed = true;
                 }

--- a/src/services/summaryService.js
+++ b/src/services/summaryService.js
@@ -66,6 +66,10 @@ async function runSummaryJob(job, client) {
     // Its cadence is the bound.
     const summary = await getCompletion({
         ...config,
+        // No user means no tool-call budget either, so MCP stays off: a
+        // summary is written from the transcript in the prompt, not from
+        // anything a tool could fetch.
+        mcp: false,
         systemPrompt: 'You are a helpful assistant that creates concise summaries of Discord channel activity.',
         history: [],
         prompt: `Summarize the key topics, decisions, and highlights from these Discord messages as bullet points:\n\n${transcript}`,
@@ -165,6 +169,8 @@ async function runDailyDigest(guildSettings, client) {
     // Its cadence is the bound.
     const summary = await getCompletion({
         ...config,
+        // Same as the channel digest above: no user, so no tool budget — MCP off.
+        mcp: false,
         systemPrompt: persona,
         history: [],
         prompt: `Summarize today's activity in this Discord server. Write in the same tone and voice as your persona. Focus on key topics, decisions, and highlights. Keep it concise and engaging:\n\n${transcript}`,

--- a/tests/aiActionsMentionPolicy.test.js
+++ b/tests/aiActionsMentionPolicy.test.js
@@ -1,0 +1,94 @@
+'use strict';
+
+// The AI action executor posts model-authored text too, and one of its sends
+// leaves the transport's guarded helpers entirely: the mod-log message built
+// from the model's `suggest_mod_action` suggestion. It has to carry the same
+// NO_MENTIONS policy as everything else the model writes (#818), or a user who
+// talks the model into typing `@everyone` pings the mod-log channel.
+
+jest.mock('../src/models/Reminder', () => ({
+    countDocuments: jest.fn(async () => 0),
+    create: jest.fn(async () => ({}))
+}));
+
+const mockGuildFindOne = jest.fn();
+jest.mock('../src/models/Guild', () => ({
+    findOne: (...args) => mockGuildFindOne(...args)
+}));
+
+const { executeAction } = require('../src/services/ai/actions');
+
+function fakeMessage({ logChannel } = {}) {
+    return {
+        author: { id: 'u1' },
+        guild: {
+            id: 'g1',
+            channels: { cache: { get: jest.fn(() => logChannel) } }
+        },
+        channel: { id: 'c1', send: jest.fn(async payload => payload) },
+        member: { permissions: { has: jest.fn(() => true) } }
+    };
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockGuildFindOne.mockResolvedValue({ moderation: { logChannelId: 'log1' } });
+});
+
+describe('suggest_mod_action', () => {
+    test('the mod-log send parses no mentions out of the suggestion', async () => {
+        const logChannel = { send: jest.fn(async payload => payload) };
+        const message = fakeMessage({ logChannel });
+
+        await executeAction(
+            { type: 'suggest_mod_action', suggestion: '@everyone ban them all' },
+            message
+        );
+
+        expect(logChannel.send).toHaveBeenCalledTimes(1);
+        const [payload] = logChannel.send.mock.calls[0];
+        // The text is posted as written — it is what the model said — but
+        // Discord is told to parse no mentions out of it.
+        expect(payload.content).toContain('@everyone ban them all');
+        expect(payload.allowedMentions).toEqual({ parse: [] });
+    });
+
+    test('a non-moderator does not reach the mod-log channel at all', async () => {
+        const logChannel = { send: jest.fn(async payload => payload) };
+        const message = fakeMessage({ logChannel });
+        message.member.permissions.has = jest.fn(() => false);
+
+        await executeAction({ type: 'suggest_mod_action', suggestion: 'x' }, message);
+
+        expect(logChannel.send).not.toHaveBeenCalled();
+    });
+});
+
+describe('a failed action is reported, not swallowed', () => {
+    test('the channel is told, without pinging anybody', async () => {
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const logChannel = { send: jest.fn(async () => { throw new Error('Missing Access'); }) };
+        const message = fakeMessage({ logChannel });
+
+        await executeAction({ type: 'suggest_mod_action', suggestion: 'x' }, message);
+
+        expect(consoleSpy).toHaveBeenCalled();
+        expect(message.channel.send).toHaveBeenCalledTimes(1);
+        const [payload] = message.channel.send.mock.calls[0];
+        expect(payload.content).toMatch(/couldn't deliver the mod suggestion/);
+        expect(payload.allowedMentions).toEqual({ parse: [] });
+        consoleSpy.mockRestore();
+    });
+
+    test('a failure report that itself fails does not throw', async () => {
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        mockGuildFindOne.mockRejectedValue(new Error('db down'));
+        const message = fakeMessage({});
+        message.channel.send = jest.fn(async () => { throw new Error('Missing Access'); });
+
+        await expect(
+            executeAction({ type: 'suggest_mod_action', suggestion: 'x' }, message)
+        ).resolves.toBeUndefined();
+        consoleSpy.mockRestore();
+    });
+});

--- a/tests/mcpClient.test.js
+++ b/tests/mcpClient.test.js
@@ -402,6 +402,35 @@ describe('server-sent event responses', () => {
         await expect(new McpHttpClient({ url: URL }).initialize())
             .rejects.toThrow(/closed the stream/);
     });
+
+    test('a stream that never answers is cut off at the deadline (#816)', async () => {
+        // 200 with event-stream headers, then silence: axios's own timeout only
+        // covers the headers, so this is the shape that used to hang forever.
+        const hanging = new Readable({ read() {} });
+        axios.post.mockImplementation(async (_url, payload) => {
+            if (payload.method === 'notifications/initialized') return acceptedResponse();
+            if (payload.method === 'initialize') return jsonResponse({ jsonrpc: '2.0', id: payload.id, result: INIT_RESULT });
+            return { status: 200, headers: { 'content-type': 'text/event-stream' }, data: hanging };
+        });
+
+        const client = new McpHttpClient({ url: URL });
+        await expect(client.callTool('search', {}, { timeout: 50 }))
+            .rejects.toThrow(/no answer before the deadline/);
+        // The socket is released, not left open behind the settled promise.
+        expect(hanging.destroyed).toBe(true);
+    });
+
+    test('an error body that never arrives is cut off at the deadline too', async () => {
+        const hanging = new Readable({ read() {} });
+        axios.post.mockImplementation(async () => ({
+            status: 500, headers: { 'content-type': 'text/plain' }, data: hanging
+        }));
+
+        const client = new McpHttpClient({ url: URL });
+        await expect(client.post({ jsonrpc: '2.0', id: 1, method: 'x' }, { id: 1, timeout: 50 }))
+            .rejects.toThrow(/no answer before the deadline/);
+        expect(hanging.destroyed).toBe(true);
+    });
 });
 
 describe('tools/list', () => {

--- a/tests/mcpConnections.test.js
+++ b/tests/mcpConnections.test.js
@@ -35,7 +35,8 @@ const {
     resetMcpCache,
     LIST_TTL_MS,
     STALE_TTL_MS,
-    MAX_PARALLEL_PER_SERVER
+    MAX_PARALLEL_PER_SERVER,
+    SLOT_WAIT_TIMEOUT_MS
 } = require('../src/services/ai/mcp/connections');
 
 const SERVER = {
@@ -320,5 +321,38 @@ describe('one server does not see the whole round at once', () => {
 
         expect(entry.inFlight).toBe(0);
         await expect(withServerLimit(entry, async () => 'ok')).resolves.toBe('ok');
+    });
+
+    test('a waiter does not wait for a slot forever (#816)', async () => {
+        jest.useFakeTimers();
+        try {
+            const entry = entryFor(SERVER);
+            const gates = [];
+            const busy = () => withServerLimit(entry, () => {
+                const gate = deferred();
+                gates.push(gate);
+                return gate.promise;
+            });
+
+            // Three calls hold every slot; a fourth queues behind them.
+            const held = [busy(), busy(), busy()];
+            const outcome = withServerLimit(entry, async () => 'ok').catch(err => err);
+            await Promise.resolve();
+
+            jest.advanceTimersByTime(SLOT_WAIT_TIMEOUT_MS + 1);
+            const err = await outcome;
+            expect(err).toBeInstanceOf(McpError);
+            expect(err.message).toMatch(/waiting for a free connection slot/);
+
+            // The held calls are untouched, the abandoned waiter is off the
+            // queue, and the slots come back once they finish.
+            expect(entry.waiters).toHaveLength(0);
+            gates.forEach(gate => gate.resolve('done'));
+            await expect(Promise.all(held)).resolves.toEqual(['done', 'done', 'done']);
+            expect(entry.inFlight).toBe(0);
+            await expect(withServerLimit(entry, async () => 'ok')).resolves.toBe('ok');
+        } finally {
+            jest.useRealTimers();
+        }
     });
 });

--- a/tests/reminderService.test.js
+++ b/tests/reminderService.test.js
@@ -79,19 +79,58 @@ describe('checkReminders delivery', () => {
         expect(reminder.completed).toBe(true);
     });
 
-    test('marks completed (does not throw) when both channel and DM delivery fail', async () => {
+    test('a failed delivery leaves the reminder due and counts the attempt (#817)', async () => {
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
         const reminder = makeReminder();
         Reminder.find.mockResolvedValue([reminder]);
         const client = makeClient({ channel: undefined, dmUser: undefined });
 
         await expect(checkReminders(client)).resolves.toBeUndefined();
-        expect(reminder.completed).toBe(true);
+
+        // Not lost: still open, still due, picked up again next tick.
+        expect(reminder.completed).toBe(false);
+        expect(reminder.deliveryAttempts).toBe(1);
         expect(reminder.save).toHaveBeenCalled();
+        consoleSpy.mockRestore();
+    });
+
+    test('a delivery that succeeds after failures resets the attempt counter', async () => {
+        const reminder = makeReminder({ deliveryAttempts: 3 });
+        Reminder.find.mockResolvedValue([reminder]);
+        const channel = { send: jest.fn().mockResolvedValue(undefined) };
+        const client = makeClient({ channel });
+
+        await checkReminders(client);
+
+        expect(reminder.completed).toBe(true);
+        expect(reminder.deliveryAttempts).toBe(0);
+    });
+
+    test('a destination that stays dead is given up on after the attempt cap', async () => {
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const reminder = makeReminder({ deliveryAttempts: 4 });
+        Reminder.find.mockResolvedValue([reminder]);
+        const client = makeClient({ channel: undefined, dmUser: undefined });
+
+        await checkReminders(client);
+
+        // Fifth consecutive failure: completed so it stops retrying forever,
+        // and the loss is logged rather than silent.
+        expect(reminder.completed).toBe(true);
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Giving up on reminder'));
+        consoleSpy.mockRestore();
     });
 });
 
 describe('checkReminders recurrence', () => {
-    afterEach(() => jest.clearAllMocks());
+    // Rescheduling is measured against "now": missed occurrences are skipped,
+    // so these tests pin the clock just past each reminder's due time to see
+    // the ordinary single-interval advance.
+    beforeEach(() => jest.useFakeTimers().setSystemTime(new Date('2026-07-14T12:00:30Z')));
+    afterEach(() => {
+        jest.useRealTimers();
+        jest.clearAllMocks();
+    });
 
     test('one-time reminders are marked completed, not rescheduled', async () => {
         const reminder = makeReminder({ repeatInterval: null });
@@ -132,6 +171,7 @@ describe('checkReminders recurrence', () => {
     });
 
     test('daily reminders preserve local wall-clock time across a DST transition', async () => {
+        jest.setSystemTime(new Date('2026-03-07T14:00:30Z'));
         // 9am EST on 2026-03-07 — the day before America/New_York springs forward.
         const reminder = makeReminder({
             repeatInterval: 'daily',
@@ -159,6 +199,24 @@ describe('checkReminders recurrence', () => {
         await checkReminders(client);
 
         expect(reminder.remindAt.getTime()).toBe(originalTime + 24 * 60 * 60 * 1000);
+    });
+
+    test('a daily reminder several days behind skips to the next future occurrence (#817)', async () => {
+        // Three missed days of downtime: one delivery now, then straight to
+        // tomorrow — not three catch-up deliveries on consecutive ticks.
+        const reminder = makeReminder({
+            repeatInterval: 'daily',
+            remindAt: new Date('2026-07-11T12:00:00Z')
+        });
+        Reminder.find.mockResolvedValue([reminder]);
+        const channel = { send: jest.fn().mockResolvedValue(undefined) };
+        const client = makeClient({ channel });
+
+        await checkReminders(client);
+
+        expect(channel.send).toHaveBeenCalledTimes(1);
+        expect(reminder.completed).toBe(false);
+        expect(reminder.remindAt.toISOString()).toBe('2026-07-15T12:00:00.000Z');
     });
 });
 


### PR DESCRIPTION
## Summary

This PR addresses three critical issues affecting reliability and security:

1. **Mention parsing in AI-generated mod suggestions** (#818): Model-authored text sent to the mod-log channel now has mention parsing disabled, preventing users from tricking the model into pinging `@everyone`.

2. **Reminder delivery resilience** (#817): Failed reminder deliveries are now retried up to 5 times before being abandoned, and recurring reminders that fall behind during downtime skip missed occurrences rather than replaying them.

3. **MCP stream timeout handling** (#816): HTTP responses with streaming bodies are now bounded by a deadline that covers both headers and body, preventing indefinite hangs. Connection slot waiters also timeout after 60 seconds to avoid holding reply slots forever.

## Key Changes

- **src/services/ai/actions.js**: Added `allowedMentions: { parse: [] }` to mod-log suggestion sends and error reporting to prevent unintended mentions. Added error handling that reports failures back to the user without throwing.

- **src/services/reminderService.js**: 
  - Implemented `MAX_DELIVERY_ATTEMPTS` (5) to give up on permanently dead destinations
  - Added `deliveryAttempts` tracking to distinguish transient failures from permanent ones
  - Implemented `nextOccurrence()` to skip missed intervals after downtime instead of replaying them
  - Failed deliveries now increment attempt counter and retry on next tick instead of marking complete

- **src/services/ai/mcp/client.js**: 
  - Added `readWithDeadline()` wrapper that enforces a deadline covering both response headers and body streaming
  - Applied deadline to both error body reads and event-stream reads to prevent indefinite hangs

- **src/services/ai/mcp/connections.js**:
  - Added `SLOT_WAIT_TIMEOUT_MS` (60 seconds) for connection slot waiters
  - Implemented timeout rejection for waiters that exceed the deadline, cleaning up the queue

- **src/models/Reminder.js**: Added `deliveryAttempts` field to track consecutive failed delivery attempts

- **src/services/dmService.js**, **src/services/summaryService.js**, **src/services/newspaperService.js**: Disabled MCP tool calls in contexts without a userId (narrator, summary generation, scheduled newspaper runs) to prevent unbounded tool usage.

- **tests/**: Added comprehensive test coverage for mention parsing, delivery retry logic, missed occurrence skipping, and MCP timeout scenarios.

## Implementation Details

- The mention parsing fix is applied at the point where the mod-log message leaves the guarded transport helpers, ensuring consistency with other model-authored text.
- Reminder retry logic uses a simple counter approach: failures increment, successes reset to 0, and the 5th consecutive failure triggers a logged abandonment.
- The MCP deadline uses `Promise.race()` with explicit stream destruction on timeout to ensure sockets are released rather than left open behind settled promises.
- Connection slot waiters store both resolve and timer references to allow cleanup on timeout without race conditions.

https://claude.ai/code/session_015QP7sBBkHxSLnXJoR9biXq