### PR TITLE
Read what the user said, not the index it sat at, and verify the refund

### DIFF
--- a/src/commands/economy/forge.js
+++ b/src/commands/economy/forge.js
@@ -7,6 +7,7 @@ const AiItem  = require('../../models/AiItem');
 const { resolveProviderConfig, getCompletion } = require('../../services/aiService');
 const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const { requestModelJson } = require('../../utils/modelJson');
+const cooldownStore = require('../../utils/commandCooldowns');
 
 const RARITY_CONFIG = {
     common:    { label: 'Common',    emoji: '⚪', color: 0xAAAAAA, cost: 500,   xpReward: 25  },
@@ -25,6 +26,48 @@ const COOLDOWNS_MS = {
     mythic:    6 * 60 * 60 * 1000,   // 6h
     legendary: 24 * 60 * 60 * 1000,  // 24h
 };
+
+// A single pictographic grapheme: one base emoji, its skin-tone and
+// presentation modifiers, and any ZWJ-joined parts. The model is *asked* for
+// one emoji and will hand back whatever it likes — a word, a sentence, a
+// `<:name:id>` token it invented — and clamping that to eight characters only
+// ever bounded how much of it landed in the embed. This is the check that was
+// missing; anything failing it falls back to the rarity's own emoji (#829).
+const SINGLE_EMOJI = /^\p{Extended_Pictographic}(?:[\u{1F3FB}-\u{1F3FF}]|\uFE0F|\u20E3)*(?:\u200D\p{Extended_Pictographic}(?:[\u{1F3FB}-\u{1F3FF}]|\uFE0F|\u20E3)*)*$/u;
+
+function pickEmoji(raw, fallback) {
+    const candidate = String(raw ?? '').trim();
+    return SINGLE_EMOJI.test(candidate) ? candidate : fallback;
+}
+
+/**
+ * Put the forge's cost back, and say whether it actually went back.
+ *
+ * Both failure paths below tell the user their coins have been returned, so
+ * both have to know whether that is true. The AI-failure path already checked;
+ * the persistence-failure path swallowed the refund's own error and promised a
+ * refund regardless, which is how a user could pay 25,000 coins for nothing and
+ * be told otherwise (#829). One helper, so the two cannot drift apart again.
+ *
+ * The claimed cooldown window goes back with the coins: a forge that produced
+ * no item should not lock its rarity for the next day either.
+ */
+async function refundForge(interaction, cost, cooldownScope, context) {
+    const refunded = await User.updateOne(
+        { userId: interaction.user.id, guildId: interaction.guild.id },
+        { $inc: { balance: cost } },
+    ).then(res => res.modifiedCount > 0)
+     .catch(err => { console.error(`[FORGE] Refund failed after ${context}:`, err); return false; });
+
+    if (cooldownScope) {
+        await cooldownStore.release(interaction.client, cooldownScope).catch(err =>
+            console.error('[FORGE] Cooldown release failed:', err));
+    }
+
+    return refunded;
+}
+
+const REFUND_FAILED = 'The refund failed to process — please contact a server admin, your coins were not returned automatically.';
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -66,26 +109,34 @@ module.exports = {
             });
         }
 
-        // Cooldown check per rarity (only for rare+)
+        // Cooldown per rarity (only for rare+). Taken, not just read: the old
+        // check asked the most recent AiItem how long ago the last forge was and
+        // then acted on the answer, and two `/forge legendary` calls a moment
+        // apart both read "long enough" before either had written an item (#829).
+        // utils/commandCooldowns takes the window in the same operation that
+        // checks it — the same store and the same lock the dispatcher uses. It
+        // is a different record of the same thing, so the deploy that moves to
+        // it hands back whatever windows were open at the time, once.
         const cooldownMs = COOLDOWNS_MS[rarityKey] ?? 0;
-        if (cooldownMs > 0) {
-            const lastForge = await AiItem.findOne({
-                createdBy: interaction.user.id,
+        const cooldownScope = cooldownMs > 0
+            ? {
+                bucket: `forge:${rarityKey}`,
+                userId: interaction.user.id,
                 guildId: interaction.guild.id,
-                rarity: cfg.label,
-            }).sort({ createdAt: -1 }).lean();
+                cooldownMs,
+            }
+            : null;
 
-            if (lastForge) {
-                const elapsed = Date.now() - new Date(lastForge.createdAt).getTime();
-                if (elapsed < cooldownMs) {
-                    const remaining = cooldownMs - elapsed;
-                    const h = Math.floor(remaining / 3_600_000);
-                    const m = Math.floor((remaining % 3_600_000) / 60_000);
-                    const timeStr = h > 0 ? `${h}h ${m}m` : `${m}m`;
-                    return interaction.editReply({
-                        content: `The ${cfg.emoji} ${cfg.label} forge is cooling down. Try again in **${timeStr}**.`,
-                    });
-                }
+        if (cooldownScope) {
+            const expiry = await cooldownStore.claimIfAvailable(interaction.client, cooldownScope);
+            if (expiry) {
+                const remaining = expiry - Date.now();
+                const h = Math.floor(remaining / 3_600_000);
+                const m = Math.floor((remaining % 3_600_000) / 60_000);
+                const timeStr = h > 0 ? `${h}h ${m}m` : `${m}m`;
+                return interaction.editReply({
+                    content: `The ${cfg.emoji} ${cfg.label} forge is cooling down. Try again in **${timeStr}**.`,
+                });
             }
         }
 
@@ -96,6 +147,13 @@ module.exports = {
             { new: true }
         );
         if (!chargedUser) {
+            // The window was claimed a moment ago and nothing was forged with
+            // it, so it goes straight back — a user who could not afford the
+            // item must not be locked out of the rarity for a day over it.
+            if (cooldownScope) {
+                await cooldownStore.release(interaction.client, cooldownScope).catch(err =>
+                    console.error('[FORGE] Cooldown release failed:', err));
+            }
             const currency = guildSettings?.economy?.currency ?? '💰';
             return interaction.editReply({
                 content: `You need **${currency}${cfg.cost.toLocaleString()}** to forge a ${cfg.emoji} ${cfg.label} item. Your balance: **${currency}${(user?.balance ?? 0).toLocaleString()}**`,
@@ -146,24 +204,20 @@ Respond with ONLY the JSON object. No markdown, no extra text.`;
             // decides what the message says. A swallowed write error used to
             // leave the user told they had been refunded when they had not,
             // with nothing but the log to say otherwise.
-            const refunded = await User.updateOne(
-                { userId: interaction.user.id, guildId: interaction.guild.id },
-                { $inc: { balance: cfg.cost } }
-            ).then(res => res.modifiedCount > 0)
-             .catch(refundErr => { console.error('[FORGE] Refund failed after AI failure:', refundErr); return false; });
+            const refunded = await refundForge(interaction, cfg.cost, cooldownScope, 'AI failure');
             const failure = err?.rateLimited
                 ? `This server's AI limit has been reached (${err.limit} per ${err.windowMin}m).`
                 : 'The forge misfired!';
             return interaction.editReply({
                 content: refunded
                     ? `${failure} Your coins have been refunded. Try again in a moment.`
-                    : `${failure} The refund failed to process — please contact a server admin, your coins were not returned automatically.`,
+                    : `${failure} ${REFUND_FAILED}`,
             });
         }
 
         // Sanitize
         const name        = String(parsed.name        || 'Mysterious Relic').slice(0, 60);
-        const emoji       = String(parsed.emoji       || cfg.emoji).slice(0, 8);
+        const emoji       = pickEmoji(parsed.emoji, cfg.emoji);
         const description = String(parsed.description || '').slice(0, 200);
         const lore        = String(parsed.lore        || '').slice(0, 300);
 
@@ -186,11 +240,12 @@ Respond with ONLY the JSON object. No markdown, no extra text.`;
             if (!granted) throw new Error('user document not found');
         } catch (err) {
             console.error('[FORGE] Persistence failed:', err?.message || err);
-            await User.updateOne(
-                { userId: interaction.user.id, guildId: interaction.guild.id },
-                { $inc: { balance: cfg.cost } }
-            ).catch(() => {});
-            return interaction.editReply({ content: 'The forge failed to save your item! Your coins have been refunded. Try again in a moment.' });
+            const refunded = await refundForge(interaction, cfg.cost, cooldownScope, 'persistence failure');
+            return interaction.editReply({
+                content: refunded
+                    ? 'The forge failed to save your item! Your coins have been refunded. Try again in a moment.'
+                    : `The forge failed to save your item! ${REFUND_FAILED}`,
+            });
         }
 
         const embed = new EmbedBuilder()

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -130,13 +130,18 @@ module.exports = {
                             const blocked = await handleAutoModeration(message, guildSettings);
                             if (blocked) return;
                         }
-                        // Strip bot mention tokens so NL reminder detection works on the real content
+                        // Strip bot mention tokens once, and use the result for
+                        // everything downstream. NL reminder detection needs the real
+                        // content, and so does the chat handler: it was reading
+                        // `message.content` itself, so `@Clawdia !reset` never matched
+                        // the reset command and the raw `<@id>` token went into the
+                        // model prompt on every mention-triggered message (#820).
                         const strippedContent = message.content
                             .replace(new RegExp(`<@!?${client.user.id}>`, 'g'), '')
                             .trim();
                         const reminderHandled = await handleNLReminder(message, strippedContent);
                         if (!reminderHandled) {
-                            await handleAIChat(message, effectiveSettings);
+                            await handleAIChat(message, effectiveSettings, strippedContent);
                         }
                         return;
                     }

--- a/src/services/ai/discordChat.js
+++ b/src/services/ai/discordChat.js
@@ -140,7 +140,16 @@ function chunkText(text, size = DISCORD_MAX_LEN) {
     return chunks;
 }
 
-async function handleAIChat(message, aiSettings) {
+/**
+ * `promptContent` is the message text with the bot's own mention tokens already
+ * removed (src/events/messageCreate.js). Everything here that reads what the
+ * user actually said — the `!reset` match, knowledge retrieval, the prompt sent
+ * to the provider, the history entry — reads it rather than `message.content`,
+ * which on a mention-triggered message still carries the raw `<@id>` token
+ * (#820). Callers that have no stripped form to hand fall back to the raw
+ * content, which is the right answer for the reply-to-bot trigger.
+ */
+async function handleAIChat(message, aiSettings, promptContent) {
     const { provider, model, temperature, maxTokens, apiKey, baseUrl, mcpServers, mcpConfirm, mcpRoute, rateLimit } = resolveProviderConfig(aiSettings);
     const providerDef = providers.get(provider);
     const providerLabel = providerDef?.label || provider;
@@ -154,10 +163,17 @@ async function handleAIChat(message, aiSettings) {
         return reply(message, modelError);
     }
 
-    const content = message.content.trim();
+    const content = (promptContent ?? message.content).trim();
     if (content.toLowerCase() === '!reset') {
         await clearHistory(message.guild.id, message.channel.id, message.author.id);
         return reply(message, 'Conversation history cleared.');
+    }
+
+    // A bare `@Clawdia` is all mention and no question. Before the token was
+    // stripped this reached the provider as the literal `<@id>`; now it would
+    // reach it as an empty prompt, which some providers reject outright.
+    if (!content) {
+        return reply(message, 'You mentioned me but did not ask anything — what can I help with?');
     }
 
     // A peek, not a consuming check: the slot is spent inside getCompletion /

--- a/src/services/dmService.js
+++ b/src/services/dmService.js
@@ -279,11 +279,22 @@ async function takeAction(interaction) {
 
     await interaction.deferReply();
 
-    // Anchor history roles to global storyLog parity so slicing doesn't flip them
+    // Roles are counted back from the end of the log, never forward from its
+    // start. The log is written in exactly two places — `/dm begin` pushes the
+    // opening scene, and the action below pushes the player entry and the
+    // narration together in one atomic `$push` — so its last entry is always
+    // the DM's, whatever has been dropped off the front.
+    //
+    // Counting forward assumed index 0 was still the opening scene, and the
+    // `$slice: -MAX_STORY_LOG` trim on that same write breaks that assumption
+    // for good: the log grows 1, 3, 5, … entries, so the first trim (at 21)
+    // drops exactly one and shifts every stored index by one. From the 11th
+    // action on, every history message went to the model with the wrong role —
+    // player actions as `assistant`, narration as `user` — in precisely the
+    // long campaigns where the history matters most (#821).
     const recentLog = session.storyLog.slice(-8);
-    const startIndex = session.storyLog.length - recentLog.length;
     const history = recentLog.map((entry, i) => ({
-        role: (startIndex + i) % 2 === 0 ? 'assistant' : 'user',
+        role: (recentLog.length - 1 - i) % 2 === 0 ? 'assistant' : 'user',
         content: entry
     }));
 

--- a/src/utils/commandCooldowns.js
+++ b/src/utils/commandCooldowns.js
@@ -193,6 +193,32 @@ async function claim(client, { bucket, userId, guildId, cooldownMs }) {
     });
 }
 
+/**
+ * Gives a claimed window back.
+ *
+ * For the commands that have to claim *before* the work that justifies the
+ * cooldown, because claiming after it is a race — `/forge` charges, claims, and
+ * only then asks a model that may never answer. It refunds the coins when that
+ * happens, and this refunds the window with them: a user who got nothing for
+ * their 25,000 coins should not also be locked out of the forge for a day.
+ *
+ * Best-effort in the same shape as `claim`: the in-memory entry is what holds
+ * for this process, so a failed write costs the release only if the process
+ * restarts before the window would have ended anyway.
+ */
+async function release(client, { bucket, userId, guildId, cooldownMs }) {
+    bucketFor(client.cooldowns, keyFor(bucket, guildId)).delete(userId);
+
+    if (cooldownMs < PERSIST_THRESHOLD_MS || !guildId) return;
+
+    await User.updateOne(
+        { userId, guildId },
+        { $unset: { [`commandCooldowns.${bucket}`]: '' } },
+    ).catch(err => {
+        console.error(`[cooldown] could not release ${bucket} for ${userId}:`, err.message);
+    });
+}
+
 async function readPersisted(bucket, userId, guildId) {
     try {
         const doc = await User.findOne(
@@ -255,6 +281,7 @@ module.exports = {
     expiresAt,
     claimIfAvailable,
     claim,
+    release,
     sweep,
     startCooldownSweeper,
     PERSIST_THRESHOLD_MS,

--- a/tests/aiJsonCommands.test.js
+++ b/tests/aiJsonCommands.test.js
@@ -22,6 +22,13 @@ jest.mock('../src/models/Guild', () => ({ findOne: jest.fn() }));
 jest.mock('../src/models/AiItem', () => ({ findOne: jest.fn(), create: jest.fn() }));
 jest.mock('../src/models/AiQuest', () => ({ findOne: jest.fn(), create: jest.fn(), deleteOne: jest.fn() }));
 jest.mock('../src/utils/inventoryGrant', () => ({ grantInventoryItem: jest.fn(async () => true) }));
+// The rarity cooldown is taken through the shared store rather than read off
+// the last AiItem, so /forge's own tests watch the store (#829). What the store
+// does with a claim is pinned in tests/commandCooldownPersistence.test.js.
+jest.mock('../src/utils/commandCooldowns', () => ({
+    claimIfAvailable: jest.fn(async () => 0),
+    release: jest.fn(async () => {}),
+}));
 
 const mockGetCompletion = jest.fn();
 jest.mock('../src/services/aiService', () => ({
@@ -33,6 +40,7 @@ const User = require('../src/models/User');
 const Guild = require('../src/models/Guild');
 const AiItem = require('../src/models/AiItem');
 const AiQuest = require('../src/models/AiQuest');
+const cooldownStore = require('../src/utils/commandCooldowns');
 
 const forge = require('../src/commands/economy/forge');
 const questgen = require('../src/commands/community/questgen');
@@ -46,6 +54,7 @@ function makeInteraction(options = {}) {
         guild: { id: GUILD_ID },
         channelId: 'c1',
         options: { getString: name => options[name] ?? null },
+        client: { cooldowns: new Map() },
         deferReply: jest.fn(async () => {}),
         editReply: jest.fn(async payload => payload),
     };
@@ -93,6 +102,10 @@ describe('/forge', () => {
         User.updateOne.mockResolvedValue({ modifiedCount: 1 });
         AiItem.findOne.mockReturnValue({ sort: () => ({ lean: async () => null }) });
         AiItem.create.mockResolvedValue({});
+        // `clearAllMocks` drops recorded calls, not implementations, so the
+        // default is restored here for the tests that override it.
+        cooldownStore.claimIfAvailable.mockResolvedValue(0);
+        cooldownStore.release.mockResolvedValue(undefined);
     });
 
     const run = () => {
@@ -181,6 +194,130 @@ describe('/forge', () => {
 
         expect(refunds()).toEqual([COMMON_COST]);
         expect(replyText(interaction)).toMatch(/failed to save/);
+    });
+
+    // The persistence path promised a refund whatever became of the write —
+    // its error was caught and dropped on the floor — so a user could pay
+    // 25,000 coins, receive no item, and be told their coins were back (#829).
+    // It answers to the same write the AI path does now.
+    test('and says so when that refund did not land either', async () => {
+        mockGetCompletion.mockResolvedValue('{"name":"Ember Fang"}');
+        AiItem.create.mockRejectedValue(new Error('write failed'));
+        User.updateOne.mockResolvedValue({ modifiedCount: 0 });
+
+        const interaction = await run();
+
+        expect(replyText(interaction)).toMatch(/contact a server admin/);
+        expect(replyText(interaction)).not.toMatch(/have been refunded/);
+    });
+
+    test('and when that refund write throws', async () => {
+        mockGetCompletion.mockResolvedValue('{"name":"Ember Fang"}');
+        AiItem.create.mockRejectedValue(new Error('write failed'));
+        User.updateOne.mockRejectedValue(new Error('mongo is down'));
+
+        const interaction = await run();
+
+        expect(replyText(interaction)).toMatch(/contact a server admin/);
+    });
+
+    // The model is told to send "a single emoji" and sends whatever it likes.
+    // Clamping it to eight characters only bounded how much of a sentence — or
+    // of an invented `<:name:id>` token — landed in the embed (#829).
+    describe('the emoji the model chose', () => {
+        const forged = () => AiItem.create.mock.calls.at(-1)?.[0];
+
+        const withEmoji = async emoji => {
+            mockGetCompletion.mockResolvedValue(JSON.stringify({ name: 'Ember Fang', emoji }));
+            await run();
+            return forged().emoji;
+        };
+
+        test.each([
+            ['🔥', '🔥'],
+            ['⚔️', '⚔️'],
+            ['🧙🏽‍♂️', '🧙🏽‍♂️'],
+        ])('keeps %s', async (given, kept) => {
+            expect(await withEmoji(given)).toBe(kept);
+        });
+
+        test.each([
+            ['a glowing sword'],
+            ['<:ember:12345>'],
+            ['@everyone'],
+            ['🔥🔥'],
+            [''],
+        ])('falls back to the rarity emoji for %p', async given => {
+            expect(await withEmoji(given)).toBe('⚪');
+        });
+    });
+
+    // The window used to be inferred from the timestamp on the last AiItem —
+    // read, then acted on, so two /forge calls a moment apart both read "long
+    // enough" before either had written anything (#829).
+    describe('the rarity cooldown', () => {
+        const runRare = () => {
+            const interaction = makeInteraction({ rarity: 'rare' });
+            return forge.execute(interaction).then(() => interaction);
+        };
+
+        beforeEach(() => mockGetCompletion.mockResolvedValue('{"name":"Ember Fang","emoji":"🔥"}'));
+
+        test('is taken in the same operation that checks it', async () => {
+            await runRare();
+
+            expect(cooldownStore.claimIfAvailable).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({ bucket: 'forge:rare', userId: USER_ID, guildId: GUILD_ID, cooldownMs: 30 * 60 * 1000 }),
+            );
+            expect(cooldownStore.release).not.toHaveBeenCalled();
+        });
+
+        test('refuses without charging when the window is held', async () => {
+            cooldownStore.claimIfAvailable.mockResolvedValue(Date.now() + 20 * 60 * 1000);
+
+            const interaction = await runRare();
+
+            expect(replyText(interaction)).toMatch(/cooling down.*20m/s);
+            expect(User.findOneAndUpdate).not.toHaveBeenCalled();
+            expect(mockGetCompletion).not.toHaveBeenCalled();
+        });
+
+        // A forge that produced no item must not lock the rarity for the day.
+        test('goes back with the coins when the model never answers', async () => {
+            mockGetCompletion.mockRejectedValue(new Error('provider down'));
+
+            const interaction = await runRare();
+
+            expect(refunds()).toEqual([2500]);
+            expect(cooldownStore.release).toHaveBeenCalledWith(
+                expect.anything(), expect.objectContaining({ bucket: 'forge:rare' }),
+            );
+            expect(replyText(interaction)).toMatch(/refunded/);
+        });
+
+        test('goes back when the item cannot be saved', async () => {
+            AiItem.create.mockRejectedValue(new Error('write failed'));
+
+            await runRare();
+
+            expect(cooldownStore.release).toHaveBeenCalledWith(
+                expect.anything(), expect.objectContaining({ bucket: 'forge:rare' }),
+            );
+        });
+
+        // Claimed before the debit, which can still fail against a balance a
+        // concurrent command has already spent.
+        test('goes back when the debit finds the coins gone', async () => {
+            User.findOneAndUpdate.mockResolvedValue(null);
+
+            const interaction = await runRare();
+
+            expect(cooldownStore.release).toHaveBeenCalledWith(
+                expect.anything(), expect.objectContaining({ bucket: 'forge:rare' }),
+            );
+            expect(replyText(interaction)).toMatch(/You need/);
+        });
     });
 });
 

--- a/tests/aiMentionStripping.test.js
+++ b/tests/aiMentionStripping.test.js
@@ -1,0 +1,188 @@
+'use strict';
+
+// #820: what the user actually said, once the bot's own mention token is out of it.
+//
+// A mention-triggered message arrives as `<@botid> !reset`. The event handler
+// stripped that token for the natural-language reminder check and then threw
+// the result away, so the chat transport went on reading `message.content`:
+// `!reset` never matched behind a mention — it only ever worked as a bare reply
+// to the bot — and the raw `<@123…>` token was pasted into every prompt, every
+// knowledge lookup and every history entry.
+//
+// The stripped content is now computed once and handed down, which is one fix
+// for both. These cover the two halves: the handler passing it, and the
+// transport using it in place of `message.content`.
+
+jest.mock('../src/models/User', () => ({
+    findOne: jest.fn(() => ({ lean: async () => null })),
+    create: jest.fn(),
+}));
+jest.mock('../src/models/Guild', () => ({ create: jest.fn() }));
+jest.mock('../src/models/Case', () => ({ findOne: jest.fn().mockResolvedValue(null), countDocuments: jest.fn().mockResolvedValue(0) }));
+jest.mock('../src/models/Reminder', () => ({ create: jest.fn() }));
+jest.mock('../src/utils/guildSettingsCache', () => ({ getGuildSettings: jest.fn() }));
+
+// The event handler reaches the transport through the facade, so that is what
+// the wiring half watches. The transport half requires the module itself, which
+// this mock does not stand in front of.
+jest.mock('../src/services/aiService', () => ({ handleAIChat: jest.fn() }));
+
+jest.mock('../src/services/ai/knowledge', () => ({
+    retrieveKnowledge: jest.fn(async () => ({ entries: [], isBackground: false })),
+    buildKnowledgeContext: jest.fn(() => ''),
+}));
+jest.mock('../src/services/ai/history', () => ({
+    loadHistory: jest.fn(async () => ({ messages: [] })),
+    appendHistory: jest.fn(async () => {}),
+    clearHistory: jest.fn(async () => {}),
+}));
+jest.mock('../src/services/ai/mcp/resources', () => ({ retrieveMcpKnowledge: jest.fn(async () => null) }));
+jest.mock('../src/services/ai/mcp/usage', () => ({ recordToolCalls: jest.fn(async () => {}) }));
+jest.mock('../src/services/ai/providers', () => ({
+    providers: new Map([['mock', { name: 'mock', label: 'Mock' }]]),
+    mcpMode: () => null,
+    usesClientTools: () => false,
+}));
+
+const mockStream = jest.fn();
+const mockComplete = jest.fn();
+jest.mock('../src/services/ai', () => ({
+    resolveProviderConfig: () => ({
+        provider: 'mock', model: 'mock-1', temperature: 0.7, maxTokens: 512,
+        apiKey: 'k', baseUrl: null, mcpServers: [],
+        rateLimit: { perUser: 0, perChannel: 0, windowMin: 10 },
+    }),
+    streamCompletion: (...args) => mockStream(...args),
+    getCompletion: (...args) => mockComplete(...args),
+    DEFAULT_MODELS: { mock: 'mock-1' },
+}));
+
+const { handleAIChat: facadeChat } = require('../src/services/aiService');
+const { getGuildSettings } = require('../src/utils/guildSettingsCache');
+const { retrieveKnowledge } = require('../src/services/ai/knowledge');
+const { appendHistory, clearHistory } = require('../src/services/ai/history');
+const messageCreate = require('../src/events/messageCreate');
+const { handleAIChat } = require('../src/services/ai/discordChat');
+
+const BOT_ID = 'bot1';
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockStream.mockImplementation(async function* () { yield 'an answer'; });
+    mockComplete.mockResolvedValue('an answer');
+});
+
+describe('the event handler', () => {
+    function mentionMessage(content) {
+        return {
+            id: 'msg1',
+            content,
+            author: { id: 'author1', bot: false, toString: () => '<@author1>' },
+            attachments: new Map(),
+            mentions: { has: () => true },
+            member: { id: 'author1', permissions: { has: () => false }, roles: { cache: { some: () => false } } },
+            guild: { id: 'guild1', name: 'Guild One' },
+            channel: { id: 'chan1', send: jest.fn(), sendTyping: jest.fn() },
+            client: { user: { id: BOT_ID } },
+        };
+    }
+
+    const run = message => messageCreate.execute(message, { user: { id: BOT_ID } });
+
+    // The third argument is the stripped content the transport now reads.
+    const promptGiven = () => facadeChat.mock.calls.at(-1)?.[2];
+
+    beforeEach(() => {
+        getGuildSettings.mockResolvedValue({
+            ai: { enabled: true, channelPersonas: [] },
+            leveling: { enabled: false },
+            moderation: { enabled: false },
+            suggestions: { enabled: false },
+            bibleVerse: { autoRespond: false },
+        });
+    });
+
+    test('hands the chat transport the content without the mention token', async () => {
+        await run(mentionMessage(`<@${BOT_ID}> what is the capital of France?`));
+
+        expect(facadeChat).toHaveBeenCalledTimes(1);
+        expect(promptGiven()).toBe('what is the capital of France?');
+        expect(promptGiven()).not.toContain(BOT_ID);
+    });
+
+    // Discord sends either form of the token depending on the client.
+    test('and the nickname form of the token', async () => {
+        await run(mentionMessage(`<@!${BOT_ID}> hello`));
+
+        expect(promptGiven()).toBe('hello');
+    });
+
+    test('a mention-triggered !reset reaches the transport as !reset', async () => {
+        await run(mentionMessage(`<@${BOT_ID}> !reset`));
+
+        expect(promptGiven()).toBe('!reset');
+    });
+});
+
+describe('the chat transport', () => {
+    const SETTINGS = { provider: 'mock', streaming: false, actionsEnabled: false, maxHistory: 20 };
+
+    function fakeMessage(content) {
+        return {
+            content,
+            author: { id: 'u1' },
+            guild: { id: 'g1' },
+            channel: { id: 'c1', send: jest.fn(async () => ({})), sendTyping: jest.fn(async () => {}) },
+            reply: jest.fn(async payload => ({ payload, edit: jest.fn(), delete: jest.fn() })),
+        };
+    }
+
+    const replyText = message => {
+        const payload = message.reply.mock.calls.at(-1)?.[0];
+        return typeof payload === 'string' ? payload : payload?.content ?? '';
+    };
+
+    test('!reset behind a mention clears the history', async () => {
+        const message = fakeMessage(`<@${BOT_ID}> !reset`);
+
+        await handleAIChat(message, SETTINGS, '!reset');
+
+        expect(clearHistory).toHaveBeenCalledWith('g1', 'c1', 'u1');
+        expect(mockComplete).not.toHaveBeenCalled();
+        expect(replyText(message)).toMatch(/history cleared/i);
+    });
+
+    test('the mention token reaches neither the prompt, the knowledge lookup nor the history', async () => {
+        const message = fakeMessage(`<@${BOT_ID}> who are you?`);
+
+        await handleAIChat(message, SETTINGS, 'who are you?');
+
+        expect(mockComplete).toHaveBeenCalledWith(expect.objectContaining({ prompt: 'who are you?' }));
+        expect(retrieveKnowledge).toHaveBeenCalledWith('g1', 'who are you?');
+        expect(appendHistory).toHaveBeenCalledWith(
+            'g1', 'c1', 'u1', 'who are you?', expect.any(String), 20, expect.anything(),
+        );
+    });
+
+    // Nothing was passed down, so the raw content is what it reads — which is
+    // what the reply-to-bot trigger wants, since that content has no token in it.
+    test('falls back to the raw content when nothing was stripped for it', async () => {
+        const message = fakeMessage('who are you?');
+
+        await handleAIChat(message, SETTINGS);
+
+        expect(mockComplete).toHaveBeenCalledWith(expect.objectContaining({ prompt: 'who are you?' }));
+    });
+
+    // A bare `@Clawdia` is all mention and no question. It used to reach the
+    // provider as the literal token; stripped, it would reach it as an empty
+    // prompt, which some providers reject outright.
+    test('a mention with nothing after it asks rather than sending an empty prompt', async () => {
+        const message = fakeMessage(`<@${BOT_ID}>`);
+
+        await handleAIChat(message, SETTINGS, '');
+
+        expect(mockComplete).not.toHaveBeenCalled();
+        expect(replyText(message)).toMatch(/did not ask anything/i);
+    });
+});

--- a/tests/aiNarrativeServices.test.js
+++ b/tests/aiNarrativeServices.test.js
@@ -169,6 +169,83 @@ describe('the DM campaign reading HP back out of the story', () => {
     });
 });
 
+// #821: the roles the campaign history goes to the model with.
+//
+// The storyLog is a flat array of strings — the opening scene, then a player
+// entry and a narration per action — and the role of each entry used to be its
+// index's parity, on the assumption that index 0 was still the opening scene.
+// The same write that appends the pair trims the log with `$slice: -20`, and a
+// log that grows 1, 3, 5, … entries first overflows at 21: exactly one entry is
+// dropped and every index shifts by one, permanently. From the 11th action on,
+// the model was handed the player's actions as its own words and its own
+// narration as the player's.
+describe('the DM campaign history roles', () => {
+    const PLAYER = { userId: 'u1', name: 'Aric', characterClass: 'Warrior', hp: 120, inventory: ['Longsword'] };
+
+    function interaction() {
+        return {
+            user: { id: 'u1' },
+            guild: { id: 'g1' },
+            channel: { id: 'c1', send: jest.fn(async () => ({ id: 'm1' })), messages: { fetch: jest.fn() } },
+            channelId: 'c1',
+            options: { getString: () => 'push on' },
+            deferReply: jest.fn(async () => {}),
+            editReply: jest.fn(async payload => payload),
+            reply: jest.fn(async payload => payload),
+        };
+    }
+
+    // The history the model was handed for this action.
+    async function historyFor(storyLog) {
+        const doc = { sessionId: 'g1:c1', guildId: 'g1', channelId: 'c1', hostId: 'u1', players: [PLAYER], storyLog, active: true };
+        DmSession.findOne.mockResolvedValue(doc);
+        DmSession.findOneAndUpdate.mockResolvedValue(doc);
+        mockGetCompletion.mockResolvedValue('The corridor narrows.');
+
+        await takeAction(interaction());
+        return mockGetCompletion.mock.calls.at(-1)[0].history;
+    }
+
+    // An untrimmed log: the opening scene, then (player, narration) pairs.
+    const untrimmed = actions => [
+        'The gate stands open.',
+        ...Array.from({ length: actions }, (_, i) => [`Aric: action ${i}`, `Narration ${i}`]).flat(),
+    ];
+
+    test('the narration the player is answering is the assistant, the action is the user', async () => {
+        const history = await historyFor(untrimmed(2));
+
+        expect(history.map(m => m.role)).toEqual(['assistant', 'user', 'assistant', 'user', 'assistant']);
+        expect(history.at(-1)).toEqual({ role: 'assistant', content: 'Narration 1' });
+        expect(history.at(-2)).toEqual({ role: 'user', content: 'Aric: action 1' });
+    });
+
+    // The state the trim leaves behind: the opening scene is gone, so the log
+    // now *starts* with a player entry and every forward index is off by one.
+    test('and still does once the trim has dropped the opening scene', async () => {
+        const history = await historyFor(untrimmed(10).slice(1));
+
+        for (const entry of history) {
+            expect(entry.role).toBe(entry.content.startsWith('Aric:') ? 'user' : 'assistant');
+        }
+        expect(history.map(m => m.role)).toContain('user');
+    });
+
+    // Every log the campaign can be in, at the depth the model actually sees.
+    test('no length of log ever inverts them', async () => {
+        for (let actions = 0; actions <= 12; actions++) {
+            const full = untrimmed(actions);
+            // What Mongo would hold after `$slice: -20` on each write.
+            const stored = full.slice(-20);
+            const history = await historyFor(stored);
+
+            for (const entry of history) {
+                expect(entry.role).toBe(entry.content.startsWith('Aric:') ? 'user' : 'assistant');
+            }
+        }
+    });
+});
+
 describe('the newspaper when the model does not deliver', () => {
     const guildDoc = (overrides = {}) => ({
         guildId: 'g1',

--- a/tests/commandCooldownPersistence.test.js
+++ b/tests/commandCooldownPersistence.test.js
@@ -33,6 +33,49 @@ beforeEach(() => {
     User.findOne.mockReturnValue(leanDoc(null));
 });
 
+// #829: a command that has to claim its window *before* the work that justifies
+// it — /forge charges, claims, then asks a model that may never answer — needs a
+// way to hand the window back when that work comes to nothing.
+describe('giving a window back', () => {
+    test('a released short window is free again immediately, with no query', async () => {
+        const client = fakeClient();
+        await store.claim(client, scope({ cooldownMs: SHORT }));
+        expect(await store.expiresAt(client, scope({ cooldownMs: SHORT }))).toBeGreaterThan(0);
+
+        await store.release(client, scope({ cooldownMs: SHORT }));
+
+        expect(await store.expiresAt(client, scope({ cooldownMs: SHORT }))).toBe(0);
+        expect(User.updateOne).not.toHaveBeenCalled();
+    });
+
+    test('a released long window is unset on the document as well as in memory', async () => {
+        const client = fakeClient();
+        expect(await store.claimIfAvailable(client, scope({ cooldownMs: LONG }))).toBe(0);
+
+        await store.release(client, scope({ cooldownMs: LONG }));
+
+        const [filter, update] = User.updateOne.mock.calls.at(-1);
+        expect(filter).toEqual({ userId: 'u1', guildId: 'g1' });
+        expect(update).toEqual({ $unset: { 'commandCooldowns.daily': '' } });
+
+        // And the next claim takes it, rather than finding it held.
+        User.findOne.mockReturnValue(leanDoc(null));
+        expect(await store.claimIfAvailable(client, scope({ cooldownMs: LONG }))).toBe(0);
+    });
+
+    test('a failed unset is logged, not thrown at the caller mid-refund', async () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const client = fakeClient();
+        await store.claim(client, scope({ cooldownMs: LONG }));
+        User.updateOne.mockRejectedValue(new Error('mongo is down'));
+
+        await expect(store.release(client, scope({ cooldownMs: LONG }))).resolves.toBeUndefined();
+
+        expect(errorSpy).toHaveBeenCalled();
+        errorSpy.mockRestore();
+    });
+});
+
 describe('the threshold', () => {
     test('is 15 minutes', () => {
         expect(store.PERSIST_THRESHOLD_MS).toBe(15 * 60 * 1000);


### PR DESCRIPTION
#820 — `!reset` was unreachable behind a mention, and the mention token went
into every prompt. The event handler stripped the token for the natural-language
reminder check and then discarded the result, so the chat transport went on
reading `message.content`: `<@bot> !reset` never matched the reset command, and
the raw `<@123…>` was pasted into the prompt, the knowledge lookup and the
history entry on every mention-triggered message. The stripped content is
computed once and handed down, which fixes both. A mention with nothing after it
now gets an answer rather than an empty prompt some providers reject outright.

#821 — the DM campaign's history roles inverted the moment the story log was
trimmed. Roles were the entry's index parity, on the assumption index 0 was
still the opening scene; the write that appends a (player, narration) pair trims
with `$slice: -20`, and a log that grows 1, 3, 5, … entries first overflows at
21, dropping exactly one entry and shifting every index permanently. From the
11th action on the model was handed the player's actions as its own words.
Roles are now counted back from the end, which is trim-invariant: the log is
written in two places and both leave the narration last.

#829 — `/forge`'s persistence-failure path told the user "your coins have been
refunded" whatever became of the refund, its error caught and dropped. Both
failure paths now go through one helper that answers to the write, as the
AI-failure path already did. Two things in the same file, folded in: the model's
emoji is checked as a single pictographic grapheme rather than only clamped to
eight characters, and the rare+ cooldown is taken through utils/commandCooldowns
in the operation that checks it, instead of being read off the last item's
timestamp and then acted on. A forge that produced no item hands the window back
with the coins, so `release` joins the store.

Closes #820
Closes #821
Closes #829

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `/forge` reliability with safer cooldown handling, automatic refunds, and clearer failure messages.
  * Added stricter emoji validation for forged items.

* **Bug Fixes**
  * Bot mentions are now removed from AI prompts, allowing commands such as `!reset` to work correctly.
  * Empty mention-only messages receive a helpful clarification instead of being sent to the AI.
  * Improved DM campaign history accuracy, preventing player actions and narration from being misclassified in longer campaigns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->