### PR TITLE
Teach the extension guide the ephemeral flag the code actually uses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,12 @@ GEMINI_API_KEY=AIza_your_gemini_key_here
 OPENAI_API_KEY=sk-your_openai_key_here
 ANTHROPIC_API_KEY=sk-ant-your_anthropic_key_here
 OPENROUTER_API_KEY=sk-or-your_openrouter_key_here
+# OpenRouter asks callers to identify themselves with an HTTP-Referer, and shows
+# it on the model's public leaderboard. Unset, requests are attributed to this
+# project's repository — set it to your own site or bot page if you would rather
+# they were attributed to you. It is not a credential and does not affect
+# billing or access.
+# OPENROUTER_REFERER=https://github.com/TheShield2594/clawdia
 # Base URL of a self-hosted Ollama instance, e.g. http://ollama:11434
 OLLAMA_BASE_URL=
 
@@ -173,6 +179,11 @@ AUDIT_LOG_RETENTION_DAYS=90
 # default otherwise) renders a readable line instead. `docker logs clawdia |
 # npx pino-pretty` reads a JSON stream the same way.
 # LOG_FORMAT=json
+# The pretty renderer colours the level and the component when it is writing to
+# a terminal. Set NO_COLOR to any value to turn that off — the no-color.org
+# convention, honoured here for a terminal that renders the escapes literally.
+# Irrelevant under LOG_FORMAT=json, which never colours.
+# NO_COLOR=1
 
 # Where to send an uncaught exception or an unhandled rejection, on top of
 # logging it. Unset — the default — nothing is sent and the process exits
@@ -185,6 +196,10 @@ AUDIT_LOG_RETENTION_DAYS=90
 # ERROR_WEBHOOK_URL=https://discord.com/api/webhooks/...
 # How long the process waits for that POST before exiting anyway (default 2000).
 # ERROR_REPORT_TIMEOUT_MS=2000
+# The `service` field on that report (default "clawdia"). Worth setting when one
+# collector receives crashes from more than one deployment — a staging bot and a
+# production one — so the two can be told apart.
+# SERVICE_NAME=clawdia
 
 # ── Sharding (optional) ──────────────────────────────────────────────────────
 # `npm start` runs one process and one gateway connection, and is the default.
@@ -198,6 +213,11 @@ AUDIT_LOG_RETENTION_DAYS=90
 # scheduler — see src/utils/sharding.js for why, and for the guild-to-shard
 # affinity rule the live multiplayer rounds depend on.
 # SHARD_COUNT=2
+#
+# SHARD_ID is deliberately not a setting here. The ShardingManager puts it into
+# each child process it spawns, and the code prefers the id discord.js reports
+# anyway; setting it by hand on the parent tells every shard it is shard 0, and
+# every shard would then run the dashboard and the migrations.
 
 # Paired with the http://localhost DASHBOARD_URL above so this file works as-is
 # for local development. Switch BOTH to production values together: set this to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,9 +56,10 @@ npm test                # the whole suite, ~20s
 npm run lint            # eslint, flat config
 ```
 
-`npm test -- --coverage` additionally applies the two coverage ratchets, which
-is what CI runs — see [Coverage](#coverage) below. `npm run lint:fix` applies
-what ESLint can fix on its own.
+The two coverage ratchets are two separate commands: `npm test -- --coverage`
+applies Jest's global thresholds, and `npm run coverage:check` applies the
+per-directory floors. CI runs both — see [Coverage](#coverage) below.
+`npm run lint:fix` applies what ESLint can fix on its own.
 
 Formatting is `npm run format -- <paths>`, and it takes explicit paths on
 purpose: Prettier's settings match the style the tree is already written in,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,195 @@
+# Contributing to Clawdia
+
+The contribution guidance used to be six bullets at the bottom of the extension
+guide, the fourth of which was "test thoroughly" — without naming `npm test`
+([#718]). This is the rest of it: what to install, what has to pass before a
+pull request is worth opening, and the handful of things about this codebase
+that will surprise you if nobody says them first.
+
+- [Getting set up](#getting-set-up)
+- [Before you open a pull request](#before-you-open-a-pull-request)
+- [Tests](#tests)
+- [Things that will surprise you](#things-that-will-surprise-you)
+- [Adding a command, a route or a model](#adding-a-command-a-route-or-a-model)
+- [Commits and pull requests](#commits-and-pull-requests)
+
+## Getting set up
+
+Node **24.19.0** or newer — the version in `.nvmrc`, which CI reads and
+`package.json` enforces via `engines`. A MongoDB you can write to; the compose
+stack brings one up if you would rather not install it.
+
+```bash
+git clone https://github.com/TheShield2594/clawdia.git
+cd clawdia
+npm ci                  # ci, not install — the lockfile is the build
+cp .env.example .env    # then fill it in
+npm test                # should be green before you change anything
+```
+
+[`.env.example`](.env.example) is the complete, annotated list of every
+environment variable the bot reads, and the only one — a test fails the build
+if the code reads something the file does not explain. Five variables are
+start-or-fail: `DISCORD_TOKEN`, `CLIENT_ID`, `CLIENT_SECRET`, `MONGODB_URI` and
+a `SESSION_SECRET` of 32 characters or more. Everything else is defaulted.
+
+`src/config/validateEnv.js` checks all of it before the process touches the
+database, and reports every problem at once rather than one per restart.
+
+You do not need a real Discord bot or a real database to run the tests. You do
+need both to run the bot: [SETUP_GUIDE.md](SETUP_GUIDE.md) walks through
+creating the application, and the integration suites use
+`mongodb-memory-server`, which downloads a MongoDB binary on first run.
+
+```bash
+npm run dev             # nodemon, restarts on save
+npm start               # plain node, and what the image runs
+```
+
+## Before you open a pull request
+
+Both of these gate CI, and the Docker image is only built when they pass, so a
+red one means nothing ships:
+
+```bash
+npm test                # the whole suite, ~20s
+npm run lint            # eslint, flat config
+```
+
+`npm test -- --coverage` additionally applies the two coverage ratchets, which
+is what CI runs — see [Coverage](#coverage) below. `npm run lint:fix` applies
+what ESLint can fix on its own.
+
+Formatting is `npm run format -- <paths>`, and it takes explicit paths on
+purpose: Prettier's settings match the style the tree is already written in,
+but it has never been run over the whole tree, because that would rewrite
+~45,000 lines and every `git blame` along with them. Run it on the files your
+change already touches, nothing else.
+
+Some documentation is generated and a test compares it against a fresh render,
+so adding a command or an endpoint turns the suite red until you regenerate:
+
+```bash
+npm run docs:commands   # README's command list, from the loaded command set
+npm run docs:api        # API_REFERENCE's endpoint tables, from the routers
+npm run docs:panels     # the dashboard panel reference
+```
+
+## Tests
+
+Every `*.test.js` under `tests/`, run by Jest.
+
+```bash
+npm test                            # everything
+npx jest tests/birthday.test.js     # one file
+npx jest -t "leap day"              # every test whose name matches
+npx jest --watch                    # re-run affected files on save
+```
+
+A new test goes next to its subject in `tests/`, named after what it holds
+rather than after the file it imports. [docs/EXTENDING.md](docs/EXTENDING.md#testing)
+covers how the suite is laid out and how to write one against Mongo and against
+Discord's API.
+
+`npm test` deliberately does **not** pass `--forceExit`. A suite that leaks a
+Mongoose connection or an un-`unref`'d timer hangs at the end of the run instead
+of being silently shot, because the hang is the bug. If your new test hangs the
+run, something it opened is still open.
+
+### Coverage
+
+Two ratchets, both applied by CI, both failable locally:
+
+```bash
+npm test -- --coverage    # the global thresholds in jest.config.js
+npm run coverage:check    # the per-directory floors in coverage-floors.json
+```
+
+The global number cannot see *where* coverage is — `src/services/ai` sits near
+80% and `src/commands/economy` near 20%, and deleting every AI test would cost
+about four points of the total and stay green. So `coverage-floors.json` holds
+a floor per directory, and also fails on a file that stops being executed at
+all. Raise a floor when you raise the coverage under it; do not lower one to
+land a change.
+
+## Things that will surprise you
+
+**Migrations run themselves, on every boot.** `src/index.js` runs everything in
+`src/migrations/` in order before the bot logs in and before the dashboard opens
+its port. There is no separate migrate step and no way to start without them.
+Some are irreversible and none roll back on their own, so the runner takes a
+`mongodump` before an irreversible one — set `MIGRATION_BACKUP=require` to make
+a failed backup abort startup rather than warn. Writing one:
+[docs/EXTENDING.md](docs/EXTENDING.md#schema-migrations).
+
+**The bot registers its own slash commands.** It publishes the command set to
+Discord on connect, and only when it differs from the set last published. That
+is what makes the Docker deploy work at all — the image runs `node src/index.js`
+and nothing in either stack file runs a registration step. Changing a command's
+*shape* re-publishes on the next restart; changing only its handler body sends
+nothing. `DEPLOY_COMMANDS=never` turns it off, `always` forces it.
+
+**A command file that fails to load is fatal.** Startup refuses to come up with
+an incomplete set, because the deploy publishes exactly the collection startup
+builds — a command that quietly failed to load would otherwise unregister itself
+from Discord on the next boot.
+
+**Dependencies only run one way.** `eslint-rules/layer-boundaries.js` enforces
+the layering declared in `eslint.config.js`: models and config at the bottom,
+then utils, views, services, commands, and the dashboard and events at the top.
+A module may require its own layer and anything below it. There is exactly one
+documented exception. `npm run lint` is where you find out.
+
+**`GET /health` is the operator's window in.** Served on the dashboard port,
+unauthenticated, and behind both Docker healthchecks. `healthy` answers 200 and
+anything less answers 503 — `degraded` means MongoDB is up but a scheduled
+service is failing every run, which is exactly the half-broken bot a monitor
+exists to catch. The compose healthchecks parse `status` out of the body and
+restart only on `unhealthy`, deliberately: restarting does not fix a feed that
+is 404ing, and a restart loop is worse than a degraded bot. If you add a
+scheduled service, report its runs through `src/health.js` so it shows up there.
+
+**Ephemeral replies use the flag, not the boolean.** `flags:
+MessageFlags.Ephemeral`, never `ephemeral: true`, which discord.js v14
+deprecated. ESLint fails the build on the boolean.
+
+## Adding a command, a route or a model
+
+[docs/EXTENDING.md](docs/EXTENDING.md) is the guide, and the part worth reading
+before your first command is
+[the full module contract](docs/EXTENDING.md#the-full-module-contract).
+
+A command is one object. `data` and `execute` are required and the loader
+refuses to start without them. Four optional hooks are read by name and
+validated by nothing: `cooldownAmount`, `cooldownKey`, `autocomplete` and
+`requiredPermissions`. A typo in any of them is not an error — it is a key
+nobody reads, so the command loads, deploys, runs, and your hook never fires.
+On `requiredPermissions` that is a security bug rather than an annoyance,
+because `setDefaultMemberPermissions` on the builder is only a default that a
+guild admin can reassign.
+
+For an HTTP endpoint, [API_REFERENCE.md](API_REFERENCE.md) documents what the
+dashboard's API already serves and how its authentication, authorization and
+response envelopes work; the tables in it are generated, so write the route's
+one-sentence `//` comment and run `npm run docs:api`.
+
+## Commits and pull requests
+
+Work on a branch. One logical change per commit.
+
+Commit subjects here are sentence-case and imperative, and say what the change
+does rather than which files it touches — "Move the feed cursor only as far as
+delivery actually got", not "fix(rss): update cursor". No conventional-commit
+prefixes. Then a body explaining *why*, which is the part that survives: the
+constraint you found, the failure mode you were closing, what you rejected.
+Close an issue with `Fixes #123`.
+
+Before you push: the tests and the lint pass, the generated docs are
+regenerated if you touched their sources, and the diff contains nothing you
+cannot explain.
+
+Releases are cut separately and are not part of an ordinary change — see
+[docs/RELEASING.md](docs/RELEASING.md). Do not bump the version in a feature
+pull request.
+
+[#718]: https://github.com/TheShield2594/clawdia/issues/718

--- a/README.md
+++ b/README.md
@@ -156,31 +156,46 @@ the files a change already touches.
 
 ## Environment Variables
 
-- `DISCORD_TOKEN` - Your Discord bot token
-- `CLIENT_ID` - Discord application client ID
-- `CLIENT_SECRET` - Discord OAuth2 client secret
-- `MONGODB_URI` - MongoDB connection string (required)
-- `DASHBOARD_PORT` - Web dashboard port (default: 3000)
-- `DASHBOARD_URL` - Public URL for the dashboard
-- `SESSION_SECRET` - Random string for session encryption
-- `SECRET_ENCRYPTION_KEY` - (Optional, recommended) Encrypts the per-server AI provider keys that admins enter in the dashboard, so database backups hold ciphertext rather than live credentials. Generate with `openssl rand -base64 32`; keep it, because the stored keys cannot be read back without it. See [SETUP_GUIDE.md](SETUP_GUIDE.md#encrypting-stored-provider-keys)
-- `OPENAI_API_KEY` - (Optional) OpenAI API key for AI features
-- `GEMINI_API_KEY` - (Optional) Google Gemini API key for AI features
-- `ANTHROPIC_API_KEY` - (Optional) Anthropic Claude API key for AI features
-- `OPENROUTER_API_KEY` - (Optional) OpenRouter API key for AI features
-- `OLLAMA_BASE_URL` - (Optional) Local Ollama endpoint (e.g., `http://localhost:11434`). This is the operator's endpoint: a base URL a server admin types into the dashboard is only allowed to reach a private or internal address if it matches this value (or the `localhost:11434` default), so set it when Ollama runs somewhere on your LAN or compose network
-- `MCP_SERVERS_CONFIG` - (Optional) Path to the MCP server list (default: `config/mcp-servers.json`)
-- `MCP_ALLOW_GUILD_SERVERS` - (Optional) Set to `false` to disable dashboard-managed MCP servers
-- `IMGFLIP_USERNAME` / `IMGFLIP_PASSWORD` - (Optional) Imgflip credentials for `/meme` command
-- `LOG_LEVEL` - (Optional) `trace`, `debug`, `info` (default), `warn`, `error`, `fatal` or `silent`. See [Logging](#logging)
-- `LOG_FORMAT` - (Optional) `json` or `pretty`. Defaults to `json` when `NODE_ENV=production`, `pretty` otherwise
-- `ERROR_WEBHOOK_URL` - (Optional) Where to send an uncaught exception or unhandled rejection, on top of logging it. Must be `https://`, or `http://` to loopback. A Discord webhook URL is recognised and formatted for Discord; anything else receives a flat JSON event. Unset, nothing is sent and the crash path behaves exactly as before
-- `ERROR_REPORT_TIMEOUT_MS` - (Optional) How long the process waits for that POST before exiting anyway (default 2000)
-- `DEPLOY_COMMANDS` - (Optional) `auto` (default — publish the slash commands at startup, but only when the set changed), `always`, or `never`
-- `MIGRATION_TIMEOUT_MS` - (Optional) Per-migration wall-clock budget in milliseconds (default 30000)
-- `MIGRATION_BACKUP` - (Optional) `require` to abort startup rather than run an irreversible migration without a `mongodump` first; `skip` to not attempt one. Unset, it is attempted and a failure is a loud warning. See [Schema migrations](SETUP_GUIDE.md#schema-migrations)
-- `BACKUP_RETENTION_DAYS` - (Optional) Days of nightly `mongodump` archives to keep (default 30)
-- `SHARD_COUNT` - (Optional) Pin a shard count for `npm run start:sharded`; unset takes Discord's recommendation
+[`.env.example`](.env.example) is the complete list, and the only one — every
+variable the bot reads is in it, annotated with what it does and what happens if
+you leave it alone. Copy it to `.env` and work through it; there is no second
+list to cross-check.
+
+It was not always the only one. README and SETUP_GUIDE each carried a
+hand-maintained copy, the two had dropped different variables, and
+`OPENROUTER_REFERER` was read by the OpenRouter provider and named in none of
+the three ([#707]). `tests/envExampleDrift.test.js` now fails the suite when a
+`process.env.SOMETHING` appears in `src/` that `.env.example` does not explain,
+so the file cannot fall behind the code again.
+
+These five are the ones `src/config/validateEnv.js` refuses to start without:
+
+| Variable | What it is |
+| --- | --- |
+| `DISCORD_TOKEN` | The bot token from the Discord Developer Portal |
+| `CLIENT_ID` | The Discord application's client id |
+| `CLIENT_SECRET` | The OAuth2 client secret, for dashboard login |
+| `MONGODB_URI` | MongoDB connection string |
+| `SESSION_SECRET` | Random string signing the dashboard session, 32 characters or more — `openssl rand -hex 32` |
+
+`DASHBOARD_URL` is the sixth to set in practice. It defaults to
+`http://localhost:$DASHBOARD_PORT`, which is right for development and wrong
+for anything else — and it *must* be `https://` whenever `NODE_ENV=production`,
+or startup aborts before the database is touched.
+
+Everything else is optional and defaulted. The ones most often wanted:
+`SECRET_ENCRYPTION_KEY` (encrypts the provider keys guild admins enter in the
+dashboard — see [SETUP_GUIDE.md](SETUP_GUIDE.md#encrypting-stored-provider-keys)),
+one of `OPENAI_API_KEY` / `GEMINI_API_KEY` / `ANTHROPIC_API_KEY` /
+`OPENROUTER_API_KEY` / `OLLAMA_BASE_URL` for the AI features,
+`ERROR_WEBHOOK_URL` so a crash reaches you, and `LOG_LEVEL` / `LOG_FORMAT` (see
+[Logging](#logging)).
+
+Any secret can be delivered as a file instead of a value — set `<NAME>_FILE` to
+a path, which is what to use with Docker secrets, since a plain environment
+variable is readable via `docker inspect` and a path is not.
+
+[#707]: https://github.com/TheShield2594/clawdia/issues/707
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,10 @@ npm run docs:api               # Regenerate API_REFERENCE's endpoint tables from
 ```
 
 CI runs the tests and the lint, and the Docker image is only published when
-both pass.
+both pass. [CONTRIBUTING.md](CONTRIBUTING.md) covers the rest: getting set up,
+the coverage ratchets, and the things about this codebase that surprise people
+— migrations that run themselves on every boot, a bot that registers its own
+slash commands, and a lint rule that decides which module may require which.
 
 `npm run docs:commands` rewrites the **Commands** block below from the command
 set the bot loads — the same catalog `/help` renders. A test compares the two,

--- a/README.md
+++ b/README.md
@@ -195,8 +195,9 @@ one of `OPENAI_API_KEY` / `GEMINI_API_KEY` / `ANTHROPIC_API_KEY` /
 [Logging](#logging)).
 
 Any secret can be delivered as a file instead of a value — set `<NAME>_FILE` to
-a path, which is what to use with Docker secrets, since a plain environment
-variable is readable via `docker inspect` and a path is not.
+a path, which is what to use with Docker secrets. `docker inspect` still shows
+the variable and the path it holds; what it no longer shows is the secret
+itself, which stays in the mounted file.
 
 [#707]: https://github.com/TheShield2594/clawdia/issues/707
 

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -474,7 +474,14 @@ slash command for it.
 
 ### Environment Variables
 
-Create a `.env` file with these required variables:
+**Start from [`.env.example`](.env.example)** — `cp .env.example .env` — rather
+than from a list in a guide. It is the complete set, it is annotated variable by
+variable, and a test fails the build when the code reads something it does not
+explain. This guide used to carry its own copy of the list, which had already
+dropped `ANTHROPIC_API_KEY` and `OLLAMA_BASE_URL` ([#707]).
+
+What follows is the smallest `.env` that boots, to show the shape of the file
+and the one pairing that catches people out. It is not the whole set.
 
 ```env
 # Discord Configuration
@@ -496,26 +503,17 @@ DASHBOARD_PORT=3000
 DASHBOARD_URL=http://localhost:3000
 SESSION_SECRET=random_string_here_32_characters_min
 
-# Encrypts the per-server AI provider keys stored in MongoDB (Optional,
-# recommended). See "Encrypting stored provider keys" below.
-SECRET_ENCRYPTION_KEY=
-
-# AI (Optional - can also configure per-server in dashboard)
-OPENAI_API_KEY=sk-your_openai_key_here
-GEMINI_API_KEY=AIza_your_gemini_key_here
-
-# MCP servers, used by whichever AI provider is selected (Optional)
-# Defaults to config/mcp-servers.json; set this only to read it from elsewhere.
-# MCP_SERVERS_CONFIG=/opt/clawdia/config/mcp-servers.json
-
-# Meme Generation (Optional — required for /meme command)
-# Free account at https://imgflip.com/api
-IMGFLIP_USERNAME=your_imgflip_username
-IMGFLIP_PASSWORD=your_imgflip_password
-
 # Environment
 NODE_ENV=development
 ```
+
+Everything else is optional and defaulted, `.env.example` says what each one
+does, and the ones worth knowing about early are `SECRET_ENCRYPTION_KEY`
+("Encrypting stored provider keys" below), the AI provider keys —
+`OPENAI_API_KEY`, `GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`,
+`OLLAMA_BASE_URL` — and `IMGFLIP_USERNAME` / `IMGFLIP_PASSWORD` for `/meme`.
+
+[#707]: https://github.com/TheShield2594/clawdia/issues/707
 
 The block above is a working local setup: `NODE_ENV=development` goes with the
 `http://localhost:3000` dashboard URL. Going to production means changing both

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -829,9 +829,12 @@ npx jest -t "leap day"              # every test whose name matches
 npx jest --watch                    # re-run the affected files on save
 ```
 
-`--forceExit` is in the npm script rather than in a config: a few suites leave a
-mongoose connection or a timer handle open, and without it Jest waits on them
-after the last assertion has already passed.
+`npm test` deliberately does **not** pass `--forceExit`. It used to (#630), and
+that made a leaked handle — an undisconnected mongoose client, a cron nobody
+`.unref()`d — invisible: Jest shot it at the end of the run and reported a pass.
+Without the flag such a leak hangs after the last assertion instead, which is
+the signal. If a suite you wrote hangs the run, something it opened is still
+open; CI bounds the step so the hang fails there rather than sitting for hours.
 
 ### How the suite is laid out
 
@@ -1275,13 +1278,9 @@ Never hardcode tokens or API keys!
 
 ## Contributing
 
-When adding new features:
-
-1. Create commands in appropriate category folder
-2. Use existing patterns and conventions
-3. Add proper error handling
-4. Test thoroughly before committing
-5. Update documentation
-6. Consider dashboard integration
+This file is the *how* — how to add a command, a model, a route, a migration.
+[CONTRIBUTING.md](../CONTRIBUTING.md) is the *process*: getting set up, what has
+to be green before a pull request is worth opening, the coverage ratchets, and
+the handful of things about this codebase that surprise people.
 
 Happy coding! 🚀

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -1005,7 +1005,7 @@ async execute(interaction) {
         if (interaction.deferred) {
             await interaction.editReply(errorMessage);
         } else {
-            await interaction.reply({ content: errorMessage, ephemeral: true });
+            await interaction.reply({ content: errorMessage, flags: MessageFlags.Ephemeral });
         }
     }
 }
@@ -1030,14 +1030,26 @@ async execute(interaction) {
 
 ### Ephemeral Replies
 
-For private responses:
+For a reply only the person who ran the command can see:
 
 ```javascript
+const { MessageFlags } = require('discord.js');
+
 await interaction.reply({
     content: 'Only you can see this!',
-    ephemeral: true
+    flags: MessageFlags.Ephemeral
 });
 ```
+
+`flags: MessageFlags.Ephemeral`, not `ephemeral: true`. The boolean option is
+deprecated in discord.js v14 — it still works, and logs a deprecation warning
+on every call — and this codebase does not use it anywhere. Write the flag and
+your file matches the other 800-odd reply sites; write the boolean and the next
+person to grep for the pattern finds one file that disagrees.
+
+The same flag goes on `deferReply` when the eventual reply should be private:
+`await interaction.deferReply({ flags: MessageFlags.Ephemeral })`. Deferring
+publicly and then editing does not make the reply private afterwards.
 
 ### Button Interactions
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -57,6 +57,10 @@ and `eslint.config.js`.
 
 ## Creating a New Command
 
+A command is one file under `src/commands/<category>/`, or a folder with an
+`index.js` when it has outgrown one file. The category comes from the
+directory; nothing else registers a command.
+
 ### Basic Command Template
 
 ```javascript
@@ -73,6 +77,138 @@ module.exports = {
     }
 };
 ```
+
+That is the smallest working command, not the whole contract — see
+[The full module contract](#the-full-module-contract) below for the four
+optional keys the interaction handler also looks for.
+
+### The full module contract
+
+A command module is a plain object. Two keys are required and the loader
+refuses to start without them; the rest are optional hooks
+`events/interactionCreate.js` looks for by name.
+
+| Key | Required | Shape | What reads it |
+| --- | --- | --- | --- |
+| `data` | yes | a `SlashCommandBuilder` (anything with `toJSON()`) | the loader, for `client.commands`; the deploy, for what it publishes to Discord |
+| `execute` | yes | `async (interaction, client) => void` | run on every chat-input use |
+| `cooldown` | no | seconds, number — defaults to `3` | the per-user cooldown gate |
+| `cooldownAmount` | no | `(interaction) => seconds` | same gate, when the window depends on which subcommand or option was used |
+| `cooldownKey` | no | `(interaction) => string` — defaults to the command name | which bucket the cooldown is charged to |
+| `autocomplete` | no | `async (interaction, client) => void` | autocomplete interactions for this command |
+| `requiredPermissions` | no | an array of `PermissionFlagsBits` | checked before `execute`, and before the cooldown is claimed |
+| `category` | never set this | string | stamped by the loader from the directory the file is in |
+
+#### The two required keys
+
+`isCommandModule` in `utils/commandLoader.js` checks that `execute` is callable
+and that `data` has a callable `toJSON`. Both, not merely present: a module
+whose `execute` holds a string is caught at startup rather than the moment
+someone runs the command. A file that fails the check is fatal — startup
+refuses to come up with an incomplete set, because the deploy publishes exactly
+the collection startup builds, and a command that quietly failed to load would
+otherwise *unregister* itself from Discord on the next boot.
+
+#### A typo in an optional key fails silently
+
+Nothing validates the optional keys. They are read as `command.cooldownKey`,
+`command.autocomplete` and so on, so `cooldownkey` or `autoComplete` is not an
+error — it is a key nobody reads. The command loads, deploys and runs, and the
+hook you wrote never fires. `requiredPermissions` is the one where that is a
+security bug rather than an annoyance, so grep an existing user of the key and
+copy the spelling:
+
+```
+cooldownAmount   cooldownKey   autocomplete   requiredPermissions
+```
+
+#### Cooldowns
+
+`cooldown` is one number for the whole command. That is wrong for a command
+whose subcommands cost different amounts, and it is wrong for a command whose
+window should not be shared across its subcommands — which is why the two
+function forms exist. `casino.js`, `heist.js`, `syndicate.js` and
+`newspaper.js` use them today:
+
+```javascript
+module.exports = {
+    data: /* … a builder with blackjack / roulette / slots subcommands */,
+
+    // Per-subcommand window: a slots pull is not a blackjack hand.
+    cooldownAmount: interaction =>
+        interaction.options.getSubcommand() === 'blackjack' ? 10 : 3,
+
+    // Per-subcommand bucket: being on cooldown for slots must not lock
+    // roulette. Without this, every subcommand shares the key `casino`.
+    cooldownKey: interaction => `casino:${interaction.options.getSubcommand()}`,
+
+    async execute(interaction) { /* … */ },
+};
+```
+
+`cooldownAmount` overrides `cooldown` when both are present. Whatever it
+returns is coerced: a non-finite or negative value falls back to 3 seconds, and
+the value is clamped to `2^31-1` milliseconds, because Node's `setTimeout`
+treats a longer delay as 1 ms and would hand the window straight back. A guild
+can also set per-role cooldown overrides for a command from the dashboard; the
+lowest override matching the caller's roles replaces whatever these return.
+
+None of this is what *enforces* an economy cooldown. Anything that pays out
+claims its own window atomically in Mongo — see the cooldown note in
+`src/index.js` and `tests/economyCooldownClaims.test.js`.
+
+#### Autocomplete
+
+Discord sends autocomplete as its own interaction type, not through `execute`.
+Declare a sibling method and it is called with the same arguments:
+
+```javascript
+async autocomplete(interaction) {
+    const query = interaction.options.getFocused().toLowerCase();
+    const matches = ITEMS.filter(i => i.name.toLowerCase().includes(query));
+    // Discord accepts at most 25, and rejects the whole response over that.
+    await interaction.respond(
+        matches.slice(0, 25).map(i => ({ name: i.name, value: i.id })),
+    );
+}
+```
+
+The option itself also has to be built with `.setAutocomplete(true)`, or
+Discord never sends the interaction. A command with an autocompleting option
+and no `autocomplete` method answers with an empty list rather than failing,
+and a method that throws is logged and answers empty too — the user sees no
+suggestions, not an error. `ai.js`, `pet.js`, `shop.js`, `craft.js` and
+`use.js` implement it.
+
+#### Permissions
+
+`requiredPermissions` is the gate that actually holds:
+
+```javascript
+const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('ban')
+        .setDescription('Ban a member')
+        .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers),
+    requiredPermissions: [PermissionFlagsBits.BanMembers],
+    async execute(interaction) { /* … */ },
+};
+```
+
+Both lines, and they are not redundant. `setDefaultMemberPermissions` is a
+*default* Discord hands the server on install: a guild admin can reassign the
+command to any role from Server Settings, and Discord then delivers it without
+the bot being told anything changed. On its own it is a suggestion.
+`requiredPermissions` is re-checked against `interaction.memberPermissions` on
+every call, in one place, ahead of the cooldown claim — rather than in fifteen
+handlers where the sixteenth forgets. Administrators and the guild owner
+satisfy any bit, because Discord folds that into the permissions it sends.
+
+A member missing a bit gets an ephemeral list of what they need and the
+interaction is recorded as `missing_permissions`. Keep the builder line too:
+it keeps the command out of the picker for people who cannot run it.
 
 ### Command with Options
 
@@ -110,12 +246,17 @@ module.exports = {
         .setName('announce')
         .setDescription('Make an announcement')
         .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages),
+    requiredPermissions: [PermissionFlagsBits.ManageMessages],
     async execute(interaction) {
         // Only users with Manage Messages can use this
         await interaction.reply('Announcement!');
     }
 };
 ```
+
+The builder line alone does not gate anything the server cannot undo — see
+[Permissions](#permissions) under the module contract for why both lines are
+there.
 
 ### Command with Embeds
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -79,7 +79,7 @@ module.exports = {
 ```
 
 That is the smallest working command, not the whole contract — see
-[The full module contract](#the-full-module-contract) below for the four
+[The full module contract](#the-full-module-contract) below for the five
 optional keys the interaction handler also looks for.
 
 ### The full module contract
@@ -1133,6 +1133,9 @@ npm run migrate:rollback -- 019_add_streak_field
 ### Error Handling
 
 ```javascript
+const { MessageFlags } = require('discord.js');
+
+// …inside the command module:
 async execute(interaction) {
     try {
         await interaction.deferReply();

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,6 +65,16 @@ const shared = {
     // this codebase are written on purpose, and console logging is how the bot
     // reports for itself. Neither is a defect here.
     'no-console': 'off',
+    'no-restricted-syntax': ['error', {
+        // discord.js v14 deprecated the `ephemeral: true` reply option in favour
+        // of `flags: MessageFlags.Ephemeral`. Every one of the ~830 ephemeral
+        // replies here is written with the flag; the boolean still works, so a
+        // stray one does not fail anything at runtime, it just leaves the
+        // codebase with two ways of saying the same thing and a deprecation
+        // warning per call. One had already drifted back in (#706).
+        selector: 'Property[key.name="ephemeral"][value.value=true]',
+        message: 'Use `flags: MessageFlags.Ephemeral` — the `ephemeral` option is deprecated in discord.js v14.',
+    }],
 };
 
 module.exports = [

--- a/src/services/ai/index.js
+++ b/src/services/ai/index.js
@@ -8,6 +8,30 @@ const { enforceRateLimit, toolCallBudget } = require('./rateLimit');
 // non-streaming paths are a single registry lookup — adding a provider means
 // adding one module to providers/, nothing here changes.
 
+/**
+ * Turn a guild's stored AI settings into the config object every call into this
+ * module takes — provider, model, sampling parameters, resolved credentials,
+ * and the guild's MCP servers and spend limits riding along.
+ *
+ * Everything a downstream caller might need is folded in here on purpose, so
+ * that spreading this config is enough: a transport does not have to know MCP
+ * servers exist to keep them attached, and does not have to remember to look up
+ * rate limits for the enforcement below to bind.
+ *
+ * Credentials come from the provider's own `resolveAuth`, which reads the
+ * guild's dashboard-entered key before the bot-wide environment fallback. A
+ * provider that resolves neither yields `apiKey: null` rather than throwing —
+ * the call fails at the provider, where the error can say which key is missing.
+ *
+ * @param {object} aiSettings a guild's `ai` settings subdocument
+ * @returns {{provider: string, model: string, temperature: number,
+ *   maxTokens: number, contextTokens: ?number, apiKey: ?string,
+ *   baseUrl: ?string, mcpServers: object[], mcpConfirm: string,
+ *   mcpRoute: string, rateLimit: {perUser: number, perChannel: number,
+ *   windowMin: number, monthlyTokens: number, monthlyCost: number}}}
+ *   `contextTokens` is null when the guild has not overridden it, meaning
+ *   "take the window from the table in budget.js"
+ */
 function resolveProviderConfig(aiSettings) {
     const providerName = aiSettings.provider || 'openai';
     const model = aiSettings.model || DEFAULT_MODELS[providerName];
@@ -64,13 +88,27 @@ function resolveProviderConfig(aiSettings) {
     };
 }
 
-// `mcp` controls whether configured MCP servers are offered to the model. It is
-// on by default for conversational calls; callers that parse the reply as JSON
-// pass mcp: false so tool output cannot derail the format they expect.
-// Deliberately not an async generator itself: the limit has to be spent when
-// the caller asks for the stream, not when it pulls the first chunk. The
-// Discord transport posts a placeholder message before it starts iterating, so
-// a lazy check would put "…" on screen for a request that was never allowed.
+/**
+ * Stream a completion, spending the caller's rate-limit slot up front.
+ *
+ * Deliberately not an async generator itself: the limit has to be spent when
+ * the caller asks for the stream, not when it pulls the first chunk. The
+ * Discord transport posts a placeholder message before it starts iterating, so
+ * a lazy check would put "…" on screen for a request that was never allowed.
+ * Usage is recorded against the guild once the stream is exhausted.
+ *
+ * @param {object} args a `resolveProviderConfig` result plus the request
+ * @param {string} [args.userId] who to charge the per-user window to
+ * @param {string} [args.channelId] and the per-channel one
+ * @param {string} [args.guildId] whose ledger and whose limits
+ * @param {object} [args.rateLimit] from the resolved config
+ * @param {boolean} [args.mcp] whether the guild's MCP servers are offered to
+ *   the model; true by default. Callers that parse the reply as JSON pass
+ *   false, so tool output cannot derail the format they expect
+ * @param {object} [args.usageOut] filled in with token counts as the stream runs
+ * @returns {AsyncGenerator<string>} text chunks
+ * @throws {AiRateLimitError|AiBudgetError} before the provider is touched
+ */
 function streamCompletion({ userId, channelId, rateLimit, ...args }) {
     // Before the provider is touched: every route into a paid API goes through
     // here, so this is the only place a limit has to be applied to bound spend.
@@ -92,6 +130,21 @@ async function* streamProvider({ provider, guildId, mcp = true, usageOut, ...req
     }
 }
 
+/**
+ * One completion, awaited whole. The non-streaming half of the same path:
+ * limits are enforced before the provider is touched and usage is recorded
+ * against the guild afterwards.
+ *
+ * @param {object} req a `resolveProviderConfig` result plus the request
+ * @param {string} req.provider which provider module answers
+ * @param {string} [req.guildId] whose ledger and whose limits
+ * @param {boolean} [req.mcp] offer the guild's MCP servers; true by default
+ * @param {string} [req.userId]
+ * @param {string} [req.channelId]
+ * @param {object} [req.rateLimit]
+ * @returns {Promise<string>} the reply text — not the provider's result object
+ * @throws {AiRateLimitError|AiBudgetError} before the provider is touched
+ */
 async function getCompletion({ provider, guildId, mcp = true, userId, channelId, rateLimit, ...req }) {
     enforceRateLimit({ guildId, userId, channelId, rateLimit });
     const result = await getProvider(provider).complete({

--- a/src/services/ai/mcp/elicitation.js
+++ b/src/services/ai/mcp/elicitation.js
@@ -2,7 +2,7 @@
 
 const {
     ActionRowBuilder, ButtonBuilder, ButtonStyle, ModalBuilder,
-    TextInputBuilder, TextInputStyle, PermissionFlagsBits,
+    TextInputBuilder, TextInputStyle, PermissionFlagsBits, MessageFlags,
 } = require('discord.js');
 const { rejectOtherUser } = require('../../../utils/collectorOwner');
 const { toolLabel } = require('../../../utils/toolLabel');
@@ -391,7 +391,7 @@ function createElicitationHandler(message, { timeoutMs = ELICIT_TIMEOUT_MS } = {
             // worse one for the tool call holding its request open behind it —
             // and the model is told what went wrong, so it can ask again in its
             // own words if the answer mattered.
-            await submission.reply({ content: `⚠️ ${answers.error} Nothing was sent to the server.`, ephemeral: true }).catch(() => {});
+            await submission.reply({ content: `⚠️ ${answers.error} Nothing was sent to the server.`, flags: MessageFlags.Ephemeral }).catch(() => {});
             console.warn(`[MCP] an answer for "${serverName}" did not fit its schema: ${answers.error}`);
             return settle(
                 `⚠️ <@${submission.user.id}> — that answer did not fit what the server asked for.`,

--- a/src/services/dmService.js
+++ b/src/services/dmService.js
@@ -12,10 +12,15 @@ const MAX_STORY_LOG = 20;
  * `DmSession` document rather than by memory, so a restart mid-adventure loses
  * nothing.
  *
- * Every exported function below is a `/dm` subcommand handler and owns its
- * interaction end to end — each one replies or defers itself, so a caller must
- * not have replied first. They resolve to whatever the reply resolved to; none
- * of them is awaited for a value.
+ * The `/dm` subcommand handlers — `startSession`, `joinSession`,
+ * `beginSession`, `takeAction`, `partyStatus` and `stopSession` — each own
+ * their interaction end to end: they reply or defer themselves, so a caller
+ * must not have replied first, and they resolve to whatever the reply resolved
+ * to rather than to anything worth reading.
+ *
+ * `handleDmButton` is the exception, and is not a subcommand handler at all: it
+ * is a button router entry, and its boolean result is the whole point — see its
+ * own note below.
  *
  * A session is keyed on `guildId:channelId`, so two channels can run their own
  * adventures and one channel cannot run two.

--- a/src/services/dmService.js
+++ b/src/services/dmService.js
@@ -7,6 +7,20 @@ const COLORS = require('../utils/embedColors');
 const MAX_PLAYERS = 6;
 const MAX_STORY_LOG = 20;
 
+/**
+ * The AI Dungeon Master: one persistent D&D session per channel, backed by the
+ * `DmSession` document rather than by memory, so a restart mid-adventure loses
+ * nothing.
+ *
+ * Every exported function below is a `/dm` subcommand handler and owns its
+ * interaction end to end — each one replies or defers itself, so a caller must
+ * not have replied first. They resolve to whatever the reply resolved to; none
+ * of them is awaited for a value.
+ *
+ * A session is keyed on `guildId:channelId`, so two channels can run their own
+ * adventures and one channel cannot run two.
+ */
+
 const CLASSES = ['Warrior', 'Mage', 'Rogue', 'Cleric', 'Ranger', 'Paladin'];
 const CLASS_HP = { Warrior: 120, Mage: 70, Rogue: 90, Cleric: 100, Ranger: 95, Paladin: 110 };
 const CLASS_INVENTORY = {
@@ -94,6 +108,13 @@ function amountFor(narrative, namePattern, verbs, unit, otherNames = []) {
     return null;
 }
 
+/**
+ * `/dm start` — open a session in this channel, with the caller as host.
+ * Refuses if one is already active here.
+ *
+ * @param {import('discord.js').ChatInputCommandInteraction} interaction
+ * @returns {Promise<*>} the reply
+ */
 async function startSession(interaction) {
     const { guild, channel, user } = interaction;
 
@@ -132,6 +153,13 @@ async function startSession(interaction) {
     return interaction.reply({ embeds: [embed] });
 }
 
+/**
+ * `/dm join` — add the caller to the party with a character name and class.
+ * Capped at six players; a class sets starting HP and inventory.
+ *
+ * @param {import('discord.js').ChatInputCommandInteraction} interaction
+ * @returns {Promise<*>} the reply
+ */
 async function joinSession(interaction) {
     const { guild, channel, user } = interaction;
     const characterName = interaction.options.getString('name');
@@ -183,6 +211,13 @@ async function joinSession(interaction) {
     return interaction.reply({ embeds: [embed] });
 }
 
+/**
+ * `/dm begin` — host only. Asks the model for an opening scene and pushes it as
+ * the first entry in the story log, which is what `takeAction` counts back from.
+ *
+ * @param {import('discord.js').ChatInputCommandInteraction} interaction
+ * @returns {Promise<*>} the reply
+ */
 async function beginSession(interaction) {
     const { guild, channel, user } = interaction;
 
@@ -259,6 +294,18 @@ async function beginSession(interaction) {
     }
 }
 
+/**
+ * `/dm action` — narrate one player's action and apply what the narration says
+ * happened: damage taken, items gained or lost.
+ *
+ * Defers first, because the model call will outrun Discord's three seconds. The
+ * player entry and the DM's narration are written together in one atomic
+ * `$push`, which is what lets roles be counted back from the end of a log the
+ * `$slice` trim keeps rewriting the front of.
+ *
+ * @param {import('discord.js').ChatInputCommandInteraction} interaction
+ * @returns {Promise<*>} the reply
+ */
 async function takeAction(interaction) {
     const { guild, channel, user } = interaction;
     const actionText = interaction.options.getString('action');
@@ -391,6 +438,12 @@ async function takeAction(interaction) {
     }
 }
 
+/**
+ * `/dm party` — each character's HP and inventory, and how long the log is.
+ *
+ * @param {import('discord.js').ChatInputCommandInteraction} interaction
+ * @returns {Promise<*>} the reply
+ */
 async function partyStatus(interaction) {
     const { guild, channel } = interaction;
 
@@ -418,6 +471,13 @@ async function partyStatus(interaction) {
     return interaction.reply({ embeds: [embed] });
 }
 
+/**
+ * `/dm stop` — end the session. The host may always stop their own; anyone else
+ * needs Manage Server.
+ *
+ * @param {import('discord.js').ChatInputCommandInteraction} interaction
+ * @returns {Promise<*>} the reply
+ */
 async function stopSession(interaction) {
     const { guild, channel, user } = interaction;
 
@@ -498,6 +558,17 @@ async function postOrUpdateStatCard(channel, session) {
     );
 }
 
+/**
+ * The "Story so far" button under the stat card: an ephemeral recap of the log.
+ *
+ * Routed from `interactionCreate` alongside the other button handlers, so it
+ * has to say whether the click was one of its own.
+ *
+ * @param {import('discord.js').ButtonInteraction} interaction
+ * @param {import('discord.js').Client} _client unused; the router's signature
+ * @returns {Promise<boolean>} true if this handler owned the button and has
+ *   answered it, false to let the router try the next handler
+ */
 async function handleDmButton(interaction, _client) {
     if (!interaction.customId.startsWith('dm_storysofar_')) return false;
 

--- a/src/services/raidService.js
+++ b/src/services/raidService.js
@@ -17,9 +17,18 @@ const COLORS = require('../utils/embedColors');
 // store using sorted sets (ZADD/ZRANGEBYSCORE with TTL) for atomic, shared state.
 const joinLog = new Map();
 
-// Tracks which guilds are currently in active raid mode (in-memory mirror of DB field).
+/**
+ * Guild ids currently in raid mode — an in-memory mirror of
+ * `raidDetection.raidModeActive` on the Guild document, exported so callers can
+ * ask without a database round trip. The document is the source of truth.
+ * @type {Set<string>}
+ */
 const raidModeActive = new Set();
-// 'auto' | 'manual' per guild
+/**
+ * How each active raid mode was turned on: `'auto'` by the join-rate detector,
+ * `'manual'` by a moderator. Only `'auto'` is swept off again.
+ * @type {Map<string, 'auto'|'manual'>}
+ */
 const raidModeActivatedBy = new Map();
 // Last join timestamp per guild (used for calm-window detection)
 const lastJoinTime = new Map();
@@ -47,6 +56,25 @@ async function applyRaidAction(member, rd, minAccountAgeDays) {
  * `settings` is the caller's already-resolved guild settings, passed down by
  * guildMemberAdd so one join costs one settings read rather than three (#593).
  * Omit it and this reads for itself.
+ */
+/**
+ * Record a join in the guild's sliding window and, if the window is now over
+ * threshold, turn raid mode on and act on the joiner.
+ *
+ * Called from the `guildMemberAdd` event for every join, so the cheap exits
+ * come first: a guild with raid detection disabled costs one settings read, or
+ * none when the caller already has them.
+ *
+ * Only accounts younger than `minAccountAgeDays` are kicked or quarantined —
+ * raid mode being on does not by itself act on an established member.
+ *
+ * @param {import('discord.js').GuildMember} member the member who joined
+ * @param {import('discord.js').Client} _client unused; the signature is the
+ *   event handler's
+ * @param {object} [settings] the guild's settings, when the caller has already
+ *   read them. Omit and they are fetched; a read failure is logged and the join
+ *   is ignored rather than throwing into the event handler
+ * @returns {Promise<void>}
  */
 async function handleMemberJoin(member, _client, settings) {
     const guildId = member.guild.id;
@@ -148,7 +176,21 @@ async function handleMemberJoin(member, _client, settings) {
     }
 }
 
-// Called by /raidmode toggle to manually enable or disable raid mode.
+/**
+ * Turn raid mode on or off by hand, from `/raidmode toggle`.
+ *
+ * Writes both the in-memory mirror and the Guild document, and announces the
+ * change in the raid alert channel (or the moderation log, if no raid channel
+ * is set). A mode set this way is marked `manual`, which is what stops
+ * `sweepRaidModes` from turning it off again when the server goes quiet — a
+ * moderator's decision outlasts the calm window.
+ *
+ * @param {string} guildId
+ * @param {import('discord.js').Guild} guild for resolving the alert channel
+ * @param {boolean} active on or off
+ * @param {object} guildSettings the guild's settings, already read
+ * @returns {Promise<void>}
+ */
 async function setRaidMode(guildId, guild, active, guildSettings) {
     const rd = guildSettings.raidDetection;
     const alertChannelId = rd.alertChannelId || guildSettings.moderation?.logChannelId;
@@ -197,12 +239,18 @@ async function setRaidMode(guildId, guild, active, guildSettings) {
     }
 }
 
-// Periodic tick: auto-disable raid mode once the server calms down.
-//
-// Registered in services/scheduler as a job rather than owning a setInterval
-// here (#611). The interval ran outside runJob, so a throw inside it recorded
-// nothing: no dead-letter entry, no failed run on the health payload, and
-// /health went on reporting healthy while raid mode never auto-disabled again.
+/**
+ * Periodic tick: auto-disable raid mode in every guild that has gone quiet for
+ * its calm window. Guilds whose raid mode was set manually are skipped.
+ *
+ * Registered in services/scheduler as a job rather than owning a `setInterval`
+ * here (#611). The interval ran outside `runJob`, so a throw inside it recorded
+ * nothing: no dead-letter entry, no failed run on the health payload, and
+ * /health went on reporting healthy while raid mode never auto-disabled again.
+ *
+ * @param {import('discord.js').Client} client
+ * @returns {Promise<void>}
+ */
 async function sweepRaidModes(client) {
     if (raidModeActive.size === 0) return;
 

--- a/src/services/rssService.js
+++ b/src/services/rssService.js
@@ -266,8 +266,23 @@ async function deliverFeedUpdate(client, guild, feed, parsedFeed, entries) {
     return delivered;
 }
 
-// Overlap protection lives in the scheduler: this runs through runJob, which
-// drops a tick while the previous sweep is still in flight.
+/**
+ * One sweep of every subscribed feed across every guild: fetch, post what is
+ * new to each subscribing channel, and advance each feed's cursor only as far
+ * as delivery actually got.
+ *
+ * Overlap protection lives in the scheduler: this runs through `runJob`, which
+ * drops a tick while the previous sweep is still in flight. A feed that keeps
+ * failing is parked for a cooldown rather than retried every tick, and one
+ * sweep logs a single summary line — feeds having stopped posting used to be
+ * indistinguishable from nothing having been published.
+ *
+ * Does not throw: a per-feed failure is logged and counted, and the sweep
+ * carries on to the rest.
+ *
+ * @param {import('discord.js').Client} client
+ * @returns {Promise<void>}
+ */
 async function checkRssFeeds(client) {
     try {
         // Projected and lean: a full Guild document carries every shop item's
@@ -422,10 +437,22 @@ async function sendDailyNewsForProfile(client, guild, profile) {
 }
 
 /**
+ * Send one guild's daily news digest now.
+ *
  * Failures propagate: both callers need them. The scheduled run goes through
- * runJob, which records the failure and files a dead-letter entry, and the
+ * `runJob`, which records the failure and files a dead-letter entry, and the
  * dashboard's "send now" button answers 500 instead of reporting success for a
  * digest that never went out.
+ *
+ * A profile with no feeds, or one disabled, is skipped rather than treated as
+ * an error, as is a guild that no longer exists.
+ *
+ * @param {import('discord.js').Client} client
+ * @param {string} guildId
+ * @param {?string} [profileId] one digest profile; null sends every enabled
+ *   profile the guild has
+ * @returns {Promise<void>}
+ * @throws whatever the send failed with — deliberately not swallowed
  */
 async function sendDailyNews(client, guildId, profileId = null) {
     const guild = await Guild.findOne({ guildId });
@@ -532,6 +559,12 @@ async function runDueDailyNews(client) {
     }
 }
 
+/**
+ * Start the daily news scheduler. Called once at startup.
+ *
+ * @param {import('discord.js').Client} client
+ * @returns {void}
+ */
 function scheduleDailyNews(client) {
     // A minute tick over persisted state, not one in-memory cron job per
     // profile: survives restarts, catches up after downtime, and needs no

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -1,3 +1,36 @@
+/**
+ * The periodic economy and competition jobs: war and season resolution, the
+ * weekly awards, shop price recalculation, bank interest, and returning expired
+ * market listings.
+ *
+ * Nothing here schedules itself. Every exported function is registered as a job
+ * in `services/scheduler/index.js`, which owns the cron expressions and runs
+ * each through `runJob` — so a throw is recorded on the health payload and
+ * filed as a dead-letter entry, and a tick is dropped rather than overlapped
+ * while the previous run is still going. Adding a `setInterval` here instead
+ * costs all of that (#611).
+ *
+ * They share a shape, and it is the shape a job that pays people out has to
+ * have:
+ *
+ * - **Idempotent.** Payouts go through `creditCoinsOnce` / `grantItemOnce`
+ *   against a payout key, so a job that runs twice — a retry, two processes,
+ *   a resolution racing a manual one — pays once.
+ * - **Per-guild failure isolation.** One guild's error is logged and the loop
+ *   moves to the next; a bad document does not cost every other server its
+ *   week. What propagates is a failure of the job itself, which is what
+ *   `runJob` is there to record.
+ * - **Announcements are best-effort.** A missing channel or a revoked
+ *   permission never rolls back a payout that already landed.
+ *
+ * Each takes the Discord client and resolves when the sweep is done. None
+ * returns a value; what they did is in the database and the announcements.
+ * `returnExpiredMarketListings` is the exception — it posts nothing, so it
+ * takes no client.
+ *
+ * @module services/schedulerService
+ */
+
 const Guild = require('../models/Guild');
 const User  = require('../models/User');
 const SeasonRecord = require('../models/SeasonRecord');
@@ -191,6 +224,13 @@ async function resolveOneWar(client, guildDoc) {
     return true;
 }
 
+/**
+ * Resolve every guild war whose window has closed: award the winner, hand out
+ * boosters and badges, and post the victory banner to both servers.
+ *
+ * @param {import('discord.js').Client} client
+ * @returns {Promise<void>}
+ */
 async function resolveExpiredWars(client) {
     const expired = await Guild.find({
         'activeWar.status': 'active',
@@ -327,6 +367,13 @@ async function resolveOneSeason(client, guildDoc) {
     return true;
 }
 
+/**
+ * Close out every expired economy season: freeze the leaderboard, pay the top
+ * three, reset season coins, and post the recap.
+ *
+ * @param {import('discord.js').Client} client
+ * @returns {Promise<void>}
+ */
 async function resolveExpiredSeasons(client) {
     const expired = await Guild.find({
         'currentSeason.id': { $ne: null },
@@ -342,8 +389,16 @@ async function resolveExpiredSeasons(client) {
     }
 }
 
-// Awards 7-day 👑 #1 badges to the top user in each leaderboard category across all guilds.
-// Run once per week (Sunday 23:59 UTC recommended).
+/**
+ * Award the 7-day 👑 #1 badge to the top member in each leaderboard category,
+ * in every guild. Weekly.
+ *
+ * Takes a short lease per guild (`badgesAwardLeaseAt`) so a second runner
+ * cannot double-award the same week.
+ *
+ * @param {import('discord.js').Client} client
+ * @returns {Promise<void>}
+ */
 async function awardWeeklyLeaderboardBadges(client) {
     const { EmbedBuilder } = require('discord.js');
 
@@ -458,6 +513,13 @@ async function awardWeeklyLeaderboardBadges(client) {
 // Pet of the Week payout. Overridable per guild via economy.potwReward.
 const POTW_COIN_REWARD = 5_000;
 
+/**
+ * Pick each guild's Pet of the Week and pay its owner — 5,000 coins by default,
+ * overridable per guild with `economy.potwReward`.
+ *
+ * @param {import('discord.js').Client} client
+ * @returns {Promise<void>}
+ */
 async function selectPetOfTheWeek(client) {
     const { EmbedBuilder, AttachmentBuilder } = require('discord.js');
     const { generatePetSprite } = require('../utils/cardGenerator');
@@ -622,6 +684,17 @@ const WEEKLY_CATEGORY_ORDER = ['hunt', 'mine', 'fish', 'explore'];
 // does not print coins by the hour.
 const WEEKLY_CHAMPION_REWARD = 10_000;
 
+/**
+ * Crown one champion per grind category — hunt, mine, fish, explore — in each
+ * guild, and pay each 10,000 coins.
+ *
+ * Weekly and one prize per category, deliberately: the hourly payout this
+ * replaced scaled with how often people played rather than how well, and
+ * printed coins by the hour.
+ *
+ * @param {import('discord.js').Client} client
+ * @returns {Promise<void>}
+ */
 async function announceWeeklyChampions(client) {
     const { EmbedBuilder } = require('discord.js');
     const WeeklyChampion = require('../models/WeeklyChampion');
@@ -830,6 +903,20 @@ function weeklyRunNote(winner) {
 // So the shop is read under a projection that names only the pricing fields, and
 // the new prices go back as a `bulkWrite` of per-item `$set`s. The Buffers are
 // never read and never rewritten.
+/**
+ * Move every dynamic-pricing guild's shop prices one step toward what demand
+ * says they should be, decay the demand scores, and append to the price history.
+ *
+ * Reads the shop under a projection naming only the pricing fields and writes
+ * the new prices as a `bulkWrite` of per-item `$set`s. That is not a
+ * micro-optimisation: shop items carry their icon inline as an `imageData`
+ * Buffer, so the whole-document read-mutate-`save()` this replaced pulled every
+ * icon of every guild into the process every fifteen minutes and wrote them all
+ * back untouched.
+ *
+ * @param {import('discord.js').Client} client
+ * @returns {Promise<void>}
+ */
 async function recalcShopPrices(client) {
     const { EmbedBuilder } = require('discord.js');
     // Only the lease window is needed here; the claim below re-reads the guild.
@@ -987,6 +1074,14 @@ async function recalcShopPrices(client) {
 //  1. Awards top-3 prizes (coins + seasonal title)
 //  2. Soft-decays all ELO toward 1200
 //  3. Resets season counters and starts the next season
+/**
+ * Roll over expired ranked-duel seasons: pay the top three and give them the
+ * seasonal title, soft-decay every ELO toward 1200, reset the counters and
+ * start the next season.
+ *
+ * @param {import('discord.js').Client} client
+ * @returns {Promise<void>}
+ */
 async function resolveRankedSeasons(client) {
     const { EmbedBuilder } = require('discord.js');
     const now = new Date();
@@ -1134,6 +1229,19 @@ const INTEREST_BEARING_CAP = 100_000;
 // trips for an equally unbounded amount of memory.
 const INTEREST_BATCH_SIZE = 1_000;
 
+/**
+ * Pay weekly interest on bank balances, in batches of 1,000 users.
+ *
+ * Only the first 100,000 coins of a balance earn: uncapped 5%/week compounds to
+ * roughly 260% APY, which lets a large balance inflate the economy without
+ * bound. Batched rather than one document at a time because a guild with tens
+ * of thousands of bankers would otherwise cost that many sequential round
+ * trips, and holding every operation in one array trades those round trips for
+ * an equally unbounded amount of memory.
+ *
+ * @param {import('discord.js').Client} client
+ * @returns {Promise<void>}
+ */
 async function applyBankInterest(client) {
     const { EmbedBuilder } = require('discord.js');
     const { isDistrictActive } = require('./districtService');
@@ -1220,9 +1328,16 @@ async function applyBankInterest(client) {
     }
 }
 
-// Return expired market listings to sellers before the MongoDB TTL index deletes them.
-// TTL-deleted documents do not fire Mongoose hooks, so without this job items would
-// permanently vanish from the economy when a listing expires unclaimed.
+/**
+ * Return expired market listings to their sellers before the MongoDB TTL index
+ * deletes them.
+ *
+ * TTL-deleted documents do not fire Mongoose hooks, so without this job an item
+ * whose listing expired unclaimed would vanish from the economy permanently.
+ * The one job here that needs no client: it posts nothing.
+ *
+ * @returns {Promise<void>}
+ */
 async function returnExpiredMarketListings() {
     const MarketListing = require('../models/MarketListing');
     const now = new Date();

--- a/src/utils/cardGenerator.js
+++ b/src/utils/cardGenerator.js
@@ -9,17 +9,19 @@
  *
  * Drawing happens on the main thread, because the canvas API leaves no choice.
  * The PNG encode does not: it goes through `canvasEncode`, which hands it to
- * libuv's thread pool. That matters because every card here is drawn off a
- * gateway event rather than off a slash command, and the synchronous encode was
- * ~10 ms per card of gateway heartbeats the bot could not read (#592).
+ * libuv's thread pool. The synchronous encode it replaced cost ~10 ms per card
+ * of event-loop time (#592) — which is time the gateway cannot read a
+ * heartbeat in, whatever drew the card. `createWelcomeCard` is the sharpest
+ * case, because it runs off `guildMemberAdd` with no interaction waiting on
+ * it, but a slash-command card like `/rank` blocks the same loop.
  *
  * @module utils/cardGenerator
  */
 
 const { createCanvas, loadImage } = require('canvas');
 const { ensureFontsRegistered } = require('./registerFonts');
-// Every card here is drawn off a gateway event rather than off a slash command,
-// so the encode must not be the synchronous one (#592). See canvasEncode.js.
+// The encode must not be the synchronous one (#592). See canvasEncode.js and
+// the note at the top of this file.
 const { encodeCanvas } = require('./canvasEncode');
 
 ensureFontsRegistered();

--- a/src/utils/cardGenerator.js
+++ b/src/utils/cardGenerator.js
@@ -1,3 +1,21 @@
+/**
+ * Every image the bot draws for itself: the welcome card, the rank card, the
+ * war and wealth banners, pet sprites, achievement toasts and the season recap.
+ *
+ * Each `create*` returns a PNG `Buffer`, ready to hand to discord.js as an
+ * `AttachmentBuilder`. They never throw for a missing avatar or a broken image
+ * URL — a fetch that fails or takes more than 5 seconds is drawn around, so a
+ * slow CDN costs a placeholder rather than a member's welcome message.
+ *
+ * Drawing happens on the main thread, because the canvas API leaves no choice.
+ * The PNG encode does not: it goes through `canvasEncode`, which hands it to
+ * libuv's thread pool. That matters because every card here is drawn off a
+ * gateway event rather than off a slash command, and the synchronous encode was
+ * ~10 ms per card of gateway heartbeats the bot could not read (#592).
+ *
+ * @module utils/cardGenerator
+ */
+
 const { createCanvas, loadImage } = require('canvas');
 const { ensureFontsRegistered } = require('./registerFonts');
 // Every card here is drawn off a gateway event rather than off a slash command,
@@ -8,6 +26,15 @@ ensureFontsRegistered();
 
 const EMOJI_FONT = '"DejaVu Sans", "Noto Color Emoji"';
 
+/**
+ * Shorten text with an ellipsis until it fits a pixel width, measured in the
+ * font currently set on the context.
+ *
+ * @param {import('canvas').CanvasRenderingContext2D} ctx
+ * @param {string} text
+ * @param {number} maxWidth in pixels
+ * @returns {string} the text unchanged when it already fits
+ */
 function truncateText(ctx, text, maxWidth) {
     if (ctx.measureText(text).width <= maxWidth) return text;
     while (text.length > 0 && ctx.measureText(text + '…').width > maxWidth) {
@@ -16,6 +43,14 @@ function truncateText(ctx, text, maxWidth) {
     return text + '…';
 }
 
+/**
+ * `loadImage` with a deadline, so a slow or hanging avatar CDN cannot hold a
+ * card open. Callers draw a placeholder on rejection.
+ *
+ * @param {string} url
+ * @param {number} [ms] deadline in milliseconds
+ * @returns {Promise<import('canvas').Image>} rejects on timeout or fetch failure
+ */
 function loadImageWithTimeout(url, ms = 5000) {
     let timer;
     const image = loadImage(url).then(
@@ -30,7 +65,13 @@ function loadImageWithTimeout(url, ms = 5000) {
     ]);
 }
 
-// Returns frame/accent color and a corner glyph for each level band
+/**
+ * The frame/accent colour, corner glyph and label the rank card uses for a
+ * level band: Bronze, Silver, Gold, Diamond, Mythic.
+ *
+ * @param {number} level
+ * @returns {{color: string, glyph: string, label: string}}
+ */
 function getTierStyle(level) {
     if (level >= 100) return { color: '#ff6200', glyph: '✦', label: 'Mythic' };
     if (level >= 50)  return { color: '#b9f2ff', glyph: '◇', label: 'Diamond' };
@@ -39,6 +80,16 @@ function getTierStyle(level) {
     return                  { color: '#cd7f32', glyph: '⬡', label: 'Bronze' };
 }
 
+/**
+ * The 800×300 card posted when a member joins: their avatar, name, and the
+ * server's member count.
+ *
+ * Drawn off `guildMemberAdd`, so it is the card most sensitive to blocking —
+ * see the note at the top of this file.
+ *
+ * @param {import('discord.js').GuildMember} member
+ * @returns {Promise<Buffer>} PNG
+ */
 async function createWelcomeCard(member) {
     const canvas = createCanvas(800, 300);
     const ctx = canvas.getContext('2d');
@@ -83,6 +134,20 @@ async function createWelcomeCard(member) {
     return encodeCanvas(canvas);
 }
 
+/**
+ * The 900×300 `/rank` card: avatar, level, XP bar, position on the
+ * leaderboard, and a tier-coloured accent for the level band.
+ *
+ * @param {import('discord.js').User} user whose avatar and name are drawn
+ * @param {{level: number, xp: number}} userData their stored progress
+ * @param {number} rank position on the guild leaderboard
+ * @param {number} requiredXp XP needed for the next level, for the bar
+ * @param {object} [opts]
+ * @param {number} [opts.streakCurrent] daily streak, drawn when non-zero
+ * @param {boolean} [opts.hasActiveBoost] draws the XP boost marker
+ * @param {?object} [opts.rarestCatch] their best catch, drawn when present
+ * @returns {Promise<Buffer>} PNG
+ */
 async function createRankCard(user, userData, rank, requiredXp, opts = {}) {
     const { streakCurrent = 0, hasActiveBoost = false, rarestCatch = null } = opts;
 
@@ -212,6 +277,16 @@ const WAR_VICTORY_LINES = [
     'No mercy. No retreat. All glory.',
 ];
 
+/**
+ * The 900×260 banner posted to both servers when a guild war resolves.
+ *
+ * @param {string} winnerName
+ * @param {number} winnerScore
+ * @param {string} loserName
+ * @param {number} loserScore
+ * @param {string} mvpName the winning side's top contributor
+ * @returns {Promise<Buffer>} PNG
+ */
 async function createWarVictoryBanner(winnerName, winnerScore, loserName, loserScore, mvpName) {
     const canvas = createCanvas(900, 260);
     const ctx = canvas.getContext('2d');
@@ -278,6 +353,14 @@ async function createWarVictoryBanner(winnerName, winnerScore, loserName, loserS
     return encodeCanvas(canvas);
 }
 
+/**
+ * The 900×200 banner posted when a member crosses into a new wealth tier.
+ *
+ * @param {string} username
+ * @param {string} tierLabel the tier's display name
+ * @param {string} tierColor a CSS colour, used for the accent bars
+ * @returns {Promise<Buffer>} PNG
+ */
 async function createWealthTierBanner(username, tierLabel, tierColor) {
     const canvas = createCanvas(900, 200);
     const ctx = canvas.getContext('2d');
@@ -346,6 +429,15 @@ const PET_SPRITE_EMOJIS = {
 
 // An evolved pet should not look identical to a hatchling: stage 2 and 3 swap in
 // the evolved emoji and gain ring pips so the tier reads at a glance.
+/**
+ * A pet's sprite, drawn from its palette rather than loaded from a file.
+ *
+ * @param {string} petId a key of the sprite palette; an unknown id draws grey
+ *   rather than failing
+ * @param {number} [size] square, in pixels
+ * @param {number} [stage] growth stage, clamped to 1–3
+ * @returns {Promise<Buffer>} PNG
+ */
 async function generatePetSprite(petId, size = 80, stage = 1) {
     const canvas = createCanvas(size, size);
     const ctx    = canvas.getContext('2d');
@@ -447,6 +539,15 @@ function _achTier(xpReward) {
     return                                   { label: 'Platinum', color: '#e5e4e2' };
 }
 
+/**
+ * The 520×110 achievement toast. The XP reward picks the tier, which picks the
+ * icon and its colour.
+ *
+ * @param {string} text the achievement's name
+ * @param {string} description
+ * @param {number} xpReward
+ * @returns {Promise<Buffer>} PNG
+ */
 async function createAchievementCard(text, description, xpReward) {
     const W = 520, H = 110, ICON_SIZE = 58, PAD = 16;
     const canvas = createCanvas(W, H);
@@ -511,6 +612,15 @@ async function createAchievementCard(text, description, xpReward) {
 
 // ── End-of-season recap card ──────────────────────────────────────────────────
 
+/**
+ * The 700×420 card posted to a member when an economy season ends.
+ *
+ * @param {import('discord.js').User} user
+ * @param {string} seasonName
+ * @param {number} leaderboardRank where they finished
+ * @param {number} totalPlayers out of how many
+ * @returns {Promise<Buffer>} PNG
+ */
 async function createSeasonRecapCard(user, seasonName, leaderboardRank, totalPlayers) {
     const W = 700, H = 420;
     const canvas = createCanvas(W, H);

--- a/src/utils/dynamicPricing.js
+++ b/src/utils/dynamicPricing.js
@@ -104,9 +104,12 @@ function decayDemand(item, volatility = 'medium') {
  * How far an item has moved from its base price, and the glyph `/market` shows
  * for it: 🔥 at +15%, 📈 at +5%, 🧊 at -15%, 📉 at -5%, `·` in between.
  *
+ * An item with no `basePrice` is compared against `price` instead, so it still
+ * reports a real percentage as long as one of the two is set.
+ *
  * @param {{price: number, basePrice?: number, currentPrice?: number}} item
- * @returns {{pct: number, arrow: string}} `{pct: 0, arrow: '·'}` for an item
- *   with no base price to compare against
+ * @returns {{pct: number, arrow: string}} `{pct: 0, arrow: '·'}` only when
+ *   neither `basePrice` nor `price` gives a non-zero base to divide by
  */
 function trendBucket(item) {
     const base = item.basePrice ?? item.price;

--- a/src/utils/dynamicPricing.js
+++ b/src/utils/dynamicPricing.js
@@ -8,7 +8,17 @@ const VOLATILITY_FACTORS = {
 
 const HISTORY_CAP = 30;
 
-// Ensure pricing fields are populated for every shop item. Returns true if mutated.
+/**
+ * Backfill `basePrice`, `currentPrice` and `demandScore` on shop items that
+ * predate dynamic pricing, so the rest of this module can assume they exist.
+ *
+ * Mutates the items in place and reports whether it changed anything, so a
+ * caller can skip the save when it did not.
+ *
+ * @param {Array<{price: number, basePrice?: number, currentPrice?: number,
+ *   demandScore?: number}>} shopItems mutated in place
+ * @returns {boolean} true if any field was filled in
+ */
 function ensurePricingFields(shopItems) {
     let changed = false;
     for (const item of shopItems) {
@@ -28,7 +38,22 @@ function ensurePricingFields(shopItems) {
     return changed;
 }
 
-// Compute next price based on demand, clamped to ±band of basePrice.
+/**
+ * The price this item should move to on the next recalculation tick.
+ *
+ * Demand is put through `tanh` so extreme demand asymptotes rather than running
+ * away, scaled to at most `band` either side of `basePrice`; the result is then
+ * approached 60% of the way from the current price rather than jumped to, which
+ * is what keeps the `/market` price chart readable. Never returns less than 1.
+ *
+ * @param {{price: number, basePrice?: number, currentPrice?: number,
+ *   demandScore?: number}} item
+ * @param {number} band the maximum swing either side of base, as a fraction
+ *   (`0.5` is ±50%); falsy is treated as 0.5
+ * @param {'low'|'medium'|'high'} [volatility] how hard demand pushes;
+ *   unrecognised values fall back to medium
+ * @returns {number} a whole number of coins
+ */
 function nextPrice(item, band, volatility = 'medium') {
     const cfg = VOLATILITY_FACTORS[volatility] || VOLATILITY_FACTORS.medium;
     const base = item.basePrice ?? item.price;
@@ -41,17 +66,32 @@ function nextPrice(item, band, volatility = 'medium') {
     return Math.round(cur + (target - cur) * 0.6);
 }
 
-// The per-tick decay as a plain multiplier, so a caller can hand it to Mongo's
-// `$mul` and let the decay apply to whatever the stored score is at write time
-// rather than to the value it happened to read a moment earlier. Buys `$inc`
-// this field concurrently (see commands/economy/shop.js), and a decayed value
-// written back with `$set` would swallow any that landed in between.
+/**
+ * The per-tick decay as a plain multiplier, so a caller can hand it to Mongo's
+ * `$mul` and let the decay apply to whatever the stored score is at write time
+ * rather than to the value it happened to read a moment earlier. Buys `$inc`
+ * this field concurrently (see commands/economy/shop.js), and a decayed value
+ * written back with `$set` would swallow any that landed in between.
+ *
+ * @param {'low'|'medium'|'high'} [volatility] unrecognised values fall back to
+ *   medium
+ * @returns {number} between 0 and 1
+ */
 function demandDecayFactor(volatility = 'medium') {
     const cfg = VOLATILITY_FACTORS[volatility] || VOLATILITY_FACTORS.medium;
     return 1 - cfg.decay;
 }
 
-// Decay demand toward zero (oversupply if negative, demand if positive).
+/**
+ * This item's demand score after one tick of decay toward zero.
+ *
+ * Prefer `demandDecayFactor` and `$mul` for the write — see the note there.
+ * This is for callers that need the number itself, such as a preview.
+ *
+ * @param {{demandScore?: number}} item
+ * @param {'low'|'medium'|'high'} [volatility]
+ * @returns {number} signed: negative is oversupply, positive is demand
+ */
 function decayDemand(item, volatility = 'medium') {
     return (item.demandScore ?? 0) * demandDecayFactor(volatility);
 }
@@ -60,7 +100,14 @@ function decayDemand(item, volatility = 'medium') {
 // write rather than by rebuilding the array in JS, so the cap is enforced by the
 // database. HISTORY_CAP is exported for that write and for readers of the chart.
 
-// Convenience: % change between currentPrice and basePrice for /market trends display.
+/**
+ * How far an item has moved from its base price, and the glyph `/market` shows
+ * for it: 🔥 at +15%, 📈 at +5%, 🧊 at -15%, 📉 at -5%, `·` in between.
+ *
+ * @param {{price: number, basePrice?: number, currentPrice?: number}} item
+ * @returns {{pct: number, arrow: string}} `{pct: 0, arrow: '·'}` for an item
+ *   with no base price to compare against
+ */
 function trendBucket(item) {
     const base = item.basePrice ?? item.price;
     const cur  = item.currentPrice ?? base;

--- a/src/utils/paginator.js
+++ b/src/utils/paginator.js
@@ -1,6 +1,16 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, ComponentType, EmbedBuilder, MessageFlags } = require('discord.js');
 const { ownedBy } = require('../utils/collectorOwner');
 
+/**
+ * Split a list into fixed-size chunks — one per page, typically, before each
+ * chunk is rendered into an embed and the set handed to `paginate`.
+ *
+ * @param {Array} items
+ * @param {number} chunkSize
+ * @returns {Array[]} empty when `items` is not an array or `chunkSize` is not
+ *   positive, rather than throwing: callers page over query results that may
+ *   legitimately be empty
+ */
 function chunkArray(items, chunkSize) {
     if (!Array.isArray(items) || chunkSize <= 0) return [];
     const chunks = [];
@@ -10,6 +20,16 @@ function chunkArray(items, chunkSize) {
     return chunks;
 }
 
+/**
+ * The previous/next row, with the button at either end of the range disabled.
+ * The interaction id is in the custom ids so two paginated replies in the same
+ * channel cannot collect each other's clicks.
+ *
+ * @param {number} page zero-based
+ * @param {number} totalPages
+ * @param {string} interactionId
+ * @returns {import('discord.js').ActionRowBuilder}
+ */
 function buildControls(page, totalPages, interactionId) {
     return new ActionRowBuilder().addComponents(
         new ButtonBuilder()
@@ -25,12 +45,41 @@ function buildControls(page, totalPages, interactionId) {
     );
 }
 
+/**
+ * The same row with everything disabled, left behind when the collector expires
+ * so the buttons read as dead rather than unresponsive.
+ *
+ * @param {number} page
+ * @param {number} totalPages
+ * @param {string} interactionId
+ * @returns {import('discord.js').ActionRowBuilder}
+ */
 function buildDisabledControls(page, totalPages, interactionId) {
     const row = buildControls(page, totalPages, interactionId);
     row.components.forEach(component => component.setDisabled(true));
     return row;
 }
 
+/**
+ * Reply with a page-through-able set of embeds.
+ *
+ * Owns the whole interaction: it sends the reply, so the caller must not have
+ * replied or deferred. Each embed's footer gains `Page n / m`, appended to
+ * whatever footer it already carried. A single page is sent without controls,
+ * and an empty set gets an ephemeral "Nothing to display" rather than an error.
+ *
+ * Only the member who ran the command can page — someone else's click is
+ * refused by `ownedBy` with a note telling them to run it themselves. The
+ * collector lives 2 minutes; when it ends the buttons are disabled in place.
+ *
+ * Resolves once the reply is sent, not when paging finishes: the collector
+ * outlives the call.
+ *
+ * @param {import('discord.js').ChatInputCommandInteraction} interaction an
+ *   unreplied, undeferred interaction
+ * @param {import('discord.js').EmbedBuilder[]} pages one embed per page
+ * @returns {Promise<void>}
+ */
 async function paginate(interaction, pages) {
     if (!pages?.length) {
         return interaction.reply({ content: 'Nothing to display.', flags: MessageFlags.Ephemeral });

--- a/src/utils/paginator.js
+++ b/src/utils/paginator.js
@@ -6,13 +6,17 @@ const { ownedBy } = require('../utils/collectorOwner');
  * chunk is rendered into an embed and the set handed to `paginate`.
  *
  * @param {Array} items
- * @param {number} chunkSize
- * @returns {Array[]} empty when `items` is not an array or `chunkSize` is not
- *   positive, rather than throwing: callers page over query results that may
- *   legitimately be empty
+ * @param {number} chunkSize a positive integer
+ * @returns {Array[]} empty when `items` is not an array or `chunkSize` is not a
+ *   positive integer, rather than throwing: callers page over query results
+ *   that may legitimately be empty
  */
 function chunkArray(items, chunkSize) {
-    if (!Array.isArray(items) || chunkSize <= 0) return [];
+    // `chunkSize <= 0` alone let NaN and undefined through — the comparison is
+    // false for both — and the loop then advanced `i` by NaN, returning a
+    // single empty chunk that reads to a caller as one blank page. A fraction
+    // got through the same way and cut chunks at fractional offsets.
+    if (!Array.isArray(items) || !Number.isInteger(chunkSize) || chunkSize <= 0) return [];
     const chunks = [];
     for (let i = 0; i < items.length; i += chunkSize) {
         chunks.push(items.slice(i, i + chunkSize));

--- a/src/utils/prestige.js
+++ b/src/utils/prestige.js
@@ -29,7 +29,18 @@ const UNLOCK_LABELS = {
 
 const SOFT_PRESTIGE_BONUS = { yieldPct: 0.02, xpPct: 0.02 };
 
-// Returns the tier definition for a given rank (largest rank ≤ requested).
+/**
+ * The tier definition governing a rank: the highest entry in `PRESTIGE_TIERS`
+ * whose `rank` is at or below the one asked for.
+ *
+ * The table is not dense above rank 5, so this floors rather than looks up —
+ * which is right for bonuses and unlocks (a rank between two entries keeps the
+ * lower one's) and wrong for the display title, since flooring rank 7 would
+ * render it "Prestige V". Use `titleForExactRank` for anything a user reads.
+ *
+ * @param {number} rank a prestige rank; anything non-numeric or negative is 0
+ * @returns {{rank: number, title: ?string, bonuses: object, unlocks: string[]}}
+ */
 function tierFor(rank) {
     const r = Math.max(0, Number(rank) || 0);
     let best = PRESTIGE_TIERS[0];
@@ -39,9 +50,14 @@ function tierFor(rank) {
     return best;
 }
 
-// Returns the exact display title for a rank — uses the explicit PRESTIGE_TIERS
-// entry when one exists, otherwise synthesizes `Prestige <roman>` so P6–P9
-// don't render as the floored "Prestige V" label.
+/**
+ * The display title for exactly this rank — the explicit `PRESTIGE_TIERS` entry
+ * when there is one, otherwise a synthesized `Prestige <roman>`, so a rank the
+ * table does not name does not render as the floored tier below it.
+ *
+ * @param {number} rank
+ * @returns {?string} null at rank 0, which has no title
+ */
 function titleForExactRank(rank) {
     const r = Math.max(0, Number(rank) || 0);
     if (r === 0) return null;
@@ -50,7 +66,17 @@ function titleForExactRank(rank) {
     return `Prestige ${roman(r)}`;
 }
 
-// Returns the explicit definition for the upcoming rank (used in /prestige confirmation).
+/**
+ * What the next prestige buys — the tier at `rank + 1`, for the confirmation
+ * `/prestige` shows before it resets an account.
+ *
+ * Above the last explicit entry there is nothing to look up, so this carries the
+ * current tier's bonuses and unlocks forward under the new rank and title. The
+ * result is shaped like a `PRESTIGE_TIERS` entry either way.
+ *
+ * @param {number} rank the rank held now
+ * @returns {{rank: number, title: ?string, bonuses: object, unlocks: string[]}}
+ */
 function nextTierAfter(rank) {
     const r = Math.max(0, Number(rank) || 0);
     const target = r + 1;
@@ -62,6 +88,12 @@ function nextTierAfter(rank) {
     return { ...prior, rank: target, title: `Prestige ${roman(target)}` };
 }
 
+/**
+ * Roman numerals, for the synthesized tier titles.
+ *
+ * @param {number} n
+ * @returns {string} `'0'` for anything at or below zero
+ */
 function roman(n) {
     if (n <= 0) return '0';
     const map = [['M',1000],['CM',900],['D',500],['CD',400],['C',100],['XC',90],['L',50],['XL',40],['X',10],['IX',9],['V',5],['IV',4],['I',1]];
@@ -72,8 +104,17 @@ function roman(n) {
     return out;
 }
 
-// Aggregate active bonus multipliers from prestige rank.
-// Returns { yieldMult, xpMult, staminaRegenMult, crimeSuccessMult }
+/**
+ * The prestige bonuses as multipliers a caller can apply directly — 1.0 at rank
+ * 0, so an un-prestiged account needs no special case at the call site.
+ *
+ * `rareTierShift` is the odd one out: it is an additive probability shift, not a
+ * multiplier, and is 0 rather than 1 when the rank grants none.
+ *
+ * @param {number} rank
+ * @returns {{yieldMult: number, xpMult: number, staminaRegenMult: number,
+ *   crimeSuccessMult: number, rareTierShift: number}}
+ */
 function getBonusMultipliers(rank) {
     const tier = tierFor(rank);
     const b = tier.bonuses || {};
@@ -86,10 +127,24 @@ function getBonusMultipliers(rank) {
     };
 }
 
+/**
+ * Whether a rank has unlocked a piece of content.
+ *
+ * @param {number} rank
+ * @param {string} unlockId a key of `UNLOCK_LABELS` — `'black_market'`,
+ *   `'daily_challenge'`, and so on
+ * @returns {boolean}
+ */
 function hasUnlock(rank, unlockId) {
     return tierFor(rank).unlocks.includes(unlockId);
 }
 
+/**
+ * The badge shown beside a name: `✨` at 10, `⭐` from 5, `⟦P3⟧` below that.
+ *
+ * @param {number} rank
+ * @returns {string} empty at rank 0, so it can be concatenated unconditionally
+ */
 function badgeFor(rank) {
     if (!rank) return '';
     if (rank >= 10) return '✨';

--- a/src/utils/prestige.js
+++ b/src/utils/prestige.js
@@ -33,10 +33,13 @@ const SOFT_PRESTIGE_BONUS = { yieldPct: 0.02, xpPct: 0.02 };
  * The tier definition governing a rank: the highest entry in `PRESTIGE_TIERS`
  * whose `rank` is at or below the one asked for.
  *
- * The table is not dense above rank 5, so this floors rather than looks up —
- * which is right for bonuses and unlocks (a rank between two entries keeps the
- * lower one's) and wrong for the display title, since flooring rank 7 would
- * render it "Prestige V". Use `titleForExactRank` for anything a user reads.
+ * `PRESTIGE_TIERS` names every rank from 0 to 10, so for those this is a plain
+ * lookup. The flooring only does work for a rank the table does not name — one
+ * past 10, or a fractional one — and it is the right answer for bonuses and
+ * unlocks, which should keep the highest tier actually reached.
+ *
+ * It is the wrong answer for a title, which would then name a rank the account
+ * has passed. Use `titleForExactRank` for anything a user reads.
  *
  * @param {number} rank a prestige rank; anything non-numeric or negative is 0
  * @returns {{rank: number, title: ?string, bonuses: object, unlocks: string[]}}

--- a/tests/commandContractDocs.test.js
+++ b/tests/commandContractDocs.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+// The command-module contract is a duck-typed object: `interactionCreate` reads
+// `command.cooldownAmount`, `command.cooldownKey`, `command.autocomplete` and
+// `command.requiredPermissions` by name, and nothing validates that any of them
+// exist or are spelled right. For a long time the guide documented three of the
+// eight keys (#719), so four commands were using hooks a contributor reading the
+// docs had no way to know about — and a fifth key was a permission gate.
+//
+// A table in a markdown file drifts the moment someone adds a hook, so this
+// holds the two together: read a new `command.<key>` in the handler or the
+// loader and `npm test` goes red until docs/EXTENDING.md has a row for it.
+
+const fs = require('fs');
+const path = require('path');
+
+const GUIDE = path.join(__dirname, '../docs/EXTENDING.md');
+const SOURCES = [
+    path.join(__dirname, '../src/events/interactionCreate.js'),
+    path.join(__dirname, '../src/utils/commandLoader.js'),
+];
+
+// The contract table is the one under this heading; the guide has other tables.
+const TABLE_HEADING = '### The full module contract';
+
+function documentedKeys() {
+    const guide = fs.readFileSync(GUIDE, 'utf8');
+    const start = guide.indexOf(TABLE_HEADING);
+    if (start === -1) throw new Error(`"${TABLE_HEADING}" is gone from docs/EXTENDING.md`);
+
+    // Up to the next heading of the same or higher level, so the sub-sections
+    // below the table (which quote keys in prose) cannot pad the set.
+    const rest = guide.slice(start + TABLE_HEADING.length);
+    const end = rest.search(/\n#{1,3} /);
+    const section = end === -1 ? rest : rest.slice(0, end);
+
+    return new Set(
+        [...section.matchAll(/^\|\s*`(\w+)`\s*\|/gm)].map(m => m[1]),
+    );
+}
+
+function keysReadFromModules() {
+    const keys = new Set();
+    for (const file of SOURCES) {
+        const src = fs.readFileSync(file, 'utf8');
+        // `command.data`, `command.data?.toJSON`, `command.cooldownKey` — the
+        // first hop is the contract key, which is all this needs.
+        for (const m of src.matchAll(/\bcommand\.(\w+)/g)) keys.add(m[1]);
+    }
+    return keys;
+}
+
+describe('command-module contract', () => {
+    test('every key the handler and loader read has a row in the guide', () => {
+        const documented = documentedKeys();
+        const undocumented = [...keysReadFromModules()].filter(k => !documented.has(k));
+
+        expect(undocumented).toEqual([]);
+    });
+
+    test('the guide does not document keys nothing reads', () => {
+        const read = keysReadFromModules();
+        const invented = [...documentedKeys()].filter(k => !read.has(k));
+
+        expect(invented).toEqual([]);
+    });
+
+    // The rows are only worth holding to if they name the keys that are actually
+    // load-bearing, so pin the ones a wrong spelling breaks silently.
+    test.each(['data', 'execute', 'cooldown', 'cooldownAmount', 'cooldownKey', 'autocomplete', 'requiredPermissions', 'category'])(
+        'documents %s',
+        key => expect(documentedKeys().has(key)).toBe(true),
+    );
+});

--- a/tests/docsLinks.test.js
+++ b/tests/docsLinks.test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+// Cross-references between the markdown files are load-bearing now that no file
+// repeats another: README points at .env.example for the variables, CONTRIBUTING
+// points at docs/EXTENDING.md for the command contract, and both point into
+// SETUP_GUIDE by anchor. A moved heading breaks that quietly — the link still
+// renders, it just lands at the top of the file.
+//
+// So: every relative link in every markdown file must resolve, anchor included.
+// Eleven files, no exceptions granted, because there are none to grant today.
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const SKIP_DIRS = new Set(['node_modules', '.git', 'coverage']);
+
+function markdownFiles(dir = ROOT) {
+    const out = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (SKIP_DIRS.has(entry.name)) continue;
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) out.push(...markdownFiles(full));
+        else if (entry.name.endsWith('.md')) out.push(full);
+    }
+    return out;
+}
+
+// GitHub's slug: lowercase, drop anything that is not a word character, space or
+// hyphen, then spaces to hyphens. Close enough for the headings in this repo.
+function anchorsIn(markdown) {
+    const slugs = new Set();
+    for (const line of markdown.split('\n')) {
+        const heading = /^#{1,6}\s+(.*)$/.exec(line);
+        if (!heading) continue;
+        const slug = heading[1]
+            .trim()
+            .toLowerCase()
+            .replace(/[`*_]/g, '')
+            .replace(/[^\w\s-]/g, '')
+            .replace(/\s+/g, '-')
+            .replace(/^-+|-+$/g, '');
+        slugs.add(slug);
+    }
+    return slugs;
+}
+
+describe('markdown cross-references', () => {
+    test('every relative link resolves, anchor included', () => {
+        const broken = [];
+
+        for (const file of markdownFiles()) {
+            const text = fs.readFileSync(file, 'utf8');
+            const from = path.relative(ROOT, file);
+
+            for (const [, link] of text.matchAll(/\[[^\]]*\]\(([^)\s]+)\)/g)) {
+                if (/^(https?:|mailto:)/.test(link)) continue;
+
+                const [target, anchor] = link.split('#');
+                let resolved = file;
+
+                if (target) {
+                    resolved = path.resolve(path.dirname(file), target);
+                    if (!fs.existsSync(resolved)) {
+                        broken.push(`${from} -> ${link} (no such file)`);
+                        continue;
+                    }
+                }
+                if (!anchor || !resolved.endsWith('.md')) continue;
+
+                if (!anchorsIn(fs.readFileSync(resolved, 'utf8')).has(anchor)) {
+                    broken.push(`${from} -> ${link} (no such heading)`);
+                }
+            }
+        }
+
+        expect(broken).toEqual([]);
+    });
+});
+
+// CONTRIBUTING.md tells a newcomer which commands to run and which Node to run
+// them on. Both are claims about files in this repo, so neither is left to
+// someone noticing.
+describe('CONTRIBUTING.md', () => {
+    const contributing = fs.readFileSync(path.join(ROOT, 'CONTRIBUTING.md'), 'utf8');
+
+    test('names only npm scripts that exist', () => {
+        const { scripts } = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+        const named = [...contributing.matchAll(/\bnpm run ([\w:]+)/g)].map(m => m[1]);
+
+        expect(named.length).toBeGreaterThan(0);
+        expect(named.filter(name => !(name in scripts))).toEqual([]);
+    });
+
+    test('names the Node version in .nvmrc', () => {
+        const nvmrc = fs.readFileSync(path.join(ROOT, '.nvmrc'), 'utf8').trim();
+
+        expect(contributing).toContain(nvmrc);
+    });
+
+    test('names the variables validateEnv actually requires', () => {
+        const { REQUIRED_ENV } = require('../src/config/validateEnv');
+        const sentence = /Five variables are\s+start-or-fail:([^.]*)\./.exec(contributing);
+
+        expect(sentence).not.toBeNull();
+        for (const name of REQUIRED_ENV) expect(sentence[1]).toContain(name);
+    });
+});

--- a/tests/docsLinks.test.js
+++ b/tests/docsLinks.test.js
@@ -45,6 +45,20 @@ function anchorsIn(markdown) {
     return slugs;
 }
 
+// `[text](target)` and `[text](target "Title")`. The title is optional and
+// separated by whitespace, so a pattern that stops at the first space would
+// simply not match a titled link — and a link this test cannot see is a link it
+// cannot report as broken, which is the failure mode worth avoiding in a test
+// whose whole job is catching them.
+const INLINE_LINK = /\[[^\]]*\]\(\s*(<[^>]*>|[^)\s]+)(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*\)/g;
+
+/** Every link target in one markdown document, titles stripped. */
+function linkTargets(markdown) {
+    return [...markdown.matchAll(INLINE_LINK)]
+        // Angle brackets are markdown's escape for a target containing spaces.
+        .map(([, target]) => target.replace(/^<|>$/g, ''));
+}
+
 describe('markdown cross-references', () => {
     test('every relative link resolves, anchor included', () => {
         const broken = [];
@@ -53,7 +67,7 @@ describe('markdown cross-references', () => {
             const text = fs.readFileSync(file, 'utf8');
             const from = path.relative(ROOT, file);
 
-            for (const [, link] of text.matchAll(/\[[^\]]*\]\(([^)\s]+)\)/g)) {
+            for (const link of linkTargets(text)) {
                 if (/^(https?:|mailto:)/.test(link)) continue;
 
                 const [target, anchor] = link.split('#');
@@ -75,6 +89,28 @@ describe('markdown cross-references', () => {
         }
 
         expect(broken).toEqual([]);
+    });
+
+    // The extraction is the part that can fail silently, so it is checked
+    // directly rather than only through the sweep above.
+    test('sees a link carrying a title, so a broken one cannot hide behind it', () => {
+        expect(linkTargets('[guide](docs/GONE.md "The Guide")')).toEqual(['docs/GONE.md']);
+        expect(linkTargets("[a](x.md#frag 'Title')")).toEqual(['x.md#frag']);
+        expect(linkTargets('[a](<a file.md> "T")')).toEqual(['a file.md']);
+    });
+
+    test('still sees plain links, and does not invent one from bracketed prose', () => {
+        expect(linkTargets('[a](b.md) and [c](d.md#e)')).toEqual(['b.md', 'd.md#e']);
+        expect(linkTargets('a [footnote] and (an aside)')).toEqual([]);
+    });
+
+    test('a broken relative link with a title is reported', () => {
+        // The sweep's own logic, run over one synthetic document: without the
+        // title handling this link is invisible and the assertion fails.
+        const targets = linkTargets('see the [guide](docs/NOT_HERE.md "The Guide").');
+
+        expect(targets).toEqual(['docs/NOT_HERE.md']);
+        expect(fs.existsSync(path.join(ROOT, targets[0]))).toBe(false);
     });
 });
 

--- a/tests/envExampleDrift.test.js
+++ b/tests/envExampleDrift.test.js
@@ -57,22 +57,58 @@ function walk(dir) {
     return out;
 }
 
+// `process.env.NAME` and the literal bracket forms `process.env['NAME']` /
+// `process.env["NAME"]`, which are the same read written differently and would
+// otherwise slip past this test entirely. A computed key —
+// `process.env[match[1]]` in config/mcpServers.js — is not a name and cannot be
+// resolved here; that one is by design, resolving `${VAR}` placeholders out of
+// the MCP config file.
+const ENV_READ = /\bprocess\.env(?:\.([A-Z][A-Z0-9_]*)|\[\s*['"]([A-Z][A-Z0-9_]*)['"]\s*\])/g;
+
 function readByTheBot() {
     const names = new Map();
     for (const file of walk(path.join(ROOT, 'src'))) {
         const src = fs.readFileSync(file, 'utf8');
-        for (const m of src.matchAll(/\bprocess\.env\.([A-Z][A-Z0-9_]*)/g)) {
-            if (!names.has(m[1])) names.set(m[1], path.relative(ROOT, file));
+        for (const [, dotted, bracketed] of src.matchAll(ENV_READ)) {
+            const name = dotted || bracketed;
+            if (!names.has(name)) names.set(name, path.relative(ROOT, file));
         }
     }
     return names;
 }
 
-// A key counts as documented whether it is live (`NAME=value`) or commented out
-// as an optional knob (`# NAME=value`) — the file uses both on purpose.
+/**
+ * A key counts as documented when the file both names it — live as
+ * `NAME=value`, or commented out as an optional knob, since it uses both on
+ * purpose — and says something about it.
+ *
+ * The second half is the point. A bare `# NEW_KEY=` would satisfy a test that
+ * only looked for the name, and would satisfy it while telling an operator
+ * nothing, which is the state this whole file exists to prevent. So a key is
+ * documented only if there is prose in its block: the run of non-blank lines
+ * above it, up to the blank line that separates one group from the next. That
+ * is per-group rather than per-line deliberately — the four `MONGODB_*` auth
+ * variables share one explanation, and splitting it four ways would be worse.
+ */
 function documentedInEnvExample() {
-    const text = fs.readFileSync(ENV_EXAMPLE, 'utf8');
-    return new Set([...text.matchAll(/^#?\s*([A-Z][A-Z0-9_]*)=/gm)].map(m => m[1]));
+    const lines = fs.readFileSync(ENV_EXAMPLE, 'utf8').split('\n');
+    const assignment = /^#?\s*([A-Z][A-Z0-9_]*)=/;
+    const documented = new Set();
+
+    for (let i = 0; i < lines.length; i++) {
+        const named = assignment.exec(lines[i]);
+        if (!named) continue;
+
+        for (let j = i - 1; j >= 0 && lines[j].trim() !== ''; j--) {
+            const above = lines[j].trim();
+            // A commented-out assignment is another knob, not prose about this one.
+            if (above.startsWith('#') && !assignment.test(above)) {
+                documented.add(named[1]);
+                break;
+            }
+        }
+    }
+    return documented;
 }
 
 describe('.env.example is the source of truth for configuration', () => {

--- a/tests/envExampleDrift.test.js
+++ b/tests/envExampleDrift.test.js
@@ -1,0 +1,143 @@
+'use strict';
+
+// Four sources used to disagree about which environment variables exist:
+// `OPENROUTER_REFERER` was read by the OpenRouter provider and named nowhere at
+// all, and both README and SETUP_GUIDE carried hand-maintained copies of the
+// list that had each dropped a different variable (#707).
+//
+// `.env.example` is the single source of truth now — it is the only one that was
+// accurate, and it is the file an operator actually copies. This is what keeps
+// it that way: read a new `process.env.SOMETHING` in src/ and `npm test` goes
+// red until the variable is in `.env.example` with a comment saying what it
+// does.
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const ENV_EXAMPLE = path.join(ROOT, '.env.example');
+
+// Read by the bot but deliberately not offered as a setting. Each one needs a
+// reason, because "add it to the allowlist" is otherwise the cheapest way past
+// this test and would make it worthless.
+const NOT_A_SETTING = {
+    SHARD_ID: 'injected into each child process by the ShardingManager; setting '
+        + 'it by hand on the parent tells every shard it is shard 0',
+};
+
+// Some of the file's variables are consumed outside the bot process — by the
+// compose stacks, by scripts/mongo-init.js, or as the `<NAME>_FILE` form of a
+// secret. Those are listed rather than searched for, so that a variable nobody
+// consumes anywhere cannot hide behind a grep that happens to hit a comment.
+const CONSUMED_OUTSIDE_SRC = new Set([
+    'DASHBOARD_HOST_PORT',
+    'BACKUP_RETENTION_DAYS',
+    'MONGODB_ROOT_USERNAME',
+    'MONGODB_ROOT_PASSWORD',
+    'MONGODB_APP_USERNAME',
+    'MONGODB_APP_PASSWORD',
+    'DISCORD_TOKEN_FILE',
+]);
+
+// Where those are allowed to turn up.
+const OUTSIDE_CONSUMERS = [
+    'docker-compose.yml',
+    'portainer-stack.yml',
+    'scripts/mongo-init.js',
+    'src/config/fileSecrets.js',
+];
+
+function walk(dir) {
+    const out = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) out.push(...walk(full));
+        else if (entry.name.endsWith('.js')) out.push(full);
+    }
+    return out;
+}
+
+function readByTheBot() {
+    const names = new Map();
+    for (const file of walk(path.join(ROOT, 'src'))) {
+        const src = fs.readFileSync(file, 'utf8');
+        for (const m of src.matchAll(/\bprocess\.env\.([A-Z][A-Z0-9_]*)/g)) {
+            if (!names.has(m[1])) names.set(m[1], path.relative(ROOT, file));
+        }
+    }
+    return names;
+}
+
+// A key counts as documented whether it is live (`NAME=value`) or commented out
+// as an optional knob (`# NAME=value`) — the file uses both on purpose.
+function documentedInEnvExample() {
+    const text = fs.readFileSync(ENV_EXAMPLE, 'utf8');
+    return new Set([...text.matchAll(/^#?\s*([A-Z][A-Z0-9_]*)=/gm)].map(m => m[1]));
+}
+
+describe('.env.example is the source of truth for configuration', () => {
+    test('every variable the bot reads is in it', () => {
+        const documented = documentedInEnvExample();
+        const missing = [...readByTheBot()]
+            .filter(([name]) => !documented.has(name) && !(name in NOT_A_SETTING))
+            .map(([name, file]) => `${name} (read at ${file})`);
+
+        expect(missing).toEqual([]);
+    });
+
+    test('it does not offer variables nothing consumes', () => {
+        const read = readByTheBot();
+        const stale = [...documentedInEnvExample()]
+            .filter(name => !read.has(name) && !CONSUMED_OUTSIDE_SRC.has(name));
+
+        expect(stale).toEqual([]);
+    });
+
+    test('a variable held back from the file has a reason recorded', () => {
+        for (const [name, why] of Object.entries(NOT_A_SETTING)) {
+            expect(typeof why).toBe('string');
+            expect(why.length).toBeGreaterThan(20);
+            // And it is genuinely still read — an allowlist entry for a variable
+            // nobody reads any more is just litter.
+            expect(readByTheBot().has(name)).toBe(true);
+        }
+    });
+
+    // The list above is itself a place drift can hide, so hold it to the files
+    // it claims: a variable dropped from the compose stacks should come off this
+    // list and out of `.env.example`, not sit here forever.
+    test('each variable excused as consumed elsewhere really is', () => {
+        const haystack = OUTSIDE_CONSUMERS
+            .map(rel => fs.readFileSync(path.join(ROOT, rel), 'utf8'))
+            .join('\n');
+        const orphaned = [...CONSUMED_OUTSIDE_SRC].filter(name => !haystack.includes(name));
+
+        expect(orphaned).toEqual([]);
+    });
+
+    // The ones the issue found missing, pinned by name so a regeneration or a
+    // careless edit cannot quietly drop them again.
+    test.each(['OPENROUTER_REFERER', 'SERVICE_NAME', 'NO_COLOR', 'AUDIT_LOG_RETENTION_DAYS', 'NODE_ENV'])(
+        'documents %s',
+        name => expect(documentedInEnvExample().has(name)).toBe(true),
+    );
+});
+
+// README no longer repeats the whole list, but it does still name the handful
+// without which the bot will not boot — which is a claim about
+// `validateEnv.js`, and therefore a claim that can go stale.
+describe('README required-variable table', () => {
+    test('names exactly what validateEnv refuses to start without', () => {
+        const { REQUIRED_ENV } = require('../src/config/validateEnv');
+        const readme = fs.readFileSync(path.join(ROOT, 'README.md'), 'utf8');
+
+        const heading = 'These five are the ones';
+        const start = readme.indexOf(heading);
+        expect(start).toBeGreaterThan(-1);
+
+        const table = readme.slice(start, readme.indexOf('\n\n', readme.indexOf('| ---', start)));
+        const listed = [...table.matchAll(/^\|\s*`([A-Z][A-Z0-9_]*)`\s*\|/gm)].map(m => m[1]);
+
+        expect(listed.sort()).toEqual([...REQUIRED_ENV].sort());
+    });
+});


### PR DESCRIPTION
docs/EXTENDING.md taught `{ ephemeral: true }` as the way to reply
privately. That option is deprecated in discord.js v14, and no reply site
in this codebase used it — all ~830 wrote `flags: MessageFlags.Ephemeral`.
A contributor following the guide wrote code that disagreed with every
other file, and got a deprecation warning per call for it.

One had already drifted back in at the MCP elicitation form, which is what
a documented-but-unused pattern eventually produces. Fixed, and added an
eslint rule so the next one fails `npm run lint` rather than waiting for
someone to grep. The rule matches the boolean property specifically, so
Anthropic's `cache_control: { type: 'ephemeral' }` is untouched.

The guide now also says to put the flag on `deferReply` rather than
deferring publicly and hoping the edit makes it private.

Fixes #706

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contributor setup, development, testing, deployment, and pull-request guidance.
  * Updated environment-variable documentation and established `.env.example` as the authoritative reference.
  * Expanded command-development guidance, including permissions, cooldowns, autocomplete, and ephemeral replies.
  * Added clearer documentation across AI, messaging, scheduling, pricing, pagination, prestige, and card-generation features.

* **Developer Experience**
  * Added safeguards against deprecated ephemeral reply options.
  * Added automated checks for documentation links, environment-variable accuracy, and command documentation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->