### PR TITLE
Charge for tool calls that ran, show what is being approved, claim only the files that go

### DIFF
--- a/src/services/ai/mcp/activity.js
+++ b/src/services/ai/mcp/activity.js
@@ -144,14 +144,19 @@ function createToolActivity() {
             // A chart, a screenshot, a rendered page: something the channel can
             // show and the model cannot use. Dropped past the cap rather than
             // queued — a reply that arrives is worth more than every file in it.
+            //
+            // The answer goes back to the toolkit, which is still writing the
+            // sentence that tells the model what happened to this block (#828):
+            // a file refused here has to read as "not sent" there, or the model
+            // narrates pictures that never reached the channel.
             case 'attachment': {
-                if (!Buffer.isBuffer(event.buffer) || !event.buffer.length) break;
-                if (files.length >= MAX_ATTACHMENTS) break;
-                if (fileBytes + event.buffer.length > MAX_ATTACHMENT_BYTES) break;
+                if (!Buffer.isBuffer(event.buffer) || !event.buffer.length) return false;
+                if (files.length >= MAX_ATTACHMENTS) return false;
+                if (fileBytes + event.buffer.length > MAX_ATTACHMENT_BYTES) return false;
                 used = true;
                 fileBytes += event.buffer.length;
                 files.push({ attachment: event.buffer, name: event.name });
-                break;
+                return true;
             }
         }
     }

--- a/src/services/ai/mcp/approval.js
+++ b/src/services/ai/mcp/approval.js
@@ -65,11 +65,26 @@ function renderArgs(args) {
     if (clean.length <= MAX_ARGS_CHARS) return `\n\`\`\`json\n${clean}\n\`\`\``;
 
     // The count is the point: "truncated" alone tells somebody the preview
-    // stops, not that they are approving four thousand characters they have
-    // not read.
-    const hidden = clean.length - MAX_ARGS_CHARS;
-    const body = `${clean.slice(0, MAX_ARGS_CHARS)}\n… (truncated — ${hidden} of ${clean.length} characters not shown)`;
+    // stops, not that they are approving four thousand bytes they have not
+    // read. Bytes rather than characters because that is the unit the size
+    // limit above is in — a payload of emoji or CJK is two to four times the
+    // size its character count suggests, and the number is here to say how much
+    // is going unread.
+    const shown = clip(clean, MAX_ARGS_CHARS);
+    const total = Buffer.byteLength(clean, 'utf8');
+    const hidden = total - Buffer.byteLength(shown, 'utf8');
+    const body = `${shown}\n… (truncated — ${hidden} of ${total} bytes not shown)`;
     return `\n\`\`\`json\n${body}\n\`\`\``;
+}
+
+// `text` cut to `limit` UTF-16 units without splitting a surrogate pair: half
+// an emoji is a replacement character sitting in the middle of the payload
+// somebody is being asked to read, which is the one thing this preview exists
+// to render faithfully.
+function clip(text, limit) {
+    if (text.length <= limit) return text;
+    const last = text.charCodeAt(limit - 1);
+    return text.slice(0, last >= 0xD800 && last <= 0xDBFF ? limit - 1 : limit);
 }
 
 // The arguments as JSON, or null when there is nothing to show — no arguments

--- a/src/services/ai/mcp/approval.js
+++ b/src/services/ai/mcp/approval.js
@@ -27,6 +27,23 @@ const CONFIRM_TIMEOUT_MS = 60_000;
 // for a human, not the payload.
 const MAX_ARGS_CHARS = 500;
 
+// The rest of the payload, when the preview is not all of it (#827).
+//
+// A person clicking "Run it" on a tool that writes something is answering for
+// the whole call, and the tail of a long argument is exactly where a prompt
+// injection would put the part it did not want read. So the preview says how
+// much it is not showing, and the whole JSON goes up beside the buttons as a
+// file — Discord renders a small one inline and offers the rest as a download,
+// which is the difference between an approval that is partial and one that is
+// partial without anybody knowing.
+const ARGS_FILE_NAME = 'arguments.json';
+
+// Past this, the file is the problem rather than the answer: a megabyte of JSON
+// is not something anybody reads off a phone before clicking, and holding it to
+// post it is a cost per prompt. The preview still says what it left out, and
+// the size is itself worth seeing before approving.
+const MAX_ARGS_FILE_BYTES = 1024 * 1024;
+
 const APPROVE = 'mcp-approve';
 const DENY = 'mcp-deny';
 
@@ -41,17 +58,46 @@ const NOT_YOURS = 'Only the person who asked, or someone who can manage this ser
  * on the send, which is the part a string cannot get wrong.
  */
 function renderArgs(args) {
-    if (!args || typeof args !== 'object' || !Object.keys(args).length) return '';
+    const json = argsJson(args);
+    if (json === null) return '';
 
-    let json;
-    try {
-        json = JSON.stringify(args, null, 1);
-    } catch {
-        return '';
-    }
     const clean = json.replace(/`/g, "'");
-    const body = clean.length > MAX_ARGS_CHARS ? `${clean.slice(0, MAX_ARGS_CHARS)}\n… (truncated)` : clean;
+    if (clean.length <= MAX_ARGS_CHARS) return `\n\`\`\`json\n${clean}\n\`\`\``;
+
+    // The count is the point: "truncated" alone tells somebody the preview
+    // stops, not that they are approving four thousand characters they have
+    // not read.
+    const hidden = clean.length - MAX_ARGS_CHARS;
+    const body = `${clean.slice(0, MAX_ARGS_CHARS)}\n… (truncated — ${hidden} of ${clean.length} characters not shown)`;
     return `\n\`\`\`json\n${body}\n\`\`\``;
+}
+
+// The arguments as JSON, or null when there is nothing to show — no arguments
+// at all, or a value that will not serialise.
+function argsJson(args) {
+    if (!args || typeof args !== 'object' || !Object.keys(args).length) return null;
+    try {
+        const json = JSON.stringify(args, null, 1);
+        return typeof json === 'string' ? json : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * The whole payload as a file, for a call whose preview is only part of it.
+ *
+ * Returns null when the preview is the whole thing, and when the payload is too
+ * big to be worth posting — in which case the preview's own count is what the
+ * approver goes on, and it says the number out loud.
+ */
+function argsAttachment(args) {
+    const json = argsJson(args);
+    if (json === null || json.length <= MAX_ARGS_CHARS) return null;
+
+    const buffer = Buffer.from(json, 'utf8');
+    if (buffer.length > MAX_ARGS_FILE_BYTES) return null;
+    return { attachment: buffer, name: ARGS_FILE_NAME };
 }
 
 // What the server said about the tool, when it said anything worth repeating.
@@ -83,10 +129,17 @@ function buttons(disabled = false) {
 function createToolConfirmer(message, { timeoutMs = CONFIRM_TIMEOUT_MS } = {}) {
     return async ({ server, tool, args, annotations }) => {
         const heading = `<@${message.author.id}> — run \`${toolLabel(server)} · ${toolLabel(tool)}\`?${describeTool(annotations)}`;
-        const content = `🔧 ${heading}${renderArgs(args)}`;
+        const file = argsAttachment(args);
+        const content = `🔧 ${heading}${renderArgs(args)}${
+            file ? `\n-# The preview above is cut short — the full arguments are attached as \`${ARGS_FILE_NAME}\`.` : ''
+        }`;
 
         const prompt = await message.channel.send({
             content,
+            // Beside the buttons rather than after the answer: it is what the
+            // answer is about. An edit below that names no files leaves this
+            // one on the message, so the record keeps what was approved.
+            files: file ? [file] : [],
             components: [buttons()],
             // The asker is pinged because they are the one being waited on;
             // nothing in the tool name or the arguments can ping anybody,
@@ -124,4 +177,4 @@ function createToolConfirmer(message, { timeoutMs = CONFIRM_TIMEOUT_MS } = {}) {
     };
 }
 
-module.exports = { createToolConfirmer, CONFIRM_TIMEOUT_MS, renderArgs };
+module.exports = { createToolConfirmer, CONFIRM_TIMEOUT_MS, renderArgs, argsAttachment, MAX_ARGS_CHARS, ARGS_FILE_NAME };

--- a/src/services/ai/mcp/toolkit.js
+++ b/src/services/ai/mcp/toolkit.js
@@ -351,6 +351,9 @@ function renderResult(
 ) {
     const parts = [];
     const attachments = [];
+    // Files this result put forward, taken or not — what the per-result cap is
+    // counting. `attachments` is the ones that went.
+    let offered = 0;
     const json = structured ? asJson(structuredContent) : null;
     if (json !== null) parts.push(json);
 
@@ -369,7 +372,12 @@ function renderResult(
         }
         if (!block.type) continue;
 
-        const file = attachments.length < MAX_ATTACHMENTS_PER_RESULT
+        // Counted against what this result offered, not against what was taken:
+        // a reply that is already full turns every file away, and counting
+        // those as free would decode a dozen base64 blobs to throw all of them
+        // out. The name still numbers the files that went, so a result whose
+        // first picture was refused calls its second the first.
+        const file = offered < MAX_ATTACHMENTS_PER_RESULT
             ? asAttachment(block, namePrefix, attachments.length)
             : null;
 
@@ -377,6 +385,8 @@ function renderResult(
             parts.push(`[${block.type} content omitted]`);
             continue;
         }
+        offered++;
+
         // The reply is already carrying as many files as it can. The bytes are
         // dropped either way; the difference is whether the model knows.
         if (typeof reserve === 'function' && reserve(file) === false) {

--- a/src/services/ai/mcp/toolkit.js
+++ b/src/services/ai/mcp/toolkit.js
@@ -150,9 +150,15 @@ function notifier(onToolEvent) {
     if (typeof onToolEvent !== 'function') return () => {};
     return event => {
         try {
-            onToolEvent(event);
+            // The listener's answer is passed back for the one event that has
+            // one: an attachment is offered to the transport, which may be full
+            // (#828). Every other event is announced rather than asked, and a
+            // listener that answers nothing — or that threw — reads as consent,
+            // which is what every listener before this did.
+            return onToolEvent(event);
         } catch (err) {
             console.warn(`[MCP] tool event listener failed: ${err.message}`);
+            return undefined;
         }
     };
 }
@@ -329,8 +335,20 @@ function asJson(structuredContent) {
  * arrives is usually both — and the JSON is the half a model can be relied on
  * to read the same way twice. Without a schema it stays what it always was: a
  * fallback for a result that carried no text at all.
+ *
+ * `reserve` is how the text stops lying about the files (#828). This cap is per
+ * result, and the transport has its own per *reply* — four files and eight
+ * megabytes for everything the turn produced — so two results carrying three
+ * pictures each used to be told six were sent when four arrived, and the model
+ * would then talk about media nobody could see. So each file is offered to the
+ * caller before it is claimed, and one that is turned away is reported as not
+ * sent rather than as sent. A caller that offers no `reserve` takes every file,
+ * which is what the unattributed callers and the tests were.
  */
-function renderResult({ content, structuredContent, isError }, { namePrefix = 'result', structured = false } = {}) {
+function renderResult(
+    { content, structuredContent, isError },
+    { namePrefix = 'result', structured = false, reserve = null } = {}
+) {
     const parts = [];
     const attachments = [];
     const json = structured ? asJson(structuredContent) : null;
@@ -355,12 +373,18 @@ function renderResult({ content, structuredContent, isError }, { namePrefix = 'r
             ? asAttachment(block, namePrefix, attachments.length)
             : null;
 
-        if (file) {
-            attachments.push(file);
-            parts.push(`[${block.type} sent to the channel as ${file.name}]`);
-        } else {
+        if (!file) {
             parts.push(`[${block.type} content omitted]`);
+            continue;
         }
+        // The reply is already carrying as many files as it can. The bytes are
+        // dropped either way; the difference is whether the model knows.
+        if (typeof reserve === 'function' && reserve(file) === false) {
+            parts.push(`[${block.type} not sent to the channel — this reply cannot carry any more files]`);
+            continue;
+        }
+        attachments.push(file);
+        parts.push(`[${block.type} sent to the channel as ${file.name}]`);
     }
 
     if (!parts.length) {
@@ -400,7 +424,10 @@ function renderResult({ content, structuredContent, isError }, { namePrefix = 'r
  *        built without one refuses every call that would need it
  * @param {Function} [options.toolBudget] spends one of the user's tool-call
  *        allowance and reports whether there was one to spend; a toolkit built
- *        without one is unbounded, which is what the unattributed callers are
+ *        without one is unbounded, which is what the unattributed callers are.
+ *        An optional `toolBudget.peek()` reports the same without spending, so
+ *        a call waiting on a person's approval can be refused early and charged
+ *        late (#826)
  * @param {Array} [options.botTools] tools the bot owns rather than a server —
  *        the in-channel actions (#832). Each carries the same fields a
  *        discovered tool does plus `run(args)`, which is called instead of a
@@ -739,15 +766,24 @@ async function prepareMcpToolkit(guildServers = [], {
             return 'This turn has spent its time budget, so the tool was not run. Answer from what you have and offer to continue.';
         }
 
-        // And the same for the allowance this user has across turns, for the
-        // same reason: the limit is a refusal, so it is answered before anybody
-        // is asked to approve something that will not run either way.
-        if (typeof toolBudget === 'function' && !toolBudget()) {
+        const outOfBudget = () => {
             finish(false, { error: 'rate limit' });
             return 'This user has used up the tool calls they are allowed in this window, so the tool was not run. Answer from what you have, and say they can try again shortly.';
-        }
+        };
 
+        // And the same for the allowance this user has across turns, for the
+        // same reason: the limit is a refusal, so it is answered before anybody
+        // is asked to approve something that will not run either way — but with
+        // a peek, not a spend (#826). A call somebody declines, or that nobody
+        // answers, never happened, and charging for it lets a guild running
+        // confirm-mode empty an allowance without a single tool having run.
+        // Peeking is not a reservation: another call can take the last slot
+        // while the buttons are on screen, and the spend below is what actually
+        // decides. A budget that cannot be peeked is simply charged after the
+        // answer, which is the half of this that matters.
         if (target.confirm) {
+            if (typeof toolBudget?.peek === 'function' && !toolBudget.peek()) return outOfBudget();
+
             emit({ ...describe, type: 'confirm', annotations: target.annotations });
             const decision = await askApproval(describe, target, args);
             if (!decision.approved) {
@@ -755,6 +791,8 @@ async function prepareMcpToolkit(guildServers = [], {
                 return decision.message;
             }
         }
+
+        if (typeof toolBudget === 'function' && !toolBudget()) return outOfBudget();
 
         emit({ ...describe, type: 'start' });
 
@@ -832,11 +870,13 @@ async function prepareMcpToolkit(guildServers = [], {
 
             // The file name is the tool's, so a reply carrying two charts from
             // two tools says which came from where.
-            const { text, attachments } = renderResult(result, {
+            const { text } = renderResult(result, {
                 namePrefix: fileNameFor(target.toolName, id),
-                structured: target.structured
+                structured: target.structured,
+                // Offered as it is rendered rather than after, so the sentence
+                // the model reads is the one the transport agreed to (#828).
+                reserve: file => emit({ ...describe, type: 'attachment', ...file }) !== false
             });
-            for (const file of attachments) emit({ ...describe, type: 'attachment', ...file });
             // A tool that answers "no such repository" ran fine; it is the
             // model's problem, not something to flag to the channel.
             finish(!result.isError);

--- a/src/services/ai/rateLimit.js
+++ b/src/services/ai/rateLimit.js
@@ -134,6 +134,11 @@ function userRateLimitKey(guildId, userId) {
  * nobody to attribute it to (the scheduled digests and newspapers, which run on
  * a cadence the guild set rather than on demand). The toolkit treats a missing
  * budget as unbounded, which is what those callers were before.
+ *
+ * `peek` on the returned function answers the same question without spending
+ * anything. The toolkit uses it for a call that needs a person's approval: the
+ * refusal can still be given before the buttons go up, while the slot is only
+ * charged once somebody has said yes and the call is actually going to run.
  */
 function toolCallBudget({ guildId, userId, rateLimit }) {
     if (!rateLimit || !userId) return null;
@@ -144,7 +149,9 @@ function toolCallBudget({ guildId, userId, rateLimit }) {
     const limit = perUser * TOOL_CALLS_PER_MESSAGE;
     const windowMs = (windowMin || 10) * 60 * 1000;
 
-    return () => toolCallLimits.check(key, windowMs, limit);
+    const budget = () => toolCallLimits.check(key, windowMs, limit);
+    budget.peek = () => toolCallLimits.peek(key, windowMs, limit);
+    return budget;
 }
 
 module.exports = {

--- a/tests/mcpApproval.test.js
+++ b/tests/mcpApproval.test.js
@@ -201,13 +201,35 @@ describe('rendering the arguments', () => {
 
     test('says how much of the payload it is not showing', () => {
         // "Truncated" alone says the preview stops, not that somebody is being
-        // asked to approve four thousand characters they have not read — which
-        // is where a payload with something to hide would put it.
+        // asked to approve four thousand bytes they have not read — which is
+        // where a payload with something to hide would put it.
         const rendered = renderArgs({ blob: 'x'.repeat(5000) });
-        const [, hidden, total] = rendered.match(/truncated — (\d+) of (\d+) characters not shown/);
+        const [, hidden, total] = rendered.match(/truncated — (\d+) of (\d+) bytes not shown/);
 
         expect(Number(total)).toBeGreaterThan(5000);
         expect(Number(hidden)).toBe(Number(total) - MAX_ARGS_CHARS);
+    });
+
+    test('counts what an emoji actually costs, not what it looks like', () => {
+        // The size limit on the attachment is in bytes, and for a payload that
+        // is not ASCII the two are nowhere near the same number: saying
+        // "5000 characters" of something three times that size understates the
+        // part going unread.
+        const rendered = renderArgs({ blob: '🎉'.repeat(2000) });
+        const [, , total] = rendered.match(/truncated — (\d+) of (\d+) bytes not shown/);
+
+        // Four bytes each, not the two UTF-16 units the string reports.
+        expect(Number(total)).toBeGreaterThan(8000);
+    });
+
+    test('never cuts an emoji in half at the boundary', () => {
+        // A lone surrogate renders as a replacement character sitting in the
+        // middle of the payload somebody is being asked to read.
+        for (let pad = 480; pad < 510; pad++) {
+            const rendered = renderArgs({ n: 'a'.repeat(pad) + '🎉' + 'b'.repeat(50) });
+            expect(rendered).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+            expect(rendered).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
+        }
     });
 });
 

--- a/tests/mcpApproval.test.js
+++ b/tests/mcpApproval.test.js
@@ -9,7 +9,13 @@
 // from the server and the arguments come from the model, and this message is
 // posted to a channel by a bot that can mention everyone.
 
-const { createToolConfirmer, renderArgs } = require('../src/services/ai/mcp/approval');
+const {
+    createToolConfirmer,
+    renderArgs,
+    argsAttachment,
+    MAX_ARGS_CHARS,
+    ARGS_FILE_NAME
+} = require('../src/services/ai/mcp/approval');
 
 const APPROVE = 'mcp-approve';
 const DENY = 'mcp-deny';
@@ -191,6 +197,59 @@ describe('rendering the arguments', () => {
         const rendered = renderArgs({ blob: 'x'.repeat(5000) });
         expect(rendered.length).toBeLessThan(700);
         expect(rendered).toContain('truncated');
+    });
+
+    test('says how much of the payload it is not showing', () => {
+        // "Truncated" alone says the preview stops, not that somebody is being
+        // asked to approve four thousand characters they have not read — which
+        // is where a payload with something to hide would put it.
+        const rendered = renderArgs({ blob: 'x'.repeat(5000) });
+        const [, hidden, total] = rendered.match(/truncated — (\d+) of (\d+) characters not shown/);
+
+        expect(Number(total)).toBeGreaterThan(5000);
+        expect(Number(hidden)).toBe(Number(total) - MAX_ARGS_CHARS);
+    });
+});
+
+describe('the part the preview leaves out', () => {
+    test('goes up beside the buttons as a file', () => {
+        const file = argsAttachment({ body: 'y'.repeat(5000) });
+
+        expect(file.name).toBe(ARGS_FILE_NAME);
+        // The payload as the tool would receive it, not the fenced preview.
+        expect(JSON.parse(file.attachment.toString('utf8'))).toEqual({ body: 'y'.repeat(5000) });
+    });
+
+    test('is nothing at all when the preview was the whole thing', () => {
+        expect(argsAttachment({ q: 'clawdia' })).toBeNull();
+        expect(argsAttachment({})).toBeNull();
+        expect(argsAttachment(null)).toBeNull();
+    });
+
+    test('is left to the preview\'s own count when it is too big to post', () => {
+        expect(argsAttachment({ blob: 'z'.repeat(2 * 1024 * 1024) })).toBeNull();
+    });
+
+    test('reaches the channel with the prompt that asks about it', async () => {
+        const fake = fakeMessage();
+        fake.prompt.awaitMessageComponent.mockResolvedValue(click(APPROVE));
+
+        await createToolConfirmer(fake.message)({ ...CALL, args: { body: 'y'.repeat(5000) } });
+        const [sent] = fake.sends;
+
+        expect(sent.files).toHaveLength(1);
+        expect(sent.files[0].name).toBe(ARGS_FILE_NAME);
+        // And the message says the file is there, so a partial approval is at
+        // least a knowing one.
+        expect(sent.content).toContain(ARGS_FILE_NAME);
+    });
+
+    test('is not attached to a call whose arguments fit', async () => {
+        const fake = fakeMessage();
+        fake.prompt.awaitMessageComponent.mockResolvedValue(click(APPROVE));
+
+        await createToolConfirmer(fake.message)(CALL);
+        expect(fake.sends[0].files).toEqual([]);
     });
 
     test('drops arguments that cannot be serialised at all', () => {

--- a/tests/mcpAttachments.test.js
+++ b/tests/mcpAttachments.test.js
@@ -121,6 +121,67 @@ describe('what does not', () => {
     });
 });
 
+describe('what the model is told about a file the reply cannot carry', () => {
+    // The cap in renderResult is per result; the transport's is per reply. Two
+    // results carrying three pictures each used to claim six were sent when
+    // four arrived, and the model would then talk about media nobody could see.
+    test('the claim follows the answer of whoever is taking the files', () => {
+        const reserve = jest.fn(() => false);
+        const { text, attachments } = renderResult(result([image()]), { namePrefix: 'x', reserve });
+
+        expect(reserve).toHaveBeenCalledWith(expect.objectContaining({ name: 'x-1.png' }));
+        expect(attachments).toEqual([]);
+        expect(text).toBe('[image not sent to the channel — this reply cannot carry any more files]');
+    });
+
+    test('one refusal does not cost the files after it their names', () => {
+        // The number in a file name is its place among the files that went, so
+        // a result whose first picture was refused still calls its second the
+        // first — the model is told a name the channel will actually show.
+        let offers = 0;
+        const reserve = jest.fn(() => offers++ > 0);
+        const { text, attachments } = renderResult(result([image(), image()]), { namePrefix: 'x', reserve });
+
+        expect(attachments.map(a => a.name)).toEqual(['x-1.png']);
+        expect(text).toContain('[image sent to the channel as x-1.png]');
+        expect(text).toContain('cannot carry any more files');
+    });
+
+    test('a caller with no answer to give takes them all, as before', () => {
+        const { attachments } = renderResult(result([image()]), { namePrefix: 'x' });
+        expect(attachments).toHaveLength(1);
+    });
+
+    test('the toolkit asks the turn, and reports what it says', async () => {
+        // Four files in, two results out: the second result's text has to say
+        // the pictures did not go, because the transport has already said no.
+        mockCallTool.mockResolvedValue(result([image(), image(), image()]));
+        const activity = createToolActivity();
+        const toolkit = await prepareMcpToolkit([GITHUB], { onToolEvent: activity.onEvent });
+
+        const first = await toolkit.call('github__render_chart', {});
+        const second = await toolkit.call('github__render_chart', {});
+
+        expect(activity.attachments).toHaveLength(MAX_ATTACHMENTS);
+        expect(first).not.toContain('cannot carry');
+        // Three claimed and three sent, then one sent and two refused — the
+        // count the model reads matches the count the channel gets.
+        expect(second.match(/sent to the channel as/g)).toHaveLength(1);
+        expect(second.match(/cannot carry any more files/g)).toHaveLength(2);
+    });
+
+    test('a listener that throws is not read as a refusal', async () => {
+        // A broken transport is a bug in the transport, not a reason to tell
+        // the model its picture went missing.
+        mockCallTool.mockResolvedValue(result([image()]));
+        const toolkit = await prepareMcpToolkit([GITHUB], {
+            onToolEvent: () => { throw new Error('listener down'); }
+        });
+
+        expect(await toolkit.call('github__render_chart', {})).toContain('sent to the channel');
+    });
+});
+
 describe('reaching the transport', () => {
     test('the toolkit reports each file to whoever is listening', async () => {
         mockCallTool.mockResolvedValue(result([image()]));

--- a/tests/mcpAttachments.test.js
+++ b/tests/mcpAttachments.test.js
@@ -147,6 +147,22 @@ describe('what the model is told about a file the reply cannot carry', () => {
         expect(text).toContain('cannot carry any more files');
     });
 
+    test('a reply that takes nothing still only decodes what one result may send', () => {
+        // The cap counts what the result offered, not what was accepted:
+        // counting only the files that went would decode a dozen base64 blobs
+        // for a reply that was always going to refuse every one of them.
+        const reserve = jest.fn(() => false);
+        const many = Array.from({ length: MAX_ATTACHMENTS_PER_RESULT + 8 }, () => image());
+        const { text, attachments } = renderResult(result(many), { namePrefix: 'x', reserve });
+
+        expect(reserve).toHaveBeenCalledTimes(MAX_ATTACHMENTS_PER_RESULT);
+        expect(attachments).toEqual([]);
+        // The ones past the cap read as they always did; the refused ones say
+        // the reply could not carry them.
+        expect(text.match(/cannot carry any more files/g)).toHaveLength(MAX_ATTACHMENTS_PER_RESULT);
+        expect(text.match(/content omitted/g)).toHaveLength(8);
+    });
+
     test('a caller with no answer to give takes them all, as before', () => {
         const { attachments } = renderResult(result([image()]), { namePrefix: 'x' });
         expect(attachments).toHaveLength(1);

--- a/tests/mcpPrewarmAndLimits.test.js
+++ b/tests/mcpPrewarmAndLimits.test.js
@@ -155,6 +155,17 @@ describe('what a user costs across turns', () => {
         expect(budget()).toBe(false);
     });
 
+    test('it can be asked without being spent', () => {
+        // What the toolkit uses to refuse a call before the approval buttons
+        // go up without charging for the answer nobody has given yet.
+        const budget = toolCallBudget({ guildId: 'g1', userId: 'peek', rateLimit });
+        const allowed = rateLimit.perUser * TOOL_CALLS_PER_MESSAGE;
+
+        for (let n = 0; n < allowed * 2; n++) expect(budget.peek()).toBe(true);
+        for (let n = 0; n < allowed; n++) expect(budget()).toBe(true);
+        expect(budget.peek()).toBe(false);
+    });
+
     test('the window is per guild, so one server does not eat another\'s allowance', () => {
         const here = toolCallBudget({ guildId: 'g1', userId: 'u1', rateLimit });
         const there = toolCallBudget({ guildId: 'g2', userId: 'u1', rateLimit });
@@ -186,14 +197,68 @@ describe('what a user costs across turns', () => {
 
     test('nobody is asked to approve a call the limit has already refused', async () => {
         const confirmTool = jest.fn(async () => ({ approved: true }));
-        const toolkit = await prepareMcpToolkit([GITHUB], {
+        // The real budget can be asked without being spent, which is what lets
+        // the refusal come before the buttons rather than instead of them.
+        const toolBudget = () => false;
+        toolBudget.peek = () => false;
+        const toolkit = await prepareMcpToolkit([GITHUB], { confirmMode: 'always', confirmTool, toolBudget });
+
+        expect(await toolkit.call('github__search', {})).toMatch(/tool calls they are allowed/);
+        expect(confirmTool).not.toHaveBeenCalled();
+    });
+
+    // A slot spent on a call nobody agreed to run is an allowance emptied by
+    // tools that never ran — the failure a guild with confirm-mode on hits
+    // first, and the one it would never think to look for.
+    describe('a call somebody has to approve', () => {
+        const peekable = spend => {
+            const budget = jest.fn(spend);
+            budget.peek = jest.fn(() => true);
+            return budget;
+        };
+
+        const confirming = (decision, toolBudget) => prepareMcpToolkit([GITHUB], {
             confirmMode: 'always',
-            confirmTool,
-            toolBudget: () => false
+            confirmTool: async () => decision,
+            toolBudget
         });
 
-        await toolkit.call('github__search', {});
-        expect(confirmTool).not.toHaveBeenCalled();
+        test('costs nothing when it is declined', async () => {
+            const toolBudget = peekable(() => true);
+            const toolkit = await confirming({ approved: false }, toolBudget);
+
+            expect(await toolkit.call('github__search', {})).toMatch(/declined/);
+            expect(toolBudget).not.toHaveBeenCalled();
+            // Asked, though: a call with no allowance left should not put
+            // buttons in front of somebody either way.
+            expect(toolBudget.peek).toHaveBeenCalled();
+        });
+
+        test('costs nothing when nobody answers', async () => {
+            const toolBudget = peekable(() => true);
+            const toolkit = await confirming({ approved: false, timedOut: true }, toolBudget);
+
+            expect(await toolkit.call('github__search', {})).toMatch(/in time/);
+            expect(toolBudget).not.toHaveBeenCalled();
+        });
+
+        test('costs a slot once it runs', async () => {
+            const toolBudget = peekable(() => true);
+            const toolkit = await confirming({ approved: true }, toolBudget);
+
+            expect(await toolkit.call('github__search', {})).toContain('ok');
+            expect(toolBudget).toHaveBeenCalledTimes(1);
+        });
+
+        test('is refused if the last slot went while the buttons were up', async () => {
+            // A peek is not a reservation: the calls of one round run together,
+            // and the spend is what decides.
+            const toolBudget = peekable(() => false);
+            const toolkit = await confirming({ approved: true }, toolBudget);
+
+            expect(await toolkit.call('github__search', {})).toMatch(/tool calls they are allowed/);
+            expect(mockCallTool).not.toHaveBeenCalled();
+        });
     });
 
     test('a toolkit built without a budget is unbounded, as the unattributed callers were', async () => {


### PR DESCRIPTION
Three ways the MCP tool loop told somebody something that was not so.

A call held at the approval prompt spent one of the user's tool-call slots
before the buttons went up, so a guild running confirm-mode could empty an
allowance on calls that were declined or that nobody answered — tools that
never ran. The slot is now spent after the answer; the refusal still comes
before the prompt, from a peek that costs nothing, so nobody is asked to
approve a call the limit has already refused. A peek is not a reservation, and
the spend is still what decides.

The approval prompt previewed the arguments cut off at 500 characters and said
only "truncated", which is where a payload with something to hide would put it.
The preview now says how many characters of how many it is not showing, and the
whole JSON goes up beside the buttons as a file, so a partial approval is at
least a knowing one.

And a tool result claimed "[image sent to the channel as X]" for up to four
files per result, while the transport caps the whole reply at four files and
eight megabytes and dropped the rest in silence — two results with three
pictures each claimed six and delivered four, and the model then narrated media
nobody could see. Each file is now offered to the transport as the result is
rendered, and one it cannot take is reported as not sent.

Closes #826
Closes #827
Closes #828

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Large tool-call arguments can now be attached as a JSON file when previews are truncated.
  * Attachment limits are enforced, with clear messages when files cannot be sent.
  * Approval prompts check availability before confirmation and charge usage only after approval.

* **Bug Fixes**
  * Refused or unavailable attachments are accurately reported as not sent.
  * Declined and expired approvals no longer consume tool-call limits.
  * Preview messages now specify how many characters were hidden.

* **Tests**
  * Added coverage for attachment handling, truncation, approval limits, refusals, and budget behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->