### PR TITLE
Give the logs a level, the deploy a gate, and the images a digest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,13 +122,62 @@ IMGFLIP_PASSWORD=your_imgflip_password
 # Dashboard audit log retention, in days (default 90).
 AUDIT_LOG_RETENTION_DAYS=90
 
-# Per-migration wall-clock budget, in milliseconds (default 30000). Schema
-# migrations run before the bot opens its port, and one that runs out of budget
-# aborts startup — on a large database that is a restart loop, since the next
-# boot hits the same wall. Raise this to give the slow migration room; the log
-# line names which one it was. A migration may ask for more than this on its
-# own (005 does), in which case the larger of the two applies.
+# ── Schema migrations ────────────────────────────────────────────────────────
+# The files in src/migrations/ run automatically, in order, on every boot —
+# before the bot logs in and before the dashboard opens its port. There is no
+# separate migrate step to run, and no way to boot without them. Some are
+# irreversible (dropped fields, merged documents) and none roll back on their
+# own. See "Schema migrations" in SETUP_GUIDE.md.
+
+# Per-migration wall-clock budget, in milliseconds (default 30000). One that
+# runs out of budget aborts startup — on a large database that is a restart
+# loop, since the next boot hits the same wall. Raise this to give the slow
+# migration room; the log line names which one it was. A migration may ask for
+# more than this on its own (005 does), in which case the larger applies.
 # MIGRATION_TIMEOUT_MS=30000
+
+# What to do about the mongodump the runner takes immediately before an
+# irreversible migration — which is the only way back from one.
+#   unset      attempt it; warn loudly and continue if mongodump is missing
+#   require    a failed or impossible backup aborts startup instead
+#   skip       do not attempt one
+# `require` is the right setting for a production deploy that has mongodump in
+# the image or on the host.
+# MIGRATION_BACKUP=require
+# Where that archive lands (default ./backups, the same directory the nightly
+# backup service prunes). Named pre-migration-<timestamp>.gz.
+# MIGRATION_BACKUP_DIR=./backups
+
+# ── Slash-command registration ───────────────────────────────────────────────
+# The bot registers its own commands with Discord when it connects, which is
+# what makes the Docker quick-start produce a bot that has commands: the image
+# runs `node src/index.js` and nothing in either stack file runs `npm run
+# deploy`.
+#   auto     (default) publish only when the command set differs from the one
+#            last published — the ordinary restart makes no Discord call
+#   always   publish on every boot
+#   never    never publish from the bot; you run `npm run deploy` yourself
+# DEPLOY_COMMANDS=auto
+
+# ── Logging ──────────────────────────────────────────────────────────────────
+# Everything the bot logs goes through pino: one JSON object per line, on
+# stdout, with a level, an ISO timestamp, the subsystem as `component`, and a
+# `requestId` on every line a dashboard request produced.
+#
+# trace | debug | info (default) | warn | error | fatal | silent
+# LOG_LEVEL=info
+# json (default when NODE_ENV=production) renders the objects; pretty (the
+# default otherwise) renders a readable line instead. `docker logs clawdia |
+# npx pino-pretty` reads a JSON stream the same way.
+# LOG_FORMAT=json
+
+# Where to send an uncaught exception or an unhandled rejection, on top of
+# logging it. Unset — the default — nothing is sent and the process exits
+# exactly as it always did. A Discord webhook URL is recognised and formatted
+# for Discord; anything else receives a flat JSON event.
+# ERROR_WEBHOOK_URL=https://discord.com/api/webhooks/...
+# How long the process waits for that POST before exiting anyway (default 2000).
+# ERROR_REPORT_TIMEOUT_MS=2000
 
 # ── Sharding (optional) ──────────────────────────────────────────────────────
 # `npm start` runs one process and one gateway connection, and is the default.

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,18 @@
 # ships a runtime nothing ever tested. tests/nodeVersionAlignment.test.js fails
 # the build if the three drift apart. 24 is the active LTS line; move all three
 # together when 26 reaches LTS.
-FROM node:24-alpine AS build
+#
+# The `@sha256:` suffix is what makes the build reproducible (#644). `node:24-alpine`
+# on its own is a moving target — it is re-published whenever the 24 line gets a
+# patch or Alpine gets a rebuild — so the same Dockerfile, the same commit and the
+# same `docker build` produce a different runtime depending on the day, and a
+# rebuild to roll back a regression can quietly carry a *newer* base than the
+# image it is replacing. The tag is kept alongside the digest because it is the
+# only human-readable half; the digest is what Docker actually resolves.
+# Dependabot's `docker` ecosystem (.github/dependabot.yml) raises the bump, and
+# tests/imagePinning.test.js fails if any reference here or in either stack file
+# loses its digest.
+FROM node:24-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a015ba7a4eaf AS build
 
 RUN apk add --no-cache \
     cairo-dev \
@@ -31,7 +42,7 @@ RUN npm ci --omit=dev && npm cache clean --force
 
 # ---- runtime stage -----------------------------------------------------------
 # Same major as the build stage and as .nvmrc — see the note above.
-FROM node:24-alpine
+FROM node:24-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a015ba7a4eaf
 
 # Shared libraries canvas links against at runtime (the -dev headers and the
 # compiler are deliberately left behind in the build stage), plus the DejaVu

--- a/README.md
+++ b/README.md
@@ -78,13 +78,28 @@ command sets put together.
 docker-compose up -d
 ```
 
+That is the whole deploy. In particular there is no separate command-registration
+step: the bot publishes its slash commands to Discord itself when it connects,
+and re-publishes only when the command set has actually changed — so a restart
+costs nothing and an upgrade that adds a command needs no extra action. Global
+commands can take up to an hour to appear in every server the first time.
+`DEPLOY_COMMANDS` below turns that off if you would rather drive it by hand.
+
+Schema migrations run on boot too, before the dashboard opens its port. Some are
+irreversible; see [Schema migrations](SETUP_GUIDE.md#schema-migrations) before
+the first upgrade of a deployment with data in it.
+
 ## Manual Installation
 
 ```bash
 npm install
-npm run deploy  # Deploy slash commands globally
+npm run deploy  # Optional: publish the slash commands now, without starting
 npm start
 ```
+
+`npm run deploy` is the manual path — useful while developing a command, or to
+re-publish after `DEPLOY_COMMANDS=never`. It is not a prerequisite for
+`npm start`, which registers them itself.
 
 ### Sharding
 
@@ -157,6 +172,15 @@ the files a change already touches.
 - `MCP_SERVERS_CONFIG` - (Optional) Path to the MCP server list (default: `config/mcp-servers.json`)
 - `MCP_ALLOW_GUILD_SERVERS` - (Optional) Set to `false` to disable dashboard-managed MCP servers
 - `IMGFLIP_USERNAME` / `IMGFLIP_PASSWORD` - (Optional) Imgflip credentials for `/meme` command
+- `LOG_LEVEL` - (Optional) `trace`, `debug`, `info` (default), `warn`, `error`, `fatal` or `silent`. See [Logging](#logging)
+- `LOG_FORMAT` - (Optional) `json` or `pretty`. Defaults to `json` when `NODE_ENV=production`, `pretty` otherwise
+- `ERROR_WEBHOOK_URL` - (Optional) Where to send an uncaught exception or unhandled rejection, on top of logging it. A Discord webhook URL is recognised and formatted for Discord; anything else receives a flat JSON event. Unset, nothing is sent and the crash path behaves exactly as before
+- `ERROR_REPORT_TIMEOUT_MS` - (Optional) How long the process waits for that POST before exiting anyway (default 2000)
+- `DEPLOY_COMMANDS` - (Optional) `auto` (default — publish the slash commands at startup, but only when the set changed), `always`, or `never`
+- `MIGRATION_TIMEOUT_MS` - (Optional) Per-migration wall-clock budget in milliseconds (default 30000)
+- `MIGRATION_BACKUP` - (Optional) `require` to abort startup rather than run an irreversible migration without a `mongodump` first; `skip` to not attempt one. Unset, it is attempted and a failure is a loud warning. See [Schema migrations](SETUP_GUIDE.md#schema-migrations)
+- `BACKUP_RETENTION_DAYS` - (Optional) Days of nightly `mongodump` archives to keep (default 30)
+- `SHARD_COUNT` - (Optional) Pin a shard count for `npm run start:sharded`; unset takes Discord's recommendation
 
 ## Commands
 
@@ -297,6 +321,7 @@ Configuration that previously lived behind slash commands (settings link, level 
 - MongoDB with Mongoose
 - Express.js
 - Passport (Discord OAuth2)
+- Pino (structured logging)
 - OpenAI API / Google Gemini API / Anthropic Claude API / Ollama (optional)
 - RSS Parser
 - Canvas (Image generation)
@@ -470,6 +495,47 @@ The Daily News feature compiles multiple RSS feeds into a single daily post.
 
 Use the **Send digest now** button in the dashboard's Daily News panel.
 
+## Logging
+
+Everything the bot writes goes through [pino](https://getpino.io): one line per
+event, carrying a level, an ISO timestamp, the subsystem it came from, and — for
+anything a dashboard request produced — a correlation id shared by every line of
+that request.
+
+```json
+{"level":"error","time":"2026-08-14T11:42:35.001Z","component":"RSS","requestId":"5f3c…","msg":"Feed fetch failed","err":{"type":"Error","message":"404"}}
+```
+
+| Variable | Default | Effect |
+|---|---|---|
+| `LOG_LEVEL` | `info` | `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `silent`. Anything below the level is not written at all |
+| `LOG_FORMAT` | `json` under `NODE_ENV=production`, else `pretty` | `pretty` renders `11:42:35.001 ERROR [RSS] Feed fetch failed` instead |
+
+`component` is the `[TAG]` every log line in this codebase already carried —
+`READY`, `MIGRATIONS`, `RSS`, `DASHBOARD` — promoted to a field, so a log backend
+can filter on it rather than grepping text. Under sharding, `shard` is a field
+too. Credentials are redacted before a line is written: tokens, `Authorization`
+headers, cookies and provider keys come out as `[redacted]`.
+
+Everything goes to stdout, errors included — a change from the bare
+`console.error` this replaced, and the convention every JSON log shipper
+expects. The `json-file` driver in `docker-compose.yml` captures it either way
+(50 MB × 5 files per service). To read a production stream by hand:
+
+```bash
+docker logs clawdia -f | npx pino-pretty
+docker logs clawdia --since 1h | jq -c 'select(.level=="error")'
+```
+
+**`ERROR_WEBHOOK_URL` is the other half.** An uncaught exception or a burst of
+unhandled rejections exits the process, and until you set this the only record
+is a line in a rolling file nobody is watching — which is how a bot that
+crash-loops at 04:00 gets noticed days later, by a user. Set it to a Discord
+webhook (recognised and formatted as a Discord message) or to any endpoint that
+accepts a JSON POST, and the process reports the crash before it goes. It waits
+at most `ERROR_REPORT_TIMEOUT_MS` (2000) for that and exits either way; unset,
+the exit is synchronous and nothing is sent.
+
 ## Monitoring
 
 The bot serves `GET /health` on the dashboard port. It is unauthenticated and
@@ -536,7 +602,7 @@ is not a healthcheck failure: restarting the process does not fix a feed that is
 
 ## Troubleshooting
 
-- **Slash commands not appearing**: Run `npm run deploy` and ensure the bot has `applications.commands` scope.
+- **Slash commands not appearing**: The bot publishes them itself at startup — check the log for a `[READY] Deployed N slash commands` line, and that the invite used the `applications.commands` scope. Newly registered global commands can take up to an hour to appear. `npm run deploy` re-publishes them by hand; `DEPLOY_COMMANDS=always` makes the bot re-publish on every boot rather than only when the set changes.
 - **Portainer/Docker startup fails**: Verify `MONGODB_URI` is reachable from the container network and `.env` is properly mounted.
 - **AI commands timeout**: Check API key validity or Ollama endpoint accessibility from the bot container.
 

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -649,6 +649,21 @@ docker-compose pull
 docker-compose up -d
 ```
 
+Two things happen on that first boot without being asked for, and both are worth
+knowing about before an upgrade rather than during one:
+
+- **Schema migrations run**, before the dashboard opens its port. Some are
+  irreversible. See [Schema migrations](#schema-migrations) — in particular
+  `MIGRATION_BACKUP=require`, which is the setting you want here.
+- **Slash commands re-register** if the command set changed, so a release that
+  adds or renames a command needs no separate step. Newly registered global
+  commands can take up to an hour to appear.
+
+`mongo:7` and the `node:24-alpine` base are pinned by `@sha256:` digest rather
+than by tag, so `docker-compose pull` fetches the exact images the release was
+tested against and a rebuild for a rollback cannot quietly pick up a newer base.
+Dependabot raises the bumps; there is nothing to do by hand.
+
 ### Viewing Logs
 
 **Portainer:** Stacks > clawdia > bot > Logs
@@ -658,6 +673,34 @@ docker-compose up -d
 ```bash
 docker logs clawdia -f
 ```
+
+Under `NODE_ENV=production` those lines are JSON, one object per event — a
+level, an ISO timestamp, the subsystem as `component`, and a `requestId` shared
+by every line a single dashboard request produced:
+
+```json
+{"level":"error","time":"2026-08-14T11:42:35.001Z","component":"RSS","msg":"Feed fetch failed","err":{"type":"Error","message":"404"}}
+```
+
+That is meant for a log backend, and it is legible by hand with a filter:
+
+```bash
+docker logs clawdia -f | npx pino-pretty                       # readable lines
+docker logs clawdia --since 1h | jq -c 'select(.level=="error")'
+docker logs clawdia --since 1h | jq -c 'select(.component=="MIGRATIONS")'
+```
+
+`LOG_LEVEL` (default `info`) drops anything below it before it is written —
+`LOG_LEVEL=warn` is the setting for a busy install whose 250 MB of retention is
+being spent on startup notices. `LOG_FORMAT=pretty` renders readable lines in
+the container itself, if you would rather not pipe. Tokens, `Authorization`
+headers, cookies and provider keys are replaced with `[redacted]` before a line
+is written.
+
+Nothing here reaches anyone on its own. `ERROR_WEBHOOK_URL` is what makes a
+crash arrive somewhere — set it to a Discord webhook (formatted as a Discord
+message) or any JSON endpoint, and an uncaught exception is reported before the
+process exits. README's **Logging** section has the full table.
 
 ### Health Monitoring
 
@@ -686,6 +729,87 @@ section covers the setup, and the optional `autoheal` service that restarts an
 ### MongoDB Connection
 
 The bot automatically creates the database and collections. No manual setup needed.
+
+### Schema migrations
+
+**Schema migrations run automatically on every boot.** There is no migrate step
+to invoke and no flag that skips them. `src/index.js` runs
+`src/migrations/runner.js` after the database connects and *before* the bot logs
+in or the dashboard opens its port, so a container that is accepting traffic is
+a container whose migrations have already finished. Under sharding only shard 0
+runs them.
+
+That matters more than it usually would, because of what these migrations do:
+
+- **They are forward-only in practice.** The runner never rolls back on its own.
+- **Several are irreversible.** Dropping a field or merging two documents cannot
+  be computed backwards, so those migrations declare `irreversible: true` and
+  have no `down()` at all. Six of the eighteen are: `005_grind_profiles`,
+  `006_drop_wheel_fields`, `008_pet_decay_cursor`,
+  `010_merge_duplicate_inventory_slots`, `011_clamp_negative_balances` and
+  `017_merge_slots_jackpot_pool`.
+- **A failed migration aborts startup.** Booting on a half-applied schema would
+  be worse than not booting, so the runner rethrows and the process exits — a
+  supervisor then restarts it and it tries again. The exception is a migration
+  marked `optional` (a performance index, not a schema change): that one is
+  logged, left unapplied, and retried next boot.
+
+**Before the first upgrade of a deployment that has data in it, set
+`MIGRATION_BACKUP=require`.** Immediately before any irreversible migration the
+runner takes a `mongodump` into `MIGRATION_BACKUP_DIR` (default `./backups`,
+which both stack files mount) named `pre-migration-<timestamp>.gz` — and with
+`MIGRATION_BACKUP` unset, a `mongodump` that is missing from `PATH` or fails is
+a loud warning and the destructive step runs anyway. `require` turns that into
+an aborted startup instead. `skip` does not attempt one.
+
+Restore it with `scripts/restore.sh`, the same as any nightly archive. These
+dumps are pruned on the same `BACKUP_RETENTION_DAYS` schedule as the rest.
+
+What it looks like in the log:
+
+```
+[MIGRATIONS] Already applied: 001_add_indexes
+[MIGRATIONS] Taking pre-migration backup → /app/backups/pre-migration-20260814T114235Z.gz
+[MIGRATIONS] Pre-migration backup complete.
+[MIGRATIONS] Applying: 018_encrypt_guild_ai_keys (budget 30000ms)
+[MIGRATIONS] Applied 018_encrypt_guild_ai_keys in 412ms
+[MIGRATIONS] Applied 1 migration(s).
+```
+
+Each migration records its name in the `migrationrecords` collection when it
+succeeds, and that record is the only thing that stops it running again:
+
+```bash
+docker exec -it clawdia-mongodb mongosh ultrabot --eval \
+  'db.migrationrecords.find({}, {name: 1, appliedAt: 1, durationMs: 1}).sort({name: 1})'
+```
+
+**If startup hangs or loops on a migration**, the budget is the usual cause. Each
+one gets 30 seconds of wall-clock by default, and `005_grind_profiles` rewrites
+every user document — on a large install that is a boot loop, since every
+restart hits the same wall. Raise it without shipping a code change:
+
+```bash
+MIGRATION_TIMEOUT_MS=300000
+```
+
+The log line names which migration ran out. A migration may also ask for more
+than the default on its own, in which case the larger of the two applies.
+
+**Rolling one back** is a deliberate, manual act, and only possible for a
+migration that has a `down()`:
+
+```bash
+npm run migrate:rollback -- 013_split_guild_analytics
+```
+
+It runs `down()` and deletes the `MigrationRecord`, which means the next boot
+re-applies it — so pair a rollback with deploying the code you are rolling back
+to. Only the most recently applied migration can be rolled back. For an
+irreversible one there is no rollback: restore the pre-migration dump and
+redeploy the old image, in that order. [docs/RELEASING.md](docs/RELEASING.md)
+covers the version-rollback case; [docs/EXTENDING.md](docs/EXTENDING.md#schema-migrations)
+covers writing a new migration.
 
 ### Enabling MongoDB authentication
 

--- a/coverage-floors.json
+++ b/coverage-floors.json
@@ -175,10 +175,10 @@
             "lines": 15
         },
         "src/utils": {
-            "statements": 60,
-            "branches": 61,
-            "functions": 65,
-            "lines": 61
+            "statements": 62,
+            "branches": 64,
+            "functions": 67,
+            "lines": 63
         },
         "src/views": {
             "statements": 62,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 services:
   mongodb:
-    image: mongo:7
+    # Digest-pinned so the same stack file always deploys the same mongod (#644);
+    # `mongo:7` alone is re-published on every 7.x patch. Bumped by Dependabot,
+    # held by tests/imagePinning.test.js. The tag stays for readability — Docker
+    # resolves the digest.
+    image: mongo:7@sha256:b6421fd6d1c5ded6377b397d8983e2f82e2100dc5123332dcfda2065a472be5b
     container_name: clawdia-mongodb
     restart: unless-stopped
     # Authentication (#648). The internal-only network keeps the outside world
@@ -183,7 +187,7 @@ services:
   # README's Monitoring section: it sees the same state over HTTP and pages a
   # human instead of restarting on its own.
   autoheal:
-    image: willfarrell/autoheal:1.2.0
+    image: willfarrell/autoheal:1.2.0@sha256:31f580ef0279eaced5b38d631b08c474d70d8403c1c2fdd6ddcf2e879d5f3f7c
     container_name: clawdia-autoheal
     profiles:
       - autoheal
@@ -210,7 +214,7 @@ services:
   # a history. Set BACKUP_RETENTION_DAYS to tune retention; to opt out entirely,
   # `docker compose up -d --scale backup=0`.
   backup:
-    image: mongo:7
+    image: mongo:7@sha256:b6421fd6d1c5ded6377b397d8983e2f82e2100dc5123332dcfda2065a472be5b
     container_name: clawdia-backup
     restart: unless-stopped
     env_file:

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -832,14 +832,156 @@ explained.
 
 ### Logging
 
-```javascript
-// Simple console logging
-console.log('[INFO]', 'Something happened');
-console.error('[ERROR]', 'Error occurred:', error);
+Everything the process writes goes through pino (`src/utils/logger.js`). The
+entry points install a bridge over `console.*`, so the ~660 call sites already
+in the tree get a level, an ISO timestamp and JSON output without being
+rewritten — which means the way to log in this codebase is still `console.*`,
+and it is not a stopgap:
 
-// With timestamps
-const timestamp = new Date().toISOString();
-console.log(`[${timestamp}] Event occurred`);
+```javascript
+// The [TAG] prefix is the convention, and it is load-bearing: the bridge lifts
+// it out and emits it as `component`, which is what a log backend filters on.
+console.log('[QUESTS] Rebuilt %d dailies', count);
+console.warn('[QUESTS] Skipping guild %s: no settings document', guildId);
+
+// Pass the Error itself rather than error.message. The bridge routes the first
+// Error argument into `err`, so the stack is a queryable field instead of text
+// flattened into the message.
+console.error('[QUESTS] Rebuild failed:', error);
+```
+
+Reach for the logger directly when you have structured fields worth keeping:
+
+```javascript
+const { logger } = require('../utils/logger');
+
+logger.info({ component: 'QUESTS', guildId, durationMs }, 'Rebuilt dailies');
+logger.debug({ component: 'QUESTS', questId }, 'Skipped, already complete');
+```
+
+`logger.debug` and `logger.trace` are free when `LOG_LEVEL` is above them — the
+call returns before it formats anything — so they are worth leaving in.
+
+**Correlation.** Dashboard requests run inside a context carrying a `requestId`,
+and every line written anywhere below them picks it up automatically. Open one
+around any other unit of work worth following end to end:
+
+```javascript
+const { withContext, addContext } = require('../utils/logger');
+
+await withContext({ jobId, component: 'RSS' }, async () => {
+    // every log line in here, however deep, carries jobId
+    await pollAllFeeds();
+});
+
+addContext({ guildId });   // extends the context already in force
+```
+
+**Do not log a credential.** `REDACT_PATHS` in `src/utils/logger.js` censors
+`token`, `authorization`, cookies and `apiKey` wherever they appear in a record,
+but that is a backstop, not permission — an interpolated string
+(`` `key=${apiKey}` ``) is text by the time it arrives and nothing can catch it.
+
+Two things are deliberately *not* wired into the logger. `console.*` is left
+alone in `scripts/` and in `src/deploy-commands.js`, which are terminal tools
+whose output is the point; and the bridge is installed by `src/index.js` and
+`src/shard.js` only, so a test that asserts on `console.error` still sees the
+real console. Tests that want the structured record should use
+`createLogger({ format: 'json', out })` — see `tests/structuredLogging.test.js`.
+
+## Schema Migrations
+
+`src/migrations/` holds the numbered files that reshape the database, and
+`src/migrations/runner.js` applies them. Two facts drive everything about
+writing one:
+
+- **They run at boot, automatically**, after the database connects and before
+  the bot logs in — see [Schema migrations](../SETUP_GUIDE.md#schema-migrations)
+  for the operator's side of that.
+- **A failure aborts startup.** Booting on a half-applied schema is worse than
+  not booting, so a migration that throws takes the process down with it.
+
+### Writing a migration
+
+Add a file named `NNN_short_description.js` — the number is the apply order, and
+it is the next one after the highest already there. It exports a `name` (which
+becomes the `MigrationRecord`, so it must never change once shipped), an `up()`,
+and a rollback story:
+
+```javascript
+// src/migrations/019_add_streak_field.js
+const User = require('../models/User');
+
+module.exports = {
+    name: '019_add_streak_field',
+
+    // `timeoutMs` receives the budget actually in force (the default 30s, or
+    // MIGRATION_TIMEOUT_MS if the operator raised it). Pass it to any query
+    // that could run long: the runner stops *waiting* at the budget, it cannot
+    // cancel work already sent to the server.
+    async up({ timeoutMs }) {
+        const result = await User.collection.updateMany(
+            { dailyStreak: { $exists: false } },
+            { $set: { dailyStreak: 0 } },
+            { maxTimeMS: timeoutMs }
+        );
+        console.log(`[MIGRATIONS] 019: set dailyStreak on ${result.modifiedCount} users`);
+    },
+
+    async down() {
+        await User.collection.updateMany({}, { $unset: { dailyStreak: '' } });
+    },
+};
+```
+
+Every migration must declare one of two rollback stories, and
+`tests/migrationRollback.test.js` fails the build if one does not:
+
+| Export | Use it when |
+|---|---|
+| `async down()` | The change can be computed backwards — an added field, a created index |
+| `irreversible: true` | It cannot: a dropped field, merged documents, a clamped value. Declaring it is what makes the runner take a `mongodump` first, which is then the only way back |
+
+Two optional exports:
+
+- `timeoutMs` — this migration is heavier than the 30s default. The larger of
+  this and `MIGRATION_TIMEOUT_MS` applies, so an operator raising the env var is
+  never overruled by a file.
+- `optional: true` — its failure should not stop the bot booting. Only for work
+  the bot is merely *faster* with, such as building an index: it is left
+  unrecorded and retried on the next boot, so re-running it later, out of order,
+  has to be harmless.
+
+### Rules that are not obvious
+
+- **Never edit a shipped migration.** Its `MigrationRecord` already exists on
+  every deployment that has run it, so an edit runs nowhere and the two halves
+  of the fleet diverge silently. Write the next number instead.
+- **Use `Model.collection`, not the Mongoose model, for bulk rewrites.** Schema
+  defaults, setters and validators are written against *today's* schema and will
+  quietly rewrite fields the migration is not about.
+- **Make it idempotent where you can.** A migration killed after the write but
+  before its record is written runs again on the next boot.
+- **Do not read from `src/services` or anything above `models`.** Migrations sit
+  in the lowest layer (see [Which way dependencies run](#which-way-dependencies-run)),
+  and the code above them is on its way to changing.
+
+### Testing a migration
+
+`tests/migrationRunner.test.js` and `tests/migrationRollback.test.js` cover the
+runner and the declarations; `tests/integration/migrations.test.js` applies the
+real files against a real mongod, which is where a migration's own behaviour
+belongs:
+
+```bash
+npx jest tests/migrationRollback.test.js
+npx jest tests/integration/migrations.test.js   # needs a downloadable mongod
+```
+
+Rolling back locally, to check that `down()` does what it says:
+
+```bash
+npm run migrate:rollback -- 019_add_streak_field
 ```
 
 ## Best Practices
@@ -939,9 +1081,24 @@ docker build -t clawdia:latest .
 
 ```bash
 npm install
-npm run deploy  # Deploy commands to Discord
-npm start       # Start the bot
+npm start       # Start the bot — it registers its own slash commands
 ```
+
+`npm start` publishes the command set to Discord on connect, and only when it
+differs from the set last published (the fingerprint lives in the
+`commanddeployments` collection). That is what makes the Docker deploy work at
+all: the image is `CMD ["node", "src/index.js"]` and nothing in either stack
+file runs a registration step.
+
+```bash
+npm run deploy               # publish now, without starting the bot
+DEPLOY_COMMANDS=always npm start   # re-publish on every boot
+DEPLOY_COMMANDS=never npm start    # never publish; you drive it by hand
+```
+
+While iterating on a command's *shape* — its name, description or options — the
+gate notices the change and re-publishes on the next restart. Only the handler
+body changes nothing Discord holds, so nothing is sent.
 
 ### Environment Variables
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "openai": "^7.5.0",
         "passport": "^0.7.0",
         "passport-oauth2": "^1.8.0",
+        "pino": "^9.14.0",
         "rss-parser": "^3.13.0"
       },
       "devDependencies": {
@@ -1701,6 +1702,12 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2594,6 +2601,15 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/axios": {
       "version": "1.19.0",
@@ -5479,7 +5495,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7329,6 +7345,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -7697,6 +7722,43 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/pirates": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -7802,6 +7864,22 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+      "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/protobufjs": {
       "version": "7.6.5",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
@@ -7905,6 +7983,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
     },
     "node_modules/random-bytes": {
       "version": "1.0.0",
@@ -8010,6 +8094,15 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8104,6 +8197,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -8403,6 +8505,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8431,6 +8542,15 @@
       "license": "MIT",
       "dependencies": {
         "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -8864,6 +8984,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/tldts": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "openai": "^7.5.0",
     "passport": "^0.7.0",
     "passport-oauth2": "^1.8.0",
+    "pino": "^9.14.0",
     "rss-parser": "^3.13.0"
   },
   "devDependencies": {

--- a/portainer-stack.yml
+++ b/portainer-stack.yml
@@ -38,7 +38,11 @@
 
 services:
   mongodb:
-    image: mongo:7
+    # Digest-pinned so the same stack file always deploys the same mongod (#644);
+    # `mongo:7` alone is re-published on every 7.x patch. Bumped by Dependabot,
+    # held by tests/imagePinning.test.js. The tag stays for readability — Docker
+    # resolves the digest.
+    image: mongo:7@sha256:b6421fd6d1c5ded6377b397d8983e2f82e2100dc5123332dcfda2065a472be5b
     container_name: clawdia-mongodb
     restart: unless-stopped
     # Authentication (#648). The internal-only network keeps the outside world
@@ -275,7 +279,7 @@ services:
   #     sh -c 'cp /b/clawdia-<timestamp>.gz /out/'
   # To restore one, see scripts/restore.sh and scripts/verify-backup.sh.
   backup:
-    image: mongo:7
+    image: mongo:7@sha256:b6421fd6d1c5ded6377b397d8983e2f82e2100dc5123332dcfda2065a472be5b
     container_name: clawdia-backup
     restart: unless-stopped
     environment:
@@ -358,7 +362,7 @@ services:
   # README's Monitoring section: it sees the same state over HTTP and pages a
   # human instead of restarting on its own.
   # autoheal:
-  #   image: willfarrell/autoheal:1.2.0
+  #   image: willfarrell/autoheal:1.2.0@sha256:31f580ef0279eaced5b38d631b08c474d70d8403c1c2fdd6ddcf2e879d5f3f7c
   #   container_name: clawdia-autoheal
   #   restart: unless-stopped
   #   environment:

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -7,6 +7,7 @@ const passport = require('passport');
 const { Strategy: DiscordStrategy, DiscordScope } = require('./lib/discordStrategy');
 const path = require('path');
 const { getStatus, httpStatusFor } = require('../health');
+const { withContext: withLogContext, addContext: addLogContext } = require('../utils/logger');
 const { hasManagePermission } = require('./lib/permissions');
 const { jsonForScript } = require('./lib/jsonForScript');
 const { asset } = require('./lib/assets');
@@ -172,6 +173,24 @@ function createApp({ client = null, bot: injectedBot, sessionStore, configurePas
     // and the routers so it covers assets and rendered views alike.
     app.use(compression());
 
+    // A correlation id per request, carried on every log line the request
+    // produces however deep in a service it is written (#647). Without it, two
+    // concurrent dashboard saves interleave in the log and neither can be read
+    // back. The id is echoed as X-Request-Id so a report from a user can be
+    // matched to its lines, and an inbound X-Request-Id from a reverse proxy is
+    // adopted rather than replaced, so the two logs join up.
+    //
+    // Registered before the routers, and before the static handler is asked for
+    // anything expensive, so it covers everything below.
+    app.use((req, res, next) => {
+        const inbound = String(req.headers['x-request-id'] || '').trim();
+        // Bounded and character-restricted: this value ends up in a response
+        // header and in every log line, and it arrives from the network.
+        const requestId = /^[\w.-]{1,64}$/.test(inbound) ? inbound : crypto.randomUUID();
+        res.setHeader('X-Request-Id', requestId);
+        withLogContext({ requestId }, () => next());
+    });
+
     // Assets are requested through the asset() helper, which stamps each URL
     // with a hash of the file's contents — a deploy changes the URL, so a long
     // immutable cache never serves stale JavaScript or CSS.
@@ -274,6 +293,11 @@ function createApp({ client = null, bot: injectedBot, sessionStore, configurePas
     const bot = injectedBot ?? createBotGateway(client);
     app.use((req, res, next) => {
         req.bot = bot;
+        // Runs after passport has restored the session, so the correlation id
+        // set above can now name who it belongs to. Added to the context that
+        // is already in force rather than opening a new one, so the request id
+        // survives. Only the Discord user id — never a token or a display name.
+        if (req.user?.id) addLogContext({ userId: req.user.id });
         next();
     });
 

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -1,4 +1,4 @@
-const { deployCommands } = require('../utils/commandDeployer');
+const { deployCommandsIfChanged } = require('../utils/commandDeployer');
 const { startScheduler } = require('../services/scheduler');
 const User = require('../models/User');
 const { logTransaction } = require('../utils/logTransaction');
@@ -11,12 +11,33 @@ module.exports = {
         console.log(`[READY] Serving ${client.guilds.cache.size} guilds`);
 
         try {
-            // Deploy the commands startup already loaded rather than walking and
-            // requiring src/commands a second time (#607). It is also what keeps
-            // the registered set and the running set the same set.
-            const count = await deployCommands(client.user.id, process.env.DISCORD_TOKEN, client.commands.values());
-            console.log(`[READY] Deployed ${count} slash commands`);
+            // Registering here, rather than in a separate step, is what makes
+            // the documented Docker quick-start produce a bot with commands:
+            // the image runs `node src/index.js` and neither stack file runs
+            // `npm run deploy`, so anything outside this process never runs
+            // (#643).
+            //
+            // Deploys the commands startup already loaded rather than walking
+            // and requiring src/commands a second time (#607) — which is also
+            // what keeps the registered set and the running set the same set —
+            // and only when that set differs from the one last published, so
+            // the ordinary restart costs one indexed read instead of a full PUT
+            // of ~98 commands, and N shards do not each publish the same set.
+            const { deployed, count, reason } = await deployCommandsIfChanged(
+                client.user.id,
+                process.env.DISCORD_TOKEN,
+                client.commands.values()
+            );
+            if (deployed) {
+                console.log(`[READY] Deployed ${count} slash commands (${reason})`);
+            } else {
+                console.log(`[READY] Slash command deploy skipped: ${reason} (${count} registered)`);
+            }
         } catch (error) {
+            // Logged, not fatal. The bot is already connected and every command
+            // Discord has registered from a previous boot still works; refusing
+            // to finish startup over a failed re-registration would take a
+            // working bot down to fix a stale command description.
             console.error('[READY] Failed to deploy slash commands:', error);
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,16 @@ require('./config/fileSecrets').loadFileSecrets();
 // call if any of them fail.
 require('./config/validateEnv').assertEnv({ label: 'STARTUP' });
 
+// Route every `console.*` in the process through the pino logger, so the ~660
+// existing call sites get levels, timestamps, a `component` taken from their
+// `[TAG]` prefix, and JSON output under NODE_ENV=production (#647). Installed
+// here rather than inside utils/logger.js so that requiring the logger — which
+// tests and `npm run deploy` do — never silently replaces the console. This is
+// the first thing after the environment is known and before anything below
+// logs, so no line escapes it. See LOG_LEVEL / LOG_FORMAT in the README.
+require('./utils/logger').installConsoleBridge();
+const { reportAndExit, reportError, isConfigured: errorSinkConfigured } = require('./utils/errorReporter');
+
 const health = require('./health');
 const { makeCache, sweepers } = require('./utils/cacheOptions');
 const { isPrimaryShard, shardTag } = require('./utils/sharding');
@@ -204,6 +214,10 @@ const REJECTION_WINDOW_MS = 60_000;
 const REJECTION_LIMIT = 10;
 const recentRejections = [];
 
+// Reported to ERROR_WEBHOOK_URL as well as logged, when one is set. A line in
+// a 250 MB rolling text stream that nothing watches is how a 04:00 crash-loop
+// stayed invisible for days (#647). With no sink configured every path below
+// behaves exactly as it did before, exit timing included.
 process.on('unhandledRejection', (error) => {
     health.incrementUnhandledRejections();
     console.error('[PROCESS] Unhandled promise rejection:', error);
@@ -216,15 +230,25 @@ process.on('unhandledRejection', (error) => {
     }
     if (recentRejections.length >= REJECTION_LIMIT) {
         console.error(`[PROCESS] ${REJECTION_LIMIT} unhandled rejections in ${REJECTION_WINDOW_MS / 1000}s — forcing exit.`);
-        process.exit(1);
+        reportAndExit('unhandledRejection', error, {
+            extra: { rejectionsInWindow: recentRejections.length, windowMs: REJECTION_WINDOW_MS },
+        });
+        return;
+    }
+    // Below the limit the process keeps running, so there is nothing to wait
+    // for — fire the report and let it finish on its own.
+    if (errorSinkConfigured()) {
+        reportError('unhandledRejection', error).catch(() => {});
     }
 });
 
 process.on('uncaughtException', (error) => {
     health.incrementUncaughtExceptions();
     console.error('[PROCESS] Uncaught exception:', error);
-    // uncaughtException leaves the process in an undefined state; always exit
-    process.exit(1);
+    // uncaughtException leaves the process in an undefined state; always exit.
+    // reportAndExit exits synchronously when no sink is configured, and is
+    // bounded by ERROR_REPORT_TIMEOUT_MS when one is.
+    reportAndExit('uncaughtException', error);
 });
 
 process.on('SIGTERM', () => shutdown('SIGTERM'));

--- a/src/models/CommandDeployment.js
+++ b/src/models/CommandDeployment.js
@@ -1,0 +1,38 @@
+const { Schema, model } = require('mongoose');
+
+/**
+ * What the global slash-command set looked like the last time it was published
+ * (#643).
+ *
+ * The bot deploys its commands on every `clientReady`, which is what makes the
+ * documented Docker quick-start produce a bot that actually has commands — no
+ * `npm run deploy` step the container never runs. Doing that unconditionally
+ * meant a full `PUT` of ~98 commands to Discord on every restart, and under
+ * sharding one per shard, all publishing the same set. This is the record that
+ * makes the deploy conditional: one document, holding a hash of the payload
+ * that was last accepted.
+ *
+ * `pending` is the crash marker. It is set when a deploy claims the hash and
+ * cleared when Discord accepts the payload, so a process that dies mid-`PUT`
+ * leaves a claim the next boot can see and retry rather than a hash that says
+ * "already done".
+ */
+const CommandDeploymentSchema = new Schema({
+    // Fixed key — there is exactly one global command set per application.
+    // Declared as a String so it is the name the gate supplies rather than a
+    // generated ObjectId; with one of those, every boot would insert a new
+    // document and never match the previous one, and the claim could not be an
+    // upsert.
+    _id: { type: String, required: true },
+    // sha256 of the serialized payload plus the application id. Null while a
+    // deploy is being retried, so the next boot's `$ne` always matches.
+    hash: { type: String, default: null },
+    // Set on claim, cleared on success. A document left pending is a deploy
+    // that never finished.
+    pending: { type: Boolean, default: false },
+    clientId: { type: String, default: null },
+    commandCount: { type: Number, default: null },
+    deployedAt: { type: Date, default: null },
+}, { versionKey: false });
+
+module.exports = model('CommandDeployment', CommandDeploymentSchema);

--- a/src/shard.js
+++ b/src/shard.js
@@ -38,6 +38,10 @@ const { ShardingManager } = require('discord.js');
 // this process too.
 require('./config/validateEnv').assertEnv({ label: 'SHARD' });
 
+// Same bridge the children install (#647), so the manager's own lines are
+// structured too rather than being the one unparsed thing in the stream.
+require('./utils/logger').installConsoleBridge();
+
 function resolveShardCount() {
     const pinned = Number(process.env.SHARD_COUNT);
     if (Number.isInteger(pinned) && pinned > 0) return pinned;

--- a/src/utils/commandDeployer.js
+++ b/src/utils/commandDeployer.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const { REST, Routes } = require('discord.js');
 const { listCommandFiles, loadCommandModules } = require('./commandLoader');
 
@@ -16,18 +17,18 @@ const GLOBAL_COMMAND_LIMIT = 100;
 const COMMAND_BUDGET = 97;
 
 /**
- * Publish the global command set.
+ * Serialize the command set that is about to be published, and refuse to
+ * produce a partial one.
  *
- * @param {string} clientId
- * @param {string} token
  * @param {Iterable<object>} [loadedCommands] commands already required at
  *   startup (`client.commands`). Startup has just required all 98 of them; a
  *   second walk-and-require here bought nothing but ~800 ms and a chance for
  *   the deployed set to disagree with the running one. Omit it — as the
- *   standalone `npm run deploy` does, where no client exists — and the deploy
- *   loads them itself.
+ *   standalone `npm run deploy` does, where no client exists — and the payload
+ *   is loaded from disk here.
+ * @returns {object[]} the JSON bodies, in the order they were handed over.
  */
-async function deployCommands(clientId, token, loadedCommands = null) {
+function buildCommandPayload(loadedCommands = null) {
     const commands = [];
     const failures = [];
 
@@ -66,6 +67,11 @@ async function deployCommands(clientId, token, loadedCommands = null) {
         throw new Error(`${failures.length} command file(s) failed to load; aborting so the registered set is not silently truncated.`);
     }
 
+    return commands;
+}
+
+/** The one call that actually changes what Discord has registered. */
+async function putCommands(clientId, token, commands) {
     const rest = new REST().setToken(token);
     try {
         await rest.put(Routes.applicationCommands(clientId), { body: commands });
@@ -78,4 +84,169 @@ async function deployCommands(clientId, token, loadedCommands = null) {
     return commands.length;
 }
 
-module.exports = { deployCommands, listCommandFiles, GLOBAL_COMMAND_LIMIT, COMMAND_BUDGET };
+/**
+ * Publish the global command set, unconditionally.
+ *
+ * This is the `npm run deploy` path: an operator asking for a deploy gets one,
+ * with no database involved and nothing to reason about. The boot path wants
+ * the opposite — see deployCommandsIfChanged below.
+ *
+ * @param {string} clientId
+ * @param {string} token
+ * @param {Iterable<object>} [loadedCommands] see buildCommandPayload.
+ */
+async function deployCommands(clientId, token, loadedCommands = null) {
+    return putCommands(clientId, token, buildCommandPayload(loadedCommands));
+}
+
+// The single document in the CommandDeployment collection. There is one global
+// command set per application, so the key is fixed.
+const DEPLOYMENT_KEY = 'global';
+
+/**
+ * Fingerprint of a command payload, as published.
+ *
+ * Sorted by name so that the order `client.commands` happens to iterate in
+ * cannot change the hash — only the commands themselves can. The application id
+ * is folded in because the same payload published under a different CLIENT_ID
+ * is a different registration.
+ */
+function commandSetHash(clientId, commands) {
+    const sorted = [...commands].sort((a, b) => String(a.name).localeCompare(String(b.name)));
+    return crypto.createHash('sha256')
+        .update(JSON.stringify({ clientId, commands: sorted }))
+        .digest('hex');
+}
+
+/**
+ * How DEPLOY_COMMANDS is read. Anything unrecognised falls back to 'auto' with
+ * a warning rather than silently disabling the deploy — an operator who
+ * mistypes it should get commands, not a bot with none.
+ */
+function deployMode() {
+    const raw = String(process.env.DEPLOY_COMMANDS ?? '').trim().toLowerCase();
+    if (raw === '') return 'auto';
+    if (raw === 'auto' || raw === 'always' || raw === 'never') return raw;
+    console.warn(
+        `[DEPLOY] Ignoring DEPLOY_COMMANDS="${process.env.DEPLOY_COMMANDS}": expected auto, always or never. Using auto.`
+    );
+    return 'auto';
+}
+
+/**
+ * Publish the global command set, but only when it differs from the set that
+ * was last published (#643).
+ *
+ * The deploy at `clientReady` is what makes the Docker quick-start work — the
+ * image's CMD is `node src/index.js` and nothing in either stack file runs
+ * `npm run deploy`, so a deploy step outside the process is a step that never
+ * happens. Running it on every boot, though, means a full PUT of every command
+ * to Discord each restart, and under sharding one PUT per shard publishing the
+ * identical set. The hash below is what turns "on every boot" into "when it
+ * actually changed": the common restart does one indexed read and no API call.
+ *
+ * The claim is a single conditional update, so it also settles which shard
+ * deploys: whichever one wins the write does the PUT and the rest see their own
+ * hash already recorded and skip.
+ *
+ * @returns {Promise<{deployed: boolean, count: number, reason: string}>}
+ *   `reason` is why it did or did not deploy, suitable for a log line.
+ */
+async function deployCommandsIfChanged(clientId, token, loadedCommands = null) {
+    const mode = deployMode();
+    if (mode === 'never') {
+        return { deployed: false, count: 0, reason: 'DEPLOY_COMMANDS=never' };
+    }
+
+    const commands = buildCommandPayload(loadedCommands);
+
+    if (mode === 'always') {
+        const count = await putCommands(clientId, token, commands);
+        // Recorded even here, so switching back to `auto` does not re-deploy an
+        // unchanged set once. Non-fatal for the same reason as below.
+        try {
+            await recordDeployment(clientId, commandSetHash(clientId, commands), count);
+        } catch (error) {
+            console.error('[DEPLOY] Published, but could not record the deployment:', error.message);
+        }
+        return { deployed: true, count, reason: 'DEPLOY_COMMANDS=always' };
+    }
+
+    const hash = commandSetHash(clientId, commands);
+    // Required lazily: `npm run deploy` (src/deploy-commands.js) runs this
+    // module with no database connection and must not pull mongoose in.
+    const CommandDeployment = require('../models/CommandDeployment');
+
+    let claimed;
+    try {
+        // Deploy when the recorded hash differs *or* when a previous attempt
+        // claimed this hash and never finished. Without the second clause a
+        // process killed mid-PUT would leave its hash recorded and every later
+        // boot would skip the deploy it never actually made.
+        await CommandDeployment.findOneAndUpdate(
+            { _id: DEPLOYMENT_KEY, $or: [{ hash: { $ne: hash } }, { pending: true }] },
+            { $set: { hash, pending: true, clientId } },
+            { upsert: true, new: true }
+        );
+        claimed = true;
+    } catch (error) {
+        // The document exists and did not match the filter, so the upsert tried
+        // to insert a second one against the fixed _id. That is precisely the
+        // "already deployed, nothing to do" case.
+        if (error?.code === 11000) claimed = false;
+        else throw error;
+    }
+
+    if (!claimed) {
+        return { deployed: false, count: commands.length, reason: 'command set unchanged' };
+    }
+
+    let count;
+    try {
+        count = await putCommands(clientId, token, commands);
+    } catch (error) {
+        // Release the claim so the next boot retries instead of inheriting a
+        // hash that was never accepted. Best-effort: `pending` already marks the
+        // document as unfinished, so a failure here is not worth masking the
+        // deploy error with.
+        try {
+            await CommandDeployment.updateOne(
+                { _id: DEPLOYMENT_KEY },
+                { $set: { hash: null, pending: true } }
+            );
+        } catch (releaseError) {
+            console.error('[DEPLOY] Could not release the deployment claim:', releaseError.message);
+        }
+        throw error;
+    }
+
+    // Discord has the new set. A failure to write the bookkeeping after that
+    // must not be reported as a failed deploy: the document still says
+    // `pending`, so the next boot re-publishes — which is wasteful, not wrong.
+    try {
+        await recordDeployment(clientId, hash, count);
+    } catch (error) {
+        console.error('[DEPLOY] Published, but could not record the deployment:', error.message);
+    }
+    return { deployed: true, count, reason: 'command set changed' };
+}
+
+async function recordDeployment(clientId, hash, count) {
+    const CommandDeployment = require('../models/CommandDeployment');
+    await CommandDeployment.updateOne(
+        { _id: DEPLOYMENT_KEY },
+        { $set: { hash, pending: false, clientId, commandCount: count, deployedAt: new Date() } },
+        { upsert: true }
+    );
+}
+
+module.exports = {
+    deployCommands,
+    buildCommandPayload,
+    deployCommandsIfChanged,
+    commandSetHash,
+    listCommandFiles,
+    GLOBAL_COMMAND_LIMIT,
+    COMMAND_BUDGET,
+    DEPLOYMENT_KEY,
+};

--- a/src/utils/errorReporter.js
+++ b/src/utils/errorReporter.js
@@ -1,0 +1,126 @@
+'use strict';
+
+/**
+ * Somewhere for a fatal error to go other than the log (#647).
+ *
+ * `unhandledRejection` and `uncaughtException` in src/index.js wrote a line and
+ * exited. That line lands in a 250 MB rolling text stream with nothing watching
+ * it, so the practical failure mode was a bot that restarted at 04:00 and an
+ * operator who found out days later, from a user.
+ *
+ * ERROR_WEBHOOK_URL is the opt-out-by-default sink: unset — the shipped
+ * default — nothing changes at all, including the timing of the exit. Set, the
+ * process posts the error once, waits at most ERROR_REPORT_TIMEOUT_MS for it,
+ * and exits regardless.
+ *
+ * A Discord webhook URL is recognised and sent Discord's payload shape, because
+ * that is the sink the operator of a Discord bot already has. Anything else
+ * gets a flat JSON body, which is what Sentry's or Better Stack's ingest
+ * endpoints (and any 20-line receiver) want.
+ */
+
+const DEFAULT_TIMEOUT_MS = 2000;
+const DISCORD_WEBHOOK = /^https:\/\/(?:\w+\.)?discord(?:app)?\.com\/api\/(?:v\d+\/)?webhooks\//;
+// Discord rejects a message over 2000 characters outright, so the stack has to
+// be cut somewhere; short enough to leave room for the frame around it.
+const DISCORD_LIMIT = 1800;
+
+function timeoutMs() {
+    const raw = Number(process.env.ERROR_REPORT_TIMEOUT_MS);
+    return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_TIMEOUT_MS;
+}
+
+/** Whether anything is configured. Callers use this to decide to wait at all. */
+function isConfigured() {
+    return Boolean(String(process.env.ERROR_WEBHOOK_URL || '').trim());
+}
+
+function describe(error) {
+    if (error instanceof Error) {
+        return { name: error.name, message: error.message, stack: error.stack || null };
+    }
+    // An unhandled rejection can carry anything at all, including a string or
+    // undefined; `String(undefined)` is more use than an empty object.
+    return { name: typeof error, message: String(error), stack: null };
+}
+
+function buildBody(url, event) {
+    if (!DISCORD_WEBHOOK.test(url)) return event;
+    const stack = event.error.stack || event.error.message;
+    return {
+        content:
+            `**${event.kind}** on \`${event.service}\`${event.shard === undefined ? '' : ` (shard ${event.shard})`}\n` +
+            '```\n' + String(stack).slice(0, DISCORD_LIMIT) + '\n```',
+    };
+}
+
+/**
+ * Report one fatal error. Never rejects and never throws: this runs on the path
+ * to `process.exit`, where a failure to report must not replace the error being
+ * reported.
+ *
+ * @returns {Promise<boolean>} whether the sink accepted it.
+ */
+async function reportError(kind, error, extra = {}) {
+    const url = String(process.env.ERROR_WEBHOOK_URL || '').trim();
+    if (!url) return false;
+
+    const event = {
+        kind,
+        service: process.env.SERVICE_NAME || 'clawdia',
+        environment: process.env.NODE_ENV || 'development',
+        timestamp: new Date().toISOString(),
+        pid: process.pid,
+        error: describe(error),
+        ...extra,
+    };
+
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(buildBody(url, event)),
+            // Bounds the wait rather than the delivery: the exit below happens
+            // either way, and a sink that is itself down is the likeliest thing
+            // to be down at the same moment as the bot.
+            signal: AbortSignal.timeout(timeoutMs()),
+        });
+        return response.ok;
+    } catch {
+        // Deliberately silent about the URL — it is a credential.
+        return false;
+    }
+}
+
+/**
+ * Report, then exit, without the reporting being able to hold the process open.
+ *
+ * `uncaughtException` leaves the process in an undefined state, so the exit is
+ * the important half and the report is best-effort around it. With no sink
+ * configured the exit is synchronous, exactly as it was before this existed.
+ */
+function reportAndExit(kind, error, { code = 1, exit = c => process.exit(c), extra = {} } = {}) {
+    if (!isConfigured()) {
+        exit(code);
+        return Promise.resolve(false);
+    }
+
+    let done = false;
+    const finish = () => {
+        if (done) return;
+        done = true;
+        exit(code);
+    };
+
+    // The belt to the AbortSignal's braces: an exit that depends on a network
+    // call completing is an exit that can fail to happen.
+    const guard = setTimeout(finish, timeoutMs() + 250);
+    if (typeof guard.unref === 'function') guard.unref();
+
+    return reportError(kind, error, extra).then(
+        delivered => { clearTimeout(guard); finish(); return delivered; },
+        () => { clearTimeout(guard); finish(); return false; }
+    );
+}
+
+module.exports = { reportError, reportAndExit, isConfigured, describe, buildBody };

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,262 @@
+'use strict';
+
+/**
+ * Structured logging (#647).
+ *
+ * The bot reported for itself through 660-odd raw `console.*` calls: one flat
+ * text stream, no levels, nothing to filter on, and 250 MB of retention per
+ * service holding lines no tool can query. `LOG_LEVEL=warn` had nowhere to be
+ * read, and an error that mattered looked exactly like a startup notice.
+ *
+ * This is a pino logger and, crucially, a bridge that routes the existing
+ * `console.*` calls through it. Rewriting 660 call sites would have been 660
+ * chances to change a message while nothing tested it; routing them instead
+ * means every one of them gains a level, a timestamp, a component and JSON
+ * output on the day the bridge is installed, and new code can use the logger
+ * directly. `[TAG] message` — the convention every one of those lines already
+ * follows — becomes the `component` field, so the tags that were only ever
+ * greppable text become something a log backend can facet on.
+ *
+ * The bridge is installed explicitly by the entry points (src/index.js,
+ * src/shard.js) and by nothing else: a test that asserts on `console.error`,
+ * and `npm run deploy`, both want the real console.
+ */
+
+const { AsyncLocalStorage } = require('async_hooks');
+const { formatWithOptions } = require('util');
+const pino = require('pino');
+
+const LEVELS = ['trace', 'debug', 'info', 'warn', 'error', 'fatal', 'silent'];
+const DEFAULT_LEVEL = 'info';
+
+// Fields that must never reach a log backend, wherever in the object they turn
+// up. The bot handles a gateway token, an OAuth client secret, a session secret
+// and up to five provider keys; one `logger.error({ err }, ...)` on a failed
+// axios call is otherwise enough to print an Authorization header into a stream
+// with 250 MB of retention.
+const REDACT_PATHS = [
+    'token', '*.token', '*.*.token',
+    'password', '*.password',
+    'authorization', '*.authorization',
+    'headers.authorization', '*.headers.authorization',
+    'headers.cookie', '*.headers.cookie',
+    'apiKey', '*.apiKey',
+    'DISCORD_TOKEN', 'CLIENT_SECRET', 'SESSION_SECRET', 'SECRET_ENCRYPTION_KEY',
+];
+
+/**
+ * Per-request / per-interaction fields that every log line inside the same
+ * async chain should carry — the correlation id above all. AsyncLocalStorage
+ * is what lets that happen without threading a logger argument through every
+ * service signature.
+ */
+const store = new AsyncLocalStorage();
+
+function currentContext() {
+    return store.getStore() || null;
+}
+
+/**
+ * Run `fn` with `fields` attached to every log line it produces, directly or
+ * through anything it awaits. Nested calls merge rather than replace, so a
+ * guild id added inside a request keeps the request id.
+ */
+function withContext(fields, fn) {
+    const merged = { ...(currentContext() || {}), ...fields };
+    return store.run(merged, fn);
+}
+
+/** Add fields to the context already in force. A no-op outside one. */
+function addContext(fields) {
+    const current = currentContext();
+    if (!current) return false;
+    Object.assign(current, fields);
+    return true;
+}
+
+function resolveLevel(raw, warn = () => {}) {
+    const value = String(raw ?? '').trim().toLowerCase();
+    if (value === '') return DEFAULT_LEVEL;
+    if (LEVELS.includes(value)) return value;
+    // Ignored rather than fatal: a typo in LOG_LEVEL should not be the reason
+    // a bot will not boot, and defaulting to silent would hide that it was.
+    warn(`[LOGGER] Ignoring LOG_LEVEL="${raw}": expected one of ${LEVELS.join(', ')}. Using ${DEFAULT_LEVEL}.`);
+    return DEFAULT_LEVEL;
+}
+
+function resolveFormat(raw) {
+    const value = String(raw ?? '').trim().toLowerCase();
+    if (value === 'json' || value === 'pretty') return value;
+    // Production ships to a log driver, where JSON is the whole point. A
+    // developer reading a terminal wants the line, not the envelope.
+    return process.env.NODE_ENV === 'production' ? 'json' : 'pretty';
+}
+
+const LEVEL_COLOURS = {
+    trace: '\x1b[90m', debug: '\x1b[36m', info: '\x1b[32m',
+    warn: '\x1b[33m', error: '\x1b[31m', fatal: '\x1b[35m',
+};
+const RESET = '\x1b[0m';
+
+/**
+ * The human-readable renderer.
+ *
+ * Deliberately written here rather than pulled in as a pino transport: a
+ * transport runs on a worker thread, which means log lines can be lost when the
+ * process exits — and this process exits on `uncaughtException`, which is
+ * exactly the moment its last line matters most. A plain destination object is
+ * synchronous and has no such window.
+ */
+function prettyLine(record, colour = false) {
+    const { level, time, msg, component, err, pid: _pid, hostname: _hostname, ...rest } = record;
+    const stamp = new Date(time).toISOString().slice(11, 23);
+    const tint = colour ? (LEVEL_COLOURS[level] || '') : '';
+    const off = tint ? RESET : '';
+    const tag = component ? ` [${component}]` : '';
+
+    let line = `${stamp} ${tint}${String(level).toUpperCase().padEnd(5)}${off}${tag} ${msg ?? ''}`;
+
+    const extras = Object.keys(rest);
+    if (extras.length) line += ` ${JSON.stringify(rest)}`;
+    if (err) line += `\n${err.stack || `${err.type || 'Error'}: ${err.message}`}`;
+    return `${line}\n`;
+}
+
+function createDestination(format, out) {
+    if (format === 'json') return out;
+    const colour = Boolean(out.isTTY) && !process.env.NO_COLOR;
+    return {
+        write(chunk) {
+            try {
+                out.write(prettyLine(JSON.parse(chunk), colour));
+            } catch {
+                // Not one of ours (or truncated) — pass it through rather than
+                // dropping it. A logger that eats output is worse than an ugly
+                // line.
+                out.write(chunk);
+            }
+        },
+    };
+}
+
+function createLogger({
+    level = process.env.LOG_LEVEL,
+    format = process.env.LOG_FORMAT,
+    out = process.stdout,
+    warn = msg => process.stderr.write(`${msg}\n`),
+} = {}) {
+    return pino({
+        level: resolveLevel(level, warn),
+        // ISO rather than pino's default epoch millis: these lines are read by
+        // people at least as often as by machines.
+        timestamp: pino.stdTimeFunctions.isoTime,
+        // `level: "info"` beats `level: 30` for anyone querying the stream.
+        formatters: { level: label => ({ level: label }) },
+        redact: { paths: REDACT_PATHS, censor: '[redacted]' },
+        // Whatever the current request/interaction put in scope, on every line.
+        mixin: () => currentContext() || {},
+    }, createDestination(resolveFormat(format), out));
+}
+
+const logger = createLogger();
+
+// `[TAG] the rest of the message` — the convention every existing log line in
+// this codebase follows. Anchored, and bounded to the shapes actually in use
+// (`[READY]`, `[AI/MCP]`), so a message that merely opens with a bracket is
+// left alone.
+const TAG = /^\[([A-Za-z0-9 _/:.-]{1,32})\]\s*/;
+// `shardTag()` in utils/sharding.js prefixes lines with this when the process
+// is one of several.
+const SHARD_TAG = /^\[shard (\d+)\/(\d+)\]\s*/;
+
+function splitArgs(args) {
+    // The first Error becomes `err`, so pino serializes its stack into a field
+    // instead of `util.format` flattening it into the message text. The rest is
+    // formatted exactly as console would have.
+    let err = null;
+    const rest = [];
+    for (const arg of args) {
+        if (!err && arg instanceof Error) err = arg;
+        else rest.push(arg);
+    }
+    return { err, rest };
+}
+
+/**
+ * Turn a `console.*` argument list into the `(fields, message)` pair pino
+ * takes. Exported so tests can pin the parsing without capturing output.
+ */
+function toRecord(args) {
+    const { err, rest } = splitArgs(args);
+    let msg = rest.length ? formatWithOptions({ colors: false, depth: 4 }, ...rest) : '';
+
+    let shard;
+    const shardMatch = SHARD_TAG.exec(msg);
+    if (shardMatch) {
+        shard = Number(shardMatch[1]);
+        msg = msg.slice(shardMatch[0].length);
+    }
+
+    let component;
+    const match = TAG.exec(msg);
+    if (match) {
+        component = match[1];
+        msg = msg.slice(match[0].length);
+    }
+
+    if (!msg && err) msg = err.message;
+
+    const fields = {};
+    if (component) fields.component = component;
+    if (shard !== undefined) fields.shard = shard;
+    if (err) fields.err = err;
+    return { fields, msg };
+}
+
+/**
+ * Point `console.log/info/warn/error/debug` at the logger.
+ *
+ * Returns a function that puts the originals back, which is what tests use.
+ * Idempotent: installing twice does not stack two bridges, and the restore
+ * still returns the real console.
+ */
+function installConsoleBridge({ target = console, log = logger } = {}) {
+    if (target.__clawdiaConsoleBridge) return target.__clawdiaConsoleBridge;
+
+    const original = {};
+    const map = { log: 'info', info: 'info', debug: 'debug', warn: 'warn', error: 'error' };
+
+    for (const [method, level] of Object.entries(map)) {
+        original[method] = target[method];
+        target[method] = (...args) => {
+            const { fields, msg } = toRecord(args);
+            log[level](fields, msg);
+        };
+    }
+
+    const restore = () => {
+        for (const [method, fn] of Object.entries(original)) target[method] = fn;
+        delete target.__clawdiaConsoleBridge;
+    };
+    Object.defineProperty(target, '__clawdiaConsoleBridge', {
+        value: restore, configurable: true, enumerable: false, writable: false,
+    });
+    return restore;
+}
+
+module.exports = {
+    logger,
+    createLogger,
+    installConsoleBridge,
+    withContext,
+    addContext,
+    currentContext,
+    // Exported for the tests that pin the parsing, the rendering and the
+    // environment handling.
+    toRecord,
+    prettyLine,
+    resolveLevel,
+    resolveFormat,
+    LEVELS,
+    REDACT_PATHS,
+};

--- a/tests/commandDeployGate.test.js
+++ b/tests/commandDeployGate.test.js
@@ -1,0 +1,215 @@
+'use strict';
+
+/**
+ * #643. Slash-command registration is not a deploy step anyone runs: the image
+ * is `CMD ["node", "src/index.js"]` and neither stack file overrides it, so the
+ * only registration that ever happens is the one the bot does for itself at
+ * `clientReady`. That has to stay true — and it has to stop re-publishing an
+ * unchanged set of ~98 commands on every restart, once per shard.
+ */
+
+const mockPut = jest.fn().mockResolvedValue(undefined);
+jest.mock('discord.js', () => ({
+    REST: jest.fn().mockImplementation(() => ({
+        setToken() { return this; },
+        put: (...args) => mockPut(...args),
+    })),
+    Routes: { applicationCommands: id => `/applications/${id}/commands` },
+}));
+
+const mockFindOneAndUpdate = jest.fn();
+const mockUpdateOne = jest.fn().mockResolvedValue({});
+jest.mock('../src/models/CommandDeployment', () => ({
+    findOneAndUpdate: (...args) => mockFindOneAndUpdate(...args),
+    updateOne: (...args) => mockUpdateOne(...args),
+}));
+
+const {
+    deployCommandsIfChanged,
+    commandSetHash,
+    DEPLOYMENT_KEY,
+} = require('../src/utils/commandDeployer');
+
+const fakeCommand = name => ({
+    data: { name, toJSON: () => ({ name, description: `${name} description` }) },
+});
+
+// What Mongo raises when an upsert whose filter did not match tries to insert a
+// second document against the fixed _id — i.e. "the recorded hash is already
+// this one".
+const duplicateKey = () => Object.assign(new Error('E11000 duplicate key'), { code: 11000 });
+
+const COMMANDS = [fakeCommand('fish'), fakeCommand('hunt')];
+
+beforeEach(() => {
+    mockPut.mockClear().mockResolvedValue(undefined);
+    mockFindOneAndUpdate.mockReset().mockResolvedValue({});
+    mockUpdateOne.mockClear().mockResolvedValue({});
+    delete process.env.DEPLOY_COMMANDS;
+});
+
+afterAll(() => {
+    delete process.env.DEPLOY_COMMANDS;
+});
+
+describe('the boot deploy', () => {
+    test('publishes when the recorded hash does not match', async () => {
+        const result = await deployCommandsIfChanged('client-id', 'token', COMMANDS);
+
+        expect(result).toEqual({ deployed: true, count: 2, reason: 'command set changed' });
+        expect(mockPut).toHaveBeenCalledWith('/applications/client-id/commands', {
+            body: [
+                { name: 'fish', description: 'fish description' },
+                { name: 'hunt', description: 'hunt description' },
+            ],
+        });
+    });
+
+    test('records the hash it published, so the next boot can skip', async () => {
+        await deployCommandsIfChanged('client-id', 'token', COMMANDS);
+
+        const [filter, update] = mockUpdateOne.mock.calls.at(-1);
+        expect(filter).toEqual({ _id: DEPLOYMENT_KEY });
+        expect(update.$set.hash).toBe(commandSetHash('client-id', COMMANDS.map(c => c.data.toJSON())));
+        expect(update.$set.pending).toBe(false);
+        expect(update.$set.commandCount).toBe(2);
+    });
+
+    test('makes no Discord call when the set is unchanged', async () => {
+        mockFindOneAndUpdate.mockRejectedValue(duplicateKey());
+
+        const result = await deployCommandsIfChanged('client-id', 'token', COMMANDS);
+
+        expect(result).toEqual({ deployed: false, count: 2, reason: 'command set unchanged' });
+        expect(mockPut).not.toHaveBeenCalled();
+    });
+
+    test('claims a hash that a previous boot left pending', async () => {
+        // The crash case: a process killed mid-PUT leaves `pending: true` with
+        // the new hash already written. Matching only on `hash: { $ne }` would
+        // skip that deploy forever.
+        await deployCommandsIfChanged('client-id', 'token', COMMANDS);
+
+        const [filter, update] = mockFindOneAndUpdate.mock.calls[0];
+        expect(filter._id).toBe(DEPLOYMENT_KEY);
+        expect(filter.$or).toContainEqual({ pending: true });
+        expect(update.$set.pending).toBe(true);
+    });
+
+    test('releases the claim when Discord rejects the payload', async () => {
+        mockPut.mockRejectedValue(new Error('rate limited'));
+
+        await expect(deployCommandsIfChanged('client-id', 'token', COMMANDS))
+            .rejects.toThrow('rate limited');
+
+        // Without this the failed hash stays recorded and every later boot
+        // skips a deploy that never actually happened.
+        const [, update] = mockUpdateOne.mock.calls.at(-1);
+        expect(update.$set).toEqual({ hash: null, pending: true });
+    });
+
+    test('propagates a database error rather than silently not deploying', async () => {
+        mockFindOneAndUpdate.mockRejectedValue(new Error('connection lost'));
+
+        await expect(deployCommandsIfChanged('client-id', 'token', COMMANDS))
+            .rejects.toThrow('connection lost');
+        expect(mockPut).not.toHaveBeenCalled();
+    });
+});
+
+describe('DEPLOY_COMMANDS', () => {
+    test('never: no Discord call and no database read', async () => {
+        process.env.DEPLOY_COMMANDS = 'never';
+
+        const result = await deployCommandsIfChanged('client-id', 'token', COMMANDS);
+
+        expect(result.deployed).toBe(false);
+        expect(mockPut).not.toHaveBeenCalled();
+        expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    test('always: publishes without consulting the recorded hash', async () => {
+        process.env.DEPLOY_COMMANDS = 'always';
+
+        const result = await deployCommandsIfChanged('client-id', 'token', COMMANDS);
+
+        expect(result.deployed).toBe(true);
+        expect(mockPut).toHaveBeenCalled();
+        expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+        // Still recorded, so switching back to `auto` does not cost one more
+        // deploy of a set that is already registered.
+        expect(mockUpdateOne.mock.calls.at(-1)[1].$set.pending).toBe(false);
+    });
+
+    test('an unrecognised value falls back to auto rather than disabling the deploy', async () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        process.env.DEPLOY_COMMANDS = 'yes please';
+
+        const result = await deployCommandsIfChanged('client-id', 'token', COMMANDS);
+
+        expect(result.deployed).toBe(true);
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('DEPLOY_COMMANDS'));
+        warn.mockRestore();
+    });
+});
+
+describe('commandSetHash', () => {
+    const payload = COMMANDS.map(c => c.data.toJSON());
+
+    test('does not depend on the order the commands are iterated in', () => {
+        expect(commandSetHash('client-id', [...payload].reverse()))
+            .toBe(commandSetHash('client-id', payload));
+    });
+
+    test('changes when a command does', () => {
+        const edited = [{ ...payload[0], description: 'now with bait' }, payload[1]];
+        expect(commandSetHash('client-id', edited)).not.toBe(commandSetHash('client-id', payload));
+    });
+
+    test('changes when the application does', () => {
+        // Same payload under a different CLIENT_ID is a registration that has
+        // never been made.
+        expect(commandSetHash('other-id', payload)).not.toBe(commandSetHash('client-id', payload));
+    });
+});
+
+describe('the CommandDeployment record', () => {
+    // The real model, not the mock the tests above install: what is asserted
+    // here is the shape the gate depends on.
+    const CommandDeployment = jest.requireActual('../src/models/CommandDeployment');
+    const paths = CommandDeployment.schema.paths;
+
+    test('is keyed by a name the gate supplies, so the claim can be an upsert', () => {
+        // An auto-generated ObjectId would make every boot insert a new
+        // document and never match the previous one.
+        expect(paths._id.instance).toBe('String');
+        expect(new CommandDeployment({})._id).toBeUndefined();
+    });
+
+    test('carries the hash, the crash marker and what was published', () => {
+        expect(Object.keys(paths)).toEqual(
+            expect.arrayContaining(['hash', 'pending', 'clientId', 'commandCount', 'deployedAt'])
+        );
+    });
+
+    test('starts unpending with no hash, so a fresh install deploys', () => {
+        const fresh = new CommandDeployment({ _id: DEPLOYMENT_KEY });
+        expect(fresh.hash).toBeNull();
+        expect(fresh.pending).toBe(false);
+    });
+});
+
+describe('a deploy that published but could not record itself', () => {
+    test('is still reported as deployed', async () => {
+        // Discord already has the new set. Calling that a failure would put a
+        // scary line in the log for a state that self-corrects on the next boot.
+        mockUpdateOne.mockRejectedValue(new Error('connection lost'));
+        const errors = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const result = await deployCommandsIfChanged('client-id', 'token', COMMANDS);
+
+        expect(result.deployed).toBe(true);
+        expect(errors).toHaveBeenCalledWith(expect.stringContaining('could not record'), expect.anything());
+        errors.mockRestore();
+    });
+});

--- a/tests/errorReporter.test.js
+++ b/tests/errorReporter.test.js
@@ -1,0 +1,169 @@
+'use strict';
+
+/**
+ * #647. `unhandledRejection` and `uncaughtException` wrote a line and exited,
+ * into a rolling text stream nothing watches — so a bot that crash-looped at
+ * 04:00 was found out days later, by a user.
+ *
+ * What these hold is that the sink is genuinely opt-in (unset, the exit stays
+ * synchronous and nothing is sent), that it can never keep the process alive,
+ * and that a failing sink cannot replace the error it was reporting.
+ */
+
+const { reportError, reportAndExit, isConfigured, describe: describeError, buildBody } =
+    require('../src/utils/errorReporter');
+
+const DISCORD_URL = 'https://discord.com/api/webhooks/123/abc';
+const PLAIN_URL = 'https://errors.example.com/ingest';
+
+let fetchMock;
+const saved = {};
+
+beforeEach(() => {
+    for (const key of ['ERROR_WEBHOOK_URL', 'ERROR_REPORT_TIMEOUT_MS', 'NODE_ENV', 'SERVICE_NAME']) {
+        saved[key] = process.env[key];
+        delete process.env[key];
+    }
+    fetchMock = jest.fn().mockResolvedValue({ ok: true });
+    global.fetch = fetchMock;
+});
+
+afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+    }
+});
+
+describe('with no sink configured', () => {
+    test('reports nothing', async () => {
+        expect(isConfigured()).toBe(false);
+        await expect(reportError('uncaughtException', new Error('boom'))).resolves.toBe(false);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    test('exits synchronously, exactly as the handler did before', () => {
+        const exit = jest.fn();
+        // Not awaited on purpose: the assertion is that the exit has already
+        // happened by the time reportAndExit returns.
+        reportAndExit('uncaughtException', new Error('boom'), { exit });
+        expect(exit).toHaveBeenCalledWith(1);
+    });
+});
+
+describe('with a sink configured', () => {
+    beforeEach(() => { process.env.ERROR_WEBHOOK_URL = PLAIN_URL; });
+
+    test('posts a flat JSON event describing the error', async () => {
+        process.env.NODE_ENV = 'production';
+
+        await reportError('unhandledRejection', new Error('boom'), { guildId: '42' });
+
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toBe(PLAIN_URL);
+        expect(init.method).toBe('POST');
+        const body = JSON.parse(init.body);
+        expect(body).toMatchObject({
+            kind: 'unhandledRejection',
+            service: 'clawdia',
+            environment: 'production',
+            guildId: '42',
+        });
+        expect(body.error).toMatchObject({ name: 'Error', message: 'boom' });
+        expect(body.error.stack).toContain('boom');
+    });
+
+    test('handles a rejection carrying something that is not an Error', async () => {
+        // `Promise.reject('nope')` is legal and does reach this handler.
+        await reportError('unhandledRejection', 'nope');
+        expect(JSON.parse(fetchMock.mock.calls[0][1].body).error)
+            .toEqual({ name: 'string', message: 'nope', stack: null });
+    });
+
+    test('exits once the report resolves', async () => {
+        const exit = jest.fn();
+        await reportAndExit('uncaughtException', new Error('boom'), { exit });
+        expect(fetchMock).toHaveBeenCalled();
+        expect(exit).toHaveBeenCalledTimes(1);
+        expect(exit).toHaveBeenCalledWith(1);
+    });
+
+    test('still exits when the sink itself is down', async () => {
+        // The likeliest thing to be broken at the same moment as the bot.
+        fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+        const exit = jest.fn();
+
+        await expect(reportAndExit('uncaughtException', new Error('boom'), { exit }))
+            .resolves.toBe(false);
+        expect(exit).toHaveBeenCalledWith(1);
+    });
+
+    test('reports a non-2xx as undelivered rather than throwing', async () => {
+        fetchMock.mockResolvedValue({ ok: false, status: 500 });
+        await expect(reportError('uncaughtException', new Error('boom'))).resolves.toBe(false);
+    });
+
+    test('exits only once, however the report finishes', async () => {
+        const exit = jest.fn();
+        await reportAndExit('uncaughtException', new Error('boom'), { exit });
+        // The timeout guard is still armed at this point; it must not fire a
+        // second exit into a process that has already started shutting down.
+        await new Promise(resolve => setTimeout(resolve, 30));
+        expect(exit).toHaveBeenCalledTimes(1);
+    });
+
+    test('bounds the wait rather than the delivery', async () => {
+        process.env.ERROR_REPORT_TIMEOUT_MS = '50';
+        await reportError('uncaughtException', new Error('boom'));
+        expect(fetchMock.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal);
+    });
+
+    test('does not name the URL when delivery fails — it is a credential', async () => {
+        fetchMock.mockRejectedValue(new Error(`connect ECONNREFUSED ${PLAIN_URL}`));
+        const errors = [];
+        const spy = jest.spyOn(console, 'error').mockImplementation((...a) => errors.push(a.join(' ')));
+
+        await reportError('uncaughtException', new Error('boom'));
+
+        expect(errors.join('\n')).not.toContain(PLAIN_URL);
+        spy.mockRestore();
+    });
+});
+
+describe('a Discord webhook', () => {
+    test('gets Discord’s payload shape, since that is the sink a bot operator has', () => {
+        const event = {
+            kind: 'uncaughtException', service: 'clawdia', shard: 2,
+            error: { message: 'boom', stack: 'Error: boom\n    at x' },
+        };
+        const body = buildBody(DISCORD_URL, event);
+        expect(body.content).toContain('uncaughtException');
+        expect(body.content).toContain('shard 2');
+        expect(body.content).toContain('Error: boom');
+    });
+
+    test('truncates, because Discord rejects a message over 2000 characters', () => {
+        const event = {
+            kind: 'uncaughtException', service: 'clawdia',
+            error: { message: 'boom', stack: 'x'.repeat(50_000) },
+        };
+        // Rejected outright, not truncated by Discord — so an untruncated
+        // report is no report at all.
+        expect(buildBody(DISCORD_URL, event).content.length).toBeLessThan(2000);
+    });
+
+    test('anything else keeps the flat JSON event', () => {
+        const event = { kind: 'uncaughtException', error: { message: 'boom' } };
+        expect(buildBody(PLAIN_URL, event)).toBe(event);
+    });
+});
+
+describe('describe()', () => {
+    test('keeps name, message and stack for an Error', () => {
+        expect(describeError(new TypeError('bad'))).toMatchObject({ name: 'TypeError', message: 'bad' });
+    });
+
+    test('says something useful about undefined', () => {
+        expect(describeError(undefined)).toEqual({ name: 'undefined', message: 'undefined', stack: null });
+    });
+});

--- a/tests/imagePinning.test.js
+++ b/tests/imagePinning.test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+/**
+ * #644. `node:24-alpine` and `mongo:7` are floating tags: Docker Hub
+ * re-publishes them on every patch of the line, so the same commit built on two
+ * days produces two different runtimes — and a rebuild meant to roll a
+ * regression back can quietly ship a *newer* base than the image it replaces.
+ *
+ * Every third-party image reference therefore carries an `@sha256:` digest.
+ * These assertions are what notices when one loses it — a Dependabot bump that
+ * rewrites the tag only, or a hand-edit during an incident.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const read = file => fs.readFileSync(path.join(ROOT, file), 'utf8');
+
+const DIGEST = /@sha256:[0-9a-f]{64}$/;
+
+// The bot's own image. `docker compose build` produces it and the Portainer
+// stack pulls it, so there is no digest to pin to at the time the file is
+// written — the tag is the interface between the two halves of the deploy.
+// CLAWDIA_IMAGE_TAG is how a deploy names a specific build.
+const OWN_IMAGE = 'ghcr.io/theshield2594/clawdia';
+
+// Reads `image:` values out of a compose file as text rather than through a
+// YAML parse, so commented-out services (the Portainer stack ships `autoheal`
+// commented out) are checked too: uncommenting one should not be the moment the
+// pinning silently lapses.
+function imageRefs(file) {
+    return [...read(file).matchAll(/^\s*#?\s*image:\s*(\S+)\s*$/gm)].map(m => m[1]);
+}
+
+describe('Dockerfile base images', () => {
+    const froms = [...read('Dockerfile').matchAll(/^FROM\s+(\S+)/gm)].map(m => m[1]);
+
+    it('has at least the build and runtime stages', () => {
+        expect(froms.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it.each(froms)('%s is pinned by digest', ref => {
+        expect(ref).toMatch(DIGEST);
+    });
+
+    it('keeps the readable tag beside the digest', () => {
+        // A bare `node@sha256:…` builds the same image but leaves nobody able to
+        // tell which Node major it is without resolving the digest — and
+        // tests/nodeVersionAlignment.test.js reads the major off this line.
+        for (const ref of froms) expect(ref).toMatch(/^node:\d+[^@]*@sha256:/);
+    });
+});
+
+describe.each(['docker-compose.yml', 'portainer-stack.yml'])('%s', file => {
+    const refs = imageRefs(file);
+
+    it('references at least the database and the bot', () => {
+        expect(refs.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('pins every third-party image by digest', () => {
+        const unpinned = refs
+            .filter(ref => !ref.startsWith(OWN_IMAGE))
+            .filter(ref => !DIGEST.test(ref));
+        expect(unpinned).toEqual([]);
+    });
+
+    it('leaves the bot image on a tag, since compose is what builds it', () => {
+        const own = refs.filter(ref => ref.startsWith(OWN_IMAGE));
+        expect(own.length).toBeGreaterThan(0);
+        for (const ref of own) expect(ref).toBe(`${OWN_IMAGE}:\${CLAWDIA_IMAGE_TAG:-latest}`);
+    });
+});
+
+describe('the two stack files agree on the images they share', () => {
+    const compose = imageRefs('docker-compose.yml');
+    const stack = imageRefs('portainer-stack.yml');
+    const byName = refs => {
+        const map = new Map();
+        for (const ref of refs) map.set(ref.split('@')[0].split(':')[0], ref);
+        return map;
+    };
+
+    it('pins the same digest for every image present in both', () => {
+        const a = byName(compose);
+        const b = byName(stack);
+        for (const [name, ref] of a) {
+            if (!b.has(name)) continue;
+            // Two digests for one image means one of the two files was bumped
+            // and the other was not, so the production stack and the file it
+            // was tested from are running different code.
+            expect([name, b.get(name)]).toEqual([name, ref]);
+        }
+    });
+});
+
+describe('Dependabot', () => {
+    const dependabot = read('.github/dependabot.yml');
+
+    it('watches the docker ecosystem, so the pins do not rot', () => {
+        // A digest that nothing bumps is a security problem of its own: the
+        // build stops picking up base-image CVE fixes entirely.
+        expect(dependabot).toMatch(/package-ecosystem:\s*docker/);
+    });
+});

--- a/tests/structuredLogging.test.js
+++ b/tests/structuredLogging.test.js
@@ -1,0 +1,316 @@
+'use strict';
+
+/**
+ * #647. 660-odd raw `console.*` calls, no levels, nothing an operator can
+ * filter on, and 250 MB of retention per service holding unparsed text.
+ *
+ * The fix is a pino logger plus a bridge that routes the existing calls through
+ * it, so what these assertions hold is the bridge: that a `[TAG] message` line
+ * comes out as a level, a component and a message; that an Error keeps its
+ * stack as a field rather than being flattened into text; that secrets are
+ * redacted; and that installing the bridge is reversible, since the rest of the
+ * suite asserts on the real console.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const {
+    createLogger,
+    installConsoleBridge,
+    withContext,
+    addContext,
+    toRecord,
+    prettyLine,
+    resolveLevel,
+    resolveFormat,
+} = require('../src/utils/logger');
+
+/** A destination that collects the JSON records pino writes. */
+function collector() {
+    const lines = [];
+    return {
+        lines,
+        records: () => lines.map(l => JSON.parse(l)),
+        write(chunk) { lines.push(chunk); },
+    };
+}
+
+function jsonLogger(level = 'trace') {
+    const out = collector();
+    return { out, log: createLogger({ level, format: 'json', out }) };
+}
+
+describe('the console bridge', () => {
+    test('turns a [TAG] prefix into a component field', () => {
+        const { out, log } = jsonLogger();
+        const target = {};
+        installConsoleBridge({ target, log });
+
+        target.log('[READY] Logged in as %s', 'Clawdia#1');
+
+        // The tag was greppable text and nothing else; it is now a field a log
+        // backend can facet on, and the message reads without it.
+        expect(out.records()[0]).toMatchObject({
+            component: 'READY',
+            msg: 'Logged in as Clawdia#1',
+        });
+    });
+
+    test('maps console methods onto levels', () => {
+        const { out, log } = jsonLogger();
+        const target = {};
+        installConsoleBridge({ target, log });
+
+        target.log('[A] one');
+        target.info('[A] two');
+        target.warn('[A] three');
+        target.error('[A] four');
+        target.debug('[A] five');
+
+        expect(out.records().map(r => r.level)).toEqual(['info', 'info', 'warn', 'error', 'debug']);
+    });
+
+    test('keeps an Error as a serialized field rather than flattening it', () => {
+        const { out, log } = jsonLogger();
+        const target = {};
+        installConsoleBridge({ target, log });
+
+        target.error('[DEPLOY] Discord rejected the payload:', new Error('boom'));
+
+        const [record] = out.records();
+        expect(record.component).toBe('DEPLOY');
+        expect(record.err.message).toBe('boom');
+        expect(record.err.stack).toContain('boom');
+        // The message keeps the human half; the stack is queryable on its own.
+        expect(record.msg).toContain('Discord rejected the payload');
+    });
+
+    test('falls back to the error message when there is nothing else to say', () => {
+        const { msg } = toRecord([new Error('lonely')]);
+        expect(msg).toBe('lonely');
+    });
+
+    test('applies console format specifiers exactly as console would', () => {
+        expect(toRecord(['%s scored %d', 'fish', 12]).msg).toBe('fish scored 12');
+        expect(toRecord(['[X] state', { a: 1 }]).msg).toBe("state { a: 1 }");
+    });
+
+    test('lifts the shard prefix out of the message', () => {
+        // utils/sharding.js prefixes lines with `[shard 0/4] ` when there is
+        // more than one process; as text it is unfilterable.
+        const { fields, msg } = toRecord(['[shard 2/4] [DASHBOARD] Not the primary shard']);
+        expect(fields).toMatchObject({ shard: 2, component: 'DASHBOARD' });
+        expect(msg).toBe('Not the primary shard');
+    });
+
+    test('leaves a message that merely starts with a bracket alone', () => {
+        const { fields, msg } = toRecord(['[this is not a tag, it is a sentence] etc']);
+        expect(fields.component).toBeUndefined();
+        expect(msg).toBe('[this is not a tag, it is a sentence] etc');
+    });
+
+    test('restores the real console, which the rest of the suite depends on', () => {
+        const original = () => {};
+        const target = { log: original, info: original, warn: original, error: original, debug: original };
+        const restore = installConsoleBridge({ target, log: jsonLogger().log });
+
+        expect(target.log).not.toBe(original);
+        restore();
+        expect(target.log).toBe(original);
+    });
+
+    test('is idempotent, so a double install cannot trap the real console', () => {
+        const original = () => {};
+        const target = { log: original, info: original, warn: original, error: original, debug: original };
+        const first = installConsoleBridge({ target, log: jsonLogger().log });
+        const second = installConsoleBridge({ target, log: jsonLogger().log });
+
+        expect(second).toBe(first);
+        first();
+        expect(target.log).toBe(original);
+    });
+});
+
+describe('correlation context', () => {
+    test('attaches its fields to every line inside it, across an await', async () => {
+        const { out, log } = jsonLogger();
+        const target = {};
+        installConsoleBridge({ target, log });
+
+        await withContext({ requestId: 'req-1' }, async () => {
+            target.log('[API] before');
+            await Promise.resolve();
+            target.log('[API] after');
+        });
+        target.log('[API] outside');
+
+        const records = out.records();
+        expect(records.map(r => r.requestId)).toEqual(['req-1', 'req-1', undefined]);
+    });
+
+    test('merges rather than replaces, so a nested scope keeps the request id', async () => {
+        const { out, log } = jsonLogger();
+        const target = {};
+        installConsoleBridge({ target, log });
+
+        await withContext({ requestId: 'req-1' }, async () => {
+            await withContext({ guildId: '42' }, async () => target.log('[API] nested'));
+        });
+
+        expect(out.records()[0]).toMatchObject({ requestId: 'req-1', guildId: '42' });
+    });
+
+    test('addContext extends the scope in force and is a no-op outside one', async () => {
+        const { out, log } = jsonLogger();
+        const target = {};
+        installConsoleBridge({ target, log });
+
+        expect(addContext({ userId: 'u1' })).toBe(false);
+        await withContext({ requestId: 'req-1' }, async () => {
+            expect(addContext({ userId: 'u1' })).toBe(true);
+            target.log('[API] hello');
+        });
+
+        expect(out.records()[0]).toMatchObject({ requestId: 'req-1', userId: 'u1' });
+    });
+});
+
+describe('redaction', () => {
+    test('censors credentials wherever they appear in the record', () => {
+        const { out, log } = jsonLogger();
+
+        log.error({
+            token: 'gateway-token',
+            headers: { authorization: 'Bearer abc' },
+            config: { apiKey: 'sk-live-123' },
+        }, 'request failed');
+
+        const line = out.lines[0];
+        expect(line).not.toContain('gateway-token');
+        expect(line).not.toContain('Bearer abc');
+        expect(line).not.toContain('sk-live-123');
+        expect(line).toContain('[redacted]');
+    });
+});
+
+describe('LOG_LEVEL and LOG_FORMAT', () => {
+    test('a level below the threshold is not written at all', () => {
+        const { out, log } = jsonLogger('warn');
+        const target = {};
+        installConsoleBridge({ target, log });
+
+        target.log('[A] chatty');
+        target.error('[A] serious');
+
+        expect(out.records().map(r => r.msg)).toEqual(['serious']);
+    });
+
+    test('an unrecognised level warns and falls back to info', () => {
+        const warnings = [];
+        expect(resolveLevel('verbose', m => warnings.push(m))).toBe('info');
+        expect(warnings[0]).toContain('LOG_LEVEL');
+        // A typo must not silence the bot.
+        expect(resolveLevel('verbose', () => {})).not.toBe('silent');
+    });
+
+    test('an empty or absent level is info', () => {
+        expect(resolveLevel(undefined)).toBe('info');
+        expect(resolveLevel('  ')).toBe('info');
+        expect(resolveLevel('DEBUG')).toBe('debug');
+    });
+
+    test('production defaults to JSON and development to pretty', () => {
+        const saved = process.env.NODE_ENV;
+        try {
+            process.env.NODE_ENV = 'production';
+            expect(resolveFormat(undefined)).toBe('json');
+            process.env.NODE_ENV = 'development';
+            expect(resolveFormat(undefined)).toBe('pretty');
+            // An explicit setting wins in either direction.
+            expect(resolveFormat('json')).toBe('json');
+            process.env.NODE_ENV = 'production';
+            expect(resolveFormat('pretty')).toBe('pretty');
+        } finally {
+            process.env.NODE_ENV = saved;
+        }
+    });
+
+    test('the JSON record carries level, ISO time, component and message', () => {
+        const { out, log } = jsonLogger();
+        const target = {};
+        installConsoleBridge({ target, log });
+
+        target.warn('[MIGRATIONS] slow');
+
+        const [record] = out.records();
+        expect(record.level).toBe('warn');
+        expect(record.component).toBe('MIGRATIONS');
+        expect(record.msg).toBe('slow');
+        expect(record.time).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/);
+    });
+});
+
+describe('the pretty renderer', () => {
+    const record = {
+        level: 'warn', time: '2026-08-14T11:42:35.000Z', msg: 'slow',
+        component: 'MIGRATIONS', pid: 1, hostname: 'box', durationMs: 900,
+    };
+
+    test('reads as a log line, with the extras appended as JSON', () => {
+        const line = prettyLine(record);
+        expect(line).toBe('11:42:35.000 WARN  [MIGRATIONS] slow {"durationMs":900}\n');
+    });
+
+    test('drops pid and hostname, which are noise in a terminal', () => {
+        expect(prettyLine(record)).not.toContain('hostname');
+    });
+
+    test('prints the stack under the line', () => {
+        const line = prettyLine({ ...record, err: { message: 'boom', stack: 'Error: boom\n    at x' } });
+        expect(line).toContain('\nError: boom\n    at x');
+    });
+
+    test('passes a line through unparsed rather than dropping it', () => {
+        // Anything that is not one of ours still has to reach the operator.
+        const written = [];
+        const log = createLogger({ level: 'info', format: 'pretty', out: { write: s => written.push(s) } });
+        log.info('hello');
+        expect(written.join('')).toContain('hello');
+    });
+});
+
+describe('where the bridge is installed', () => {
+    const read = file => fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+
+    // A bot that logs through pino and a shard manager that does not would put
+    // one unparsed stream in the middle of the JSON.
+    test.each(['src/index.js', 'src/shard.js'])('%s installs it', file => {
+        expect(read(file)).toContain("require('./utils/logger').installConsoleBridge()");
+    });
+
+    test('it goes in before anything else can log', () => {
+        const source = read('src/index.js');
+        // Every line written before this point escapes the bridge, so its
+        // position in the file is the guarantee, not just its presence.
+        expect(source.indexOf('installConsoleBridge'))
+            .toBeLessThan(source.indexOf("require('./health')"));
+    });
+
+    test('the standalone deploy leaves the real console alone', () => {
+        // `npm run deploy` is a terminal tool whose output is the point, and it
+        // runs with no database and no log backend to ship JSON to.
+        expect(read('src/deploy-commands.js')).not.toContain('installConsoleBridge');
+    });
+
+    test('the crash handlers report as well as log', () => {
+        const source = read('src/index.js');
+        for (const handler of ['unhandledRejection', 'uncaughtException']) {
+            expect([handler, source.includes(handler)]).toEqual([handler, true]);
+        }
+        // Both paths exit through reportAndExit, which is synchronous when no
+        // sink is configured and bounded when one is.
+        expect(source).toContain("reportAndExit('uncaughtException'");
+        expect(source).toContain("reportAndExit('unhandledRejection'");
+    });
+});


### PR DESCRIPTION
Closes #647, closes #643, closes #644, closes #716. #717 needs no change — see below.

Five DevOps and documentation issues, all of which came down to the same thing: a fact about how this deploys that only the code knew.

## Structured logging (#647)

660 raw `console.*` calls, no levels, and 250 MB of retention per service holding text nothing can query — so `LOG_LEVEL` had nowhere to be read and a startup notice looked exactly like an error that mattered.

`src/utils/logger.js` is a pino logger plus a bridge over `console.*`, installed by `src/index.js` and `src/shard.js` and nowhere else. Rewriting 660 call sites would have been 660 chances to change a message with nothing testing it; routing them instead means all of them gain a level, an ISO timestamp and JSON output at once, and the `[TAG]` prefix each already carried becomes a `component` field a backend can facet on.

```json
{"level":"error","time":"2026-08-14T11:42:35.001Z","component":"RSS","requestId":"5f3c…","msg":"Feed fetch failed","err":{"type":"Error","message":"404"}}
```

- `LOG_LEVEL` (default `info`) and `LOG_FORMAT` (`json` under `NODE_ENV=production`, `pretty` otherwise).
- Dashboard requests run inside an `AsyncLocalStorage` context carrying a correlation id, echoed as `X-Request-Id` and adopted from a reverse proxy when one sends it, so every line of one request reads back together. `withContext`/`addContext` open one around any other unit of work.
- Credentials are redacted before a line is written — tokens, `Authorization` headers, cookies, provider keys.
- The pretty renderer is written here rather than pulled in as a pino transport on purpose: a transport runs on a worker thread, and this process exits on `uncaughtException`, which is when its last line matters most.

`ERROR_WEBHOOK_URL` is the other half the issue asked for. Until now a crash's only record was a line in a rolling file nobody watches — which is how a bot that crash-loops at 04:00 gets noticed days later, by a user. Set it to a Discord webhook (recognised and formatted for Discord) or any JSON endpoint and the process reports before it exits, bounded by `ERROR_REPORT_TIMEOUT_MS`. Unset — the default — the exit stays synchronous and nothing is sent.

## Slash-command registration (#643)

Partly stale: the bot has published its own commands at `clientReady` since #607, which is what makes the documented Docker quick-start work at all — the image is `CMD ["node", "src/index.js"]` and neither stack file runs a registration step. So the quick-start is not broken today.

What was left is the hash gate the issue recommends. It published unconditionally, so every restart `PUT` ~98 commands to Discord, and under sharding once per shard, all publishing the same set. `deployCommandsIfChanged` gates that on a fingerprint of the payload held in a new `CommandDeployment` record:

- The ordinary restart is one indexed read and no API call.
- The conditional claim also settles which shard deploys — whichever wins the write does the `PUT`, the rest see their own hash recorded and skip.
- A process killed mid-`PUT` leaves the claim marked `pending`, so the next boot retries rather than skipping a deploy that never happened; a rejected `PUT` releases the claim.
- A published set whose bookkeeping write then fails is still reported as deployed — Discord has it, and the state self-corrects next boot.
- `DEPLOY_COMMANDS=auto|always|never` covers the cases the gate gets in the way of. An unrecognised value warns and falls back to `auto`, never to "no commands".

## Reproducible builds (#644)

Also partly stale in its details: the Dockerfile is on `node:24-alpine`, not `node:26-alpine`, and Dependabot's `docker` ecosystem was already configured. The substance stands — a floating tag is re-published on every patch of the line, so the same commit built on two days produced two different runtimes, and a rebuild meant to roll a regression back could quietly ship a *newer* base than the image it replaced.

`node:24-alpine`, `mongo:7` and `willfarrell/autoheal` are pinned by `@sha256:` digest across the `Dockerfile` and both stack files, with the readable tag kept beside each. The bot's own GHCR image deliberately stays on a tag: compose builds it and the stack pulls it, so the tag is the interface between the two halves of the deploy.

`tests/imagePinning.test.js` fails if a reference loses its digest, if the two stack files disagree on an image they share, or if Dependabot stops watching the ecosystem — a digest nothing bumps stops picking up base-image CVE fixes, which is a problem of its own.

## Schema migrations (#716)

Eighteen files reshape the schema on every boot, six of them irreversibly, and "migration" appeared in no markdown outside a couple of passing mentions. `MIGRATION_BACKUP` and `MIGRATION_BACKUP_DIR` were undocumented entirely.

- **SETUP_GUIDE.md** gains a **Schema migrations** section: that they run automatically before the port opens, which six cannot be undone, that a failure aborts startup, `MIGRATION_BACKUP` and why a production deploy wants `require`, the timeout that turns a slow migration into a boot loop, how to read `migrationrecords`, and the rollback path. **Updating the Bot** now says what happens on the first boot after a pull.
- **docs/EXTENDING.md** gains **Schema Migrations**: writing one, the `down()`/`irreversible` choice, `timeoutMs` and `optional`, and the rules that are not obvious (never edit a shipped migration, use `Model.collection` for bulk rewrites, stay in the lowest layer).
- README, `.env.example` and the environment-variable list carry the same facts.

## /health (#717)

No change needed. README's **Monitoring** section and SETUP_GUIDE's **Health Monitoring** already document the endpoint, the three states and the monitoring setup, more fully than the issue asks — and the issue's premise is out of date: `degraded` answers 503, not 200. Left open for you to close, or I can close it.

## Verification

- `npm run lint` clean; 255 suites / 4721 tests pass.
- `npm run coverage:check` passes. The `src/utils` floor is ratcheted up to match the two new files; no other floor is touched, since the rest of the drift is not this change's.
- New: `tests/structuredLogging.test.js`, `tests/errorReporter.test.js`, `tests/commandDeployGate.test.js`, `tests/imagePinning.test.js`.
- The three `tests/integration/` suites fail in my sandbox only — `mongodb-memory-server` gets a 403 fetching a mongod binary — and fail identically on a clean checkout of `main`. CI should run them normally.

## Behaviour changes worth knowing

- **All log output now goes to stdout**, errors included, where `console.error` previously went to stderr. The `json-file` driver captures both either way, but a setup that splits the streams will see the difference.
- **Production log output is JSON.** `LOG_FORMAT=pretty` restores readable lines in the container; `docker logs clawdia -f | npx pino-pretty` does the same outside it.
- **The first boot after this merges will re-publish the command set once**, since no fingerprint is recorded yet. Every boot after that is a no-op unless the commands change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYW5CbvZAAw9prkEv7TRMb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable structured logging with JSON or human-readable output, context tracking, and sensitive-data redaction.
  - Added optional crash and error reporting through webhooks.
  - Slash commands now deploy automatically only when changes are detected, with configurable deployment modes.
  - Added request correlation IDs for easier troubleshooting.

- **Documentation**
  - Expanded setup, migration, logging, deployment, backup, and troubleshooting guidance.

- **Security & Reliability**
  - Pinned container images to immutable digests.
  - Added automatic schema migration safeguards and improved startup failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->