### PR TITLE
Make the deploy claim exclusive, and vet what the crash report is sent over

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,7 +145,10 @@ AUDIT_LOG_RETENTION_DAYS=90
 # the image or on the host.
 # MIGRATION_BACKUP=require
 # Where that archive lands (default ./backups, the same directory the nightly
-# backup service prunes). Named pre-migration-<timestamp>.gz.
+# backup service prunes). Named pre-migration-<timestamp>.gz, and aged out on
+# the BACKUP_RETENTION_DAYS window set in the Backups section above — these
+# dumps are not kept any longer than an ordinary nightly archive, so copy one
+# out if you need it past that.
 # MIGRATION_BACKUP_DIR=./backups
 
 # ── Slash-command registration ───────────────────────────────────────────────
@@ -175,6 +178,10 @@ AUDIT_LOG_RETENTION_DAYS=90
 # logging it. Unset — the default — nothing is sent and the process exits
 # exactly as it always did. A Discord webhook URL is recognised and formatted
 # for Discord; anything else receives a flat JSON event.
+#
+# Must be https://, or http:// to loopback (a collector on this same host).
+# The report carries a stack trace, so a cleartext URL to anywhere else is
+# refused with a warning rather than sent, and redirects are not followed.
 # ERROR_WEBHOOK_URL=https://discord.com/api/webhooks/...
 # How long the process waits for that POST before exiting anyway (default 2000).
 # ERROR_REPORT_TIMEOUT_MS=2000

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ the files a change already touches.
 - `IMGFLIP_USERNAME` / `IMGFLIP_PASSWORD` - (Optional) Imgflip credentials for `/meme` command
 - `LOG_LEVEL` - (Optional) `trace`, `debug`, `info` (default), `warn`, `error`, `fatal` or `silent`. See [Logging](#logging)
 - `LOG_FORMAT` - (Optional) `json` or `pretty`. Defaults to `json` when `NODE_ENV=production`, `pretty` otherwise
-- `ERROR_WEBHOOK_URL` - (Optional) Where to send an uncaught exception or unhandled rejection, on top of logging it. A Discord webhook URL is recognised and formatted for Discord; anything else receives a flat JSON event. Unset, nothing is sent and the crash path behaves exactly as before
+- `ERROR_WEBHOOK_URL` - (Optional) Where to send an uncaught exception or unhandled rejection, on top of logging it. Must be `https://`, or `http://` to loopback. A Discord webhook URL is recognised and formatted for Discord; anything else receives a flat JSON event. Unset, nothing is sent and the crash path behaves exactly as before
 - `ERROR_REPORT_TIMEOUT_MS` - (Optional) How long the process waits for that POST before exiting anyway (default 2000)
 - `DEPLOY_COMMANDS` - (Optional) `auto` (default — publish the slash commands at startup, but only when the set changed), `always`, or `never`
 - `MIGRATION_TIMEOUT_MS` - (Optional) Per-migration wall-clock budget in milliseconds (default 30000)
@@ -535,6 +535,12 @@ webhook (recognised and formatted as a Discord message) or to any endpoint that
 accepts a JSON POST, and the process reports the crash before it goes. It waits
 at most `ERROR_REPORT_TIMEOUT_MS` (2000) for that and exits either way; unset,
 the exit is synchronous and nothing is sent.
+
+The report carries a stack trace, so the URL must be `https://` — or `http://`
+to loopback, for a collector on the same host, where there is no wire to read.
+Anything else is refused with a warning rather than sent in cleartext, and a
+redirect is never followed, so a `3xx` cannot walk the report to a host you did
+not configure.
 
 ## Monitoring
 

--- a/src/models/CommandDeployment.js
+++ b/src/models/CommandDeployment.js
@@ -30,6 +30,12 @@ const CommandDeploymentSchema = new Schema({
     // Set on claim, cleared on success. A document left pending is a deploy
     // that never finished.
     pending: { type: Boolean, default: false },
+    // Compare-and-swap token, rewritten on every claim attempt. It is what makes
+    // the claim exclusive: two shards that read the same token both try to
+    // replace it, and only the first write matches. Without it, N shards whose
+    // filter merely said "hash differs" would all match the same document and
+    // all publish.
+    claimToken: { type: String, default: null },
     clientId: { type: String, default: null },
     commandCount: { type: Number, default: null },
     deployedAt: { type: Date, default: null },

--- a/src/utils/commandDeployer.js
+++ b/src/utils/commandDeployer.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto');
+const { randomUUID } = crypto;
 const { REST, Routes } = require('discord.js');
 const { listCommandFiles, loadCommandModules } = require('./commandLoader');
 
@@ -71,6 +72,12 @@ function buildCommandPayload(loadedCommands = null) {
 }
 
 /** The one call that actually changes what Discord has registered. */
+/**
+ * @param {string} clientId
+ * @param {string} token the bot token.
+ * @param {object[]} commands the bodies to publish.
+ * @returns {Promise<number>} how many were published.
+ */
 async function putCommands(clientId, token, commands) {
     const rest = new REST().setToken(token);
     try {
@@ -92,8 +99,9 @@ async function putCommands(clientId, token, commands) {
  * the opposite — see deployCommandsIfChanged below.
  *
  * @param {string} clientId
- * @param {string} token
+ * @param {string} token the bot token.
  * @param {Iterable<object>} [loadedCommands] see buildCommandPayload.
+ * @returns {Promise<number>} how many commands were published.
  */
 async function deployCommands(clientId, token, loadedCommands = null) {
     return putCommands(clientId, token, buildCommandPayload(loadedCommands));
@@ -111,6 +119,11 @@ const DEPLOYMENT_KEY = 'global';
  * is folded in because the same payload published under a different CLIENT_ID
  * is a different registration.
  */
+/**
+ * @param {string} clientId the Discord application the set would be published under.
+ * @param {object[]} commands the serialized command bodies.
+ * @returns {string} a sha256 hex digest, stable across iteration order.
+ */
 function commandSetHash(clientId, commands) {
     const sorted = [...commands].sort((a, b) => String(a.name).localeCompare(String(b.name)));
     return crypto.createHash('sha256')
@@ -123,6 +136,9 @@ function commandSetHash(clientId, commands) {
  * a warning rather than silently disabling the deploy — an operator who
  * mistypes it should get commands, not a bot with none.
  */
+/**
+ * @returns {'auto'|'always'|'never'} how DEPLOY_COMMANDS says to behave.
+ */
 function deployMode() {
     const raw = String(process.env.DEPLOY_COMMANDS ?? '').trim().toLowerCase();
     if (raw === '') return 'auto';
@@ -131,6 +147,67 @@ function deployMode() {
         `[DEPLOY] Ignoring DEPLOY_COMMANDS="${process.env.DEPLOY_COMMANDS}": expected auto, always or never. Using auto.`
     );
     return 'auto';
+}
+
+/**
+ * Take exclusive ownership of the right to publish `hash`.
+ *
+ * A plain `findOneAndUpdate` on `{ hash: { $ne } }` is not exclusive: when the
+ * document already exists holding an older hash, every shard's filter matches
+ * it and every shard proceeds to PUT. Mongo serializes the writes but matches
+ * all of them, so the duplicate-key error only ever guarded the case where no
+ * document existed yet.
+ *
+ * So the claim is a compare-and-swap on a token that changes on every attempt:
+ * each caller reads the token it saw, and only the writer whose filter still
+ * names that token wins. The loser's filter no longer matches and it is told
+ * the set is being published by someone else.
+ *
+ * There is deliberately no lease expiry. A claim abandoned by a crashed process
+ * is recovered by `pending` — the next boot sees an unfinished claim and takes
+ * it over — which needs no wall clock and no guess at how long a PUT may
+ * legitimately take.
+ *
+ * @param {import('mongoose').Model} CommandDeployment
+ * @param {string} hash fingerprint of the set to publish.
+ * @param {string} clientId
+ * @returns {Promise<{claimed: boolean, token: string|null, reason: string}>}
+ */
+async function claimDeployment(CommandDeployment, hash, clientId) {
+    const current = await CommandDeployment.findOne({ _id: DEPLOYMENT_KEY }).lean();
+
+    // Already published, and the publish finished. The common restart.
+    if (current && current.hash === hash && current.pending !== true) {
+        return { claimed: false, token: null, reason: 'command set unchanged' };
+    }
+
+    const token = randomUUID();
+    // `null` matches a missing field as well as an explicit null, which is what
+    // makes this work against a document written before claimToken existed.
+    const expected = current
+        ? { _id: DEPLOYMENT_KEY, claimToken: current.claimToken ?? null }
+        : { _id: DEPLOYMENT_KEY, claimToken: null };
+
+    try {
+        const claimed = await CommandDeployment.findOneAndUpdate(
+            expected,
+            { $set: { hash, pending: true, clientId, claimToken: token } },
+            // Only the no-document case may insert. With a document present an
+            // upsert would race a concurrent insert into a duplicate key rather
+            // than losing cleanly.
+            { upsert: !current, new: true }
+        );
+        return claimed
+            ? { claimed: true, token, reason: 'command set changed' }
+            : { claimed: false, token: null, reason: 'another process is publishing this set' };
+    } catch (error) {
+        // Another process inserted the document between our read and our write.
+        // It holds the claim; we do not.
+        if (error?.code === 11000) {
+            return { claimed: false, token: null, reason: 'another process is publishing this set' };
+        }
+        throw error;
+    }
 }
 
 /**
@@ -177,28 +254,9 @@ async function deployCommandsIfChanged(clientId, token, loadedCommands = null) {
     // module with no database connection and must not pull mongoose in.
     const CommandDeployment = require('../models/CommandDeployment');
 
-    let claimed;
-    try {
-        // Deploy when the recorded hash differs *or* when a previous attempt
-        // claimed this hash and never finished. Without the second clause a
-        // process killed mid-PUT would leave its hash recorded and every later
-        // boot would skip the deploy it never actually made.
-        await CommandDeployment.findOneAndUpdate(
-            { _id: DEPLOYMENT_KEY, $or: [{ hash: { $ne: hash } }, { pending: true }] },
-            { $set: { hash, pending: true, clientId } },
-            { upsert: true, new: true }
-        );
-        claimed = true;
-    } catch (error) {
-        // The document exists and did not match the filter, so the upsert tried
-        // to insert a second one against the fixed _id. That is precisely the
-        // "already deployed, nothing to do" case.
-        if (error?.code === 11000) claimed = false;
-        else throw error;
-    }
-
-    if (!claimed) {
-        return { deployed: false, count: commands.length, reason: 'command set unchanged' };
+    const claim = await claimDeployment(CommandDeployment, hash, clientId);
+    if (!claim.claimed) {
+        return { deployed: false, count: commands.length, reason: claim.reason };
     }
 
     let count;
@@ -211,7 +269,10 @@ async function deployCommandsIfChanged(clientId, token, loadedCommands = null) {
         // deploy error with.
         try {
             await CommandDeployment.updateOne(
-                { _id: DEPLOYMENT_KEY },
+                // Only this claim may release it. Without the token a shard
+                // whose PUT failed would clear a claim a *later* boot had since
+                // taken, and both would then publish.
+                { _id: DEPLOYMENT_KEY, claimToken: claim.token },
                 { $set: { hash: null, pending: true } }
             );
         } catch (releaseError) {
@@ -224,19 +285,31 @@ async function deployCommandsIfChanged(clientId, token, loadedCommands = null) {
     // must not be reported as a failed deploy: the document still says
     // `pending`, so the next boot re-publishes — which is wasteful, not wrong.
     try {
-        await recordDeployment(clientId, hash, count);
+        await recordDeployment(clientId, hash, count, claim.token);
     } catch (error) {
         console.error('[DEPLOY] Published, but could not record the deployment:', error.message);
     }
     return { deployed: true, count, reason: 'command set changed' };
 }
 
-async function recordDeployment(clientId, hash, count) {
+/**
+ * Mark the claim satisfied: this hash is what Discord now has.
+ *
+ * `token` scopes the write to the claim that actually made the call, so a slow
+ * shard cannot mark someone else's in-flight claim finished. The `always` path
+ * has no claim to scope to and passes none.
+ *
+ * @param {string} clientId
+ * @param {string} hash fingerprint of the published set.
+ * @param {number} count how many commands were published.
+ * @param {string|null} [token] the claim token this deploy holds, if any.
+ */
+async function recordDeployment(clientId, hash, count, token = null) {
     const CommandDeployment = require('../models/CommandDeployment');
     await CommandDeployment.updateOne(
-        { _id: DEPLOYMENT_KEY },
+        token ? { _id: DEPLOYMENT_KEY, claimToken: token } : { _id: DEPLOYMENT_KEY },
         { $set: { hash, pending: false, clientId, commandCount: count, deployedAt: new Date() } },
-        { upsert: true }
+        { upsert: !token }
     );
 }
 
@@ -245,6 +318,7 @@ module.exports = {
     buildCommandPayload,
     deployCommandsIfChanged,
     commandSetHash,
+    claimDeployment,
     listCommandFiles,
     GLOBAL_COMMAND_LIMIT,
     COMMAND_BUDGET,

--- a/src/utils/errorReporter.js
+++ b/src/utils/errorReporter.js
@@ -25,16 +25,78 @@ const DISCORD_WEBHOOK = /^https:\/\/(?:\w+\.)?discord(?:app)?\.com\/api\/(?:v\d+
 // be cut somewhere; short enough to leave room for the frame around it.
 const DISCORD_LIMIT = 1800;
 
+const LOOPBACK = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+
+/**
+ * Parse and vet the configured sink.
+ *
+ * The report carries a stack trace and whatever failure context the caller
+ * attached, so where it goes and how it gets there both matter: over cleartext
+ * it is readable on the wire, and a sink that answers 3xx could otherwise walk
+ * the report to a host the operator never configured.
+ *
+ * https is always allowed. Plain http is allowed only to loopback, which is the
+ * legitimate case — a collector sidecar on the same host — and is the one place
+ * cleartext costs nothing. Anything else is refused rather than downgraded.
+ *
+ * @param {string} raw the ERROR_WEBHOOK_URL value.
+ * @returns {URL|null} the parsed URL, or null if it must not be used.
+ */
+function parseSink(raw) {
+    let url;
+    try {
+        url = new URL(raw);
+    } catch {
+        return null;
+    }
+    if (url.protocol === 'https:') return url;
+    if (url.protocol === 'http:' && LOOPBACK.has(url.hostname)) return url;
+    return null;
+}
+
+// Refusing a misconfigured sink silently would leave an operator believing
+// crashes were being reported. Said once per process, not once per crash.
+let warnedAboutSink = false;
+/**
+ * @param {string} raw the rejected value, used only for its scheme.
+ */
+function warnOnce(raw) {
+    if (warnedAboutSink) return;
+    warnedAboutSink = true;
+    // Deliberately does not echo the URL — it is a credential.
+    console.warn(
+        `[ERRORS] Ignoring ERROR_WEBHOOK_URL: expected an https:// URL (or http:// to loopback), got ${
+            raw.split(':')[0] || 'an unparseable value'
+        }://… — crash reports are NOT being sent.`
+    );
+}
+
+/**
+ * @returns {number} the wait budget for one report, in milliseconds — the
+ *   ERROR_REPORT_TIMEOUT_MS override when it is a positive number, else 2000.
+ */
 function timeoutMs() {
     const raw = Number(process.env.ERROR_REPORT_TIMEOUT_MS);
     return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_TIMEOUT_MS;
 }
 
-/** Whether anything is configured. Callers use this to decide to wait at all. */
+/**
+ * Whether a usable sink is configured. Callers use this to decide whether to
+ * wait before exiting at all — a URL that will be refused must not buy the
+ * crash path an extra two seconds.
+ */
 function isConfigured() {
-    return Boolean(String(process.env.ERROR_WEBHOOK_URL || '').trim());
+    const raw = String(process.env.ERROR_WEBHOOK_URL || '').trim();
+    return raw !== '' && parseSink(raw) !== null;
 }
 
+/**
+ * Reduce a thrown value to something JSON-serializable.
+ *
+ * @param {unknown} error anything at all — an unhandled rejection can carry a
+ *   string, or nothing.
+ * @returns {{name: string, message: string, stack: string|null}}
+ */
 function describe(error) {
     if (error instanceof Error) {
         return { name: error.name, message: error.message, stack: error.stack || null };
@@ -44,6 +106,13 @@ function describe(error) {
     return { name: typeof error, message: String(error), stack: null };
 }
 
+/**
+ * Shape the event for the sink it is going to.
+ *
+ * @param {string} url the destination, which is what decides the shape.
+ * @param {object} event the flat crash event.
+ * @returns {object} a Discord message for a Discord webhook, else `event` itself.
+ */
 function buildBody(url, event) {
     if (!DISCORD_WEBHOOK.test(url)) return event;
     const stack = event.error.stack || event.error.message;
@@ -62,8 +131,14 @@ function buildBody(url, event) {
  * @returns {Promise<boolean>} whether the sink accepted it.
  */
 async function reportError(kind, error, extra = {}) {
-    const url = String(process.env.ERROR_WEBHOOK_URL || '').trim();
-    if (!url) return false;
+    const raw = String(process.env.ERROR_WEBHOOK_URL || '').trim();
+    if (!raw) return false;
+
+    const url = parseSink(raw);
+    if (!url) {
+        warnOnce(raw);
+        return false;
+    }
 
     const event = {
         kind,
@@ -79,7 +154,10 @@ async function reportError(kind, error, extra = {}) {
         const response = await fetch(url, {
             method: 'POST',
             headers: { 'content-type': 'application/json' },
-            body: JSON.stringify(buildBody(url, event)),
+            body: JSON.stringify(buildBody(url.href, event)),
+            // A 3xx would otherwise carry the stack trace to whatever host the
+            // Location header names. The report is not worth following one for.
+            redirect: 'error',
             // Bounds the wait rather than the delivery: the exit below happens
             // either way, and a sink that is itself down is the likeliest thing
             // to be down at the same moment as the bot.
@@ -123,4 +201,4 @@ function reportAndExit(kind, error, { code = 1, exit = c => process.exit(c), ext
     );
 }
 
-module.exports = { reportError, reportAndExit, isConfigured, describe, buildBody };
+module.exports = { reportError, reportAndExit, isConfigured, describe, buildBody, parseSink };

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -74,6 +74,11 @@ function addContext(fields) {
     return true;
 }
 
+/**
+ * @param {unknown} raw the LOG_LEVEL value, as the environment gave it.
+ * @param {(msg: string) => void} [warn] where to report a value that was ignored.
+ * @returns {string} a level pino accepts.
+ */
 function resolveLevel(raw, warn = () => {}) {
     const value = String(raw ?? '').trim().toLowerCase();
     if (value === '') return DEFAULT_LEVEL;
@@ -84,6 +89,11 @@ function resolveLevel(raw, warn = () => {}) {
     return DEFAULT_LEVEL;
 }
 
+/**
+ * @param {unknown} raw the LOG_FORMAT value.
+ * @returns {'json'|'pretty'} explicit setting if it names one, else the default
+ *   for this NODE_ENV.
+ */
 function resolveFormat(raw) {
     const value = String(raw ?? '').trim().toLowerCase();
     if (value === 'json' || value === 'pretty') return value;
@@ -122,6 +132,12 @@ function prettyLine(record, colour = false) {
     return `${line}\n`;
 }
 
+/**
+ * @param {'json'|'pretty'} format
+ * @param {NodeJS.WritableStream} out
+ * @returns {object} what pino writes to: the stream itself for JSON, or a
+ *   renderer wrapping it for pretty.
+ */
 function createDestination(format, out) {
     if (format === 'json') return out;
     const colour = Boolean(out.isTTY) && !process.env.NO_COLOR;
@@ -139,6 +155,17 @@ function createDestination(format, out) {
     };
 }
 
+/**
+ * Build a logger. The module's own `logger` is one of these over stdout; tests
+ * make their own over a collector so they can assert on the records.
+ *
+ * @param {object} [options]
+ * @param {string} [options.level] overrides LOG_LEVEL.
+ * @param {string} [options.format] overrides LOG_FORMAT.
+ * @param {NodeJS.WritableStream} [options.out] where lines go.
+ * @param {(msg: string) => void} [options.warn] where a rejected LOG_LEVEL is reported.
+ * @returns {import('pino').Logger}
+ */
 function createLogger({
     level = process.env.LOG_LEVEL,
     format = process.env.LOG_FORMAT,
@@ -169,6 +196,11 @@ const TAG = /^\[([A-Za-z0-9 _/:.-]{1,32})\]\s*/;
 // is one of several.
 const SHARD_TAG = /^\[shard (\d+)\/(\d+)\]\s*/;
 
+/**
+ * @param {unknown[]} args
+ * @returns {{err: Error|null, rest: unknown[]}} the first Error, and everything
+ *   else in the order it was passed.
+ */
 function splitArgs(args) {
     // The first Error becomes `err`, so pino serializes its stack into a field
     // instead of `util.format` flattening it into the message text. The rest is
@@ -182,13 +214,65 @@ function splitArgs(args) {
     return { err, rest };
 }
 
+// Keys whose value is a credential, whatever the object around them is called.
+// Matched as a substring so `discordToken`, `X-Api-Key` and `sessionSecret` are
+// all caught alongside the bare names.
+const SECRET_KEY = /token|secret|password|passwd|api[-_]?key|apikey|authorization|cookie|credential/i;
+
+// Deep enough for the shapes that actually turn up (an axios error's
+// `config.headers`, a Mongo command document); past that the value is
+// truncated by `formatWithOptions` anyway.
+const SCRUB_DEPTH = 4;
+
+/**
+ * Replace credential-valued keys in a console argument with `[redacted]`,
+ * returning a copy — the original object belongs to the caller and is very
+ * often the live config or request that is about to be retried.
+ *
+ * pino's own `redact` covers `logger.x({ ... })` calls, but it only sees
+ * structured fields, and a bridged `console.error('[X] failed', err.config)`
+ * has been through `util.format` into a message string long before pino is
+ * handed it. Scrubbing the argument first is what makes the two paths agree,
+ * and it works at any nesting depth rather than needing a redact path
+ * enumerated per shape.
+ *
+ * @param {unknown} value
+ * @param {number} [depth] recursion budget remaining.
+ * @param {WeakSet} [seen] guards the cycles that `util.format` prints as
+ *   `[Circular]` and a naive walk would follow forever.
+ * @returns {unknown} the value, or a scrubbed copy of it.
+ */
+function scrubSecrets(value, depth = SCRUB_DEPTH, seen = new WeakSet()) {
+    if (value === null || typeof value !== 'object' || depth <= 0) return value;
+    // An Error's own enumerable properties can carry a request config; the
+    // stack is handled separately, so leave the instance itself alone rather
+    // than copying it into a plain object and losing that.
+    if (value instanceof Error) return value;
+    if (seen.has(value)) return value;
+    seen.add(value);
+
+    if (Array.isArray(value)) return value.map(v => scrubSecrets(v, depth - 1, seen));
+
+    const out = {};
+    for (const [key, v] of Object.entries(value)) {
+        out[key] = SECRET_KEY.test(key) ? '[redacted]' : scrubSecrets(v, depth - 1, seen);
+    }
+    return out;
+}
+
 /**
  * Turn a `console.*` argument list into the `(fields, message)` pair pino
  * takes. Exported so tests can pin the parsing without capturing output.
+ *
+ * @param {unknown[]} args exactly what was passed to `console.*`.
+ * @returns {{fields: object, msg: string}}
  */
 function toRecord(args) {
     const { err, rest } = splitArgs(args);
-    let msg = rest.length ? formatWithOptions({ colors: false, depth: 4 }, ...rest) : '';
+    // The format string itself is never an object, so scrubbing the whole list
+    // cannot disturb the specifiers in it.
+    const safe = rest.map(arg => scrubSecrets(arg));
+    let msg = safe.length ? formatWithOptions({ colors: false, depth: 4 }, ...safe) : '';
 
     let shard;
     const shardMatch = SHARD_TAG.exec(msg);
@@ -219,6 +303,12 @@ function toRecord(args) {
  * Returns a function that puts the originals back, which is what tests use.
  * Idempotent: installing twice does not stack two bridges, and the restore
  * still returns the real console.
+ */
+/**
+ * @param {object} [options]
+ * @param {object} [options.target] the console to replace; defaults to the real one.
+ * @param {import('pino').Logger} [options.log] where the calls are routed.
+ * @returns {() => void} restores the original methods.
  */
 function installConsoleBridge({ target = console, log = logger } = {}) {
     if (target.__clawdiaConsoleBridge) return target.__clawdiaConsoleBridge;
@@ -254,6 +344,7 @@ module.exports = {
     // Exported for the tests that pin the parsing, the rendering and the
     // environment handling.
     toRecord,
+    scrubSecrets,
     prettyLine,
     resolveLevel,
     resolveFormat,

--- a/tests/commandDeployGate.test.js
+++ b/tests/commandDeployGate.test.js
@@ -17,12 +17,51 @@ jest.mock('discord.js', () => ({
     Routes: { applicationCommands: id => `/applications/${id}/commands` },
 }));
 
+const mockFindOne = jest.fn();
 const mockFindOneAndUpdate = jest.fn();
 const mockUpdateOne = jest.fn().mockResolvedValue({});
 jest.mock('../src/models/CommandDeployment', () => ({
+    findOne: (...args) => ({ lean: () => mockFindOne(...args) }),
     findOneAndUpdate: (...args) => mockFindOneAndUpdate(...args),
     updateOne: (...args) => mockUpdateOne(...args),
 }));
+
+/**
+ * A single-document stand-in for the collection, with Mongo's matching rules
+ * for the two things the claim depends on: `null` also matches a missing field,
+ * and a filter that does not match updates nothing. Stubbing findOneAndUpdate
+ * with a fixed answer would assert the mock, not the compare-and-swap.
+ */
+function fakeCollection(initial = null) {
+    let doc = initial ? { ...initial } : null;
+    const matches = filter => {
+        if (!doc) return false;
+        return Object.entries(filter).every(([key, want]) => {
+            if (key === '_id') return true;
+            const have = doc[key] ?? null;
+            return (want ?? null) === have;
+        });
+    };
+    mockFindOne.mockImplementation(async () => (doc ? { ...doc } : null));
+    mockFindOneAndUpdate.mockImplementation(async (filter, update, options = {}) => {
+        if (matches(filter)) {
+            doc = { ...doc, ...update.$set };
+            return { ...doc };
+        }
+        if (options.upsert && !doc) {
+            doc = { _id: DEPLOYMENT_KEY, ...update.$set };
+            return { ...doc };
+        }
+        if (options.upsert && doc) throw duplicateKey();
+        return null;
+    });
+    mockUpdateOne.mockImplementation(async (filter, update, options = {}) => {
+        if (matches(filter)) doc = { ...doc, ...update.$set };
+        else if (options.upsert && !doc) doc = { _id: DEPLOYMENT_KEY, ...update.$set };
+        return {};
+    });
+    return { current: () => doc };
+}
 
 const {
     deployCommandsIfChanged,
@@ -40,12 +79,16 @@ const fakeCommand = name => ({
 const duplicateKey = () => Object.assign(new Error('E11000 duplicate key'), { code: 11000 });
 
 const COMMANDS = [fakeCommand('fish'), fakeCommand('hunt')];
+const HASH = commandSetHash('client-id', COMMANDS.map(c => c.data.toJSON()));
 
 beforeEach(() => {
     mockPut.mockClear().mockResolvedValue(undefined);
-    mockFindOneAndUpdate.mockReset().mockResolvedValue({});
-    mockUpdateOne.mockClear().mockResolvedValue({});
+    mockFindOne.mockReset();
+    mockFindOneAndUpdate.mockReset();
+    mockUpdateOne.mockReset().mockResolvedValue({});
     delete process.env.DEPLOY_COMMANDS;
+    // Empty collection: a fresh install.
+    fakeCollection(null);
 });
 
 afterAll(() => {
@@ -69,34 +112,49 @@ describe('the boot deploy', () => {
         await deployCommandsIfChanged('client-id', 'token', COMMANDS);
 
         const [filter, update] = mockUpdateOne.mock.calls.at(-1);
-        expect(filter).toEqual({ _id: DEPLOYMENT_KEY });
-        expect(update.$set.hash).toBe(commandSetHash('client-id', COMMANDS.map(c => c.data.toJSON())));
+        expect(filter._id).toBe(DEPLOYMENT_KEY);
+        // Scoped to this deploy's own claim, so a slow shard cannot mark
+        // someone else's in-flight claim finished.
+        expect(filter.claimToken).toEqual(expect.any(String));
+        expect(update.$set.hash).toBe(HASH);
         expect(update.$set.pending).toBe(false);
         expect(update.$set.commandCount).toBe(2);
     });
 
     test('makes no Discord call when the set is unchanged', async () => {
-        mockFindOneAndUpdate.mockRejectedValue(duplicateKey());
+        fakeCollection({ _id: DEPLOYMENT_KEY, hash: HASH, pending: false, claimToken: 'tok-1' });
 
         const result = await deployCommandsIfChanged('client-id', 'token', COMMANDS);
 
         expect(result).toEqual({ deployed: false, count: 2, reason: 'command set unchanged' });
         expect(mockPut).not.toHaveBeenCalled();
+        // Not even a write: the common restart is one indexed read.
+        expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    test('publishes when the recorded hash is an older set', async () => {
+        fakeCollection({ _id: DEPLOYMENT_KEY, hash: 'an-older-hash', pending: false, claimToken: 'tok-1' });
+
+        const result = await deployCommandsIfChanged('client-id', 'token', COMMANDS);
+
+        expect(result.deployed).toBe(true);
+        expect(mockPut).toHaveBeenCalledTimes(1);
     });
 
     test('claims a hash that a previous boot left pending', async () => {
         // The crash case: a process killed mid-PUT leaves `pending: true` with
-        // the new hash already written. Matching only on `hash: { $ne }` would
-        // skip that deploy forever.
-        await deployCommandsIfChanged('client-id', 'token', COMMANDS);
+        // the new hash already written. Treating that as "already published"
+        // would skip the deploy forever.
+        fakeCollection({ _id: DEPLOYMENT_KEY, hash: HASH, pending: true, claimToken: 'tok-1' });
 
-        const [filter, update] = mockFindOneAndUpdate.mock.calls[0];
-        expect(filter._id).toBe(DEPLOYMENT_KEY);
-        expect(filter.$or).toContainEqual({ pending: true });
-        expect(update.$set.pending).toBe(true);
+        const result = await deployCommandsIfChanged('client-id', 'token', COMMANDS);
+
+        expect(result.deployed).toBe(true);
+        expect(mockPut).toHaveBeenCalledTimes(1);
     });
 
     test('releases the claim when Discord rejects the payload', async () => {
+        const store = fakeCollection(null);
         mockPut.mockRejectedValue(new Error('rate limited'));
 
         await expect(deployCommandsIfChanged('client-id', 'token', COMMANDS))
@@ -104,12 +162,23 @@ describe('the boot deploy', () => {
 
         // Without this the failed hash stays recorded and every later boot
         // skips a deploy that never actually happened.
-        const [, update] = mockUpdateOne.mock.calls.at(-1);
-        expect(update.$set).toEqual({ hash: null, pending: true });
+        expect(store.current()).toMatchObject({ hash: null, pending: true });
+    });
+
+    test('only the claim holder may release it', async () => {
+        // A shard whose PUT failed must not clear a claim that a later boot has
+        // since taken, or both would publish.
+        const store = fakeCollection(null);
+        mockPut.mockRejectedValue(new Error('rate limited'));
+        const deploy = deployCommandsIfChanged('client-id', 'token', COMMANDS);
+        await expect(deploy).rejects.toThrow('rate limited');
+
+        const released = store.current();
+        expect(mockUpdateOne.mock.calls.at(-1)[0].claimToken).toBe(released.claimToken);
     });
 
     test('propagates a database error rather than silently not deploying', async () => {
-        mockFindOneAndUpdate.mockRejectedValue(new Error('connection lost'));
+        mockFindOne.mockRejectedValue(new Error('connection lost'));
 
         await expect(deployCommandsIfChanged('client-id', 'token', COMMANDS))
             .rejects.toThrow('connection lost');
@@ -211,5 +280,93 @@ describe('a deploy that published but could not record itself', () => {
         expect(result.deployed).toBe(true);
         expect(errors).toHaveBeenCalledWith(expect.stringContaining('could not record'), expect.anything());
         errors.mockRestore();
+    });
+});
+
+describe('concurrent startups', () => {
+    // #854 review: the original claim matched on `hash: { $ne }`, which every
+    // shard's filter satisfies when the stored document holds an older hash —
+    // so N shards all claimed and all published the same set. These hold the
+    // compare-and-swap that replaced it.
+
+    /**
+     * Holds every PUT open until released, so the callers genuinely overlap —
+     * a winner parked mid-publish is exactly the window in which a second
+     * claimant must not also reach Discord. A PUT that arrives after the
+     * release resolves at once, so the test never depends on how many ticks the
+     * claim takes.
+     */
+    function pendingPuts() {
+        let released = false;
+        const resolvers = [];
+        mockPut.mockImplementation(() => (released
+            ? Promise.resolve()
+            : new Promise(resolve => resolvers.push(resolve))));
+        return {
+            release() {
+                released = true;
+                for (const resolve of resolvers) resolve();
+            },
+        };
+    }
+
+    /** Lets every caller run to its first real suspension point. */
+    const settle = () => new Promise(resolve => setImmediate(resolve));
+
+    test('only one of four shards publishes, from an empty collection', async () => {
+        fakeCollection(null);
+        const puts = pendingPuts();
+
+        const results = Promise.all(
+            [0, 1, 2, 3].map(() => deployCommandsIfChanged('client-id', 'token', COMMANDS))
+        );
+        await settle();
+        puts.release();
+
+        const settled = await results;
+        expect(mockPut).toHaveBeenCalledTimes(1);
+        expect(settled.filter(r => r.deployed)).toHaveLength(1);
+    });
+
+    test('only one of four shards publishes when an older set is recorded', async () => {
+        // The case the duplicate-key guard never covered: the document exists,
+        // so nothing inserts and every filter used to match.
+        fakeCollection({ _id: DEPLOYMENT_KEY, hash: 'an-older-hash', pending: false, claimToken: 'tok-1' });
+        const puts = pendingPuts();
+
+        const results = Promise.all(
+            [0, 1, 2, 3].map(() => deployCommandsIfChanged('client-id', 'token', COMMANDS))
+        );
+        await settle();
+        puts.release();
+
+        const settled = await results;
+        expect(mockPut).toHaveBeenCalledTimes(1);
+        expect(settled.filter(r => r.deployed)).toHaveLength(1);
+        for (const loser of settled.filter(r => !r.deployed)) {
+            expect(loser.reason).toBe('another process is publishing this set');
+        }
+    });
+
+    test('only one of four shards takes over a claim left pending by a crash', async () => {
+        fakeCollection({ _id: DEPLOYMENT_KEY, hash: HASH, pending: true, claimToken: 'tok-1' });
+        const puts = pendingPuts();
+
+        const results = Promise.all(
+            [0, 1, 2, 3].map(() => deployCommandsIfChanged('client-id', 'token', COMMANDS))
+        );
+        await settle();
+        puts.release();
+
+        await results;
+        expect(mockPut).toHaveBeenCalledTimes(1);
+    });
+
+    test('the winner leaves the record settled on the hash it published', async () => {
+        const store = fakeCollection({ _id: DEPLOYMENT_KEY, hash: 'older', pending: false, claimToken: 'tok-1' });
+
+        await Promise.all([0, 1].map(() => deployCommandsIfChanged('client-id', 'token', COMMANDS)));
+
+        expect(store.current()).toMatchObject({ hash: HASH, pending: false, commandCount: 2 });
     });
 });

--- a/tests/errorReporter.test.js
+++ b/tests/errorReporter.test.js
@@ -10,7 +10,7 @@
  * and that a failing sink cannot replace the error it was reporting.
  */
 
-const { reportError, reportAndExit, isConfigured, describe: describeError, buildBody } =
+const { reportError, reportAndExit, isConfigured, describe: describeError, buildBody, parseSink } =
     require('../src/utils/errorReporter');
 
 const DISCORD_URL = 'https://discord.com/api/webhooks/123/abc';
@@ -60,7 +60,9 @@ describe('with a sink configured', () => {
         await reportError('unhandledRejection', new Error('boom'), { guildId: '42' });
 
         const [url, init] = fetchMock.mock.calls[0];
-        expect(url).toBe(PLAIN_URL);
+        // A parsed URL, not the raw string — fetch is handed only what
+        // parseSink vetted.
+        expect(String(url)).toBe(PLAIN_URL);
         expect(init.method).toBe('POST');
         const body = JSON.parse(init.body);
         expect(body).toMatchObject({
@@ -165,5 +167,63 @@ describe('describe()', () => {
 
     test('says something useful about undefined', () => {
         expect(describeError(undefined)).toEqual({ name: 'undefined', message: 'undefined', stack: null });
+    });
+});
+
+describe('the sink URL is vetted before anything is sent', () => {
+    // #854 review (CWE-319): the report carries a stack trace and whatever
+    // failure context the caller attached, so cleartext delivery exposes it,
+    // and a 3xx would hand it to a host the operator never configured.
+
+    test.each([
+        ['https://errors.example.com/ingest', true],
+        ['https://discord.com/api/webhooks/1/a', true],
+        // Loopback is the legitimate cleartext case — a collector sidecar on
+        // the same host, where there is no wire to read.
+        ['http://localhost:9000/ingest', true],
+        ['http://127.0.0.1:9000/ingest', true],
+        ['http://errors.example.com/ingest', false],
+        ['http://logs.internal:9000/ingest', false],
+        ['ftp://errors.example.com/ingest', false],
+        ['javascript:alert(1)', false],
+        ['not a url at all', false],
+    ])('%s → %s', (url, allowed) => {
+        expect(Boolean(parseSink(url))).toBe(allowed);
+    });
+
+    test('a cleartext sink sends nothing and says so once', async () => {
+        process.env.ERROR_WEBHOOK_URL = 'http://errors.example.com/ingest';
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        await expect(reportError('uncaughtException', new Error('boom'))).resolves.toBe(false);
+
+        expect(fetchMock).not.toHaveBeenCalled();
+        // Silence would leave an operator believing crashes were being reported.
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('ERROR_WEBHOOK_URL'));
+        // ...and never echoes the URL, which is a credential.
+        expect(warn.mock.calls[0][0]).not.toContain('errors.example.com');
+        warn.mockRestore();
+    });
+
+    test('a refused sink does not buy the crash path an extra wait', () => {
+        process.env.ERROR_WEBHOOK_URL = 'http://errors.example.com/ingest';
+        expect(isConfigured()).toBe(false);
+
+        const exit = jest.fn();
+        reportAndExit('uncaughtException', new Error('boom'), { exit });
+        // Synchronous, as with no sink at all.
+        expect(exit).toHaveBeenCalledWith(1);
+    });
+
+    test('refuses to follow a redirect', async () => {
+        process.env.ERROR_WEBHOOK_URL = PLAIN_URL;
+        await reportError('uncaughtException', new Error('boom'));
+        expect(fetchMock.mock.calls[0][1].redirect).toBe('error');
+    });
+
+    test('passes the parsed URL through, so the sent target is the vetted one', async () => {
+        process.env.ERROR_WEBHOOK_URL = PLAIN_URL;
+        await reportError('uncaughtException', new Error('boom'));
+        expect(String(fetchMock.mock.calls[0][0])).toBe(PLAIN_URL);
     });
 });

--- a/tests/structuredLogging.test.js
+++ b/tests/structuredLogging.test.js
@@ -21,6 +21,7 @@ const {
     withContext,
     addContext,
     toRecord,
+    scrubSecrets,
     prettyLine,
     resolveLevel,
     resolveFormat,
@@ -173,6 +174,63 @@ describe('correlation context', () => {
         });
 
         expect(out.records()[0]).toMatchObject({ requestId: 'req-1', userId: 'u1' });
+    });
+});
+
+describe('redaction through the console bridge', () => {
+    // #854 review: pino's `redact` only sees structured fields, and the bridge
+    // hands it a message string that `util.format` has already flattened — so
+    // a credential passed as a console argument reached the log intact. The
+    // argument is scrubbed before it is formatted.
+
+    test.each([
+        ['token', { token: 'gateway-token' }, 'gateway-token'],
+        ['authorization', { headers: { authorization: 'Bearer abc' } }, 'Bearer abc'],
+        ['apiKey', { config: { apiKey: 'sk-live-123' } }, 'sk-live-123'],
+    ])('censors %s passed as a console argument', (_label, payload, secret) => {
+        const { out, log } = jsonLogger();
+        const target = {};
+        installConsoleBridge({ target, log });
+
+        target.error('[AI] request failed', payload);
+
+        expect(out.lines[0]).not.toContain(secret);
+        expect(out.lines[0]).toContain('[redacted]');
+    });
+
+    test('catches a credential nested below the top level', () => {
+        // An axios error's `config.headers.Authorization` is three deep, which
+        // is why this is a walk rather than a fixed path list.
+        const scrubbed = scrubSecrets({ a: { b: { c: { sessionSecret: 'shh' } } } });
+        expect(JSON.stringify(scrubbed)).not.toContain('shh');
+    });
+
+    test('matches the key by substring, not by exact name', () => {
+        const scrubbed = scrubSecrets({ discordToken: 'x', 'X-Api-Key': 'y', refreshToken: 'z' });
+        expect(Object.values(scrubbed)).toEqual(['[redacted]', '[redacted]', '[redacted]']);
+    });
+
+    test('leaves everything else exactly as it was', () => {
+        const input = { url: 'https://x', retries: 2, nested: { ok: true } };
+        expect(scrubSecrets(input)).toEqual(input);
+    });
+
+    test('copies rather than mutating — the caller is often about to retry it', () => {
+        const config = { headers: { authorization: 'Bearer abc' } };
+        scrubSecrets(config);
+        expect(config.headers.authorization).toBe('Bearer abc');
+    });
+
+    test('survives a cycle', () => {
+        const cyclic = { token: 'x' };
+        cyclic.self = cyclic;
+        expect(() => scrubSecrets(cyclic)).not.toThrow();
+        expect(scrubSecrets(cyclic).token).toBe('[redacted]');
+    });
+
+    test('leaves an Error instance intact, so its stack still serializes', () => {
+        const err = new Error('boom');
+        expect(scrubSecrets(err)).toBe(err);
     });
 });
 


### PR DESCRIPTION
Follow-up to #854. Those fixes were pushed about a minute after that PR merged, so they missed it — #854 merged with one commit and this is the second. Everything here is a fix to code #854 introduced; nothing else is touched.

CodeRabbit left four findings on #854 ([review](https://github.com/TheShield2594/clawdia/pull/854#pullrequestreview-5054246813)). Three were real and are fixed here; the fourth I declined with reasons, on [its thread](https://github.com/TheShield2594/clawdia/pull/854#discussion_r3883311055). All four threads carry replies over there, but their fixes live here — hence this note, so the trail joins up.

## The deployment claim was not exclusive

The one that matters most, and it was worse than reported. `findOneAndUpdate` on `{ hash: { $ne } }` matches *every* caller once the document exists holding an older hash — Mongo serializes the writes but matches all of them, so the duplicate-key error only ever guarded the case where no document existed yet. The gate therefore did nothing on precisely the boot it was written for: the first restart after a command changes.

Single-process deploys (`npm start`, the default) have no concurrency and were unaffected. Under `npm run start:sharded` every shard claimed and every shard PUT the full ~98-command set.

Replaced with a compare-and-swap on a `claimToken` rewritten by every attempt: each caller CASes against the token it read, so only the first write matches and the losers get `null` back. The release and the success write are scoped to the same token, so a shard whose PUT failed cannot clear a claim a later boot has since taken.

Deliberately **no lease expiry**, which is where this departs from the review's suggestion. An abandoned claim is already recovered by `pending` — the next boot sees an unfinished claim and takes it over — which needs no wall clock and no guess at how long a legitimate PUT may take. A lease would add a second recovery path with a timeout to tune, for a case the first one already covers.

The gate's test double is now a small in-memory collection implementing Mongo's matching rules for the two things the CAS turns on (`null` matches a missing field; a non-matching filter updates nothing). Stubbing `findOneAndUpdate` with a fixed answer would have asserted the mock rather than the swap. Four overlapping callers, held mid-PUT, against an empty collection, against a recorded older hash, and against a claim left pending by a crash — `mockPut` fires exactly once in each.

## Credentials passed to `console.*` bypassed redaction

Live for every deployment on the merged code. pino's `redact` only sees structured fields, and the bridge hands it a message string `util.format` flattened long before — so `console.error('[AI] request failed', err.config)` wrote an Authorization header into the log. The redact list only ever protected direct `logger.x({ ... })` calls, which was the half of the traffic that was not the problem.

Console arguments are now scrubbed before they are formatted. Took the "redact before formatting" option rather than lifting objects into a structured field: lifting needs a redact path enumerated per shape (pino's paths have no recursive wildcard) and would leave the pretty renderer printing the raw object anyway.

`scrubSecrets` matches credential-named keys by substring, so `discordToken`, `X-Api-Key` and `sessionSecret` are caught alongside the bare names. Depth-bounded, cycle-safe, and it copies rather than mutates — the caller is usually about to retry with that same config object, and handing back a `[redacted]` header would break the retry.

Still not caught, and not catchable: an interpolated string. By the time `` `key=${apiKey}` `` arrives it is text with nothing to distinguish it from any other text. `docs/EXTENDING.md` already tells contributors not to treat redaction as permission.

## The crash report is sent over a vetted URL (CWE-319)

Latent rather than live — `ERROR_WEBHOOK_URL` ships in this release, so no deployment has one set yet. The report carries a stack trace and whatever context the caller attached, and the URL was taken as given: any scheme, any host, redirects followed.

Now parsed with `URL` and required to be `https:` — or `http:` to loopback, which is narrower than the review asked for and deliberate: a collector sidecar on the same host is the legitimate cleartext case, with no wire to read, and https-only would break it for no gain. Everything else non-https is refused.

Two things fell out of the fix:

- The refusal is not silent. It warns once per process, because an operator who set a cleartext URL and got nothing would otherwise believe crashes were being reported. The warning names the scheme only, never the URL, which is a credential.
- `isConfigured()` vets rather than just checking for a non-empty string, so a rejected sink cannot buy the crash path its full `ERROR_REPORT_TIMEOUT_MS` wait before exiting on a request that was never going to be made.

`redirect: 'error'` stops a `3xx` walking the report to a host nobody configured.

## Also

- JSDoc tags on the functions that had prose but no annotations, which is what CodeRabbit's docstring-coverage check was counting.
- `.env.example` now says the pre-migration dumps age out on `BACKUP_RETENTION_DAYS`, and that they need copying out to survive past it. This is the real gap under the fourth finding — the variable was already in the template at line 62, and a second assignment would have meant dotenv silently ignoring the first.

## Verification

Rebased onto the merged `main` (`80329bf`) and re-validated there, since none of this ever ran through CI on #854:

- `npm run lint` clean.
- 256 suites / 4773 tests pass.
- `npm run coverage:check` passes; `src/utils` measures higher again but the floor is left where #854 set it.
- The three `tests/integration/` suites are excluded locally — `mongodb-memory-server` gets a 403 fetching a mongod binary in my sandbox — and pass in CI, as they did on #854.

No behaviour change beyond the three fixes. The `ERROR_WEBHOOK_URL` constraint is the only one an operator could notice, and only if they set a cleartext non-loopback URL, which would previously have sent stack traces in the clear.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYW5CbvZAAw9prkEv7TRMb)_