### PR TITLE
Fix RSS feed polling to handle unordered feeds and burst items

### DIFF
--- a/src/services/pollService.js
+++ b/src/services/pollService.js
@@ -128,7 +128,14 @@ async function scheduleActivePollExpirations(client) {
         // No lower bound on endsAt: a poll that expired while the process was
         // down has no timer left anywhere, so excluding it here is what left it
         // open forever. scheduleExpiry closes an overdue one immediately.
-        const active = await Poll.find({ closed: false });
+        //
+        // `endsAt: null` is excluded, though, because it is not an overdue poll
+        // — it is `/poll` without a duration, which is stored open on purpose
+        // and has no timer to restore. Those were being handed to
+        // scheduleExpiry, where `endsAt.getTime()` threw once per such poll on
+        // every boot, and they were counted in the pickup line below as if
+        // something had been rescheduled.
+        const active = await Poll.find({ closed: false, endsAt: { $ne: null } });
         for (const poll of active) {
             try {
                 const guild = client.guilds.cache.get(poll.guildId);

--- a/src/services/rssService.js
+++ b/src/services/rssService.js
@@ -198,49 +198,72 @@ const MAX_ITEMS_PER_SWEEP = 5;
  * Returns the number of items posted, for the sweep's summary line.
  */
 async function deliverFeedUpdate(client, guild, feed, parsedFeed, entries) {
+    // First sight of a feed posts its newest item and nothing else. Without
+    // that, subscribing to a feed would empty its whole archive into the
+    // channel.
+    const fresh = feed.lastPublished
+        ? entries.filter(entry => entry.date > feed.lastPublished)
+        : entries.slice(-1);
+    if (!fresh.length) return 0;
+
+    const toPost = fresh.slice(-MAX_ITEMS_PER_SWEEP);
+
+    // The cursor is moved to what was actually delivered, never past it. A
+    // batch that stops half way must not repost the half that landed on the
+    // next sweep, and must not skip the half that did not.
+    let delivered = 0;
+    let cursor = null;
+
     try {
-        // First sight of a feed posts its newest item and nothing else. Without
-        // that, subscribing to a feed would empty its whole archive into the
-        // channel.
-        const fresh = feed.lastPublished
-            ? entries.filter(entry => entry.date > feed.lastPublished)
-            : entries.slice(-1);
-        if (!fresh.length) return 0;
-
-        const newest = fresh[fresh.length - 1].date;
-        const toPost = fresh.slice(-MAX_ITEMS_PER_SWEEP);
-
         const channel = await fetchSendableChannel(client, feed.channelId);
 
-        if (channel) {
-            for (const { item, date } of toPost) {
-                const embed = new EmbedBuilder()
-                    .setColor(COLORS.INFO)
-                    .setTitle(item.title || 'New Post')
-                    .setURL(item.link)
-                    .setDescription(item.contentSnippet?.substring(0, 200) || 'No description available')
-                    .setTimestamp(date);
+        // No channel is not a delivery. Advancing the cursor here would drop
+        // the whole burst for good on a channel that was only briefly
+        // unreachable — `channels.fetch` failing with nothing in the cache
+        // looks exactly like a deleted one. Leaving it where it is costs a
+        // no-op re-check each sweep while the channel is really gone, which is
+        // the cheaper of the two mistakes.
+        if (!channel) return 0;
 
-                if (parsedFeed.image?.url) {
-                    embed.setThumbnail(parsedFeed.image.url);
-                }
+        for (const { item, date } of toPost) {
+            const embed = new EmbedBuilder()
+                .setColor(COLORS.INFO)
+                .setTitle(item.title || 'New Post')
+                .setURL(item.link)
+                .setDescription(item.contentSnippet?.substring(0, 200) || 'No description available')
+                .setTimestamp(date);
 
-                await channel.send({ embeds: [embed] });
+            if (parsedFeed.image?.url) {
+                embed.setThumbnail(parsedFeed.image.url);
             }
+
+            await channel.send({ embeds: [embed] });
+            delivered++;
+            cursor = date;
         }
 
-        // Targets the one subdocument rather than rewriting the whole
-        // rssFeeds array, which is also what `guild.save()` on a
-        // projected document could not do.
-        await Guild.updateOne(
-            { guildId: guild.guildId, 'rssFeeds._id': feed._id },
-            { $set: { 'rssFeeds.$.lastPublished': newest } }
-        );
-        return channel ? toPost.length : 0;
+        // The whole batch landed, so the cursor may also skip whatever the
+        // per-sweep cap left behind — those are not coming.
+        cursor = fresh[fresh.length - 1].date;
     } catch (error) {
         console.error(`Error delivering RSS update for ${feed.url} to guild ${guild.guildId}:`, error);
-        return 0;
     }
+
+    if (cursor) {
+        try {
+            // Targets the one subdocument rather than rewriting the whole
+            // rssFeeds array, which is also what `guild.save()` on a
+            // projected document could not do.
+            await Guild.updateOne(
+                { guildId: guild.guildId, 'rssFeeds._id': feed._id },
+                { $set: { 'rssFeeds.$.lastPublished': cursor } }
+            );
+        } catch (error) {
+            console.error(`Error advancing the RSS cursor for ${feed.url} in guild ${guild.guildId}:`, error);
+        }
+    }
+
+    return delivered;
 }
 
 // Overlap protection lives in the scheduler: this runs through runJob, which
@@ -268,8 +291,6 @@ async function checkRssFeeds(client) {
         // workers — bounded parallelism without chunking (no worker idles
         // while a slow feed holds up its chunk).
         const urls = [...subscriptionsByUrl.keys()];
-        if (!urls.length) return;
-
         let next = 0;
         let posted = 0;
         let failed = 0;

--- a/src/services/rssService.js
+++ b/src/services/rssService.js
@@ -165,34 +165,68 @@ async function fetchSendableChannel(client, channelId) {
 
     return channel;
 }
+// Most feeds list newest first, but nothing in RSS or Atom requires it, and a
+// feed that lists oldest first pinned `items[0]` to an article that never
+// changes — so the sweep advanced its cursor once and then had nothing new to
+// say for the rest of the feed's life. Order is taken from the dates, not from
+// the document.
+//
+// An item whose pubDate does not parse is dropped rather than posted: its date
+// is both the "is this new" test and the embed's timestamp, and
+// `setTimestamp(new Date('...'))` on an unparseable one throws RangeError —
+// which, on a feed being seen for the first time, aborted the delivery before
+// the cursor was written and so repeated on every sweep, forever.
+function datedItems(parsedFeed) {
+    return (parsedFeed.items || [])
+        .map(item => ({ item, date: new Date(item.pubDate || item.isoDate) }))
+        .filter(entry => !Number.isNaN(entry.date.getTime()))
+        .sort((a, b) => a.date - b.date);
+}
+
+// A feed that publishes a burst between two sweeps posts at most this many of
+// them, newest kept. The cursor still advances past the whole burst: a channel
+// is not a backfill target, and the alternative — posting all of them — is a
+// feed that reposts its archive the first time it is polled after an outage.
+const MAX_ITEMS_PER_SWEEP = 5;
+
 /**
- * Delivers a freshly-parsed feed to one guild's subscription: sends the embed
- * if the latest item is new for that guild, and advances its lastPublished
- * cursor. Per-subscription failures are contained here so one guild's deleted
- * channel does not stop the fan-out to the others.
+ * Delivers a freshly-parsed feed to one guild's subscription: sends what is new
+ * for that guild and advances its lastPublished cursor. Per-subscription
+ * failures are contained here so one guild's deleted channel does not stop the
+ * fan-out to the others.
+ *
+ * Returns the number of items posted, for the sweep's summary line.
  */
-async function deliverFeedUpdate(client, guild, feed, parsedFeed, latestItem, itemDate) {
+async function deliverFeedUpdate(client, guild, feed, parsedFeed, entries) {
     try {
-        // Not `itemDate <= lastPublished`: an unparseable pubDate gives an
-        // invalid Date, which compares false both ways, and it must skip (as
-        // it always has) rather than post with a timestamp that cannot render.
-        if (feed.lastPublished && !(itemDate > feed.lastPublished)) return;
+        // First sight of a feed posts its newest item and nothing else. Without
+        // that, subscribing to a feed would empty its whole archive into the
+        // channel.
+        const fresh = feed.lastPublished
+            ? entries.filter(entry => entry.date > feed.lastPublished)
+            : entries.slice(-1);
+        if (!fresh.length) return 0;
+
+        const newest = fresh[fresh.length - 1].date;
+        const toPost = fresh.slice(-MAX_ITEMS_PER_SWEEP);
 
         const channel = await fetchSendableChannel(client, feed.channelId);
 
         if (channel) {
-            const embed = new EmbedBuilder()
-                .setColor(COLORS.INFO)
-                .setTitle(latestItem.title || 'New Post')
-                .setURL(latestItem.link)
-                .setDescription(latestItem.contentSnippet?.substring(0, 200) || 'No description available')
-                .setTimestamp(itemDate);
+            for (const { item, date } of toPost) {
+                const embed = new EmbedBuilder()
+                    .setColor(COLORS.INFO)
+                    .setTitle(item.title || 'New Post')
+                    .setURL(item.link)
+                    .setDescription(item.contentSnippet?.substring(0, 200) || 'No description available')
+                    .setTimestamp(date);
 
-            if (parsedFeed.image?.url) {
-                embed.setThumbnail(parsedFeed.image.url);
+                if (parsedFeed.image?.url) {
+                    embed.setThumbnail(parsedFeed.image.url);
+                }
+
+                await channel.send({ embeds: [embed] });
             }
-
-            await channel.send({ embeds: [embed] });
         }
 
         // Targets the one subdocument rather than rewriting the whole
@@ -200,10 +234,12 @@ async function deliverFeedUpdate(client, guild, feed, parsedFeed, latestItem, it
         // projected document could not do.
         await Guild.updateOne(
             { guildId: guild.guildId, 'rssFeeds._id': feed._id },
-            { $set: { 'rssFeeds.$.lastPublished': itemDate } }
+            { $set: { 'rssFeeds.$.lastPublished': newest } }
         );
+        return channel ? toPost.length : 0;
     } catch (error) {
         console.error(`Error delivering RSS update for ${feed.url} to guild ${guild.guildId}:`, error);
+        return 0;
     }
 }
 
@@ -232,11 +268,16 @@ async function checkRssFeeds(client) {
         // workers — bounded parallelism without chunking (no worker idles
         // while a slow feed holds up its chunk).
         const urls = [...subscriptionsByUrl.keys()];
+        if (!urls.length) return;
+
         let next = 0;
+        let posted = 0;
+        let failed = 0;
+        let skipped = 0;
         const worker = async () => {
             while (next < urls.length) {
                 const url = urls[next++];
-                if (shouldSkipDeadFeed(url)) continue;
+                if (shouldSkipDeadFeed(url)) { skipped++; continue; }
 
                 let parsedFeed;
                 try {
@@ -244,16 +285,15 @@ async function checkRssFeeds(client) {
                     recordFeedSuccess(url);
                 } catch (error) {
                     recordFeedFailure(url, error);
+                    failed++;
                     continue;
                 }
 
-                if (parsedFeed.items.length === 0) continue;
-
-                const latestItem = parsedFeed.items[0];
-                const itemDate = new Date(latestItem.pubDate || latestItem.isoDate);
+                const entries = datedItems(parsedFeed);
+                if (!entries.length) continue;
 
                 for (const { guild, feed } of subscriptionsByUrl.get(url)) {
-                    await deliverFeedUpdate(client, guild, feed, parsedFeed, latestItem, itemDate);
+                    posted += await deliverFeedUpdate(client, guild, feed, parsedFeed, entries);
                 }
             }
         };
@@ -261,6 +301,12 @@ async function checkRssFeeds(client) {
         await Promise.all(
             Array.from({ length: Math.min(RSS_FETCH_CONCURRENCY, urls.length) }, worker)
         );
+
+        // One line per sweep, always. "Feeds stopped posting" was previously
+        // indistinguishable from "nothing new was published" from the outside,
+        // and the per-feed errors say what broke without ever saying how much
+        // of the sweep it was.
+        console.log(`[RSS] Sweep: ${urls.length} feed(s), ${posted} posted, ${failed} failed, ${skipped} parked.`);
     } catch (error) {
         console.error('Error checking RSS feeds:', error);
     }
@@ -275,9 +321,10 @@ async function sendDailyNewsForProfile(client, guild, profile) {
 
     const allItems = [];
     const cutoffMs = Date.now() - (24 * 60 * 60 * 1000);
+    let unreachable = 0;
 
     for (const feedUrl of profile.feeds) {
-        if (shouldSkipDeadFeed(feedUrl)) continue;
+        if (shouldSkipDeadFeed(feedUrl)) { unreachable++; continue; }
 
         try {
             const parsedFeed = await parseFeedUrl(feedUrl);
@@ -298,6 +345,7 @@ async function sendDailyNewsForProfile(client, guild, profile) {
             allItems.push(...feedItems);
         } catch (error) {
             recordFeedFailure(feedUrl, error);
+            unreachable++;
         }
     }
 
@@ -313,7 +361,16 @@ async function sendDailyNewsForProfile(client, guild, profile) {
         uniqueItems.push(item);
     }
 
-    if (uniqueItems.length === 0) return;
+    // A digest that posts nothing looks identical from Discord to a digest that
+    // never ran, and its slot is already claimed for the day either way — so the
+    // two get told apart here, in the one place that knows which it was.
+    if (uniqueItems.length === 0) {
+        const why = profile.feeds.length > 0 && unreachable === profile.feeds.length
+            ? `all ${profile.feeds.length} feed(s) unreachable`
+            : 'nothing new in the last 24h';
+        console.log(`[RSS] Daily news for guild ${guild.guildId} (${profile.profileId}): sent nothing — ${why}.`);
+        return;
+    }
 
     uniqueItems.sort(compareByDateDesc);
 
@@ -470,5 +527,6 @@ module.exports = {
         feedFailCounts, feedLastFailTime, shouldSkipDeadFeed,
         DEAD_FEED_THRESHOLD, DEAD_FEED_COOLDOWN_MS, RSS_FETCH_CONCURRENCY,
         dailyNewsDue, runDueDailyNews, DAILY_NEWS_REFIRE_GUARD_MS,
+        datedItems, MAX_ITEMS_PER_SWEEP,
     },
 };

--- a/src/utils/safeFeedFetch.js
+++ b/src/utils/safeFeedFetch.js
@@ -19,6 +19,14 @@
 const SOCKET_IDLE_MS = 8000;
 const HOP_DEADLINE_MS = 8000;
 
+// Identifies the bot to the feed host. This module serves the scheduled poller
+// as much as the dashboard's validate button, so the old
+// "Clawdia-FeedValidator/1.0" both misdescribed most of its own traffic and
+// read to a bot filter as an unattributed scraper — and a feed that answers a
+// browser but 403s this string is a feed that silently stops posting. A name
+// and a URL is what a well-behaved reader sends.
+const FEED_USER_AGENT = 'Clawdia/1.0 (+https://github.com/TheShield2594/clawdia; Discord RSS reader)';
+
 const dns = require('dns');
 const net = require('net');
 const http = require('http');
@@ -137,8 +145,13 @@ async function safeFetchFeed(urlStr, maxRedirects = 5) {
             const fail = finish(reject);
 
             const commonHeaders = {
-                'User-Agent': 'Clawdia-FeedValidator/1.0',
+                'User-Agent': FEED_USER_AGENT,
                 Accept: 'application/rss+xml,application/atom+xml,application/xml,text/xml,*/*',
+                // Nothing here decompresses, and a server that gzips anyway
+                // would hand the parser binary and be reported as malformed
+                // XML. Asking for identity is the difference between a feed
+                // that fails for a stated reason and one that fails for none.
+                'Accept-Encoding': 'identity',
                 Host: current.hostname, // required when connecting directly to a pinned IP
             };
 
@@ -177,6 +190,19 @@ async function safeFetchFeed(urlStr, maxRedirects = 5) {
                     res.destroy();
                     return succeed({ redirect: loc });
                 }
+
+                // A non-2xx body is not a feed, and handing it to the parser
+                // anyway is how "the host is refusing us" was reported as
+                // "Feed not recognized as RSS 1 or 2". The status is the whole
+                // diagnosis — a 403 from a bot filter, a 404 for a feed that
+                // moved, a 429 to back off from — so it goes in the message
+                // rather than being replaced by a parser error downstream.
+                if (res.statusCode < 200 || res.statusCode > 299) {
+                    const status = res.statusCode;
+                    res.destroy();
+                    return fail(new Error(`Feed request failed with HTTP ${status}.`));
+                }
+
                 const chunks = [];
                 let totalBytes = 0;
                 res.on('data', c => {

--- a/tests/guildScanProjection.test.js
+++ b/tests/guildScanProjection.test.js
@@ -144,7 +144,11 @@ describe('the RSS feed check', () => {
             rssFeeds: [{ _id: 'feed1', url: 'https://example.com/rss', channelId: 'chan1', lastPublished: null }],
         }]);
 
-        await checkRssFeeds({ channels: { fetch: jest.fn().mockResolvedValue(null) } });
+        // A real sendable channel: the cursor only moves for an item that was
+        // actually delivered, so a null channel now writes nothing and would
+        // say nothing about the shape of the write, which is what this asserts.
+        const channel = { send: jest.fn().mockResolvedValue({}), isTextBased: () => true };
+        await checkRssFeeds({ channels: { fetch: jest.fn().mockResolvedValue(channel) } });
 
         expect(Guild.updateOne).toHaveBeenCalledTimes(1);
         const [filter, update] = Guild.updateOne.mock.calls[0];

--- a/tests/pollExpiryTimer.test.js
+++ b/tests/pollExpiryTimer.test.js
@@ -7,8 +7,9 @@
 jest.mock('../src/models/Poll', () => ({ findOne: jest.fn(), find: jest.fn(), create: jest.fn() }));
 jest.mock('../src/utils/jobRunner', () => ({ runJob: jest.fn() }));
 
+const Poll = require('../src/models/Poll');
 const { runJob } = require('../src/utils/jobRunner');
-const { scheduleExpiry } = require('../src/services/pollService');
+const { scheduleExpiry, scheduleActivePollExpirations } = require('../src/services/pollService');
 
 const MAX_TIMEOUT_MS = 2_147_483_647;
 const msg = { id: 'msg1', guildId: 'g1', edit: jest.fn() };
@@ -57,5 +58,49 @@ describe('a poll that expires further out than a 32-bit timer reaches', () => {
 
         jest.advanceTimersByTime(0);
         expect(runJob).toHaveBeenCalledTimes(1);
+    });
+});
+
+// ── Picking unclosed polls back up at boot ──────────────────────────────────
+//
+// `/poll` without a duration is stored open with `endsAt: null` — that is the
+// feature, not a stalled poll. The startup sweep selected every unclosed poll
+// and handed each to scheduleExpiry, where `endsAt.getTime()` threw
+// "Cannot read properties of null (reading 'getTime')" once per no-expiry poll
+// on every boot, and counted them in the pickup line as if a timer had been
+// armed for them.
+describe('scheduleActivePollExpirations', () => {
+    function clientWith(msg) {
+        const channel = { messages: { fetch: jest.fn(async () => msg) } };
+        const guild = { channels: { cache: new Map([['c1', channel]]) } };
+        return { guilds: { cache: new Map([['g1', guild]]) } };
+    }
+
+    beforeEach(() => {
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+    afterEach(() => jest.restoreAllMocks());
+
+    test('asks only for polls that actually carry a deadline', async () => {
+        Poll.find.mockResolvedValue([]);
+
+        await scheduleActivePollExpirations(clientWith(msg));
+
+        expect(Poll.find).toHaveBeenCalledWith({ closed: false, endsAt: { $ne: null } });
+    });
+
+    test('arms a timer for an overdue poll without logging a failure', async () => {
+        Poll.find.mockResolvedValue([{
+            messageId: 'msg1', guildId: 'g1', channelId: 'c1',
+            question: 'q', options: ['a', 'b'],
+            endsAt: new Date(Date.now() - 5_000), createdBy: 'someone',
+        }]);
+
+        await scheduleActivePollExpirations(clientWith(msg));
+
+        jest.advanceTimersByTime(0);
+        expect(runJob).toHaveBeenCalledTimes(1);
+        expect(console.error).not.toHaveBeenCalled();
     });
 });

--- a/tests/rssCheckFeeds.test.js
+++ b/tests/rssCheckFeeds.test.js
@@ -38,12 +38,23 @@ jest.mock('../src/models/Guild', () => ({
 
 const Guild = require('../src/models/Guild');
 const { checkRssFeeds, __test__ } = require('../src/services/rssService');
-const { feedFailCounts, feedLastFailTime, DEAD_FEED_THRESHOLD, RSS_FETCH_CONCURRENCY } = __test__;
+const { feedFailCounts, feedLastFailTime, DEAD_FEED_THRESHOLD, RSS_FETCH_CONCURRENCY, MAX_ITEMS_PER_SWEEP } = __test__;
 
 function rssXml({ title = 'Feed', itemTitle = 'Post', link = 'https://example.com/post', pubDate = 'Wed, 20 Aug 2025 12:00:00 GMT' } = {}) {
+    return rssXmlItems([{ title: itemTitle, link, pubDate }], title);
+}
+
+// `items` in document order, so a test can put the newest last (as plenty of
+// real feeds do) and assert the sweep does not trust that order.
+function rssXmlItems(items, title = 'Feed') {
+    const body = items.map(i =>
+        `<item><title>${i.title}</title><link>${i.link}</link>` +
+        (i.pubDate === null ? '' : `<pubDate>${i.pubDate}</pubDate>`) +
+        '</item>'
+    ).join('\n');
     return `<?xml version="1.0"?>
 <rss version="2.0"><channel><title>${title}</title>
-<item><title>${itemTitle}</title><link>${link}</link><pubDate>${pubDate}</pubDate></item>
+${body}
 </channel></rss>`;
 }
 
@@ -168,4 +179,121 @@ test('one guild whose delivery blows up does not stop the fan-out to the rest', 
         { guildId: 'g2', 'rssFeeds._id': 'f2' },
         { $set: { 'rssFeeds.$.lastPublished': expect.any(Date) } }
     );
+});
+
+
+// ── What the cursor is read from ────────────────────────────────────────────
+//
+// The sweep used to take `items[0]` as "the latest item" and its pubDate as the
+// cursor. Nothing in RSS or Atom orders a feed, an unparseable date is not a
+// timestamp an embed can carry, and a feed can publish more than once between
+// two five-minute sweeps. Each of those is a way a feed went quiet with nothing
+// in the log to say so.
+
+test('a feed listed oldest-first posts its newest item, not its first', async () => {
+    const url = 'https://example.com/rss';
+    mockFeedBodies.set(url, rssXmlItems([
+        { title: 'Older', link: 'https://example.com/old', pubDate: 'Mon, 18 Aug 2025 12:00:00 GMT' },
+        { title: 'Newest', link: 'https://example.com/new', pubDate: 'Wed, 20 Aug 2025 12:00:00 GMT' },
+    ]));
+    mockGuilds = [{ guildId: 'g1', rssFeeds: [{ _id: 'f1', url, channelId: 'c1', lastPublished: null }] }];
+    const client = makeClient();
+
+    await checkRssFeeds(client);
+
+    expect(client.send).toHaveBeenCalledTimes(1);
+    expect(client.send.mock.calls[0][0].embeds[0].data.title).toBe('Newest');
+    expect(Guild.updateOne).toHaveBeenCalledWith(
+        { guildId: 'g1', 'rssFeeds._id': 'f1' },
+        { $set: { 'rssFeeds.$.lastPublished': new Date('2025-08-20T12:00:00Z') } }
+    );
+});
+
+test('a first sight of a feed posts one item, not its whole archive', async () => {
+    const url = 'https://example.com/rss';
+    mockFeedBodies.set(url, rssXmlItems([
+        { title: 'A', link: 'https://example.com/a', pubDate: 'Mon, 18 Aug 2025 12:00:00 GMT' },
+        { title: 'B', link: 'https://example.com/b', pubDate: 'Tue, 19 Aug 2025 12:00:00 GMT' },
+        { title: 'C', link: 'https://example.com/c', pubDate: 'Wed, 20 Aug 2025 12:00:00 GMT' },
+    ]));
+    mockGuilds = [{ guildId: 'g1', rssFeeds: [{ _id: 'f1', url, channelId: 'c1', lastPublished: null }] }];
+    const client = makeClient();
+
+    await checkRssFeeds(client);
+
+    expect(client.send).toHaveBeenCalledTimes(1);
+    expect(client.send.mock.calls[0][0].embeds[0].data.title).toBe('C');
+});
+
+test('every item published since the last sweep is posted, oldest first', async () => {
+    const url = 'https://example.com/rss';
+    mockFeedBodies.set(url, rssXmlItems([
+        { title: 'C', link: 'https://example.com/c', pubDate: 'Wed, 20 Aug 2025 12:00:00 GMT' },
+        { title: 'B', link: 'https://example.com/b', pubDate: 'Tue, 19 Aug 2025 12:00:00 GMT' },
+        { title: 'A', link: 'https://example.com/a', pubDate: 'Mon, 18 Aug 2025 12:00:00 GMT' },
+    ]));
+    mockGuilds = [{
+        guildId: 'g1',
+        rssFeeds: [{ _id: 'f1', url, channelId: 'c1', lastPublished: new Date('2025-08-18T18:00:00Z') }],
+    }];
+    const client = makeClient();
+
+    await checkRssFeeds(client);
+
+    expect(client.send.mock.calls.map(c => c[0].embeds[0].data.title)).toEqual(['B', 'C']);
+});
+
+test('a burst larger than the per-sweep cap posts the newest and cursors past the rest', async () => {
+    const url = 'https://example.com/rss';
+    const items = Array.from({ length: MAX_ITEMS_PER_SWEEP + 3 }, (_, i) => ({
+        title: `item${i}`,
+        link: `https://example.com/${i}`,
+        pubDate: new Date(Date.UTC(2025, 7, 20, i)).toUTCString(),
+    }));
+    mockFeedBodies.set(url, rssXmlItems(items));
+    mockGuilds = [{ guildId: 'g1', rssFeeds: [{ _id: 'f1', url, channelId: 'c1', lastPublished: new Date('2025-08-19T00:00:00Z') }] }];
+    const client = makeClient();
+
+    await checkRssFeeds(client);
+
+    expect(client.send).toHaveBeenCalledTimes(MAX_ITEMS_PER_SWEEP);
+    const titles = client.send.mock.calls.map(c => c[0].embeds[0].data.title);
+    expect(titles[titles.length - 1]).toBe(`item${items.length - 1}`);
+    expect(Guild.updateOne).toHaveBeenCalledWith(
+        { guildId: 'g1', 'rssFeeds._id': 'f1' },
+        { $set: { 'rssFeeds.$.lastPublished': new Date(Date.UTC(2025, 7, 20, items.length - 1)) } }
+    );
+});
+
+test('an unparseable pubDate on a fresh feed is skipped, not retried forever', async () => {
+    // setTimestamp(new Date('not a date')) throws RangeError, which aborted the
+    // delivery before the cursor was written — so the same feed threw again on
+    // every sweep and never posted anything.
+    const url = 'https://example.com/rss';
+    mockFeedBodies.set(url, rssXmlItems([
+        { title: 'Undated', link: 'https://example.com/undated', pubDate: 'not a date' },
+        { title: 'Dated', link: 'https://example.com/dated', pubDate: 'Wed, 20 Aug 2025 12:00:00 GMT' },
+    ]));
+    mockGuilds = [{ guildId: 'g1', rssFeeds: [{ _id: 'f1', url, channelId: 'c1', lastPublished: null }] }];
+    const client = makeClient();
+
+    await checkRssFeeds(client);
+
+    expect(client.send).toHaveBeenCalledTimes(1);
+    expect(client.send.mock.calls[0][0].embeds[0].data.title).toBe('Dated');
+    expect(Guild.updateOne).toHaveBeenCalledTimes(1);
+});
+
+test('a feed with no usable dates at all posts nothing and raises nothing', async () => {
+    const url = 'https://example.com/rss';
+    mockFeedBodies.set(url, rssXmlItems([
+        { title: 'Undated', link: 'https://example.com/undated', pubDate: null },
+    ]));
+    mockGuilds = [{ guildId: 'g1', rssFeeds: [{ _id: 'f1', url, channelId: 'c1', lastPublished: null }] }];
+    const client = makeClient();
+
+    await checkRssFeeds(client);
+
+    expect(client.send).not.toHaveBeenCalled();
+    expect(Guild.updateOne).not.toHaveBeenCalled();
 });

--- a/tests/rssCheckFeeds.test.js
+++ b/tests/rssCheckFeeds.test.js
@@ -297,3 +297,62 @@ test('a feed with no usable dates at all posts nothing and raises nothing', asyn
     expect(client.send).not.toHaveBeenCalled();
     expect(Guild.updateOne).not.toHaveBeenCalled();
 });
+
+
+// ── What the cursor is allowed to skip ──────────────────────────────────────
+//
+// Batching made partial delivery possible for the first time: before it, one
+// item was posted or none was, so "sent" and "cursored" could not disagree.
+
+test('a batch that fails half way cursors to the last item that landed', async () => {
+    const url = 'https://example.com/rss';
+    mockFeedBodies.set(url, rssXmlItems([
+        { title: 'A', link: 'https://example.com/a', pubDate: 'Mon, 18 Aug 2025 12:00:00 GMT' },
+        { title: 'B', link: 'https://example.com/b', pubDate: 'Tue, 19 Aug 2025 12:00:00 GMT' },
+        { title: 'C', link: 'https://example.com/c', pubDate: 'Wed, 20 Aug 2025 12:00:00 GMT' },
+    ]));
+    mockGuilds = [{
+        guildId: 'g1',
+        rssFeeds: [{ _id: 'f1', url, channelId: 'c1', lastPublished: new Date('2025-08-17T00:00:00Z') }],
+    }];
+    const client = makeClient();
+    client.send
+        .mockResolvedValueOnce({})                            // A lands
+        .mockRejectedValueOnce(new Error('rate limited'));    // B does not
+
+    await checkRssFeeds(client);
+
+    // A must not be reposted next sweep, and B must not be skipped.
+    expect(client.send).toHaveBeenCalledTimes(2);
+    expect(Guild.updateOne).toHaveBeenCalledTimes(1);
+    expect(Guild.updateOne).toHaveBeenCalledWith(
+        { guildId: 'g1', 'rssFeeds._id': 'f1' },
+        { $set: { 'rssFeeds.$.lastPublished': new Date('2025-08-18T12:00:00Z') } }
+    );
+});
+
+test('an unreachable channel leaves the cursor alone rather than dropping the burst', async () => {
+    // channels.fetch throwing with nothing cached looks identical to a deleted
+    // channel, so advancing here would lose the items for good on a blip.
+    const url = 'https://example.com/rss';
+    mockFeedBodies.set(url, rssXml());
+    mockGuilds = [{ guildId: 'g1', rssFeeds: [{ _id: 'f1', url, channelId: 'c1', lastPublished: null }] }];
+    const client = makeClient();
+    client.channels.fetch.mockRejectedValue(new Error('500 internal server error'));
+
+    await checkRssFeeds(client);
+
+    expect(client.send).not.toHaveBeenCalled();
+    expect(Guild.updateOne).not.toHaveBeenCalled();
+});
+
+test('a sweep with no configured feeds still reports itself', async () => {
+    // Otherwise "no guild has a feed" and "the job never ran" read the same
+    // from the log, which is the gap the summary line exists to close.
+    mockGuilds = [];
+    const log = jest.spyOn(console, 'log');
+
+    await checkRssFeeds(makeClient());
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('[RSS] Sweep: 0 feed(s)'));
+});

--- a/tests/safeFeedFetch.test.js
+++ b/tests/safeFeedFetch.test.js
@@ -183,6 +183,42 @@ describe('safeFetchFeed', () => {
         await expect(safeFetchFeed('http://example.com/feed')).resolves.toBe('<rss>ok</rss>');
     });
 
+    it('reports the HTTP status instead of handing an error page to the parser', async () => {
+        // A 403 body is not a feed. Returning it anyway meant the poller's only
+        // trace of "this host is refusing us" was rss-parser's downstream
+        // "Feed not recognized as RSS 1 or 2", which names nothing.
+        allowPublicDns();
+        mockRequest((cb) => respond(cb, {
+            statusCode: 403,
+            chunks: ['<html><body>Forbidden</body></html>'],
+        }));
+
+        await expect(safeFetchFeed('http://example.com/feed')).rejects.toThrow(/HTTP 403/);
+    });
+
+    it('reports a 404 for a feed that has moved', async () => {
+        allowPublicDns();
+        mockRequest((cb) => respond(cb, { statusCode: 404, chunks: ['gone'] }));
+        await expect(safeFetchFeed('http://example.com/feed')).rejects.toThrow(/HTTP 404/);
+    });
+
+    it('asks for an uncompressed body, since nothing here decompresses one', async () => {
+        allowPublicDns();
+        let sentHeaders;
+        jest.spyOn(http, 'request').mockImplementation((opts, cb) => {
+            sentHeaders = opts.headers;
+            const req = new EventEmitter();
+            req.end = () => setImmediate(() => respond(cb, { chunks: ['<rss/>'] }));
+            req.destroy = jest.fn();
+            return req;
+        });
+
+        await safeFetchFeed('http://example.com/feed');
+
+        expect(sentHeaders['Accept-Encoding']).toBe('identity');
+        expect(sentHeaders['User-Agent']).toMatch(/^Clawdia\//);
+    });
+
     it('refuses a URL that resolves to a private address before connecting', async () => {
         jest.spyOn(dns, 'lookup').mockImplementation((host, opts, cb) =>
             cb(null, [{ address: '169.254.169.254' }]));


### PR DESCRIPTION
## Summary

This PR fixes several critical issues in RSS feed polling that caused feeds to go silent or post incomplete archives:

1. **Feed ordering**: The poller was taking the first item in the feed as "the latest," but RSS/Atom don't guarantee order. Feeds listed oldest-first would pin the cursor to an unchanging article and never post again.

2. **Burst handling**: When a feed published multiple items between sweeps, only the first was posted. Now up to 5 items per sweep are posted (newest kept), with the cursor advancing past the entire burst.

3. **Date parsing**: Unparseable `pubDate` values would throw `RangeError` when setting embed timestamps, aborting delivery before the cursor was written—causing the same feed to fail on every subsequent sweep.

4. **HTTP error handling**: Non-2xx responses were being passed to the parser instead of reporting the actual HTTP status, making it impossible to diagnose 403/404 errors.

5. **Poll boot recovery**: Polls with `endsAt: null` (no expiry) were being passed to `scheduleExpiry`, causing `getTime()` errors on every boot.

## Key Changes

- **RSS feed polling** (`rssService.js`):
  - Added `datedItems()` to extract and sort items by parsed date, filtering out unparseable dates
  - Added `MAX_ITEMS_PER_SWEEP` constant (5 items) to cap burst posting while advancing cursor past all new items
  - Refactored `deliverFeedUpdate()` to handle multiple items per feed, post oldest-first, and return count posted
  - First sight of a feed now posts only the newest item (not the whole archive)
  - Added sweep summary logging: feed count, items posted, failures, and parked feeds
  - Added daily news digest logging to distinguish "nothing new" from "all feeds unreachable"

- **Feed fetching** (`safeFeedFetch.js`):
  - Added `FEED_USER_AGENT` constant with proper bot identification and project URL
  - Added `Accept-Encoding: identity` header to prevent gzip responses that the parser can't decompress
  - Added HTTP status validation: non-2xx responses now throw with the status code instead of being parsed

- **Poll service** (`pollService.js`):
  - Fixed `scheduleActivePollExpirations()` to exclude `endsAt: null` polls (which have no expiry by design)

- **Tests**:
  - Refactored `rssXml()` helper to use new `rssXmlItems()` for flexible multi-item test feeds
  - Added comprehensive tests for feed ordering, burst handling, date parsing, and edge cases
  - Added tests for HTTP error reporting and feed fetch headers
  - Added tests for poll boot recovery with no-expiry polls

https://claude.ai/code/session_01GiDokzMyHcrWbmwapmyN7P

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - RSS updates can now deliver multiple new items per sweep, while preserving chronological order and limiting large bursts.
  - Feed processing now provides clearer status reporting for posted, skipped, failed, and unreachable feeds.

- **Bug Fixes**
  - Improved handling of unavailable or invalid RSS feeds with clearer HTTP errors.
  - Prevented startup errors for intentionally open polls without expiration times.
  - Improved compatibility with compressed feed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->