### PR TITLE
Remove --forceExit flag and add open handle detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,19 @@ jobs:
       # what applies the coverageThreshold ratchet in jest.config.js. Without
       # it the thresholds exist but nothing ever checks them, which is the
       # state this replaced (#635).
+      #
+      # `npm test` no longer passes `--forceExit` (#630), which is what makes a
+      # leaked handle — an undisconnected Mongoose client, a cron nobody
+      # `.unref()`d — visible instead of silently shot at the end of the run.
+      # The trade is that such a leak now hangs rather than exits, so this step
+      # is bounded on its own. Under the job's 20 so the hang fails *here*, with
+      # enough of the budget left for the three `always()` steps below to still
+      # report; without it they would be killed alongside it and the run would
+      # say nothing about coverage or lint at all. The suite takes about a
+      # minute, or a few on a cold cache while mongodb-memory-server fetches its
+      # binary for the integration suites, so ten is slack rather than a target.
       - name: Run tests
+        timeout-minutes: 10
         run: npm test -- --ci --coverage
 
       # The global ratchet is one number over the whole of src, so it cannot

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write",
-    "test": "jest --forceExit",
-    "test:coverage": "jest --forceExit --coverage",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
     "coverage:check": "node scripts/check-coverage.js"
   },
   "keywords": [

--- a/tests/aiRateLimitEnforcement.test.js
+++ b/tests/aiRateLimitEnforcement.test.js
@@ -27,6 +27,22 @@ jest.mock('../src/services/ai/providers', () => {
     };
 });
 
+// The ledger, which this file is not about but does reach. `getCompletion`
+// consults the guild's monthly totals, and `usage.js` refreshes them in the
+// background without awaiting the result. With no Mongoose connection that
+// `AIUsage.find()` is not an error — it is *buffered*, against a 10s
+// `bufferTimeoutMS` timer nobody ever settles, which outlives the suite and
+// keeps the Jest worker alive ("A worker process has failed to exit
+// gracefully"). `--forceExit` used to hide that; it no longer does (#630).
+//
+// tests/aiMonthlyBudget.test.js mocks this model for the same reason. Empty
+// rows here rather than a fixture, because every assertion below is about the
+// per-user and per-channel windows, not about spend.
+jest.mock('../src/models/AIUsage', () => ({
+    find: () => ({ lean: async () => [] }),
+    updateOne: async () => ({}),
+}));
+
 const providersMock = require('../src/services/ai/providers');
 const { resolveProviderConfig, getCompletion, streamCompletion } = require('../src/services/ai');
 const { SCHEDULED_TOOL_CALLS_PER_HOUR } = require('../src/services/ai/rateLimit');

--- a/tests/fishService.test.js
+++ b/tests/fishService.test.js
@@ -73,9 +73,24 @@ function makeUser(fishingOverrides = {}) {
     return user;
 }
 
-// Casts until the predicate is satisfied, topping up the resources a cast spends.
-// Lets RNG-driven tests assert on outcomes without depending on the internal
-// order of Math.random() calls.
+/**
+ * Casts until `predicate` accepts a result, and returns that result, topping up
+ * the resources a cast spends. Lets RNG-driven tests assert on outcomes without
+ * depending on the internal order of Math.random() calls.
+ *
+ * Exhausting `maxCasts` throws. It used to return `null`, and three of the
+ * seven call sites below never looked at what came back (#633) — they cast,
+ * then asserted against the fixture. A `null` there is not a failure: the
+ * fixture is simply unchanged, which is exactly what "a lighter fish did not
+ * take the record" looks like, so the test passed without a fish ever having
+ * been caught. The assertions were green because nothing had happened.
+ *
+ * Guarding each call site with `expect(...).not.toBeNull()` was the obvious fix
+ * and is the one this replaced: it leaves the same trap set for the eighth call
+ * site. A helper that cannot hand back a non-answer needs no discipline at the
+ * call sites at all, and the throw names what it was looking for, which `null`
+ * never did.
+ */
 function castUntil(user, predicate, { maxCasts = 4000, username = 'angler' } = {}) {
     for (let i = 0; i < maxCasts; i++) {
         user.fishing.stamina = 10;
@@ -84,10 +99,32 @@ function castUntil(user, predicate, { maxCasts = 4000, username = 'angler' } = {
         const result = executeCast(user, 'pond', { reactionFactor: 1.0, username });
         if (predicate(result)) return result;
     }
-    return null;
+    throw new Error(
+        `castUntil: ${predicate.name || 'the predicate'} matched nothing in ${maxCasts} casts. ` +
+        'The catch tables or the cast path changed; the assertions after this call never ran.',
+    );
 }
 
 const isWeighedFish = r => r.success && r.catchType === 'fish' && r.weightLbs > 0;
+
+// ─── Cast helper ─────────────────────────────────────────────────────────────
+// The helper's own guarantee (#633). Every weeklyRecord test below leans on it
+// instead of checking a return value, so it is worth one test of its own: a
+// predicate that never matches must stop the run, not hand back a value the
+// assertions can pass against.
+describe('castUntil', () => {
+    test('exhausting the casts throws, naming the predicate', () => {
+        const neverMatches = () => false;
+        expect(() => castUntil(makeUser(), neverMatches, { maxCasts: 5 }))
+            .toThrow(/neverMatches matched nothing in 5 casts/);
+    });
+
+    test('a matching predicate returns the result it matched', () => {
+        const caught = castUntil(makeUser(), isWeighedFish);
+        expect(caught.catchType).toBe('fish');
+        expect(caught.weightLbs).toBeGreaterThan(0);
+    });
+});
 
 // ─── Reference guard ─────────────────────────────────────────────────────────
 // Two shipped features were dead because a function was called but never added
@@ -316,7 +353,6 @@ describe('weeklyRecord', () => {
         });
 
         const caught = castUntil(user, isWeighedFish);
-        expect(caught).not.toBeNull();
 
         expect(user.fishing.weeklyRecord.weight).toBe(caught.weightLbs);
         expect(user.fishing.weeklyRecord.weight).toBeLessThan(9999);
@@ -357,8 +393,7 @@ describe('weeklyRecord', () => {
         // end and the EU spring-forward. None of those is seven days, so the
         // week has not expired and a lighter fish must not take the record.
         const user = makeUser();
-        const first = castUntil(user, isWeighedFish);
-        expect(first).not.toBeNull();
+        castUntil(user, isWeighedFish);
         user.fishing.weeklyRecord.weight = 9999;
 
         advanceClock(2 * DAY);
@@ -369,15 +404,16 @@ describe('weeklyRecord', () => {
         // next weighed fish takes it.
         advanceClock(6 * DAY);
         const later = castUntil(user, isWeighedFish);
-        expect(later).not.toBeNull();
         expect(user.fishing.weeklyRecord.weight).toBe(later.weightLbs);
     });
 
     test('a new record records who set it', () => {
         const user = makeUser();
         const caught = castUntil(user, isWeighedFish, { username: 'reelbigfish' });
-        expect(caught).not.toBeNull();
 
+        // The catch this names is the one that set it: castUntil returns on the
+        // first weighed fish, and on a user with no record that fish takes it.
+        expect(user.fishing.weeklyRecord.weight).toBe(caught.weightLbs);
         expect(user.fishing.weeklyRecord.userId).toBe('u1');
         expect(user.fishing.weeklyRecord.username).toBe('reelbigfish');
         expect(user.fishing.weeklyRecord.weekStart).toBeTruthy();

--- a/tests/openHandleGate.test.js
+++ b/tests/openHandleGate.test.js
@@ -9,6 +9,39 @@ const read = file => fs.readFileSync(path.join(root, file), 'utf8');
 const pkg = JSON.parse(read('package.json'));
 const ci  = read('.github/workflows/ci.yml');
 
+/**
+ * The index of `marker` in the workflow, having asserted it is there.
+ *
+ * Everything below works on a slice of ci.yml between two markers, and
+ * `indexOf` answers -1 for a marker that is no longer there — which `slice`
+ * turns into an empty or reversed range rather than an error. An assertion that
+ * something is *absent* then passes against that empty string, so renaming the
+ * job would leave this file green while checking nothing at all. That is the
+ * same vacuous pass #633 was about, and it gets the same treatment: no
+ * non-answer.
+ */
+function markerAt(marker) {
+    const at = ci.indexOf(marker);
+    if (at < 0) {
+        throw new Error(
+            `ci.yml has no ${JSON.stringify(marker)}. The workflow was restructured and the ` +
+            'assertions below no longer read what they name — update the markers.',
+        );
+    }
+    return at;
+}
+
+/** The YAML of each of a job's steps, keyed by the step's name. */
+function stepsOf(job) {
+    const names = [...job.matchAll(/^ {6}- name: (.+)$/gm)];
+    return new Map(names.map((m, i) => [
+        m[1].trim(),
+        job.slice(m.index, i + 1 < names.length ? names[i + 1].index : job.length),
+    ]));
+}
+
+const testJob = ci.slice(markerAt('\n  test:'), markerAt('\n  publish:'));
+
 // #630. `jest --forceExit` kills the run once the last assertion has finished,
 // whether or not anything is still holding the event loop open. That is not a
 // fix for a leak, it is the removal of the only signal that one exists: a
@@ -42,7 +75,6 @@ describe('open-handle detection is not suppressed', () => {
     // one explains at length why `--forceExit` is gone, and a naive search of
     // the job text finds that explanation and calls it a violation.
     test('CI does not add it back on the command line', () => {
-        const testJob = ci.slice(ci.indexOf('\n  test:'), ci.indexOf('\n  publish:'));
         const commands = testJob
             .split('\n')
             .filter(line => !/^\s*#/.test(line))
@@ -61,17 +93,34 @@ describe('open-handle detection is not suppressed', () => {
     // the job's whole budget and takes the coverage and lint steps down with
     // it, so the run reports nothing at all. A step-level bound turns that into
     // a failed step with the other answers still intact.
-    test('a hung test step is bounded, so the steps after it still report', () => {
-        const step = ci.slice(ci.indexOf('- name: Run tests'), ci.indexOf('- name: Check per-subsystem'));
-        expect(step).toMatch(/timeout-minutes: \d+/);
+    test('the test step is bounded, and under the job that contains it', () => {
+        const steps = stepsOf(testJob);
+        const run = steps.get('Run tests');
+        expect(run).toMatch(/timeout-minutes: \d+/);
 
-        const stepBudget = Number(step.match(/timeout-minutes: (\d+)/)[1]);
-        // The job's own budget, which is declared before `steps:` — not the
-        // per-step ones, of which this step is now one.
-        const jobHeader = ci.slice(ci.indexOf('\n  test:'), ci.indexOf('\n    steps:'));
+        const stepBudget = Number(run.match(/timeout-minutes: (\d+)/)[1]);
+        // The job's own budget, declared before `steps:` — not the per-step
+        // ones, of which the test step is now one.
+        const jobHeader = ci.slice(markerAt('\n  test:'), markerAt('\n    steps:'));
         const jobBudget = Number(jobHeader.match(/timeout-minutes: (\d+)/)[1]);
         // Strictly under the job's own timeout, or the job dies first and the
         // bound has bought nothing.
         expect([stepBudget, stepBudget < jobBudget]).toEqual([stepBudget, true]);
+    });
+
+    // The other half of that bargain, and the half the bound is *for*. Sending
+    // the hang to a single step only helps if the steps after it still run;
+    // without `if: always()` they are skipped the moment the test step goes
+    // red, and a timed-out run reports neither coverage nor lint — exactly the
+    // silence the step budget was meant to prevent. Asserting the timeout alone
+    // would leave that removable with this file still green.
+    test.each([
+        'Check per-subsystem coverage floors',
+        'Report coverage',
+        'Lint',
+    ])('the %s step still reports when the tests fail', name => {
+        const step = stepsOf(testJob).get(name);
+        expect([name, step !== undefined]).toEqual([name, true]);
+        expect([name, /\n\s*if: always\(\)/.test(step)]).toEqual([name, true]);
     });
 });

--- a/tests/openHandleGate.test.js
+++ b/tests/openHandleGate.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const read = file => fs.readFileSync(path.join(root, file), 'utf8');
+
+const pkg = JSON.parse(read('package.json'));
+const ci  = read('.github/workflows/ci.yml');
+
+// #630. `jest --forceExit` kills the run once the last assertion has finished,
+// whether or not anything is still holding the event loop open. That is not a
+// fix for a leak, it is the removal of the only signal that one exists: a
+// Mongoose connection nobody disconnects, a `setInterval` nobody `.unref()`s, a
+// listener on a socket that stays open — all of them look exactly like a clean
+// exit once the process is shot in the head.
+//
+// It was added for a real reason. Three suites transitively loaded the native
+// `canvas` addon and left a worker hanging, and `--forceExit` was the blunt way
+// past that. The addon has since been bumped (canvas 3.2.3) and no longer does
+// it: all 241 non-integration suites now exit on their own, and so does a suite
+// that loads canvas and draws with it. The flag outlived its cause, and the
+// cost of leaving it is that the *next* leak arrives silently.
+//
+// So the flag is gone, and this is what stops it coming back — because it will
+// look like the obvious fix the first time a genuinely leaky test appears, and
+// at that point the leak is the thing to fix.
+describe('open-handle detection is not suppressed', () => {
+    // Both scripts, not just `test`: `test:coverage` is the one a contributor
+    // reaches for when the ratchet fails, and a leak masked there is masked in
+    // the run most likely to be looked at closely.
+    for (const script of ['test', 'test:coverage']) {
+        test(`npm run ${script} does not pass --forceExit`, () => {
+            expect([script, pkg.scripts[script]]).toEqual([script, expect.any(String)]);
+            expect(pkg.scripts[script]).not.toMatch(/--forceExit\b/);
+        });
+    }
+
+    // The flag can also be smuggled in past the scripts, as an argument on the
+    // CI invocation itself. Comments are stripped first: the step above this
+    // one explains at length why `--forceExit` is gone, and a naive search of
+    // the job text finds that explanation and calls it a violation.
+    test('CI does not add it back on the command line', () => {
+        const testJob = ci.slice(ci.indexOf('\n  test:'), ci.indexOf('\n  publish:'));
+        const commands = testJob
+            .split('\n')
+            .filter(line => !/^\s*#/.test(line))
+            .join('\n');
+        expect(commands).not.toMatch(/--forceExit\b/);
+    });
+
+    // ...or globally, from the config, where it applies to every invocation at
+    // once and no command line mentions it.
+    test('jest.config.js does not set it either', () => {
+        expect(require('../jest.config.js').forceExit).toBeUndefined();
+    });
+
+    // Removing `--forceExit` means a leaked handle hangs the run instead of
+    // ending it, and an unbounded hang in CI is its own failure mode: it burns
+    // the job's whole budget and takes the coverage and lint steps down with
+    // it, so the run reports nothing at all. A step-level bound turns that into
+    // a failed step with the other answers still intact.
+    test('a hung test step is bounded, so the steps after it still report', () => {
+        const step = ci.slice(ci.indexOf('- name: Run tests'), ci.indexOf('- name: Check per-subsystem'));
+        expect(step).toMatch(/timeout-minutes: \d+/);
+
+        const stepBudget = Number(step.match(/timeout-minutes: (\d+)/)[1]);
+        // The job's own budget, which is declared before `steps:` — not the
+        // per-step ones, of which this step is now one.
+        const jobHeader = ci.slice(ci.indexOf('\n  test:'), ci.indexOf('\n    steps:'));
+        const jobBudget = Number(jobHeader.match(/timeout-minutes: (\d+)/)[1]);
+        // Strictly under the job's own timeout, or the job dies first and the
+        // bound has bought nothing.
+        expect([stepBudget, stepBudget < jobBudget]).toEqual([stepBudget, true]);
+    });
+});

--- a/tests/petBattle.test.js
+++ b/tests/petBattle.test.js
@@ -12,6 +12,25 @@ const {
     PET_MAX_LEVEL,
 } = require('../src/services/petService');
 
+/**
+ * A deterministic stand-in for `Math.random`, seeded from a constant (#634).
+ *
+ * mulberry32: 32 bits of state and one multiply-xor round per call. It is not a
+ * PRNG for anything that depends on the quality of its output, and it does not
+ * need to be — the requirement is that the same seed produces the same sequence
+ * on every machine and every run, so a case that fails can be looked at again.
+ * `Math.random` is seedless by specification and cannot do that.
+ */
+function seededRng(seed) {
+    let state = seed >>> 0;
+    return () => {
+        state = (state + 0x6D2B79F5) >>> 0;
+        let t = Math.imul(state ^ (state >>> 15), state | 1);
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
 describe('pet XP curve', () => {
     test('level 1 needs no XP; curve is strictly increasing', () => {
         expect(xpForLevel(1)).toBe(0);
@@ -104,15 +123,40 @@ describe('simulateBattle', () => {
         expect(r1.rounds.length).toBe(r2.rounds.length);
     });
 
+    // #634. The 50 level pairs came from live `Math.random()`, and the battles
+    // ran on the default `Math.random` rng too, so a failure named neither the
+    // levels that produced it nor the rolls inside it — the one thing needed to
+    // look at it again was gone by the time the output was read. Both are
+    // seeded from a constant now: the same 50 pairs and the same rolls on every
+    // machine and every run, and the pair travels into the assertion so a
+    // failure says which one it was.
+    //
+    // A fixed table of pairs would also have been replayable, and this is
+    // preferred only because the seed still drives the battle's own rolls,
+    // which is where the interesting variation is: 30 rounds of variance and
+    // crit per battle, rather than 50 hand-picked levels.
     test('always produces a single winner', () => {
+        const rng = seededRng(0x5EEDF00D);
+        const seen = new Set();
+
         for (let i = 0; i < 50; i++) {
-            const lvlA = 1 + Math.floor(Math.random() * 30);
-            const lvlB = 1 + Math.floor(Math.random() * 30);
+            const lvlA = 1 + Math.floor(rng() * 30);
+            const lvlB = 1 + Math.floor(rng() * 30);
+            const pair = `level ${lvlA} v ${lvlB}`;
+            seen.add(pair);
+
             const a = { petId: 'wolf', level: lvlA, evolutionStage: 1, personality: 'energetic' };
             const b = { petId: 'cat',  level: lvlB, evolutionStage: 1, personality: 'loyal' };
-            const res = simulateBattle(a, b);
-            expect(['a', 'b']).toContain(res.winner);
+            const res = simulateBattle(a, b, rng);
+
+            expect([pair, ['a', 'b'].includes(res.winner)]).toEqual([pair, true]);
+            expect([pair, res.rounds.length > 0]).toEqual([pair, true]);
         }
+
+        // A seed that happened to collapse the pairs would leave this looking
+        // like 50 cases while testing two or three. It is a property of the
+        // constant above, so it is checked rather than assumed.
+        expect(seen.size).toBeGreaterThan(40);
     });
 });
 


### PR DESCRIPTION
## Summary

This PR removes the `--forceExit` flag from Jest test scripts and adds comprehensive detection to prevent it from being reintroduced. The flag was masking resource leaks (undisconnected Mongoose clients, unref'd timers, etc.) by forcefully terminating the process after tests complete, rather than allowing the event loop to naturally drain.

## Key Changes

- **Removed `--forceExit` from npm scripts**: Updated `package.json` to remove the flag from both `test` and `test:coverage` scripts, allowing tests to exit naturally and making leaks visible as hangs
- **Added open handle detection test suite**: Created `tests/openHandleGate.test.js` with four assertions that prevent `--forceExit` from being reintroduced via:
  - npm script definitions
  - CI command line invocations
  - Jest configuration file
- **Added step-level timeout to CI**: Set `timeout-minutes: 10` on the test step in `.github/workflows/ci.yml` to bound any hangs while allowing subsequent steps (coverage, lint) to still report
- **Fixed test helper to throw on failure**: Modified `castUntil()` in `tests/fishService.test.js` to throw an error instead of returning `null` when exhausting max casts, preventing silent test failures. Removed now-unnecessary `expect(...).not.toBeNull()` assertions at call sites
- **Added deterministic RNG for pet battle tests**: Implemented `seededRng()` in `tests/petBattle.test.js` to make battle simulations reproducible, and updated test to use it for both level generation and battle rolls. Enhanced assertions to include the level pair in failure messages
- **Added AIUsage model mock**: Added mock in `tests/aiRateLimitEnforcement.test.js` to prevent buffered Mongoose queries from keeping the worker alive

## Implementation Details

The removal of `--forceExit` is protected by a dedicated test file that validates the flag's absence across multiple configuration points. This prevents accidental reintroduction when future leaks appear and developers reach for the "obvious fix."

The `castUntil()` helper change improves test reliability by making predicate failures explicit rather than silent—tests that fail to catch fish now fail loudly rather than passing against unchanged fixtures.

The seeded RNG changes make flaky pet battle tests deterministic and reproducible, with failure messages that include the specific level pair that failed.

https://claude.ai/code/session_01SoVoSsL8pNUDrLkWoAP5oX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test behavior so hanging processes fail clearly instead of being forcibly terminated.
  * Prevented rate-limit tests from depending on an active database connection.

* **Tests**
  * Added coverage for casting failures and successful matches.
  * Made battle simulation tests deterministic and more reliable.
  * Added safeguards verifying CI timeouts and test configuration.

* **Chores**
  * Improved CI handling so coverage and lint reporting can still run after test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->