### PR TITLE
Close the six small gaps around the MCP client (#838)

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,11 +384,18 @@ looking up does not eat the allowance for the next one, and a user cannot spend
 without bound by asking the same expensive question over and over. Past it the
 model is told the call was refused and answers from what it has.
 
-Tools that write something can be made to wait: the Approval setting posts
+Tools that write something wait for a person: the Approval setting posts
 **Run it** / **Cancel** in the channel for a tool call and does not run it until
-the person who asked, or anyone who can manage the server, says so. The
-Connections tab also keeps a seven-day rollup of what each connection has been
-doing — calls, failures, refusals, latency and the last error.
+the person who asked, or anyone who can manage the server, says so. Adding a
+first connection turns that on for writes, since connecting a server is not by
+itself consent to unattended ones.
+
+It runs the other way too. A tool that gets halfway and needs one more fact can
+ask, and the question appears in the channel as a form to fill in — bounded to
+two questions a reply, and labelled with which server is asking, because a real
+one will not ask for a password or a key. The Connections tab also keeps a
+seven-day rollup of what each connection has been doing — calls, failures,
+refusals, latency and the last error.
 
 Approvals and that rollup both need the bot to be the one making the call, which
 on Claude it is not by default — Anthropic's connector opens the connections on

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -349,13 +349,23 @@ malformed config disables the connector, it never stops the bot from starting.
   run concurrently, up to six at a time. A round costs its slowest call rather
   than the sum, but a server on the far side sees several requests together.
 - **Approval** (Connections → Approval) decides which tool calls stop and wait
-  for someone to click **Run it** in the channel. `off` is the default and runs
-  everything straight away. `destructive` and `writes` both read the annotations
-  a server publishes about its own tools; they differ over a tool that publishes
-  none, which `destructive` lets through and `writes` asks about. `always` asks
-  about every call, reads included. A prompt can be answered by whoever asked or
-  by anyone with Manage Server, and expires unanswered after a minute — which
-  means the tool does not run.
+  for someone to click **Run it** in the channel. Adding your first connection
+  sets this to `writes`, because connecting a server is not by itself consent to
+  unattended writes on it; change it to `off` if you would rather everything ran
+  straight away. `destructive` and `writes` both read the annotations a server
+  publishes about its own tools; they differ over a tool that publishes none,
+  which `destructive` lets through and `writes` asks about. `always` asks about
+  every call, reads included. A prompt can be answered by whoever asked or by
+  anyone with Manage Server, and expires unanswered after a minute — which means
+  the tool does not run.
+- **Questions from a server** are the same idea in reverse. A tool that gets
+  halfway and needs one more fact — which environment, which of your three
+  organisations — can ask, and the question appears in the channel with an
+  **Answer** button that opens a form. Whoever asked, or anyone with Manage
+  Server, can fill it in; nobody answering means the server is told so and the
+  tool decides what to do about it. At most two questions per reply, and the
+  prompt says out loud that a real server will not ask for a password, an API
+  key or a login code — cancel if one does.
 - Tool annotations come from the server, so the two middle modes are worth what
   that server is honest about. *Never these tools* and the per-connection
   *Always ask before these tools* list ask the server nothing; use those where

--- a/src/config/mcpServers.js
+++ b/src/config/mcpServers.js
@@ -39,7 +39,22 @@ const MAX_TOKEN_LENGTH = 4096;
  * itself. An admin who needs a guarantee uses that, or the block list.
  */
 const CONFIRM_MODES = ['off', 'destructive', 'writes', 'always'];
+
+// What a guild that has never chosen is read as. Still `off`: this is the value
+// behind every guild running today, and changing it would start asking them to
+// approve calls that have been running unattended since they set the feature up.
 const DEFAULT_CONFIRM_MODE = 'off';
+
+// What the dashboard *writes* onto a guild adding its first server (#838).
+//
+// The distinction is the whole point. `off` is a fine reading of silence and a
+// poor first answer: connecting a server is not consent to unattended writes on
+// it, and an admin who has just typed in a GitHub endpoint has no idea a
+// default even exists to be changed. Storing a value on the first save makes
+// the policy visible in the panel from the start, and one click undoes it —
+// whereas moving `DEFAULT_CONFIRM_MODE` would silently re-govern every guild
+// that has been running on the old reading of silence.
+const FIRST_SERVER_CONFIRM_MODE = 'writes';
 
 /**
  * How a guild on Claude reaches its MCP servers.
@@ -515,6 +530,7 @@ module.exports = {
     NAME_PATTERN,
     CONFIRM_MODES,
     DEFAULT_CONFIRM_MODE,
+    FIRST_SERVER_CONFIRM_MODE,
     MCP_ROUTES,
     DEFAULT_MCP_ROUTE,
     guildServersAllowed,

--- a/src/dashboard/routes/api/mcpOAuth.js
+++ b/src/dashboard/routes/api/mcpOAuth.js
@@ -64,10 +64,33 @@ const { decryptSecret } = require('../../../config/secretBox');
 
 const CALLBACK_PATH = '/mcp/oauth/callback';
 
-/** The one redirect URI every flow uses. See the note above on why it is fixed. */
+/**
+ * The one redirect URI every flow uses. See the note above on why it is fixed.
+ *
+ * The localhost fallback is for a developer running the dashboard on their own
+ * machine and nobody else (#838). In a deployment it is worse than nothing: the
+ * URI is registered with the authorization server *and* checked by it on the
+ * way back, so an unset `DASHBOARD_URL` produces a flow that either fails at
+ * registration or sends the admin's browser to a port on their own laptop
+ * carrying an authorization code — with an error, if it surfaces at all, that
+ * says nothing about which variable is missing.
+ *
+ * So it is refused rather than guessed at whenever the process is not plainly
+ * local: the caller turns this into a 500 naming the variable, which is a
+ * minute of an admin's time instead of an afternoon.
+ */
 function redirectUriFor() {
-    const base = process.env.DASHBOARD_URL || `http://localhost:${process.env.DASHBOARD_PORT || 3000}`;
-    return `${base.replace(/\/+$/, '')}/api${CALLBACK_PATH}`;
+    const configured = String(process.env.DASHBOARD_URL || '').trim();
+    if (!configured) {
+        if (process.env.NODE_ENV === 'production') {
+            throw new OAuthError(
+                'DASHBOARD_URL is not set, so there is no address to send the OAuth callback back to. '
+                + 'Set it to the dashboard\'s public URL and try again.',
+            );
+        }
+        return `http://localhost:${process.env.DASHBOARD_PORT || 3000}/api${CALLBACK_PATH}`;
+    }
+    return `${configured.replace(/\/+$/, '')}/api${CALLBACK_PATH}`;
 }
 
 /**

--- a/src/dashboard/routes/api/mcpServers.js
+++ b/src/dashboard/routes/api/mcpServers.js
@@ -14,6 +14,7 @@ const {
     requiresApproval,
     CONFIRM_MODES,
     DEFAULT_CONFIRM_MODE,
+    FIRST_SERVER_CONFIRM_MODE,
     MCP_ROUTES,
     DEFAULT_MCP_ROUTE
 } = require('../../../config/mcpServers');
@@ -373,6 +374,7 @@ router.put('/guild/:guildId/mcp-servers/:name', checkAuth, checkGuildAccess, che
         const tokenProvided = typeof req.body?.authorizationToken === 'string';
         const token = tokenProvided ? (req.body.authorizationToken.trim() || null) : undefined;
         let oauthCleared = null;
+        let confirmModeDefaulted = null;
 
         if (existing) {
             // An OAuth grant is bound to the resource it was issued for and to
@@ -401,6 +403,31 @@ router.put('/guild/:guildId/mcp-servers/:name', checkAuth, checkGuildAccess, che
                 addedBy: req.user?.id || null
             });
             guildSettings.ai.mcpServers = servers;
+
+            // The first connection a guild adds picks the approval policy up
+            // with it (#838). `off` is the stored default, and a default of
+            // "run anything the model asks for, unattended" is the wrong first
+            // answer for a feature whose whole point is reaching somebody
+            // else's system — an admin who connects a GitHub server has not
+            // consented to unattended issue-filing by connecting it.
+            //
+            // Written on the guild's *first* server rather than by changing
+            // the constant, which is what keeps this from being a behaviour
+            // change under everyone: a guild already running servers on `off`
+            // chose that by running on it, and flipping the default would
+            // start asking them to approve calls that have been silent for
+            // months. `writes` rather than `always` because reads are the
+            // majority of calls and confirming those turns the feature into a
+            // button-clicking exercise, which is how an admin ends up setting
+            // it back to `off`.
+            //
+            // It goes in as a stored value, not an inferred one, so the
+            // dashboard shows it selected and it can be changed to `off` in
+            // one click by anybody who wants what the old default gave them.
+            if (servers.length === 1 && !guildSettings.ai.mcpConfirm) {
+                guildSettings.ai.mcpConfirm = FIRST_SERVER_CONFIRM_MODE;
+                confirmModeDefaulted = FIRST_SERVER_CONFIRM_MODE;
+            }
         }
 
         await guildSettings.save();
@@ -410,7 +437,8 @@ router.put('/guild/:guildId/mcp-servers/:name', checkAuth, checkGuildAccess, che
             enabled: validated.value.enabled,
             resources: validated.value.resources,
             tokenChanged: token !== undefined,
-            oauthCleared
+            oauthCleared,
+            confirmModeDefaulted
         });
 
         // The saved server, dialled now rather than on whoever sends the next
@@ -431,7 +459,14 @@ router.put('/guild/:guildId/mcp-servers/:name', checkAuth, checkGuildAccess, che
                 ...validated.value,
                 authorizationToken: token ?? existing?.authorizationToken ?? null,
                 oauth: existing?.oauth ?? null,
-            }]).catch(err => console.warn(`[MCP] prewarm after save failed: ${err.message}`));
+            }], {
+                // Just the one that was saved (#838). Warming resolves the
+                // operator's config file in alongside it, and without this a
+                // save of one server dials every shared server in that file
+                // too — a handshake apiece, per save, for connections nobody
+                // touched.
+                only: [validated.value.name],
+            }).catch(err => console.warn(`[MCP] prewarm after save failed: ${err.message}`));
         }
 
         res.json({
@@ -440,7 +475,13 @@ router.put('/guild/:guildId/mcp-servers/:name', checkAuth, checkGuildAccess, che
             // Said out loud rather than left to be noticed: an admin who
             // renamed a URL and found the connection unauthenticated an hour
             // later has no way to work out why.
-            ...(oauthCleared ? { notice: `The OAuth login for "${name}" was removed because ${oauthCleared}. Reconnect it.` } : {})
+            ...(oauthCleared ? { notice: `The OAuth login for "${name}" was removed because ${oauthCleared}. Reconnect it.` } : {}),
+            // Same reasoning for the policy that was just chosen on the admin's
+            // behalf: a setting that appears without being asked for is one
+            // they should be told about while they are still looking at it.
+            ...(confirmModeDefaulted
+                ? { confirmMode: confirmModeDefaulted, confirmNotice: 'Tool calls that write something will ask for approval in Discord before they run. Change this under Approval.' }
+                : {})
         });
     } catch (error) {
         if (error?.name === 'ValidationError') {

--- a/src/services/ai/discordChat.js
+++ b/src/services/ai/discordChat.js
@@ -20,6 +20,7 @@ const { buildMcpAddendum } = require('./mcp/prompt');
 const { retrieveMcpKnowledge } = require('./mcp/resources');
 const { createToolActivity, STATUS_RESERVE } = require('./mcp/activity');
 const { createToolConfirmer } = require('./mcp/approval');
+const { createElicitationHandler } = require('./mcp/elicitation');
 const { recordToolCalls } = require('./mcp/usage');
 
 // Discord transport for the AI chat loop: rate limiting, prompt assembly,
@@ -409,6 +410,11 @@ async function handleAIChat(message, aiSettings, promptContent) {
             // holds the call until this resolves, so a tool that writes
             // something does not run until somebody in the channel says so.
             mcpConfirm, mcpRoute, confirmTool: createToolConfirmer(message),
+            // And the question a server may ask back (#838). Same channel, same
+            // rule about who may answer — the difference is that this one
+            // carries data, and the tool on the far side is holding its request
+            // open until it arrives.
+            elicit: createElicitationHandler(message),
             // The bot's own tools ride the same loop as the servers' — same
             // approval prompt, same activity footer, same result budget.
             botTools: toolActions ? botTools : [],

--- a/src/services/ai/mcp/client.js
+++ b/src/services/ai/mcp/client.js
@@ -143,6 +143,16 @@ async function readEventStream(stream, id, onNotification = null, onServerReques
      * the loop keeps reading. A JSON-RPC notification is a message with a
      * method and no id; a server-initiated request has both; a response to
      * some other request on the same stream has only an id, and is skipped.
+     *
+     * `method` is tested before the id, and that order is load-bearing. Each
+     * side numbers its own outgoing requests, so the two counters share a
+     * namespace by accident and will eventually collide — a server that has
+     * sent a few requests over a pooled session lands on the id of the call in
+     * flight. Matching on the id first would then return the server's
+     * *request* as though it were our answer, which reads as a result with no
+     * content ("the tool returned no output") while the server waits out a
+     * question nobody will ever answer. A message carrying a method is never a
+     * response, whatever id it has.
      */
     const finish = () => {
         if (!data.length) return undefined;
@@ -157,9 +167,9 @@ async function readEventStream(stream, id, onNotification = null, onServerReques
             return undefined;
         }
         if (!message || typeof message !== 'object') return undefined;
-        if (message.id === id) return message;
-
-        if (typeof message.method !== 'string') return undefined;
+        if (typeof message.method !== 'string') {
+            return message.id === id ? message : undefined;
+        }
 
         const listener = message.id === undefined ? onNotification : onServerRequest;
         try {
@@ -208,9 +218,13 @@ function parseJsonBody(text, id) {
     } catch {
         throw new McpError(`server sent a non-JSON response: ${text.slice(0, 200)}`);
     }
-    // Batched responses are legal even for a single request.
+    // Batched responses are legal even for a single request, and a batch may
+    // carry the server's own requests alongside the answer. `method` rules
+    // those out before the id is looked at, for the same reason the event
+    // reader does it in that order: the two sides number their requests
+    // independently, so an id match alone is not proof of a response.
     const list = Array.isArray(parsed) ? parsed : [parsed];
-    const match = list.find(m => m && m.id === id);
+    const match = list.find(m => m && m.id === id && typeof m.method !== 'string');
     if (!match) throw new McpError('server response did not answer the request');
     return match;
 }

--- a/src/services/ai/mcp/client.js
+++ b/src/services/ai/mcp/client.js
@@ -55,6 +55,10 @@ const MAX_LIST_PAGES = 10;
 // thing — rather than failed, so the list methods read this as an empty list.
 const METHOD_NOT_FOUND = -32601;
 
+// JSON-RPC's "it went wrong on my side", which is what a client answers a
+// server request it accepted and then could not carry out.
+const INTERNAL_ERROR = -32603;
+
 // The shared servers — DeepWiki, Context7 without a key — rate-limit, and a
 // 429 that says "try again in two seconds" is worth waiting out rather than
 // reporting to a Discord channel as a failure. Only once, and only for a wait
@@ -120,8 +124,15 @@ function jsonRpcResult(message) {
  * ellipsis wants to know — and everything else is skipped. The stream is
  * dropped as soon as the answer arrives: the server is allowed to hold it open
  * afterwards, and waiting that out would stall the turn.
+ *
+ * A stream can also carry a *request* from the server — an `elicitation/create`
+ * asking the person for something the tool needs (#838). Those have both an id
+ * and a method, which is what tells them from the two kinds of message that
+ * have only one, and they go to `onServerRequest`. It is called and not
+ * awaited: answering means asking a human, the reply comes back as a separate
+ * POST, and the tool result is still coming down this stream in the meantime.
  */
-async function readEventStream(stream, id, onNotification = null) {
+async function readEventStream(stream, id, onNotification = null, onServerRequest = null) {
     let buffer = '';
     let data = [];
 
@@ -130,8 +141,8 @@ async function readEventStream(stream, id, onNotification = null) {
      *
      * A notification is delivered on the way past and reported as "not it", so
      * the loop keeps reading. A JSON-RPC notification is a message with a
-     * method and no id, which is also what tells it apart from a response to
-     * some other request on the same stream.
+     * method and no id; a server-initiated request has both; a response to
+     * some other request on the same stream has only an id, and is skipped.
      */
     const finish = () => {
         if (!data.length) return undefined;
@@ -148,14 +159,18 @@ async function readEventStream(stream, id, onNotification = null) {
         if (!message || typeof message !== 'object') return undefined;
         if (message.id === id) return message;
 
-        if (onNotification && message.id === undefined && typeof message.method === 'string') {
-            try {
-                onNotification(message);
-            } catch (err) {
-                // A listener that throws is a bug in whoever is watching, not a
-                // reason to lose the tool result still coming down this stream.
-                console.warn(`[MCP] notification listener failed: ${err.message}`);
-            }
+        if (typeof message.method !== 'string') return undefined;
+
+        const listener = message.id === undefined ? onNotification : onServerRequest;
+        try {
+            // A server request with no handler is answered by the caller's own
+            // "method not found", which is `post`'s business rather than this
+            // reader's; here there is simply nobody to hand it to.
+            if (listener) listener(message);
+        } catch (err) {
+            // A listener that throws is a bug in whoever is watching, not a
+            // reason to lose the tool result still coming down this stream.
+            console.warn(`[MCP] ${message.id === undefined ? 'notification' : 'request'} listener failed: ${err.message}`);
         }
         return undefined;
     };
@@ -269,7 +284,7 @@ async function readWithDeadline(read, stream, deadline) {
         return await Promise.race([
             read,
             new Promise((_, reject) => {
-                timer = setTimeout(() => {
+                const abort = () => {
                     // The read is about to lose the race; whatever destroying
                     // the stream makes it throw has nowhere to go and must not
                     // surface as an unhandled rejection.
@@ -279,11 +294,25 @@ async function readWithDeadline(read, stream, deadline) {
                         'the server sent response headers but no answer before the deadline',
                         { code: 'ETIMEDOUT' }
                     ));
-                }, Math.max(1, deadline - Date.now()));
-                timer.unref?.();
+                };
+
+                // Re-aimed rather than re-armed. The deadline moves when an
+                // elicitation puts the exchange in front of a person (#838),
+                // and the two ways to handle that are a timer that fires only
+                // to discover it should not have, or the extension moving the
+                // timer. The second is one `clearTimeout` per extension
+                // instead of one wakeup per deadline, and it keeps this a
+                // one-shot timer rather than a self-rescheduling one.
+                deadline.reschedule = () => {
+                    clearTimeout(timer);
+                    timer = setTimeout(abort, Math.max(1, deadline.at - Date.now()));
+                    timer.unref?.();
+                };
+                deadline.reschedule();
             })
         ]);
     } finally {
+        deadline.reschedule = null;
         clearTimeout(timer);
     }
 }
@@ -337,8 +366,25 @@ class McpHttpClient {
      *        `notifications/tools/list_changed` arrives on — a message about the
      *        connection rather than about any one request, and one no caller is
      *        in a position to be waiting for.
+     * @param {boolean} [options.elicitation] whether to tell servers this
+     *        client can put a question to a person (#838). A declaration rather
+     *        than a handler, because the handler is per *request*: this client
+     *        is pooled by (url, credential), so one instance is shared by every
+     *        guild pointed at that server, and a person to ask belongs to one
+     *        Discord message rather than to the connection. The question
+     *        arrives on the stream of the tool call that caused it, which is
+     *        exactly the scope that knows whose channel to ask in — see
+     *        `callTool`'s `onElicit`. A request with nobody behind it is
+     *        answered `cancel`, which is the spec's "no choice was made".
      */
-    constructor({ url, authorizationToken = null, label = 'MCP server', getAccessToken = null, onNotification = null }) {
+    constructor({
+        url,
+        authorizationToken = null,
+        label = 'MCP server',
+        getAccessToken = null,
+        onNotification = null,
+        elicitation = false,
+    }) {
         // Throws for anything that is not a plain http(s) URL, and for a literal
         // private address — the one destination that is knowable before DNS.
         this.url = assertPublicHttpUrl(url, `${label} URL`).toString();
@@ -348,6 +394,7 @@ class McpHttpClient {
             : null;
         this.getAccessToken = typeof getAccessToken === 'function' ? getAccessToken : null;
         this.onNotification = typeof onNotification === 'function' ? onNotification : null;
+        this.elicitation = Boolean(elicitation);
         this.sessionId = null;
         this.protocolVersion = null;
         this.serverInfo = null;
@@ -422,13 +469,16 @@ class McpHttpClient {
         };
     }
 
-    async post(payload, { id = null, timeout = CONNECT_TIMEOUT_MS, retryable = true, authRetried = false, onNotification = null } = {}) {
+    async post(payload, { id = null, timeout = CONNECT_TIMEOUT_MS, retryable = true, authRetried = false, onNotification = null, onServerRequest = null } = {}) {
         await this.authorize();
 
         // One deadline for the whole exchange, headers and body alike. The
         // axios timeout below only bounds the wait for headers; every body
         // read after it gets whatever is left of the same budget.
-        const deadline = Date.now() + timeout;
+        // An object rather than a number, because an elicitation moves it: the
+        // time a person spends answering the server's question is not time the
+        // server spent failing to answer ours.
+        const deadline = { at: Date.now() + timeout, reschedule: null };
         let response;
         try {
             response = await axios.post(this.url, payload, {
@@ -453,7 +503,7 @@ class McpHttpClient {
             if (wait !== null) {
                 response.data?.destroy?.();
                 await new Promise(resolve => setTimeout(resolve, wait));
-                return this.post(payload, { id, timeout, retryable: false, authRetried, onNotification });
+                return this.post(payload, { id, timeout, retryable: false, authRetried, onNotification, onServerRequest });
             }
         }
 
@@ -471,7 +521,7 @@ class McpHttpClient {
             // token: retrying with the same credential is the same request again.
             if (response.status === 401 && this.getAccessToken && !authRetried
                 && await this.authorize({ force: true })) {
-                return this.post(payload, { id, timeout, retryable, authRetried: true, onNotification });
+                return this.post(payload, { id, timeout, retryable, authRetried: true, onNotification, onServerRequest });
             }
 
             throw httpError(response.status, body, challenge);
@@ -488,9 +538,68 @@ class McpHttpClient {
 
         const contentType = String(response.headers['content-type'] || '');
         const read = contentType.includes('text/event-stream')
-            ? readEventStream(response.data, id, this.notificationSink(onNotification))
+            ? readEventStream(
+                response.data,
+                id,
+                this.notificationSink(onNotification),
+                request => this.answerServerRequest(request, onServerRequest, deadline)
+            )
             : collectText(response.data).then(text => parseJsonBody(text, id));
         return readWithDeadline(read, response.data, deadline);
+    }
+
+    /**
+     * Answer a request the *server* sent us, on a POST of its own.
+     *
+     * The transport has no way to write back up the stream a request arrived
+     * on, so the answer is an ordinary POST carrying a JSON-RPC response with
+     * the server's id on it. Nothing waits for it here: the tool result is
+     * still coming down the original stream, and answering an elicitation
+     * means asking a person, which takes as long as a person takes.
+     *
+     * The deadline is pushed out for exactly that reason. Sixty seconds of
+     * somebody reading a question is not sixty seconds of the server failing to
+     * answer, and without this the tool call the elicitation belongs to would
+     * be killed underneath the prompt still sitting in the channel — and the
+     * server left holding a request nobody will ever answer.
+     *
+     * A method this client does not serve is refused with JSON-RPC's own "no
+     * such method" rather than ignored, because a server that gets no answer
+     * waits for one: an unanswered `sampling/createMessage` is a tool call that
+     * hangs until its own deadline instead of failing in a sentence.
+     */
+    async answerServerRequest(request, onElicit, deadline) {
+        const reply = body => this.post({ jsonrpc: '2.0', id: request.id, ...body })
+            .catch(err => console.warn(`[MCP] could not answer "${this.label}"'s ${request.method}: ${err.message}`));
+
+        if (request.method !== 'elicitation/create') {
+            return reply({ error: { code: METHOD_NOT_FOUND, message: `${request.method} is not supported by this client` } });
+        }
+        if (typeof onElicit !== 'function') {
+            // The capability is the connection's and the person is the
+            // request's, so a scheduled task or a command parsing the reply as
+            // JSON reaches here with nobody to ask. `cancel` is the spec's
+            // "no choice was made", which is exactly true.
+            return reply({ result: { action: 'cancel' } });
+        }
+
+        try {
+            const result = await onElicit(request.params ?? {}, {
+                // Handed to the handler rather than applied around it: only the
+                // handler knows how long it is about to be, and a fixed
+                // extension would be either too short for a person or long
+                // enough to hold a Discord reply open on a server that asked
+                // and then went away.
+                extendDeadline: ms => {
+                    deadline.at = Math.max(deadline.at, Date.now() + ms);
+                    deadline.reschedule?.();
+                }
+            });
+            return reply({ result });
+        } catch (err) {
+            console.warn(`[MCP] "${this.label}" asked for ${request.method} and it failed: ${err.message}`);
+            return reply({ error: { code: INTERNAL_ERROR, message: err.message || 'the client could not answer' } });
+        }
     }
 
     /**
@@ -501,8 +610,11 @@ class McpHttpClient {
      * so a caller with nothing to show is not sent updates it would throw away.
      * The request id doubles as the token — it is already unique per connection,
      * which is what the spec asks of it.
+     *
+     * `onElicit` is opt-in for a different reason: it is a person, and a
+     * request is the smallest scope that knows which one (#838).
      */
-    async request(method, params, { timeout, onProgress } = {}) {
+    async request(method, params, { timeout, onProgress, onElicit } = {}) {
         const id = ++this.nextId;
         const wantsProgress = typeof onProgress === 'function';
         const body = wantsProgress
@@ -511,7 +623,12 @@ class McpHttpClient {
 
         const message = await this.post(
             { jsonrpc: '2.0', id, method, params: body },
-            { id, timeout, onNotification: wantsProgress ? progressReader(id, onProgress) : null }
+            {
+                id,
+                timeout,
+                onNotification: wantsProgress ? progressReader(id, onProgress) : null,
+                onServerRequest: onElicit,
+            }
         );
         return jsonRpcResult(message);
     }
@@ -540,9 +657,7 @@ class McpHttpClient {
     async handshakeOnce() {
         const result = await this.request('initialize', {
             protocolVersion: PROTOCOL_VERSION,
-            // Empty on purpose: this client answers no server-initiated
-            // requests, so it claims no capability that would invite one.
-            capabilities: {},
+            capabilities: this.clientCapabilities(),
             clientInfo: { name: 'clawdia', version: CLAWDIA_VERSION }
         });
 
@@ -560,6 +675,31 @@ class McpHttpClient {
 
         await this.notify('notifications/initialized');
         return this;
+    }
+
+    /**
+     * What this client tells a server it will answer.
+     *
+     * Read off the handlers it was actually given, because a capability is a
+     * promise: a server that is told `elicitation` and then gets "no such
+     * method" has been sent down a path that ends in a tool call hanging until
+     * its deadline. Declaring nothing is the honest answer for a caller with no
+     * person to ask — a scheduled task, a command parsing the reply as JSON —
+     * and it is also what this client did in every case before (#838).
+     *
+     * `roots` stays absent on purpose rather than by omission. It is the
+     * client offering a filesystem for a server to work inside, and this client
+     * is a Discord bot: there is no project directory a guild's question is
+     * being asked about, and the honest answer to "what are your roots" is that
+     * there are none. `sampling` is absent for a different reason — it is a
+     * server asking to spend the guild's model budget, which wants the same
+     * ledger and confirmation the tool loop already has, and that is more than
+     * a capability declaration.
+     */
+    clientCapabilities() {
+        const capabilities = {};
+        if (this.elicitation) capabilities.elicitation = {};
+        return capabilities;
     }
 
     /**
@@ -686,7 +826,7 @@ class McpHttpClient {
      * thrown: "that repository does not exist" is an answer the model should see
      * and work around, not a reason to abandon the reply.
      */
-    async callTool(name, args, { onProgress, timeout } = {}) {
+    async callTool(name, args, { onProgress, timeout, onElicit } = {}) {
         await this.initialize();
         // A caller with a deadline of its own can ask for less than the call
         // timeout, never more: a tool that answers in forty seconds is still a
@@ -699,7 +839,10 @@ class McpHttpClient {
         const result = await this.request(
             'tools/call',
             { name, arguments: args && typeof args === 'object' ? args : {} },
-            { timeout: limit, onProgress }
+            // `onElicit` rides with the call rather than with the connection:
+            // a question this tool raises belongs to the message that asked for
+            // it, and the pooled client is shared by every guild on this URL.
+            { timeout: limit, onProgress, onElicit }
         );
         return {
             content: Array.isArray(result.content) ? result.content : [],
@@ -732,6 +875,7 @@ class McpHttpClient {
 module.exports = {
     McpHttpClient,
     McpError,
+    INTERNAL_ERROR,
     retryAfterMs,
     progressReader,
     MAX_RETRY_AFTER_MS,

--- a/src/services/ai/mcp/client.js
+++ b/src/services/ai/mcp/client.js
@@ -330,8 +330,15 @@ class McpHttpClient {
      *        pooled client is sitting idle and the store is what knows when to
      *        refresh. `force` is the 401 path: the server rejected a token this
      *        believed was live, so refresh and try once more.
+     * @param {Function|null} [options.onNotification] `(notification) => void`
+     *        for every server-sent notification on every stream this client
+     *        reads (#838), as opposed to `request`'s per-call `onProgress`,
+     *        which is scoped to the one request that asked for it. This is what
+     *        `notifications/tools/list_changed` arrives on — a message about the
+     *        connection rather than about any one request, and one no caller is
+     *        in a position to be waiting for.
      */
-    constructor({ url, authorizationToken = null, label = 'MCP server', getAccessToken = null }) {
+    constructor({ url, authorizationToken = null, label = 'MCP server', getAccessToken = null, onNotification = null }) {
         // Throws for anything that is not a plain http(s) URL, and for a literal
         // private address — the one destination that is knowable before DNS.
         this.url = assertPublicHttpUrl(url, `${label} URL`).toString();
@@ -340,6 +347,7 @@ class McpHttpClient {
             ? authorizationToken.trim()
             : null;
         this.getAccessToken = typeof getAccessToken === 'function' ? getAccessToken : null;
+        this.onNotification = typeof onNotification === 'function' ? onNotification : null;
         this.sessionId = null;
         this.protocolVersion = null;
         this.serverInfo = null;
@@ -391,6 +399,27 @@ class McpHttpClient {
         const changed = Boolean(token) && token !== this.token;
         if (token) this.token = token;
         return changed;
+    }
+
+    /**
+     * The two notification audiences as one listener, or null when there is
+     * neither.
+     *
+     * A request's own progress reader and the connection-level handler both
+     * want every notification on the stream, and neither should be able to stop
+     * the other seeing one — so the second is delivered in a `finally`, and a
+     * listener that throws costs its own delivery rather than the other's.
+     */
+    notificationSink(perRequest) {
+        if (!this.onNotification) return perRequest || null;
+        if (!perRequest) return this.onNotification;
+        return notification => {
+            try {
+                perRequest(notification);
+            } finally {
+                this.onNotification(notification);
+            }
+        };
     }
 
     async post(payload, { id = null, timeout = CONNECT_TIMEOUT_MS, retryable = true, authRetried = false, onNotification = null } = {}) {
@@ -459,7 +488,7 @@ class McpHttpClient {
 
         const contentType = String(response.headers['content-type'] || '');
         const read = contentType.includes('text/event-stream')
-            ? readEventStream(response.data, id, onNotification)
+            ? readEventStream(response.data, id, this.notificationSink(onNotification))
             : collectText(response.data).then(text => parseJsonBody(text, id));
         return readWithDeadline(read, response.data, deadline);
     }

--- a/src/services/ai/mcp/connections.js
+++ b/src/services/ai/mcp/connections.js
@@ -131,12 +131,13 @@ function entryFor(server) {
  * particular is easy to add in one place and forget in the other, which shows
  * up as a connection that works in a channel and 401s in the panel.
  */
-function mcpClientFor(server) {
+function mcpClientFor(server, { onNotification = null } = {}) {
     const grant = server.connection.oauth;
     return new McpHttpClient({
         url: server.connection.url,
         authorizationToken: server.connection.authorizationToken,
         label: server.name,
+        onNotification,
         // Required lazily: the store reaches the Guild model, and this module is
         // loaded by the config layer the model's own schema sits under. A static
         // token connection never touches it.
@@ -147,7 +148,9 @@ function mcpClientFor(server) {
 }
 
 function clientFor(entry, server) {
-    if (!entry.client) entry.client = mcpClientFor(server);
+    if (!entry.client) {
+        entry.client = mcpClientFor(server, { onNotification: notificationListener(entry, server.name) });
+    }
     return entry.client;
 }
 
@@ -211,10 +214,82 @@ async function withServerLimit(entry, fn) {
 function slotFor(entry, kind) {
     let slot = entry.lists.get(kind);
     if (!slot) {
-        slot = { value: null, expires: 0, staleUntil: 0, error: null, errorExpire: 0, pending: null };
+        // `generation` counts the times a server has told us this list is out
+        // of date. A refresh records the generation it started under, so one
+        // that was already in flight when the notification arrived cannot
+        // write its answer back as though it were current — see refreshList.
+        slot = { value: null, expires: 0, staleUntil: 0, error: null, errorExpire: 0, pending: null, generation: 0 };
         entry.lists.set(kind, slot);
     }
     return slot;
+}
+
+/**
+ * The three notifications a server sends when one of its lists changes, and
+ * the cache slot each of them is about (#838).
+ *
+ * Without these the five-minute TTL is the whole answer, which is fine for the
+ * servers that never change and wrong for the ones that do it on purpose: a
+ * server that publishes its real toolset only after a login, or one whose tools
+ * depend on a repository the model just selected, announces the change the
+ * moment it happens and then waits up to five minutes to be believed. In
+ * between, the model is offered tools that are gone and not offered the ones
+ * that arrived.
+ */
+const LIST_CHANGED_KINDS = {
+    'notifications/tools/list_changed': 'tools',
+    'notifications/resources/list_changed': 'resources',
+    'notifications/prompts/list_changed': 'prompts',
+};
+
+/**
+ * Drop a cached list because the server said it is no longer true.
+ *
+ * The value goes rather than merely expiring, and the stale window with it.
+ * Expiry means "worth checking" and the pool answers it by serving the old list
+ * while a refresh runs behind — which is right for a TTL and wrong here, where
+ * the server has stated the list is wrong. A model handed a tool that no longer
+ * exists calls it and gets an error it cannot do anything about.
+ *
+ * Bumping `generation` is what covers the refresh that was already in flight
+ * when this arrived: its answer predates the change, so it is allowed to land
+ * but not to look current.
+ */
+function invalidateList(entry, kind) {
+    const slot = entry.lists.get(kind);
+    if (!slot) return false;
+
+    slot.generation++;
+    slot.value = null;
+    slot.expires = 0;
+    slot.staleUntil = 0;
+    slot.error = null;
+    slot.errorExpire = 0;
+    return true;
+}
+
+/**
+ * The connection-level notification listener for one pooled entry.
+ *
+ * Notifications reach this on whatever stream happens to be open — a tool call
+ * in progress, a list being fetched — because this client speaks the Streamable
+ * HTTP transport request-by-request and does not hold the standing GET channel
+ * open. That covers the case the TTL is worst at, which is a server changing
+ * its toolset *because of something the bot just did*, and it is deliberately
+ * not the whole of the spec's story: a change announced while the bot is idle
+ * is still noticed by the TTL a few minutes later rather than at once. A
+ * standing SSE socket per pooled connection is a real cost — one per (url,
+ * credential) for the life of the process, with its own reconnect and its own
+ * failure modes — to shorten a window the TTL already bounds at five minutes.
+ */
+function notificationListener(entry, label) {
+    return notification => {
+        const kind = LIST_CHANGED_KINDS[notification?.method];
+        if (!kind) return;
+        if (invalidateList(entry, kind)) {
+            console.log(`[MCP] "${label}" says its ${kind} changed; the cached list was dropped`);
+        }
+    };
 }
 
 /** Record a list somebody else already fetched, as though this pool had. */
@@ -239,12 +314,20 @@ function primeList(entry, kind, value) {
 // nobody, since an expired list is served stale while this runs.
 function refreshList(entry, server, kind, fn) {
     const slot = slotFor(entry, kind);
+    const generation = slot.generation;
 
     slot.pending = withServerLimit(entry, () => withSession(entry, server, fn))
         .then(value => {
+            // A `list_changed` that landed while this was in flight means the
+            // answer predates the change (#838). It is still the best list
+            // anybody has, and the caller waiting on this promise gets it — but
+            // it is stored already expired, so the next message fetches the one
+            // the server was telling us about rather than trusting this for
+            // another five minutes.
+            const current = slot.generation === generation;
             slot.value = value;
-            slot.expires = Date.now() + LIST_TTL_MS;
-            slot.staleUntil = slot.expires + STALE_TTL_MS;
+            slot.expires = current ? Date.now() + LIST_TTL_MS : 0;
+            slot.staleUntil = current ? slot.expires + STALE_TTL_MS : 0;
             slot.error = null;
             slot.errorExpire = 0;
             return value;
@@ -319,6 +402,9 @@ module.exports = {
     entryFor,
     clientFor,
     mcpClientFor,
+    invalidateList,
+    notificationListener,
+    LIST_CHANGED_KINDS,
     withSession,
     withServerLimit,
     cachedList,

--- a/src/services/ai/mcp/connections.js
+++ b/src/services/ai/mcp/connections.js
@@ -131,13 +131,14 @@ function entryFor(server) {
  * particular is easy to add in one place and forget in the other, which shows
  * up as a connection that works in a channel and 401s in the panel.
  */
-function mcpClientFor(server, { onNotification = null } = {}) {
+function mcpClientFor(server, { onNotification = null, elicitation = false } = {}) {
     const grant = server.connection.oauth;
     return new McpHttpClient({
         url: server.connection.url,
         authorizationToken: server.connection.authorizationToken,
         label: server.name,
         onNotification,
+        elicitation,
         // Required lazily: the store reaches the Guild model, and this module is
         // loaded by the config layer the model's own schema sits under. A static
         // token connection never touches it.
@@ -149,7 +150,22 @@ function mcpClientFor(server, { onNotification = null } = {}) {
 
 function clientFor(entry, server) {
     if (!entry.client) {
-        entry.client = mcpClientFor(server, { onNotification: notificationListener(entry, server.name) });
+        entry.client = mcpClientFor(server, {
+            onNotification: notificationListener(entry, server.name),
+            // Declared on every pooled client, and answered per call (#838).
+            // The declaration has to be the connection's — it is made once, in
+            // a handshake shared by every guild on this URL — while the person
+            // to ask belongs to one Discord message, so the handler rides with
+            // the tool call instead. A call with nobody behind it answers
+            // "cancel", which is the spec's "no choice was made" and true.
+            //
+            // The alternative was to declare it only for connections a chat
+            // turn opens, which would mean a second pool keyed on who is
+            // asking: a scheduled digest and a channel message would stop
+            // sharing a session with the same server, for a capability the
+            // digest declines in one line anyway.
+            elicitation: true,
+        });
     }
     return entry.client;
 }

--- a/src/services/ai/mcp/elicitation.js
+++ b/src/services/ai/mcp/elicitation.js
@@ -1,0 +1,388 @@
+'use strict';
+
+const {
+    ActionRowBuilder, ButtonBuilder, ButtonStyle, ModalBuilder,
+    TextInputBuilder, TextInputStyle, PermissionFlagsBits,
+} = require('discord.js');
+const { rejectOtherUser } = require('../../../utils/collectorOwner');
+const { toolLabel } = require('../../../utils/toolLabel');
+
+/**
+ * Letting an MCP server ask the person a question mid-tool-call (#838).
+ *
+ * Everything else in this directory is the bot asking a server for something.
+ * Elicitation is the one exchange that runs the other way: a tool that has got
+ * halfway and needs one more fact — which of your three organisations, what
+ * date, are you sure — sends `elicitation/create` down the stream its result is
+ * still coming on, and waits. A client that does not answer leaves the server
+ * holding a request forever, which is why this is a capability rather than a
+ * courtesy: it is claimed only when there is somebody to ask.
+ *
+ * The shape is very close to `approval.js` — a message in the channel, buttons,
+ * an answer routed back to a caller waiting on a promise, a clock. What is
+ * different is that the answer carries data rather than a yes, and Discord's
+ * only way to collect typed data is a modal, which can only be opened from an
+ * interaction. So it is two steps: a message with an Answer button, and the
+ * modal that button opens.
+ *
+ * ── What a server is allowed to ask for ────────────────────────────────────
+ * The spec restricts `requestedSchema` to a flat object of primitives, and this
+ * enforces that rather than trusting it: a nested schema, or one with twenty
+ * fields, is refused before anything reaches the channel. That is not
+ * defensiveness for its own sake — a modal holds five inputs, and a schema this
+ * cannot render honestly is better declined in a sentence the model can read
+ * than half-collected.
+ *
+ * ── What it is not allowed to ask for ──────────────────────────────────────
+ * The spec says servers must not use this for secrets, which is a rule for
+ * well-behaved servers and no protection at all from the others. A guild admin
+ * connects these servers, so the URL is trusted to the extent the admin is; the
+ * person answering the prompt in a channel is often not that admin. So every
+ * prompt names the server asking and says, in the prompt itself, that a real
+ * one will not ask for a password or a token. It is the same defence the
+ * approval prompt uses for tool arguments: show the person exactly who is
+ * asking and what for, and make the unusual case look unusual.
+ */
+
+// How long a question waits. Longer than a tool approval, which is a yes or a
+// no to something already written out: this one has to be read, understood and
+// typed into, and the tool on the far side is holding its own request open for
+// as long as we take.
+const ELICIT_TIMEOUT_MS = 120_000;
+
+// Discord's modal holds five components, so a schema wanting more than five
+// answers cannot be put to somebody in one prompt. Refused rather than
+// truncated: half the fields collected is a tool call that fails on the far
+// side with a message about the fields it did not get.
+const MAX_FIELDS = 5;
+
+// Label and placeholder ceilings Discord enforces, applied here so a server
+// with a long field description gets a trimmed label rather than an API error
+// that loses the whole prompt.
+const MAX_LABEL_CHARS = 45;
+const MAX_PLACEHOLDER_CHARS = 100;
+const MAX_VALUE_CHARS = 1000;
+
+// The server's own words, in a channel. Clamped because they are somebody
+// else's text going into a Discord message with a length limit of its own.
+const MAX_MESSAGE_CHARS = 600;
+
+// Per turn. An elicitation is a person being interrupted, and a server that
+// asks four times in one reply is not collecting an argument, it is running a
+// form — or fishing. Past this they are declined in words the model can read.
+const MAX_ELICITATIONS_PER_TURN = 2;
+
+const ANSWER = 'mcp-elicit-answer';
+const DECLINE = 'mcp-elicit-decline';
+const MODAL = 'mcp-elicit-modal';
+
+const NOT_YOURS = 'Only the person who asked, or someone who can manage this server, can answer this.';
+
+// The three answers the spec defines. `accept` carries content; the other two
+// are the person saying no and the client saying nobody said anything, and the
+// server is expected to tell them apart — "I decided not to" is not "ask me
+// again later".
+const ACCEPT = 'accept';
+const DECLINE_ACTION = 'decline';
+const CANCEL = 'cancel';
+
+/** Server-written text, safe to put inside a Discord message. */
+function clean(text, limit) {
+    const flat = String(text ?? '').replace(/\s+/g, ' ').trim().replace(/`/g, "'");
+    return flat.length > limit ? `${flat.slice(0, limit - 1).trimEnd()}…` : flat;
+}
+
+/**
+ * One property of a `requestedSchema` as something a modal can render, or null
+ * when it is not a primitive this can honestly collect.
+ *
+ * `enum` is checked before `type` because an enum of strings is a choice rather
+ * than free text, and the difference matters to what the person is shown: a
+ * list of the legal answers beats a blank box they can get wrong.
+ */
+function fieldOf(name, schema) {
+    if (!schema || typeof schema !== 'object') return null;
+
+    const title = clean(schema.title || name, MAX_LABEL_CHARS);
+    const description = clean(schema.description || '', MAX_PLACEHOLDER_CHARS);
+    const options = Array.isArray(schema.enum)
+        ? schema.enum.filter(v => typeof v === 'string' || typeof v === 'number').map(String)
+        : null;
+
+    if (options?.length) return { name, title, description, kind: 'enum', options };
+
+    switch (schema.type) {
+        case 'string':
+            return { name, title, description, kind: 'string' };
+        case 'number':
+        case 'integer':
+            return { name, title, description, kind: schema.type, minimum: schema.minimum, maximum: schema.maximum };
+        case 'boolean':
+            return { name, title, description, kind: 'boolean' };
+        default:
+            // An object, an array, or a type nobody named. The spec does not
+            // allow these here, and a modal could not collect one anyway.
+            return null;
+    }
+}
+
+/**
+ * A `requestedSchema` as the fields to put in a modal, or a refusal.
+ *
+ * The refusal is a string rather than a throw because it is an answer: the
+ * server is told the client declined and why, and the model sees the tool
+ * result that follows from it. Nothing about a schema this cannot render is
+ * recoverable by trying again.
+ */
+function fieldsOf(requestedSchema) {
+    const properties = requestedSchema?.properties;
+    if (!properties || typeof properties !== 'object' || Array.isArray(properties)) {
+        return { error: 'the requested schema has no properties to fill in' };
+    }
+
+    const required = new Set(Array.isArray(requestedSchema.required) ? requestedSchema.required : []);
+    const entries = Object.entries(properties);
+    if (!entries.length) return { error: 'the requested schema asks for nothing' };
+    if (entries.length > MAX_FIELDS) {
+        return { error: `the requested schema asks for ${entries.length} values and this client can collect at most ${MAX_FIELDS} at once` };
+    }
+
+    const fields = [];
+    for (const [name, schema] of entries) {
+        const field = fieldOf(name, schema);
+        if (!field) return { error: `"${clean(name, 40)}" is not a type this client can ask a person for` };
+        fields.push({ ...field, required: required.has(name) });
+    }
+    return { fields };
+}
+
+/** Words a person types when they mean yes, and when they mean no. */
+const TRUTHY = new Set(['true', 'yes', 'y', '1', 'on']);
+const FALSY = new Set(['false', 'no', 'n', '0', 'off']);
+
+/**
+ * One typed answer as the value the schema asked for, or an error to show.
+ *
+ * An empty answer to an optional field is an omission rather than an empty
+ * string: the server asked whether we had one, and "" is a different statement
+ * from "no value", especially to a tool that will pass it on to an API.
+ */
+function coerce(field, raw) {
+    const text = String(raw ?? '').trim();
+
+    if (!text) {
+        if (field.required) return { error: `${field.title} is required.` };
+        return { omitted: true };
+    }
+
+    switch (field.kind) {
+        case 'boolean': {
+            const lowered = text.toLowerCase();
+            if (TRUTHY.has(lowered)) return { value: true };
+            if (FALSY.has(lowered)) return { value: false };
+            return { error: `${field.title} should be yes or no.` };
+        }
+        case 'number':
+        case 'integer': {
+            const value = Number(text);
+            if (!Number.isFinite(value)) return { error: `${field.title} should be a number.` };
+            if (field.kind === 'integer' && !Number.isInteger(value)) {
+                return { error: `${field.title} should be a whole number.` };
+            }
+            if (field.minimum != null && value < field.minimum) return { error: `${field.title} should be at least ${field.minimum}.` };
+            if (field.maximum != null && value > field.maximum) return { error: `${field.title} should be at most ${field.maximum}.` };
+            return { value };
+        }
+        case 'enum': {
+            // Case-insensitively, because the person is typing one of a list
+            // they were shown and the list is the authority on spelling.
+            const match = field.options.find(option => option.toLowerCase() === text.toLowerCase());
+            if (!match) return { error: `${field.title} should be one of: ${field.options.join(', ')}.` };
+            return { value: match };
+        }
+        default:
+            return { value: text };
+    }
+}
+
+/** Every answer, or the first thing wrong with them. */
+function collect(fields, read) {
+    const content = {};
+    for (const field of fields) {
+        const answer = coerce(field, read(field.name));
+        if (answer.error) return { error: answer.error };
+        if (!answer.omitted) content[field.name] = answer.value;
+    }
+    return { content };
+}
+
+/** What the person sees above the buttons. */
+function promptText(userId, server, message, fields) {
+    const asks = fields
+        .map(field => `• **${field.title}**${field.required ? '' : ' (optional)'}`
+            + `${field.kind === 'enum' ? ` — one of: ${field.options.join(', ')}` : ''}`
+            + `${field.kind === 'boolean' ? ' — yes or no' : ''}`)
+        .join('\n');
+
+    return `❓ <@${userId}> — the \`${toolLabel(server)}\` server is asking you a question:\n`
+        + `> ${clean(message, MAX_MESSAGE_CHARS) || 'It did not say what for.'}\n\n${asks}\n`
+        + '-# A real server will not ask for a password, an API key or a login code. Cancel if this one does.';
+}
+
+function buttons(disabled = false) {
+    return new ActionRowBuilder().addComponents(
+        new ButtonBuilder().setCustomId(ANSWER).setLabel('Answer').setStyle(ButtonStyle.Primary).setDisabled(disabled),
+        new ButtonBuilder().setCustomId(DECLINE).setLabel('Cancel').setStyle(ButtonStyle.Secondary).setDisabled(disabled)
+    );
+}
+
+function modalFor(server, fields) {
+    const modal = new ModalBuilder().setCustomId(MODAL).setTitle(clean(`${server} needs an answer`, MAX_LABEL_CHARS));
+
+    for (const field of fields) {
+        const input = new TextInputBuilder()
+            .setCustomId(field.name)
+            .setLabel(field.title || field.name.slice(0, MAX_LABEL_CHARS))
+            .setStyle(TextInputStyle.Short)
+            .setRequired(field.required)
+            .setMaxLength(MAX_VALUE_CHARS);
+
+        const hint = field.kind === 'enum'
+            ? field.options.join(' / ')
+            : (field.kind === 'boolean' ? 'yes or no' : field.description);
+        if (hint) input.setPlaceholder(clean(hint, MAX_PLACEHOLDER_CHARS));
+
+        modal.addComponents(new ActionRowBuilder().addComponents(input));
+    }
+    return modal;
+}
+
+/**
+ * An `elicitation/create` handler for one Discord message's turn.
+ *
+ * Bound to a server name by the toolkit and handed to `callTool`, not to the
+ * client: clients are pooled by (url, credential) and shared by every guild
+ * pointed at that server, so a handler living on one would answer another
+ * guild's question in this guild's channel. A tool call belongs to exactly one
+ * message, which is the scope that knows whose channel to ask in.
+ *
+ * The per-turn count lives in this closure for the same reason — it is a count
+ * of interruptions to one person, not of requests to one server.
+ *
+ * @param {object} message the message that started the turn
+ * @returns {(server: string, params: object, ctx: object) => Promise<object>}
+ */
+function createElicitationHandler(message, { timeoutMs = ELICIT_TIMEOUT_MS } = {}) {
+    let asked = 0;
+
+    return async (serverName, { message: question, requestedSchema } = {}, { extendDeadline } = {}) => {
+        // Declining is a first-class answer, so every refusal below is one:
+        // the server is told no and carries on, rather than waiting out a
+        // request nobody is going to answer.
+        //
+        // Nothing but `action` and `content` goes back: the reason is for the
+        // log, and a field the spec does not define is one a strict server is
+        // entitled to reject the whole response over.
+        const declined = reason => {
+            console.warn(`[MCP] declined an elicitation from "${serverName}": ${reason}`);
+            return { action: DECLINE_ACTION };
+        };
+
+        if (++asked > MAX_ELICITATIONS_PER_TURN) {
+            return declined(`this reply has already put ${MAX_ELICITATIONS_PER_TURN} questions to the user`);
+        }
+
+        const parsed = fieldsOf(requestedSchema);
+        if (parsed.error) return declined(parsed.error);
+
+        // Before the prompt goes up, not after somebody has answered it: the
+        // deadline this is pushing out is the one that would otherwise destroy
+        // the stream while they are still reading.
+        extendDeadline?.(timeoutMs + 15_000);
+
+        const content = promptText(message.author.id, serverName, question, parsed.fields);
+        const prompt = await message.channel.send({
+            content,
+            components: [buttons()],
+            // The asker is pinged because they are the one being waited on.
+            // Nothing the server wrote can ping anybody, whatever it put in the
+            // question or the field names.
+            allowedMentions: { users: [message.author.id] }
+        });
+
+        // The prompt is edited in place rather than answered with a new
+        // message, so the channel keeps one record of what was asked and what
+        // was said — and the buttons go, so a click an hour later cannot land
+        // on a request the server stopped waiting for.
+        const settle = async (text, result) => {
+            await prompt.edit({ content: `${content}\n${text}`, components: [], allowedMentions: { parse: [] } }).catch(() => {});
+            return result;
+        };
+
+        const filter = interaction => {
+            if (interaction.customId !== ANSWER && interaction.customId !== DECLINE) return false;
+            if (interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) return true;
+            return !rejectOtherUser(interaction, message.author.id, NOT_YOURS);
+        };
+
+        let click;
+        try {
+            click = await prompt.awaitMessageComponent({ filter, time: timeoutMs });
+        } catch {
+            // Nobody answered. `cancel` rather than `decline`: the person did
+            // not refuse, they were not there, and a server may reasonably
+            // treat those differently.
+            return settle('⏳ Nobody answered.', { action: CANCEL });
+        }
+
+        if (click.customId === DECLINE) {
+            await click.deferUpdate().catch(() => {});
+            return settle(`🚫 Cancelled by <@${click.user.id}>.`, { action: DECLINE_ACTION });
+        }
+
+        await click.showModal(modalFor(serverName, parsed.fields));
+
+        let submission;
+        try {
+            submission = await click.awaitModalSubmit({
+                time: timeoutMs,
+                // Discord only shows the modal to whoever clicked, so this is
+                // belt and braces — and it answers rather than dropping a
+                // submission in silence, the same as every other filter here.
+                filter: interaction => interaction.customId === MODAL
+                    && !rejectOtherUser(interaction, click.user.id, NOT_YOURS),
+            });
+        } catch {
+            return settle('⏳ The form was not submitted.', { action: CANCEL });
+        }
+
+        const answers = collect(parsed.fields, name => submission.fields.getTextInputValue(name));
+        if (answers.error) {
+            // One shot at the form. A retry loop is a nicer experience and a
+            // worse one for the tool call holding its request open behind it —
+            // and the model is told what went wrong, so it can ask again in its
+            // own words if the answer mattered.
+            await submission.reply({ content: `⚠️ ${answers.error} Nothing was sent to the server.`, ephemeral: true }).catch(() => {});
+            console.warn(`[MCP] an answer for "${serverName}" did not fit its schema: ${answers.error}`);
+            return settle(
+                `⚠️ <@${submission.user.id}> — that answer did not fit what the server asked for.`,
+                { action: DECLINE_ACTION },
+            );
+        }
+
+        await submission.deferUpdate().catch(() => {});
+        return settle(`✅ Answered by <@${submission.user.id}>.`, { action: ACCEPT, content: answers.content });
+    };
+}
+
+module.exports = {
+    createElicitationHandler,
+    fieldsOf,
+    fieldOf,
+    coerce,
+    collect,
+    promptText,
+    ELICIT_TIMEOUT_MS,
+    MAX_FIELDS,
+    MAX_ELICITATIONS_PER_TURN,
+};

--- a/src/services/ai/mcp/elicitation.js
+++ b/src/services/ai/mcp/elicitation.js
@@ -74,7 +74,26 @@ const MAX_ELICITATIONS_PER_TURN = 2;
 
 const ANSWER = 'mcp-elicit-answer';
 const DECLINE = 'mcp-elicit-decline';
-const MODAL = 'mcp-elicit-modal';
+
+/**
+ * The modal's custom id, unique per question.
+ *
+ * `awaitModalSubmit` is not scoped the way `awaitMessageComponent` is: it hands
+ * the collector no message, channel or guild, so *every* live collector in the
+ * process is offered *every* modal submission and the filter is the only thing
+ * that separates them. With one shared id, two questions open at once — which
+ * a round running two tool calls can produce, and the per-turn ceiling allows —
+ * would both match the first form submitted. Overlapping field names is the bad
+ * case: one server is silently sent the answer somebody typed for the other,
+ * and both prompts say it was answered.
+ *
+ * So the id carries a counter, and the filter matches it exactly. The button
+ * step needs none of this: `Message#awaitMessageComponent` scopes its collector
+ * to the message the buttons are on.
+ */
+const MODAL_PREFIX = 'mcp-elicit-modal';
+let modalSeq = 0;
+const nextModalId = () => `${MODAL_PREFIX}:${Date.now().toString(36)}:${++modalSeq}`;
 
 const NOT_YOURS = 'Only the person who asked, or someone who can manage this server, can answer this.';
 
@@ -236,8 +255,8 @@ function buttons(disabled = false) {
     );
 }
 
-function modalFor(server, fields) {
-    const modal = new ModalBuilder().setCustomId(MODAL).setTitle(clean(`${server} needs an answer`, MAX_LABEL_CHARS));
+function modalFor(server, fields, customId) {
+    const modal = new ModalBuilder().setCustomId(customId).setTitle(clean(`${server} needs an answer`, MAX_LABEL_CHARS));
 
     for (const field of fields) {
         const input = new TextInputBuilder()
@@ -340,16 +359,26 @@ function createElicitationHandler(message, { timeoutMs = ELICIT_TIMEOUT_MS } = {
             return settle(`🚫 Cancelled by <@${click.user.id}>.`, { action: DECLINE_ACTION });
         }
 
-        await click.showModal(modalFor(serverName, parsed.fields));
+        const modalId = nextModalId();
+        await click.showModal(modalFor(serverName, parsed.fields, modalId));
+
+        // The clock again. Answering is two waits, not one — noticing the
+        // prompt and clicking, then reading the form and typing — and the
+        // extension above only covered the first. Without this second one the
+        // stream is destroyed while somebody is mid-form, and the tool call is
+        // reported as failed a minute before they press Submit.
+        extendDeadline?.(timeoutMs + 15_000);
 
         let submission;
         try {
             submission = await click.awaitModalSubmit({
                 time: timeoutMs,
-                // Discord only shows the modal to whoever clicked, so this is
-                // belt and braces — and it answers rather than dropping a
-                // submission in silence, the same as every other filter here.
-                filter: interaction => interaction.customId === MODAL
+                // The id is this question's alone; see MODAL_PREFIX for why
+                // that matters. The user check is belt and braces on top —
+                // Discord only shows the modal to whoever clicked — and it
+                // answers rather than dropping a submission in silence, the
+                // same as every other filter here.
+                filter: interaction => interaction.customId === modalId
                     && !rejectOtherUser(interaction, click.user.id, NOT_YOURS),
             });
         } catch {
@@ -377,6 +406,7 @@ function createElicitationHandler(message, { timeoutMs = ELICIT_TIMEOUT_MS } = {
 
 module.exports = {
     createElicitationHandler,
+    MODAL_PREFIX,
     fieldsOf,
     fieldOf,
     coerce,

--- a/src/services/ai/mcp/oauthStore.js
+++ b/src/services/ai/mcp/oauthStore.js
@@ -36,13 +36,73 @@
 
 const Guild = require('../../../models/Guild');
 const { encryptSecret, decryptSecret } = require('../../../config/secretBox');
-const { refreshTokens, needsRefresh, OAuthError } = require('./oauth');
+const { refreshTokens, needsRefresh, OAuthError, REFRESH_SKEW_MS } = require('./oauth');
 
 // One in-flight refresh per grant, keyed by guild and server name. Concurrent
 // callers await the same promise rather than each spending the refresh token.
 const inFlight = new Map();
 
 const keyOf = (guildId, server) => `${guildId} ${server}`;
+
+/**
+ * The live access token per grant, so a request that needs one does not read
+ * Mongo to be told what it was told a second ago (#838).
+ *
+ * `accessTokenFor` is asked before *every* MCP request — the client re-asks
+ * rather than caching, because a pooled connection sits idle while its token
+ * expires — and a turn that runs six tool calls across two servers was six
+ * `findOne`s deep before a single byte went out. The token itself is what
+ * changes on a clock the process already knows about, so it is the thing worth
+ * holding.
+ *
+ * Held only while it is unambiguously live: `MEMO_SKEW_MS` short of the grant's
+ * own expiry, so a memo never outlives the refresh it should have triggered.
+ * A grant with no expiry is not memoized at all — a token of unknown lifetime
+ * is one the database is entitled to have changed.
+ *
+ * Dropped on every write to the grant (`saveGrant`, `clearGrant`, a refresh)
+ * and on the forced path, which is what a 401 takes: the server has just said
+ * the memoized token is no good, and re-offering it would spend the retry on
+ * the same credential. This is per process and deliberately so — another shard
+ * refreshing early is a token this one has not seen, which costs it one 401 and
+ * the forced refresh that already handles exactly that.
+ */
+const tokenMemo = new Map();
+
+// How far ahead of the grant's expiry the memo is dropped. Derived from the
+// refresh margin rather than written out again, and twice it, so the memo is
+// always the first of the two to lapse: a memo that outlived `needsRefresh`
+// would hand back a token in the window the store had already decided to
+// refresh, which is the one thing it must not do.
+const MEMO_SKEW_MS = REFRESH_SKEW_MS * 2;
+
+// `expiresAt` reaches here as whatever Mongo gave back — a Date, or the string
+// a `.lean()` read of a fresh write can carry — so it is normalised rather
+// than assumed. Anything unparseable is treated as no expiry at all, which
+// means no memo.
+function expiryMs(expiresAt) {
+    if (!expiresAt) return null;
+    const at = expiresAt instanceof Date ? expiresAt.getTime() : new Date(expiresAt).getTime();
+    return Number.isFinite(at) ? at : null;
+}
+
+function memoGet(key) {
+    const entry = tokenMemo.get(key);
+    if (!entry) return null;
+    if (entry.until <= Date.now()) {
+        tokenMemo.delete(key);
+        return null;
+    }
+    return entry.token;
+}
+
+function memoSet(key, token, expiresAt) {
+    const at = expiryMs(expiresAt);
+    if (!token || at === null) return;
+    const until = at - MEMO_SKEW_MS;
+    if (until <= Date.now()) return;
+    tokenMemo.set(key, { token, until });
+}
 
 /** The stored grant with its secrets decrypted, or null. */
 function openGrant(stored) {
@@ -99,6 +159,7 @@ async function readGrant(guildId, server) {
 
 /** Writes a grant, replacing whatever was there. Used by the dashboard callback. */
 async function saveGrant(guildId, server, grant) {
+    tokenMemo.delete(keyOf(guildId, server));
     const result = await Guild.updateOne(
         { guildId, 'ai.mcpServers.name': server },
         {
@@ -117,6 +178,7 @@ async function saveGrant(guildId, server, grant) {
 /** Drops a grant, so the connection goes back to being unauthenticated. */
 async function clearGrant(guildId, server) {
     inFlight.delete(keyOf(guildId, server));
+    tokenMemo.delete(keyOf(guildId, server));
     const result = await Guild.updateOne(
         { guildId, 'ai.mcpServers.name': server },
         { $set: { 'ai.mcpServers.$.oauth': null } },
@@ -157,6 +219,8 @@ async function refreshGrant(guildId, server, grant, { encryptedRefreshToken }) {
     const existing = inFlight.get(key);
     if (existing) return existing;
 
+    tokenMemo.delete(key);
+
     const attempt = (async () => {
         const fresh = await refreshTokens(grant.tokenEndpoint, {
             refreshToken: grant.refreshToken,
@@ -177,12 +241,17 @@ async function refreshGrant(guildId, server, grant, { encryptedRefreshToken }) {
         };
 
         const stored = await storeRefreshed(guildId, server, encryptedRefreshToken, updated);
-        if (stored) return updated;
+        if (stored) {
+            memoSet(key, updated.accessToken, updated.expiresAt);
+            return updated;
+        }
 
         // Somebody else got there first. Theirs is newer than this one by
         // definition, so it is the one to use.
         const other = await readGrant(guildId, server);
-        return other?.accessToken ? other : updated;
+        const winner = other?.accessToken ? other : updated;
+        memoSet(key, winner.accessToken, winner.expiresAt);
+        return winner;
     })().finally(() => inFlight.delete(key));
 
     inFlight.set(key, attempt);
@@ -206,6 +275,16 @@ async function refreshGrant(guildId, server, grant, { encryptedRefreshToken }) {
 async function accessTokenFor(guildId, server, { force = false } = {}) {
     if (!guildId || !server) return null;
 
+    const key = keyOf(guildId, server);
+    if (force) {
+        // The caller is here because the server rejected what it was last
+        // given, which may well be what is memoized.
+        tokenMemo.delete(key);
+    } else {
+        const memoized = memoGet(key);
+        if (memoized) return memoized;
+    }
+
     const doc = await Guild.findOne(
         { guildId, 'ai.mcpServers.name': server },
         { 'ai.mcpServers.$': 1 },
@@ -216,6 +295,7 @@ async function accessTokenFor(guildId, server, { force = false } = {}) {
     if (!grant?.accessToken && !grant?.refreshToken) return null;
 
     if (!force && grant.accessToken && !needsRefresh(grant.expiresAt)) {
+        memoSet(key, grant.accessToken, grant.expiresAt);
         return grant.accessToken;
     }
     if (!grant.refreshToken) {
@@ -246,9 +326,10 @@ async function accessTokenFor(guildId, server, { force = false } = {}) {
 /** Test seam: drops the in-flight refresh map. */
 function _resetOAuthStore() {
     inFlight.clear();
+    tokenMemo.clear();
 }
 
 module.exports = {
     readGrant, saveGrant, clearGrant, accessTokenFor,
-    openGrant, sealGrant, _resetOAuthStore,
+    openGrant, sealGrant, _resetOAuthStore, MEMO_SKEW_MS,
 };

--- a/src/services/ai/mcp/oauthStore.js
+++ b/src/services/ai/mcp/oauthStore.js
@@ -86,6 +86,31 @@ function expiryMs(expiresAt) {
     return Number.isFinite(at) ? at : null;
 }
 
+/**
+ * How many times this grant has been invalidated, so a read that started before
+ * an invalidation cannot install its answer after one.
+ *
+ * The race is narrow and its worst case is not: `accessTokenFor` issues a
+ * `findOne`, an admin clicks Disconnect, `clearGrant` empties the memo and
+ * nulls the row — and then the in-flight read returns the grant as it was and
+ * memoizes the token that was just revoked. Nothing reads the row again while
+ * the memo answers, and there is no grant left to refresh from, so a
+ * disconnected connection would go on authenticating from process memory until
+ * the token expired on its own.
+ *
+ * Every writer bumps the epoch; a reader captures it before its query and
+ * declines to memoize if it moved. Same shape as the list cache's
+ * `generation` in connections.js, for the same reason.
+ */
+const epochs = new Map();
+
+const epochOf = key => epochs.get(key) || 0;
+
+function invalidate(key) {
+    epochs.set(key, epochOf(key) + 1);
+    tokenMemo.delete(key);
+}
+
 function memoGet(key) {
     const entry = tokenMemo.get(key);
     if (!entry) return null;
@@ -96,9 +121,10 @@ function memoGet(key) {
     return entry.token;
 }
 
-function memoSet(key, token, expiresAt) {
+function memoSet(key, token, expiresAt, epoch) {
     const at = expiryMs(expiresAt);
     if (!token || at === null) return;
+    if (epoch !== undefined && epoch !== epochOf(key)) return;
     const until = at - MEMO_SKEW_MS;
     if (until <= Date.now()) return;
     tokenMemo.set(key, { token, until });
@@ -159,7 +185,7 @@ async function readGrant(guildId, server) {
 
 /** Writes a grant, replacing whatever was there. Used by the dashboard callback. */
 async function saveGrant(guildId, server, grant) {
-    tokenMemo.delete(keyOf(guildId, server));
+    invalidate(keyOf(guildId, server));
     const result = await Guild.updateOne(
         { guildId, 'ai.mcpServers.name': server },
         {
@@ -178,7 +204,7 @@ async function saveGrant(guildId, server, grant) {
 /** Drops a grant, so the connection goes back to being unauthenticated. */
 async function clearGrant(guildId, server) {
     inFlight.delete(keyOf(guildId, server));
-    tokenMemo.delete(keyOf(guildId, server));
+    invalidate(keyOf(guildId, server));
     const result = await Guild.updateOne(
         { guildId, 'ai.mcpServers.name': server },
         { $set: { 'ai.mcpServers.$.oauth': null } },
@@ -219,7 +245,8 @@ async function refreshGrant(guildId, server, grant, { encryptedRefreshToken }) {
     const existing = inFlight.get(key);
     if (existing) return existing;
 
-    tokenMemo.delete(key);
+    invalidate(key);
+    const refreshEpoch = epochOf(key);
 
     const attempt = (async () => {
         const fresh = await refreshTokens(grant.tokenEndpoint, {
@@ -242,7 +269,7 @@ async function refreshGrant(guildId, server, grant, { encryptedRefreshToken }) {
 
         const stored = await storeRefreshed(guildId, server, encryptedRefreshToken, updated);
         if (stored) {
-            memoSet(key, updated.accessToken, updated.expiresAt);
+            memoSet(key, updated.accessToken, updated.expiresAt, refreshEpoch);
             return updated;
         }
 
@@ -250,7 +277,7 @@ async function refreshGrant(guildId, server, grant, { encryptedRefreshToken }) {
         // definition, so it is the one to use.
         const other = await readGrant(guildId, server);
         const winner = other?.accessToken ? other : updated;
-        memoSet(key, winner.accessToken, winner.expiresAt);
+        memoSet(key, winner.accessToken, winner.expiresAt, refreshEpoch);
         return winner;
     })().finally(() => inFlight.delete(key));
 
@@ -279,11 +306,15 @@ async function accessTokenFor(guildId, server, { force = false } = {}) {
     if (force) {
         // The caller is here because the server rejected what it was last
         // given, which may well be what is memoized.
-        tokenMemo.delete(key);
+        invalidate(key);
     } else {
         const memoized = memoGet(key);
         if (memoized) return memoized;
     }
+
+    // Captured before the read, not after it: what makes the answer below safe
+    // to memoize is that nothing invalidated the grant while it was in flight.
+    const epoch = epochOf(key);
 
     const doc = await Guild.findOne(
         { guildId, 'ai.mcpServers.name': server },
@@ -295,7 +326,7 @@ async function accessTokenFor(guildId, server, { force = false } = {}) {
     if (!grant?.accessToken && !grant?.refreshToken) return null;
 
     if (!force && grant.accessToken && !needsRefresh(grant.expiresAt)) {
-        memoSet(key, grant.accessToken, grant.expiresAt);
+        memoSet(key, grant.accessToken, grant.expiresAt, epoch);
         return grant.accessToken;
     }
     if (!grant.refreshToken) {
@@ -327,6 +358,7 @@ async function accessTokenFor(guildId, server, { force = false } = {}) {
 function _resetOAuthStore() {
     inFlight.clear();
     tokenMemo.clear();
+    epochs.clear();
 }
 
 module.exports = {

--- a/src/services/ai/mcp/toolkit.js
+++ b/src/services/ai/mcp/toolkit.js
@@ -467,6 +467,12 @@ function renderResult(
  *        An optional `toolBudget.peek()` reports the same without spending, so
  *        a call waiting on a person's approval can be refused early and charged
  *        late (#826)
+ * @param {Function} [options.elicit] `(server, params, ctx) => result` for a
+ *        server that asks the user a question mid-call (#838). Per turn, and
+ *        passed down to the call rather than held on the pooled client, because
+ *        the client is shared by every guild on that URL and the person to ask
+ *        belongs to one message. Absent — a scheduled task, a command parsing
+ *        the reply as JSON — means questions are answered "no choice made"
  * @param {Array} [options.botTools] tools the bot owns rather than a server —
  *        the in-channel actions (#832). Each carries the same fields a
  *        discovered tool does plus `run(args)`, which is called instead of a
@@ -478,6 +484,7 @@ async function prepareMcpToolkit(guildServers = [], {
     onToolEvent,
     confirmMode = DEFAULT_CONFIRM_MODE,
     confirmTool,
+    elicit,
     toolBudget,
     botTools = [],
     // Both default to the chat numbers, so every existing caller gets exactly
@@ -933,6 +940,15 @@ async function prepareMcpToolkit(guildServers = [], {
         const onProgress = ({ progress, total, message }) =>
             emit({ ...describe, type: 'progress', progress, total, message });
 
+        // A question this call raises, put to the person who asked for the
+        // reply. Bound to the server name here because that is what the prompt
+        // has to say out loud — "the github server is asking you" — and the
+        // handler itself belongs to the turn rather than to any one call, so
+        // its per-turn ceiling counts every server's questions together.
+        const onElicit = typeof elicit === 'function'
+            ? (params, ctx) => elicit(server, params, ctx)
+            : undefined;
+
         try {
             // Queued behind this server's other calls rather than the round's:
             // six calls at one server is a burst that server sees as one client
@@ -949,7 +965,7 @@ async function prepareMcpToolkit(guildServers = [], {
                 // after it. Below the call timeout this is the tighter of the
                 // two; above it, the call timeout still wins.
                 return withSession(target.entry, target.server, client =>
-                    client.callTool(target.toolName, args, { onProgress, timeout: remaining }));
+                    client.callTool(target.toolName, args, { onProgress, timeout: remaining, onElicit }));
             });
 
             if (!result) {
@@ -1045,11 +1061,11 @@ async function prewarmMcpServers(guildServers = [], { concurrency = 4, only = nu
  * `useMcp` is the caller's switch — commands that parse the reply as JSON pass
  * it false — and is checked here so no provider has to remember to.
  */
-async function toolkitFor({ useMcp = true, mcpServers, onToolEvent, mcpConfirm, confirmTool, toolBudget, botTools, maxRounds, turnBudgetMs } = {}) {
+async function toolkitFor({ useMcp = true, mcpServers, onToolEvent, mcpConfirm, confirmTool, elicit, toolBudget, botTools, maxRounds, turnBudgetMs } = {}) {
     if (useMcp === false) return null;
     try {
         return await prepareMcpToolkit(mcpServers, {
-            onToolEvent, confirmMode: mcpConfirm, confirmTool, toolBudget, botTools, maxRounds, turnBudgetMs
+            onToolEvent, confirmMode: mcpConfirm, confirmTool, elicit, toolBudget, botTools, maxRounds, turnBudgetMs
         });
     } catch (err) {
         // Discovery is best-effort in every direction: an unreadable config or

--- a/src/services/ai/mcp/toolkit.js
+++ b/src/services/ai/mcp/toolkit.js
@@ -260,23 +260,31 @@ function summarize(tool, serverName) {
  * trip re-sends the entire conversation. A catalogue line is about a tenth of a
  * schema; the round trip is the whole context again. The line wins.
  */
-function loadToolDefinition(deferred) {
-    const lines = deferred.map(entry => `- ${entry.name}: ${entry.summary}`).join('\n');
+function loadToolDefinition() {
     return {
         name: LOAD_TOOL_NAME,
         serverName: null,
         toolName: LOAD_TOOL_NAME,
+        // "Round", not "turn" (#838). A turn is the whole exchange — the user's
+        // message through to the reply — and a model told to wait for its next
+        // *turn* has been told to give up and wait for somebody to type again.
+        // What it actually has to do is finish this round, which it does by
+        // ending its message; the tool is declared on the request after that,
+        // several of which fit inside one turn.
         description:
             'Load the full definitions of tools that are available but not yet loaded. '
-            + 'Call this with the names you need, then call those tools on your next turn — '
-            + 'they cannot be called in the same turn they are loaded in.',
+            + 'Call this with the names you need, then call those tools in your next round — '
+            + 'they cannot be called in the same round they are loaded in.',
         inputSchema: {
             type: 'object',
             properties: {
                 names: {
                     type: 'array',
-                    items: { type: 'string', enum: deferred.map(entry => entry.name) },
-                    description: `The tools to load. Available:\n${lines}`
+                    // Rebuilt by `refreshCatalog` as tools are loaded, so the
+                    // enum offers what is still loadable rather than what was
+                    // loadable when the turn started.
+                    items: { type: 'string', enum: [] },
+                    description: ''
                 }
             },
             required: ['names']
@@ -615,7 +623,44 @@ async function prepareMcpToolkit(guildServers = [], {
     const byCatalogName = new Map(deferred.map(entry => [entry.name, entry]));
     const loaded = new Set();
 
-    if (deferred.length) definitions.push(loadToolDefinition(deferred));
+    // The meta-tool's own definition, kept so its catalogue can be rewritten
+    // (#838). It is one object living in `definitions`, and every round's
+    // request rebuilds its provider-side parameters from whatever is in there
+    // now — so editing it in place is how the model is told that a name it has
+    // already loaded is no longer something to load.
+    const loadDefinition = deferred.length ? loadToolDefinition() : null;
+
+    /**
+     * Point the meta-tool at the tools that are still deferred.
+     *
+     * An enum that keeps the names it has already handed over is an invitation
+     * to spend a round loading them again: the model reads the enum as the list
+     * of legal values, sees `create_issue` in it, and asks for it a second time
+     * because nothing in the schema says it already has it. Once the catalogue
+     * is empty the meta-tool is dropped from `definitions` altogether — a tool
+     * whose only legal argument list is the empty one is a round waiting to
+     * happen.
+     */
+    function refreshCatalog() {
+        if (!loadDefinition) return;
+
+        const remaining = deferred.filter(entry => !loaded.has(entry.name));
+        if (!remaining.length) {
+            const at = definitions.indexOf(loadDefinition);
+            if (at >= 0) definitions.splice(at, 1);
+            return;
+        }
+
+        const names = loadDefinition.inputSchema.properties.names;
+        names.items.enum = remaining.map(entry => entry.name);
+        names.description = 'The tools to load. Available:\n'
+            + remaining.map(entry => `- ${entry.name}: ${entry.summary}`).join('\n');
+    }
+
+    if (loadDefinition) {
+        definitions.push(loadDefinition);
+        refreshCatalog();
+    }
 
     /**
      * Declare the named tools from here on, and say what happened.
@@ -658,11 +703,16 @@ async function prepareMcpToolkit(guildServers = [], {
             added.push(name);
         }
 
+        // After the loop rather than per name: one rewrite for a request that
+        // loaded six tools, and the meta-tool is only dropped once the last of
+        // them has been taken.
+        if (added.length) refreshCatalog();
+
         const parts = [];
         if (added.length) {
             parts.push(
-                `Loaded: ${added.join(', ')}. These are available from your next turn onwards — `
-                + 'finish this turn, then call them.',
+                `Loaded: ${added.join(', ')}. These are available from your next round onwards — `
+                + 'finish this round, then call them.',
             );
         }
         if (already.length) parts.push(`Already available, call directly: ${already.join(', ')}.`);
@@ -941,13 +991,25 @@ async function prepareMcpToolkit(guildServers = [], {
  *
  * @returns {Promise<number>} how many connections now have a tool list
  */
-async function prewarmMcpServers(guildServers = [], { concurrency = 4 } = {}) {
+async function prewarmMcpServers(guildServers = [], { concurrency = 4, only = null } = {}) {
     let servers;
     try {
         servers = resolveMcpServers(guildServers);
     } catch (err) {
         console.warn(`[MCP] prewarm could not resolve servers: ${err.message}`);
         return 0;
+    }
+
+    // `only` narrows the warm-up to the servers named (#838). Resolution merges
+    // the operator's config file into whatever it is handed, which is right for
+    // the startup sweep and wrong for a dashboard save: an admin editing one
+    // server would dial every shared server in the config file as well, on
+    // every save, and a guild that has never used those pays their handshakes.
+    // The save still goes through resolution rather than around it, because
+    // that is what applies the file's defaults to the entry being saved.
+    if (only) {
+        const wanted = new Set(only);
+        servers = servers.filter(server => wanted.has(server.name));
     }
 
     const unique = new Map();

--- a/src/services/ai/mcp/toolkit.js
+++ b/src/services/ai/mcp/toolkit.js
@@ -9,6 +9,7 @@ const {
     DEFAULT_CONFIRM_MODE
 } = require('../../../config/mcpServers');
 const { MAX_RESPONSE_BYTES } = require('./client');
+const { trimResult } = require('./trim');
 const {
     entryFor,
     withSession,
@@ -433,9 +434,12 @@ function renderResult(
             ? 'The tool reported an error but sent no message.'
             : 'The tool returned no output.';
     }
-    if (text.length > MAX_TOOL_RESULT_CHARS) {
-        text = `${text.slice(0, MAX_TOOL_RESULT_CHARS)}\n[truncated: the tool returned more than ${MAX_TOOL_RESULT_CHARS} characters]`;
-    }
+    // Whole records rather than bytes (#838). A `slice` here landed in the
+    // middle of whatever JSON the tool returned, and the round after it read
+    // the half-written last field as though it were a value — a filename to
+    // call the next tool with, an id to look up — so the failure surfaced
+    // several steps downstream as an error about something that never existed.
+    text = trimResult(text, MAX_TOOL_RESULT_CHARS);
 
     return {
         text: isError ? `The tool reported an error: ${text}` : text,
@@ -798,7 +802,11 @@ async function prepareMcpToolkit(guildServers = [], {
             return text;
         }
         charsSpent = MAX_TOOL_RESULT_CHARS_PER_TURN;
-        return `${text.slice(0, remaining)}\n[truncated: the reply has taken in as much tool output as it can hold]`;
+        // Same reasoning as the per-result cap above, and the more important of
+        // the two: a result reaching this one is by definition in a turn that
+        // has already run other tools, which is exactly the multi-step chain a
+        // mid-JSON cut poisons.
+        return trimResult(text, remaining);
     }
 
     /**

--- a/src/services/ai/mcp/toolkit.js
+++ b/src/services/ai/mcp/toolkit.js
@@ -777,7 +777,9 @@ async function prepareMcpToolkit(guildServers = [], {
     // Spent across the whole turn rather than per call: see the two constants
     // above for why neither ceiling works on its own.
     let charsSpent = 0;
-    const deadline = Date.now() + turnBudgetMs;
+    // Not const: time spent waiting for a *person* is credited back below, so
+    // one question does not spend the whole turn's allowance (#838).
+    let deadline = Date.now() + turnBudgetMs;
 
     /**
      * A result, labelled with where it came from.
@@ -945,8 +947,25 @@ async function prepareMcpToolkit(guildServers = [], {
         // has to say out loud — "the github server is asking you" — and the
         // handler itself belongs to the turn rather than to any one call, so
         // its per-turn ceiling counts every server's questions together.
+        // The turn budget exists to bound how long a Discord reply is held open
+        // waiting on somebody else's server. A person reading a question is not
+        // that: they are engaged, and the reply is waiting on them on purpose.
+        // Charging their thinking time to the same ninety seconds means one
+        // question ends the turn — every call after it finds the budget spent
+        // and is refused — so the wait is measured and given back.
+        //
+        // Only the wait, and only once it is over: a question that is never
+        // answered still costs its own time, so a turn cannot be held open
+        // indefinitely by a server that asks and goes away.
         const onElicit = typeof elicit === 'function'
-            ? (params, ctx) => elicit(server, params, ctx)
+            ? async (params, ctx) => {
+                const askedAt = Date.now();
+                try {
+                    return await elicit(server, params, ctx);
+                } finally {
+                    deadline += Date.now() - askedAt;
+                }
+            }
             : undefined;
 
         try {

--- a/src/services/ai/mcp/trim.js
+++ b/src/services/ai/mcp/trim.js
@@ -1,0 +1,239 @@
+'use strict';
+
+/**
+ * Cutting an over-long tool result down to what the reply can hold (#838).
+ *
+ * Both of the toolkit's caps used to do this with `text.slice(0, limit)`, and
+ * the failure that causes is specific rather than cosmetic. A tool result is
+ * usually JSON, so slicing lands in the middle of a string, an escape sequence
+ * or a nesting level, and what reaches the model is a document that cannot be
+ * parsed and whose last field is a half-written value. In a one-shot answer
+ * that is merely lossy. In a multi-step chain it poisons the round after it:
+ * the model reads `"path": "src/servi` as a filename and calls the next tool
+ * with it, and the failure surfaces three steps downstream as a tool error
+ * about a file that does not exist.
+ *
+ * The fix is to drop whole units instead of bytes.
+ *
+ *   - A JSON array is the common shape — search hits, files, issues, rows —
+ *     and it has an obvious unit. Elements come out of the middle until the
+ *     rest fits, and what is left is re-serialised, so the model is handed
+ *     valid JSON containing genuinely complete records rather than an invalid
+ *     document ending mid-record.
+ *   - A JSON object usually carries one big array and some small scalars
+ *     (`{ total, nextCursor, items: [...] }`). Shrinking the array keeps the
+ *     cursor and the count, which are exactly the fields a next step needs.
+ *   - Anything else — prose, a diff, a log, a directory listing — gets a head
+ *     and a tail rather than a head alone. The end of a log is where the error
+ *     is, and the end of a diff is where the file it belongs to is named; a
+ *     head-only cut reliably removes the half that was worth reading.
+ *
+ * Every path says what it dropped and in what unit, because "some of this is
+ * missing" is what stops a model reporting three results as though they were
+ * the whole answer. The note is prose *after* the JSON rather than an entry
+ * inside it: a marker pushed into an array changes the type of its elements,
+ * and a model that has been handed forty objects and a string has been given a
+ * new bug to work around rather than a smaller answer.
+ *
+ * Deterministic and local, rather than the cheap-model summarisation pass the
+ * issue also offers. Summarising costs a provider round trip inside a tool
+ * loop the user is already watching an ellipsis through, it costs tokens
+ * against the same budget this is trying to protect, and it puts a model's
+ * paraphrase where the model below expects the server's own field names — a
+ * summarised directory listing is no longer something you can call the next
+ * tool with. This keeps the records verbatim and drops the ones that do not
+ * fit, which is the property a chain actually needs.
+ */
+
+// Below this there is no room for two JSON records and a note, so the shapes
+// below cannot produce anything more useful than a plain cut.
+const MIN_STRUCTURED_LIMIT = 200;
+
+// How much of a plain-text budget goes to the head. The head carries what the
+// output *is* — the command, the header row, the first hits — and the tail
+// carries how it ended, which is shorter and usually the error.
+const HEAD_SHARE = 0.7;
+
+// Elements kept from the front when an array has to lose its middle. Whatever
+// the budget, a couple from each end says more about the shape of the answer
+// than the same count taken from the front alone.
+const MIN_HEAD_ITEMS = 1;
+const MIN_TAIL_ITEMS = 1;
+
+/** `value` as pretty JSON, or null when it will not serialise. */
+function stringify(value) {
+    try {
+        const json = JSON.stringify(value, null, 1);
+        return typeof json === 'string' ? json : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * `text` parsed as JSON, or null.
+ *
+ * Only a container is interesting: a bare string or number that is over the
+ * limit is one long scalar, and there is nothing structural to drop out of it.
+ */
+function parseContainer(text) {
+    const trimmed = text.trim();
+    if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return null;
+    try {
+        const parsed = JSON.parse(trimmed);
+        return parsed && typeof parsed === 'object' ? parsed : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * The largest number of elements from `items` whose serialisation fits, taken
+ * from both ends, or null when not even the minimum does.
+ *
+ * A binary search rather than a loop that adds one element at a time: a tool
+ * returning ten thousand rows would otherwise serialise the array ten thousand
+ * times to find out where it stops fitting.
+ */
+function fitItems(items, wrap, limit) {
+    const measure = count => {
+        const head = Math.max(MIN_HEAD_ITEMS, Math.ceil(count * HEAD_SHARE));
+        const kept = count >= items.length
+            ? items
+            : [...items.slice(0, head), ...items.slice(items.length - Math.max(MIN_TAIL_ITEMS, count - head))];
+        const json = stringify(wrap(kept));
+        return json === null ? null : { kept, json };
+    };
+
+    const smallest = measure(MIN_HEAD_ITEMS + MIN_TAIL_ITEMS);
+    if (!smallest || smallest.json.length > limit) return null;
+
+    let best = smallest;
+    let low = MIN_HEAD_ITEMS + MIN_TAIL_ITEMS;
+    let high = items.length - 1;
+
+    while (low <= high) {
+        const mid = Math.floor((low + high) / 2);
+        const attempt = measure(mid);
+        if (attempt && attempt.json.length <= limit) {
+            best = attempt;
+            low = mid + 1;
+        } else {
+            high = mid - 1;
+        }
+    }
+    return best;
+}
+
+/**
+ * The note that goes after a trimmed result.
+ *
+ * It says the unit and both numbers, because "truncated" alone tells a model
+ * that something stopped, not that it is holding three of fifty records — and
+ * a model told the first is liable to answer as though it had all fifty.
+ */
+function note(kept, total, unit) {
+    return `\n[trimmed to fit the reply: ${kept} of ${total} ${unit} shown, taken from the start and the end. `
+        + 'Say so if the answer depends on what is missing, and narrow the call rather than guessing at it.]';
+}
+
+// The seam between the two halves, which is also what stops them reading as one
+// continuous piece of output — two adjacent log lines a thousand lines apart.
+function elision(count, unit) {
+    return `\n[… ${count} ${unit} omitted …]\n`;
+}
+
+// The smallest thing that is still an honest answer, for a budget with no room
+// for a sentence. Nine characters buys the difference between output the model
+// knows is partial and output it will summarise as though it were whole.
+const SHORT_MARKER = '\n[cut…]';
+
+function shortCut(text, limit) {
+    if (limit <= SHORT_MARKER.length) return text.slice(0, limit);
+    return text.slice(0, limit - SHORT_MARKER.length) + SHORT_MARKER;
+}
+
+/** Whichever array property of `object` is longest, or null. */
+function largestArrayKey(object) {
+    let best = null;
+    for (const [key, value] of Object.entries(object)) {
+        if (Array.isArray(value) && (!best || value.length > object[best].length)) best = key;
+    }
+    return best && object[best].length > 1 ? best : null;
+}
+
+/**
+ * Head and tail of `text` on line boundaries, for a result with no structure to
+ * preserve.
+ *
+ * Snapping to a newline is what keeps the two halves readable — a cut mid-line
+ * reads as a corrupted line rather than as an omission — and it is abandoned
+ * when the nearest boundary is most of the budget away, which is the one-very-
+ * long-line case where snapping would throw away the whole allowance.
+ */
+function headAndTail(text, limit, unit = 'characters') {
+    // Both pieces of furniture are measured against their own upper bounds —
+    // nothing shown can exceed `limit`, and nothing omitted can exceed the
+    // whole text — so the reserve is never an under-estimate and the result
+    // never exceeds the budget it was given.
+    const reserve = note(limit, text.length, unit).length + elision(text.length, unit).length;
+    const room = limit - reserve;
+    // Not enough left for two halves and a sentence explaining them. The one
+    // thing that still has to survive is the fact that something was dropped:
+    // a result that fits exactly and says nothing about what it lost is the
+    // failure this module exists to stop, and it is worse at a small budget
+    // than a large one, because a small budget cuts more.
+    if (room < 80) return shortCut(text, limit);
+
+    const headRoom = Math.floor(room * HEAD_SHARE);
+    const tailRoom = room - headRoom;
+
+    let head = text.slice(0, headRoom);
+    const headBreak = head.lastIndexOf('\n');
+    if (headBreak > headRoom / 2) head = head.slice(0, headBreak);
+
+    let tail = text.slice(text.length - tailRoom);
+    const tailBreak = tail.indexOf('\n');
+    if (tailBreak >= 0 && tailBreak < tailRoom / 2) tail = tail.slice(tailBreak + 1);
+
+    const shown = head.length + tail.length;
+    return head + elision(text.length - shown, unit) + tail + note(shown, text.length, unit);
+}
+
+/**
+ * `text` cut to `limit` characters, dropping whole records where it can.
+ *
+ * Never returns more than `limit` from the structured paths; the plain-text
+ * path is held to the same budget for its content and then adds its note, which
+ * is the one thing worth going a line over — a result that fits exactly and
+ * says nothing about what it lost is the failure this module exists to stop.
+ */
+function trimResult(text, limit) {
+    if (typeof text !== 'string' || text.length <= limit || limit <= 0) return text;
+    if (limit < MIN_STRUCTURED_LIMIT) return shortCut(text, limit);
+
+    const parsed = parseContainer(text);
+
+    if (Array.isArray(parsed) && parsed.length > 1) {
+        const room = limit - note(limit, parsed.length, 'items').length;
+        const fitted = room > 0 ? fitItems(parsed, kept => kept, room) : null;
+        if (fitted) return fitted.json + note(fitted.kept.length, parsed.length, 'items');
+    }
+
+    if (parsed && !Array.isArray(parsed)) {
+        const key = largestArrayKey(parsed);
+        if (key) {
+            const items = parsed[key];
+            const room = limit - note(limit, items.length, `${key} entries`).length;
+            const fitted = room > 0 ? fitItems(items, kept => ({ ...parsed, [key]: kept }), room) : null;
+            // The scalars beside the array — a total, a next cursor — are what a
+            // following step needs, and they survive here where a byte-slice
+            // would have taken whichever of them sorted last.
+            if (fitted) return fitted.json + note(fitted.kept.length, items.length, `${key} entries`);
+        }
+    }
+
+    return headAndTail(text, limit);
+}
+
+module.exports = { trimResult, headAndTail, MIN_STRUCTURED_LIMIT, HEAD_SHARE, SHORT_MARKER };

--- a/src/services/ai/mcp/trim.js
+++ b/src/services/ai/mcp/trim.js
@@ -162,6 +162,79 @@ function largestArrayKey(object) {
     return best && object[best].length > 1 ? best : null;
 }
 
+// Below this a string is not what is making the document too big, and cutting
+// it further costs a field its meaning without buying room worth having.
+const MIN_SHRINKABLE_STRING = 80;
+
+// How many halvings to try before giving up and letting the text path have it.
+// Each pass halves the longest string, so this is far more than enough to take
+// a megabyte down to nothing; it exists so a pathological document cannot spin.
+const MAX_SHRINK_PASSES = 60;
+
+/**
+ * Every string in a document that is long enough to be worth shortening, as
+ * things that can be written back.
+ *
+ * Top level and one level in, which is where tool results keep their prose: an
+ * object's own fields (`{ content: "<the whole file>" }`) and the fields of an
+ * array's elements (`[{ path, body }, …]`). Deeper than that and this would be
+ * a general tree rewriter, which is a different and much less predictable
+ * thing than "the one enormous field is what will not fit".
+ */
+function longStrings(value, into = [], depth = 0) {
+    if (depth > 1 || !value || typeof value !== 'object') return into;
+
+    for (const [key, child] of Object.entries(value)) {
+        if (typeof child === 'string') {
+            if (child.length >= MIN_SHRINKABLE_STRING) into.push({ holder: value, key });
+        } else if (child && typeof child === 'object') {
+            longStrings(child, into, depth + 1);
+        }
+    }
+    return into;
+}
+
+/**
+ * `parsed` with its longest strings cut down until it serialises inside
+ * `limit`, or null when there is nothing long enough to be worth cutting.
+ *
+ * This is the shape the array paths above do not cover and a byte-slice
+ * handles worst: one field holding the whole answer — a file's contents, a
+ * page of HTML, a stack trace — beside the fields that say what it is. Cutting
+ * the string keeps the document valid and keeps `path`, `status` and the rest
+ * of the scalars a following call needs; cutting the document loses them,
+ * because they sort after the big one about half the time.
+ *
+ * The value is mutated in place, which is safe because it came out of
+ * `JSON.parse` a few lines ago and belongs to nobody else.
+ */
+function shrinkStrings(parsed, limit) {
+    const slots = longStrings(parsed);
+    if (!slots.length) return null;
+
+    for (let pass = 0; pass < MAX_SHRINK_PASSES; pass++) {
+        const json = stringify(parsed);
+        if (json === null) return null;
+        if (json.length <= limit) return { json };
+
+        // The longest one each time, so a document with one enormous field and
+        // twenty small ones loses the enormous one rather than all twenty.
+        let longest = null;
+        for (const slot of slots) {
+            const text = slot.holder[slot.key];
+            if (typeof text === 'string' && (!longest || text.length > longest.holder[longest.key].length)) {
+                longest = slot;
+            }
+        }
+        const current = longest && longest.holder[longest.key];
+        if (!current || current.length < MIN_SHRINKABLE_STRING) return null;
+
+        const keep = Math.max(MIN_SHRINKABLE_STRING >> 1, Math.floor(current.length / 2));
+        longest.holder[longest.key] = `${current.slice(0, keep)}… [${current.length - keep} characters omitted]`;
+    }
+    return null;
+}
+
 /**
  * Head and tail of `text` on line boundaries, for a result with no structure to
  * preserve.
@@ -233,7 +306,17 @@ function trimResult(text, limit) {
         }
     }
 
+    // Nothing to drop whole, but perhaps something to shorten: one field
+    // holding the entire answer beside the scalars that describe it. Cutting
+    // the field keeps the document valid and keeps those; cutting the document
+    // loses whichever of them sorted after it.
+    if (parsed) {
+        const room = limit - note(limit, text.length, 'characters').length;
+        const shrunk = room > 0 ? shrinkStrings(parsed, room) : null;
+        if (shrunk) return shrunk.json + note(shrunk.json.length, text.length, 'characters');
+    }
+
     return headAndTail(text, limit);
 }
 
-module.exports = { trimResult, headAndTail, MIN_STRUCTURED_LIMIT, HEAD_SHARE, SHORT_MARKER };
+module.exports = { trimResult, headAndTail, shrinkStrings, MIN_STRUCTURED_LIMIT, HEAD_SHARE, SHORT_MARKER };

--- a/src/services/ai/providers/ollama.js
+++ b/src/services/ai/providers/ollama.js
@@ -218,8 +218,8 @@ async function* separated(pieces) {
     }
 }
 
-async function* stream({ baseUrl, model, systemPrompt, history, prompt, images, temperature, maxTokens, usageOut, useMcp = true, mcpServers, onToolEvent, mcpConfirm, confirmTool, toolBudget, botTools, maxRounds, turnBudgetMs }) {
-    const toolkit = await toolkitFor({ useMcp, mcpServers, onToolEvent, mcpConfirm, confirmTool, toolBudget, botTools, maxRounds, turnBudgetMs });
+async function* stream({ baseUrl, model, systemPrompt, history, prompt, images, temperature, maxTokens, usageOut, useMcp = true, mcpServers, onToolEvent, mcpConfirm, confirmTool, elicit, toolBudget, botTools, maxRounds, turnBudgetMs }) {
+    const toolkit = await toolkitFor({ useMcp, mcpServers, onToolEvent, mcpConfirm, confirmTool, elicit, toolBudget, botTools, maxRounds, turnBudgetMs });
     const rounds = roundsFor(toolkit);
     const { url, agents } = resolveEndpoint(baseUrl);
     const messages = buildMessages({ systemPrompt, history, prompt, images, model });
@@ -257,8 +257,8 @@ async function* stream({ baseUrl, model, systemPrompt, history, prompt, images, 
     if (usageOut && sawUsage) usageOut.usage = totals;
 }
 
-async function complete({ baseUrl, model, systemPrompt, history, prompt, images, temperature, maxTokens, useMcp = true, mcpServers, onToolEvent, mcpConfirm, confirmTool, toolBudget, botTools, maxRounds, turnBudgetMs }) {
-    const toolkit = await toolkitFor({ useMcp, mcpServers, onToolEvent, mcpConfirm, confirmTool, toolBudget, botTools, maxRounds, turnBudgetMs });
+async function complete({ baseUrl, model, systemPrompt, history, prompt, images, temperature, maxTokens, useMcp = true, mcpServers, onToolEvent, mcpConfirm, confirmTool, elicit, toolBudget, botTools, maxRounds, turnBudgetMs }) {
+    const toolkit = await toolkitFor({ useMcp, mcpServers, onToolEvent, mcpConfirm, confirmTool, elicit, toolBudget, botTools, maxRounds, turnBudgetMs });
     const rounds = roundsFor(toolkit);
     const { url, agents } = resolveEndpoint(baseUrl);
     const messages = buildMessages({ systemPrompt, history, prompt, images, model });

--- a/src/services/ai/providers/openai.js
+++ b/src/services/ai/providers/openai.js
@@ -231,8 +231,8 @@ async function runToolCalls({ toolkit, messages, calls, content }) {
     });
 }
 
-async function* stream({ apiKey, model, systemPrompt, history, prompt, images, temperature, maxTokens, visionCapable, baseURL, defaultHeaders, usageOut, useMcp = true, mcpServers, onToolEvent, mcpConfirm, confirmTool, toolBudget, botTools, maxRounds, turnBudgetMs }) {
-    const toolkit = await toolkitFor({ useMcp, mcpServers, onToolEvent, mcpConfirm, confirmTool, toolBudget, botTools, maxRounds, turnBudgetMs });
+async function* stream({ apiKey, model, systemPrompt, history, prompt, images, temperature, maxTokens, visionCapable, baseURL, defaultHeaders, usageOut, useMcp = true, mcpServers, onToolEvent, mcpConfirm, confirmTool, elicit, toolBudget, botTools, maxRounds, turnBudgetMs }) {
+    const toolkit = await toolkitFor({ useMcp, mcpServers, onToolEvent, mcpConfirm, confirmTool, elicit, toolBudget, botTools, maxRounds, turnBudgetMs });
     const rounds = roundsFor(toolkit);
     const client = new OpenAI({ apiKey, baseURL, defaultHeaders });
     // What `noStreamOptions` is keyed on. `baseURL` is undefined for OpenAI
@@ -293,8 +293,8 @@ async function* stream({ apiKey, model, systemPrompt, history, prompt, images, t
     if (usageOut && sawUsage) usageOut.usage = totals;
 }
 
-async function complete({ apiKey, model, systemPrompt, history, prompt, images, temperature, maxTokens, visionCapable, baseURL, defaultHeaders, useMcp = true, mcpServers, onToolEvent, mcpConfirm, confirmTool, toolBudget, botTools, maxRounds, turnBudgetMs }) {
-    const toolkit = await toolkitFor({ useMcp, mcpServers, onToolEvent, mcpConfirm, confirmTool, toolBudget, botTools, maxRounds, turnBudgetMs });
+async function complete({ apiKey, model, systemPrompt, history, prompt, images, temperature, maxTokens, visionCapable, baseURL, defaultHeaders, useMcp = true, mcpServers, onToolEvent, mcpConfirm, confirmTool, elicit, toolBudget, botTools, maxRounds, turnBudgetMs }) {
+    const toolkit = await toolkitFor({ useMcp, mcpServers, onToolEvent, mcpConfirm, confirmTool, elicit, toolBudget, botTools, maxRounds, turnBudgetMs });
     const rounds = roundsFor(toolkit);
     const client = new OpenAI({ apiKey, baseURL, defaultHeaders });
     const messages = buildMessages({ systemPrompt, history, prompt, images, model, visionCapable });

--- a/src/services/ai/providers/openai.js
+++ b/src/services/ai/providers/openai.js
@@ -130,6 +130,60 @@ function accumulateToolCalls(pending, deltas) {
     }
 }
 
+/**
+ * Endpoints that answered a stream with "I do not know what stream_options is".
+ *
+ * `stream_options: { include_usage: true }` is how a streamed OpenAI response
+ * is made to report its token counts — without it the usage ledger has nothing
+ * to charge and the guild's spend goes unmeasured — but it is an OpenAI
+ * extension, and `baseURL` points this provider at anything that speaks the
+ * chat-completions shape: llama.cpp, vLLM, LM Studio, a corporate gateway.
+ * Several of those reject the unknown field with a 400 rather than ignoring it,
+ * which turned "your usage numbers are missing" into "the bot cannot answer"
+ * (#838).
+ *
+ * So it is sent by default and withdrawn on evidence: the first 400 that names
+ * the parameter is retried without it, and the endpoint is remembered for the
+ * life of the process so the next message pays no failed request. Usage for
+ * that endpoint is then whatever the stream reports on its own, which for most
+ * of them is nothing — the same position the bot was in before, and better than
+ * a reply that does not arrive.
+ */
+const noStreamOptions = new Set();
+
+// A 400 from an endpoint that has never heard of the field. Matched on the
+// parameter name rather than on a status alone: a 400 for a bad model name or
+// an over-long context is not something dropping usage reporting would fix,
+// and retrying those would double every genuine failure.
+function rejectsStreamOptions(err) {
+    if (err?.status !== 400) return false;
+    const text = `${err.message || ''} ${JSON.stringify(err.error ?? '')}`.toLowerCase();
+    return text.includes('stream_options') || text.includes('include_usage');
+}
+
+/**
+ * Open one streamed round, dropping `stream_options` for an endpoint that has
+ * refused it before — or that refuses it now.
+ *
+ * The retry is safe to make because nothing has been consumed: a request that
+ * fails at 400 produced no tokens, ran no tool, and cost nothing to repeat.
+ */
+async function openStream(client, params, endpoint) {
+    if (noStreamOptions.has(endpoint)) return client.chat.completions.create(params);
+
+    try {
+        return await client.chat.completions.create({
+            ...params,
+            stream_options: { include_usage: true }
+        });
+    } catch (err) {
+        if (!rejectsStreamOptions(err)) throw err;
+        console.warn(`[AI:openai] ${endpoint} rejects stream_options; usage will go unreported for it`);
+        noStreamOptions.add(endpoint);
+        return client.chat.completions.create(params);
+    }
+}
+
 function toolCallsOf(message) {
     return (message?.tool_calls || []).map((call, index) => ({
         id: call.id || `call_${index}`,
@@ -181,6 +235,10 @@ async function* stream({ apiKey, model, systemPrompt, history, prompt, images, t
     const toolkit = await toolkitFor({ useMcp, mcpServers, onToolEvent, mcpConfirm, confirmTool, toolBudget, botTools, maxRounds, turnBudgetMs });
     const rounds = roundsFor(toolkit);
     const client = new OpenAI({ apiKey, baseURL, defaultHeaders });
+    // What `noStreamOptions` is keyed on. `baseURL` is undefined for OpenAI
+    // itself, which is a key like any other — and the one endpoint guaranteed
+    // never to end up in the set.
+    const endpoint = baseURL || 'openai';
     const messages = buildMessages({ systemPrompt, history, prompt, images, model, visionCapable });
 
     const totals = { inputTokens: 0, outputTokens: 0 };
@@ -197,14 +255,13 @@ async function* stream({ apiKey, model, systemPrompt, history, prompt, images, t
         // tool call, and the user would get an empty message.
         const offerTools = Boolean(toolkit) && round < rounds;
 
-        const response = await client.chat.completions.create({
+        const response = await openStream(client, {
             model,
             messages,
             ...tuningParams(model, temperature, maxTokens),
             stream: true,
-            stream_options: { include_usage: true },
             ...(offerTools ? { tools: toolParams(toolkit) } : {})
-        });
+        }, endpoint);
 
         let content = '';
         let roundUsage = null;

--- a/tests/mcpClient.test.js
+++ b/tests/mcpClient.test.js
@@ -836,3 +836,236 @@ describe('a server that is rate-limiting us', () => {
         });
     });
 });
+
+/**
+ * #838. Elicitation is the one exchange that runs the other way: the server
+ * sends a *request* down the stream its tool result is still coming on, and
+ * waits for an answer. Two things make it different from everything else here
+ * — the answer goes back on a POST of its own, because the transport has no way
+ * to write up the stream it arrived on, and the clock has to stop, because what
+ * the client is doing in the meantime is asking a person.
+ */
+describe('a request from the server', () => {
+    /** A stream that asks a question, then answers the tool call. */
+    function askingStream(payload, params) {
+        return sseResponse([
+            { jsonrpc: '2.0', id: 'srv-1', method: 'elicitation/create', params },
+            { jsonrpc: '2.0', id: payload.id, result: { content: [{ type: 'text', text: 'done' }] } }
+        ]);
+    }
+
+    function serverThatAsks(params = { message: 'which one?', requestedSchema: { type: 'object', properties: {} } }) {
+        const answers = [];
+        axios.post.mockImplementation(async (_url, payload) => {
+            if (payload.method === 'notifications/initialized') return acceptedResponse();
+            if (payload.method === 'initialize') return jsonResponse({ jsonrpc: '2.0', id: payload.id, result: INIT_RESULT });
+            // A JSON-RPC message with no method is the client answering us.
+            if (!payload.method) {
+                answers.push(payload);
+                return acceptedResponse();
+            }
+            return askingStream(payload, params);
+        });
+        return answers;
+    }
+
+    /** Waits for the answer POST, which is deliberately not awaited in-band. */
+    const settled = async answers => {
+        for (let i = 0; i < 20 && !answers.length; i++) await new Promise(r => setImmediate(r));
+        return answers;
+    };
+
+    test('reaches the handler the call carried, with the server\'s params', async () => {
+        serverThatAsks({ message: 'which repo?', requestedSchema: { type: 'object', properties: { repo: { type: 'string' } } } });
+        const seen = [];
+
+        await new McpHttpClient({ url: URL, elicitation: true }).callTool('deploy', {}, {
+            onElicit: async params => { seen.push(params); return { action: 'accept', content: { repo: 'clawdia' } }; }
+        });
+
+        expect(seen).toEqual([{ message: 'which repo?', requestedSchema: { type: 'object', properties: { repo: { type: 'string' } } } }]);
+    });
+
+    test('and the answer goes back as a JSON-RPC response with the server\'s id', async () => {
+        const answers = serverThatAsks();
+
+        await new McpHttpClient({ url: URL, elicitation: true }).callTool('deploy', {}, {
+            onElicit: async () => ({ action: 'accept', content: { repo: 'clawdia' } })
+        });
+
+        await settled(answers);
+        expect(answers[0]).toEqual({
+            jsonrpc: '2.0',
+            id: 'srv-1',
+            result: { action: 'accept', content: { repo: 'clawdia' } }
+        });
+    });
+
+    // The tool result is still coming down the original stream while a person
+    // reads the question, so the question must not block the read.
+    test('the tool result still arrives while the question is outstanding', async () => {
+        serverThatAsks();
+        let release;
+        const asked = new Promise(resolve => { release = resolve; });
+
+        const result = await new McpHttpClient({ url: URL, elicitation: true }).callTool('deploy', {}, {
+            onElicit: () => asked.then(() => ({ action: 'decline' }))
+        });
+
+        expect(result.content).toEqual([{ type: 'text', text: 'done' }]);
+        release();
+    });
+
+    // The capability is the connection's and the person is the request's, so a
+    // scheduled task reaches here with nobody to ask. `cancel` is the spec's
+    // "no choice was made", which is exactly true.
+    test('with nobody to ask, it is answered cancel rather than left hanging', async () => {
+        const answers = serverThatAsks();
+
+        await new McpHttpClient({ url: URL, elicitation: true }).callTool('deploy', {});
+
+        await settled(answers);
+        expect(answers[0]).toMatchObject({ id: 'srv-1', result: { action: 'cancel' } });
+    });
+
+    // A server that gets no answer waits for one, so an unsupported method has
+    // to be refused rather than ignored: silence is a tool call that hangs
+    // until its deadline instead of failing in a sentence.
+    test('a method this client does not serve is refused, not ignored', async () => {
+        const answers = [];
+        axios.post.mockImplementation(async (_url, payload) => {
+            if (payload.method === 'notifications/initialized') return acceptedResponse();
+            if (payload.method === 'initialize') return jsonResponse({ jsonrpc: '2.0', id: payload.id, result: INIT_RESULT });
+            if (!payload.method) { answers.push(payload); return acceptedResponse(); }
+            return sseResponse([
+                { jsonrpc: '2.0', id: 'srv-9', method: 'sampling/createMessage', params: {} },
+                { jsonrpc: '2.0', id: payload.id, result: { content: [] } }
+            ]);
+        });
+
+        await new McpHttpClient({ url: URL, elicitation: true }).callTool('think', {});
+
+        await settled(answers);
+        expect(answers[0].error).toMatchObject({ code: -32601, message: expect.stringContaining('sampling/createMessage') });
+    });
+
+    test('a handler that throws becomes an error response, not a hang', async () => {
+        const answers = serverThatAsks();
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        await new McpHttpClient({ url: URL, elicitation: true }).callTool('deploy', {}, {
+            onElicit: async () => { throw new Error('the channel is gone'); }
+        });
+
+        await settled(answers);
+        expect(answers[0].error).toMatchObject({ code: -32603, message: 'the channel is gone' });
+        warn.mockRestore();
+    });
+});
+
+/**
+ * The clock. A tool call is bounded so a Discord reply cannot be held open
+ * forever, and `readWithDeadline` enforces that by destroying the stream. An
+ * elicitation puts the exchange in front of a person, and the seconds they
+ * spend reading it are not the server being slow — without moving the deadline,
+ * the call the question belongs to is killed underneath the prompt still
+ * sitting in the channel, and the server is left holding a request nobody will
+ * ever answer.
+ */
+describe('the deadline while somebody is answering', () => {
+    /** A stream held open by the test, so the deadline is what decides. */
+    function heldStream() {
+        const stream = new Readable({ read() {} });
+        return {
+            stream,
+            push: event => stream.push(`event: message\ndata: ${JSON.stringify(event)}\n\n`),
+            end: () => stream.push(null),
+        };
+    }
+
+    test('is pushed out by the handler, so the call outlives its original budget', async () => {
+        const held = heldStream();
+        axios.post.mockImplementation(async (_url, payload) => {
+            if (payload.method === 'notifications/initialized') return acceptedResponse();
+            if (payload.method === 'initialize') return jsonResponse({ jsonrpc: '2.0', id: payload.id, result: INIT_RESULT });
+            if (!payload.method) return acceptedResponse();
+            callId = payload.id;
+            setImmediate(() => held.push({ jsonrpc: '2.0', id: 'srv-1', method: 'elicitation/create', params: {} }));
+            return { status: 200, headers: { 'content-type': 'text/event-stream' }, data: held.stream };
+        });
+
+        let callId;
+        let answered;
+        const client = new McpHttpClient({ url: URL, elicitation: true });
+        const call = client.callTool('deploy', {}, {
+            timeout: 60,
+            onElicit: (_params, { extendDeadline }) => {
+                extendDeadline(5000);
+                return new Promise(resolve => { answered = resolve; });
+            }
+        });
+
+        // Comfortably past the 60ms the call started with. Without the
+        // extension the stream is destroyed here and the call rejects.
+        await new Promise(resolve => setTimeout(resolve, 250));
+        answered({ action: 'accept', content: {} });
+        held.push({ jsonrpc: '2.0', id: callId, result: { content: [{ type: 'text', text: 'deployed' }] } });
+
+        await expect(call).resolves.toMatchObject({ content: [{ type: 'text', text: 'deployed' }] });
+    });
+
+    // The extension is not a reprieve from the clock, only a longer one: a
+    // server that asks and then goes away still loses the call rather than
+    // holding a Discord reply open indefinitely.
+    test('and still expires when nobody answers at all', async () => {
+        const held = heldStream();
+        axios.post.mockImplementation(async (_url, payload) => {
+            if (payload.method === 'notifications/initialized') return acceptedResponse();
+            if (payload.method === 'initialize') return jsonResponse({ jsonrpc: '2.0', id: payload.id, result: INIT_RESULT });
+            if (!payload.method) return acceptedResponse();
+            setImmediate(() => held.push({ jsonrpc: '2.0', id: 'srv-1', method: 'elicitation/create', params: {} }));
+            return { status: 200, headers: { 'content-type': 'text/event-stream' }, data: held.stream };
+        });
+
+        const client = new McpHttpClient({ url: URL, elicitation: true });
+        await expect(client.callTool('deploy', {}, {
+            timeout: 60,
+            onElicit: (_params, { extendDeadline }) => {
+                extendDeadline(150);
+                return new Promise(() => {});
+            }
+        })).rejects.toThrow(/before the deadline/);
+    });
+});
+
+describe('what the client tells a server it can do', () => {
+    async function capabilitiesOf(options) {
+        let sent;
+        axios.post.mockImplementation(async (_url, payload) => {
+            if (payload.method === 'initialize') sent = payload.params.capabilities;
+            if (payload.method === 'notifications/initialized') return acceptedResponse();
+            return jsonResponse({ jsonrpc: '2.0', id: payload.id, result: payload.method === 'initialize' ? INIT_RESULT : { tools: [] } });
+        });
+        await new McpHttpClient({ url: URL, ...options }).listTools();
+        return sent;
+    }
+
+    test('nothing at all, when there is nobody to ask', async () => {
+        expect(await capabilitiesOf({})).toEqual({});
+    });
+
+    test('elicitation, when there is', async () => {
+        expect(await capabilitiesOf({ elicitation: true })).toEqual({ elicitation: {} });
+    });
+
+    // A capability is a promise to answer, and these two are promises this
+    // client should not make: `roots` offers a filesystem for a server to work
+    // inside, and a Discord bot has none; `sampling` is a server asking to
+    // spend the guild's model budget, which wants the ledger and the
+    // confirmation the tool loop already has rather than a declaration.
+    test('and never roots or sampling', async () => {
+        const capabilities = await capabilitiesOf({ elicitation: true });
+        expect(capabilities).not.toHaveProperty('roots');
+        expect(capabilities).not.toHaveProperty('sampling');
+    });
+});

--- a/tests/mcpClient.test.js
+++ b/tests/mcpClient.test.js
@@ -302,6 +302,72 @@ describe('server-sent event responses', () => {
         expect(tools).toEqual([{ name: 'search' }]);
     });
 
+    /**
+     * #838. A `list_changed` is about the connection rather than about any one
+     * request, so nobody is waiting for it: it arrives on whatever stream
+     * happens to be open, and without a connection-level listener it was read
+     * off the wire and dropped.
+     */
+    test('forwards every notification to the connection-level listener', async () => {
+        axios.post.mockImplementation(async (_url, payload) => {
+            if (payload.method === 'notifications/initialized') return acceptedResponse();
+            if (payload.method === 'initialize') return jsonResponse({ jsonrpc: '2.0', id: payload.id, result: INIT_RESULT });
+            return sseResponse([
+                { jsonrpc: '2.0', method: 'notifications/tools/list_changed' },
+                { jsonrpc: '2.0', id: payload.id, result: { tools: [{ name: 'search' }] } }
+            ]);
+        });
+
+        const seen = [];
+        const client = new McpHttpClient({ url: URL, onNotification: n => seen.push(n.method) });
+        await client.listTools();
+
+        expect(seen).toContain('notifications/tools/list_changed');
+    });
+
+    // Nobody asked for progress here, which used to mean no listener was passed
+    // at all and every notification on the stream went unread.
+    test('and does so on a request that asked for no progress', async () => {
+        axios.post.mockImplementation(async (_url, payload) => {
+            if (payload.method === 'notifications/initialized') return acceptedResponse();
+            if (payload.method === 'initialize') return jsonResponse({ jsonrpc: '2.0', id: payload.id, result: INIT_RESULT });
+            return sseResponse([
+                { jsonrpc: '2.0', method: 'notifications/resources/list_changed' },
+                { jsonrpc: '2.0', id: payload.id, result: { content: [{ type: 'text', text: 'ok' }] } }
+            ]);
+        });
+
+        const seen = [];
+        const client = new McpHttpClient({ url: URL, onNotification: n => seen.push(n.method) });
+        const result = await client.callTool('search', {});
+
+        expect(seen).toEqual(['notifications/resources/list_changed']);
+        expect(result.content).toEqual([{ type: 'text', text: 'ok' }]);
+    });
+
+    // Both audiences want every notification, and neither may cost the other
+    // one — a progress reader that throws is a bug in the caller, not a reason
+    // to miss the server saying its tool list moved.
+    test('a per-request listener that throws does not cost the connection one', async () => {
+        axios.post.mockImplementation(async (_url, payload) => {
+            if (payload.method === 'notifications/initialized') return acceptedResponse();
+            if (payload.method === 'initialize') return jsonResponse({ jsonrpc: '2.0', id: payload.id, result: INIT_RESULT });
+            return sseResponse([
+                { jsonrpc: '2.0', method: 'notifications/progress', params: { progressToken: payload.params._meta.progressToken, progress: 1 } },
+                { jsonrpc: '2.0', method: 'notifications/tools/list_changed' },
+                { jsonrpc: '2.0', id: payload.id, result: { content: [] } }
+            ]);
+        });
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const seen = [];
+        const client = new McpHttpClient({ url: URL, onNotification: n => seen.push(n.method) });
+        await client.callTool('search', {}, { onProgress: () => { throw new Error('listener bug'); } });
+
+        expect(seen).toEqual(['notifications/progress', 'notifications/tools/list_changed']);
+        warn.mockRestore();
+    });
+
     test('forwards progress notifications to a caller that asked for them', async () => {
         axios.post.mockImplementation(async (_url, payload) => {
             if (payload.method === 'notifications/initialized') return acceptedResponse();

--- a/tests/mcpClient.test.js
+++ b/tests/mcpClient.test.js
@@ -972,6 +972,58 @@ describe('a request from the server', () => {
  * sitting in the channel, and the server is left holding a request nobody will
  * ever answer.
  */
+/**
+ * Each side of a JSON-RPC connection numbers its own outgoing requests, so the
+ * two counters share a namespace by accident and will eventually collide: a
+ * server that has sent a few requests over a pooled session lands on the id of
+ * the call in flight. A message carrying a `method` is never a response,
+ * whatever id it has, and reading it as one is the difference between a
+ * question that gets answered and a tool that reports no output while the
+ * server waits out a request nobody will ever see.
+ */
+describe('a server request whose id collides with ours', () => {
+    test('is not mistaken for the answer to our call', async () => {
+        const answers = [];
+        axios.post.mockImplementation(async (_url, payload) => {
+            if (payload.method === 'notifications/initialized') return acceptedResponse();
+            if (payload.method === 'initialize') return jsonResponse({ jsonrpc: '2.0', id: payload.id, result: INIT_RESULT });
+            if (!payload.method) { answers.push(payload); return acceptedResponse(); }
+            return sseResponse([
+                // The server's own request, numbered the same as ours.
+                { jsonrpc: '2.0', id: payload.id, method: 'elicitation/create', params: { message: 'which?' } },
+                { jsonrpc: '2.0', id: payload.id, result: { content: [{ type: 'text', text: 'the real answer' }] } }
+            ]);
+        });
+
+        const client = new McpHttpClient({ url: URL, elicitation: true });
+        const result = await client.callTool('deploy', {}, {
+            onElicit: async () => ({ action: 'decline' })
+        });
+
+        expect(result.content).toEqual([{ type: 'text', text: 'the real answer' }]);
+        for (let i = 0; i < 20 && !answers.length; i++) await new Promise(r => setImmediate(r));
+        // Answered under the id the *server* used, which is the same number
+        // our call carried — that collision is the whole point of this test.
+        expect(answers[0]).toMatchObject({ result: { action: 'decline' } });
+        expect(answers[0].id).toBe(2);
+    });
+
+    // Same reasoning for a batched JSON body, which may carry the server's own
+    // requests alongside the answer.
+    test('and not in a batched JSON body either', async () => {
+        axios.post.mockImplementation(async (_url, payload) => {
+            if (payload.method === 'notifications/initialized') return acceptedResponse();
+            if (payload.method === 'initialize') return jsonResponse({ jsonrpc: '2.0', id: payload.id, result: INIT_RESULT });
+            return jsonResponse([
+                { jsonrpc: '2.0', id: payload.id, method: 'ping' },
+                { jsonrpc: '2.0', id: payload.id, result: { tools: [{ name: 'search' }] } }
+            ]);
+        });
+
+        await expect(new McpHttpClient({ url: URL }).listTools()).resolves.toEqual([{ name: 'search' }]);
+    });
+});
+
 describe('the deadline while somebody is answering', () => {
     /** A stream held open by the test, so the deadline is what decides. */
     function heldStream() {

--- a/tests/mcpConnections.test.js
+++ b/tests/mcpConnections.test.js
@@ -356,3 +356,122 @@ describe('one server does not see the whole round at once', () => {
         }
     });
 });
+
+/**
+ * #838. Without these the five-minute TTL is the whole answer, which is fine
+ * for the servers that never change and wrong for the ones that do it on
+ * purpose: a server that publishes its real toolset only after a login, or one
+ * whose tools depend on what the model just selected, announces the change and
+ * then waits up to five minutes to be believed. In between the model is offered
+ * tools that are gone and denied the ones that arrived.
+ */
+describe('a server saying its list changed', () => {
+    /** The listener the pool wires onto the client it builds for this entry. */
+    const listenerFor = entry => { clientFor(entry, SERVER); return entry.client.options.onNotification; };
+    const changed = method => ({ jsonrpc: '2.0', method });
+
+    let log;
+    beforeEach(() => { log = jest.spyOn(console, 'log').mockImplementation(() => {}); });
+    afterEach(() => log.mockRestore());
+
+    test('is wired onto every pooled client', () => {
+        expect(typeof listenerFor(entryFor(SERVER))).toBe('function');
+    });
+
+    test('drops the cached list, so the next caller fetches a fresh one', async () => {
+        const entry = entryFor(SERVER);
+        const list = jest.fn(async () => ['search']);
+
+        await cachedList(entry, SERVER, 'tools', list);
+        await cachedList(entry, SERVER, 'tools', list);
+        expect(list).toHaveBeenCalledTimes(1);
+
+        listenerFor(entry)(changed('notifications/tools/list_changed'));
+
+        await cachedList(entry, SERVER, 'tools', list);
+        expect(list).toHaveBeenCalledTimes(2);
+    });
+
+    // Expiry means "worth checking" and the pool answers it by serving the old
+    // list while a refresh runs. That is right for a TTL and wrong here: the
+    // server has *stated* the list is wrong, and a model handed a tool that no
+    // longer exists calls it and gets an error it cannot route around.
+    test('and does not serve it stale in the meantime', async () => {
+        const entry = entryFor(SERVER);
+        await cachedList(entry, SERVER, 'tools', async () => ['old']);
+
+        listenerFor(entry)(changed('notifications/tools/list_changed'));
+
+        await expect(cachedList(entry, SERVER, 'tools', async () => ['new'])).resolves.toEqual(['new']);
+    });
+
+    test('and clears a cached failure too, so a recovered server is retried', async () => {
+        const entry = entryFor(SERVER);
+        await expect(cachedList(entry, SERVER, 'tools', async () => { throw new McpError('down'); })).rejects.toThrow('down');
+
+        listenerFor(entry)(changed('notifications/tools/list_changed'));
+
+        await expect(cachedList(entry, SERVER, 'tools', async () => ['back'])).resolves.toEqual(['back']);
+    });
+
+    test('touches only the list it named', async () => {
+        const entry = entryFor(SERVER);
+        const tools = jest.fn(async () => ['search']);
+        const resources = jest.fn(async () => ['doc']);
+        await cachedList(entry, SERVER, 'tools', tools);
+        await cachedList(entry, SERVER, 'resources', resources);
+
+        listenerFor(entry)(changed('notifications/resources/list_changed'));
+
+        await cachedList(entry, SERVER, 'tools', tools);
+        await cachedList(entry, SERVER, 'resources', resources);
+        expect(tools).toHaveBeenCalledTimes(1);
+        expect(resources).toHaveBeenCalledTimes(2);
+    });
+
+    test('prompts too', async () => {
+        const entry = entryFor(SERVER);
+        const prompts = jest.fn(async () => ['review']);
+        await cachedList(entry, SERVER, 'prompts', prompts);
+
+        listenerFor(entry)(changed('notifications/prompts/list_changed'));
+
+        await cachedList(entry, SERVER, 'prompts', prompts);
+        expect(prompts).toHaveBeenCalledTimes(2);
+    });
+
+    test('a notification about anything else changes nothing', async () => {
+        const entry = entryFor(SERVER);
+        const list = jest.fn(async () => ['search']);
+        await cachedList(entry, SERVER, 'tools', list);
+
+        listenerFor(entry)(changed('notifications/progress'));
+        listenerFor(entry)(changed('notifications/message'));
+        listenerFor(entry)({});
+
+        await cachedList(entry, SERVER, 'tools', list);
+        expect(list).toHaveBeenCalledTimes(1);
+    });
+
+    // The likeliest moment to receive one, since notifications arrive on
+    // whatever stream is open: the answer in flight predates the change, so it
+    // may be handed to the caller waiting on it but must not be believed for
+    // another five minutes.
+    test('a refresh already in flight lands but is stored already expired', async () => {
+        const entry = entryFor(SERVER);
+        const gate = deferred();
+        const first = cachedList(entry, SERVER, 'tools', () => gate.promise);
+
+        listenerFor(entry)(changed('notifications/tools/list_changed'));
+        gate.resolve(['stale']);
+        await expect(first).resolves.toEqual(['stale']);
+
+        const second = jest.fn(async () => ['fresh']);
+        await expect(cachedList(entry, SERVER, 'tools', second)).resolves.toEqual(['fresh']);
+        expect(second).toHaveBeenCalledTimes(1);
+    });
+
+    test('a list nobody has cached is a no-op rather than a thrown listener', () => {
+        expect(() => listenerFor(entryFor(SERVER))(changed('notifications/tools/list_changed'))).not.toThrow();
+    });
+});

--- a/tests/mcpDeferredTools.test.js
+++ b/tests/mcpDeferredTools.test.js
@@ -145,17 +145,67 @@ describe('loading a tool', () => {
         expect(declared(toolkit)).toContain(wanted());
     });
 
-    test('says it cannot be called until the next turn', async () => {
+    test('says it cannot be called until the next round', async () => {
         const reply = await toolkit.call(LOAD_TOOL_NAME, { names: [wanted()] });
 
         expect(reply).toContain('Loaded: ');
         expect(reply).toContain(wanted());
-        expect(reply).toMatch(/next turn/i);
+        // "Round", not "turn" (#838): a model told to wait for its next *turn*
+        // has been told to stop and wait for the user to type again, which is
+        // the one thing it must not do with a tool it has just asked for.
+        expect(reply).toMatch(/next round/i);
+        expect(reply).not.toMatch(/next turn/i);
     });
 
     test('runs nothing against the server', async () => {
         await toolkit.call(LOAD_TOOL_NAME, { names: [wanted()] });
         expect(mockCallTool).not.toHaveBeenCalled();
+    });
+
+    // #838. The enum is what the model reads as "the legal values", so a name
+    // left in it after being handed over is an invitation to spend another
+    // round asking for a tool it already has.
+    test('takes the loaded name back out of the catalogue', async () => {
+        await toolkit.call(LOAD_TOOL_NAME, { names: [wanted()] });
+
+        const { enum: options } = loadTool(toolkit).inputSchema.properties.names.items;
+        expect(options).not.toContain(wanted());
+        expect(options).toHaveLength(9);
+        expect(loadTool(toolkit).inputSchema.properties.names.description)
+            .not.toContain(`- ${wanted()}:`);
+    });
+
+    test('leaves the names it did not load in the catalogue', async () => {
+        await toolkit.call(LOAD_TOOL_NAME, { names: [wanted()] });
+
+        const { enum: options } = loadTool(toolkit).inputSchema.properties.names.items;
+        expect(options).toContain(`github__tool_${DEFERRED_AFTER + 1}`);
+    });
+
+    // A meta-tool whose only legal argument is the empty list is a round
+    // waiting to happen, so it goes away once it has nothing left to offer.
+    test('drops the meta-tool once the catalogue is empty', async () => {
+        await toolkit.call(LOAD_TOOL_NAME, { names: [...toolkit.deferred] });
+
+        expect(loadTool(toolkit)).toBeUndefined();
+        expect(declared(toolkit)).toContain(wanted());
+    });
+
+    test('keeps the meta-tool while anything is still deferred', async () => {
+        await toolkit.call(LOAD_TOOL_NAME, { names: toolkit.deferred.slice(0, 9) });
+
+        expect(loadTool(toolkit)).toBeDefined();
+        expect(loadTool(toolkit).inputSchema.properties.names.items.enum).toHaveLength(1);
+    });
+
+    // A name asked for twice is answered as "you already have it", and the
+    // catalogue rewrite must not make it disappear from the world instead.
+    test('a name asked for twice is reported as already available', async () => {
+        await toolkit.call(LOAD_TOOL_NAME, { names: [wanted()] });
+        const reply = await toolkit.call(LOAD_TOOL_NAME, { names: [wanted()] });
+
+        expect(reply).toMatch(/already available/i);
+        expect(reply).toContain(wanted());
     });
 
     test('loads several at once', async () => {

--- a/tests/mcpElicitation.test.js
+++ b/tests/mcpElicitation.test.js
@@ -215,7 +215,7 @@ describe('what the person is shown', () => {
  * than as a promise nobody settles: the tool on the far side is holding its
  * request open until this resolves.
  */
-const { createElicitationHandler } = require('../src/services/ai/mcp/elicitation');
+const { createElicitationHandler, MODAL_PREFIX } = require('../src/services/ai/mcp/elicitation');
 
 function fakeMessage() {
     const prompt = {
@@ -235,26 +235,36 @@ function fakeMessage() {
     return { message, prompt, sends };
 }
 
-/** A button click, and the modal submission it goes on to open. */
+/**
+ * A button click, and the modal submission it goes on to open.
+ *
+ * `awaitModalSubmit` runs the real filter against the modal that was shown, so
+ * a filter that would accept somebody else's form fails here rather than in
+ * production — the collector Discord builds for it is client-global, and the
+ * filter is the only thing separating two open questions.
+ */
 function click(customId, { userId = 'asker', manageGuild = false, typed = null } = {}) {
-    const submission = typed && {
-        user: { id: userId },
-        fields: { getTextInputValue: name => typed[name] ?? '' },
-        deferUpdate: jest.fn(async () => {}),
-        reply: jest.fn(async () => {}),
-    };
-    return {
+    const interaction = {
         customId,
         user: { id: userId },
         memberPermissions: { has: () => manageGuild },
         deferUpdate: jest.fn(async () => {}),
-        showModal: jest.fn(async () => {}),
-        awaitModalSubmit: jest.fn(async () => {
-            if (!submission) throw new Error('never submitted');
-            return submission;
-        }),
-        submission,
+        shown: null,
+        showModal: jest.fn(async modal => { interaction.shown = modal.toJSON(); }),
+        submission: typed && {
+            user: { id: userId },
+            fields: { getTextInputValue: name => typed[name] ?? '' },
+            deferUpdate: jest.fn(async () => {}),
+            reply: jest.fn(async () => {}),
+        },
     };
+    interaction.awaitModalSubmit = jest.fn(async ({ filter }) => {
+        if (!interaction.submission) throw new Error('never submitted');
+        const offered = { ...interaction.submission, customId: interaction.shown.custom_id };
+        if (!filter(offered)) throw new Error('filtered out');
+        return interaction.submission;
+    });
+    return interaction;
 }
 
 const ASK = {
@@ -414,5 +424,85 @@ describe('a server that asks too much', () => {
 
         expect(result).toEqual({ action: 'decline' });
         expect(message.channel.send).not.toHaveBeenCalled();
+    });
+});
+
+/**
+ * `Message#awaitMessageComponent` scopes its collector to the message the
+ * buttons are on. `awaitModalSubmit` does not: it hands the collector no
+ * message, channel or guild, so every live collector in the process is offered
+ * every modal submission and the filter is the only thing that separates them.
+ *
+ * A round running two tool calls can have two questions open at once, which the
+ * per-turn ceiling allows. With one shared custom id, both would match the
+ * first form submitted — and where the two schemas share a field name (`name`,
+ * `path`, `confirm` — entirely plausible across two servers) one server would
+ * be silently sent the answer somebody typed for the other, with both prompts
+ * reporting success.
+ */
+describe('two questions open at once', () => {
+    test('get different modal ids', async () => {
+        const first = fakeMessage();
+        const second = fakeMessage();
+        const a = click('mcp-elicit-answer', { typed: { env: 'staging' } });
+        const b = click('mcp-elicit-answer', { typed: { env: 'production' } });
+        first.prompt.awaitMessageComponent.mockResolvedValue(a);
+        second.prompt.awaitMessageComponent.mockResolvedValue(b);
+
+        await createElicitationHandler(first.message)('github', ASK, {});
+        await createElicitationHandler(second.message)('linear', ASK, {});
+
+        expect(a.shown.custom_id).toMatch(new RegExp(`^${MODAL_PREFIX}:`));
+        expect(b.shown.custom_id).toMatch(new RegExp(`^${MODAL_PREFIX}:`));
+        expect(a.shown.custom_id).not.toBe(b.shown.custom_id);
+    });
+
+    // The filter is the only discriminator Discord applies, so it has to be
+    // the one that rejects the other question's form.
+    test('and each only accepts its own form back', async () => {
+        const { message, prompt } = fakeMessage();
+        const interaction = click('mcp-elicit-answer', { typed: { env: 'staging' } });
+        prompt.awaitMessageComponent.mockResolvedValue(interaction);
+
+        await createElicitationHandler(message)('github', ASK, {});
+
+        const { filter } = interaction.awaitModalSubmit.mock.calls[0][0];
+        const mine = { customId: interaction.shown.custom_id, user: { id: 'asker' } };
+        const somebodyElses = { customId: `${MODAL_PREFIX}:other:99`, user: { id: 'asker' } };
+
+        expect(filter(mine)).toBe(true);
+        expect(filter(somebodyElses)).toBe(false);
+    });
+});
+
+/**
+ * Answering is two waits, not one — noticing the prompt and clicking, then
+ * reading the form and typing — and each is allowed the full timeout. An
+ * extension that covers only the first leaves the stream destroyed while
+ * somebody is mid-form: the tool call is reported as failed, and then the
+ * answer they eventually submit is posted to a server that has stopped
+ * waiting, over a prompt that says it was answered.
+ */
+describe('the clock across both waits', () => {
+    test('is pushed out again once the form is open', async () => {
+        const { message, prompt } = fakeMessage();
+        const extendDeadline = jest.fn();
+        prompt.awaitMessageComponent.mockResolvedValue(click('mcp-elicit-answer', { typed: { env: 'staging' } }));
+
+        await createElicitationHandler(message)('github', ASK, { extendDeadline });
+
+        expect(extendDeadline).toHaveBeenCalledTimes(2);
+    });
+
+    // Only after the modal is shown: extending twice up front would buy the
+    // same total for a question that never reaches the form.
+    test('and not for a question cancelled at the button', async () => {
+        const { message, prompt } = fakeMessage();
+        const extendDeadline = jest.fn();
+        prompt.awaitMessageComponent.mockResolvedValue(click('mcp-elicit-decline'));
+
+        await createElicitationHandler(message)('github', ASK, { extendDeadline });
+
+        expect(extendDeadline).toHaveBeenCalledTimes(1);
     });
 });

--- a/tests/mcpElicitation.test.js
+++ b/tests/mcpElicitation.test.js
@@ -1,0 +1,418 @@
+'use strict';
+
+/**
+ * #838, the schema half. Everything else in the MCP directory is the bot asking
+ * a server for something; elicitation is the one exchange that runs the other
+ * way — a tool that has got halfway and needs one more fact asks the person,
+ * down the same stream its result is still coming on, and waits.
+ *
+ * What is pinned here is what a server is allowed to ask for and what comes
+ * back when it asks for something else. The spec restricts `requestedSchema` to
+ * a flat object of primitives; this enforces it rather than trusting it,
+ * because a modal holds five inputs and a schema this cannot render honestly is
+ * better declined in a sentence the model can read than half-collected.
+ */
+
+const {
+    fieldsOf, fieldOf, coerce, collect, promptText, MAX_FIELDS, MAX_ELICITATIONS_PER_TURN,
+} = require('../src/services/ai/mcp/elicitation');
+
+const schema = (properties, required = []) => ({ type: 'object', properties, required });
+
+describe('what a server is allowed to ask for', () => {
+    test('a flat object of primitives becomes fields', () => {
+        const { fields } = fieldsOf(schema({
+            name: { type: 'string', title: 'Your name' },
+            count: { type: 'integer' },
+            confirm: { type: 'boolean' },
+        }, ['name']));
+
+        expect(fields).toEqual([
+            expect.objectContaining({ name: 'name', title: 'Your name', kind: 'string', required: true }),
+            expect.objectContaining({ name: 'count', kind: 'integer', required: false }),
+            expect.objectContaining({ name: 'confirm', kind: 'boolean', required: false }),
+        ]);
+    });
+
+    // A list of legal answers beats a blank box somebody can get wrong, so an
+    // enum is read as a choice before its declared type is looked at.
+    test('an enum is a choice rather than free text', () => {
+        expect(fieldOf('env', { type: 'string', enum: ['staging', 'production'] }))
+            .toMatchObject({ kind: 'enum', options: ['staging', 'production'] });
+    });
+
+    test('a nested object is refused, not flattened', () => {
+        expect(fieldsOf(schema({ user: { type: 'object', properties: {} } })).error)
+            .toMatch(/not a type this client can ask a person for/);
+    });
+
+    test('an array is refused too', () => {
+        expect(fieldsOf(schema({ tags: { type: 'array' } })).error).toBeTruthy();
+    });
+
+    test('a schema with no properties is refused', () => {
+        expect(fieldsOf({ type: 'object' }).error).toMatch(/no properties/);
+        expect(fieldsOf(schema({})).error).toMatch(/asks for nothing/);
+        expect(fieldsOf(null).error).toBeTruthy();
+    });
+
+    // Half the fields collected is a tool call that fails on the far side with
+    // a message about the ones it did not get.
+    test(`more than ${MAX_FIELDS} fields is refused rather than truncated`, () => {
+        const many = Object.fromEntries(
+            Array.from({ length: MAX_FIELDS + 1 }, (_, i) => [`f${i}`, { type: 'string' }]),
+        );
+        expect(fieldsOf(schema(many)).error).toMatch(new RegExp(`at most ${MAX_FIELDS}`));
+    });
+
+    test(`exactly ${MAX_FIELDS} is allowed`, () => {
+        const many = Object.fromEntries(
+            Array.from({ length: MAX_FIELDS }, (_, i) => [`f${i}`, { type: 'string' }]),
+        );
+        expect(fieldsOf(schema(many)).fields).toHaveLength(MAX_FIELDS);
+    });
+
+    // Titles and descriptions are somebody else's text going into a Discord
+    // message, and a backtick in the wrong place turns the rest of it into
+    // prose.
+    test('the server\'s own words are flattened and clamped', () => {
+        const { fields } = fieldsOf(schema({
+            q: { type: 'string', title: `a\nvery ${'long '.repeat(30)}title with \`backticks\`` },
+        }));
+
+        expect(fields[0].title).not.toContain('\n');
+        expect(fields[0].title).not.toContain('`');
+        expect(fields[0].title.length).toBeLessThanOrEqual(45);
+    });
+});
+
+describe('turning what somebody typed into what the schema asked for', () => {
+    const field = (over = {}) => ({ name: 'x', title: 'X', required: true, kind: 'string', ...over });
+
+    test('a string is itself, trimmed', () => {
+        expect(coerce(field(), '  hello  ')).toEqual({ value: 'hello' });
+    });
+
+    test.each([['yes', true], ['y', true], ['true', true], ['1', true], ['no', false], ['FALSE', false], ['off', false]])(
+        '"%s" is read as %s', (typed, value) => {
+            expect(coerce(field({ kind: 'boolean' }), typed)).toEqual({ value });
+        });
+
+    test('and anything else is an error the person can act on', () => {
+        expect(coerce(field({ kind: 'boolean' }), 'maybe').error).toMatch(/yes or no/);
+    });
+
+    test('a number has to be one', () => {
+        expect(coerce(field({ kind: 'number' }), '4.5')).toEqual({ value: 4.5 });
+        expect(coerce(field({ kind: 'number' }), 'four').error).toMatch(/should be a number/);
+    });
+
+    test('an integer has to be whole', () => {
+        expect(coerce(field({ kind: 'integer' }), '4.5').error).toMatch(/whole number/);
+        expect(coerce(field({ kind: 'integer' }), '4')).toEqual({ value: 4 });
+    });
+
+    test('and stays inside the bounds the schema gave', () => {
+        const bounded = field({ kind: 'integer', minimum: 1, maximum: 10 });
+        expect(coerce(bounded, '0').error).toMatch(/at least 1/);
+        expect(coerce(bounded, '11').error).toMatch(/at most 10/);
+        expect(coerce(bounded, '5')).toEqual({ value: 5 });
+    });
+
+    // The list is the authority on spelling; the person is typing one of the
+    // options they were just shown.
+    test('an enum matches case-insensitively and comes back canonical', () => {
+        const enumField = field({ kind: 'enum', options: ['Staging', 'Production'] });
+        expect(coerce(enumField, 'production')).toEqual({ value: 'Production' });
+        expect(coerce(enumField, 'dev').error).toMatch(/one of: Staging, Production/);
+    });
+
+    // "" is a different statement from "no value", especially to a tool that
+    // will pass it straight to an API.
+    test('an empty optional answer is an omission, not an empty string', () => {
+        expect(coerce(field({ required: false }), '   ')).toEqual({ omitted: true });
+    });
+
+    test('an empty required answer is an error', () => {
+        expect(coerce(field(), '').error).toMatch(/required/);
+    });
+});
+
+describe('collecting a whole form', () => {
+    const fields = [
+        { name: 'repo', title: 'Repo', kind: 'string', required: true },
+        { name: 'draft', title: 'Draft', kind: 'boolean', required: false },
+        { name: 'note', title: 'Note', kind: 'string', required: false },
+    ];
+
+    test('omits the optional answers nobody filled in', () => {
+        const typed = { repo: 'clawdia', draft: '', note: '' };
+        expect(collect(fields, name => typed[name])).toEqual({ content: { repo: 'clawdia' } });
+    });
+
+    test('and reports the first thing wrong rather than sending a half-form', () => {
+        const typed = { repo: 'clawdia', draft: 'perhaps', note: 'x' };
+        expect(collect(fields, name => typed[name]).error).toMatch(/yes or no/);
+        expect(collect(fields, name => typed[name]).content).toBeUndefined();
+    });
+});
+
+/**
+ * The spec says servers must not use elicitation for secrets, which is a rule
+ * for well-behaved servers and no protection from the others. A guild admin
+ * connects the server, so its URL is trusted to the extent the admin is — the
+ * person answering in a channel is often not that admin.
+ */
+describe('what the person is shown', () => {
+    const { fields } = fieldsOf(schema({
+        env: { type: 'string', enum: ['staging', 'production'] },
+        force: { type: 'boolean' },
+        note: { type: 'string' },
+    }, ['env']));
+    const text = promptText('u1', 'github', 'Which environment should I deploy to?', fields);
+
+    test('names the server doing the asking', () => {
+        expect(text).toContain('github');
+    });
+
+    test('and warns about the thing a real server will not ask for', () => {
+        expect(text).toMatch(/password|API key|login code/i);
+    });
+
+    test('shows the legal answers rather than a blank box', () => {
+        expect(text).toContain('staging, production');
+        expect(text).toContain('yes or no');
+    });
+
+    // The label is the schema's `title` when it gave one and the property name
+    // when it did not, which is what these three have.
+    test('and marks which answers are optional', () => {
+        expect(text).toContain('**note** (optional)');
+        expect(text).toContain('**force** (optional)');
+        expect(text).not.toContain('**env** (optional)');
+    });
+
+    // Nothing the server wrote can ping anybody — the send locks mentions to
+    // the asker — but the question is also flattened so it cannot break the
+    // message it sits in.
+    test('the server\'s question is flattened into the message', () => {
+        const nasty = promptText('u1', 'evil', 'line one\n@everyone\n```', fields);
+        expect(nasty.split('\n').filter(l => l.startsWith('> '))).toHaveLength(1);
+        expect(nasty).not.toContain('```');
+    });
+
+    test('and a server that said nothing still gets a readable prompt', () => {
+        expect(promptText('u1', 'github', '', fields)).toContain('It did not say what for');
+    });
+});
+
+/**
+ * The channel half. The shape is close to `approval.js` — a message, buttons,
+ * an answer routed back to a caller waiting on a promise, a clock — and what
+ * differs is that Discord's only way to collect typed data is a modal, which
+ * can only be opened from an interaction. So it is two steps, and every way of
+ * not getting an answer has to end as one of the spec's three actions rather
+ * than as a promise nobody settles: the tool on the far side is holding its
+ * request open until this resolves.
+ */
+const { createElicitationHandler } = require('../src/services/ai/mcp/elicitation');
+
+function fakeMessage() {
+    const prompt = {
+        content: '',
+        edit: jest.fn(async payload => { prompt.content = payload.content; return prompt; }),
+        awaitMessageComponent: jest.fn(),
+    };
+    const sends = [];
+    const message = {
+        author: { id: 'asker' },
+        guild: { id: 'g1' },
+        channel: {
+            id: 'c1',
+            send: jest.fn(async payload => { sends.push(payload); prompt.content = payload.content; return prompt; }),
+        },
+    };
+    return { message, prompt, sends };
+}
+
+/** A button click, and the modal submission it goes on to open. */
+function click(customId, { userId = 'asker', manageGuild = false, typed = null } = {}) {
+    const submission = typed && {
+        user: { id: userId },
+        fields: { getTextInputValue: name => typed[name] ?? '' },
+        deferUpdate: jest.fn(async () => {}),
+        reply: jest.fn(async () => {}),
+    };
+    return {
+        customId,
+        user: { id: userId },
+        memberPermissions: { has: () => manageGuild },
+        deferUpdate: jest.fn(async () => {}),
+        showModal: jest.fn(async () => {}),
+        awaitModalSubmit: jest.fn(async () => {
+            if (!submission) throw new Error('never submitted');
+            return submission;
+        }),
+        submission,
+    };
+}
+
+const ASK = {
+    message: 'Which environment?',
+    requestedSchema: {
+        type: 'object',
+        properties: { env: { type: 'string', enum: ['staging', 'production'] }, force: { type: 'boolean' } },
+        required: ['env'],
+    },
+};
+
+let warn;
+beforeEach(() => { warn = jest.spyOn(console, 'warn').mockImplementation(() => {}); });
+afterEach(() => warn.mockRestore());
+
+describe('putting a question to the channel', () => {
+    test('an answered form comes back as accept with the typed content', async () => {
+        const { message, prompt } = fakeMessage();
+        prompt.awaitMessageComponent.mockResolvedValue(
+            click('mcp-elicit-answer', { typed: { env: 'production', force: 'yes' } }),
+        );
+
+        const result = await createElicitationHandler(message)('github', ASK, {});
+
+        expect(result).toEqual({ action: 'accept', content: { env: 'production', force: true } });
+        expect(prompt.content).toMatch(/Answered by/);
+    });
+
+    test('Cancel is a decline, which is the person saying no', async () => {
+        const { message, prompt } = fakeMessage();
+        prompt.awaitMessageComponent.mockResolvedValue(click('mcp-elicit-decline'));
+
+        await expect(createElicitationHandler(message)('github', ASK, {})).resolves.toEqual({ action: 'decline' });
+        expect(prompt.content).toMatch(/Cancelled by/);
+    });
+
+    // Not the same thing, and a server may reasonably treat them differently:
+    // nobody refused, nobody was there.
+    test('silence is a cancel, which is nobody having chosen', async () => {
+        const { message, prompt } = fakeMessage();
+        prompt.awaitMessageComponent.mockRejectedValue(new Error('time'));
+
+        await expect(createElicitationHandler(message)('github', ASK, {})).resolves.toEqual({ action: 'cancel' });
+        expect(prompt.content).toMatch(/Nobody answered/);
+    });
+
+    test('and a form opened but never submitted is a cancel too', async () => {
+        const { message, prompt } = fakeMessage();
+        prompt.awaitMessageComponent.mockResolvedValue(click('mcp-elicit-answer'));
+
+        await expect(createElicitationHandler(message)('github', ASK, {})).resolves.toEqual({ action: 'cancel' });
+        expect(prompt.content).toMatch(/not submitted/);
+    });
+
+    // One shot at the form: a retry loop is a nicer experience and a worse one
+    // for the tool call holding its request open behind it.
+    test('an answer that does not fit the schema is declined, not half-sent', async () => {
+        const { message, prompt } = fakeMessage();
+        const interaction = click('mcp-elicit-answer', { typed: { env: 'dev', force: 'yes' } });
+        prompt.awaitMessageComponent.mockResolvedValue(interaction);
+
+        const result = await createElicitationHandler(message)('github', ASK, {});
+
+        expect(result).toEqual({ action: 'decline' });
+        expect(interaction.submission.reply).toHaveBeenCalledWith(
+            expect.objectContaining({ content: expect.stringMatching(/one of: staging, production/) }),
+        );
+    });
+
+    // The tool name and the question both come from the server, and this
+    // message is posted to a channel by a bot that can mention everyone.
+    test('the prompt pings the asker and nobody else', async () => {
+        const { message, prompt, sends } = fakeMessage();
+        prompt.awaitMessageComponent.mockRejectedValue(new Error('time'));
+
+        await createElicitationHandler(message)('github', ASK, {});
+
+        expect(sends[0].allowedMentions).toEqual({ users: ['asker'] });
+    });
+
+    // The buttons go, so a click an hour later cannot land on a request the
+    // server stopped waiting for.
+    test('and the buttons come off however it ended', async () => {
+        const { message, prompt } = fakeMessage();
+        prompt.awaitMessageComponent.mockResolvedValue(click('mcp-elicit-decline'));
+
+        await createElicitationHandler(message)('github', ASK, {});
+
+        expect(prompt.edit).toHaveBeenCalledWith(expect.objectContaining({ components: [] }));
+    });
+
+    // The clock this pushes out is the one that would otherwise destroy the
+    // stream while somebody is still reading the question.
+    test('the deadline is moved before the prompt goes up, not after it is answered', async () => {
+        const { message, prompt } = fakeMessage();
+        const extendDeadline = jest.fn();
+        prompt.awaitMessageComponent.mockImplementation(async () => {
+            expect(extendDeadline).toHaveBeenCalled();
+            expect(message.channel.send).toHaveBeenCalled();
+            return click('mcp-elicit-decline');
+        });
+
+        await createElicitationHandler(message)('github', ASK, { extendDeadline });
+
+        expect(extendDeadline).toHaveBeenCalledWith(expect.any(Number));
+    });
+
+    // A handler with no context at all — the deadline is somebody else's
+    // problem, and a missing one must not be a thrown TypeError inside a
+    // stream reader.
+    test('and a call with no context still works', async () => {
+        const { message, prompt } = fakeMessage();
+        prompt.awaitMessageComponent.mockResolvedValue(click('mcp-elicit-decline'));
+
+        await expect(createElicitationHandler(message)('github', ASK)).resolves.toEqual({ action: 'decline' });
+    });
+});
+
+describe('a server that asks too much', () => {
+    // An elicitation is a person being interrupted. A server that asks four
+    // times in one reply is not collecting an argument, it is running a form —
+    // or fishing.
+    test('is declined past the per-turn ceiling, without another prompt', async () => {
+        const { message, prompt } = fakeMessage();
+        prompt.awaitMessageComponent.mockResolvedValue(click('mcp-elicit-decline'));
+        const elicit = createElicitationHandler(message);
+
+        for (let i = 0; i < MAX_ELICITATIONS_PER_TURN; i++) {
+            await expect(elicit('github', ASK, {})).resolves.toEqual({ action: 'decline' });
+        }
+        const sentSoFar = message.channel.send.mock.calls.length;
+
+        await expect(elicit('github', ASK, {})).resolves.toEqual({ action: 'decline' });
+        expect(message.channel.send).toHaveBeenCalledTimes(sentSoFar);
+    });
+
+    // The ceiling counts interruptions to one person, not requests to one
+    // server, so a second server cannot start the count again.
+    test('and the ceiling counts every server together', async () => {
+        const { message, prompt } = fakeMessage();
+        prompt.awaitMessageComponent.mockResolvedValue(click('mcp-elicit-decline'));
+        const elicit = createElicitationHandler(message);
+
+        for (let i = 0; i < MAX_ELICITATIONS_PER_TURN; i++) await elicit('github', ASK, {});
+        const sentSoFar = message.channel.send.mock.calls.length;
+
+        await elicit('linear', ASK, {});
+        expect(message.channel.send).toHaveBeenCalledTimes(sentSoFar);
+    });
+
+    test('a schema this cannot render never reaches the channel at all', async () => {
+        const { message } = fakeMessage();
+
+        const result = await createElicitationHandler(message)(
+            'github', { message: 'hi', requestedSchema: { type: 'object', properties: { deep: { type: 'object' } } } }, {},
+        );
+
+        expect(result).toEqual({ action: 'decline' });
+        expect(message.channel.send).not.toHaveBeenCalled();
+    });
+});

--- a/tests/mcpInspect.test.js
+++ b/tests/mcpInspect.test.js
@@ -115,7 +115,10 @@ describe('a connection that answers', () => {
             url: 'https://api.githubcopilot.com/mcp/',
             authorizationToken: 'ghp_x',
             label: 'github',
-            getAccessToken: null
+            getAccessToken: null,
+            // A one-off probe belongs to no pooled entry, so there is no
+            // cached list for a `list_changed` to invalidate (#838).
+            onNotification: null
         }]);
     });
 

--- a/tests/mcpInspect.test.js
+++ b/tests/mcpInspect.test.js
@@ -117,8 +117,10 @@ describe('a connection that answers', () => {
             label: 'github',
             getAccessToken: null,
             // A one-off probe belongs to no pooled entry, so there is no
-            // cached list for a `list_changed` to invalidate (#838).
-            onNotification: null
+            // cached list for a `list_changed` to invalidate, and no channel
+            // to put a question to (#838).
+            onNotification: null,
+            elicitation: false
         }]);
     });
 

--- a/tests/mcpOAuthRoutes.test.js
+++ b/tests/mcpOAuthRoutes.test.js
@@ -444,3 +444,55 @@ describe('signing out', () => {
         expect(mockClearGrant).not.toHaveBeenCalled();
     });
 });
+
+/**
+ * #838. The redirect URI is registered with the authorization server *and*
+ * checked by it on the way back, so an unset `DASHBOARD_URL` in a deployment
+ * does not degrade — it produces a flow that either fails at registration or
+ * sends the admin's browser to a port on their own laptop carrying an
+ * authorization code, with an error that names nothing useful.
+ */
+describe('the redirect URI when DASHBOARD_URL is not set', () => {
+    const originalEnv = process.env.NODE_ENV;
+
+    afterEach(() => { process.env.NODE_ENV = originalEnv; });
+
+    test('is refused in production, naming the variable', async () => {
+        delete process.env.DASHBOARD_URL;
+        process.env.NODE_ENV = 'production';
+
+        const { status, body } = await api('POST', '/guild/g1/mcp-servers/linear/oauth/start');
+
+        expect(status).toBe(400);
+        expect(body.error).toMatch(/DASHBOARD_URL/);
+    });
+
+    // A developer running the dashboard on their own machine is the one case
+    // the guess is right for, so it survives there and only there.
+    test('still falls back to localhost outside production', async () => {
+        delete process.env.DASHBOARD_URL;
+        process.env.NODE_ENV = 'test';
+
+        const { status } = await api('POST', '/guild/g1/mcp-servers/linear/oauth/start');
+
+        expect(status).toBe(200);
+        expect(mockRegister).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ redirectUri: expect.stringContaining('http://localhost:') }),
+        );
+    });
+
+    test('a configured URL is used whatever the environment', async () => {
+        process.env.DASHBOARD_URL = 'https://dash.example.com/';
+        process.env.NODE_ENV = 'production';
+
+        const { status } = await api('POST', '/guild/g1/mcp-servers/linear/oauth/start');
+
+        expect(status).toBe(200);
+        expect(mockRegister).toHaveBeenCalledWith(
+            expect.anything(),
+            // The trailing slash above is stripped rather than doubled.
+            expect.objectContaining({ redirectUri: 'https://dash.example.com/api/mcp/oauth/callback' }),
+        );
+    });
+});

--- a/tests/mcpOAuthStore.test.js
+++ b/tests/mcpOAuthStore.test.js
@@ -318,3 +318,104 @@ describe('a grant that has gone', () => {
         await expect(accessTokenFor('g1', 'linear')).resolves.toBe('at2');
     });
 });
+
+/**
+ * #838. `accessTokenFor` is asked before *every* MCP request — the client
+ * re-asks rather than caching, because a pooled connection sits idle while its
+ * token expires — so a turn running six tool calls was six `findOne`s deep
+ * before a byte went out. The token is what expires on a clock this process
+ * already knows, so it is the thing worth holding.
+ */
+describe('the in-process token memo', () => {
+    test('answers a second request without reading the database again', async () => {
+        stubRead(storedGrant());
+
+        await expect(accessTokenFor('g1', 'linear')).resolves.toBe('at1');
+        await expect(accessTokenFor('g1', 'linear')).resolves.toBe('at1');
+
+        expect(Guild.findOne).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not answer for a different server, or a different guild', async () => {
+        stubRead(storedGrant());
+
+        await accessTokenFor('g1', 'linear');
+        await accessTokenFor('g1', 'github');
+        await accessTokenFor('g2', 'linear');
+
+        expect(Guild.findOne).toHaveBeenCalledTimes(3);
+    });
+
+    // The 401 path. The server has just said the memoized token is no good, so
+    // re-offering it would spend the one retry on the same credential.
+    test('is skipped and dropped by a forced refresh', async () => {
+        stubRead(storedGrant());
+        refreshTokens.mockResolvedValue({ accessToken: 'at2', refreshToken: 'rt2', expiresAt: null, scope: null });
+
+        await expect(accessTokenFor('g1', 'linear')).resolves.toBe('at1');
+        await expect(accessTokenFor('g1', 'linear', { force: true })).resolves.toBe('at2');
+
+        stubRead(storedGrant({ accessToken: 'enc:at3' }));
+        expect(await accessTokenFor('g1', 'linear')).not.toBe('at1');
+    });
+
+    // A memo that outlived `needsRefresh` would hand back a token in the very
+    // window the store had already decided to refresh.
+    test('lapses before the refresh it should have triggered is due', async () => {
+        const { MEMO_SKEW_MS } = require('../src/services/ai/mcp/oauthStore');
+        const { REFRESH_SKEW_MS } = require('../src/services/ai/mcp/oauth');
+
+        expect(MEMO_SKEW_MS).toBeGreaterThan(REFRESH_SKEW_MS);
+    });
+
+    test('holds nothing for a grant whose expiry is unknown', async () => {
+        stubRead(storedGrant({ expiresAt: null }));
+
+        await accessTokenFor('g1', 'linear');
+        await accessTokenFor('g1', 'linear');
+
+        expect(Guild.findOne).toHaveBeenCalledTimes(2);
+    });
+
+    test('holds nothing for a token already inside the refresh window', async () => {
+        stubRead(storedGrant({ expiresAt: new Date(Date.now() + 1000) }));
+        refreshTokens.mockResolvedValue({ accessToken: 'at2', refreshToken: 'rt2', expiresAt: null, scope: null });
+
+        await accessTokenFor('g1', 'linear');
+        await accessTokenFor('g1', 'linear');
+
+        expect(Guild.findOne).toHaveBeenCalledTimes(2);
+    });
+
+    test('is dropped when the grant is cleared', async () => {
+        stubRead(storedGrant());
+        await accessTokenFor('g1', 'linear');
+
+        await clearGrant('g1', 'linear');
+        stubRead(null);
+
+        await expect(accessTokenFor('g1', 'linear')).resolves.toBeNull();
+    });
+
+    test('is dropped when a new grant is written over it', async () => {
+        stubRead(storedGrant());
+        await accessTokenFor('g1', 'linear');
+
+        await saveGrant('g1', 'linear', { ...storedGrant(), accessToken: 'at9', refreshToken: 'rt9' });
+        stubRead(storedGrant({ accessToken: 'enc:at9' }));
+
+        await expect(accessTokenFor('g1', 'linear')).resolves.toBe('at9');
+    });
+
+    // A refresh that fails falls back to the token already held — which is by
+    // definition one the server may be about to reject, so it is not memoized.
+    test('holds nothing after a refresh that failed', async () => {
+        stubRead(storedGrant({ expiresAt: new Date(Date.now() - 1000) }));
+        refreshTokens.mockRejectedValue(new OAuthError('temporary', { status: 503 }));
+
+        await accessTokenFor('g1', 'linear');
+        await accessTokenFor('g1', 'linear');
+
+        expect(Guild.findOne).toHaveBeenCalledTimes(2);
+    });
+});

--- a/tests/mcpOAuthStore.test.js
+++ b/tests/mcpOAuthStore.test.js
@@ -419,3 +419,59 @@ describe('the in-process token memo', () => {
         expect(Guild.findOne).toHaveBeenCalledTimes(2);
     });
 });
+
+/**
+ * The memo's own race. Every writer empties it before the write it is
+ * invalidating for, but a read that issued its query *before* that write and
+ * returns after it carries the grant as it was — and would install the
+ * superseded token on the way out.
+ *
+ * The 401 paths self-heal at the cost of a round trip. Disconnect does not:
+ * the row is empty and there is no grant left to refresh from, so a revoked
+ * token would go on being served out of process memory until it expired.
+ */
+describe('a read that started before the grant changed', () => {
+    /** `Guild.findOne(...).lean()` that does not resolve until told to. */
+    function stubSlowRead(oauth) {
+        let release;
+        const gate = new Promise(resolve => { release = resolve; });
+        Guild.findOne.mockReturnValue({ lean: () => gate.then(() => ({ ai: { mcpServers: [{ name: 'linear', oauth }] } })) });
+        return release;
+    }
+
+    test('does not memoize the token a disconnect just revoked', async () => {
+        const release = stubSlowRead(storedGrant());
+        const inFlightRead = accessTokenFor('g1', 'linear');
+
+        await clearGrant('g1', 'linear');
+        release();
+        await inFlightRead;
+
+        // The row is empty now, and nothing may answer from memory instead.
+        stubRead(null);
+        await expect(accessTokenFor('g1', 'linear')).resolves.toBeNull();
+    });
+
+    test('nor the one a new grant was just written over', async () => {
+        const release = stubSlowRead(storedGrant());
+        const inFlightRead = accessTokenFor('g1', 'linear');
+
+        await saveGrant('g1', 'linear', { ...storedGrant(), accessToken: 'at9', refreshToken: 'rt9' });
+        release();
+        await inFlightRead;
+
+        stubRead(storedGrant({ accessToken: 'enc:at9' }));
+        await expect(accessTokenFor('g1', 'linear')).resolves.toBe('at9');
+    });
+
+    // A read with nothing racing it still memoizes, or the memo would never
+    // hold anything at all.
+    test('and an undisturbed read still memoizes', async () => {
+        stubRead(storedGrant());
+
+        await accessTokenFor('g1', 'linear');
+        await accessTokenFor('g1', 'linear');
+
+        expect(Guild.findOne).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/mcpPrewarmAndLimits.test.js
+++ b/tests/mcpPrewarmAndLimits.test.js
@@ -84,6 +84,31 @@ describe('warming the tool list before anybody asks for it', () => {
         expect(await prewarmMcpServers([])).toBe(0);
         expect(mockListTools).not.toHaveBeenCalled();
     });
+
+    // #838. Resolution merges the operator's config file into whatever it is
+    // handed, which is right for the startup sweep and wrong for a dashboard
+    // save: an admin editing one server would dial every other one they have,
+    // on every save.
+    test('`only` warms the named server and leaves the rest cold', async () => {
+        expect(await prewarmMcpServers([GITHUB, WIKI], { only: ['github'] })).toBe(1);
+        expect(mockListTools).toHaveBeenCalledTimes(1);
+
+        // The one that was warmed is the one that was named.
+        await prepareMcpToolkit([GITHUB]);
+        expect(mockListTools).toHaveBeenCalledTimes(1);
+        await prepareMcpToolkit([WIKI]);
+        expect(mockListTools).toHaveBeenCalledTimes(2);
+    });
+
+    test('`only` naming nothing that resolves warms nothing', async () => {
+        expect(await prewarmMcpServers([GITHUB], { only: ['not-a-server'] })).toBe(0);
+        expect(mockListTools).not.toHaveBeenCalled();
+    });
+
+    test('no `only` still warms everything, which is what startup wants', async () => {
+        expect(await prewarmMcpServers([GITHUB, WIKI])).toBe(2);
+        expect(mockListTools).toHaveBeenCalledTimes(2);
+    });
 });
 
 describe('what one server sees at once', () => {

--- a/tests/mcpResultTrim.test.js
+++ b/tests/mcpResultTrim.test.js
@@ -131,6 +131,81 @@ describe('a JSON object wrapping a list', () => {
     });
 });
 
+/**
+ * The shape the array paths do not cover and a byte-slice handles worst: one
+ * field holding the whole answer — a file's contents, a page of HTML, a stack
+ * trace — beside the fields that say what it is. Cutting the document loses
+ * those scalars whenever they sort after the big one, which is about half the
+ * time; cutting the string keeps every one of them.
+ */
+describe('a document whose problem is one enormous field', () => {
+    const doc = JSON.stringify({
+        path: 'src/services/ai/mcp/toolkit.js',
+        status: 'ok',
+        lines: 1029,
+        content: 'x'.repeat(9000),
+    });
+    const trimmed = trimResult(doc, 1200);
+
+    test('stays valid JSON', () => {
+        expect(() => documentOf(trimmed)).not.toThrow();
+    });
+
+    test('keeps every scalar a following call would need', () => {
+        expect(documentOf(trimmed)).toMatchObject({
+            path: 'src/services/ai/mcp/toolkit.js',
+            status: 'ok',
+            lines: 1029,
+        });
+    });
+
+    test('and cuts the field that was the problem, saying how much', () => {
+        const { content } = documentOf(trimmed);
+        expect(content.length).toBeLessThan(9000);
+        expect(content).toMatch(/… \[\d+ characters omitted\]$/);
+    });
+
+    test('within the budget', () => {
+        expect(trimmed.length).toBeLessThanOrEqual(1200);
+    });
+
+    // A document with one enormous field and twenty small ones should lose the
+    // enormous one, not all twenty.
+    test('the longest string goes first', () => {
+        const mixed = JSON.stringify({
+            big: 'a'.repeat(8000),
+            note: 'b'.repeat(200),
+            tag: 'c'.repeat(120),
+        });
+        const { big, note, tag } = documentOf(trimResult(mixed, 1500));
+
+        expect(big.length).toBeLessThan(1200);
+        expect(note).toBe('b'.repeat(200));
+        expect(tag).toBe('c'.repeat(120));
+    });
+
+    // Tool results keep their prose one level in as often as at the top.
+    test('and it reaches the fields of an array\'s elements', () => {
+        const rows = JSON.stringify([{ path: 'a.js', body: 'y'.repeat(4000) }, { path: 'b.js', body: 'z'.repeat(4000) }]);
+        const parsed = documentOf(trimResult(rows, 1500));
+
+        expect(parsed).toHaveLength(2);
+        expect(parsed.map(row => row.path)).toEqual(['a.js', 'b.js']);
+    });
+
+    // Nothing long enough to be worth cutting: the text path takes it, and says
+    // so with its own marker rather than pretending to be JSON.
+    test('a document of nothing but short fields falls through to head and tail', () => {
+        const many = JSON.stringify(Object.fromEntries(
+            Array.from({ length: 400 }, (_, i) => [`k${i}`, `v${i}`]),
+        ));
+        const out = trimResult(many, 900);
+
+        expect(out.length).toBeLessThanOrEqual(900);
+        expect(out).toMatch(/omitted …\]/);
+    });
+});
+
 describe('output with no structure to preserve', () => {
     const log = `${Array.from({ length: 600 }, (_, i) => `line ${i} of some build output`).join('\n')}\nERROR: the build failed`;
     const trimmed = trimResult(log, 1500);
@@ -215,6 +290,53 @@ describe('whatever the shape and whatever the budget', () => {
     test.each([80, 199, 200, 400, 1000, 6000])('never exceeds a %i-character budget', limit => {
         for (const shape of shapes) {
             expect(trimResult(shape, limit).length).toBeLessThanOrEqual(limit);
+        }
+    });
+
+    /**
+     * The two properties that matter, over a wide spread of shapes and budgets
+     * rather than the handful written out above: nothing exceeds its budget,
+     * nothing throws, and anything that comes back looking like a JSON document
+     * *is* one. The generator is deterministic, so a failure here is a failure
+     * anybody can reproduce.
+     */
+    test('a structured result is always parseable, and always fits', () => {
+        let seed = 20260828;
+        const rand = n => {
+            seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+            return seed % n;
+        };
+        const generators = [
+            () => JSON.stringify(rows(rand(200) + 2)),
+            () => JSON.stringify(Array.from({ length: 2 }, () => ({ blob: 'y'.repeat(5000) }))),
+            () => JSON.stringify(Array.from({ length: 3 }, () => 'z'.repeat(3000))),
+            () => JSON.stringify({ a: 1, b: 'q'.repeat(9000), items: [1, 2, 3] }),
+            () => JSON.stringify({ items: Array.from({ length: rand(100) + 2 }, (_, i) => i), cursor: 'c'.repeat(rand(500)) }),
+            () => JSON.stringify({ nested: { items: Array.from({ length: 50 }, (_, i) => i) } }),
+            () => JSON.stringify({ onlyBig: 'w'.repeat(rand(9000) + 1000) }),
+            () => JSON.stringify(Array.from({ length: rand(5) + 2 }, () => ({ u: 'é😀'.repeat(rand(400)) }))),
+            () => 'plain '.repeat(rand(3000)),
+            () => JSON.stringify({ items: [] }),
+        ];
+        const limits = [30, 60, 120, 199, 200, 250, 400, 900, 2500, 6000];
+
+        for (let i = 0; i < 2000; i++) {
+            const shape = generators[i % generators.length]();
+            const limit = limits[rand(limits.length)];
+            const out = trimResult(shape, limit);
+
+            expect(out.length).toBeLessThanOrEqual(limit);
+            if (out === shape) continue;
+
+            const at = out.indexOf('\n[trimmed');
+            if (at <= 0) continue;
+            const body = out.slice(0, at);
+            // The head-and-tail path is elided text by design and says so; a
+            // body without that marker is claiming to be a whole document.
+            if (body.includes('omitted …]')) continue;
+            if (/^\s*[[{]/.test(body)) {
+                expect(() => JSON.parse(body)).not.toThrow();
+            }
         }
     });
 

--- a/tests/mcpResultTrim.test.js
+++ b/tests/mcpResultTrim.test.js
@@ -1,0 +1,231 @@
+'use strict';
+
+/**
+ * #838. Both of the toolkit's result caps used to be `text.slice(0, limit)`,
+ * and the failure that causes is specific rather than cosmetic: a tool result
+ * is usually JSON, so the cut lands inside a string or a nesting level, and
+ * what reaches the model is a document it cannot parse whose last field is a
+ * half-written value. In a one-shot answer that is lossy. In a multi-step
+ * chain it poisons the round after it — the model reads `"path": "src/servi`
+ * as a filename and calls the next tool with it, and the failure surfaces
+ * three steps downstream as an error about a file that never existed.
+ *
+ * So these are mostly about what survives: whole records, valid JSON, the
+ * scalars a next step needs, and the end of the output as well as its start.
+ */
+
+const { trimResult, headAndTail, MIN_STRUCTURED_LIMIT, SHORT_MARKER } = require('../src/services/ai/mcp/trim');
+
+/** The JSON document out of a trimmed result, without the note after it. */
+function documentOf(text) {
+    const at = text.indexOf('\n[trimmed');
+    return JSON.parse(at >= 0 ? text.slice(0, at) : text);
+}
+
+const rows = count => Array.from({ length: count }, (_, i) => ({
+    id: i,
+    path: `src/services/module_${i}.js`,
+    summary: `the ${i}th thing this tool found, described at some length`,
+}));
+
+describe('a result that already fits', () => {
+    test('is returned exactly as it was', () => {
+        expect(trimResult('short', 100)).toBe('short');
+    });
+
+    test('at exactly the limit, too', () => {
+        const text = 'x'.repeat(500);
+        expect(trimResult(text, 500)).toBe(text);
+    });
+
+    test('and a non-string is left alone rather than coerced', () => {
+        expect(trimResult(null, 10)).toBeNull();
+        expect(trimResult(undefined, 10)).toBeUndefined();
+    });
+});
+
+describe('a JSON array over the limit', () => {
+    const text = JSON.stringify(rows(400));
+    const trimmed = trimResult(text, 4000);
+
+    test('comes back as valid JSON', () => {
+        expect(Array.isArray(documentOf(trimmed))).toBe(true);
+    });
+
+    test('within the budget it was given', () => {
+        expect(trimmed.length).toBeLessThanOrEqual(4000);
+    });
+
+    test('holding whole records, never a half-written one', () => {
+        for (const row of documentOf(trimmed)) {
+            expect(row).toMatchObject({
+                id: expect.any(Number),
+                path: expect.stringMatching(/^src\/services\/module_\d+\.js$/),
+                summary: expect.stringContaining('described at some length'),
+            });
+        }
+    });
+
+    // The two ends say what the answer looks like and where it stops. A
+    // head-only cut says only the first.
+    test('keeps the first record and the last', () => {
+        const kept = documentOf(trimmed);
+        expect(kept[0].id).toBe(0);
+        expect(kept[kept.length - 1].id).toBe(399);
+    });
+
+    test('and says how many of how many it is showing', () => {
+        const kept = documentOf(trimmed).length;
+        expect(kept).toBeGreaterThan(1);
+        expect(kept).toBeLessThan(400);
+        expect(trimmed).toContain(`${kept} of 400 items shown`);
+    });
+
+    // The note goes after the document rather than inside it: a marker pushed
+    // into an array changes the type of its elements, which hands the model a
+    // new bug to work around instead of a smaller answer.
+    test('the note is outside the JSON, so nothing changes type', () => {
+        expect(documentOf(trimmed).every(row => typeof row === 'object')).toBe(true);
+        expect(trimmed.slice(trimmed.indexOf('\n[trimmed'))).toMatch(/^\n\[trimmed/);
+    });
+
+    test('a one-element array has no middle to drop, and falls back to text', () => {
+        const one = JSON.stringify([{ blob: 'z'.repeat(5000) }]);
+        const out = trimResult(one, 1000);
+        expect(out.length).toBeLessThanOrEqual(1000);
+        expect(out).toContain('omitted');
+    });
+});
+
+describe('a JSON object wrapping a list', () => {
+    const text = JSON.stringify({ total: 812, nextCursor: 'cursor-abc-123', items: rows(300) });
+    const trimmed = trimResult(text, 4000);
+
+    test('keeps the scalars a following call needs', () => {
+        expect(documentOf(trimmed)).toMatchObject({ total: 812, nextCursor: 'cursor-abc-123' });
+    });
+
+    test('and shrinks the list instead', () => {
+        const doc = documentOf(trimmed);
+        expect(doc.items.length).toBeGreaterThan(1);
+        expect(doc.items.length).toBeLessThan(300);
+        expect(trimmed).toContain('items entries shown');
+    });
+
+    test('picking the longest array when there are several', () => {
+        const two = JSON.stringify({ tags: ['a', 'b'], results: rows(300) });
+        const doc = documentOf(trimResult(two, 4000));
+
+        expect(doc.tags).toEqual(['a', 'b']);
+        expect(doc.results.length).toBeLessThan(300);
+    });
+
+    // Nothing to drop whole: one enormous scalar. The text path takes over
+    // rather than returning something that does not fit.
+    test('an object with no list falls back to head and tail', () => {
+        const blob = JSON.stringify({ log: 'q'.repeat(9000) });
+        const out = trimResult(blob, 1200);
+
+        expect(out.length).toBeLessThanOrEqual(1200);
+        expect(out).toContain('omitted');
+    });
+});
+
+describe('output with no structure to preserve', () => {
+    const log = `${Array.from({ length: 600 }, (_, i) => `line ${i} of some build output`).join('\n')}\nERROR: the build failed`;
+    const trimmed = trimResult(log, 1500);
+
+    test('keeps the start', () => {
+        expect(trimmed).toContain('line 0 of some build output');
+    });
+
+    // The end of a log is where the error is; a head-only cut reliably removes
+    // the half that was worth reading.
+    test('and the end, which is where the error is', () => {
+        expect(trimmed).toContain('ERROR: the build failed');
+    });
+
+    test('with a seam between them, so the two halves do not read as one', () => {
+        expect(trimmed).toMatch(/\[… \d+ characters omitted …\]/);
+    });
+
+    test('and stays inside the budget', () => {
+        expect(trimmed.length).toBeLessThanOrEqual(1500);
+    });
+
+    test('cutting on line boundaries rather than mid-line', () => {
+        const [head] = trimmed.split('\n[…');
+        for (const line of head.split('\n')) {
+            if (line) expect(line).toMatch(/^line \d+ of some build output$/);
+        }
+    });
+
+    // One very long line has no boundary to snap to, and snapping anyway would
+    // throw the whole allowance away.
+    test('one enormous line is cut where it must be', () => {
+        const out = headAndTail('z'.repeat(9000), 1000);
+        expect(out.length).toBeLessThanOrEqual(1000);
+        expect(out).toContain('omitted');
+    });
+});
+
+describe('a budget too small to say anything with', () => {
+    // The one thing that still has to survive is that something was dropped:
+    // output the model thinks is whole gets summarised as though it were.
+    test('below the structured floor it still says it was cut', () => {
+        const out = trimResult(JSON.stringify(rows(50)), MIN_STRUCTURED_LIMIT - 1);
+
+        expect(out).toHaveLength(MIN_STRUCTURED_LIMIT - 1);
+        expect(out.endsWith(SHORT_MARKER)).toBe(true);
+    });
+
+    test('and so does a budget with no room for the long note', () => {
+        const out = trimResult('z'.repeat(5000), 220);
+
+        expect(out).toHaveLength(220);
+        expect(out.endsWith(SHORT_MARKER)).toBe(true);
+    });
+
+    test('a budget smaller than the marker itself is simply a cut', () => {
+        expect(trimResult('abcdefghijklmno', 4)).toBe('abcd');
+    });
+
+    test('and a zero or negative budget returns the text untouched', () => {
+        expect(trimResult('abc', 0)).toBe('abc');
+        expect(trimResult('abc', -5)).toBe('abc');
+    });
+});
+
+describe('whatever the shape and whatever the budget', () => {
+    // The property the callers depend on: the toolkit charges the turn's
+    // output budget by the length of what comes back, so a trimmer that
+    // overshoots its limit is one that overspends the budget.
+    const shapes = [
+        JSON.stringify(rows(200)),
+        JSON.stringify({ total: 9, items: rows(90) }),
+        JSON.stringify({ nested: { deep: rows(40) } }),
+        Array.from({ length: 300 }, (_, i) => `line ${i}`).join('\n'),
+        'x'.repeat(20000),
+        `\`\`\`\n${'diff --git a/x b/x\n'.repeat(500)}\`\`\``,
+        '{"unterminated": "json',
+        '[]',
+        '{}',
+    ];
+
+    test.each([80, 199, 200, 400, 1000, 6000])('never exceeds a %i-character budget', limit => {
+        for (const shape of shapes) {
+            expect(trimResult(shape, limit).length).toBeLessThanOrEqual(limit);
+        }
+    });
+
+    test('and always says something was dropped when something was', () => {
+        for (const shape of shapes) {
+            for (const limit of [40, 250, 1000]) {
+                const out = trimResult(shape, limit);
+                if (out !== shape && limit > SHORT_MARKER.length) {
+                    expect(out).toMatch(/omitted|trimmed|shown|cut…/);
+                }
+            }
+        }
+    });
+});

--- a/tests/mcpServersRoutes.test.js
+++ b/tests/mcpServersRoutes.test.js
@@ -431,7 +431,8 @@ describe('POST /guild/:id/mcp-servers/:name/test', () => {
             url: 'https://api.githubcopilot.com/mcp/',
             authorizationToken: 'ghp_good',
             label: 'github',
-            getAccessToken: null
+            getAccessToken: null,
+            onNotification: null
         }]);
         expect(body.toolCount).toBe(3);
         // delete_file is blocked, so it is offered by the server but not enabled.

--- a/tests/mcpServersRoutes.test.js
+++ b/tests/mcpServersRoutes.test.js
@@ -432,7 +432,8 @@ describe('POST /guild/:id/mcp-servers/:name/test', () => {
             authorizationToken: 'ghp_good',
             label: 'github',
             getAccessToken: null,
-            onNotification: null
+            onNotification: null,
+            elicitation: false
         }]);
         expect(body.toolCount).toBe(3);
         // delete_file is blocked, so it is offered by the server but not enabled.

--- a/tests/mcpServersRoutes.test.js
+++ b/tests/mcpServersRoutes.test.js
@@ -175,7 +175,10 @@ describe('an edit that invalidates an OAuth login', () => {
 
         await api('PUT', '/guild/g1/mcp-servers/linear', { url: 'https://mcp.example.com/mcp' });
 
-        expect(mockPrewarm).toHaveBeenCalledWith([expect.objectContaining({ name: 'linear', oauth: grant })]);
+        expect(mockPrewarm).toHaveBeenCalledWith(
+            [expect.objectContaining({ name: 'linear', oauth: grant })],
+            expect.objectContaining({ only: ['linear'] }),
+        );
     });
 
     test('and without one once the login has just been cleared', async () => {
@@ -183,7 +186,10 @@ describe('an edit that invalidates an OAuth login', () => {
 
         await api('PUT', '/guild/g1/mcp-servers/linear', { url: 'https://other.example.com/mcp' });
 
-        expect(mockPrewarm).toHaveBeenCalledWith([expect.objectContaining({ oauth: null })]);
+        expect(mockPrewarm).toHaveBeenCalledWith(
+            [expect.objectContaining({ oauth: null })],
+            expect.objectContaining({ only: ['linear'] }),
+        );
     });
 
     test('drops the login when the connection is pointed somewhere else', async () => {
@@ -260,11 +266,17 @@ describe('a saved server is dialled before it is needed', () => {
             authorizationToken: 'ghp_secret'
         });
 
-        expect(mockPrewarm).toHaveBeenCalledWith([expect.objectContaining({
-            name: 'github',
-            url: 'https://api.githubcopilot.com/mcp/',
-            authorizationToken: 'ghp_secret'
-        })]);
+        expect(mockPrewarm).toHaveBeenCalledWith(
+            [expect.objectContaining({
+                name: 'github',
+                url: 'https://api.githubcopilot.com/mcp/',
+                authorizationToken: 'ghp_secret'
+            })],
+            // Only the server that was saved (#838). Resolution folds the
+            // operator's config file in alongside it, so without this narrowing
+            // one save dials every shared server in that file as well.
+            expect.objectContaining({ only: ['github'] }),
+        );
     });
 
     test('a server saved switched off is not dialled', async () => {
@@ -668,5 +680,69 @@ describe('the route the panel is told about', () => {
 
     test('an explicit choice is reported as itself, not re-derived', async () => {
         expect((await listWith({ mcpRoute: 'connector', mcpConfirm: 'always' })).effectiveRoute).toBe('connector');
+    });
+});
+
+/**
+ * #838. `off` is a fine reading of silence and a poor first answer: connecting
+ * a server is not consent to unattended writes on it, and an admin typing in a
+ * GitHub endpoint has no idea a default exists to be changed.
+ *
+ * The value is *written* on the first save rather than read from a changed
+ * constant, which is the part that keeps this from re-governing every guild
+ * already running on `off`.
+ */
+describe('the approval policy a guild picks up with its first server', () => {
+    test('a first server stores "writes"', async () => {
+        const { body } = await api('PUT', '/guild/g1/mcp-servers/github', {
+            url: 'https://api.githubcopilot.com/mcp/',
+        });
+
+        expect(doc.ai.mcpConfirm).toBe('writes');
+        expect(body.confirmMode).toBe('writes');
+        expect(body.confirmNotice).toMatch(/approval/i);
+    });
+
+    test('a second server changes nothing', async () => {
+        doc = makeDoc([{ name: 'github', url: 'https://api.githubcopilot.com/mcp/', enabled: true, allowedTools: [], blockedTools: [] }]);
+
+        const { body } = await api('PUT', '/guild/g1/mcp-servers/linear', {
+            url: 'https://mcp.linear.app/mcp',
+        });
+
+        expect(doc.ai.mcpConfirm).toBeUndefined();
+        expect(body.confirmMode).toBeUndefined();
+    });
+
+    // The guild said what it wanted; a save is not the moment to overrule it.
+    test('a stored choice is left alone, "off" included', async () => {
+        doc = makeDoc([]);
+        doc.ai.mcpConfirm = 'off';
+
+        const { body } = await api('PUT', '/guild/g1/mcp-servers/github', {
+            url: 'https://api.githubcopilot.com/mcp/',
+        });
+
+        expect(doc.ai.mcpConfirm).toBe('off');
+        expect(body.confirmNotice).toBeUndefined();
+    });
+
+    // Editing the one server a guild already has is not "adding a first
+    // server", and must not quietly turn approvals on underneath it.
+    test('re-saving the only server does not change the policy', async () => {
+        doc = makeDoc([{ name: 'github', url: 'https://api.githubcopilot.com/mcp/', enabled: true, allowedTools: [], blockedTools: [] }]);
+
+        await api('PUT', '/guild/g1/mcp-servers/github', { url: 'https://api.githubcopilot.com/mcp/' });
+
+        expect(doc.ai.mcpConfirm).toBeUndefined();
+    });
+
+    test('the policy it chose is on the audit record', async () => {
+        await api('PUT', '/guild/g1/mcp-servers/github', { url: 'https://api.githubcopilot.com/mcp/' });
+
+        expect(logAuditEvent).toHaveBeenCalledWith(
+            expect.anything(), 'g1', 'mcp_server_add',
+            expect.objectContaining({ confirmModeDefaulted: 'writes' }),
+        );
     });
 });

--- a/tests/mcpToolkit.test.js
+++ b/tests/mcpToolkit.test.js
@@ -90,7 +90,11 @@ describe('discovery', () => {
             getAccessToken: null,
             // The pool's own listener, which drops a cached list when the
             // server says it changed (#838).
-            onNotification: expect.any(Function)
+            onNotification: expect.any(Function),
+            // Declared once per pooled connection; the handler that answers it
+            // rides with each tool call, because the person to ask belongs to
+            // one Discord message and this client is shared.
+            elicitation: true
         }]);
     });
 
@@ -651,5 +655,46 @@ describe('confirmation', () => {
 
         await toolkit.call('github__search', {});
         expect(confirmTool).toHaveBeenCalled();
+    });
+});
+
+/**
+ * #838. The client is pooled by (url, credential) and shared by every guild
+ * pointed at that server, so a handler living on it would answer one guild's
+ * question in another guild's channel. A tool call belongs to exactly one
+ * message, which is the scope that knows whose channel to ask in.
+ */
+describe('a question a tool call raises', () => {
+    test('rides with the call rather than with the connection', async () => {
+        const toolkit = await prepareMcpToolkit([GITHUB], { elicit: jest.fn() });
+        await toolkit.call('github__search_repositories', {});
+
+        expect(mockCallTool).toHaveBeenCalledWith(
+            'search_repositories', {},
+            expect.objectContaining({ onElicit: expect.any(Function) }),
+        );
+    });
+
+    // The prompt has to say which server is asking, and the call site is where
+    // that is known.
+    test('and arrives at the handler naming the server it came from', async () => {
+        const elicit = jest.fn(async () => ({ action: 'decline' }));
+        const toolkit = await prepareMcpToolkit([GITHUB], { elicit });
+        await toolkit.call('github__search_repositories', {});
+
+        const { onElicit } = mockCallTool.mock.calls[0][2];
+        await onElicit({ message: 'which one?' }, { extendDeadline: () => {} });
+
+        expect(elicit).toHaveBeenCalledWith('github', { message: 'which one?' }, expect.any(Object));
+    });
+
+    // A scheduled task or a command parsing the reply as JSON has nobody to
+    // ask, and passes no handler at all; the client answers those "cancel"
+    // rather than being handed an undefined to call.
+    test('a turn with nobody to ask passes no handler', async () => {
+        const toolkit = await prepareMcpToolkit([GITHUB]);
+        await toolkit.call('github__search_repositories', {});
+
+        expect(mockCallTool.mock.calls[0][2].onElicit).toBeUndefined();
     });
 });

--- a/tests/mcpToolkit.test.js
+++ b/tests/mcpToolkit.test.js
@@ -87,7 +87,10 @@ describe('discovery', () => {
             authorizationToken: 'ghp_x',
             label: 'github',
             // A static-token connection has no OAuth grant to fetch (#796).
-            getAccessToken: null
+            getAccessToken: null,
+            // The pool's own listener, which drops a cached list when the
+            // server says it changed (#838).
+            onNotification: expect.any(Function)
         }]);
     });
 

--- a/tests/mcpToolkit.test.js
+++ b/tests/mcpToolkit.test.js
@@ -282,13 +282,34 @@ describe('calling a tool', () => {
             .toContain('The tool reported an error: no such repo');
     });
 
-    test('truncates a result too large to be worth sending to a model', async () => {
+    test('trims a result too large to be worth sending to a model', async () => {
         mockCallTool.mockResolvedValue(textResult('y'.repeat(MAX_TOOL_RESULT_CHARS * 2)));
         const toolkit = await prepareMcpToolkit([GITHUB]);
         const text = await toolkit.call('github__search_repositories', {});
 
         expect(text.length).toBeLessThan(MAX_TOOL_RESULT_CHARS + 300);
-        expect(text).toMatch(/truncated/);
+        expect(text).toMatch(/trimmed to fit/);
+    });
+
+    // #838. The whole point of the trimmer: a chain's next round reads the last
+    // field of what it was handed, so that field has to be a whole one.
+    test('a JSON result over the cap is still parseable JSON', async () => {
+        const rows = Array.from({ length: 400 }, (_, i) => ({
+            id: i, path: `src/services/module_${i}.js`, score: i / 400,
+        }));
+        mockCallTool.mockResolvedValue(textResult(JSON.stringify(rows)));
+        const toolkit = await prepareMcpToolkit([GITHUB]);
+        const text = await toolkit.call('github__search_repositories', {});
+
+        // Past the "[Result from …]" label line, and stopping at the note the
+        // trimmer appends after the document rather than inside it.
+        const body = text.slice(text.indexOf('\n') + 1);
+        const parsed = JSON.parse(body.slice(0, body.indexOf('\n[trimmed')));
+        expect(Array.isArray(parsed)).toBe(true);
+        expect(parsed.length).toBeLessThan(rows.length);
+        // Whole records, not a record ending mid-path.
+        for (const row of parsed) expect(row.path).toMatch(/^src\/services\/module_\d+\.js$/);
+        expect(text).toMatch(/of 400 items shown/);
     });
 
     // A failed call has to come back as something the model can read: losing the

--- a/tests/mcpToolkit.test.js
+++ b/tests/mcpToolkit.test.js
@@ -698,3 +698,45 @@ describe('a question a tool call raises', () => {
         expect(mockCallTool.mock.calls[0][2].onElicit).toBeUndefined();
     });
 });
+
+/**
+ * The turn budget bounds how long a Discord reply is held open waiting on
+ * somebody else's server. A person reading a question is not that — they are
+ * engaged, and the reply is waiting on them on purpose — so charging their
+ * thinking time to the same ninety seconds means one question ends the turn:
+ * every call after it finds the budget spent and is refused without running.
+ */
+describe('what a question costs the turn', () => {
+    const waitInsideElicit = ms => jest.fn(async () => {
+        await new Promise(resolve => setTimeout(resolve, ms));
+        return { action: 'decline' };
+    });
+
+    // The wait is deliberately longer than the whole budget, so without the
+    // credit the turn is unambiguously over by the time the answer lands.
+    test('the time somebody spends answering is given back', async () => {
+        const elicit = waitInsideElicit(120);
+        const toolkit = await prepareMcpToolkit([GITHUB], { elicit, turnBudgetMs: 60 });
+
+        // First call: the server asks, and the answer takes half the budget.
+        mockCallTool.mockImplementationOnce(async (_name, _args, { onElicit }) => {
+            await onElicit({ message: 'which?' }, { extendDeadline: () => {} });
+            return textResult('ok');
+        });
+        await toolkit.call('github__search_repositories', {});
+
+        // Without the credit the turn is spent here and this is refused.
+        const second = await toolkit.call('github__search_repositories', {});
+        expect(second).not.toMatch(/spent its time budget/);
+        expect(mockCallTool).toHaveBeenCalledTimes(2);
+    });
+
+    // Only the wait, and only once it is over, so a server that asks and goes
+    // away cannot hold a turn open indefinitely.
+    test('but the budget still runs out on its own', async () => {
+        const toolkit = await prepareMcpToolkit([GITHUB], { elicit: jest.fn(), turnBudgetMs: 30 });
+        await new Promise(resolve => setTimeout(resolve, 45));
+
+        expect(await toolkit.call('github__search_repositories', {})).toMatch(/spent its time budget/);
+    });
+});

--- a/tests/openaiStreamOptions.test.js
+++ b/tests/openaiStreamOptions.test.js
@@ -1,0 +1,173 @@
+'use strict';
+
+/**
+ * #838. `stream_options: { include_usage: true }` is how a streamed OpenAI
+ * response is made to report its token counts — without it the usage ledger has
+ * nothing to charge and a guild's spend goes unmeasured — but it is an OpenAI
+ * extension, and `baseURL` points this provider at anything that speaks the
+ * chat-completions shape: llama.cpp, vLLM, LM Studio, a corporate gateway.
+ * Several of those reject the unknown field with a 400 rather than ignoring it,
+ * which turned "your usage numbers are missing" into "the bot cannot answer".
+ *
+ * So it is sent by default and withdrawn on evidence. These pin both halves:
+ * that an endpoint which accepts it keeps its usage reporting, and that one
+ * which refuses it gets an answer rather than an exception — and pays for the
+ * discovery once rather than on every message.
+ *
+ * Each test builds the provider through `jest.isolateModules`, because the
+ * set of refusing endpoints is process-lifetime state and a test that inherited
+ * another's would be pinning the wrong thing.
+ */
+
+const mockCreate = jest.fn();
+const mockConstructed = [];
+
+jest.mock('openai', () =>
+    jest.fn().mockImplementation(options => {
+        mockConstructed.push(options);
+        return { chat: { completions: { create: mockCreate } } };
+    })
+);
+
+/** One streamed round that says "ok" and reports usage. */
+function okStream() {
+    return {
+        async *[Symbol.asyncIterator]() {
+            yield { choices: [{ delta: { content: 'ok' } }] };
+            yield { usage: { prompt_tokens: 3, completion_tokens: 4 } };
+        }
+    };
+}
+
+/** The 400 an endpoint that has never heard of the parameter answers with. */
+function rejection(message = 'Unrecognized request argument supplied: stream_options') {
+    const err = new Error(message);
+    err.status = 400;
+    return err;
+}
+
+function loadProvider() {
+    let provider;
+    jest.isolateModules(() => { provider = require('../src/services/ai/providers/openai'); });
+    return provider;
+}
+
+const REQ = {
+    apiKey: 'k',
+    model: 'gpt-4o',
+    systemPrompt: 'be helpful',
+    history: [],
+    prompt: 'hi',
+    maxTokens: 100,
+    useMcp: false,
+    mcpServers: []
+};
+
+async function collect(iterable) {
+    const out = [];
+    for await (const piece of iterable) out.push(piece);
+    return out.join('');
+}
+
+let warn;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockConstructed.length = 0;
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => warn.mockRestore());
+
+describe('an endpoint that accepts stream_options', () => {
+    test('is asked for usage, and reports it', async () => {
+        mockCreate.mockResolvedValue(okStream());
+        const usageOut = {};
+
+        const text = await collect(loadProvider().stream({ ...REQ, usageOut }));
+
+        expect(text).toBe('ok');
+        expect(mockCreate.mock.calls[0][0].stream_options).toEqual({ include_usage: true });
+        expect(usageOut.usage).toMatchObject({ inputTokens: 3, outputTokens: 4 });
+    });
+
+    test('is asked once per round, not retried', async () => {
+        mockCreate.mockResolvedValue(okStream());
+
+        await collect(loadProvider().stream(REQ));
+
+        expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('an endpoint that rejects it', () => {
+    test('gets its answer from the retry without the parameter', async () => {
+        mockCreate.mockRejectedValueOnce(rejection()).mockResolvedValue(okStream());
+
+        const text = await collect(loadProvider().stream({ ...REQ, baseURL: 'http://llama.local/v1' }));
+
+        expect(text).toBe('ok');
+        expect(mockCreate).toHaveBeenCalledTimes(2);
+        expect(mockCreate.mock.calls[1][0]).not.toHaveProperty('stream_options');
+    });
+
+    // The point of remembering: a guild on such an endpoint would otherwise pay
+    // a failed request on every single message.
+    test('is not asked again on the next message', async () => {
+        mockCreate.mockRejectedValueOnce(rejection()).mockResolvedValue(okStream());
+        const provider = loadProvider();
+        const at = { ...REQ, baseURL: 'http://llama.local/v1' };
+
+        await collect(provider.stream(at));
+        mockCreate.mockClear();
+        await collect(provider.stream(at));
+
+        expect(mockCreate).toHaveBeenCalledTimes(1);
+        expect(mockCreate.mock.calls[0][0]).not.toHaveProperty('stream_options');
+    });
+
+    // Remembered per endpoint, so one gateway's refusal does not cost every
+    // other guild in the process its usage accounting.
+    test('does not speak for a different endpoint', async () => {
+        mockCreate.mockRejectedValueOnce(rejection()).mockResolvedValue(okStream());
+        const provider = loadProvider();
+
+        await collect(provider.stream({ ...REQ, baseURL: 'http://llama.local/v1' }));
+        mockCreate.mockClear();
+        await collect(provider.stream(REQ));
+
+        expect(mockCreate.mock.calls[0][0].stream_options).toEqual({ include_usage: true });
+    });
+
+    test('the error names the field, so the message is only a 400 away', async () => {
+        mockCreate.mockRejectedValueOnce(rejection('include_usage is not supported')).mockResolvedValue(okStream());
+
+        await collect(loadProvider().stream({ ...REQ, baseURL: 'http://vllm.local/v1' }));
+
+        expect(mockCreate).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('a 400 about anything else', () => {
+    // Retrying these would double every genuine failure, and dropping usage
+    // reporting would not fix one of them.
+    test('is raised rather than retried', async () => {
+        mockCreate.mockRejectedValue(rejection('model `gpt-9` does not exist'));
+
+        await expect(collect(loadProvider().stream({ ...REQ, baseURL: 'http://gw.local/v1' })))
+            .rejects.toThrow(/does not exist/);
+        expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+
+    test('and leaves the endpoint asking for usage next time', async () => {
+        mockCreate.mockRejectedValueOnce(rejection('bad model'));
+        const provider = loadProvider();
+        const at = { ...REQ, baseURL: 'http://gw.local/v1' };
+
+        await expect(collect(provider.stream(at))).rejects.toThrow();
+        mockCreate.mockResolvedValue(okStream());
+        await collect(provider.stream(at));
+
+        expect(mockCreate.mock.calls[1][0].stream_options).toEqual({ include_usage: true });
+    });
+});


### PR DESCRIPTION
Six independent fixes from the AI/agentic review, none of which changes what
the protocol does — they change what it costs, what it says, and what it
assumes when nobody has told it anything.

`load_tools` told the model its newly loaded tools would work "next turn". A
turn is the whole exchange, so that reads as "stop and wait for the user to
type again" — the one thing a model must not do with a tool it just asked for.
It is a round, and it says so now. The same tool's enum also kept handing back
names it had already loaded, which invites a second round spent asking for a
tool the model can already call; the catalogue is rewritten as tools are taken
and the meta-tool drops out of the toolkit entirely once it has nothing left
to offer.

A dashboard save warmed every server resolution could see, because resolution
folds the operator's config file in alongside the guild's own. That is right
for the startup sweep and wrong here: editing one connection dialled every
shared server in the file, per save. `prewarmMcpServers` takes an `only` now.

OAuth connections read Mongo for an access token before every single request —
the client re-asks rather than caching, because a pooled connection sits idle
while its token expires — so a turn running six tool calls was six `findOne`s
deep before a byte went out. The token is what expires on a clock this process
already knows, so it is memoized until comfortably before its own refresh is
due, and dropped on every write to the grant and on the forced-refresh path a
401 takes.

`stream_options: { include_usage: true }` went out unconditionally, and
`baseURL` points this provider at anything speaking the chat-completions
shape. Several of those reject the unknown field with a 400 rather than
ignoring it, which turns "usage is unreported" into "the reply never arrives".
It is sent by default and withdrawn on evidence, per endpoint, for the life of
the process.

`redirectUriFor` guessed `http://localhost:3000` when `DASHBOARD_URL` was
unset. In a deployment that does not degrade: the URI is registered with the
authorization server and checked on the way back, so the flow either fails at
registration or sends an admin's browser to a port on their laptop carrying an
authorization code. It is refused in production, naming the variable, and the
guess survives where it is actually right.

And a guild's first MCP server now stores `writes` as its approval policy.
Connecting a server is not consent to unattended writes on it, and an admin
typing in an endpoint has no idea a default exists to be changed. Written on
the first save rather than by moving `DEFAULT_CONFIRM_MODE`, which is what
keeps it from re-governing every guild already running on the old reading of
silence — and the response says it happened, so it can be undone in one click.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-initiated follow-up questions with secure, interactive forms in the channel.
  * Added automatic refresh when server tools, resources, or prompts change.
  * Tool results now remain readable and valid when shortened to fit response limits.
  * First server connections now require approval for write-capable actions by default.
* **Bug Fixes**
  * Production OAuth setup now requires a configured dashboard URL instead of using localhost.
  * Streaming usage reporting is more reliable across compatible and unsupported endpoints.
* **Documentation**
  * Updated MCP approval, follow-up question, and security guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->