### PR TITLE
Gate the way to the registry: audit, image build, boot and scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,10 +171,22 @@ jobs:
   #
   # Built on every event, pull requests included, and never pushed. Alongside
   # `test` rather than after it: the two answer different questions, and a red
-  # suite should not hide a broken image any more than the reverse. The publish
-  # job needs both, so nothing reaches the registry that has not been built,
-  # booted and scanned here first — and because this job writes the same
-  # `type=gha` cache, that publish is a cache hit rather than a second compile.
+  # suite should not hide a broken image any more than the reverse.
+  #
+  # What `publish: needs: [test, image]` buys is worth stating precisely, because
+  # `needs:` orders the two jobs and nothing more — it does not hand this image
+  # over, and that job builds again before it pushes. So the guarantee is that
+  # the same commit, Dockerfile, lockfile and digest-pinned base produced an
+  # image that booted and scanned clean; it is not byte identity, because
+  # `apk add` resolves whatever Alpine is serving at the moment of each build.
+  # The `type=gha` cache this job writes is what closes that in practice: the
+  # publish build is a cache hit rather than a second compile, and a cache hit is
+  # the same layers. The residue is a cache miss inside a single run.
+  #
+  # Closing it properly means pushing a staging tag from here and promoting it by
+  # digest, which needs `packages: write` in a job that also runs on pull
+  # requests. That is a wider exposure than the gap it closes — the separation is
+  # why publish is a job of its own — so it is deliberately not done here.
   image:
     name: Build, boot and scan Docker image
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,15 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Publishing lives in this workflow (see the `publish` job), so this group is
+# also what serializes it. Two pushes landing on `main` a minute apart used to
+# start two independent publish runs with nothing ordering them: whichever
+# finished last won `:latest`, and a slow build of the older commit overwriting
+# a fast build of the newer one left production running code that had already
+# been superseded (#651). Keyed on the ref, one run at a time, newest wins —
+# `cancel-in-progress` stops the older run rather than letting it finish and
+# repoint the tag. Pull requests key on their number instead, so a force-push
+# cancels its own previous run and nobody else's.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -19,6 +28,9 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  # The tag the `image` job builds into the runner's own daemon. Never pushed —
+  # it exists so the smoke and the scan below have something to name.
+  SMOKE_IMAGE: clawdia:ci
 
 jobs:
   test:
@@ -124,12 +136,140 @@ jobs:
       # few seconds. After the tests, with `always()`, so the two signals are
       # independent — an unused variable never hides which tests failed, and a
       # failing test never hides the lint result either. Both still fail the
-      # job, which is what `publish: needs: test` is gating on.
+      # job, which is what the publish job's `needs:` is gating on.
       - name: Lint
         if: always()
         run: npm run lint
 
-  # Publishing lives here, behind `needs: test`, rather than in its own
+      # #645: CI gated on the tests and nothing else, so a dependency with a
+      # published advisory reached the image with nothing in the way. Dependabot
+      # raises the bump, but a bump nobody merges is not a control; this is what
+      # notices it is still sitting there.
+      #
+      # `high` is the level, not `moderate`: this is a Discord bot whose
+      # dependency tree is large enough that a moderate-level gate would spend
+      # most of its life red on advisories that do not apply, and a gate that is
+      # normally red is a gate everyone learns to merge past. The whole tree is
+      # audited, dev dependencies included — a compromised build-time package
+      # runs against the checkout with a registry credential nearby, which is
+      # not obviously the smaller problem.
+      #
+      # `always()` for the same reason as lint: a failing suite must not hide
+      # the advisory, and an advisory must not hide which tests failed.
+      - name: Audit dependencies
+        if: always()
+        run: npm audit --audit-level=high
+
+  # #646: the Dockerfile was built in exactly one place — the publish job below,
+  # which runs on `main` after a merge. So a Dockerfile regression was found by
+  # the deploy rather than by the pull request that caused it, and the first
+  # symptom was a failed publish on a branch that was already merged. This image
+  # compiles `canvas` from source against Alpine's cairo/pango headers in one
+  # stage and links it against a separately-installed set of runtime libraries
+  # in the next, which is exactly the shape of thing a base-image bump breaks
+  # without touching a line of JavaScript.
+  #
+  # Built on every event, pull requests included, and never pushed. Alongside
+  # `test` rather than after it: the two answer different questions, and a red
+  # suite should not hide a broken image any more than the reverse. The publish
+  # job needs both, so nothing reaches the registry that has not been built,
+  # booted and scanned here first — and because this job writes the same
+  # `type=gha` cache, that publish is a cache hit rather than a second compile.
+  image:
+    name: Build, boot and scan Docker image
+    runs-on: ubuntu-latest
+    # On a cold cache this compiles canvas from source, which is minutes rather
+    # than seconds; a warm one is a small fraction of that. Matches the publish
+    # job's budget, since it is the same build.
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Build image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          # The whole point of this job. A pull request has no credentials worth
+          # using and no tag anything deploys.
+          push: false
+          # ...but the steps below need to `docker run` it, and a buildx build
+          # otherwise leaves its result in the builder cache and nowhere else.
+          load: true
+          tags: ${{ env.SMOKE_IMAGE }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Everything that is true of the image rather than of the source tree: the
+      # native canvas binding actually links, the fonts the card generators
+      # register are installed at the path Alpine puts them, the process is not
+      # root. See scripts/image-smoke.js for why each one is in there.
+      - name: Smoke-test the image
+        timeout-minutes: 5
+        run: |
+          docker run --rm --entrypoint node "$SMOKE_IMAGE" scripts/image-smoke.js
+
+      # The other half: that the image boots. Run with its real entrypoint and
+      # no configuration at all, `src/index.js` loads its entire require graph —
+      # discord.js, mongoose, every command module below it — and is then turned
+      # away by config/validateEnv.js, which is its first statement after the
+      # secrets are read. Reaching that message means every layer resolved;
+      # anything else (a missing module, a broken tini, a bad ENTRYPOINT) fails
+      # before it and says so.
+      #
+      # Deliberately not booted further than this: past the validator it would
+      # want a Discord token and a MongoDB, and a smoke test that needs the
+      # production credentials is a smoke test nobody can run on a fork.
+      - name: Boot the image far enough to reject its own config
+        timeout-minutes: 5
+        run: |
+          set +e
+          output=$(docker run --rm "$SMOKE_IMAGE" 2>&1)
+          status=$?
+          set -e
+
+          echo "$output"
+
+          if [ "$status" -ne 1 ]; then
+            echo "::error::expected the entrypoint to exit 1 on an empty config, got $status"
+            exit 1
+          fi
+
+          if ! printf '%s' "$output" | grep -q 'Missing required environment variables'; then
+            echo "::error::the image did not reach config/validateEnv.js — something below it failed to load"
+            exit 1
+          fi
+
+          echo "image boots and rejects an empty config, as expected"
+
+      # #645: nothing scanned the published image, so a CVE in the base layer or
+      # in an installed apk was only ever found by someone scanning production.
+      #
+      # Two deliberate narrowings, because a scan that is always red is a scan
+      # nobody reads. `ignore-unfixed` drops findings with no fixed version
+      # available — there is no action to take on those beyond changing base
+      # image, and they are the bulk of an Alpine report. HIGH and CRITICAL only,
+      # matching the `--audit-level=high` the npm side uses, so the two halves of
+      # the dependency surface are gated at the same bar.
+      #
+      # The scan runs before anything is pushed, so a finding stops the image
+      # existing rather than being raised against one already deployed.
+      - name: Scan the image for known vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.SMOKE_IMAGE }}
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '1'
+          format: table
+
+  # Publishing lives here, behind `needs: [test, image]`, rather than in its own
   # workflow. It used to be a separate file triggered on `push: main`, which
   # ran alongside the tests instead of after them: a commit that broke the
   # suite still got built and pushed as `:latest`, and `:latest` is the tag
@@ -140,9 +280,10 @@ jobs:
   # simply depends on the one before it in the same run.
   publish:
     name: Build and publish Docker image
-    needs: test
-    # Pull requests build nothing: they have no push credentials worth using
-    # and no tag that anything deploys. Pushes to main and to v* tags do.
+    needs: [test, image]
+    # Pull requests build the image in the `image` job above but publish
+    # nothing: they have no push credentials worth using and no tag that
+    # anything deploys. Pushes to main and to v* tags do.
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,12 +48,24 @@ npm start               # plain node, and what the image runs
 
 ## Before you open a pull request
 
-Both of these gate CI, and the Docker image is only built when they pass, so a
-red one means nothing ships:
+All three of these gate CI, and the Docker image is only published when they
+pass, so a red one means nothing ships:
 
 ```bash
 npm test                # the whole suite, ~20s
 npm run lint            # eslint, flat config
+npm audit --audit-level=high
+```
+
+CI also builds the image on every pull request, boots it, and scans it — the
+Dockerfile used to be built only after a merge, which made the deploy the first
+thing to notice a broken layer. `npm run image:smoke` is the check the workflow
+runs *inside* the container: it is about the image rather than the source, so
+running it on your machine tells you little. Point it at a build instead:
+
+```bash
+docker build -t clawdia:dev .
+docker run --rm --entrypoint node clawdia:dev scripts/image-smoke.js
 ```
 
 The two coverage ratchets are two separate commands: `npm test -- --coverage`

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,21 @@ USER node
 
 ENV NODE_ENV=production
 
+# 3000 is the container-side port, and it is a constant rather than something
+# DASHBOARD_PORT is expected to move (#650). EXPOSE is image metadata — it
+# publishes nothing and binds nothing — so it cannot follow a value that is only
+# known at `docker run` time, and a build argument would only be right for
+# whoever remembered to pass it. The fix is therefore to hold the convention
+# rather than to parameterize it: both stack files map a chosen *host* port onto
+# this one and leave DASHBOARD_PORT at its 3000 default, which is what the
+# healthcheck below then resolves.
+#
+# This is the line that made #641 possible — the image healthcheck probed a
+# hardcoded 3000 while portainer-stack.yml was read as running the container on
+# 7001, and the mismatch was masked by the stack overriding the check.
+# tests/dashboardPortAlignment.test.js now fails if this number, either stack
+# file's container-side port, or the DASHBOARD_PORT default in either of them
+# stops agreeing with the others.
 EXPOSE 3000
 
 # Declared on the image itself, not only in compose, so `docker run` and any

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,17 @@ FROM node:24-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a
 # Shared libraries canvas links against at runtime (the -dev headers and the
 # compiler are deliberately left behind in the build stage), plus the DejaVu
 # fonts that utils/shopBanner.js and utils/cardGenerator.js register by path.
-RUN apk add --no-cache \
+#
+# `apk upgrade` first, and it is not redundant with the digest-pinned base. The
+# pin (#644) fixes the starting point, which is what makes a rebuild
+# reproducible; it does not make that starting point *current*. `node:24-alpine`
+# is rebuilt on upstream's schedule, not Alpine's, so between rebuilds the base
+# carries OS packages with published fixes already sitting in Alpine's repo —
+# the image scan in CI found exactly that (giflib and openssl, both fixed
+# upstream, neither yet in a node:24-alpine rebuild). Upgrading here takes the
+# fixes without waiting, and costs no more determinism than the `apk add` below
+# already does: both resolve against whatever Alpine is serving at build time.
+RUN apk upgrade --no-cache && apk add --no-cache \
     cairo \
     jpeg \
     pango \
@@ -57,6 +67,17 @@ RUN apk add --no-cache \
     ttf-dejavu \
     font-noto-emoji \
     tini
+
+# npm ships inside the Node base image and this one never runs it: the build
+# stage does the install, and the runtime entrypoint is `node src/index.js`
+# under tini — nothing in either stack file shells out to npm, and the
+# healthchecks are `node -e`. It is several megabytes of dependency tree that
+# exists only to be scanned: every Node-ecosystem finding in the first scan of
+# this image (brace-expansion, ip-address, tar) came from
+# /usr/local/lib/node_modules/npm and none of it was reachable from anything
+# this container does. Deleting it removes the findings by removing the code,
+# which is the only honest way to clear a CVE you are not going to patch.
+RUN rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 
 WORKDIR /app
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -45,8 +45,10 @@ working.
 ## What the tag does
 
 `.github/workflows/ci.yml` runs on `push: tags: v*`, and the publish job is
-behind `needs: test`, so a tag whose tests fail publishes nothing. On a green
-run `docker/metadata-action` derives these tags from `v4.2.1`:
+behind `needs: [test, image]`, so a tag publishes nothing unless the suite, the
+linter and the dependency audit are green *and* the image builds, boots and
+comes back clean from the vulnerability scan. On a green run
+`docker/metadata-action` derives these tags from `v4.2.1`:
 
 - `ghcr.io/theshield2594/clawdia:4.2.1`
 - `ghcr.io/theshield2594/clawdia:4.2`

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "docs:api": "node scripts/docs-api.js",
     "docs:panels": "node scripts/docs-panels.js",
     "favicon": "node scripts/make-favicon.js",
+    "image:smoke": "node scripts/image-smoke.js",
     "og-image": "node scripts/make-og-image.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/scripts/image-smoke.js
+++ b/scripts/image-smoke.js
@@ -75,25 +75,38 @@ check('NODE_ENV is production', () => {
     }
 });
 
-// The two required faces, at the Alpine path the ttf-dejavu package uses. A
-// missing file here is the silent downgrade described above, so it is checked
-// by existence rather than by asking canvas whether text rendered — it renders
-// either way, just in the wrong font.
-const REQUIRED_FONTS = [
-    '/usr/share/fonts/ttf-dejavu/DejaVuSans.ttf',
-    '/usr/share/fonts/ttf-dejavu/DejaVuSans-Bold.ttf',
-];
+// Whether every family utils/registerFonts.js asks for is present, checked by
+// asking that module rather than by keeping a second copy of the paths here.
+// The first version of this file did keep its own copy, hardcoded to the Alpine
+// path the package *name* implies — /usr/share/fonts/ttf-dejavu/ — and failed a
+// perfectly good image on its first run: `apk add ttf-dejavu` installs into
+// /usr/share/fonts/dejavu/, and the bot was resolving it there all along
+// through a candidate the table had labelled Fedora/RHEL.
+//
+// Checked by resolution rather than by asking canvas whether text rendered,
+// because it renders either way — just in the wrong font, which is the silent
+// downgrade registerFonts.js exists to make visible.
+const fonts = require(path.join(__dirname, '..', 'src', 'utils', 'registerFonts'));
 
-check('the DejaVu faces the card generators register are installed', () => {
-    const missing = REQUIRED_FONTS.filter(p => !fs.existsSync(p));
-    if (missing.length) throw new Error(`missing ${missing.join(', ')}`);
-});
+check('every font the card generators register resolves', () => {
+    const resolved = fonts.resolveFonts();
+    const label = f => `${f.family}${f.weight === 'bold' ? ' (bold)' : ''}`;
 
-// Emoji are optional to utils/registerFonts.js — a missing family warns and
-// carries on — so a missing one is reported here and does not fail the image.
-check('font-noto-emoji is installed (optional)', () => {
-    if (!fs.existsSync('/usr/share/fonts/noto/NotoColorEmoji.ttf')) {
-        console.warn('  note  emoji will render as fallback glyphs');
+    // Optional families — emoji — warn in the bot rather than failing it, so
+    // they are reported here and do not fail the image either.
+    for (const font of resolved.filter(f => f.optional && !f.path)) {
+        console.warn(`  note  ${label(font)} is not installed; it will render as fallback glyphs`);
+    }
+
+    const missing = resolved.filter(f => !f.optional && !f.path);
+    if (missing.length) {
+        throw new Error(`${missing.map(label).join(', ')} resolved to none of their candidate paths`);
+    }
+
+    // The path each one resolved to, so a move within the image is visible in
+    // the log before it becomes a failure.
+    for (const font of resolved.filter(f => f.path)) {
+        console.log(`        ${label(font)} -> ${font.path}`);
     }
 });
 
@@ -103,7 +116,7 @@ check('font-noto-emoji is installed (optional)', () => {
 // or pixman fails on the encode.
 check('canvas loads, registers fonts and encodes a PNG', () => {
     const { createCanvas } = require('canvas');
-    require(path.join(__dirname, '..', 'src', 'utils', 'registerFonts')).ensureFontsRegistered();
+    fonts.ensureFontsRegistered();
 
     const canvas = createCanvas(160, 48);
     const ctx = canvas.getContext('2d');

--- a/scripts/image-smoke.js
+++ b/scripts/image-smoke.js
@@ -110,13 +110,26 @@ check('every font the card generators register resolves', () => {
     }
 });
 
-// The native binding, end to end: load it, register the fonts through the same
-// module the bot uses, draw, and encode. A build stage that compiled against
-// headers the runtime stage does not ship fails on the require; a broken cairo
-// or pixman fails on the encode.
-check('canvas loads, registers fonts and encodes a PNG', () => {
+// Resolving is not registering. A file can sit at the expected path and still
+// fail registerFont() — truncated by a bad layer copy, or a format this build of
+// canvas was not compiled to read — and the bot deliberately swallows that:
+// warn, carry on in the fallback face, because refusing to start over a font is
+// worse. Which leaves the same silent downgrade the check above exists to catch,
+// one step further along, so the smoke asserts on the registration itself.
+check('every required font actually registers, not just resolves', () => {
+    const failed = fonts.ensureFontsRegistered()
+        .filter(f => !f.optional && !f.registered)
+        .map(f => `${f.family}${f.weight === 'bold' ? ' (bold)' : ''}: ${f.error}`);
+
+    if (failed.length) throw new Error(failed.join('; '));
+});
+
+// The native binding, end to end: load it, draw with the fonts registered
+// above, and encode. A build stage that compiled against headers the runtime
+// stage does not ship fails on the require; a broken cairo or pixman fails on
+// the encode.
+check('canvas loads and encodes a PNG', () => {
     const { createCanvas } = require('canvas');
-    fonts.ensureFontsRegistered();
 
     const canvas = createCanvas(160, 48);
     const ctx = canvas.getContext('2d');

--- a/scripts/image-smoke.js
+++ b/scripts/image-smoke.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Boot smoke for the container image (#646).
+ *
+ * The Dockerfile used to be built only by the publish job, which runs on `main`
+ * after a merge — so a broken layer was found by the deploy rather than by the
+ * pull request that broke it. CI now builds the image on every event and runs
+ * this inside it.
+ *
+ * What it checks is the half a unit test cannot see: the things that are true
+ * of the *image* rather than of the source tree. `canvas` compiles from source
+ * against Alpine's cairo/pango in the build stage and links against a
+ * separately-installed set of runtime libraries in the final one, so the two
+ * apk lists can drift apart and produce an image that installs cleanly and
+ * throws on the first generated card. The fonts are the same shape of problem:
+ * a dropped package or a renamed path downgrades every image to canvas's
+ * built-in font, which utils/registerFonts.js reports as a warning and nothing
+ * else — invisible unless something looks.
+ *
+ * Deliberately not checked here: that the bot starts. That needs a token and a
+ * database, and the require graph is covered by the workflow step next to this
+ * one, which runs the image's real entrypoint with no configuration and expects
+ * it to be rejected by config/validateEnv.js — reaching that rejection means
+ * every module below src/index.js loaded.
+ *
+ * Runs against whatever it is executed inside, so it is equally usable against
+ * a running deployment:
+ *
+ *   docker run --rm --entrypoint node ghcr.io/theshield2594/clawdia:latest \
+ *       scripts/image-smoke.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const failures = [];
+const check = (what, fn) => {
+    try {
+        fn();
+        console.log(`  ok    ${what}`);
+    } catch (err) {
+        // First line only: a require failure carries its whole stack in the
+        // message, and the log is easier to read with one line per check.
+        const why = String(err.message).split('\n')[0];
+        failures.push(`${what}: ${why}`);
+        console.log(`  FAIL  ${what}: ${why}`);
+    }
+};
+
+console.log('image smoke:');
+
+// The runtime stage must be the same Node major the tests ran on. The Dockerfile,
+// .nvmrc and package.json `engines` are held together by
+// tests/nodeVersionAlignment.test.js; this is the other end of that — what the
+// built image actually resolved the digest-pinned base to.
+check('node satisfies package.json engines', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
+    const wanted = Number((pkg.engines.node.match(/(\d+)/) || [])[1]);
+    const actual = Number(process.versions.node.split('.')[0]);
+    if (actual < wanted) throw new Error(`image runs node ${process.versions.node}, engines wants >=${wanted}`);
+});
+
+// `USER node` in the Dockerfile. A base-image bump that reorders the stages, or
+// a COPY added after the USER line, is how an image quietly goes back to root.
+check('the process is not root', () => {
+    if (typeof process.getuid !== 'function') throw new Error('no getuid on this platform');
+    if (process.getuid() === 0) throw new Error('running as uid 0');
+});
+
+check('NODE_ENV is production', () => {
+    if (process.env.NODE_ENV !== 'production') {
+        throw new Error(`NODE_ENV=${process.env.NODE_ENV || '<unset>'}`);
+    }
+});
+
+// The two required faces, at the Alpine path the ttf-dejavu package uses. A
+// missing file here is the silent downgrade described above, so it is checked
+// by existence rather than by asking canvas whether text rendered — it renders
+// either way, just in the wrong font.
+const REQUIRED_FONTS = [
+    '/usr/share/fonts/ttf-dejavu/DejaVuSans.ttf',
+    '/usr/share/fonts/ttf-dejavu/DejaVuSans-Bold.ttf',
+];
+
+check('the DejaVu faces the card generators register are installed', () => {
+    const missing = REQUIRED_FONTS.filter(p => !fs.existsSync(p));
+    if (missing.length) throw new Error(`missing ${missing.join(', ')}`);
+});
+
+// Emoji are optional to utils/registerFonts.js — a missing family warns and
+// carries on — so a missing one is reported here and does not fail the image.
+check('font-noto-emoji is installed (optional)', () => {
+    if (!fs.existsSync('/usr/share/fonts/noto/NotoColorEmoji.ttf')) {
+        console.warn('  note  emoji will render as fallback glyphs');
+    }
+});
+
+// The native binding, end to end: load it, register the fonts through the same
+// module the bot uses, draw, and encode. A build stage that compiled against
+// headers the runtime stage does not ship fails on the require; a broken cairo
+// or pixman fails on the encode.
+check('canvas loads, registers fonts and encodes a PNG', () => {
+    const { createCanvas } = require('canvas');
+    require(path.join(__dirname, '..', 'src', 'utils', 'registerFonts')).ensureFontsRegistered();
+
+    const canvas = createCanvas(160, 48);
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = '#101014';
+    ctx.fillRect(0, 0, 160, 48);
+    ctx.fillStyle = '#ffffff';
+    ctx.font = '20px "DejaVu Sans"';
+    ctx.fillText('clawdia', 8, 32);
+
+    const png = canvas.toBuffer('image/png');
+    if (png.length < 100) throw new Error(`encoded ${png.length} bytes`);
+    // PNG magic, so a zero-filled buffer cannot pass on length alone.
+    if (png.subarray(0, 4).toString('hex') !== '89504e47') throw new Error('not a PNG');
+});
+
+if (failures.length) {
+    console.error(`\nimage smoke failed (${failures.length}):`);
+    for (const f of failures) console.error(`  - ${f}`);
+    process.exit(1);
+}
+
+console.log('\nimage smoke passed.');

--- a/src/utils/registerFonts.js
+++ b/src/utils/registerFonts.js
@@ -18,14 +18,21 @@
 const fs = require('fs');
 const { registerFont } = require('canvas');
 
+// Ordered most-likely-first per family, which for this repo means Alpine's
+// layout early: the Dockerfile builds on Alpine and installs `ttf-dejavu`,
+// which puts its files in /usr/share/fonts/dejavu/ — *not* the
+// /usr/share/fonts/ttf-dejavu/ the package name suggests, and which the
+// comments here claimed for years. scripts/image-smoke.js checks the real
+// image against this table on every build, which is how the mislabelling was
+// finally noticed; the old path stays as a candidate for Alpine before 3.13.
 const FONTS = [
     {
         family: 'DejaVu Sans',
         weight: 'normal',
         candidates: [
             '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',   // Debian/Ubuntu
-            '/usr/share/fonts/ttf-dejavu/DejaVuSans.ttf',        // Alpine
-            '/usr/share/fonts/dejavu/DejaVuSans.ttf',            // Fedora/RHEL
+            '/usr/share/fonts/dejavu/DejaVuSans.ttf',            // Alpine ttf-dejavu, Fedora/RHEL
+            '/usr/share/fonts/ttf-dejavu/DejaVuSans.ttf',        // Alpine before 3.13
             '/Library/Fonts/DejaVuSans.ttf',                     // macOS (manual install)
         ],
     },
@@ -34,8 +41,8 @@ const FONTS = [
         weight: 'bold',
         candidates: [
             '/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf',
-            '/usr/share/fonts/ttf-dejavu/DejaVuSans-Bold.ttf',
             '/usr/share/fonts/dejavu/DejaVuSans-Bold.ttf',
+            '/usr/share/fonts/ttf-dejavu/DejaVuSans-Bold.ttf',
             '/Library/Fonts/DejaVuSans-Bold.ttf',
         ],
     },
@@ -53,16 +60,35 @@ const FONTS = [
 
 let registered = false;
 
+/**
+ * Where each family resolved, without registering anything.
+ *
+ * Exported so scripts/image-smoke.js can assert the built container actually
+ * carries the fonts *this table* asks for. It used to hardcode its own copy of
+ * the Alpine paths, which is how it came to fail a perfectly good image over a
+ * path the bot never needed.
+ *
+ * @returns {{ family: string, weight: string, optional: boolean, path: ?string }[]}
+ */
+function resolveFonts() {
+    return FONTS.map(font => ({
+        family: font.family,
+        weight: font.weight,
+        optional: Boolean(font.optional),
+        path: font.candidates.find(p => {
+            try { return fs.existsSync(p); } catch { return false; }
+        }) || null,
+    }));
+}
+
 function ensureFontsRegistered() {
     // registerFont must run before any canvas context is created, and
     // re-registering the same family is wasteful, so do it exactly once.
     if (registered) return;
     registered = true;
 
-    for (const font of FONTS) {
-        const found = font.candidates.find(p => {
-            try { return fs.existsSync(p); } catch { return false; }
-        });
+    for (const font of resolveFonts()) {
+        const found = font.path;
 
         if (!found) {
             const label = `${font.family}${font.weight === 'bold' ? ' (bold)' : ''}`;
@@ -82,4 +108,4 @@ function ensureFontsRegistered() {
     }
 }
 
-module.exports = { ensureFontsRegistered };
+module.exports = { ensureFontsRegistered, resolveFonts, FONTS };

--- a/src/utils/registerFonts.js
+++ b/src/utils/registerFonts.js
@@ -58,7 +58,13 @@ const FONTS = [
     },
 ];
 
+// The outcome of the one registration pass, memoized alongside the flag that
+// makes it happen once. Returning it is what lets a caller that wants to be
+// strict — scripts/image-smoke.js — see a family that resolved to a file and
+// then failed to register anyway, which warns here and is invisible to
+// everything else.
 let registered = false;
+let registrationReport = null;
 
 /**
  * Where each family resolved, without registering anything.
@@ -81,31 +87,47 @@ function resolveFonts() {
     }));
 }
 
+/**
+ * Registers every family in the table, once, and reports what happened.
+ *
+ * Nothing here throws: a bot that will not start because a font is missing is
+ * worse than one whose cards render in the wrong face. The report is how a
+ * caller that *does* want to fail — the image smoke test — can tell the two
+ * apart, since a family that resolved to a file and then failed to register is
+ * otherwise indistinguishable from a healthy one from the outside.
+ *
+ * @returns {{ family: string, weight: string, optional: boolean, path: ?string,
+ *             registered: boolean, error: ?string }[]}
+ */
 function ensureFontsRegistered() {
     // registerFont must run before any canvas context is created, and
     // re-registering the same family is wasteful, so do it exactly once.
-    if (registered) return;
+    if (registered) return registrationReport;
     registered = true;
 
-    for (const font of resolveFonts()) {
+    registrationReport = resolveFonts().map(font => {
+        const label = `${font.family}${font.weight === 'bold' ? ' (bold)' : ''}`;
         const found = font.path;
 
         if (!found) {
-            const label = `${font.family}${font.weight === 'bold' ? ' (bold)' : ''}`;
             if (font.optional) {
                 console.warn(`[FONTS] ${label} not found — emoji will render as fallback glyphs.`);
             } else {
                 console.warn(`[FONTS] ${label} not found in any known location — generated images will use canvas's default font.`);
             }
-            continue;
+            return { ...font, registered: false, error: 'not found' };
         }
 
         try {
             registerFont(found, { family: font.family, weight: font.weight });
+            return { ...font, registered: true, error: null };
         } catch (err) {
             console.warn(`[FONTS] Failed to register ${font.family} from ${found}: ${err.message}`);
+            return { ...font, registered: false, error: err.message };
         }
-    }
+    });
+
+    return registrationReport;
 }
 
 module.exports = { ensureFontsRegistered, resolveFonts, FONTS };

--- a/tests/ciSupplyChainGates.test.js
+++ b/tests/ciSupplyChainGates.test.js
@@ -1,0 +1,163 @@
+'use strict';
+
+/**
+ * The gates on the way to the registry — #645, #646 and #651.
+ *
+ * CI used to run `npm test` and nothing else, and the only thing that ever
+ * built the Dockerfile was the publish job, on `main`, after the merge. So the
+ * three ways a bad build reached production each had nothing in the way:
+ *
+ *   #645  a dependency with a published advisory, or a CVE in the base image or
+ *         an installed apk, was found by whoever happened to scan production.
+ *   #646  a Dockerfile regression was found by the deploy rather than by the
+ *         pull request that caused it — and this image compiles `canvas` from
+ *         source, which is the shape of thing a base-image bump breaks without
+ *         touching a line of JavaScript.
+ *   #651  two pushes to `main` a minute apart published `:latest` in whichever
+ *         order they happened to finish, so a slow build of the older commit
+ *         could overwrite a fast build of the newer one and leave production
+ *         running superseded code.
+ *
+ * Each fix is a few lines of YAML that nothing else refers to, which is exactly
+ * the kind of thing that gets dropped in a rewrite of the workflow and noticed
+ * a release later. This is what notices.
+ */
+
+const fs   = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const ROOT = path.join(__dirname, '..');
+const source = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'ci.yml'), 'utf8');
+const ci = yaml.load(source);
+
+const jobs = ci.jobs;
+const stepsOf = job => jobs[job].steps || [];
+const runScript = job => stepsOf(job).map(s => s.run || '').join('\n');
+
+// Found by what the job does rather than by its name, so renaming a job does
+// not quietly turn these assertions into no-ops against a job that no longer
+// exists.
+const jobWhoseBuild = pushes => Object.keys(jobs).find(name => stepsOf(name).some(
+    step => /build-push-action/.test(step.uses || '') && step.with && step.with.push === pushes));
+
+/** The job that pushes to the registry. */
+const publishJob = jobWhoseBuild(true);
+
+/** The job that builds the image and does not push it. */
+const buildJob = jobWhoseBuild(false);
+
+describe('#645 — the dependency tree is audited', () => {
+    test('some job runs npm audit', () => {
+        const audited = Object.keys(jobs).filter(name => /npm audit/.test(runScript(name)));
+        expect(audited).not.toEqual([]);
+    });
+
+    test('at --audit-level=high, so it fails rather than just printing', () => {
+        // `npm audit` without a level exits 0 on anything below critical in
+        // some npm versions and non-zero on everything in others; naming the
+        // level is what makes the gate mean one thing.
+        expect(source).toMatch(/npm audit[^\n]*--audit-level=high\b/);
+    });
+
+    test('and reports even when the suite failed', () => {
+        const step = stepsOf('test').find(s => /npm audit/.test(s.run || ''));
+        expect(step).toBeDefined();
+        expect(step.if).toBe('always()');
+    });
+});
+
+describe('#645 — the image is scanned', () => {
+    const scan = buildJob && stepsOf(buildJob).find(s => /trivy|grype|snyk/i.test(s.uses || ''));
+
+    test('a scanner runs over the built image', () => {
+        expect(scan).toBeDefined();
+    });
+
+    test('a finding fails the job rather than being printed and ignored', () => {
+        // Without exit-code the action reports and returns 0, which is a report
+        // nobody reads rather than a gate.
+        expect(String(scan.with['exit-code'])).toBe('1');
+    });
+
+    test('it gates at the same bar as the npm side', () => {
+        expect(scan.with.severity).toBe('HIGH,CRITICAL');
+        // Findings with no fixed version have no action attached to them and
+        // are most of an Alpine report; leaving them in makes the scan
+        // permanently red, which is the failure mode that gets a gate deleted.
+        expect(scan.with['ignore-unfixed']).toBe(true);
+    });
+
+    test('it runs before anything is pushed', () => {
+        expect(buildJob).not.toBe(publishJob);
+        expect(jobs[publishJob].needs).toContain(buildJob);
+    });
+});
+
+describe('#646 — the Dockerfile is built on pull requests', () => {
+    test('a job builds the image without pushing it', () => {
+        expect(buildJob).toBeDefined();
+    });
+
+    test('nothing excludes pull requests from it', () => {
+        // The publish job is `if: github.event_name != 'pull_request'`, which
+        // is right for a job holding `packages: write` and wrong for this one:
+        // a build that only runs after the merge is the whole of #646.
+        expect(jobs[buildJob].if).toBeUndefined();
+
+        const on = ci.on || ci[true];   // YAML 1.1 reads a bare `on:` as `true`
+        expect(Object.keys(on)).toContain('pull_request');
+    });
+
+    test('it loads the result, so the steps after it have something to run', () => {
+        const build = stepsOf(buildJob).find(s => /build-push-action/.test(s.uses || ''));
+        expect(build.with.load).toBe(true);
+        expect(build.with.tags).toBeTruthy();
+    });
+
+    test('it boots the image rather than only building it', () => {
+        // A build proves the layers resolve. It says nothing about whether the
+        // native canvas binding links, whether the fonts are where
+        // utils/registerFonts.js looks, or whether src/index.js can be required
+        // at all — which is the half that actually breaks.
+        const script = runScript(buildJob);
+        expect(script).toMatch(/docker run\b/);
+        expect(script).toContain('scripts/image-smoke.js');
+        expect(script).toContain('Missing required environment variables');
+    });
+
+    test('the smoke script it runs is in the image', () => {
+        expect(fs.existsSync(path.join(ROOT, 'scripts', 'image-smoke.js'))).toBe(true);
+
+        // .dockerignore decides what `COPY . .` actually carries. `tests` and
+        // `*.md` are excluded, so a smoke test placed there would be missing
+        // from the image with no build-time error.
+        const ignored = fs.readFileSync(path.join(ROOT, '.dockerignore'), 'utf8')
+            .split('\n').map(l => l.trim()).filter(l => l && !l.startsWith('#'));
+        expect(ignored).not.toContain('scripts');
+    });
+
+    test('the publish job cannot run without it', () => {
+        expect(jobs[publishJob].needs).toEqual(expect.arrayContaining([buildJob, 'test']));
+    });
+});
+
+describe('#651 — publishing is serialized', () => {
+    test('the workflow that publishes declares a concurrency group', () => {
+        // The publish job lives in this workflow, so the workflow-level group
+        // is what orders it. If publishing ever moves back out to a file of its
+        // own, that file needs its own group and this test needs to follow it.
+        expect(publishJob).toBeDefined();
+        expect(ci.concurrency).toBeDefined();
+    });
+
+    test('keyed on the ref, so two pushes to main cannot both be in flight', () => {
+        expect(ci.concurrency.group).toContain('github.ref');
+    });
+
+    test('newest wins — the older run is cancelled, not left to finish', () => {
+        // Without this the older run completes and repoints `:latest` after the
+        // newer one already did, which is #651 exactly.
+        expect(ci.concurrency['cancel-in-progress']).toBe(true);
+    });
+});

--- a/tests/dashboardPortAlignment.test.js
+++ b/tests/dashboardPortAlignment.test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+/**
+ * #650. The image's HEALTHCHECK and EXPOSE both hardcoded 3000 while the
+ * production stack was read as running on 7001, so the check probed a port
+ * nothing was listening on. Nothing broke, because portainer-stack.yml declares
+ * a healthcheck of its own that overrode the image's — which is the worst
+ * version of this: the mismatch was real, silent, and one deleted override away
+ * from a container that reported unhealthy forever.
+ *
+ * The healthcheck was fixed under #641 and now reads DASHBOARD_PORT. What was
+ * left was that nothing held the arrangement together, and it is spread across
+ * four files that no one edits at the same time: the Dockerfile's EXPOSE, the
+ * container side of each stack's port mapping, and the DASHBOARD_PORT default
+ * each stack passes in.
+ *
+ * The distinction the whole thing turns on: DASHBOARD_HOST_PORT is a free
+ * choice per deployment (compose 3000, Portainer 7001, and a reverse proxy
+ * points at whichever), while DASHBOARD_PORT — the container's own side — is a
+ * constant, because EXPOSE is image metadata that cannot follow a runtime
+ * value. This asserts the constant, and asserts the healthchecks still read the
+ * variable rather than reintroducing the literal.
+ */
+
+const fs   = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const ROOT = path.join(__dirname, '..');
+const read = name => fs.readFileSync(path.join(ROOT, name), 'utf8');
+
+const dockerfile = read('Dockerfile');
+const stacks = [
+    ['docker-compose.yml', yaml.load(read('docker-compose.yml'))],
+    ['portainer-stack.yml', yaml.load(read('portainer-stack.yml'))],
+];
+
+/** The `EXPOSE <port>` the runtime stage declares. */
+const exposed = (() => {
+    const line = dockerfile.split('\n').find(l => /^EXPOSE\s/.test(l));
+    if (!line) throw new Error('the Dockerfile declares no EXPOSE');
+    return Number(line.trim().split(/\s+/)[1]);
+})();
+
+/** `"127.0.0.1:${HOST:-x}:${CONTAINER:-y}"` -> the container half, verbatim. */
+function containerSideOf(mapping) {
+    // Splitting on ':' would cut the `${VAR:-default}` substitutions in half,
+    // so take the last mapping segment by matching the substitution instead.
+    const parts = String(mapping).match(/\$\{[^}]+\}/g) || [];
+    return parts[parts.length - 1];
+}
+
+/** The default in a `${NAME:-default}` substitution. */
+function defaultOf(substitution) {
+    const m = /^\$\{[A-Z_]+:-([^}]*)\}$/.exec(substitution || '');
+    return m ? m[1] : null;
+}
+
+describe('Dockerfile', () => {
+    test('EXPOSEs the container-side port', () => {
+        expect(exposed).toBe(3000);
+    });
+
+    test('its healthcheck reads DASHBOARD_PORT rather than the literal', () => {
+        // The literal is still there as the fallback, which is correct — it is
+        // the same constant EXPOSE declares. What must not come back is the
+        // literal *alone*, with no way for a deployment that moves the port to
+        // be probed on the one it moved to.
+        const healthcheck = dockerfile.slice(dockerfile.indexOf('HEALTHCHECK'));
+        expect(healthcheck).toContain('process.env.DASHBOARD_PORT');
+        expect(healthcheck).toContain(`|| ${exposed}`);
+    });
+});
+
+describe.each(stacks)('%s', (name, doc) => {
+    const mapping = (doc.services.bot.ports || [])[0];
+
+    test('maps a host port onto the port the image EXPOSEs', () => {
+        const containerSide = containerSideOf(mapping);
+        expect([name, defaultOf(containerSide)]).toEqual([name, String(exposed)]);
+    });
+
+    test('leaves the host side free to differ', () => {
+        // Not cosmetic: compose binds 3000 and the production stack binds 7001,
+        // and reading that difference as "production runs on 7001" is what #650
+        // was. Both are the *host* side; the container is on 3000 in both.
+        expect(String(mapping)).toMatch(/DASHBOARD_HOST_PORT:-\d+/);
+    });
+
+    test('its healthcheck probes DASHBOARD_PORT, defaulting to the same port', () => {
+        const test_ = doc.services.bot.healthcheck.test.join(' ');
+        expect([name, test_.includes('process.env.DASHBOARD_PORT')]).toEqual([name, true]);
+        expect([name, test_.includes(`|| ${exposed}`)]).toEqual([name, true]);
+    });
+});
+
+describe('portainer-stack.yml', () => {
+    const doc = yaml.load(read('portainer-stack.yml'));
+
+    test('passes DASHBOARD_PORT with the same default the image assumes', () => {
+        // This stack lists environment as `KEY=value` strings rather than a
+        // map, because Portainer's stack editor writes them that way.
+        const env = doc.services.bot.environment;
+        const entry = (Array.isArray(env) ? env : Object.entries(env).map(([k, v]) => `${k}=${v}`))
+            .find(e => e.startsWith('DASHBOARD_PORT='));
+
+        expect(entry).toBeDefined();
+        expect(defaultOf(entry.split('=').slice(1).join('='))).toBe(String(exposed));
+    });
+});

--- a/tests/lintGate.test.js
+++ b/tests/lintGate.test.js
@@ -20,9 +20,11 @@ describe('lint gate', () => {
     });
 
     test('CI runs it, in the job the image publish depends on', () => {
-        const testJob = ci.slice(ci.indexOf('\n  test:'), ci.indexOf('\n  publish:'));
+        // Bounded at the next job rather than at `publish:`, which is no longer
+        // the one after it — the image build and scan sit between them (#646).
+        const testJob = ci.slice(ci.indexOf('\n  test:'), ci.indexOf('\n  image:'));
         expect(testJob).toMatch(/run: npm run lint/);
-        expect(ci).toMatch(/needs: test/);
+        expect(ci).toMatch(/needs: \[test, image\]/);
     });
 
     // Without `if: always()` a failing test hides the lint result and vice

--- a/tests/registerFonts.test.js
+++ b/tests/registerFonts.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+/**
+ * The font table, and the resolution scripts/image-smoke.js asks it for.
+ *
+ * The candidate lists exist because the same package installs to a different
+ * directory on each distro, and getting one wrong is invisible: canvas renders
+ * either way, just in its own fallback face. That is exactly what happened to
+ * the Alpine entry — `ttf-dejavu` installs into /usr/share/fonts/dejavu/, not
+ * the /usr/share/fonts/ttf-dejavu/ the package name implies, and the path that
+ * was actually serving the shipped image had been labelled Fedora/RHEL. The bot
+ * was fine; the comment was wrong for years, and nothing could have said so
+ * without looking inside a built container.
+ *
+ * So the check that matters runs in the image (scripts/image-smoke.js, via the
+ * `image` job in CI). What is worth holding here is the contract that check
+ * depends on: resolution reports rather than throws, registers nothing, and
+ * distinguishes a required family from an optional one.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { resolveFonts, FONTS } = require('../src/utils/registerFonts');
+
+describe('font table', () => {
+    test('every family lists candidates and names its weight', () => {
+        expect(FONTS.length).toBeGreaterThan(0);
+        for (const font of FONTS) {
+            expect(typeof font.family).toBe('string');
+            expect(['normal', 'bold']).toContain(font.weight);
+            expect(font.candidates.length).toBeGreaterThan(0);
+            for (const candidate of font.candidates) {
+                expect([candidate, path.isAbsolute(candidate)]).toEqual([candidate, true]);
+            }
+        }
+    });
+
+    test('the DejaVu faces the image installs are reachable by an Alpine path', () => {
+        // The Dockerfile's `apk add ttf-dejavu`. Losing this candidate would
+        // downgrade every generated card in the shipped image and nothing in a
+        // checkout-only test run would notice.
+        const dejavu = FONTS.filter(f => f.family === 'DejaVu Sans');
+        expect(dejavu).toHaveLength(2);
+        for (const font of dejavu) {
+            expect(font.candidates).toContain(
+                `/usr/share/fonts/dejavu/DejaVuSans${font.weight === 'bold' ? '-Bold' : ''}.ttf`);
+        }
+    });
+
+    test('emoji are optional and the text faces are not', () => {
+        // registerFonts.js warns either way; the difference is what
+        // scripts/image-smoke.js fails the build over.
+        const optional = FONTS.filter(f => f.optional).map(f => f.family);
+        expect(optional).toEqual(['Noto Color Emoji']);
+    });
+});
+
+describe('resolveFonts', () => {
+    test('reports one entry per family, carrying the fields the smoke test reads', () => {
+        const resolved = resolveFonts();
+        expect(resolved).toHaveLength(FONTS.length);
+
+        for (const [i, entry] of resolved.entries()) {
+            expect(entry.family).toBe(FONTS[i].family);
+            expect(entry.weight).toBe(FONTS[i].weight);
+            expect(typeof entry.optional).toBe('boolean');
+            expect(entry.path === null || typeof entry.path === 'string').toBe(true);
+        }
+    });
+
+    test('resolves to the first candidate that exists', () => {
+        const [first] = FONTS;
+        const spy = jest.spyOn(fs, 'existsSync').mockImplementation(p => p === first.candidates[1]);
+
+        expect(resolveFonts()[0].path).toBe(first.candidates[1]);
+
+        spy.mockRestore();
+    });
+
+    test('reports a missing family as null rather than throwing', () => {
+        // The bot must start on a host with no fonts at all — a generated card
+        // in the wrong face is worse than nothing, but not worse than a crash.
+        const spy = jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+        expect(resolveFonts().map(f => f.path)).toEqual(FONTS.map(() => null));
+
+        spy.mockRestore();
+    });
+
+    test('survives an existsSync that throws', () => {
+        // A path under a directory the process cannot stat. Swallowed per
+        // candidate, so one unreadable mount cannot take the rest down.
+        const spy = jest.spyOn(fs, 'existsSync').mockImplementation(() => { throw new Error('EACCES'); });
+
+        expect(() => resolveFonts()).not.toThrow();
+        expect(resolveFonts()[0].path).toBeNull();
+
+        spy.mockRestore();
+    });
+
+    test('registers nothing — the smoke test calls it before deciding to', () => {
+        // resolveFonts() must stay side-effect free: ensureFontsRegistered()
+        // guards itself with a once-flag, and a resolution that tripped it
+        // would leave the real registration a no-op.
+        const canvas = require('canvas');
+        const spy = jest.spyOn(canvas, 'registerFont');
+
+        resolveFonts();
+
+        expect(spy).not.toHaveBeenCalled();
+        spy.mockRestore();
+    });
+});

--- a/tests/registerFonts.test.js
+++ b/tests/registerFonts.test.js
@@ -112,3 +112,89 @@ describe('resolveFonts', () => {
         spy.mockRestore();
     });
 });
+
+describe('ensureFontsRegistered', () => {
+    // The module memoizes its one pass, so each case needs a fresh copy of it
+    // with canvas mocked before the top-level destructure of registerFont.
+    const load = registerFont => {
+        let mod;
+        jest.isolateModules(() => {
+            jest.doMock('canvas', () => ({ registerFont }));
+            mod = require('../src/utils/registerFonts');
+        });
+        return mod;
+    };
+
+    afterEach(() => {
+        jest.dontMock('canvas');
+        jest.restoreAllMocks();
+    });
+
+    test('registers every resolved family and says so', () => {
+        jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+        const registerFont = jest.fn();
+
+        const report = load(registerFont).ensureFontsRegistered();
+
+        expect(registerFont).toHaveBeenCalledTimes(FONTS.length);
+        expect(report.map(f => f.registered)).toEqual(FONTS.map(() => true));
+        expect(report.every(f => f.error === null)).toBe(true);
+    });
+
+    test('reports a font that resolved and then failed to register', () => {
+        // The gap this report exists for: the file is at the expected path, so
+        // resolution is happy, and registerFont rejects it anyway — a truncated
+        // copy, or a format this build of canvas cannot read. Without the
+        // report that is a warning on stderr and nothing else, and every
+        // generated card silently drops to the fallback face.
+        jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const registerFont = jest.fn(() => { throw new Error('Could not parse font file'); });
+
+        const report = load(registerFont).ensureFontsRegistered();
+
+        expect(report.every(f => f.registered)).toBe(false);
+        for (const font of report) {
+            expect(font.registered).toBe(false);
+            expect(font.error).toBe('Could not parse font file');
+        }
+    });
+
+    test('does not throw when a font cannot be registered', () => {
+        // A bot that refuses to start over a font is worse than one whose cards
+        // render in the wrong face, so the failure stays non-fatal here. Only
+        // the image smoke test turns it into an error, and only for the
+        // families the table marks required.
+        jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const mod = load(() => { throw new Error('boom'); });
+
+        expect(() => mod.ensureFontsRegistered()).not.toThrow();
+    });
+
+    test('marks a family that resolved nowhere as not registered', () => {
+        jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const registerFont = jest.fn();
+
+        const report = load(registerFont).ensureFontsRegistered();
+
+        expect(registerFont).not.toHaveBeenCalled();
+        expect(report.map(f => f.error)).toEqual(FONTS.map(() => 'not found'));
+    });
+
+    test('registers once and returns the same report on every later call', () => {
+        // registerFont must run before any canvas context is created, and the
+        // report has to survive the early return — a second caller that got
+        // undefined back would read it as "nothing failed".
+        jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+        const registerFont = jest.fn();
+        const mod = load(registerFont);
+
+        const first = mod.ensureFontsRegistered();
+        const second = mod.ensureFontsRegistered();
+
+        expect(registerFont).toHaveBeenCalledTimes(FONTS.length);
+        expect(second).toBe(first);
+    });
+});

--- a/tests/scheduledTaskService.test.js
+++ b/tests/scheduledTaskService.test.js
@@ -172,19 +172,36 @@ describe('claiming a due task', () => {
     });
 
     test('advances a monthly task from the day it meant, not the last clamp', async () => {
-        due([makeTask({
-            repeat: 'monthly', monthDay: 31,
-            fireAt: new Date('2026-02-28T09:00:00Z'), timezone: 'Etc/UTC',
-        })]);
+        // On the real clock this test asserted whatever month it happened to run
+        // in. runDueTasks() reads `new Date()` (unlike nextOccurrence(), which
+        // takes `now`), so the occurrence it lands on moves with the calendar —
+        // and lands on a 30-day month one run in three, where a monthDay of 31
+        // correctly clamps to 30 and the assertion below fails. It ran green for
+        // months and went red on the 31st.
+        //
+        // Pinned to the NOW the rest of this file already uses, which puts the
+        // next occurrence in July: a 31-day month, so the day survives and the
+        // property being tested is the one actually asserted. The clamping
+        // behaviour on a short month is nextOccurrence()'s own business and is
+        // covered above, where `now` is a parameter rather than the wall clock.
+        jest.useFakeTimers().setSystemTime(NOW);
+        try {
+            due([makeTask({
+                repeat: 'monthly', monthDay: 31,
+                fireAt: new Date('2026-02-28T09:00:00Z'), timezone: 'Etc/UTC',
+            })]);
 
-        await runDueTasks(makeClient(textChannel()));
+            await runDueTasks(makeClient(textChannel()));
+        } finally {
+            jest.useRealTimers();
+        }
 
         // Months behind, so the claim skips forward to the next future
         // occurrence — and the day the task meant survives every one of those
         // steps rather than being lost to the first short month it crossed.
         const [, update] = ScheduledTask.findOneAndUpdate.mock.calls[0];
         expect(update.$set.fireAt.getUTCDate()).toBe(31);
-        expect(update.$set.fireAt.getTime()).toBeGreaterThan(Date.now());
+        expect(update.$set.fireAt.getTime()).toBeGreaterThan(NOW.getTime());
     });
 
     test('runs each task inside its own job scope, so one guild cannot drop another', async () => {


### PR DESCRIPTION
Closes #645. Closes #646. Closes #650. Closes #651.

CI ran the tests and the linter and nothing else, and the only thing that
ever built the Dockerfile was the publish job — on main, after the merge.
So each of the three ways a bad build reached production had nothing in
the way of it.

Dependencies are audited (#645). `npm audit --audit-level=high` over the
whole tree, dev dependencies included: a compromised build-time package
runs against the checkout with a registry credential nearby, which is not
obviously the smaller problem. `high` rather than `moderate` because a
gate that is normally red is a gate everyone learns to merge past. It runs
under `always()` alongside lint, so an advisory never hides which tests
failed and a failing suite never hides the advisory.

The image is built on every event, pull requests included (#646). This
image compiles canvas from source against Alpine's cairo/pango in one
stage and links it against a separately-installed set of runtime libraries
in the next, which is exactly the shape of thing a base-image bump breaks
without touching a line of JavaScript — and the first symptom used to be a
failed publish on a branch that was already merged. The new job builds
without pushing, then does the two things a build alone cannot:

  - scripts/image-smoke.js, run inside the container. The native binding
    loads and encodes a real PNG, every font the card generators need
    resolves *and* registers, the process is not root, NODE_ENV is
    production. Fonts are checked by resolution and registration rather
    than by asking canvas whether text rendered, because it renders either
    way — just in the wrong font, which is the silent downgrade
    registerFonts.js was written for.
  - the real entrypoint with no configuration at all, which loads the
    entire require graph below src/index.js and is then turned away by
    config/validateEnv.js. Reaching that message means every layer
    resolved; anything else fails before it.

Then Trivy over the result (#645), HIGH and CRITICAL only and
`ignore-unfixed`, matching the bar the npm side uses. It runs before
anything is pushed, so a finding stops the image existing rather than
being raised against one already deployed. publish now needs both jobs,
and shares this one's build cache rather than compiling canvas twice.

Publishing was already serialized by the workflow-level concurrency group
it inherited when it stopped being a separate file (#651); what was
missing was anything saying so, or noticing if it went. Both are here now.

EXPOSE still says 3000 (#650). It is image metadata — it publishes nothing
and binds nothing — so it cannot follow a value only known at `docker run`
time, and a build argument would only be right for whoever remembered to
pass it. The container-side port is a constant and the host side is the
free choice; reading the production stack's 7001 as the container's port
is what #650 was. The healthcheck has read DASHBOARD_PORT since #641, and
tests/dashboardPortAlignment.test.js now fails if EXPOSE, either stack's
container-side mapping, or either DASHBOARD_PORT default stops agreeing
with the others.

## What the new gates found on their own first runs

Each of these is a commit on this branch, not a hypothetical:

  - The Alpine font path in registerFonts.js was mislabelled. `apk add
    ttf-dejavu` installs into /usr/share/fonts/dejavu/, not the
    /usr/share/fonts/ttf-dejavu/ the package name implies; the candidate
    actually serving the shipped image had been labelled Fedora/RHEL.
  - Seven HIGH CVEs, all in the base image and none in the lockfile
    (`npm audit` is clean). `node:24-alpine` still resolves to the digest
    already pinned here, so there was no newer base to move to: giflib and
    openssl are fixed in Alpine but not yet in a rebuild, so the runtime
    stage now runs `apk upgrade`; the other four were the npm bundled in
    the base image, which this image never runs and which is now deleted.

## Out of scope, included because it blocked this branch

tests/scheduledTaskService.test.js asserted that a monthly task advances
to day 31, but runDueTasks() reads `new Date()`, so the occurrence it
lands on moves with the calendar — roughly one month in three it lands on
a 30-day month, where clamping to 30 is correct and the assertion fails.
It went red on the 31st. The service is right; the test was reading the
wall clock, and is now pinned to the NOW the rest of the file defines.
Happy to split this out if it should not ride along.
