### PR TITLE
Give the forge cooldown window back when the debit never answers

### DIFF
--- a/src/commands/economy/forge.js
+++ b/src/commands/economy/forge.js
@@ -41,6 +41,19 @@ function pickEmoji(raw, fallback) {
 }
 
 /**
+ * Hand back a cooldown window nothing was forged with.
+ *
+ * Best-effort, and awaited rather than dropped: the caller is on its way to
+ * telling the user what happened, and a failure to release is a line in the log
+ * rather than a reason to fail that message too.
+ */
+async function releaseWindow(interaction, cooldownScope) {
+    if (!cooldownScope) return;
+    await cooldownStore.release(interaction.client, cooldownScope).catch(err =>
+        console.error('[FORGE] Cooldown release failed:', err));
+}
+
+/**
  * Put the forge's cost back, and say whether it actually went back.
  *
  * Both failure paths below tell the user their coins have been returned, so
@@ -59,10 +72,7 @@ async function refundForge(interaction, cost, cooldownScope, context) {
     ).then(res => res.modifiedCount > 0)
      .catch(err => { console.error(`[FORGE] Refund failed after ${context}:`, err); return false; });
 
-    if (cooldownScope) {
-        await cooldownStore.release(interaction.client, cooldownScope).catch(err =>
-            console.error('[FORGE] Cooldown release failed:', err));
-    }
+    await releaseWindow(interaction, cooldownScope);
 
     return refunded;
 }
@@ -141,19 +151,32 @@ module.exports = {
         }
 
         // Atomic balance deduction — guards against concurrent forge requests
-        const chargedUser = await User.findOneAndUpdate(
-            { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: cfg.cost } },
-            { $inc: { balance: -cfg.cost } },
-            { new: true }
-        );
+        let chargedUser;
+        try {
+            chargedUser = await User.findOneAndUpdate(
+                { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: cfg.cost } },
+                { $inc: { balance: -cfg.cost } },
+                { new: true }
+            );
+        } catch (err) {
+            // The window is claimed and this forge is not happening, so the
+            // window goes back. The debit does not: a rejected write says
+            // nothing about whether the server applied it, and refunding on the
+            // guess would mint the cost every time it had not. So the one thing
+            // that is knowable is undone, and the user is told what to check —
+            // rather than being handed the dispatcher's generic apology with a
+            // day-long cooldown they never spent anything on.
+            console.error('[FORGE] Balance deduction failed:', err?.message || err);
+            await releaseWindow(interaction, cooldownScope);
+            return interaction.editReply({
+                content: 'The forge could not take your payment, so nothing was made. Check your balance — if the coins are missing, contact a server admin.',
+            });
+        }
         if (!chargedUser) {
             // The window was claimed a moment ago and nothing was forged with
             // it, so it goes straight back — a user who could not afford the
             // item must not be locked out of the rarity for a day over it.
-            if (cooldownScope) {
-                await cooldownStore.release(interaction.client, cooldownScope).catch(err =>
-                    console.error('[FORGE] Cooldown release failed:', err));
-            }
+            await releaseWindow(interaction, cooldownScope);
             const currency = guildSettings?.economy?.currency ?? '💰';
             return interaction.editReply({
                 content: `You need **${currency}${cfg.cost.toLocaleString()}** to forge a ${cfg.emoji} ${cfg.label} item. Your balance: **${currency}${(user?.balance ?? 0).toLocaleString()}**`,

--- a/tests/aiJsonCommands.test.js
+++ b/tests/aiJsonCommands.test.js
@@ -42,6 +42,8 @@ const AiItem = require('../src/models/AiItem');
 const AiQuest = require('../src/models/AiQuest');
 const cooldownStore = require('../src/utils/commandCooldowns');
 
+const { useFixedClock, MINUTE } = require('./helpers/fixedClock');
+
 const forge = require('../src/commands/economy/forge');
 const questgen = require('../src/commands/community/questgen');
 
@@ -256,6 +258,12 @@ describe('/forge', () => {
     // read, then acted on, so two /forge calls a moment apart both read "long
     // enough" before either had written anything (#829).
     describe('the rarity cooldown', () => {
+        // The remaining time is floored to whole minutes, so a window set 20
+        // minutes out reads as 19 the moment the run takes longer than a tick
+        // to get there. Pinned, the fixture and the code read the same instant
+        // (#632).
+        useFixedClock();
+
         const runRare = () => {
             const interaction = makeInteraction({ rarity: 'rare' });
             return forge.execute(interaction).then(() => interaction);
@@ -274,7 +282,7 @@ describe('/forge', () => {
         });
 
         test('refuses without charging when the window is held', async () => {
-            cooldownStore.claimIfAvailable.mockResolvedValue(Date.now() + 20 * 60 * 1000);
+            cooldownStore.claimIfAvailable.mockResolvedValue(Date.now() + 20 * MINUTE);
 
             const interaction = await runRare();
 
@@ -317,6 +325,32 @@ describe('/forge', () => {
                 expect.anything(), expect.objectContaining({ bucket: 'forge:rare' }),
             );
             expect(replyText(interaction)).toMatch(/You need/);
+        });
+
+        // And when the debit does not answer at all. The dispatcher would catch
+        // the rejection and apologise, but the window would stay claimed for the
+        // day — a lockout paid for by a write that may never have landed.
+        test('goes back when the debit write throws', async () => {
+            User.findOneAndUpdate.mockRejectedValue(new Error('mongo is down'));
+
+            const interaction = await runRare();
+
+            expect(cooldownStore.release).toHaveBeenCalledWith(
+                expect.anything(), expect.objectContaining({ bucket: 'forge:rare' }),
+            );
+            expect(replyText(interaction)).toMatch(/could not take your payment/);
+            expect(mockGetCompletion).not.toHaveBeenCalled();
+        });
+
+        // A rejected write says nothing about whether the server applied it, so
+        // the cost is not handed back on the guess — that would mint it every
+        // time the debit had not landed.
+        test('and does not refund a debit it cannot know happened', async () => {
+            User.findOneAndUpdate.mockRejectedValue(new Error('mongo is down'));
+
+            await runRare();
+
+            expect(refunds()).toEqual([]);
         });
     });
 });


### PR DESCRIPTION
Follow-up to #847, from review feedback on it. That PR moved `/forge`'s rare+ cooldown to `utils/commandCooldowns`, which means the window is now *claimed* before the balance deduction rather than inferred from the last item's timestamp afterwards. This closes the one path that took the window and never gave it back.

## The problem

`User.findOneAndUpdate` — the guarded debit — was unwrapped. It has two failure modes and only one of them was handled:

- returns `null` (balance already spent by a concurrent command) → handled, window released
- **rejects** (Mongo unreachable, timeout) → the rejection propagates out of `execute`

`interactionCreate.js` catches that and apologises, so the user was never left without a reply. But the claimed window stayed claimed: locked out of that rarity for up to 24 hours, over a write that may never have landed and an item that was certainly never made.

## The fix

The debit is wrapped. On a rejection the window is released and the reply says what happened and what to check, instead of the dispatcher's generic "there was an error".

**The cost is deliberately not refunded.** A rejected write says nothing about whether the server applied it, and there's no idempotency token to reconcile against. Refunding on that guess would mint `cfg.cost` every time the write hadn't landed — a coin-minting path opened by any transient Mongo error. Releasing the window is the part that *is* knowable, so it's the part that's undone; the user is told to check their balance and contact an admin if coins are missing. `and does not refund a debit it cannot know happened` pins this so a later change doesn't quietly "improve" it into a refund.

The three release call sites are one `releaseWindow` helper now.

## Tests

Two new cases: the window goes back when the debit write throws, and no refund is issued for a debit whose outcome is unknown.

The cooldown describe block now pins the clock with `useFixedClock`. My `refuses without charging when the window is held` test from #847 asserted `20m` against a value floored to whole minutes, so it read `19m` once the run took longer than a tick to reach the assertion — it passed in isolation and failed in the full suite. Same class of flake as #632.

## Validation

`npx eslint src tests` clean. 241 suites / 4428 tests pass, run three times.

`tests/integration/*` (3 suites) are excluded and unverified: `mongodb-memory-server` gets a 403 from `fastdl.mongodb.org` through this environment's proxy. Pre-existing and unrelated to this diff — no integration-tested code is touched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhjTHt5xaWHL2jDj3s6kXP

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhjTHt5xaWHL2jDj3s6kXP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `/forge` handling when payment processing fails.
  * Prevented users from being incorrectly charged or refunded when payment status is uncertain.
  * Released cooldowns appropriately after failed payments or insufficient balance.

* **Tests**
  * Added coverage for payment failures, cooldown release, and refund behavior in `/forge`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->