### PR TITLE
Fix the boot crash from the connect-mongo 6 export change

### DIFF
--- a/src/dashboard/lib/sessionStore.js
+++ b/src/dashboard/lib/sessionStore.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const connectMongo = require('connect-mongo');
+
+/**
+ * Resolves the connect-mongo store class across the library's export shapes.
+ *
+ * connect-mongo 6 (#801 bumped it from 5) is dual-published ESM/CJS, and its
+ * CommonJS build no longer sets `module.exports = MongoStore`. `require()` now
+ * lands on the namespace object — `{ MongoStore, createKrupteinAdapter,
+ * createWebCryptoAdapter, default }` — so the pre-v6 `MongoStore.create(...)`
+ * became `undefined is not a function` and the bot died on boot with
+ * "TypeError: MongoStore.create is not a function" before the dashboard was
+ * ever served.
+ *
+ * Nothing caught the bump because createApp() takes an injected `sessionStore`
+ * and every test passes a MemoryStore, so the one line that touches
+ * connect-mongo was never executed outside production.
+ *
+ * Both shapes are accepted rather than just the current one: the named export
+ * (v6), then the ESM default interop (v5 and v6), then the module itself (v5,
+ * where the class *is* the export). The next major that shuffles them again
+ * should not be a startup crash.
+ */
+const MongoStore = connectMongo?.MongoStore ?? connectMongo?.default ?? connectMongo;
+
+/**
+ * Builds the Mongo-backed express-session store the dashboard runs on.
+ *
+ * Throws instead of returning a broken store when connect-mongo's export shape
+ * is one none of the branches above understand — an explicit "connect-mongo did
+ * not export ..." at boot is a fixable message, where handing express-session a
+ * non-store is a confusing failure several layers away.
+ */
+function createSessionStore(mongoUrl = process.env.MONGODB_URI) {
+    if (typeof MongoStore?.create !== 'function') {
+        throw new TypeError(
+            'connect-mongo did not export a session store with a static create(); ' +
+            'the installed version has an export shape src/dashboard/lib/sessionStore.js does not understand.'
+        );
+    }
+
+    return MongoStore.create({ mongoUrl, collectionName: 'sessions' });
+}
+
+module.exports = { MongoStore, createSessionStore };

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -2,7 +2,7 @@ const crypto = require('crypto');
 const express = require('express');
 const compression = require('compression');
 const session = require('express-session');
-const MongoStore = require('connect-mongo');
+const { createSessionStore } = require('./lib/sessionStore');
 const passport = require('passport');
 const { Strategy: DiscordStrategy, DiscordScope } = require('./lib/discordStrategy');
 const path = require('path');
@@ -251,7 +251,7 @@ function createApp({ client = null, bot: injectedBot, sessionStore, configurePas
     // bounds how long a stale snapshot can survive when Discord cannot be
     // reached to take that second opinion.
     app.use(session({
-        store: sessionStore ?? MongoStore.create({ mongoUrl: process.env.MONGODB_URI, collectionName: 'sessions' }),
+        store: sessionStore ?? createSessionStore(),
         secret: process.env.SESSION_SECRET,
         resave: false,
         rolling: true,

--- a/tests/sessionStore.test.js
+++ b/tests/sessionStore.test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const session = require('express-session');
+
+const { MongoStore, createSessionStore } = require('../src/dashboard/lib/sessionStore');
+
+// #801 bumped connect-mongo from 5 to 6, and v6's CommonJS build stopped
+// setting `module.exports = MongoStore`. The dashboard's `MongoStore.create(...)`
+// therefore became a call on the namespace object, and the bot died on boot:
+//
+//   TypeError: MongoStore.create is not a function
+//       at createApp (src/dashboard/server.js:254)
+//
+// Nothing in the suite noticed, because createApp() takes an injected
+// `sessionStore` and every test hands it a MemoryStore — the line that touches
+// connect-mongo was only ever executed in production. These tests execute it.
+
+const SAVED_URI = process.env.MONGODB_URI;
+
+afterEach(() => {
+    if (SAVED_URI === undefined) delete process.env.MONGODB_URI;
+    else process.env.MONGODB_URI = SAVED_URI;
+    jest.restoreAllMocks();
+});
+
+describe('the store resolved from the installed connect-mongo', () => {
+    it('has the static create() the dashboard calls', () => {
+        expect(typeof MongoStore.create).toBe('function');
+    });
+
+    it('is an express-session store, which is what session() will accept', () => {
+        expect(MongoStore.prototype).toBeInstanceOf(session.Store);
+    });
+});
+
+describe('createSessionStore()', () => {
+    it('builds the store from MONGODB_URI, in the sessions collection', () => {
+        const create = jest.spyOn(MongoStore, 'create').mockReturnValue('the store');
+        process.env.MONGODB_URI = 'mongodb://mongo.example:27017/clawdia';
+
+        expect(createSessionStore()).toBe('the store');
+        expect(create).toHaveBeenCalledWith({
+            mongoUrl: 'mongodb://mongo.example:27017/clawdia',
+            collectionName: 'sessions',
+        });
+    });
+
+    it('takes an explicit URL over the environment', () => {
+        const create = jest.spyOn(MongoStore, 'create').mockReturnValue('the store');
+        process.env.MONGODB_URI = 'mongodb://from-the-environment/clawdia';
+
+        createSessionStore('mongodb://explicit/clawdia');
+        expect(create).toHaveBeenCalledWith({
+            mongoUrl: 'mongodb://explicit/clawdia',
+            collectionName: 'sessions',
+        });
+    });
+});
+
+// The resolution is deliberately version-tolerant, so each shape it claims to
+// understand is asserted against a stand-in for that version of the library.
+describe('the export shapes it understands', () => {
+    afterEach(() => {
+        jest.dontMock('connect-mongo');
+    });
+
+    function resolveAgainst(moduleExports) {
+        let module;
+        jest.isolateModules(() => {
+            jest.doMock('connect-mongo', () => moduleExports);
+            module = require('../src/dashboard/lib/sessionStore');
+        });
+        return module;
+    }
+
+    it('takes the named export, which is where connect-mongo 6 puts the class', () => {
+        class Store6 { static create() { return 'v6 store'; } }
+        const resolved = resolveAgainst({
+            MongoStore: Store6,
+            default: Store6,
+            createKrupteinAdapter: () => {},
+            createWebCryptoAdapter: () => {},
+        });
+
+        expect(resolved.MongoStore).toBe(Store6);
+        expect(resolved.createSessionStore('mongodb://x/y')).toBe('v6 store');
+    });
+
+    it('takes the module itself, which is what connect-mongo 5 exported', () => {
+        class Store5 { static create() { return 'v5 store'; } }
+        const resolved = resolveAgainst(Store5);
+
+        expect(resolved.MongoStore).toBe(Store5);
+        expect(resolved.createSessionStore('mongodb://x/y')).toBe('v5 store');
+    });
+
+    it('names connect-mongo when the shape is one it cannot read, instead of handing session() a non-store', () => {
+        const resolved = resolveAgainst({ somethingElse: true });
+
+        expect(() => resolved.createSessionStore('mongodb://x/y'))
+            .toThrow(/connect-mongo did not export a session store/);
+    });
+});
+
+it('is the only place the dashboard reaches for connect-mongo', () => {
+    const server = fs.readFileSync(path.join(__dirname, '..', 'src', 'dashboard', 'server.js'), 'utf8');
+    expect(server).not.toMatch(/require\(['"]connect-mongo['"]\)/);
+});


### PR DESCRIPTION
#801 bumped connect-mongo from 5 to 6. v6 is dual-published ESM/CJS and its
CommonJS build no longer sets `module.exports = MongoStore`: `require()` now
lands on the namespace object, `{ MongoStore, createKrupteinAdapter,
createWebCryptoAdapter, default }`. The dashboard's `MongoStore.create(...)`
was therefore a call on a property that no longer exists, and the bot died
during startup, after loading every command and event, with

    TypeError: MongoStore.create is not a function
        at createApp (src/dashboard/server.js:254)

Nothing in the suite noticed. createApp() takes an injected `sessionStore` and
every test hands it a MemoryStore, so the one line that touches connect-mongo
had no coverage outside production — a dependency bump could change the shape
of the import underneath it and CI stayed green.

The resolution moves to src/dashboard/lib/sessionStore.js, which accepts the
named export (v6), the ESM default interop, and the module itself (v5), and
throws a message naming connect-mongo if it is handed a shape it cannot read
rather than passing a non-store to express-session. tests/sessionStore.test.js
executes it against the installed library — the assertion that broke here is
`typeof MongoStore.create === 'function'` — against stand-ins for both export
shapes, and asserts server.js does not reach for connect-mongo directly again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard session handling across supported connect-mongo versions.
  * Added clearer startup errors when session storage cannot be initialized.
  * Session storage continues to use the configured MongoDB connection and sessions collection.

* **Tests**
  * Added coverage for default and custom MongoDB connection settings, supported library formats, and invalid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->