### PR TITLE
Sweep the spam tracker, finish the async encodes, keep the dashboard's failures its own

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -100,7 +100,9 @@ const SYNC_CANVAS_ENCODE = [
         message: 'Use `encodeCanvas(canvas)` from utils/canvasEncode.js — `canvas.toBuffer()` blocks the event loop (#592).',
     },
     {
-        selector: 'CallExpression[callee.property.name="toBuffer"][arguments.0.type="Literal"]',
+        // A template literal is the same call written with backticks, and it is
+        // the spelling a copy-paste out of a formatted string arrives in.
+        selector: 'CallExpression[callee.property.name="toBuffer"]:matches([arguments.0.type="Literal"], [arguments.0.type="TemplateLiteral"])',
         message: 'Use `encodeCanvas(canvas, mimeType)` from utils/canvasEncode.js — the one-argument `toBuffer` blocks the event loop (#592).',
     },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,6 +37,17 @@ const LAYER_EXCEPTIONS = [
     'models/Guild -> utils/guildSettingsCache',
 ];
 
+// discord.js v14 deprecated the `ephemeral: true` reply option in favour of
+// `flags: MessageFlags.Ephemeral`. Every one of the ~830 ephemeral replies here
+// is written with the flag; the boolean still works, so a stray one does not
+// fail anything at runtime, it just leaves the codebase with two ways of saying
+// the same thing and a deprecation warning per call. One had already drifted
+// back in (#706).
+const DEPRECATED_EPHEMERAL = {
+    selector: 'Property[key.name="ephemeral"][value.value=true]',
+    message: 'Use `flags: MessageFlags.Ephemeral` — the `ephemeral` option is deprecated in discord.js v14.',
+};
+
 const shared = {
     // `_`-prefixed arguments and catch bindings are the established way here of
     // saying "this is part of the signature and deliberately unused".
@@ -65,17 +76,34 @@ const shared = {
     // this codebase are written on purpose, and console logging is how the bot
     // reports for itself. Neither is a defect here.
     'no-console': 'off',
-    'no-restricted-syntax': ['error', {
-        // discord.js v14 deprecated the `ephemeral: true` reply option in favour
-        // of `flags: MessageFlags.Ephemeral`. Every one of the ~830 ephemeral
-        // replies here is written with the flag; the boolean still works, so a
-        // stray one does not fail anything at runtime, it just leaves the
-        // codebase with two ways of saying the same thing and a deprecation
-        // warning per call. One had already drifted back in (#706).
-        selector: 'Property[key.name="ephemeral"][value.value=true]',
-        message: 'Use `flags: MessageFlags.Ephemeral` — the `ephemeral` option is deprecated in discord.js v14.',
-    }],
+    'no-restricted-syntax': ['error', DEPRECATED_EPHEMERAL],
 };
+
+// The synchronous node-canvas encode, in both of its spellings:
+// `canvas.toBuffer()` and `canvas.toBuffer('image/png')`. The callback form —
+// `toBuffer(cb, mimeType)`, which is the one utils/canvasEncode.js wraps — has a
+// function as its first argument and is not matched by either selector.
+//
+// This is a bot on one event loop. A PNG encode measured ~10 ms for the 800×300
+// welcome card and grows with the surface, and every millisecond of it is a
+// millisecond the gateway cannot read a heartbeat — which on a join raid is
+// hundreds of them back to back (#592). The async form hands the encode to
+// libuv's thread pool instead, so the rule is: in src/, encode through
+// utils/canvasEncode.js.
+//
+// Scoped to `src/` deliberately. scripts/ is one-shot CLI work with no gateway
+// to stall, and the one deliberate exception inside src/ carries a disable
+// comment that says why.
+const SYNC_CANVAS_ENCODE = [
+    {
+        selector: 'CallExpression[callee.property.name="toBuffer"][arguments.length=0]',
+        message: 'Use `encodeCanvas(canvas)` from utils/canvasEncode.js — `canvas.toBuffer()` blocks the event loop (#592).',
+    },
+    {
+        selector: 'CallExpression[callee.property.name="toBuffer"][arguments.0.type="Literal"]',
+        message: 'Use `encodeCanvas(canvas, mimeType)` from utils/canvasEncode.js — the one-argument `toBuffer` blocks the event loop (#592).',
+    },
+];
 
 module.exports = [
     {
@@ -102,6 +130,18 @@ module.exports = [
                 layers: LAYERS,
                 allow: LAYER_EXCEPTIONS,
             }],
+        },
+    },
+
+    // ── Canvas encodes inside the bot ───────────────────────────────────
+    // `no-restricted-syntax` takes one options array, and a later block replaces
+    // rather than extends it, so the shared restriction is repeated here beside
+    // the src-only one.
+    {
+        files: ['src/**/*.js'],
+        ignores: ['src/dashboard/public/**'],
+        rules: {
+            'no-restricted-syntax': ['error', DEPRECATED_EPHEMERAL, ...SYNC_CANVAS_ENCODE],
         },
     },
 

--- a/src/commands/fun/caption.js
+++ b/src/commands/fun/caption.js
@@ -2,6 +2,9 @@ const { SlashCommandBuilder, AttachmentBuilder, MessageFlags } = require('discor
 const { createCanvas, loadImage } = require('canvas');
 const dns = require('dns');
 const { checkImageRateLimit } = require('../../utils/imageRateLimit');
+// The PNG encode goes to libuv's thread pool rather than blocking the gateway
+// on the way out — see utils/canvasEncode.js (#592).
+const { encodeCanvas } = require('../../utils/canvasEncode');
 
 const MAX_WIDTH   = 800;
 const MAX_DIM     = 4000;
@@ -75,7 +78,7 @@ module.exports = {
 
             ctx.drawImage(src, 0, captionH, w, h);
 
-            const attachment = new AttachmentBuilder(canvas.toBuffer('image/png'), { name: 'caption.png' });
+            const attachment = new AttachmentBuilder(await encodeCanvas(canvas), { name: 'caption.png' });
             await interaction.editReply({ files: [attachment] });
         } catch (err) {
             console.error('caption: image load or render failed', err);

--- a/src/commands/fun/wanted.js
+++ b/src/commands/fun/wanted.js
@@ -9,6 +9,9 @@ const {
 const { createCanvas, loadImage } = require('canvas');
 const { checkImageRateLimit } = require('../../utils/imageRateLimit');
 const { applySepia } = require('../../utils/canvasFilters');
+// The PNG encode goes to libuv's thread pool rather than blocking the gateway
+// on the way out — see utils/canvasEncode.js (#592).
+const { encodeCanvas } = require('../../utils/canvasEncode');
 
 const W           = 400;
 const H           = 530;
@@ -109,7 +112,7 @@ async function generatePoster(interaction, target) {
             ctx.fillStyle = '#3a1a00';
             ctx.fillText('Contact your local sheriff', W / 2, AVATAR_Y + AVATAR_SIZE + 130);
 
-            const attachment = new AttachmentBuilder(canvas.toBuffer('image/png'), { name: 'wanted.png' });
+            const attachment = new AttachmentBuilder(await encodeCanvas(canvas), { name: 'wanted.png' });
             const regenId = `wanted_regen_${interaction.id}_${Date.now()}`;
             const row = new ActionRowBuilder().addComponents(
                 new ButtonBuilder().setCustomId(regenId).setLabel('🤠 Wanted: Me').setStyle(ButtonStyle.Secondary),

--- a/src/commands/fun/wasted.js
+++ b/src/commands/fun/wasted.js
@@ -9,6 +9,9 @@ const {
 const { createCanvas, loadImage } = require('canvas');
 const { checkImageRateLimit } = require('../../utils/imageRateLimit');
 const { applyGrayscale } = require('../../utils/canvasFilters');
+// The PNG encode goes to libuv's thread pool rather than blocking the gateway
+// on the way out — see utils/canvasEncode.js (#592).
+const { encodeCanvas } = require('../../utils/canvasEncode');
 
 const SIZE = 512;
 
@@ -66,7 +69,7 @@ async function generateWasted(interaction, target) {
             ctx.lineWidth    = 4;
             ctx.strokeText('WASTED', SIZE / 2, SIZE / 2);
 
-            const attachment = new AttachmentBuilder(canvas.toBuffer('image/png'), { name: 'wasted.png' });
+            const attachment = new AttachmentBuilder(await encodeCanvas(canvas), { name: 'wasted.png' });
             const regenId = `wasted_regen_${interaction.id}_${Date.now()}`;
             const row = new ActionRowBuilder().addComponents(
                 new ButtonBuilder().setCustomId(regenId).setLabel('💀 Waste: Me').setStyle(ButtonStyle.Secondary),

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -371,8 +371,18 @@ function listen(app, port = process.env.DASHBOARD_PORT || 3000) {
     return server;
 }
 
-function start(client) {
-    return listen(createApp({ client }));
+/**
+ * Build and bind in one call — what src/index.js uses.
+ *
+ * `deps` is passed straight through to `createApp`, so the same injection the
+ * factory takes is reachable from the one entry point that actually starts a
+ * dashboard. Failures are deliberately left to propagate: everything that can
+ * go wrong here goes wrong synchronously, inside the caller's stack, which is
+ * what lets src/index.js catch a dashboard that cannot be built and keep the
+ * gateway up rather than exiting the process with it (#616).
+ */
+function start(client, deps = {}) {
+    return listen(createApp({ client, ...deps }));
 }
 
 module.exports = { createApp, listen, start, errorHandler, discordStrategyOptions };

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -481,8 +481,12 @@ async function handleAutoModeration(message, guildSettings) {
         // Clamped to the range the dashboard's own input offers. Nothing
         // validates `spamWindow` on the way into the database, and the sweep
         // above is only sound while no guild's window outruns it.
+        //
+        // `??`, not `||`: an out-of-range value is the clamp's job, so a stored
+        // 0 becomes the one-second floor rather than being read as "unset" and
+        // silently given the five-second default.
         const windowMs = Math.min(
-            Math.max((mod.spamWindow || 5) * 1000, SPAM_MIN_WINDOW_MS),
+            Math.max((mod.spamWindow ?? 5) * 1000, SPAM_MIN_WINDOW_MS),
             SPAM_MAX_WINDOW_MS
         );
         const threshold = mod.spamThreshold || 5;

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -69,8 +69,33 @@ const LEET_MAP = {
     '6': 'b', '8': 'b'
 };
 
-// messageId -> { userId -> [timestamps] }
-const spamTracker = new Map();
+// One entry per (guild, user) seen inside the spam window.
+//
+// This was a `Map<guildId, Map<userId, timestamps>>` with nothing that ever
+// removed an entry: a user's array was pruned only when *that same user* posted
+// again, so a visitor who said one word in one guild two months ago was still
+// resident, and the outer map grew a guild entry per guild for the life of the
+// process (#600). The bounded limiter is what the rest of the bot already uses
+// for exactly this — a hard key ceiling with FIFO eviction, plus a sweep that
+// drops keys whose timestamps have all aged out.
+//
+// The key is `guildId:userId` rather than a nested map because the ceiling has
+// to bound the whole thing; a cap on the outer map alone bounds nothing, since
+// the arrays hang off the inner ones. Eviction only forgives whatever a user
+// had accumulated, which costs them a longer run-up to the threshold — the same
+// trade every other limiter here makes.
+const SPAM_MAX_KEYS = 20_000;
+
+// The dashboard offers 1–60 seconds for the window, so 60s is the longest one
+// any guild can be running. The sweep uses it, which is what makes the sweep
+// safe: `cleanup` only drops a key once every timestamp on it predates the
+// window it is given, so sweeping on the *widest* configurable window can never
+// forget a message some guild's narrower window would still have counted.
+const SPAM_MIN_WINDOW_MS = 1_000;
+const SPAM_MAX_WINDOW_MS = 60_000;
+
+const spamLimiter = new BoundedRateLimiter(SPAM_MAX_KEYS);
+setInterval(() => spamLimiter.cleanup(SPAM_MAX_WINDOW_MS), SPAM_MAX_WINDOW_MS).unref();
 
 // Normalize leet-speak and obfuscation attempts before profanity check
 function normalizeToxic(text) {
@@ -90,6 +115,11 @@ module.exports = {
     name: 'messageCreate',
     // Exported for unit testing only
     _getCustomBadWordRegexes: getCustomBadWordRegexes,
+    // The spam window's backing store. Exposed so a test can assert the sweep
+    // actually reclaims it (#600) — a leak is invisible from the outside,
+    // because a tracker that never forgets behaves identically until it is the
+    // thing using the memory.
+    _spamLimiter: spamLimiter,
     async execute(message, client) {
         if (message.author.bot || !message.guild) return;
 
@@ -448,20 +478,22 @@ async function handleAutoModeration(message, guildSettings) {
     if (mod.spamProtection && !isModerator) {
         const guildId = message.guild.id;
         const userId = message.author.id;
-        const now = Date.now();
-        const windowMs = (mod.spamWindow || 5) * 1000;
+        // Clamped to the range the dashboard's own input offers. Nothing
+        // validates `spamWindow` on the way into the database, and the sweep
+        // above is only sound while no guild's window outruns it.
+        const windowMs = Math.min(
+            Math.max((mod.spamWindow || 5) * 1000, SPAM_MIN_WINDOW_MS),
+            SPAM_MAX_WINDOW_MS
+        );
         const threshold = mod.spamThreshold || 5;
 
-        if (!spamTracker.has(guildId)) spamTracker.set(guildId, new Map());
-        const guildMap = spamTracker.get(guildId);
-        if (!guildMap.has(userId)) guildMap.set(userId, []);
+        const key = `${guildId}:${userId}`;
 
-        const timestamps = guildMap.get(userId).filter(t => now - t < windowMs);
-        timestamps.push(now);
-        guildMap.set(userId, timestamps);
-
-        if (timestamps.length >= threshold) {
-            guildMap.set(userId, []);
+        if (spamLimiter.hit(key, windowMs) >= threshold) {
+            // Forget the burst that just earned a punishment, so the next
+            // message starts a fresh count instead of tripping the same
+            // still-full window again.
+            spamLimiter.reset(key);
             await message.delete().catch(console.error);
             const warn = await message.channel.send(`${message.author}, slow down! You're sending messages too fast.`);
             setTimeout(() => warn.delete().catch(() => {}), 5000);

--- a/src/index.js
+++ b/src/index.js
@@ -154,8 +154,29 @@ async function startDashboard() {
         console.log(`${shardTag(client)}[DASHBOARD] Not the primary shard — dashboard not started.`);
         return;
     }
-    const dashboard = require('./dashboard/server');
-    dashboard.start(client);
+    // Nothing the dashboard does at construction time is worth the gateway
+    // (#616). `listen` already holds this line for a socket that cannot bind —
+    // "the dashboard being unreachable is bad; the bot leaving every guild
+    // because of it is worse" — but the half in front of it did not: a throw out
+    // of `createApp` propagated through startBot() to the `process.exit(1)` at
+    // the bottom of this file, and the bot never logged in at all.
+    //
+    // That is not hypothetical. A connect-mongo major bump changed the shape of
+    // its export, and the one line that builds the session store took the whole
+    // bot down on boot with `MongoStore.create is not a function` — a dashboard
+    // detail, on a path that had nothing to do with Discord (see
+    // dashboard/lib/sessionStore.js).
+    //
+    // Configuration is deliberately not covered by this: config/validateEnv.js
+    // runs before the database is even connected and exits there, so a bad
+    // DASHBOARD_URL is still a refusal to start rather than a bot that quietly
+    // serves Discord with no dashboard.
+    try {
+        const dashboard = require('./dashboard/server');
+        dashboard.start(client);
+    } catch (err) {
+        console.error('[DASHBOARD] Failed to start. The bot continues without it:', err);
+    }
 }
 
 // Graceful shutdown: close DB and destroy Discord client before exiting

--- a/src/utils/boundedRateLimiter.js
+++ b/src/utils/boundedRateLimiter.js
@@ -93,11 +93,18 @@ class BoundedRateLimiter {
         this._map.delete(key);
     }
 
-    /** Drops keys whose recorded requests have all aged out of `windowMs`. */
+    /**
+     * Drops keys whose recorded requests have all aged out of `windowMs`.
+     *
+     * The comparison is inclusive because `check` and `hit` keep a timestamp
+     * only while `now - t < windowMs` — a timestamp exactly `windowMs` old has
+     * already expired for them. A strict `<` here would disagree with that on
+     * the boundary and hold the key for one more sweep.
+     */
     cleanup(windowMs) {
         const cutoff = Date.now() - windowMs;
         for (const [key, timestamps] of this._map) {
-            if (timestamps.every(t => t < cutoff)) this._map.delete(key);
+            if (timestamps.every(t => t <= cutoff)) this._map.delete(key);
         }
     }
 

--- a/src/utils/boundedRateLimiter.js
+++ b/src/utils/boundedRateLimiter.js
@@ -57,6 +57,42 @@ class BoundedRateLimiter {
         return arr.filter(t => now - t < windowMs).length < limit;
     }
 
+    /**
+     * Records a hit against `key` and returns how many hits fall inside
+     * `windowMs`, counting the one just recorded.
+     *
+     * `check` above answers "may this happen?" and refuses to record once the
+     * limit is reached. Some callers want the opposite reading: the event is
+     * real and has already happened, and the count itself is the signal — spam
+     * detection fires *because* the fifth message in five seconds exists. Those
+     * callers get the count and decide, rather than being handed a boolean that
+     * has already made the decision with an off-by-one to unpick.
+     *
+     * Eviction is the same FIFO rule `check` uses, so a caller mixing the two
+     * on one instance sees one bounded map rather than two policies.
+     */
+    hit(key, windowMs) {
+        const now = Date.now();
+        const timestamps = (this._map.get(key) || []).filter(t => now - t < windowMs);
+        if (!this._map.has(key) && this._map.size >= this._maxSize) {
+            this._map.delete(this._map.keys().next().value);
+        }
+        timestamps.push(now);
+        this._map.set(key, timestamps);
+        return timestamps.length;
+    }
+
+    /**
+     * Forgets `key` entirely, so its next hit counts as the first.
+     *
+     * This is what a caller that *acted* on a count needs: having punished the
+     * spammer, the window that proved it must not also prove the next message,
+     * or one burst becomes a punishment per message until it ages out.
+     */
+    reset(key) {
+        this._map.delete(key);
+    }
+
     /** Drops keys whose recorded requests have all aged out of `windowMs`. */
     cleanup(windowMs) {
         const cutoff = Date.now() - windowMs;

--- a/src/utils/eightBallImage.js
+++ b/src/utils/eightBallImage.js
@@ -222,6 +222,13 @@ function renderEightBall(text, type) {
     drawWindow(ctx, TINTS[type] ?? TINTS.neutral);
     drawAnswer(ctx, text);
 
+    // The one canvas in the bot that keeps the synchronous encode (#592). It is
+    // bounded in a way none of the others are: the answer table has twenty
+    // entries, the cache above is keyed on the answer, so this line runs at
+    // most twenty times in the life of the process and never again once each
+    // answer has been drawn once. Making it async would turn every caller into
+    // one that awaits a value the cache almost always already has.
+    // eslint-disable-next-line no-restricted-syntax -- bounded to 20 encodes, see above
     const buffer = canvas.toBuffer('image/png');
     cache.set(key, buffer);
     return buffer;

--- a/src/utils/shopBanner.js
+++ b/src/utils/shopBanner.js
@@ -2,6 +2,7 @@
 
 const { createCanvas, loadImage } = require('canvas');
 const { ensureFontsRegistered } = require('./registerFonts');
+const { encodeCanvas } = require('./canvasEncode');
 
 ensureFontsRegistered();
 
@@ -70,7 +71,10 @@ async function renderCategoryBanner({ activity, title, subtitle, items, currency
         await renderTile(ctx, safeItems[i], x, y, theme, currency);
     }
 
-    return canvas.toBuffer('image/png');
+    // Async encode, not `canvas.toBuffer()` — see utils/canvasEncode.js.
+    // This banner is far larger than the welcome card #592 measured: four
+    // tiles wide and as many rows as the category has items.
+    return encodeCanvas(canvas);
 }
 
 async function renderTile(ctx, item, x, y, theme, currency) {

--- a/tests/automodFilters.test.js
+++ b/tests/automodFilters.test.js
@@ -267,6 +267,22 @@ describe('spam window filter', () => {
         expect(next.delete).not.toHaveBeenCalled();
     });
 
+    test('clamps an out-of-range window to the floor rather than reading it as unset', async () => {
+        // 0 is not a window the dashboard can produce, but nothing validates
+        // this field on the way into the database. It means "as short as
+        // allowed" — one second — not "use the five-second default", which is
+        // what a falsy fallback would have made of it.
+        getGuildSettings.mockResolvedValue(spamSettings({ spamWindow: 0 }));
+        await run(burst('zerowindow'));
+        await run(burst('zerowindow'));
+
+        jest.advanceTimersByTime(1_500);
+        const late = burst('zerowindow');
+        await run(late);
+
+        expect(late.delete).not.toHaveBeenCalled();
+    });
+
     test('honours a configured threshold rather than the default of five', async () => {
         getGuildSettings.mockResolvedValue(spamSettings({ spamThreshold: 2 }));
         const sent = [makeMessage({ content: 'hi', userId: 'fast' }), makeMessage({ content: 'hi', userId: 'fast' })];

--- a/tests/boundedRateLimiter.test.js
+++ b/tests/boundedRateLimiter.test.js
@@ -1,0 +1,159 @@
+'use strict';
+
+/**
+ * The bounded limiter is what four different subsystems lean on to keep a
+ * per-user map from growing for the life of the process, and until #600 it had
+ * no test of its own — it was only ever exercised through whatever was using
+ * it. These cover the cap, the sweep, and the counting half of the API the spam
+ * window needs (`hit`/`reset`), where an off-by-one is a real user being
+ * punished a message early or a message late.
+ */
+
+const { BoundedRateLimiter } = require('../src/utils/boundedRateLimiter');
+
+describe('check', () => {
+    test('allows up to the limit inside the window, then refuses', () => {
+        const limiter = new BoundedRateLimiter();
+
+        expect(limiter.check('a', 1000, 2)).toBe(true);
+        expect(limiter.check('a', 1000, 2)).toBe(true);
+        expect(limiter.check('a', 1000, 2)).toBe(false);
+    });
+
+    test('a refusal is not recorded, so the window still holds exactly `limit`', () => {
+        const limiter = new BoundedRateLimiter();
+        for (let i = 0; i < 5; i++) limiter.check('a', 60_000, 2);
+
+        // Two recorded, three refused. Were refusals recorded, the key would
+        // stay over the limit for a whole window after the caller stopped.
+        expect(limiter.peek('a', 60_000, 3)).toBe(true);
+    });
+
+    test('keys age out of the window', () => {
+        jest.useFakeTimers();
+        try {
+            const limiter = new BoundedRateLimiter();
+            expect(limiter.check('a', 1000, 1)).toBe(true);
+            expect(limiter.check('a', 1000, 1)).toBe(false);
+
+            jest.advanceTimersByTime(1100);
+
+            expect(limiter.check('a', 1000, 1)).toBe(true);
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+});
+
+describe('the cap', () => {
+    test('never holds more than maxSize keys', () => {
+        const limiter = new BoundedRateLimiter(3);
+        for (let i = 0; i < 50; i++) limiter.check(`key${i}`, 60_000, 5);
+
+        expect(limiter.size).toBe(3);
+    });
+
+    test('evicts the oldest key first, so the newest arrivals survive', () => {
+        const limiter = new BoundedRateLimiter(2);
+        limiter.check('first', 60_000, 1);
+        limiter.check('second', 60_000, 1);
+        limiter.check('third', 60_000, 1);
+
+        // 'first' was dropped to make room, so its budget is forgiven — the
+        // documented failure mode under key-flooding is a briefly more
+        // permissive limit, never unbounded memory.
+        expect(limiter.check('first', 60_000, 1)).toBe(true);
+        expect(limiter.check('third', 60_000, 1)).toBe(false);
+    });
+
+    test('hit obeys the same cap', () => {
+        const limiter = new BoundedRateLimiter(3);
+        for (let i = 0; i < 50; i++) limiter.hit(`key${i}`, 60_000);
+
+        expect(limiter.size).toBe(3);
+    });
+});
+
+describe('cleanup', () => {
+    test('drops keys whose timestamps have all aged out, and keeps the rest', () => {
+        jest.useFakeTimers();
+        try {
+            const limiter = new BoundedRateLimiter();
+            limiter.check('stale', 60_000, 5);
+
+            jest.advanceTimersByTime(61_000);
+            limiter.check('fresh', 60_000, 5);
+            limiter.cleanup(60_000);
+
+            expect(limiter.size).toBe(1);
+            expect(limiter.peek('fresh', 60_000, 1)).toBe(false);
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+});
+
+describe('hit', () => {
+    test('counts the hit it just recorded', () => {
+        const limiter = new BoundedRateLimiter();
+
+        expect(limiter.hit('a', 60_000)).toBe(1);
+        expect(limiter.hit('a', 60_000)).toBe(2);
+        expect(limiter.hit('a', 60_000)).toBe(3);
+    });
+
+    test('counts only what is inside the window', () => {
+        jest.useFakeTimers();
+        try {
+            const limiter = new BoundedRateLimiter();
+            limiter.hit('a', 5_000);
+            limiter.hit('a', 5_000);
+
+            jest.advanceTimersByTime(6_000);
+
+            // The two before the gap are outside the window now — this is the
+            // slow chatter who must not be read as a burst.
+            expect(limiter.hit('a', 5_000)).toBe(1);
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('keys are independent', () => {
+        const limiter = new BoundedRateLimiter();
+        limiter.hit('a', 60_000);
+        limiter.hit('a', 60_000);
+
+        expect(limiter.hit('b', 60_000)).toBe(1);
+    });
+});
+
+describe('reset', () => {
+    test('forgets the key, so the next hit counts as the first', () => {
+        const limiter = new BoundedRateLimiter();
+        limiter.hit('a', 60_000);
+        limiter.hit('a', 60_000);
+
+        limiter.reset('a');
+
+        expect(limiter.hit('a', 60_000)).toBe(1);
+        expect(limiter.size).toBe(1);
+    });
+
+    test('resetting a key that was never seen is not an error', () => {
+        const limiter = new BoundedRateLimiter();
+
+        expect(() => limiter.reset('nobody')).not.toThrow();
+        expect(limiter.size).toBe(0);
+    });
+
+    test('forgives a check budget too', () => {
+        const limiter = new BoundedRateLimiter();
+        limiter.check('a', 60_000, 1);
+        expect(limiter.check('a', 60_000, 1)).toBe(false);
+
+        limiter.reset('a');
+
+        expect(limiter.check('a', 60_000, 1)).toBe(true);
+    });
+});

--- a/tests/boundedRateLimiter.test.js
+++ b/tests/boundedRateLimiter.test.js
@@ -91,6 +91,31 @@ describe('cleanup', () => {
             jest.useRealTimers();
         }
     });
+
+    test('expires a timestamp that is exactly one window old', () => {
+        jest.useFakeTimers();
+        try {
+            const limiter = new BoundedRateLimiter();
+            limiter.hit('a', 60_000);
+
+            jest.advanceTimersByTime(60_000);
+
+            // `check` and `hit` keep a timestamp only while `now - t <
+            // windowMs`, so at exactly `windowMs` it has already aged out for
+            // them. The sweep agrees on the same tick rather than holding the
+            // key for one more round.
+            expect(limiter.hit('a', 60_000)).toBe(1);
+            limiter.reset('a');
+
+            limiter.hit('a', 60_000);
+            jest.advanceTimersByTime(60_000);
+            limiter.cleanup(60_000);
+
+            expect(limiter.size).toBe(0);
+        } finally {
+            jest.useRealTimers();
+        }
+    });
 });
 
 describe('hit', () => {

--- a/tests/dashboardStartupIsolation.test.js
+++ b/tests/dashboardStartupIsolation.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+/**
+ * #616. The dashboard and the gateway share one process, so every way the
+ * dashboard can fail is a way every guild can lose its bot.
+ *
+ * tests/dashboardAppFactory.test.js holds the request-time half of that line:
+ * whatever a route does, the failure stops at the response. This file holds the
+ * two failures that happen outside a request, where there is no `next(err)` to
+ * catch them — the app cannot be built at all, and the port cannot be bound.
+ *
+ * Neither may reach the process-level `uncaughtException` guard in
+ * src/index.js, because that guard exits.
+ */
+
+const session = require('express-session');
+const { createApp, listen, start } = require('../src/dashboard/server');
+
+const SAVED_ENV = { ...process.env };
+
+beforeEach(() => {
+    // `listen` announces itself on every bind; this file does several.
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    process.env.SESSION_SECRET = 'x'.repeat(48);
+    process.env.MONGODB_URI = 'mongodb://127.0.0.1:27017/clawdia-test';
+    process.env.NODE_ENV = 'test';
+});
+
+afterEach(() => {
+    for (const key of ['SESSION_SECRET', 'MONGODB_URI', 'NODE_ENV', 'DASHBOARD_PORT']) {
+        if (SAVED_ENV[key] === undefined) delete process.env[key];
+        else process.env[key] = SAVED_ENV[key];
+    }
+    jest.restoreAllMocks();
+});
+
+const stubDeps = (overrides = {}) => ({
+    bot: { hasGuild: () => false },
+    sessionStore: new session.MemoryStore(),
+    configurePassport: () => {},
+    ...overrides,
+});
+
+/** Resolves once the server is listening, or rejects with whatever it emitted. */
+function whenListening(server) {
+    return new Promise((resolve, reject) => {
+        if (server.listening) return resolve(server);
+        server.once('listening', () => resolve(server));
+        server.once('error', reject);
+    });
+}
+
+const close = server => new Promise(resolve => server.close(resolve));
+
+describe('a dashboard that cannot be built', () => {
+    test('fails inside the caller, where src/index.js can catch it', () => {
+        const boom = () => { throw new Error('session store is the wrong shape'); };
+
+        // Synchronous, not a rejected promise and not a later tick: this is the
+        // property the guard in startDashboard() depends on. A construction
+        // failure that surfaced asynchronously would land on the process-level
+        // handler instead, which is the outage this is here to prevent.
+        expect(() => start({}, stubDeps({ configurePassport: boom })))
+            .toThrow('session store is the wrong shape');
+    });
+
+    test('binds no socket on the way out', async () => {
+        const boom = () => { throw new Error('nope'); };
+        expect(() => start({}, stubDeps({ configurePassport: boom }))).toThrow();
+
+        // The port is still free, so a later attempt — a restart, or an operator
+        // starting a second instance — is not competing with a half-built one.
+        const server = listen(createApp(stubDeps()), 0);
+        await whenListening(server);
+        expect(server.listening).toBe(true);
+        await close(server);
+    });
+});
+
+describe('a port that cannot be bound', () => {
+    test('is logged and survived, not thrown at the process', async () => {
+        const errors = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const first = await whenListening(listen(createApp(stubDeps()), 0));
+        const { port } = first.address();
+
+        // An 'error' event with no listener is a process-level throw, which is
+        // exactly how EADDRINUSE on the dashboard port used to take the gateway
+        // down with it.
+        const second = listen(createApp(stubDeps()), port);
+        const failure = await new Promise(resolve => second.once('error', resolve));
+
+        expect(failure.code).toBe('EADDRINUSE');
+        expect(errors).toHaveBeenCalledWith(
+            expect.stringContaining(`Server error on port ${port}`),
+            expect.stringContaining('EADDRINUSE'),
+        );
+
+        await close(first);
+    });
+});

--- a/tests/spamTrackerSweep.test.js
+++ b/tests/spamTrackerSweep.test.js
@@ -1,0 +1,126 @@
+'use strict';
+
+/**
+ * #600. The spam window used to be a `Map<guildId, Map<userId, timestamps>>`
+ * with nothing that ever removed an entry. A user's array was pruned only when
+ * *that same user* posted again, so somebody who said one word in one guild and
+ * never came back stayed resident for the life of the process — and the outer
+ * map grew a guild entry per guild and never shed one either.
+ *
+ * A leak is invisible from behaviour: a tracker that never forgets punishes
+ * exactly the same messages as one that does. So these tests read the store
+ * directly. What they hold is that entries are created where messages happen,
+ * that the periodic sweep reclaims them once their timestamps age out, and
+ * that flattening the two maps into one `guildId:userId` key did not merge two
+ * guilds' counts into one.
+ */
+
+// Installed before the handler is required, so the module-level sweep interval
+// registered at require time is a fake one this file can advance.
+jest.useFakeTimers();
+
+jest.mock('../src/models/User',     () => ({ findOne: jest.fn(), create: jest.fn() }));
+jest.mock('../src/models/Guild',    () => ({ create: jest.fn(), findOne: jest.fn() }));
+jest.mock('../src/models/Case',     () => ({ findOne: jest.fn(), countDocuments: jest.fn() }));
+jest.mock('../src/models/Reminder', () => ({ create: jest.fn() }));
+jest.mock('../src/services/moderationLogService', () => ({ logModeration: jest.fn() }));
+jest.mock('../src/services/aiService', () => ({ handleAIChat: jest.fn() }));
+jest.mock('../src/utils/guildSettingsCache', () => ({ getGuildSettings: jest.fn() }));
+
+const User = require('../src/models/User');
+const Case = require('../src/models/Case');
+const { logModeration } = require('../src/services/moderationLogService');
+const { getGuildSettings } = require('../src/utils/guildSettingsCache');
+const { makeMessage, makeModerationSettings } = require('./helpers/messageCreateMessage');
+const messageCreate = require('../src/events/messageCreate');
+
+const spamLimiter = messageCreate._spamLimiter;
+const run = message => messageCreate.execute(message, { user: { id: 'bot1' } });
+
+/** Spam protection armed with a threshold high enough that nothing under test trips it. */
+const spamSettings = (over = {}) => makeModerationSettings({
+    spamProtection: true, spamThreshold: 50, spamWindow: 5, ...over,
+});
+
+let quiet;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    quiet = jest.spyOn(console, 'error').mockImplementation(() => {});
+    User.findOne.mockResolvedValue({
+        userId: 'author1', guildId: 'guild1', behaviorScore: 0, lastScoreDecay: null,
+        save: jest.fn(async () => {}),
+    });
+    Case.countDocuments.mockResolvedValue(0);
+    Case.findOne.mockResolvedValue(null);
+    logModeration.mockResolvedValue({ caseId: 7 });
+    getGuildSettings.mockResolvedValue(spamSettings());
+
+    // Each test starts from an empty store: the tracker is module state, and
+    // the clock is frozen, so nothing ages out between tests on its own.
+    spamLimiter.reset('guild1:sweeper');
+    for (let i = 0; i < 25; i++) spamLimiter.reset(`guild1:visitor${i}`);
+    spamLimiter.reset('guild1:shared');
+    spamLimiter.reset('guild2:shared');
+});
+
+afterEach(() => {
+    jest.runOnlyPendingTimers();
+    quiet.mockRestore();
+});
+
+afterAll(() => {
+    jest.useRealTimers();
+});
+
+describe('the spam window is reclaimed', () => {
+    test('a user who posts once leaves an entry behind', async () => {
+        await run(makeMessage({ content: 'hi', userId: 'sweeper' }));
+
+        expect(spamLimiter.size).toBeGreaterThan(0);
+    });
+
+    test('the periodic sweep drops entries once their timestamps have aged out', async () => {
+        for (let i = 0; i < 25; i++) {
+            await run(makeMessage({ content: 'hi', userId: `visitor${i}` }));
+        }
+        expect(spamLimiter.size).toBe(25);
+
+        // One sweep tick is 60s — the widest window any guild can configure —
+        // so the first tick still sees timestamps inside it. The one after it
+        // is where a visitor who never came back is finally forgotten.
+        jest.advanceTimersByTime(60_000);
+        jest.advanceTimersByTime(60_000);
+
+        expect(spamLimiter.size).toBe(0);
+    });
+
+    test('the sweep keeps a user who is still inside their window', async () => {
+        await run(makeMessage({ content: 'hi', userId: 'sweeper' }));
+
+        // Far enough for the tick to fire, not far enough for a 5s window to
+        // have closed on a message sent a second ago.
+        jest.advanceTimersByTime(59_000);
+        await run(makeMessage({ content: 'hi', userId: 'sweeper' }));
+        jest.advanceTimersByTime(1_500);
+
+        expect(spamLimiter.size).toBe(1);
+    });
+});
+
+describe('one flat key per (guild, user)', () => {
+    test('the same user in two guilds is two counts, not one', async () => {
+        getGuildSettings.mockResolvedValue(spamSettings({ spamThreshold: 3 }));
+
+        await run(makeMessage({ content: 'hi', userId: 'shared', guildId: 'guild1' }));
+        await run(makeMessage({ content: 'hi', userId: 'shared', guildId: 'guild1' }));
+        const elsewhere = makeMessage({ content: 'hi', userId: 'shared', guildId: 'guild2' });
+
+        await run(elsewhere);
+
+        // Three messages from one account, but only two in either guild. A
+        // shared counter would punish someone for being active in two servers.
+        expect(elsewhere.delete).not.toHaveBeenCalled();
+        expect(spamLimiter.size).toBe(2);
+    });
+});

--- a/tests/spamTrackerSweep.test.js
+++ b/tests/spamTrackerSweep.test.js
@@ -86,10 +86,11 @@ describe('the spam window is reclaimed', () => {
         }
         expect(spamLimiter.size).toBe(25);
 
-        // One sweep tick is 60s — the widest window any guild can configure —
-        // so the first tick still sees timestamps inside it. The one after it
-        // is where a visitor who never came back is finally forgotten.
-        jest.advanceTimersByTime(60_000);
+        // The frozen clock puts every one of those messages exactly one sweep
+        // interval before the next tick, which is the expiry boundary itself: a
+        // timestamp precisely `windowMs` old is one `check` and `hit` have
+        // already stopped counting, so the sweep must not keep it for another
+        // round either. One tick, not two.
         jest.advanceTimersByTime(60_000);
 
         expect(spamLimiter.size).toBe(0);


### PR DESCRIPTION
Three findings, all about something the bot holds onto or blocks on that it
should not.

#600 — the spam window was a `Map<guildId, Map<userId, timestamps>>` with no
sweeper. A user's array was pruned only when that same user posted again, so
everyone who ever sent one message in any guild stayed resident, and the outer
map grew a guild entry per guild for the life of the process. It is a
BoundedRateLimiter now, keyed `guildId:userId` — a hard ceiling with FIFO
eviction, and an unref'd sweep on the widest window the dashboard offers, which
is what makes the sweep safe to run against every guild's own narrower one.

The limiter grew the two methods that reading takes: `hit` returns how many
events fall inside the window rather than a boolean that has already decided,
and `reset` forgets a key. Spam detection is a counting problem, not an
allow/deny one — the fifth message in five seconds is punished *because* it
exists — and expressing it through `check` would have meant a `threshold - 1`
at the call site and a burst that punished every message after the first.
`spamWindow` is clamped to the 1–60s the dashboard's own input offers, because
nothing validates it on the way into the database and the sweep depends on it.

#592 — the welcome card was fixed; five other canvases were not. shopBanner
(four tiles wide, as many rows as the category has items), /caption (up to
4000×4000 of someone else's image), /wanted and /wasted now encode through
canvasEncode, which hands the PNG to libuv's thread pool. eightBallImage keeps
the synchronous encode and says why: twenty answers, cached on the answer, so
it runs at most twenty times in the life of the process.

So it stays fixed, an ESLint rule bans both spellings of the synchronous form
in src/ — the callback form is not matched, scripts/ is not covered, and the
one exception carries a disable comment.

#616 — the request-time half was already held: whatever a route does, the
failure stops at the response. The half in front of it was not. A throw out of
`createApp` propagated through startBot() to `process.exit(1)`, so the bot
never logged in — which is not hypothetical, a connect-mongo major bump took
the whole bot down on boot with `MongoStore.create is not a function`. That is
caught now, on the same terms `listen` already had for a port it cannot bind:
the dashboard being unreachable is bad, the bot leaving every guild because of
it is worse. Configuration is deliberately still fatal — validateEnv exits
before the database is touched, and a bad DASHBOARD_URL should refuse to start.

Splitting the dashboard into its own process, the rest of #616, is untouched.

Tests: the sweep reclaims what it should and keeps what is still inside its
window; two guilds are two counts after the flattening; hit/reset/cleanup and
the cap have unit tests of their own; a dashboard that cannot be built fails
inside its caller and binds no socket, and a port that cannot be bound is
logged rather than thrown at the process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved image generation responsiveness by moving most PNG processing off the main execution path.

- **Bug Fixes**
  - Prevented dashboard startup failures from stopping the bot.
  - Improved spam tracking with bounded storage, expiration, and separate tracking across servers.
  - Preserved reliable dashboard behavior when startup encounters configuration or port issues.

- **Tests**
  - Added coverage for rate limiting, spam cleanup, image-related behavior, and dashboard startup failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->