### PR TITLE
Fix accessibility issues: icon buttons, migrations, and alt text

### DIFF
--- a/src/commands/economy/fish/shop.js
+++ b/src/commands/economy/fish/shop.js
@@ -172,7 +172,7 @@ async function handleBuyRod(interaction, user, currency) {
         )
         .setFooter({ text: 'Confirmation expires in 30 seconds' });
 
-    const rodImg = await getItemImageAttachment(`fish:${rodData.slug || rodData.id}`, interaction.guild.id).catch(() => null);
+    const rodImg = await getItemImageAttachment(`fish:${rodData.slug || rodData.id}`, interaction.guild.id, { label: rodData.name }).catch(() => null);
     if (rodImg) confirmEmbed.setThumbnail(rodImg.url);
 
     const row = new ActionRowBuilder().addComponents(

--- a/src/commands/economy/hunt/shop.js
+++ b/src/commands/economy/hunt/shop.js
@@ -231,7 +231,7 @@ async function handleBuyWeapon(interaction, user, currency) {
         });
     }
 
-    const weaponImg = await getItemImageAttachment(`hunt:${weaponData.slug || weaponData.id}`, interaction.guild.id).catch(() => null);
+    const weaponImg = await getItemImageAttachment(`hunt:${weaponData.slug || weaponData.id}`, interaction.guild.id, { label: weaponData.name }).catch(() => null);
     if (weaponImg) confirmEmbed.setThumbnail(weaponImg.url);
 
     const row = new ActionRowBuilder().addComponents(

--- a/src/commands/economy/mine/shop.js
+++ b/src/commands/economy/mine/shop.js
@@ -157,7 +157,7 @@ async function handleShop(interaction, sub) {
             )
             .setFooter({ text: 'Confirmation expires in 30 seconds' });
 
-        const pickaxeImg = await getItemImageAttachment(`mine:${pickaxeData.slug || pickaxeData.id}`, interaction.guild.id).catch(() => null);
+        const pickaxeImg = await getItemImageAttachment(`mine:${pickaxeData.slug || pickaxeData.id}`, interaction.guild.id, { label: pickaxeData.name }).catch(() => null);
         if (pickaxeImg) confirmEmbed.setThumbnail(pickaxeImg.url);
 
         const row = new ActionRowBuilder().addComponents(

--- a/src/commands/economy/pet.js
+++ b/src/commands/economy/pet.js
@@ -696,7 +696,10 @@ async function executeStatus(interaction) {
                 const spriteBuf = await generatePetSprite(pet.petId, 80, pet.evolutionStage ?? 1);
                 if (spriteBuf) {
                     showcaseEmbed.setThumbnail('attachment://pet_sprite.png');
-                    files = [new AttachmentBuilder(spriteBuf, { name: 'pet_sprite.png' })];
+                    files = [new AttachmentBuilder(spriteBuf, {
+                        name: 'pet_sprite.png',
+                        description: `Pixel-art sprite of ${name}.`,
+                    })];
                 }
             } catch { /* non-critical */ }
 

--- a/src/commands/economy/shop.js
+++ b/src/commands/economy/shop.js
@@ -628,7 +628,7 @@ module.exports = {
                     successEmbed.addFields({ name: 'Role Granted', value: `<@&${freshItem.roleId}>`, inline: true });
                 }
 
-                const successImg = await getItemImageAttachment(freshItem.itemId, interaction.guildId).catch(() => null);
+                const successImg = await getItemImageAttachment(freshItem.itemId, interaction.guildId, { label: freshItem.name }).catch(() => null);
                 if (successImg) successEmbed.setThumbnail(successImg.url);
                 const successPayload = { embeds: [successEmbed], components: [] };
                 if (successImg) successPayload.files = [successImg.attachment];
@@ -668,7 +668,7 @@ module.exports = {
                     )
                     .setFooter({ text: 'This confirmation expires in 30 seconds' });
 
-                const confirmImg = await getItemImageAttachment(item.itemId, interaction.guildId).catch(() => null);
+                const confirmImg = await getItemImageAttachment(item.itemId, interaction.guildId, { label: item.name }).catch(() => null);
                 if (confirmImg) confirmEmbed.setThumbnail(confirmImg.url);
                 const confirmPayload = { embeds: [confirmEmbed], components: [row], fetchReply: true };
                 if (confirmImg) confirmPayload.files = [confirmImg.attachment];

--- a/src/commands/fun/8ball.js
+++ b/src/commands/fun/8ball.js
@@ -266,7 +266,10 @@ async function shake(responder, { quoted, shakes, ownerId }) {
     }
 
     const response = pickResponse();
-    const ball = new AttachmentBuilder(renderEightBall(response.text, response.type), { name: BALL_FILE });
+    const ball = new AttachmentBuilder(renderEightBall(response.text, response.type), {
+        name: BALL_FILE,
+        description: `A magic 8-ball, its window reading "${response.text}".`,
+    });
 
     return responder.editReply({
         components:      [resultView(quoted, response, shakes, ownerId)],

--- a/src/commands/fun/achievement.js
+++ b/src/commands/fun/achievement.js
@@ -25,7 +25,10 @@ module.exports = {
         try {
             await interaction.deferReply();
             const buf        = await createAchievementCard(text, null, null);
-            const attachment = new AttachmentBuilder(buf, { name: 'achievement.png' });
+            const attachment = new AttachmentBuilder(buf, {
+                name: 'achievement.png',
+                description: `A Minecraft-style achievement popup reading "${text}".`,
+            });
             await interaction.editReply({ files: [attachment] });
         } catch (err) {
             console.error('achievement: render failed', err);

--- a/src/commands/fun/caption.js
+++ b/src/commands/fun/caption.js
@@ -78,7 +78,10 @@ module.exports = {
 
             ctx.drawImage(src, 0, captionH, w, h);
 
-            const attachment = new AttachmentBuilder(await encodeCanvas(canvas), { name: 'caption.png' });
+            const attachment = new AttachmentBuilder(await encodeCanvas(canvas), {
+                name: 'caption.png',
+                description: `The supplied image, captioned "${text}" in black on white above it.`,
+            });
             await interaction.editReply({ files: [attachment] });
         } catch (err) {
             console.error('caption: image load or render failed', err);

--- a/src/commands/fun/wanted.js
+++ b/src/commands/fun/wanted.js
@@ -112,7 +112,10 @@ async function generatePoster(interaction, target) {
             ctx.fillStyle = '#3a1a00';
             ctx.fillText('Contact your local sheriff', W / 2, AVATAR_Y + AVATAR_SIZE + 130);
 
-            const attachment = new AttachmentBuilder(await encodeCanvas(canvas), { name: 'wanted.png' });
+            const attachment = new AttachmentBuilder(await encodeCanvas(canvas), {
+                name: 'wanted.png',
+                description: `A Wild West wanted poster for ${target.username}, reward ${reward}.`,
+            });
             const regenId = `wanted_regen_${interaction.id}_${Date.now()}`;
             const row = new ActionRowBuilder().addComponents(
                 new ButtonBuilder().setCustomId(regenId).setLabel('🤠 Wanted: Me').setStyle(ButtonStyle.Secondary),

--- a/src/commands/fun/wasted.js
+++ b/src/commands/fun/wasted.js
@@ -69,7 +69,10 @@ async function generateWasted(interaction, target) {
             ctx.lineWidth    = 4;
             ctx.strokeText('WASTED', SIZE / 2, SIZE / 2);
 
-            const attachment = new AttachmentBuilder(await encodeCanvas(canvas), { name: 'wasted.png' });
+            const attachment = new AttachmentBuilder(await encodeCanvas(canvas), {
+                name: 'wasted.png',
+                description: `${target.username}'s avatar, greyed out under the word WASTED.`,
+            });
             const regenId = `wasted_regen_${interaction.id}_${Date.now()}`;
             const row = new ActionRowBuilder().addComponents(
                 new ButtonBuilder().setCustomId(regenId).setLabel('💀 Waste: Me').setStyle(ButtonStyle.Secondary),

--- a/src/commands/leveling/rank.js
+++ b/src/commands/leveling/rank.js
@@ -72,7 +72,13 @@ module.exports = {
             const rarestCatch     = getRarestCatch(user);
 
             const card       = await createRankCard(targetUser, user, rank, requiredXp, { streakCurrent, hasActiveBoost, rarestCatch });
-            const attachment = new AttachmentBuilder(card, { name: 'rank.png' });
+            const attachment = new AttachmentBuilder(card, {
+                name: 'rank.png',
+                description:
+                    `Rank card for ${targetUser.username}: level ${user.level}, ` +
+                    `${user.xp.toLocaleString()} of ${requiredXp.toLocaleString()} XP ` +
+                    `towards level ${user.level + 1}, ranked #${rank} in the server.`,
+            });
 
             const serverCoinMult = getServerCoinMultiplier(guildSettings);
             const serverXpMult   = getServerXpMultiplier(guildSettings);
@@ -102,35 +108,39 @@ module.exports = {
                 return { name: '🪪 Identity', value: parts.join('\n'), inline: false };
             })();
 
-            if (activeBoosters.length || hasServerBoost) {
-                const lines = [];
-                if (hasServerBoost) {
-                    const boostType = sb.type === 'coin' ? `💰 ${serverCoinMult}x Coins` : `⭐ ${serverXpMult}x XP`;
-                    lines.push(`🌐 **Server Boost** — ${boostType} (${timeRemaining(sb.expiresAt)} remaining)`);
-                }
-                for (const e of activeBoosters) {
-                    const cfg = EFFECT_CONFIGS[e.type];
-                    if (!cfg) continue;
-                    lines.push(`${cfg.emoji} **${cfg.label}** — ${timeRemaining(e.expiresAt)}`);
-                }
-                const boosterEmbed = new EmbedBuilder()
-                    .setColor(COLORS.WARN)
-                    .addFields({ name: '🚀 Active Boosters', value: lines.join('\n'), inline: false });
-                if (identityField) boosterEmbed.addFields(identityField);
-                if (xpHint) boosterEmbed.setFooter({ text: xpHint });
-                await interaction.reply({ files: [attachment], embeds: [boosterEmbed] });
-            } else if (identityField) {
-                const idEmbed = new EmbedBuilder().setColor(COLORS.RARE).addFields(identityField);
-                if (xpHint) idEmbed.setFooter({ text: xpHint });
-                await interaction.reply({ files: [attachment], embeds: [idEmbed] });
-            } else if (xpHint) {
-                const hintEmbed = new EmbedBuilder()
-                    .setColor(COLORS.NEUTRAL)
-                    .setFooter({ text: xpHint });
-                await interaction.reply({ files: [attachment], embeds: [hintEmbed] });
-            } else {
-                await interaction.reply({ files: [attachment] });
+            const boosterLines = [];
+            if (hasServerBoost) {
+                const boostType = sb.type === 'coin' ? `💰 ${serverCoinMult}x Coins` : `⭐ ${serverXpMult}x XP`;
+                boosterLines.push(`🌐 **Server Boost** — ${boostType} (${timeRemaining(sb.expiresAt)} remaining)`);
             }
+            for (const e of activeBoosters) {
+                const cfg = EFFECT_CONFIGS[e.type];
+                if (!cfg) continue;
+                boosterLines.push(`${cfg.emoji} **${cfg.label}** — ${timeRemaining(e.expiresAt)}`);
+            }
+
+            // #672. The three numbers this command exists to report — level, XP
+            // and position — used to live only on the PNG, and in the common
+            // case (no boosters, no prestige, no excluded channels) the reply
+            // was the PNG and nothing else. Anyone reading the message through
+            // a screen reader, or on a client that failed to load the image,
+            // got a rank card with no rank on it. So the embed is unconditional
+            // now and carries the numbers; the card illustrates them.
+            const rankEmbed = new EmbedBuilder()
+                .setColor(boosterLines.length ? COLORS.WARN : identityField ? COLORS.RARE : COLORS.NEUTRAL)
+                .setAuthor({ name: `${targetUser.username} — rank #${rank}`, iconURL: targetUser.displayAvatarURL() })
+                .addFields(
+                    { name: '📊 Level', value: `${user.level}`, inline: true },
+                    { name: '⭐ XP', value: `${user.xp.toLocaleString()} / ${requiredXp.toLocaleString()}`, inline: true },
+                    { name: '🏆 Server rank', value: `#${rank}`, inline: true },
+                );
+            if (boosterLines.length) {
+                rankEmbed.addFields({ name: '🚀 Active Boosters', value: boosterLines.join('\n'), inline: false });
+            }
+            if (identityField) rankEmbed.addFields(identityField);
+            if (xpHint) rankEmbed.setFooter({ text: xpHint });
+
+            await interaction.reply({ files: [attachment], embeds: [rankEmbed] });
         } catch (error) {
             console.error('Rank error:', error);
             await interaction.reply({ content: 'Failed to fetch rank.', flags: MessageFlags.Ephemeral });

--- a/src/dashboard/public/guild-settings.js
+++ b/src/dashboard/public/guild-settings.js
@@ -501,7 +501,7 @@ function renderEscalationLadder() {
             <div><label class="field-label" style="font-size:.75rem;" for="esc-${idx}-duration">Duration (min)</label><input type="number" id="esc-${idx}-duration" min="1" max="40320" value="${step.durationMinutes ?? ''}" ${needsDuration ? '' : 'disabled'} data-esc-idx="${idx}" data-esc-key="durationMinutes"></div>
             <div><label class="field-label" style="font-size:.75rem;" for="esc-${idx}-dm">DM</label><input type="checkbox" id="esc-${idx}-dm" ${step.dmUser !== false ? 'checked' : ''} data-esc-idx="${idx}" data-esc-key="dmUser"></div>
             <div><label class="field-label" style="font-size:.75rem;" for="esc-${idx}-reason">Reason (supports {count})</label><input type="text" id="esc-${idx}-reason" value="${escapeHtml(step.reason || '')}" data-esc-idx="${idx}" data-esc-key="reason"></div>
-            <div><button type="button" class="btn btn-sm" onclick="removeEscalationStep(${idx})">✕</button></div>
+            <div><button type="button" class="btn btn-sm" onclick="removeEscalationStep(${idx})" aria-label="Remove escalation step ${idx + 1}">✕</button></div>
         </div>`;
     }).join('');
 
@@ -1245,7 +1245,7 @@ function renderCpRules() {
         return '<div class="store-item-card" style="padding:.6rem .9rem;display:flex;align-items:center;gap:.75rem;">' +
             '<span style="flex:1"><strong>' + escHtml(r.command) + '</strong> — <span style="color:' + color + '">' + escHtml(r.effect) + '</span></span>' +
             '<button class="btn btn-sm" onclick="openCpRuleModal(' + i + ')">Edit</button>' +
-            '<button class="btn btn-sm" style="color:#e74c3c" onclick="_cpRules.splice(' + i + ',1);renderCpRules()">✕</button></div>';
+            '<button class="btn btn-sm" style="color:#e74c3c" onclick="_cpRules.splice(' + i + ',1);renderCpRules()" aria-label="Remove the ' + escHtml(r.command) + ' rule">✕</button></div>';
     }).join('');
 }
 var _cpRoleMap = boot('roleNames');
@@ -1257,7 +1257,7 @@ function renderCpCooldowns() {
         return '<div class="store-item-card" style="padding:.6rem .9rem;display:flex;align-items:center;gap:.75rem;">' +
             '<span style="flex:1"><strong>' + escHtml(c.command) + '</strong> — ' + escHtml(roleName) + ' → ' + escHtml(c.cooldownSeconds) + 's</span>' +
             '<button class="btn btn-sm" onclick="openCpCooldownModal(' + i + ')">Edit</button>' +
-            '<button class="btn btn-sm" style="color:#e74c3c" onclick="_cpCooldowns.splice(' + i + ',1);renderCpCooldowns()">✕</button></div>';
+            '<button class="btn btn-sm" style="color:#e74c3c" onclick="_cpCooldowns.splice(' + i + ',1);renderCpCooldowns()" aria-label="Remove the ' + escHtml(c.command) + ' cooldown override">✕</button></div>';
     }).join('');
 }
 function openCpRuleModal(idx) {
@@ -1324,6 +1324,7 @@ function addCpExcRole() {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.title = 'Remove';
+    btn.setAttribute('aria-label', 'Remove ' + roleName);
     btn.textContent = '×';
     btn.onclick = function() { tag.remove(); };
     tag.appendChild(btn);
@@ -1584,8 +1585,8 @@ function renderJobs() {
             (job.emoji ? '<span class="job-chip-emoji">' + escHtml(job.emoji) + '</span>' : '') +
             '<span class="job-name">' + escHtml(job.name) + '</span>' +
             '<span class="job-pay-badge">💰 ' + minPay + '–' + maxPay + '</span>' +
-            '<button class="job-btn" onclick="openJobModal(' + i + ')" title="Edit">✏️</button>' +
-            '<button class="job-btn" onclick="deleteJob(' + i + ')" title="Remove" style="font-size:1rem">×</button>' +
+            '<button class="job-btn" onclick="openJobModal(' + i + ')" title="Edit" aria-label="Edit the ' + escHtml(job.name) + ' job">✏️</button>' +
+            '<button class="job-btn" onclick="deleteJob(' + i + ')" title="Remove" style="font-size:1rem" aria-label="Remove the ' + escHtml(job.name) + ' job">×</button>' +
         '</div>';
     });
     if (lastTier !== null) html += '</div>';
@@ -2027,7 +2028,7 @@ function addRrMapping() {
         '<select class="rr-role" aria-label="Role to assign"><option value="">Select role</option>' +
         rrRoles.map(function(r) { return '<option value="' + r.id + '">@' + escHtml(r.name) + '</option>'; }).join('') +
         '</select>' +
-        '<button class="btn btn-sm btn-danger" type="button" onclick="this.parentElement.remove()">×</button>';
+        '<button class="btn btn-sm btn-danger" type="button" onclick="this.parentElement.remove()" aria-label="Remove this reaction role mapping">×</button>';
     list.appendChild(row);
 }
 
@@ -3446,6 +3447,7 @@ function addLevelNoXpRole() {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.title = 'Remove';
+    btn.setAttribute('aria-label', 'Remove ' + roleName);
     btn.textContent = '×';
     btn.onclick = () => tag.remove();
     tag.textContent = roleName + ' ';
@@ -3474,6 +3476,7 @@ function addLevelNoXpChannel() {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.title = 'Remove';
+    btn.setAttribute('aria-label', 'Remove ' + channelName);
     btn.textContent = '×';
     btn.onclick = () => tag.remove();
     tag.textContent = channelName + ' ';
@@ -3511,6 +3514,7 @@ function addLevelRoleReward() {
     delBtn.className = 'btn btn-danger';
     delBtn.type = 'button';
     delBtn.title = 'Remove';
+    delBtn.setAttribute('aria-label', 'Remove this level reward');
     delBtn.textContent = '×';
     delBtn.onclick = () => row.remove();
     row.appendChild(levelInput);
@@ -3541,7 +3545,7 @@ function addSeasonTierRow() {
         '<input type="number" class="season-tier-coins" min="0" style="width:90px" placeholder="Coins" aria-label="Coin reward">' +
         '<select class="season-tier-role" aria-label="Reward role">' + roleOptionsHtml + '</select>' +
         '<input type="text" class="season-tier-label" style="flex:1;min-width:100px" placeholder="Label (e.g. Bronze Tier)" aria-label="Tier label">' +
-        '<button class="btn btn-danger" type="button" onclick="this.closest(\'.season-tier-row\').remove()" title="Remove">&times;</button>';
+        '<button class="btn btn-danger" type="button" onclick="this.closest(\'.season-tier-row\').remove()" title="Remove" aria-label="Remove this tier reward">&times;</button>';
     list.appendChild(row);
 }
 
@@ -4604,7 +4608,7 @@ async function ecoAdminAction(action) {
         const safeId   = escHtml(id);
         const safeName = escHtml(name);
         const safeAv   = avatarUrl ? escHtml(avatarUrl) : '';
-        tag.innerHTML  = `${safeAv ? `<img src="${safeAv}" alt="" style="width:16px;height:16px;border-radius:50%" onerror="this.style.display='none'">` : ''}<span title="${safeId}">${safeName}</span><button type="button" title="Remove">&times;</button>`;
+        tag.innerHTML  = `${safeAv ? `<img src="${safeAv}" alt="" style="width:16px;height:16px;border-radius:50%" onerror="this.style.display='none'">` : ''}<span title="${safeId}">${safeName}</span><button type="button" title="Remove" aria-label="Remove ${safeName}">&times;</button>`;
         tag.querySelector('button').addEventListener('click', function() {
             const ta = document.getElementById(widgetId);
             if (ta) ta.value = ta.value.split('\n').map(s => s.trim()).filter(s => s && s !== id).join('\n');

--- a/src/dashboard/public/guild-settings.js
+++ b/src/dashboard/public/guild-settings.js
@@ -2016,6 +2016,78 @@ async function startBoostEvent() {
     }
 }
 
+// ── Repeated-row remove buttons ────────────────────────────────────────────
+//
+// #670 again. A repeater's remove button is one glyph, and giving every row in
+// a list the same "Remove this level reward" names none of them — a reader
+// tabbing a five-row list hears the identical thing five times. So each one is
+// named after what is in its own row.
+//
+// Which means the label cannot be written once. The values it names are the
+// row's own editable fields, so a label saying "level 5" is worse than a
+// generic one the moment the input says 12. These are rewritten whenever a row
+// changes, and after a removal, because the fallback names a row by position.
+
+const ROW_LABELLERS = {
+    'level-reward': (row, position) => {
+        const level = (row.querySelector('.level-reward-level')?.value || '').trim();
+        return level
+            ? `Remove the level ${level} reward`
+            : `Remove reward row ${position}, which has no level set`;
+    },
+    'season-tier': (row, position) => {
+        const tier = (row.querySelector('.season-tier-num')?.value || '').trim();
+        return tier
+            ? `Remove the tier ${tier} reward`
+            : `Remove tier row ${position}, which has no tier set`;
+    },
+    'rr-mapping': (row, position) => {
+        const emoji  = (row.querySelector('.rr-emoji')?.value || '').trim();
+        const select = row.querySelector('.rr-role');
+        const role   = select?.value ? select.options[select.selectedIndex].text : '';
+        if (!emoji && !role) return `Remove mapping row ${position}, which is empty`;
+        return `Remove the ${emoji || 'no emoji'} → ${role || 'no role'} mapping`;
+    },
+};
+
+/** Renames every remove button in one repeater after its own row's contents. */
+function labelRepeatedRows(list) {
+    if (!list) return;
+    Array.from(list.children).forEach((row, index) => {
+        const button = row.querySelector('[data-row-remove]');
+        const label  = button && ROW_LABELLERS[button.dataset.rowRemove];
+        if (label) button.setAttribute('aria-label', label(row, index + 1));
+    });
+}
+
+/** Every repeater on the page, wherever an edit or a removal landed. */
+function labelAllRepeatedRows() {
+    document.querySelectorAll('[data-row-list]').forEach(labelRepeatedRows);
+}
+
+// Capture, so a label still follows the edit if something downstream stops the
+// event — the same reasoning as the unsaved-changes tracker below.
+document.addEventListener('input', e => {
+    const list = e.target?.closest?.('[data-row-list]');
+    if (list) labelRepeatedRows(list);
+}, true);
+document.addEventListener('change', e => {
+    const list = e.target?.closest?.('[data-row-list]');
+    if (list) labelRepeatedRows(list);
+}, true);
+// Adding or removing a row fires neither input nor change, and a removal
+// renumbers everything after it. The click is the signal; the list it left
+// behind exists a tick later, which is why the row is read from the event
+// rather than from the button — by then the button's row is detached.
+document.addEventListener('click', e => {
+    if (!e.target?.closest?.('[data-row-list]')) return;
+    setTimeout(labelAllRepeatedRows, 0);
+}, true);
+
+onPanel('leveling',      () => labelRepeatedRows(document.getElementById('level-role-rewards-list')));
+onPanel('season',        () => labelRepeatedRows(document.getElementById('season-tier-rewards-list')));
+onPanel('reactionroles', () => labelRepeatedRows(document.getElementById('rr-mappings-list')));
+
 // ── Reaction Roles ─────────────────────────────────────────────────────────
 var rrRoles = boot('roles');
 
@@ -2028,8 +2100,9 @@ function addRrMapping() {
         '<select class="rr-role" aria-label="Role to assign"><option value="">Select role</option>' +
         rrRoles.map(function(r) { return '<option value="' + r.id + '">@' + escHtml(r.name) + '</option>'; }).join('') +
         '</select>' +
-        '<button class="btn btn-sm btn-danger" type="button" onclick="this.parentElement.remove()" aria-label="Remove this reaction role mapping">×</button>';
+        '<button class="btn btn-sm btn-danger" type="button" onclick="this.parentElement.remove()" data-row-remove="rr-mapping" aria-label="Remove this reaction role mapping">×</button>';
     list.appendChild(row);
+    labelRepeatedRows(list);
 }
 
 // See _rssAddInFlight. This one matters more: a duplicate publish posts a second
@@ -3514,13 +3587,14 @@ function addLevelRoleReward() {
     delBtn.className = 'btn btn-danger';
     delBtn.type = 'button';
     delBtn.title = 'Remove';
-    delBtn.setAttribute('aria-label', 'Remove this level reward');
+    delBtn.dataset.rowRemove = 'level-reward';
     delBtn.textContent = '×';
     delBtn.onclick = () => row.remove();
     row.appendChild(levelInput);
     row.appendChild(newSelect);
     row.appendChild(delBtn);
     list.appendChild(row);
+    labelRepeatedRows(list);
 }
 function removeLevelRoleReward(btn) {
     btn.closest('.level-reward-row').remove();
@@ -3545,8 +3619,9 @@ function addSeasonTierRow() {
         '<input type="number" class="season-tier-coins" min="0" style="width:90px" placeholder="Coins" aria-label="Coin reward">' +
         '<select class="season-tier-role" aria-label="Reward role">' + roleOptionsHtml + '</select>' +
         '<input type="text" class="season-tier-label" style="flex:1;min-width:100px" placeholder="Label (e.g. Bronze Tier)" aria-label="Tier label">' +
-        '<button class="btn btn-danger" type="button" onclick="this.closest(\'.season-tier-row\').remove()" title="Remove" aria-label="Remove this tier reward">&times;</button>';
+        '<button class="btn btn-danger" type="button" onclick="this.closest(\'.season-tier-row\').remove()" title="Remove" data-row-remove="season-tier">&times;</button>';
     list.appendChild(row);
+    labelRepeatedRows(list);
 }
 
 // ── Getting Started checklist ────────────────────────────────────────

--- a/src/dashboard/public/styles.css
+++ b/src/dashboard/public/styles.css
@@ -1238,8 +1238,9 @@ textarea.auto-resize {
 .cw-footer-inner { max-width: 1320px; margin: 0 auto; display: grid; grid-template-columns: 1.4fr 1fr 1fr 1fr 1fr; gap: 40px; }
 .cw-footer h4 { font-family: 'JetBrains Mono', monospace; font-size: 11.5px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--ink-400); margin: 0 0 14px; font-weight: 500; }
 .cw-footer ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 10px; font-size: 14px; }
-.cw-footer ul a { color: var(--cream-100); cursor: pointer; text-decoration: none; }
+.cw-footer ul a { color: var(--cream-100); text-decoration: none; }
 .cw-footer ul a:hover { color: var(--cream-50); }
+.cw-footer ul a:focus-visible { outline: 2px solid var(--claw-500); outline-offset: 4px; border-radius: 4px; }
 .cw-footer .cw-wordmark { color: var(--cream-100); }
 .cw-side-wordmark { color: var(--cream-100); font-size: 24px; }
 .cw-footer-tag { color: var(--ink-300); font-size: 14px; margin: 14px 0 0; max-width: 280px; line-height: 1.5; }

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -182,7 +182,7 @@
     <!-- Generic confirm modal -->
     <div id="confirm-modal" class="modal-overlay" style="display:none;" aria-modal="true" aria-hidden="true" role="dialog" aria-labelledby="confirm-modal-title">
         <div class="modal-box" style="max-width:440px;">
-            <div class="modal-head"><span id="confirm-modal-title">Confirm</span><button class="modal-close" onclick="_confirmResolve(false)">✕</button></div>
+            <div class="modal-head"><span id="confirm-modal-title">Confirm</span><button class="modal-close" onclick="_confirmResolve(false)" aria-label="Close the confirmation dialog">✕</button></div>
             <div class="modal-body">
                 <p id="confirm-modal-body" style="margin:0;line-height:1.5"></p>
                 <div id="confirm-modal-type-reset" style="display:none;margin-top:.75rem;">

--- a/src/dashboard/views/index.ejs
+++ b/src/dashboard/views/index.ejs
@@ -5,6 +5,11 @@
     // description, and the Open Graph pair an unfurler reads instead of either.
     const pageTitle = 'Clawdia — A chill Discord bot with serious teeth';
     const pageDescription = 'Moderation, leveling, economy, AI chat and analytics — in one self-hosted Discord bot. Own your data.';
+
+    // Where every documentation, changelog and licence link in the footer
+    // resolves. Written once so a fork renaming the repository moves them
+    // together rather than leaving a dozen 404s behind.
+    const repo = 'https://github.com/TheShield2594/clawdia';
 %>
 <head>
     <%- include('partials/head', { title: pageTitle, description: pageDescription }) %>
@@ -71,7 +76,7 @@
             <% } else { %>
                 <a href="/auth/login" class="cw-btn cw-btn-claw">Add to Discord <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
             <% } %>
-            <a href="https://github.com/TheShield2594/clawdia" target="_blank" rel="noopener" class="cw-btn cw-btn-ghost">
+            <a href="<%= repo %>" target="_blank" rel="noopener" class="cw-btn cw-btn-ghost">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
                 View on GitHub
             </a>
@@ -109,7 +114,7 @@
     </header>
 
     <!-- MODULE STRIP -->
-    <div class="cw-strip">
+    <div class="cw-strip" id="modules">
         <div class="cw-strip-inner">
             <span class="cw-strip-label">11 modules</span>
             <div class="cw-strip-items">
@@ -326,8 +331,8 @@
                     </div>
                 </div>
                 <div class="cw-host-cta">
-                    <a href="https://github.com/TheShield2594/clawdia" target="_blank" rel="noopener" class="cw-btn cw-btn-dark">Read setup guide <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
-                    <a href="https://github.com/TheShield2594/clawdia" target="_blank" rel="noopener" class="cw-btn cw-btn-ghost">⌥ View on GitHub</a>
+                    <a href="<%= repo %>" target="_blank" rel="noopener" class="cw-btn cw-btn-dark">Read setup guide <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+                    <a href="<%= repo %>" target="_blank" rel="noopener" class="cw-btn cw-btn-ghost">⌥ View on GitHub</a>
                 </div>
             </div>
             <div class="cw-terminal">
@@ -362,7 +367,7 @@
             <% } else { %>
                 <a href="/auth/login" class="cw-btn cw-btn-dark">Add to Discord <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
             <% } %>
-            <a href="https://github.com/TheShield2594/clawdia" target="_blank" rel="noopener" class="cw-btn cw-btn-cream">⌥ Self-host on Docker</a>
+            <a href="<%= repo %>" target="_blank" rel="noopener" class="cw-btn cw-btn-cream">⌥ Self-host on Docker</a>
         </div>
     </section>
 
@@ -376,39 +381,42 @@
                 </div>
                 <p class="cw-footer-tag">A chill, self-hosted Discord bot with serious teeth. Built by the community, for the community.</p>
             </div>
+            <%#
+                Every entry here is a link to somewhere that exists. The four
+                that used to sit alongside them — Discord, Sponsor, Privacy,
+                Terms — named things this project does not have, which is why
+                they had no href to give; a self-hosted bot's privacy policy is
+                its operator's to write, not ours to link.
+            -%>
             <div>
                 <h4>Product</h4>
                 <ul>
-                    <li><a>Features</a></li>
-                    <li><a>Modules</a></li>
-                    <li><a>Insights</a></li>
-                    <li><a>Changelog</a></li>
+                    <li><a href="#features">Features</a></li>
+                    <li><a href="#modules">Modules</a></li>
+                    <li><a href="#insights">Insights</a></li>
+                    <li><a href="<%= repo %>/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a></li>
                 </ul>
             </div>
             <div>
                 <h4>Resources</h4>
                 <ul>
-                    <li><a href="https://github.com/TheShield2594/clawdia" target="_blank" rel="noopener">Setup guide</a></li>
-                    <li><a>API reference</a></li>
-                    <li><a>Commands</a></li>
-                    <li><a>Discord</a></li>
+                    <li><a href="<%= repo %>/blob/main/docs/SETUP_GUIDE.md" target="_blank" rel="noopener">Setup guide</a></li>
+                    <li><a href="<%= repo %>/blob/main/docs/API_REFERENCE.md" target="_blank" rel="noopener">API reference</a></li>
+                    <li><a href="<%= repo %>/blob/main/docs/COMMANDS.md" target="_blank" rel="noopener">Commands</a></li>
                 </ul>
             </div>
             <div>
                 <h4>Community</h4>
                 <ul>
-                    <li><a href="https://github.com/TheShield2594/clawdia" target="_blank" rel="noopener">GitHub</a></li>
-                    <li><a>Contributing</a></li>
-                    <li><a>Roadmap</a></li>
-                    <li><a>Sponsor</a></li>
+                    <li><a href="<%= repo %>" target="_blank" rel="noopener">GitHub</a></li>
+                    <li><a href="<%= repo %>/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a></li>
+                    <li><a href="<%= repo %>/issues" target="_blank" rel="noopener">Roadmap</a></li>
                 </ul>
             </div>
             <div>
                 <h4>Legal</h4>
                 <ul>
-                    <li><a>License · MIT</a></li>
-                    <li><a>Privacy</a></li>
-                    <li><a>Terms</a></li>
+                    <li><a href="<%= repo %>/blob/main/LICENSE" target="_blank" rel="noopener">License · MIT</a></li>
                 </ul>
             </div>
         </div>

--- a/src/dashboard/views/index.ejs
+++ b/src/dashboard/views/index.ejs
@@ -331,7 +331,7 @@
                     </div>
                 </div>
                 <div class="cw-host-cta">
-                    <a href="<%= repo %>" target="_blank" rel="noopener" class="cw-btn cw-btn-dark">Read setup guide <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
+                    <a href="<%= repo %>/blob/main/docs/SETUP_GUIDE.md" target="_blank" rel="noopener" class="cw-btn cw-btn-dark">Read setup guide <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>
                     <a href="<%= repo %>" target="_blank" rel="noopener" class="cw-btn cw-btn-ghost">⌥ View on GitHub</a>
                 </div>
             </div>

--- a/src/dashboard/views/partials/game-item-card.ejs
+++ b/src/dashboard/views/partials/game-item-card.ejs
@@ -28,6 +28,6 @@
                 onchange="uploadActivityImage('<%= item.id %>', this)"
             >
         </label>
-        <button class="btn btn-sm btn-danger" onclick="removeActivityImage('<%= item.id %>')" title="Remove image">✕</button>
+        <button class="btn btn-sm btn-danger" onclick="removeActivityImage('<%= item.id %>')" title="Remove image" aria-label="Remove the image for <%= item.label %>">✕</button>
     </div>
 </div>

--- a/src/dashboard/views/partials/nav.ejs
+++ b/src/dashboard/views/partials/nav.ejs
@@ -28,7 +28,7 @@
         <%_ if (page === 'home') { _%>
             <div class="cw-nav-links">
                 <a href="#features">Features</a>
-                <a href="#features">Modules</a>
+                <a href="#modules">Modules</a>
                 <a href="#insights">Insights</a>
                 <a href="#self-host">Self-host</a>
                 <a href="https://github.com/TheShield2594/clawdia" target="_blank" rel="noopener">Docs</a>

--- a/src/dashboard/views/partials/panels/achievements.ejs
+++ b/src/dashboard/views/partials/panels/achievements.ejs
@@ -38,7 +38,7 @@
                     <div class="modal-box" style="max-width:480px">
                         <div class="modal-head">
                             <h3 id="ach-modal-title">Add Achievement</h3>
-                            <button class="modal-close" onclick="closeAchModal()">&times;</button>
+                            <button class="modal-close" onclick="closeAchModal()" aria-label="Close the achievement editor">&times;</button>
                         </div>
                         <div class="modal-body">
                             <div class="field">
@@ -90,7 +90,7 @@
                     <div class="modal-box" style="max-width:420px">
                         <div class="modal-head">
                             <h3 id="ach-grant-modal-title">Grant Achievement</h3>
-                            <button class="modal-close" onclick="closeAchGrantModal()">&times;</button>
+                            <button class="modal-close" onclick="closeAchGrantModal()" aria-label="Close the grant achievement dialog">&times;</button>
                         </div>
                         <div class="modal-body">
                             <input type="hidden" id="grant-ach-id">

--- a/src/dashboard/views/partials/panels/ai.ejs
+++ b/src/dashboard/views/partials/panels/ai.ejs
@@ -410,7 +410,7 @@
                         <div class="modal-box modal-box-wide">
                             <div class="modal-head">
                                 <h3 id="prompt-editor-title">Edit prompt</h3>
-                                <button class="modal-close" onclick="closePromptEditor(false)">&times;</button>
+                                <button class="modal-close" onclick="closePromptEditor(false)" aria-label="Close the prompt editor">&times;</button>
                             </div>
                             <div class="modal-body">
                                 <textarea id="prompt-editor-textarea" maxlength="4000" aria-labelledby="prompt-editor-title" oninput="updatePromptEditorCount()"></textarea>

--- a/src/dashboard/views/partials/panels/commandpolicies.ejs
+++ b/src/dashboard/views/partials/panels/commandpolicies.ejs
@@ -15,7 +15,7 @@
                                 <% (settings.commandPolicies?.exceptions?.roleIds||[]).forEach(function(rId) {
                                    var role = roles.find(function(r){ return r.id === rId; });
                                    if (role) { %>
-                                    <span class="role-tag" data-role-id="<%= rId %>">@<%= role.name %> <button type="button" onclick="this.closest('[data-role-id]').remove()" title="Remove">&times;</button></span>
+                                    <span class="role-tag" data-role-id="<%= rId %>">@<%= role.name %> <button type="button" onclick="this.closest('[data-role-id]').remove()" title="Remove" aria-label="Remove @<%= role.name %>">&times;</button></span>
                                 <% } }); %>
                             </div>
                             <div style="display:flex;gap:.5rem;align-items:center">
@@ -51,7 +51,7 @@
                 <!-- Command Policies — Rule Modal -->
                 <div id="cp-rule-modal" class="modal-overlay" style="display:none;" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="cp-rule-modal-title">
                     <div class="modal-box" style="max-width:520px;">
-                        <div class="modal-head"><span id="cp-rule-modal-title">Add Rule</span><button class="modal-close" onclick="closeCpRuleModal()">✕</button></div>
+                        <div class="modal-head"><span id="cp-rule-modal-title">Add Rule</span><button class="modal-close" onclick="closeCpRuleModal()" aria-label="Close the rule editor">✕</button></div>
                         <div class="modal-body" style="display:flex;flex-direction:column;gap:.9rem;">
                             <div class="field"><label class="field-label" for="cp-r-command">Command name</label><input type="text" id="cp-r-command" placeholder="e.g. ban"></div>
                             <div class="field"><label class="field-label" for="cp-r-effect">Effect</label><select id="cp-r-effect"><option value="allow">Allow</option><option value="deny">Deny</option></select></div>
@@ -73,7 +73,7 @@
                 <!-- Command Policies — Cooldown Modal -->
                 <div id="cp-cooldown-modal" class="modal-overlay" style="display:none;" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="cp-cooldown-modal-title">
                     <div class="modal-box" style="max-width:420px;">
-                        <div class="modal-head"><span id="cp-cooldown-modal-title">Cooldown Override</span><button class="modal-close" onclick="closeCpCooldownModal()">✕</button></div>
+                        <div class="modal-head"><span id="cp-cooldown-modal-title">Cooldown Override</span><button class="modal-close" onclick="closeCpCooldownModal()" aria-label="Close the cooldown override editor">✕</button></div>
                         <div class="modal-body" style="display:flex;flex-direction:column;gap:.9rem;">
                             <div class="field"><label class="field-label" for="cp-cd-command">Command name</label><input type="text" id="cp-cd-command" placeholder="e.g. daily"></div>
                             <div class="field"><label class="field-label" for="cp-cd-role">Role</label>

--- a/src/dashboard/views/partials/panels/economy.ejs
+++ b/src/dashboard/views/partials/panels/economy.ejs
@@ -444,7 +444,7 @@
                     <div class="modal-box">
                         <div class="modal-head">
                             <h3 id="item-modal-title">Add Store Item</h3>
-                            <button class="modal-close" onclick="closeItemModal()">&times;</button>
+                            <button class="modal-close" onclick="closeItemModal()" aria-label="Close the store item editor">&times;</button>
                         </div>
                         <div class="modal-body">
                             <div class="field">
@@ -501,7 +501,7 @@
                     <div class="modal-box" style="max-width:460px">
                         <div class="modal-head">
                             <h3 id="job-modal-title">Add Job</h3>
-                            <button class="modal-close" onclick="closeJobModal()">&times;</button>
+                            <button class="modal-close" onclick="closeJobModal()" aria-label="Close the job editor">&times;</button>
                         </div>
                         <div class="modal-body">
                             <div class="field">

--- a/src/dashboard/views/partials/panels/leveling.ejs
+++ b/src/dashboard/views/partials/panels/leveling.ejs
@@ -57,12 +57,12 @@
                     </div>
                     <div class="field" role="group" aria-labelledby="level-role-rewards-label">
                         <div class="field-label" id="level-role-rewards-label">Level role rewards</div>
-                        <div id="level-role-rewards-list" style="display:flex;flex-direction:column;gap:.5rem;margin-bottom:.75rem">
+                        <div id="level-role-rewards-list" data-row-list style="display:flex;flex-direction:column;gap:.5rem;margin-bottom:.75rem">
                             <% (settings.levelRoles || []).forEach(function(r) { %>
                                 <div class="level-reward-row" style="display:flex;gap:.5rem;align-items:center">
                                     <input type="number" class="level-reward-level" value="<%= r.level %>" min="1" max="999" style="width:80px" placeholder="Level" aria-label="Required level">
                                     <%- include('../role-select', { cls: 'level-reward-role', ariaLabel: 'Reward role', placeholder: 'Select a role', selected: r.roleId }) %>
-                                    <button class="btn btn-danger" type="button" onclick="removeLevelRoleReward(this)" title="Remove" aria-label="Remove the level <%= r.level %> reward">&times;</button>
+                                    <button class="btn btn-danger" type="button" onclick="removeLevelRoleReward(this)" title="Remove" data-row-remove="level-reward" aria-label="Remove the level <%= r.level %> reward">&times;</button>
                                 </div>
                             <% }); %>
                         </div>

--- a/src/dashboard/views/partials/panels/leveling.ejs
+++ b/src/dashboard/views/partials/panels/leveling.ejs
@@ -33,7 +33,7 @@
                             <% (settings.leveling.noXpRoleIds || []).forEach(function(rId) {
                                var role = roles.find(function(r){ return r.id === rId; });
                                if (role) { %>
-                                <span class="role-tag" data-role-id="<%= rId %>">@<%= role.name %> <button type="button" onclick="removeLevelNoXpRole('<%= rId %>')" title="Remove">&times;</button></span>
+                                <span class="role-tag" data-role-id="<%= rId %>">@<%= role.name %> <button type="button" onclick="removeLevelNoXpRole('<%= rId %>')" title="Remove" aria-label="Remove @<%= role.name %>">&times;</button></span>
                             <% } }); %>
                         </div>
                         <div style="display:flex;gap:.5rem;align-items:center">
@@ -47,7 +47,7 @@
                             <% (settings.leveling.noXpChannelIds || []).forEach(function(cId) {
                                var ch = channels.find(function(c){ return c.id === cId; });
                                if (ch) { %>
-                                <span class="role-tag" data-channel-id="<%= cId %>">#<%= ch.name %> <button type="button" onclick="removeLevelNoXpChannel('<%= cId %>')" title="Remove">&times;</button></span>
+                                <span class="role-tag" data-channel-id="<%= cId %>">#<%= ch.name %> <button type="button" onclick="removeLevelNoXpChannel('<%= cId %>')" title="Remove" aria-label="Remove #<%= ch.name %>">&times;</button></span>
                             <% } }); %>
                         </div>
                         <div style="display:flex;gap:.5rem;align-items:center">
@@ -62,7 +62,7 @@
                                 <div class="level-reward-row" style="display:flex;gap:.5rem;align-items:center">
                                     <input type="number" class="level-reward-level" value="<%= r.level %>" min="1" max="999" style="width:80px" placeholder="Level" aria-label="Required level">
                                     <%- include('../role-select', { cls: 'level-reward-role', ariaLabel: 'Reward role', placeholder: 'Select a role', selected: r.roleId }) %>
-                                    <button class="btn btn-danger" type="button" onclick="removeLevelRoleReward(this)" title="Remove">&times;</button>
+                                    <button class="btn btn-danger" type="button" onclick="removeLevelRoleReward(this)" title="Remove" aria-label="Remove the level <%= r.level %> reward">&times;</button>
                                 </div>
                             <% }); %>
                         </div>

--- a/src/dashboard/views/partials/panels/moderation.ejs
+++ b/src/dashboard/views/partials/panels/moderation.ejs
@@ -234,7 +234,7 @@
                     <div class="modal-box" style="max-width:440px">
                         <div class="modal-head">
                             <h3 id="case-note-modal-title">Add Note to Case</h3>
-                            <button class="modal-close" onclick="closeCaseNoteModal()">&times;</button>
+                            <button class="modal-close" onclick="closeCaseNoteModal()" aria-label="Close the case note dialog">&times;</button>
                         </div>
                         <div class="modal-body">
                             <input type="hidden" id="case-note-case-id">

--- a/src/dashboard/views/partials/panels/reactionroles.ejs
+++ b/src/dashboard/views/partials/panels/reactionroles.ejs
@@ -54,7 +54,7 @@
                     </div>
                     <div class="field" role="group" aria-labelledby="rr-mappings-label">
                         <div class="field-label" id="rr-mappings-label">Emoji → Role mappings</div>
-                        <div id="rr-mappings-list" style="display:flex;flex-direction:column;gap:.5rem;margin-bottom:.5rem;"></div>
+                        <div id="rr-mappings-list" data-row-list style="display:flex;flex-direction:column;gap:.5rem;margin-bottom:.5rem;"></div>
                         <button class="btn btn-sm" type="button" onclick="addRrMapping()">+ Add mapping</button>
                         <small style="display:block;margin-top:.4rem">Use a standard emoji (e.g. <code>👍</code>) or a custom Discord emoji (<code>&lt;:name:id&gt;</code>).</small>
                     </div>

--- a/src/dashboard/views/partials/panels/season.ejs
+++ b/src/dashboard/views/partials/panels/season.ejs
@@ -24,7 +24,7 @@
                                     <input type="number" class="season-tier-coins" value="<%= r.coins %>" min="0" style="width:90px" placeholder="Coins" aria-label="Coin reward">
                                     <%- include('../role-select', { cls: 'season-tier-role', ariaLabel: 'Reward role', placeholder: 'No role', selected: r.roleId }) %>
                                     <input type="text" class="season-tier-label" value="<%= r.label || '' %>" style="flex:1;min-width:100px" placeholder="Label (e.g. Bronze Tier)" aria-label="Tier label">
-                                    <button class="btn btn-danger" type="button" onclick="this.closest('.season-tier-row').remove()" title="Remove">&times;</button>
+                                    <button class="btn btn-danger" type="button" onclick="this.closest('.season-tier-row').remove()" title="Remove" aria-label="Remove the tier <%= r.tier %> reward">&times;</button>
                                 </div>
                             <% }); %>
                         </div>

--- a/src/dashboard/views/partials/panels/season.ejs
+++ b/src/dashboard/views/partials/panels/season.ejs
@@ -17,14 +17,14 @@
                     </div>
                     <div class="field" style="margin-top:.75rem;" role="group" aria-labelledby="season-tier-rewards-label">
                         <div class="field-label" id="season-tier-rewards-label">Tier rewards</div>
-                        <div id="season-tier-rewards-list" style="display:flex;flex-direction:column;gap:.5rem;margin-bottom:.75rem">
+                        <div id="season-tier-rewards-list" data-row-list style="display:flex;flex-direction:column;gap:.5rem;margin-bottom:.75rem">
                             <% (settings.season?.tierRewards || []).forEach(function(r) { %>
                                 <div class="season-tier-row" style="display:flex;gap:.5rem;align-items:center;flex-wrap:wrap">
                                     <input type="number" class="season-tier-num" value="<%= r.tier %>" min="1" style="width:70px" placeholder="Tier" aria-label="Tier number">
                                     <input type="number" class="season-tier-coins" value="<%= r.coins %>" min="0" style="width:90px" placeholder="Coins" aria-label="Coin reward">
                                     <%- include('../role-select', { cls: 'season-tier-role', ariaLabel: 'Reward role', placeholder: 'No role', selected: r.roleId }) %>
                                     <input type="text" class="season-tier-label" value="<%= r.label || '' %>" style="flex:1;min-width:100px" placeholder="Label (e.g. Bronze Tier)" aria-label="Tier label">
-                                    <button class="btn btn-danger" type="button" onclick="this.closest('.season-tier-row').remove()" title="Remove" aria-label="Remove the tier <%= r.tier %> reward">&times;</button>
+                                    <button class="btn btn-danger" type="button" onclick="this.closest('.season-tier-row').remove()" title="Remove" data-row-remove="season-tier" aria-label="Remove the tier <%= r.tier %> reward">&times;</button>
                                 </div>
                             <% }); %>
                         </div>

--- a/src/dashboard/views/partials/panels/welcome.ejs
+++ b/src/dashboard/views/partials/panels/welcome.ejs
@@ -43,7 +43,7 @@
                             <% (settings.autoRoles || []).forEach(r => { %>
                                 <% const role = roles.find(ro => ro.id === r.roleId); %>
                                 <% if (role) { %>
-                                    <span class="role-tag" data-role-id="<%= r.roleId %>">@<%= role.name %> <button data-action="autorole-remove" data-role-id="<%= r.roleId %>" title="Remove">&times;</button></span>
+                                    <span class="role-tag" data-role-id="<%= r.roleId %>">@<%= role.name %> <button data-action="autorole-remove" data-role-id="<%= r.roleId %>" title="Remove" aria-label="Remove @<%= role.name %>">&times;</button></span>
                                 <% } %>
                             <% }); %>
                         </div>

--- a/src/events/guildMemberAdd.js
+++ b/src/events/guildMemberAdd.js
@@ -96,7 +96,11 @@ module.exports = {
                         }
 
                         if (card) {
-                            const attachment = new AttachmentBuilder(card, { name: 'welcome.png' });
+                            const attachment = new AttachmentBuilder(card, {
+                                name: 'welcome.png',
+                                description: `Welcome card for ${member.user.username}, member number `
+                                    + `${member.guild.memberCount} of ${member.guild.name}.`,
+                            });
 
                             const embed = new EmbedBuilder()
                                 .setColor(COLORS.INFO)

--- a/src/migrations/runner.js
+++ b/src/migrations/runner.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
+const { randomUUID } = require('crypto');
 const MigrationRecord = require('../models/MigrationRecord');
 
 // Wall-clock budget for a single migration. A migration that hangs holds the
@@ -46,7 +47,12 @@ function withTimeout(promise, ms, label) {
     let timerId;
     const timeoutPromise = new Promise((_, reject) => {
         timerId = setTimeout(
-            () => reject(new Error(`[MIGRATIONS] Timed out after ${ms}ms: ${label}`)),
+            // Tagged, because the difference matters to the claim: a migration
+            // that rejected is over, one that timed out is still running.
+            () => reject(Object.assign(
+                new Error(`[MIGRATIONS] Timed out after ${ms}ms: ${label}`),
+                { migrationTimedOut: true },
+            )),
             ms
         ).unref();
     });
@@ -61,11 +67,13 @@ function withTimeout(promise, ms, label) {
 }
 
 // How long past a migration's own budget a claim is trusted before another
-// process treats its holder as dead and takes it over. The holder gives up on
-// its own after `timeoutMs` and deletes the claim, so this only ever elapses
-// for a process that died without unwinding — a SIGKILL, a lost container, an
-// OOM. Generous, because taking a live claim over means running the migration
-// twice concurrently, which is the thing the claim exists to prevent.
+// process treats its holder as dead and takes it over. A holder that fails
+// releases its claim immediately, so this only ever elapses for one that died
+// without unwinding — a SIGKILL, a lost container, an OOM — or one whose
+// migration overran its budget and is still running server-side, which is
+// exactly the case that must not be taken over early. Generous for that reason:
+// taking a live claim over means running the migration twice at once, which is
+// the thing the claim exists to prevent.
 const STALE_CLAIM_GRACE_MS = 60_000;
 
 // How often a process that lost the claim re-checks. Same cadence as
@@ -108,16 +116,25 @@ async function appliedNames(filter = {}) {
  * E11000 from the *bookkeeping* — a migration that had applied perfectly well
  * taking the bot down on the way to writing that it had.
  *
- * @returns {Promise<'claimed'|'applied'>} 'claimed' if this process should run
- *   the migration and complete the record; 'applied' if it is already done.
+ * The `owner` handed back is what makes the claim revocable safely. A claim can
+ * change hands — a holder that died leaves one behind, and the next process
+ * takes it over — so "the record for this migration says running" is not the
+ * same question as "this process still holds it". Every write that completes or
+ * releases a claim matches on the owner as well as the name, so a process that
+ * lost its claim cannot finish or delete its successor's.
+ *
+ * @returns {Promise<{status: 'claimed'|'applied', owner: string|null}>}
+ *   'claimed' if this process should run the migration and complete the record,
+ *   with the owner token to pass back; 'applied' if it is already done.
  */
 async function claimMigration(name, timeoutMs) {
     let waiting = false;
+    const owner = randomUUID();
 
     for (;;) {
         try {
-            await MigrationRecord.create({ name, state: 'running', startedAt: new Date() });
-            return 'claimed';
+            await MigrationRecord.create({ name, state: 'running', startedAt: new Date(), owner });
+            return { status: 'claimed', owner };
         } catch (err) {
             if (!isDuplicateKey(err)) throw err;
         }
@@ -126,7 +143,7 @@ async function claimMigration(name, timeoutMs) {
         // Gone between the insert and the read: the holder failed and cleaned
         // up after itself, so this process is free to try for the claim.
         if (!existing) continue;
-        if (existing.state !== 'running') return 'applied';
+        if (existing.state !== 'running') return { status: 'applied', owner: null };
 
         const heldFor = Date.now() - new Date(existing.startedAt ?? existing.appliedAt ?? 0).getTime();
         if (heldFor >= timeoutMs + STALE_CLAIM_GRACE_MS) {
@@ -134,8 +151,8 @@ async function claimMigration(name, timeoutMs) {
             // read, so a second process racing for the same stale claim finds
             // it already moved and goes round again.
             const taken = await MigrationRecord.findOneAndUpdate(
-                { name, state: 'running', startedAt: existing.startedAt },
-                { $set: { startedAt: new Date() } },
+                { name, state: 'running', startedAt: existing.startedAt, owner: existing.owner ?? null },
+                { $set: { startedAt: new Date(), owner } },
             );
             if (taken) {
                 console.warn(
@@ -143,7 +160,7 @@ async function claimMigration(name, timeoutMs) {
                     `${Math.round(heldFor / 1000)}s without completing, so the process that ` +
                     'took it is presumed gone.'
                 );
-                return 'claimed';
+                return { status: 'claimed', owner };
             }
             continue;
         }
@@ -317,29 +334,64 @@ async function runMigrations({ dir = __dirname } = {}) {
         // Claimed before it runs, so a second process racing this one waits for
         // the result instead of running the migration again and aborting
         // startup on the duplicate key its own bookkeeping would raise (#654).
-        if (await claimMigration(name, timeoutMs) === 'applied') {
+        const { status, owner } = await claimMigration(name, timeoutMs);
+        if (status === 'applied') {
             console.log(`[MIGRATIONS] Applied elsewhere while waiting: ${name}`);
             continue;
         }
 
+        // Every write below matches on the owner as well as the name. A claim
+        // this process no longer holds belongs to whoever took it over, and
+        // completing or deleting *their* record is worse than doing nothing:
+        // it would mark applied a migration still running elsewhere, or drop
+        // the lock out from under it.
+        const release = () => MigrationRecord.deleteOne({ name, state: 'running', owner })
+            .catch(e => console.error(`[MIGRATIONS] Could not release the claim on ${name}:`, e.message));
+
         console.log(`[MIGRATIONS] Applying: ${name} (budget ${timeoutMs}ms)`);
         const start = Date.now();
+        let work = null;
         try {
-            await withTimeout(up({ timeoutMs }), timeoutMs, name);
+            work = up({ timeoutMs });
+            await withTimeout(work, timeoutMs, name);
             const durationMs = Date.now() - start;
-            await MigrationRecord.updateOne(
-                { name },
+            const { matchedCount } = await MigrationRecord.updateOne(
+                { name, owner },
                 { $set: { state: 'complete', durationMs, appliedAt: new Date() } },
             );
-            console.log(`[MIGRATIONS] Applied ${name} in ${durationMs}ms`);
-            count++;
+            if (matchedCount === 0) {
+                // The claim was taken over while this migration ran, so another
+                // process is running it too and owns the record. Saying so is
+                // the useful thing; writing over their row is not.
+                console.warn(
+                    `[MIGRATIONS] ${name} finished here in ${durationMs}ms, but the claim had already ` +
+                    'been taken over — leaving the record to whichever process holds it now.'
+                );
+            } else {
+                console.log(`[MIGRATIONS] Applied ${name} in ${durationMs}ms`);
+                count++;
+            }
         } catch (err) {
             console.error(`[MIGRATIONS] FAILED: ${name}`, err);
-            // Release the claim. Nothing is recorded for a migration that did
-            // not finish — the next boot retries it, as it always has — and a
-            // claim left behind would block that boot until it went stale.
-            await MigrationRecord.deleteOne({ name, state: 'running' })
-                .catch(e => console.error(`[MIGRATIONS] Could not release the claim on ${name}:`, e.message));
+            if (err?.migrationTimedOut && work) {
+                // withTimeout stops waiting; it does not stop the migration.
+                // The work is still running against the server, so releasing
+                // the claim now would let another process start the same
+                // migration alongside it. The release is attached to the work
+                // instead — and if this process dies before that settles, the
+                // claim ages out and is taken over, which is the case
+                // STALE_CLAIM_GRACE_MS exists for.
+                console.warn(
+                    `[MIGRATIONS] Holding the claim on ${name}: it timed out, so it may still be ` +
+                    'running against the server. The claim is released when it settles, or ages out.'
+                );
+                work.then(release, release);
+            } else {
+                // A migration that rejected is over. Nothing is recorded for one
+                // that did not finish — the next boot retries it, as it always
+                // has — and a claim left behind would block that boot.
+                await release();
+            }
             if (!migration.optional) {
                 // Re-throw so startup aborts — running with a partially-applied schema is unsafe.
                 throw err;

--- a/src/migrations/runner.js
+++ b/src/migrations/runner.js
@@ -60,6 +60,102 @@ function withTimeout(promise, ms, label) {
     ]);
 }
 
+// How long past a migration's own budget a claim is trusted before another
+// process treats its holder as dead and takes it over. The holder gives up on
+// its own after `timeoutMs` and deletes the claim, so this only ever elapses
+// for a process that died without unwinding — a SIGKILL, a lost container, an
+// OOM. Generous, because taking a live claim over means running the migration
+// twice concurrently, which is the thing the claim exists to prevent.
+const STALE_CLAIM_GRACE_MS = 60_000;
+
+// How often a process that lost the claim re-checks. Same cadence as
+// waitForMigrations, and for the same reason: the wait is measured in whole
+// migrations, so a tighter poll only costs queries.
+const CLAIM_POLL_MS = 2_000;
+
+/**
+ * True for the duplicate-key error a losing `create` gets on `name`.
+ *
+ * Mongoose surfaces the driver's error as-is on `create`, but a write wrapped
+ * in a transaction or a bulk op can arrive with the driver error underneath, so
+ * both shapes are checked.
+ */
+function isDuplicateKey(err) {
+    return err?.code === 11000 || err?.cause?.code === 11000 || err?.writeErrors?.[0]?.code === 11000;
+}
+
+/**
+ * Migration names already recorded as *finished*.
+ *
+ * A claimed-but-unfinished row is deliberately not in here: its migration has
+ * not run yet, and treating it as applied is how a second process skips work
+ * that never happened.
+ */
+async function appliedNames(filter = {}) {
+    const records = await MigrationRecord
+        .find({ ...filter, state: { $ne: 'running' } }, 'name')
+        .lean();
+    return new Set(records.map(r => r.name));
+}
+
+/**
+ * Takes the exclusive right to run `name`, or reports that someone else already
+ * has (#654).
+ *
+ * The record is inserted before the migration runs rather than after it, so the
+ * unique index on `name` is the lock. Without one, a rolling update or a second
+ * replica ran the same migration twice and the loser aborted startup on an
+ * E11000 from the *bookkeeping* — a migration that had applied perfectly well
+ * taking the bot down on the way to writing that it had.
+ *
+ * @returns {Promise<'claimed'|'applied'>} 'claimed' if this process should run
+ *   the migration and complete the record; 'applied' if it is already done.
+ */
+async function claimMigration(name, timeoutMs) {
+    let waiting = false;
+
+    for (;;) {
+        try {
+            await MigrationRecord.create({ name, state: 'running', startedAt: new Date() });
+            return 'claimed';
+        } catch (err) {
+            if (!isDuplicateKey(err)) throw err;
+        }
+
+        const existing = await MigrationRecord.findOne({ name }).lean();
+        // Gone between the insert and the read: the holder failed and cleaned
+        // up after itself, so this process is free to try for the claim.
+        if (!existing) continue;
+        if (existing.state !== 'running') return 'applied';
+
+        const heldFor = Date.now() - new Date(existing.startedAt ?? existing.appliedAt ?? 0).getTime();
+        if (heldFor >= timeoutMs + STALE_CLAIM_GRACE_MS) {
+            // Only one taker wins: the update matches on the startedAt that was
+            // read, so a second process racing for the same stale claim finds
+            // it already moved and goes round again.
+            const taken = await MigrationRecord.findOneAndUpdate(
+                { name, state: 'running', startedAt: existing.startedAt },
+                { $set: { startedAt: new Date() } },
+            );
+            if (taken) {
+                console.warn(
+                    `[MIGRATIONS] Taking over the claim on ${name}: held for ` +
+                    `${Math.round(heldFor / 1000)}s without completing, so the process that ` +
+                    'took it is presumed gone.'
+                );
+                return 'claimed';
+            }
+            continue;
+        }
+
+        if (!waiting) {
+            console.log(`[MIGRATIONS] ${name} is being applied by another process — waiting.`);
+            waiting = true;
+        }
+        await new Promise(resolve => setTimeout(resolve, CLAIM_POLL_MS).unref());
+    }
+}
+
 // Discovers migration files and requires them, in apply order.
 function loadMigrations(dir) {
     return fs.readdirSync(dir)
@@ -161,7 +257,13 @@ function preMigrationBackup(irreversibleNames) {
  *              migration optional when running it again later, out of order,
  *              is harmless.
  *
- * Already-applied migrations are skipped (tracked in the MigrationRecord collection).
+ * Already-applied migrations are skipped (tracked in the MigrationRecord
+ * collection). Each record is written in two halves: claimed before the
+ * migration runs, completed after it returns. That claim is the lock — a second
+ * process starting at the same time loses the insert on the unique `name` and
+ * waits for the result instead of applying the migration a second time (#654).
+ * A migration that fails releases its claim and stays unrecorded, so the next
+ * boot retries it exactly as before.
  */
 async function runMigrations({ dir = __dirname } = {}) {
     const loaded = loadMigrations(dir);
@@ -171,9 +273,7 @@ async function runMigrations({ dir = __dirname } = {}) {
         return;
     }
 
-    const applied = new Set(
-        (await MigrationRecord.find({}, 'name').lean()).map(r => r.name)
-    );
+    const applied = await appliedNames();
 
     const baseTimeoutMs = envTimeoutMs() ?? DEFAULT_TIMEOUT_MS;
 
@@ -214,16 +314,32 @@ async function runMigrations({ dir = __dirname } = {}) {
         const { name, up } = migration;
         const timeoutMs = resolveTimeoutMs(migration.timeoutMs, baseTimeoutMs);
 
+        // Claimed before it runs, so a second process racing this one waits for
+        // the result instead of running the migration again and aborting
+        // startup on the duplicate key its own bookkeeping would raise (#654).
+        if (await claimMigration(name, timeoutMs) === 'applied') {
+            console.log(`[MIGRATIONS] Applied elsewhere while waiting: ${name}`);
+            continue;
+        }
+
         console.log(`[MIGRATIONS] Applying: ${name} (budget ${timeoutMs}ms)`);
         const start = Date.now();
         try {
             await withTimeout(up({ timeoutMs }), timeoutMs, name);
             const durationMs = Date.now() - start;
-            await MigrationRecord.create({ name, durationMs });
+            await MigrationRecord.updateOne(
+                { name },
+                { $set: { state: 'complete', durationMs, appliedAt: new Date() } },
+            );
             console.log(`[MIGRATIONS] Applied ${name} in ${durationMs}ms`);
             count++;
         } catch (err) {
             console.error(`[MIGRATIONS] FAILED: ${name}`, err);
+            // Release the claim. Nothing is recorded for a migration that did
+            // not finish — the next boot retries it, as it always has — and a
+            // claim left behind would block that boot until it went stale.
+            await MigrationRecord.deleteOne({ name, state: 'running' })
+                .catch(e => console.error(`[MIGRATIONS] Could not release the claim on ${name}:`, e.message));
             if (!migration.optional) {
                 // Re-throw so startup aborts — running with a partially-applied schema is unsafe.
                 throw err;
@@ -278,9 +394,7 @@ async function rollbackMigration(name, { dir = __dirname } = {}) {
         throw new Error(`[MIGRATIONS] No migration named "${name}" found in ${dir}.`);
     }
 
-    const applied = new Set(
-        (await MigrationRecord.find({}, 'name').lean()).map(r => r.name)
-    );
+    const applied = await appliedNames();
     if (!applied.has(name)) {
         throw new Error(`[MIGRATIONS] ${name} is not recorded as applied — nothing to roll back.`);
     }
@@ -353,9 +467,7 @@ async function pendingMigrationNames({ dir = __dirname } = {}) {
         .map(({ migration }) => migration.name);
     if (declared.length === 0) return [];
 
-    const applied = new Set(
-        (await MigrationRecord.find({ name: { $in: declared } }, 'name').lean()).map(r => r.name)
-    );
+    const applied = await appliedNames({ name: { $in: declared } });
     return declared.filter(name => !applied.has(name));
 }
 
@@ -401,6 +513,7 @@ async function waitForMigrations({ dir = __dirname, timeoutMs = 300_000, pollMs 
 
 module.exports = {
     runMigrations,
+    claimMigration,
     rollbackMigration,
     pendingMigrationNames,
     waitForMigrations,

--- a/src/models/MigrationRecord.js
+++ b/src/models/MigrationRecord.js
@@ -1,9 +1,38 @@
 const { Schema, model } = require('mongoose');
 
+/**
+ * One row per applied migration, and the lock that keeps two processes from
+ * applying the same one (#654).
+ *
+ * `name` is unique, which is what makes the claim work: the runner inserts the
+ * record *before* running the migration, so a second process racing it loses on
+ * a duplicate key and waits rather than running the migration a second time.
+ *
+ * That is also why `state` exists. A row is written in two halves — claimed,
+ * then completed — and only a completed one means "applied". Everything that
+ * asks whether a migration has run (the runner's own skip list, the shard-wait
+ * poll of #732, rollback) has to ignore a row that is merely claimed, or a
+ * second shard starts serving traffic against a database that is still being
+ * migrated.
+ *
+ * Records written before this field existed have no `state` at all, and a
+ * missing field is not 'running' — which is exactly how they should read: they
+ * are finished.
+ */
 const MigrationRecordSchema = new Schema({
     name: { type: String, required: true, unique: true },
     appliedAt: { type: Date, default: Date.now },
     durationMs: { type: Number, default: null },
+
+    // 'running' while the claim is held, 'complete' once up() has returned.
+    // Defaults to complete so a plain create({ name }) still means "applied",
+    // which is what the tests and any hand-written record expect.
+    state: { type: String, enum: ['running', 'complete'], default: 'complete' },
+
+    // When the claim was taken. A claim whose holder died is only tellable from
+    // its age, so this is what lets another process take one over instead of
+    // waiting on a process that is never coming back.
+    startedAt: { type: Date, default: null },
 });
 
 module.exports = model('MigrationRecord', MigrationRecordSchema);

--- a/src/models/MigrationRecord.js
+++ b/src/models/MigrationRecord.js
@@ -33,6 +33,13 @@ const MigrationRecordSchema = new Schema({
     // its age, so this is what lets another process take one over instead of
     // waiting on a process that is never coming back.
     startedAt: { type: Date, default: null },
+
+    // Which process holds the claim. A claim can change hands, so "this row
+    // says running" and "this process still holds it" are different questions;
+    // every write that completes or releases a claim matches on this as well as
+    // the name, so a runner that lost its claim cannot finish or delete the
+    // record belonging to the one that took over.
+    owner: { type: String, default: null },
 });
 
 module.exports = model('MigrationRecord', MigrationRecordSchema);

--- a/src/services/achievementService.js
+++ b/src/services/achievementService.js
@@ -187,7 +187,10 @@ async function announceAchievements(client, guildSettings, user, member, achieve
         try {
             const buf = await createAchievementCard(ach.name, ach.description, ach.xpReward);
             revealEmbed.setImage('attachment://achievement.png');
-            files = [new AttachmentBuilder(buf, { name: 'achievement.png' })];
+            files = [new AttachmentBuilder(buf, {
+                name: 'achievement.png',
+                description: `Achievement card: ${ach.name} — ${ach.description}`,
+            })];
         } catch { /* non-critical — send embed without card */ }
 
         await msg.edit({ embeds: [revealEmbed], files }).catch(() => null);

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -143,7 +143,11 @@ async function resolveOneWar(client, guildDoc) {
     if (!tied && winnerName) {
         try {
             const buf = await createWarVictoryBanner(winnerName, winnerScore, loserName, loserScore, mvpName);
-            bannerAttachment = new AttachmentBuilder(buf, { name: 'war_victory.png' });
+            bannerAttachment = new AttachmentBuilder(buf, {
+                name: 'war_victory.png',
+                description: `Victory banner: ${winnerName} beat ${loserName} by ${winnerScore} points to ${loserScore}`
+                    + (mvpName ? `, with ${mvpName} as MVP.` : '.'),
+            });
         } catch (err) {
             console.error('[scheduler] war banner generation failed:', err.message);
         }
@@ -363,7 +367,11 @@ async function resolveOneSeason(client, guildDoc) {
 
                     const rank = rankMap.get(u.userId) ?? null;
                     const buf  = await createSeasonRecapCard(u, season.name ?? season.id, rank, totalParticipants);
-                    const file = new AttachmentBuilder(buf, { name: 'season_recap.png' });
+                    const file = new AttachmentBuilder(buf, {
+                        name: 'season_recap.png',
+                        description: `${season.name ?? season.id} recap card for ${member.user.username}`
+                            + (rank ? `, finishing ${rank} of ${totalParticipants}.` : '.'),
+                    });
 
                     await member.send({
                         content: `🏁 **Your ${season.name ?? season.id} recap is here!** Screenshot and share it — see you next season!`,
@@ -671,7 +679,10 @@ async function selectPetOfTheWeek(client) {
             try {
                 const spriteBuf = await generatePetSprite(bestPet.petId, 80, bestPet.evolutionStage ?? 1);
                 embed.setThumbnail('attachment://potw_sprite.png');
-                files = [new AttachmentBuilder(spriteBuf, { name: 'potw_sprite.png' })];
+                files = [new AttachmentBuilder(spriteBuf, {
+                    name: 'potw_sprite.png',
+                    description: `Pixel-art sprite of ${name}, the pet of the week.`,
+                })];
             } catch { /* non-critical */ }
 
             await postAnnouncement(client, guildId, channelId, { embeds: [embed], files });

--- a/src/utils/itemImageHelper.js
+++ b/src/utils/itemImageHelper.js
@@ -3,6 +3,10 @@ const { AttachmentBuilder } = require('discord.js');
 /**
  * Returns { attachment, url } for use in Discord embeds, or null if no image is stored.
  *
+ * `label` is the item's display name, used for the attachment's alt text. Only
+ * the id is needed to find the image, but "Image of hunt:wooden_rifle" is not
+ * something to read out, so every caller that has the name should pass it.
+ *
  * `guildId` is the server the image is being rendered for, and every caller
  * should pass it: activity images (hunt/fish/mine) are per guild since #561,
  * and a lookup without one can only find the shared pre-#561 image.
@@ -11,7 +15,7 @@ const { AttachmentBuilder } = require('discord.js');
  * then that guild's activity image, then the shared image left over from when
  * the collection was global.
  */
-async function getItemImageAttachment(itemId, guildId = null) {
+async function getItemImageAttachment(itemId, guildId = null, { label } = {}) {
     const ItemImage = require('../models/ItemImage');
     let imageData = null;
     let imageType = 'image/png';
@@ -42,7 +46,10 @@ async function getItemImageAttachment(itemId, guildId = null) {
     // filenames, so sanitize it here without touching the lookups above.
     const safeId = itemId.replace(/[^a-zA-Z0-9_-]/g, '_');
     const filename = `item-${safeId}.${ext}`;
-    const attachment = new AttachmentBuilder(Buffer.from(imageData), { name: filename });
+    const attachment = new AttachmentBuilder(Buffer.from(imageData), {
+        name: filename,
+        description: `Artwork for the item ${label || itemId}.`,
+    });
     return { attachment, url: `attachment://${filename}` };
 }
 

--- a/src/utils/itemImageHelper.js
+++ b/src/utils/itemImageHelper.js
@@ -46,10 +46,12 @@ async function getItemImageAttachment(itemId, guildId = null, { label } = {}) {
     // filenames, so sanitize it here without touching the lookups above.
     const safeId = itemId.replace(/[^a-zA-Z0-9_-]/g, '_');
     const filename = `item-${safeId}.${ext}`;
-    const attachment = new AttachmentBuilder(Buffer.from(imageData), {
-        name: filename,
-        description: `Artwork for the item ${label || itemId}.`,
-    });
+    // Discord caps alt text at 1024 characters and rejects the upload over it,
+    // and a shop item's name is whatever an admin typed into the dashboard. The
+    // finished string is what gets cut, not just the label: capping the label
+    // alone would still let the prefix carry the total past the limit.
+    const description = `Artwork for the item ${label || itemId}.`.slice(0, 1024);
+    const attachment = new AttachmentBuilder(Buffer.from(imageData), { name: filename, description });
     return { attachment, url: `attachment://${filename}` };
 }
 

--- a/src/utils/shopBrowse.js
+++ b/src/utils/shopBrowse.js
@@ -116,7 +116,16 @@ async function runShopBrowse(interaction, config) {
             currency
         });
         const filename   = `${activity}-shop-${page.id}.png`;
-        const attachment = new AttachmentBuilder(buffer, { name: filename });
+        // Discord caps alt text at 1024 characters and rejects the upload over
+        // it, so the item list — the one part of this that grows with the page —
+        // is trimmed rather than allowed to fail the whole message.
+        const shown = items.map(i => i.name).filter(Boolean).join(', ');
+        const altText = `${title} — ${page.label}: a banner showing `
+            + (shown ? `${shown}.` : 'no items.');
+        const attachment = new AttachmentBuilder(buffer, {
+            name: filename,
+            description: altText.slice(0, 1024),
+        });
 
         const embed = new EmbedBuilder()
             .setColor(colorHex)

--- a/src/utils/wealthMilestone.js
+++ b/src/utils/wealthMilestone.js
@@ -51,7 +51,10 @@ async function checkAndBroadcastWealthMilestone(client, guildSettings, user, cha
             const memberName = (await channel.guild.members.fetch(user.userId).catch(() => null))
                 ?.user?.username ?? 'Someone';
             const bannerBuf = await createWealthTierBanner(memberName, milestone.label, milestone.color);
-            attachment = new AttachmentBuilder(bannerBuf, { name: 'wealth_banner.png' });
+            attachment = new AttachmentBuilder(bannerBuf, {
+                name: 'wealth_banner.png',
+                description: `Banner: ${memberName} reached the ${milestone.label} wealth tier.`,
+            });
         } catch {}
 
         const embed = new EmbedBuilder()

--- a/tests/attachmentAltText.test.js
+++ b/tests/attachmentAltText.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+/**
+ * #672. Every image the bot sends is a canvas render — rank cards, welcome
+ * cards, achievement popups, shop banners, pet sprites — and not one of the
+ * fifteen `new AttachmentBuilder(buf, { name })` calls passed a `description`,
+ * which is what Discord shows as the image's alt text. A screen reader
+ * announced the filename.
+ *
+ * `/rank` was the sharp end of it. In the common branch — no boosters, no
+ * prestige, no excluded channels — the reply was the card and nothing else, so
+ * the level, XP and rank position the command exists to report existed nowhere
+ * in text: not for a reader, not for a client that failed to fetch the image,
+ * not for anyone searching the channel afterwards.
+ *
+ * The sweep runs over every call site rather than the list of the ones that
+ * were wrong, because the next attachment added is the next one to forget.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SRC = path.join(__dirname, '..', 'src');
+
+function jsFiles(dir) {
+    return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) return jsFiles(full);
+        return entry.name.endsWith('.js') ? [full] : [];
+    });
+}
+
+/**
+ * The source of each `new AttachmentBuilder(...)` call, brackets balanced —
+ * the options object is on its own line in most of these, so a line-based match
+ * would see the buffer argument and nothing else.
+ */
+function attachmentCalls(source) {
+    const calls = [];
+    const marker = 'new AttachmentBuilder(';
+    for (let at = source.indexOf(marker); at !== -1; at = source.indexOf(marker, at + 1)) {
+        let depth = 0;
+        let end = at + marker.length - 1;
+        for (; end < source.length; end++) {
+            if (source[end] === '(') depth++;
+            else if (source[end] === ')' && --depth === 0) break;
+        }
+        calls.push(source.slice(at, end + 1));
+    }
+    return calls;
+}
+
+describe('image attachments carry alt text', () => {
+    const sites = jsFiles(SRC).flatMap(file =>
+        attachmentCalls(fs.readFileSync(file, 'utf8'))
+            .map(call => [path.relative(SRC, file), call]));
+
+    it('finds the call sites it is meant to be checking', () => {
+        // A sweep that discovers its own inputs reports the same green for
+        // "all of them pass one" as for "there are none".
+        expect(sites.length).toBeGreaterThan(10);
+    });
+
+    it('passes a description on every one', () => {
+        const bare = sites
+            .filter(([, call]) => !/\bdescription\s*:/.test(call))
+            .map(([file, call]) => `${file}: ${call.replace(/\s+/g, ' ').slice(0, 80)}`);
+        expect(bare).toEqual([]);
+    });
+
+    it('describes the picture rather than repeating the filename', () => {
+        const lazy = sites
+            .map(([file, call]) => [file, /description\s*:\s*([^\n]*)/.exec(call)?.[1] ?? ''])
+            .filter(([, description]) => /\.(png|jpe?g|gif|webp)/.test(description))
+            .map(([file]) => file);
+        expect(lazy).toEqual([]);
+    });
+});

--- a/tests/attachmentAltText.test.js
+++ b/tests/attachmentAltText.test.js
@@ -63,7 +63,8 @@ describe('image attachments carry alt text', () => {
 
     it('passes a description on every one', () => {
         const bare = sites
-            .filter(([, call]) => !/\bdescription\s*:/.test(call))
+            // `description: x` or the shorthand `{ name, description }`.
+            .filter(([, call]) => !/\bdescription\s*[:,}]/.test(call))
             .map(([file, call]) => `${file}: ${call.replace(/\s+/g, ' ').slice(0, 80)}`);
         expect(bare).toEqual([]);
     });

--- a/tests/dashboardIconButtons.test.js
+++ b/tests/dashboardIconButtons.test.js
@@ -1,0 +1,204 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"customExportConditions": ["node"]}
+ */
+process.env.SUPPRESS_JEST_WARNINGS = 'true';
+
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = global.TextEncoder || TextEncoder;
+global.TextDecoder = global.TextDecoder || TextDecoder;
+
+/**
+ * #670. Two dozen buttons on the dashboard were a single glyph and nothing
+ * else: modal closes rendering `×` or `✕` with neither `title` nor
+ * `aria-label`, and chip-removes carrying `title="Remove"` alone — which
+ * announces "Remove, button" nine times over on a panel holding nine chips,
+ * without ever saying what any of them removes.
+ *
+ * A glyph is not a name. The two rules below are the fix, checked over every
+ * panel rather than the list of the ones that happened to be wrong:
+ *
+ *   - A button whose visible text is only symbols carries an `aria-label`.
+ *   - That label names the thing acted on, not just the verb — so the sweep
+ *     also rejects a bare "Remove" or "Close".
+ *
+ * `dashboardFormLabels.test.js` does the same for inputs, selects and
+ * textareas, which the rules there skip buttons for; between them every
+ * control a user can reach ends up named.
+ */
+const fs = require('fs');
+const path = require('path');
+const ejs = require('ejs');
+const { guildSettingsLocals, populatedGuildSettingsLocals } = require('./helpers/guildSettingsLocals');
+
+const VIEWS = path.join(__dirname, '..', 'src', 'dashboard', 'views');
+const PANELS = path.join(VIEWS, 'partials', 'panels');
+const SCRIPT = path.join(__dirname, '..', 'src', 'dashboard', 'public', 'guild-settings.js');
+
+const panelNames = fs.readdirSync(PANELS).filter(f => f.endsWith('.ejs')).map(f => f.replace(/\.ejs$/, ''));
+
+// A sweep that discovers its own inputs reports the same green for "nothing was
+// wrong" as for "nothing was looked at".
+if (!panelNames.length) throw new Error('no panels found — the sweep would inspect nothing');
+
+const NAMED_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", times: '×', nbsp: ' ' };
+
+/**
+ * `&times;` is five letters in the source and one symbol on the screen, so a
+ * check that skips decoding sees a word where the reader sees a glyph — and
+ * passes exactly the buttons this suite exists to catch.
+ */
+function decodeEntities(text) {
+    return text.replace(/&(#x[0-9a-f]+|#\d+|[a-z]+);/gi, (whole, body) => {
+        if (body[0] === '#') {
+            const code = body[1] === 'x' || body[1] === 'X'
+                ? parseInt(body.slice(2), 16)
+                : parseInt(body.slice(1), 10);
+            return Number.isFinite(code) ? String.fromCodePoint(code) : whole;
+        }
+        return NAMED_ENTITIES[body.toLowerCase()] ?? whole;
+    });
+}
+
+/** True for text a screen reader gets nothing out of: glyphs, emoji, spacing. */
+const iconOnly = text => !/[\p{L}\p{N}]/u.test(decodeEntities(text));
+
+/**
+ * "Remove" repeated down a list of chips names none of them. A label that is
+ * only a verb is what the issue was about, so it does not count as a name.
+ */
+const VERB_ONLY = /^(remove|delete|close|edit|dismiss|clear|cancel|add|x)$/i;
+
+function accessibleName(root, el) {
+    const label = el.getAttribute('aria-label');
+    if (label && label.trim()) return label.trim();
+
+    const labelledby = el.getAttribute('aria-labelledby');
+    if (labelledby) {
+        const text = labelledby.split(/\s+/)
+            .map(id => root.querySelector(`[id="${id}"]`)?.textContent ?? '')
+            .join(' ').trim();
+        if (text) return text;
+    }
+
+    const text = el.textContent.trim();
+    return iconOnly(text) ? '' : text;
+}
+
+function parse(html) {
+    const host = document.createElement('div');
+    host.innerHTML = html;
+    return host;
+}
+
+const render = (file, locals) =>
+    ejs.render(fs.readFileSync(file, 'utf8'), locals, { filename: file });
+
+const targets = [
+    ...panelNames.map(name => [`panels/${name}.ejs`, path.join(PANELS, `${name}.ejs`)]),
+    ['guild-settings.ejs', path.join(VIEWS, 'guild-settings.ejs')],
+    ['partials/game-item-card.ejs', path.join(VIEWS, 'partials', 'game-item-card.ejs')],
+];
+
+// Both fixtures: a fresh Guild document leaves every array-backed list empty,
+// so on that one alone no chip and no repeater row is rendered at all — and the
+// chip-removes are half of what the issue was about.
+const fixtures = [
+    ['empty', guildSettingsLocals],
+    ['populated', populatedGuildSettingsLocals],
+];
+
+const cardLocals = base => ({
+    ...base,
+    item: { id: 'hunt:rifle', label: 'Hunting Rifle', emoji: '🔫', hasImage: true },
+});
+
+const cases = targets.flatMap(([name, file]) =>
+    fixtures.map(([fixture, locals]) => [
+        `${name} (${fixture})`,
+        file,
+        () => (name.endsWith('game-item-card.ejs') ? cardLocals(locals()) : locals()),
+    ]));
+
+describe.each(cases)('%s', (name, file, locals) => {
+    let root;
+    beforeAll(() => { root = parse(render(file, locals())); });
+
+    it('gives every icon-only button an accessible name', () => {
+        const nameless = [...root.querySelectorAll('button')]
+            .filter(button => iconOnly(button.textContent))
+            .filter(button => !accessibleName(root, button))
+            .map(button => button.outerHTML.replace(/\s+/g, ' ').slice(0, 90));
+        expect(nameless).toEqual([]);
+    });
+
+    it('names what each icon-only button acts on, not just the verb', () => {
+        const vague = [...root.querySelectorAll('button')]
+            .filter(button => iconOnly(button.textContent))
+            .map(button => accessibleName(root, button))
+            .filter(label => VERB_ONLY.test(label));
+        expect(vague).toEqual([]);
+    });
+});
+
+// The panel sweep above only sees what the server rendered. Chips, repeater
+// rows and list entries the user adds after load are built by the script, and
+// every one of them was a `×` with a `title="Remove"` at most.
+describe('markup the script renders at runtime', () => {
+    const script = fs.readFileSync(SCRIPT, 'utf8');
+
+    /** Every `<button …>…</button>` written as markup inside the script. */
+    function markupButtons() {
+        const found = [];
+        const open = /<button\b([^>]*)>/g;
+        for (let m = open.exec(script); m; m = open.exec(script)) {
+            const end = script.indexOf('</button>', open.lastIndex);
+            found.push({ attrs: m[1], text: end === -1 ? '' : script.slice(open.lastIndex, end) });
+        }
+        return found;
+    }
+
+    it('finds the buttons it is meant to be checking', () => {
+        // Guards against a rewrite that moves this markup somewhere the regex
+        // no longer matches, which would otherwise read as a clean sweep.
+        expect(markupButtons().length).toBeGreaterThan(5);
+        expect(markupButtons().filter(b => iconOnly(b.text)).length).toBeGreaterThan(5);
+    });
+
+    it('labels every icon-only button it writes as markup', () => {
+        const nameless = markupButtons()
+            .filter(button => iconOnly(button.text))
+            .filter(button => !/\baria-label\s*=/.test(button.attrs))
+            .map(button => `<button${button.attrs}>${button.text}`.replace(/\s+/g, ' ').slice(0, 90));
+        expect(nameless).toEqual([]);
+    });
+
+    /**
+     * The chip removes are built with createElement rather than markup, so the
+     * scan above cannot see them: `btn.textContent = '×'` is the whole label.
+     */
+    it('labels every icon-only button it builds with createElement', () => {
+        const lines = script.split('\n');
+        const created = /(?:const|let|var)\s+(\w+)\s*=\s*document\.createElement\(['"]button['"]\)/;
+        const nameless = [];
+
+        lines.forEach((line, i) => {
+            const m = created.exec(line);
+            if (!m) return;
+            const name = m[1];
+            const block = lines.slice(i, i + 15).join('\n');
+            const text = new RegExp(`${name}\\.textContent\\s*=\\s*'([^']*)'`).exec(block);
+            if (!text || !iconOnly(text[1])) return;
+            if (new RegExp(`${name}\\.(setAttribute\\(['"]aria-label|ariaLabel\\s*=)`).test(block)) return;
+            nameless.push(`${name} at line ${i + 1}`);
+        });
+
+        expect(nameless).toEqual([]);
+    });
+
+    it('finds the createElement buttons it is meant to be checking', () => {
+        const created = script.match(/document\.createElement\(['"]button['"]\)/g) || [];
+        expect(created.length).toBeGreaterThan(2);
+        expect((script.match(/setAttribute\('aria-label'/g) || []).length).toBeGreaterThan(2);
+    });
+});

--- a/tests/dashboardIconButtons.test.js
+++ b/tests/dashboardIconButtons.test.js
@@ -30,6 +30,7 @@ const fs = require('fs');
 const path = require('path');
 const ejs = require('ejs');
 const { guildSettingsLocals, populatedGuildSettingsLocals } = require('./helpers/guildSettingsLocals');
+const { renderPanel, bootPage, clickTab, settle, forgetDocumentListeners } = require('./helpers/guildSettingsPage');
 
 const VIEWS = path.join(__dirname, '..', 'src', 'dashboard', 'views');
 const PANELS = path.join(VIEWS, 'partials', 'panels');
@@ -165,10 +166,16 @@ describe('markup the script renders at runtime', () => {
         expect(markupButtons().filter(b => iconOnly(b.text)).length).toBeGreaterThan(5);
     });
 
+    // A repeater row's button is named from the row's own fields, which change
+    // under the user, so its label is written by labelRepeatedRows rather than
+    // baked into the markup. `data-row-remove` is what opts a button into that,
+    // and the DOM suite below is what checks the labels actually arrive.
+    const namedAtRuntime = attrs => /\bdata-row-remove\s*=/.test(attrs);
+
     it('labels every icon-only button it writes as markup', () => {
         const nameless = markupButtons()
             .filter(button => iconOnly(button.text))
-            .filter(button => !/\baria-label\s*=/.test(button.attrs))
+            .filter(button => !/\baria-label\s*=/.test(button.attrs) && !namedAtRuntime(button.attrs))
             .map(button => `<button${button.attrs}>${button.text}`.replace(/\s+/g, ' ').slice(0, 90));
         expect(nameless).toEqual([]);
     });
@@ -190,6 +197,8 @@ describe('markup the script renders at runtime', () => {
             const text = new RegExp(`${name}\\.textContent\\s*=\\s*'([^']*)'`).exec(block);
             if (!text || !iconOnly(text[1])) return;
             if (new RegExp(`${name}\\.(setAttribute\\(['"]aria-label|ariaLabel\\s*=)`).test(block)) return;
+            // Or it opts into being named from its row's contents at runtime.
+            if (new RegExp(`${name}\\.(dataset\\.rowRemove|setAttribute\\(['"]data-row-remove)`).test(block)) return;
             nameless.push(`${name} at line ${i + 1}`);
         });
 
@@ -200,5 +209,130 @@ describe('markup the script renders at runtime', () => {
         const created = script.match(/document\.createElement\(['"]button['"]\)/g) || [];
         expect(created.length).toBeGreaterThan(2);
         expect((script.match(/setAttribute\('aria-label'/g) || []).length).toBeGreaterThan(2);
+    });
+});
+
+// A repeater is where a static label runs out. Every row holds the same button,
+// so "Remove this level reward" five times over names none of them — and the
+// value that would name one is a field the user edits, so the label has to be
+// rewritten as the row changes rather than written once. These drive the real
+// page and read the labels back off it.
+describe('repeated rows name themselves', () => {
+    beforeEach(() => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        document.body.innerHTML = '';
+        // The populated fixture, so the server-rendered rows exist: on a fresh
+        // Guild every one of these lists is empty.
+        bootPage({
+            panelFetch: panel => ({
+                ok: true, status: 200,
+                text: async () => renderPanel(panel, populatedGuildSettingsLocals()),
+            }),
+        });
+    });
+
+    afterEach(async () => {
+        await settle();
+        forgetDocumentListeners();
+        jest.restoreAllMocks();
+    });
+
+    const labelsIn = id => [...document.querySelectorAll(`#${id} [data-row-remove]`)]
+        .map(button => button.getAttribute('aria-label'));
+
+    const openPanel = async name => { clickTab(name); await settle(); };
+    const fire = (el, type) => el.dispatchEvent(new window.Event(type, { bubbles: true }));
+    /** The relabel after a removal is scheduled a tick later, as the row goes. */
+    const nextTick = () => new Promise(resolve => setTimeout(resolve, 0));
+
+    describe('level rewards', () => {
+        beforeEach(() => openPanel('leveling'));
+
+        it('names every server-rendered row after its own level', () => {
+            expect(labelsIn('level-role-rewards-list'))
+                .toEqual(['Remove the level 5 reward', 'Remove the level 10 reward']);
+        });
+
+        it('follows the level when it is edited, rather than naming the old one', () => {
+            const input = document.querySelector('#level-role-rewards-list .level-reward-level');
+            input.value = '12';
+            fire(input, 'input');
+
+            expect(labelsIn('level-role-rewards-list')[0]).toBe('Remove the level 12 reward');
+        });
+
+        it('falls back to the row position while a new row has no level yet', () => {
+            window.addLevelRoleReward();
+            expect(labelsIn('level-role-rewards-list')[2])
+                .toBe('Remove reward row 3, which has no level set');
+        });
+
+        // The fallback names a row by position, so a removal above it makes
+        // every label below it wrong until they are rewritten.
+        it('renumbers the rows a removal moved', async () => {
+            window.addLevelRoleReward();
+            window.addLevelRoleReward();
+            expect(labelsIn('level-role-rewards-list')[3]).toBe('Remove reward row 4, which has no level set');
+
+            // The third row — the first of the two just added. jsdom does not
+            // compile the inline onclick the server-rendered rows carry, so the
+            // removal is driven from a row whose handler is a property.
+            document.querySelectorAll('#level-role-rewards-list [data-row-remove]')[2].click();
+            await nextTick();
+
+            expect(labelsIn('level-role-rewards-list')).toEqual([
+                'Remove the level 5 reward',
+                'Remove the level 10 reward',
+                'Remove reward row 3, which has no level set',
+            ]);
+        });
+    });
+
+    describe('season tiers', () => {
+        beforeEach(() => openPanel('season'));
+
+        it('names the server-rendered row after its tier', () => {
+            expect(labelsIn('season-tier-rewards-list')).toEqual(['Remove the tier 1 reward']);
+        });
+
+        it('names a row added in the browser once it has a tier', () => {
+            window.addSeasonTierRow();
+            expect(labelsIn('season-tier-rewards-list')[1])
+                .toBe('Remove tier row 2, which has no tier set');
+
+            const input = document.querySelectorAll('#season-tier-rewards-list .season-tier-num')[1];
+            input.value = '4';
+            fire(input, 'input');
+
+            expect(labelsIn('season-tier-rewards-list')[1]).toBe('Remove the tier 4 reward');
+        });
+    });
+
+    describe('reaction role mappings', () => {
+        beforeEach(() => openPanel('reactionroles'));
+
+        it('names a mapping after the emoji and role it maps', () => {
+            window.addRrMapping();
+            expect(labelsIn('rr-mappings-list')).toEqual(['Remove mapping row 1, which is empty']);
+
+            const emoji = document.querySelector('#rr-mappings-list .rr-emoji');
+            emoji.value = '👍';
+            fire(emoji, 'input');
+
+            const role = document.querySelector('#rr-mappings-list .rr-role');
+            role.value = '40';
+            fire(role, 'change');
+
+            expect(labelsIn('rr-mappings-list')).toEqual(['Remove the 👍 → @Member mapping']);
+        });
+
+        it('says which half is missing rather than going back to a bare Remove', () => {
+            window.addRrMapping();
+            const emoji = document.querySelector('#rr-mappings-list .rr-emoji');
+            emoji.value = '🎉';
+            fire(emoji, 'input');
+
+            expect(labelsIn('rr-mappings-list')).toEqual(['Remove the 🎉 → no role mapping']);
+        });
     });
 });

--- a/tests/helpers/fakeMigrationRecords.js
+++ b/tests/helpers/fakeMigrationRecords.js
@@ -24,6 +24,10 @@ const sameValue = (a, b) => {
         if (a == null || b == null) return (a ?? null) === (b ?? null);
         return new Date(a).getTime() === new Date(b).getTime();
     }
+    // Mongo matches `{ field: null }` against a document that has no such field,
+    // which is what the takeover's compare-and-set relies on for records written
+    // before `owner` existed.
+    if (a == null || b == null) return (a ?? null) === (b ?? null);
     return a === b;
 };
 
@@ -62,7 +66,7 @@ function fakeMigrationRecords() {
             if (rows.some(row => row.name === doc.name)) throw duplicateKeyError(doc.name);
             // Mirrors the schema's own defaults: a record written without a
             // state is a finished one.
-            const row = { state: 'complete', startedAt: null, appliedAt: new Date(), durationMs: null, ...doc };
+            const row = { state: 'complete', startedAt: null, owner: null, appliedAt: new Date(), durationMs: null, ...doc };
             rows.push(row);
             return clone(row);
         },
@@ -96,7 +100,7 @@ function fakeMigrationRecords() {
         model,
         rows,
         seed: (fields = {}) => {
-            const row = { state: 'complete', startedAt: null, appliedAt: new Date(), durationMs: null, ...fields };
+            const row = { state: 'complete', startedAt: null, owner: null, appliedAt: new Date(), durationMs: null, ...fields };
             rows.push(row);
             return row;
         },

--- a/tests/helpers/fakeMigrationRecords.js
+++ b/tests/helpers/fakeMigrationRecords.js
@@ -1,0 +1,108 @@
+'use strict';
+
+/**
+ * An in-memory stand-in for the MigrationRecord model.
+ *
+ * The runner's bookkeeping is a two-phase claim over a unique `name` (#654), so
+ * a mock that only implements find and create cannot see the thing that
+ * matters: the duplicate-key error a losing insert gets. This one raises it,
+ * with the driver's `code: 11000`, which is what `isDuplicateKey` reads.
+ *
+ *   const mockRecords = fakeMigrationRecords();
+ *   jest.mock('../src/models/MigrationRecord', () => mockRecords.model);
+ *   mockRecords.rows          // every record, in insertion order
+ *   mockRecords.seed({ name: '001_a' })
+ *
+ * The `mock` prefix is not decoration: jest hoists `jest.mock` above the file's
+ * own declarations and refuses a factory that closes over anything else.
+ */
+
+const clone = row => (row ? { ...row } : null);
+
+const sameValue = (a, b) => {
+    if (a instanceof Date || b instanceof Date) {
+        if (a == null || b == null) return (a ?? null) === (b ?? null);
+        return new Date(a).getTime() === new Date(b).getTime();
+    }
+    return a === b;
+};
+
+/** The handful of query shapes the runner issues, and nothing else. */
+function matches(row, filter = {}) {
+    return Object.entries(filter).every(([field, condition]) => {
+        const value = row[field];
+        if (condition && typeof condition === 'object' && !(condition instanceof Date)) {
+            if ('$in' in condition) return condition.$in.includes(value);
+            if ('$ne' in condition) return !sameValue(value, condition.$ne);
+            throw new Error(`fakeMigrationRecords: unsupported condition on ${field}: ${JSON.stringify(condition)}`);
+        }
+        return sameValue(value, condition);
+    });
+}
+
+function fakeMigrationRecords() {
+    const rows = [];
+
+    /** What mongod answers a second insert of the same unique name with. */
+    const duplicateKeyError = name => Object.assign(
+        new Error(`E11000 duplicate key error collection: test.migrationrecords index: name_1 dup key: { name: "${name}" }`),
+        { code: 11000, name: 'MongoServerError' },
+    );
+
+    const model = {
+        find: (filter = {}) => ({
+            lean: async () => rows.filter(row => matches(row, filter)).map(row => ({ name: row.name })),
+        }),
+
+        findOne: (filter = {}) => ({
+            lean: async () => clone(rows.find(row => matches(row, filter))),
+        }),
+
+        create: async doc => {
+            if (rows.some(row => row.name === doc.name)) throw duplicateKeyError(doc.name);
+            // Mirrors the schema's own defaults: a record written without a
+            // state is a finished one.
+            const row = { state: 'complete', startedAt: null, appliedAt: new Date(), durationMs: null, ...doc };
+            rows.push(row);
+            return clone(row);
+        },
+
+        updateOne: async (filter = {}, update = {}) => {
+            const row = rows.find(r => matches(r, filter));
+            if (!row) return { matchedCount: 0, modifiedCount: 0 };
+            Object.assign(row, update.$set ?? {});
+            return { matchedCount: 1, modifiedCount: 1 };
+        },
+
+        findOneAndUpdate: async (filter = {}, update = {}) => {
+            const row = rows.find(r => matches(r, filter));
+            if (!row) return null;
+            const before = clone(row);
+            Object.assign(row, update.$set ?? {});
+            return before;
+        },
+
+        deleteOne: async (filter = {}) => {
+            const at = rows.findIndex(row => matches(row, filter));
+            if (at === -1) return { deletedCount: 0 };
+            rows.splice(at, 1);
+            return { deletedCount: 1 };
+        },
+
+        modelName: 'MigrationRecord',
+    };
+
+    return {
+        model,
+        rows,
+        seed: (fields = {}) => {
+            const row = { state: 'complete', startedAt: null, appliedAt: new Date(), durationMs: null, ...fields };
+            rows.push(row);
+            return row;
+        },
+        reset: () => { rows.length = 0; },
+        names: () => rows.map(row => row.name),
+    };
+}
+
+module.exports = { fakeMigrationRecords };

--- a/tests/helpers/guildSettingsLocals.js
+++ b/tests/helpers/guildSettingsLocals.js
@@ -108,7 +108,7 @@ function populatedGuildSettingsLocals(overrides = {}) {
         cooldowns: [{ command: 'work', roleId: ROLE, seconds: 30 }],
     };
     s.antiNuke = { ...s.antiNuke, whitelistUserIds: [USER] };
-    s.autoRoles = [ROLE];
+    s.autoRoles = [{ roleId: ROLE }];
     s.reactionRoles = [{ messageId: '1', channelId: CHANNEL, emoji: '👍', roleId: ROLE }];
     s.rssFeeds = [{ url: 'https://example.com/feed.xml', channelId: CHANNEL }];
     s.moderation = {

--- a/tests/integration/migrations.test.js
+++ b/tests/integration/migrations.test.js
@@ -54,6 +54,21 @@ async function appliedInOrder() {
     return (await MigrationRecord.find({}).sort({ _id: 1 }).lean()).map(r => r.name);
 }
 
+/**
+ * Waits for `condition` to hold, polling until it does. A fixed sleep is either
+ * long enough on the machine it was written on or a flake everywhere else, and
+ * the deadline is what turns a condition that never comes into a named failure
+ * rather than a suite-level timeout.
+ */
+async function until(condition, description, { timeoutMs = 10_000, pollMs = 10 } = {}) {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+        if (await condition()) return;
+        if (Date.now() >= deadline) throw new Error(`Timed out after ${timeoutMs}ms waiting for ${description}.`);
+        await new Promise(resolve => setTimeout(resolve, pollMs));
+    }
+}
+
 const db = () => mongoose.connection.db;
 const indexNames = async collection => (await db().collection(collection).indexes()).map(i => i.name).sort();
 
@@ -647,21 +662,26 @@ describe('two processes migrating at once', () => {
     }, 30_000);
 
     test('a held claim does not read as applied while the migration is still running', async () => {
-        const dir = migrationsDir({ '001_a.js': migrationSource({ name: 'a', body: 'await new Promise(r => setTimeout(r, 500));' }) });
+        const dir = migrationsDir({ '001_a.js': migrationSource({ name: 'a', body: 'await new Promise(r => setTimeout(r, 2_000));' }) });
 
         const running = runMigrations({ dir });
-        await new Promise(resolve => setTimeout(resolve, 100));
+        // Polled rather than slept: a fixed delay is either long enough on this
+        // machine or a flake on a slower one, and the claim landing is the event
+        // this is actually waiting for.
+        await until(async () => await MigrationRecord.countDocuments({ name: 'a' }) === 1,
+            'the claim on a to be taken');
 
         // The record exists — it is the lock — but it is not a record of
         // anything having been applied yet. Every reader of that state has to
         // agree, the shard wait of #732 included, or a second shard starts
         // serving traffic against a half-migrated database.
-        expect(await MigrationRecord.countDocuments({ name: 'a' })).toBe(1);
+        expect(await MigrationRecord.findOne({ name: 'a' }).lean())
+            .toMatchObject({ state: 'running', owner: expect.any(String) });
         expect(await pendingMigrationNames({ dir })).toEqual(['a']);
 
         await running;
         expect(await pendingMigrationNames({ dir })).toEqual([]);
-    });
+    }, 30_000);
 });
 
 describe('waiting for another process to migrate', () => {

--- a/tests/integration/migrations.test.js
+++ b/tests/integration/migrations.test.js
@@ -49,9 +49,17 @@ function shippedMigrations() {
         .map(file => require(path.join(MIGRATIONS_DIR, file)));
 }
 
-/** Recorded migration names, oldest first. ObjectIds order by creation. */
+/**
+ * Migration names recorded as *applied*, oldest first. ObjectIds order by
+ * creation.
+ *
+ * A held claim is a record too — it is the lock — but it is not a record of
+ * anything having been applied, so it is excluded here for the same reason the
+ * runner excludes it from its own skip list (#654).
+ */
 async function appliedInOrder() {
-    return (await MigrationRecord.find({}).sort({ _id: 1 }).lean()).map(r => r.name);
+    return (await MigrationRecord.find({ state: { $ne: 'running' } }).sort({ _id: 1 }).lean())
+        .map(r => r.name);
 }
 
 /**
@@ -533,7 +541,13 @@ describe('failure recovery', () => {
             delete process.env.MIGRATION_TIMEOUT_MS;
         }
 
+        // Nothing after the failure is recorded as applied. `slow` does keep
+        // its claim, and deliberately: the timeout stopped the runner waiting,
+        // not the migration, which is still running against the server — so
+        // releasing the lock now would let another process start it alongside.
+        // It ages out instead.
         expect(await appliedInOrder()).toEqual(['a']);
+        expect(await MigrationRecord.findOne({ name: 'slow' }).lean()).toMatchObject({ state: 'running' });
     });
 
     test('the budget in force is handed to the migration, so it can bound its own queries', async () => {

--- a/tests/integration/migrations.test.js
+++ b/tests/integration/migrations.test.js
@@ -30,7 +30,7 @@ const os = require('os');
 const path = require('path');
 const mongoose = require('mongoose');
 
-const { useMongo } = require('../helpers/mongo');
+const { useMongo, buildIndexes } = require('../helpers/mongo');
 
 useMongo();
 
@@ -601,6 +601,66 @@ describe('rollback, against a real server', () => {
 
         await expect(rollbackMigration('gone', { dir })).rejects.toThrow(/irreversible/);
         expect(await appliedInOrder()).toEqual(['a', 'gone']);
+    });
+});
+
+// ── Two processes at once ────────────────────────────────────────────────────
+//
+// #654. This is the case a mock cannot answer: the loser's insert has to be
+// rejected by the server's own unique index, and whether the runner survives
+// that rejection is the whole question. Before the claim, both processes ran
+// the migration and the second one threw E11000 out of runMigrations — aborting
+// a boot over bookkeeping for a migration that had applied fine.
+
+describe('two processes migrating at once', () => {
+    // useMongo connects with autoIndex off, so the unique index that makes the
+    // claim a lock exists only because this asks for it — which also checks
+    // that the schema still declares it.
+    beforeEach(() => buildIndexes(MigrationRecord));
+
+    test('applies each migration once, and neither process aborts', async () => {
+        const dir = migrationsDir({
+            // Long enough that the second process is certain to find the claim
+            // held rather than already completed.
+            '001_a.js': migrationSource({ name: 'a', body: 'await new Promise(r => setTimeout(r, 150));' }),
+            '002_b.js': migrationSource({ name: 'b', body: 'await new Promise(r => setTimeout(r, 150));' }),
+        });
+
+        await expect(Promise.all([
+            runMigrations({ dir }),
+            runMigrations({ dir }),
+        ])).resolves.toEqual([undefined, undefined]);
+
+        expect(globalThis.__migrationRuns).toEqual(['a', 'b']);
+        expect(await appliedInOrder()).toEqual(['a', 'b']);
+    }, 30_000);
+
+    test('leaves one complete record per migration, with its duration on it', async () => {
+        const dir = migrationsDir({ '001_a.js': migrationSource({ name: 'a', body: 'await new Promise(r => setTimeout(r, 150));' }) });
+
+        await Promise.all([runMigrations({ dir }), runMigrations({ dir })]);
+
+        const records = await MigrationRecord.find({}).lean();
+        expect(records).toHaveLength(1);
+        expect(records[0].state).toBe('complete');
+        expect(typeof records[0].durationMs).toBe('number');
+    }, 30_000);
+
+    test('a held claim does not read as applied while the migration is still running', async () => {
+        const dir = migrationsDir({ '001_a.js': migrationSource({ name: 'a', body: 'await new Promise(r => setTimeout(r, 500));' }) });
+
+        const running = runMigrations({ dir });
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        // The record exists — it is the lock — but it is not a record of
+        // anything having been applied yet. Every reader of that state has to
+        // agree, the shard wait of #732 included, or a second shard starts
+        // serving traffic against a half-migrated database.
+        expect(await MigrationRecord.countDocuments({ name: 'a' })).toBe(1);
+        expect(await pendingMigrationNames({ dir })).toEqual(['a']);
+
+        await running;
+        expect(await pendingMigrationNames({ dir })).toEqual([]);
     });
 });
 

--- a/tests/itemImageHelper.test.js
+++ b/tests/itemImageHelper.test.js
@@ -82,4 +82,40 @@ describe('getItemImageAttachment', () => {
         expect(ItemImage.findOne).toHaveBeenNthCalledWith(2, { guildId: null, itemId: 'mine:stone_pickaxe' });
         expect(result.attachment.name).toBe('item-mine_stone_pickaxe.gif');
     });
+
+    // #672's alt text. A shop item's name is whatever an admin typed into the
+    // dashboard, and Discord rejects an upload whose description runs past 1024
+    // characters — so the whole message fails over the caption on the thumbnail.
+    describe('alt text', () => {
+        beforeEach(() => {
+            ItemImage.findOne.mockResolvedValue({ imageData: Buffer.from('fake-png-bytes'), imageType: 'image/png' });
+        });
+
+        test('names the item when the caller passes one', async () => {
+            const result = await getItemImageAttachment('sword', null, { label: 'Iron Sword' });
+            expect(result.attachment.description).toBe('Artwork for the item Iron Sword.');
+        });
+
+        test('falls back to the id, which is all some callers have', async () => {
+            const result = await getItemImageAttachment('hunt:wooden_rifle');
+            expect(result.attachment.description).toBe('Artwork for the item hunt:wooden_rifle.');
+        });
+
+        test('caps an overlong label at what Discord will accept', async () => {
+            const result = await getItemImageAttachment('sword', null, { label: 'A'.repeat(5_000) });
+            expect(result.attachment.description).toHaveLength(1024);
+        });
+
+        // The prefix counts too, so capping the label alone would leave the
+        // finished string 25 characters over the limit.
+        test('counts the prefix against the cap, not just the label', async () => {
+            const result = await getItemImageAttachment('sword', null, { label: 'A'.repeat(1024) });
+            expect(result.attachment.description).toHaveLength(1024);
+        });
+
+        test('caps a fallback id that is overlong too', async () => {
+            const result = await getItemImageAttachment('x'.repeat(5_000));
+            expect(result.attachment.description).toHaveLength(1024);
+        });
+    });
 });

--- a/tests/landingLinks.test.js
+++ b/tests/landingLinks.test.js
@@ -1,0 +1,123 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"customExportConditions": ["node"]}
+ */
+process.env.SUPPRESS_JEST_WARNINGS = 'true';
+
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = global.TextEncoder || TextEncoder;
+global.TextDecoder = global.TextDecoder || TextDecoder;
+
+/**
+ * #673. Thirteen footer entries were `<a>` with no `href`, styled
+ * `cursor: pointer` — they looked clickable, were not focusable, were not
+ * announced as links, and did nothing when clicked. Four of them named things
+ * this project does not have (a Discord server, a sponsorship page, a privacy
+ * policy, terms), which is why they had nowhere to point; those are gone. The
+ * rest now point somewhere real.
+ *
+ * The nav had the matching problem in the other direction: "Features" and
+ * "Modules" were two links to `#features`, so one of them silently did nothing
+ * a reader could tell from the other.
+ *
+ * A link that resolves nowhere renders exactly like one that does, so these
+ * check the destinations rather than the markup: every in-page anchor against
+ * the ids the page actually has, and every repository link against the file on
+ * disk it names.
+ */
+const fs = require('fs');
+const path = require('path');
+const ejs = require('ejs');
+const { asset } = require('../src/dashboard/lib/assets');
+
+const ROOT = path.join(__dirname, '..');
+const VIEWS = path.join(ROOT, 'src', 'dashboard', 'views');
+const STYLES = path.join(ROOT, 'src', 'dashboard', 'public', 'styles.css');
+
+const REPO = 'https://github.com/TheShield2594/clawdia';
+
+function landingPage(user = null) {
+    const file = path.join(VIEWS, 'index.ejs');
+    const html = ejs.render(
+        fs.readFileSync(file, 'utf8'),
+        { user, stats: { servers: 4, members: 120, uptime: '3d' }, version: '1.2.3', asset },
+        { filename: file },
+    );
+    document.documentElement.innerHTML = html;
+    return document;
+}
+
+describe('the landing page links somewhere', () => {
+    let page;
+    beforeAll(() => { page = landingPage(); });
+
+    const anchors = () => [...page.querySelectorAll('a')];
+    /** '' for an anchor with no href, so each check below reports its own
+        failure rather than the first one throwing on a null. */
+    const hrefs = () => anchors().map(a => a.getAttribute('href') || '');
+
+    it('has no anchor without an href', () => {
+        const dead = anchors()
+            .filter(a => !a.getAttribute('href')?.trim())
+            .map(a => a.textContent.trim());
+        expect(dead).toEqual([]);
+    });
+
+    it('resolves every in-page anchor against a section that exists', () => {
+        const fragments = hrefs().filter(href => href.startsWith('#'));
+
+        // A sweep that finds nothing to check reports the same green as one
+        // that finds everything in order.
+        expect(fragments.length).toBeGreaterThan(3);
+        expect(fragments.filter(href => !page.querySelector(`[id="${href.slice(1)}"]`))).toEqual([]);
+    });
+
+    it('points every repository link at a file that is actually there', () => {
+        const missing = hrefs()
+            .filter(href => href.startsWith(`${REPO}/blob/`))
+            .map(href => href.replace(`${REPO}/blob/main/`, ''))
+            .filter(file => !fs.existsSync(path.join(ROOT, file)));
+        expect(missing).toEqual([]);
+    });
+
+    it('opens every off-site link with rel="noopener"', () => {
+        const unsafe = anchors()
+            .filter(a => a.getAttribute('target') === '_blank')
+            .filter(a => !/\bnoopener\b/.test(a.getAttribute('rel') || ''))
+            .map(a => a.getAttribute('href'));
+        expect(unsafe).toEqual([]);
+    });
+
+    it('gives each nav link a destination of its own', () => {
+        const links = [...page.querySelectorAll('.cw-nav-links a')];
+        expect(links.length).toBeGreaterThan(3);
+
+        const targets = links.map(a => a.getAttribute('href'));
+        expect(targets).toEqual([...new Set(targets)]);
+    });
+
+    it('keeps the footer down to entries this project can stand behind', () => {
+        const labels = [...page.querySelectorAll('.cw-footer ul a')].map(a => a.textContent.trim());
+        expect(labels.length).toBeGreaterThan(0);
+        // The four that named things that do not exist. They had no href
+        // because there was none to give, so re-adding one is the regression.
+        for (const gone of ['Discord', 'Sponsor', 'Privacy', 'Terms']) {
+            expect(labels).not.toContain(gone);
+        }
+    });
+});
+
+describe('footer link styling', () => {
+    const styles = fs.readFileSync(STYLES, 'utf8');
+    const rule = name => new RegExp(`\\.cw-footer ul a${name}\\s*\\{([^}]*)\\}`).exec(styles)?.[1];
+
+    it('no longer paints a hand cursor onto something that may not be a link', () => {
+        // cursor: pointer is the browser's own default for an <a href>, so the
+        // declaration only ever did anything for the ones that had no href.
+        expect(rule('')).not.toMatch(/cursor:\s*pointer/);
+    });
+
+    it('shows keyboard focus, which a link with no href could never take', () => {
+        expect(rule(':focus-visible')).toMatch(/outline:/);
+    });
+});

--- a/tests/migrationClaim.test.js
+++ b/tests/migrationClaim.test.js
@@ -1,0 +1,199 @@
+'use strict';
+
+// A couple of these run the claim's poll loop under fake timers, which is what
+// Mongoose warns about on require.
+process.env.SUPPRESS_JEST_WARNINGS = 'true';
+
+/**
+ * #654. The runner wrote a migration's MigrationRecord *after* running it, and
+ * `name` is unique — so two processes starting together both ran the migration
+ * and the loser threw E11000 out of `runMigrations`, aborting startup. The
+ * failure was in the bookkeeping, not the migration: the schema change had
+ * applied perfectly well, and the bot refused to boot on the way to writing
+ * that down. Harmless while exactly one instance runs, and a deploy hazard the
+ * moment there is a rolling update or a second replica.
+ *
+ * The record is now claimed before the migration runs, which turns that unique
+ * index from the thing that broke startup into the lock that prevents the
+ * double run. These cover the claim itself; the concurrency it exists for is
+ * exercised against a real mongod in tests/integration/migrations.test.js,
+ * because a duplicate key is a server decision and a mock only agrees to raise
+ * one because it was told to.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { fakeMigrationRecords } = require('./helpers/fakeMigrationRecords');
+
+const mockRecords = fakeMigrationRecords();
+jest.mock('../src/models/MigrationRecord', () => mockRecords.model);
+
+const { claimMigration, runMigrations } = require('../src/migrations/runner');
+
+const TIMEOUT_MS = 1_000;
+const POLL_MS = 2_000;      // CLAIM_POLL_MS in the runner
+const GRACE_MS = 60_000;    // STALE_CLAIM_GRACE_MS in the runner
+
+let dir;
+
+const writeMigration = (file, body) => fs.writeFileSync(path.join(dir, file), body);
+const held = name => mockRecords.rows.find(row => row.name === name);
+
+beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'migration-claim-'));
+    mockRecords.reset();
+    process.env.MIGRATION_BACKUP = 'skip';
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    delete process.env.MIGRATION_BACKUP;
+    fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('claiming a migration', () => {
+    it('takes an unheld one and marks it running, not applied', async () => {
+        await expect(claimMigration('001_a', TIMEOUT_MS)).resolves.toBe('claimed');
+
+        expect(held('001_a').state).toBe('running');
+        expect(held('001_a').startedAt).toBeInstanceOf(Date);
+    });
+
+    it('reports one that is already complete rather than running it again', async () => {
+        mockRecords.seed({ name: '001_a', state: 'complete' });
+        await expect(claimMigration('001_a', TIMEOUT_MS)).resolves.toBe('applied');
+    });
+
+    // Records written before the claim existed have no state field at all, and
+    // reading those as "still running" would block every boot after an upgrade.
+    it('treats a record from before this field existed as applied', async () => {
+        mockRecords.rows.push({ name: '001_a', appliedAt: new Date() });
+        await expect(claimMigration('001_a', TIMEOUT_MS)).resolves.toBe('applied');
+    });
+
+    it('waits on a live claim, then reports the result the holder wrote', async () => {
+        jest.useFakeTimers();
+        mockRecords.seed({ name: '001_a', state: 'running', startedAt: new Date() });
+
+        const claim = claimMigration('001_a', TIMEOUT_MS);
+        await jest.advanceTimersByTimeAsync(0);
+        expect(held('001_a').state).toBe('running');
+
+        // The holder finishes while this process is between polls.
+        held('001_a').state = 'complete';
+        await jest.advanceTimersByTimeAsync(POLL_MS);
+
+        await expect(claim).resolves.toBe('applied');
+    });
+
+    it('claims it after all if the holder failed and released', async () => {
+        jest.useFakeTimers();
+        mockRecords.seed({ name: '001_a', state: 'running', startedAt: new Date() });
+
+        const claim = claimMigration('001_a', TIMEOUT_MS);
+        await jest.advanceTimersByTimeAsync(0);
+
+        // What the runner's own failure path does: the migration threw, so the
+        // claim goes and the record is left for the next boot to retry.
+        mockRecords.reset();
+        await jest.advanceTimersByTimeAsync(POLL_MS);
+
+        await expect(claim).resolves.toBe('claimed');
+        expect(held('001_a').state).toBe('running');
+    });
+
+    // A process killed mid-migration leaves its claim behind. Waiting on one
+    // forever is a boot that never completes, so age is what breaks the tie.
+    it('takes over a claim whose holder is long past its budget', async () => {
+        const startedAt = new Date(Date.now() - (TIMEOUT_MS + GRACE_MS + 1_000));
+        mockRecords.seed({ name: '001_a', state: 'running', startedAt });
+
+        await expect(claimMigration('001_a', TIMEOUT_MS)).resolves.toBe('claimed');
+
+        // Restamped, so the next process to come along waits on this one
+        // instead of taking the same claim over a second time.
+        expect(held('001_a').startedAt.getTime()).toBeGreaterThan(startedAt.getTime());
+        expect(console.warn.mock.calls.flat().join(' ')).toContain('Taking over the claim');
+    });
+
+    it('does not take over one that is merely slow', async () => {
+        jest.useFakeTimers();
+        // Past its own budget, inside the grace: the holder is still unwinding.
+        const startedAt = new Date(Date.now() - (TIMEOUT_MS + 1_000));
+        mockRecords.seed({ name: '001_a', state: 'running', startedAt });
+
+        let settled = false;
+        const claim = claimMigration('001_a', TIMEOUT_MS).then(result => { settled = true; return result; });
+        await jest.advanceTimersByTimeAsync(POLL_MS * 2);
+
+        expect(settled).toBe(false);
+        expect(held('001_a').startedAt).toEqual(startedAt);
+
+        held('001_a').state = 'complete';
+        await jest.advanceTimersByTimeAsync(POLL_MS);
+        await expect(claim).resolves.toBe('applied');
+    });
+
+    it('does not swallow an insert that failed for some other reason', async () => {
+        const boom = Object.assign(new Error('not primary'), { code: 10107 });
+        jest.spyOn(mockRecords.model, 'create').mockRejectedValueOnce(boom);
+
+        await expect(claimMigration('001_a', TIMEOUT_MS)).rejects.toThrow('not primary');
+    });
+});
+
+describe('the run that used to abort', () => {
+    it('skips cleanly when the record appeared after the pending list was read', async () => {
+        writeMigration('001_a.js', "module.exports = { name: 'a', async up() { throw new Error('should not run'); } };");
+
+        // Exactly the race the issue describes: the applied-set read found
+        // nothing, and by the time this process reached the claim another one
+        // had applied and recorded it.
+        jest.spyOn(mockRecords.model, 'find').mockReturnValueOnce({ lean: async () => [] });
+        mockRecords.seed({ name: 'a', state: 'complete' });
+
+        await expect(runMigrations({ dir })).resolves.toBeUndefined();
+        expect(mockRecords.names()).toEqual(['a']);
+    });
+
+    it('completes the claim it took rather than inserting a second record', async () => {
+        writeMigration('001_a.js', "module.exports = { name: 'a', async up() {} };");
+
+        await runMigrations({ dir });
+
+        expect(mockRecords.rows).toHaveLength(1);
+        expect(held('a').state).toBe('complete');
+        expect(typeof held('a').durationMs).toBe('number');
+    });
+
+    it('releases the claim when the migration fails, so the next boot retries', async () => {
+        writeMigration('001_a.js', "module.exports = { name: 'a', async up() { throw new Error('index build failed'); } };");
+
+        await expect(runMigrations({ dir })).rejects.toThrow('index build failed');
+        expect(mockRecords.rows).toEqual([]);
+    });
+
+    it('releases the claim when an optional migration fails too', async () => {
+        writeMigration('001_a.js', "module.exports = { name: 'a', optional: true, async up() { throw new Error('nope'); } };");
+
+        await expect(runMigrations({ dir })).resolves.toBeUndefined();
+        expect(mockRecords.rows).toEqual([]);
+    });
+
+    // waitForMigrations polls this; a claimed-but-unfinished record reading as
+    // applied would let every other shard start against a half-migrated
+    // database, which is the failure #732 exists to prevent.
+    it('does not report a held claim as applied', async () => {
+        writeMigration('001_a.js', "module.exports = { name: 'a', async up() {} };");
+        mockRecords.seed({ name: 'a', state: 'running', startedAt: new Date() });
+
+        const { pendingMigrationNames } = require('../src/migrations/runner');
+        expect(await pendingMigrationNames({ dir })).toEqual(['a']);
+    });
+});

--- a/tests/migrationClaim.test.js
+++ b/tests/migrationClaim.test.js
@@ -41,6 +41,9 @@ let dir;
 const writeMigration = (file, body) => fs.writeFileSync(path.join(dir, file), body);
 const held = name => mockRecords.rows.find(row => row.name === name);
 
+/** Lets a promise chain the test just unblocked run to its end. */
+const settle = () => new Promise(resolve => setTimeout(resolve, 20));
+
 beforeEach(() => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'migration-claim-'));
     mockRecords.reset();
@@ -54,27 +57,35 @@ afterEach(() => {
     jest.useRealTimers();
     jest.restoreAllMocks();
     delete process.env.MIGRATION_BACKUP;
+    delete process.env.MIGRATION_TIMEOUT_MS;
+    delete globalThis.__finishSlow;
+    delete globalThis.__failSlow;
+    delete globalThis.__finishA;
     fs.rmSync(dir, { recursive: true, force: true });
 });
 
 describe('claiming a migration', () => {
     it('takes an unheld one and marks it running, not applied', async () => {
-        await expect(claimMigration('001_a', TIMEOUT_MS)).resolves.toBe('claimed');
+        const { status, owner } = await claimMigration('001_a', TIMEOUT_MS);
 
+        expect(status).toBe('claimed');
         expect(held('001_a').state).toBe('running');
         expect(held('001_a').startedAt).toBeInstanceOf(Date);
+        // The token every later write on this claim has to present.
+        expect(held('001_a').owner).toBe(owner);
+        expect(typeof owner).toBe('string');
     });
 
     it('reports one that is already complete rather than running it again', async () => {
         mockRecords.seed({ name: '001_a', state: 'complete' });
-        await expect(claimMigration('001_a', TIMEOUT_MS)).resolves.toBe('applied');
+        await expect(claimMigration('001_a', TIMEOUT_MS)).resolves.toEqual({ status: 'applied', owner: null });
     });
 
     // Records written before the claim existed have no state field at all, and
     // reading those as "still running" would block every boot after an upgrade.
     it('treats a record from before this field existed as applied', async () => {
         mockRecords.rows.push({ name: '001_a', appliedAt: new Date() });
-        await expect(claimMigration('001_a', TIMEOUT_MS)).resolves.toBe('applied');
+        await expect(claimMigration('001_a', TIMEOUT_MS)).resolves.toEqual({ status: 'applied', owner: null });
     });
 
     it('waits on a live claim, then reports the result the holder wrote', async () => {
@@ -89,7 +100,7 @@ describe('claiming a migration', () => {
         held('001_a').state = 'complete';
         await jest.advanceTimersByTimeAsync(POLL_MS);
 
-        await expect(claim).resolves.toBe('applied');
+        await expect(claim).resolves.toMatchObject({ status: 'applied' });
     });
 
     it('claims it after all if the holder failed and released', async () => {
@@ -104,7 +115,7 @@ describe('claiming a migration', () => {
         mockRecords.reset();
         await jest.advanceTimersByTimeAsync(POLL_MS);
 
-        await expect(claim).resolves.toBe('claimed');
+        await expect(claim).resolves.toMatchObject({ status: 'claimed' });
         expect(held('001_a').state).toBe('running');
     });
 
@@ -112,14 +123,29 @@ describe('claiming a migration', () => {
     // forever is a boot that never completes, so age is what breaks the tie.
     it('takes over a claim whose holder is long past its budget', async () => {
         const startedAt = new Date(Date.now() - (TIMEOUT_MS + GRACE_MS + 1_000));
-        mockRecords.seed({ name: '001_a', state: 'running', startedAt });
+        mockRecords.seed({ name: '001_a', state: 'running', startedAt, owner: 'the-dead-one' });
 
-        await expect(claimMigration('001_a', TIMEOUT_MS)).resolves.toBe('claimed');
+        const { status, owner } = await claimMigration('001_a', TIMEOUT_MS);
 
-        // Restamped, so the next process to come along waits on this one
-        // instead of taking the same claim over a second time.
+        expect(status).toBe('claimed');
+        // Restamped and re-owned, so the next process to come along waits on
+        // this one instead of taking the same claim over a second time — and
+        // the process that lost it can no longer write to the record.
         expect(held('001_a').startedAt.getTime()).toBeGreaterThan(startedAt.getTime());
+        expect(held('001_a').owner).toBe(owner);
+        expect(owner).not.toBe('the-dead-one');
         expect(console.warn.mock.calls.flat().join(' ')).toContain('Taking over the claim');
+    });
+
+    // A record written before `owner` existed has no such field, and Mongo
+    // matches `{ owner: null }` against that — so an upgrade does not leave a
+    // stale claim nobody is allowed to take over.
+    it('takes over a stale claim from before the owner field existed', async () => {
+        const startedAt = new Date(Date.now() - (TIMEOUT_MS + GRACE_MS + 1_000));
+        mockRecords.rows.push({ name: '001_a', state: 'running', startedAt });
+
+        await expect(claimMigration('001_a', TIMEOUT_MS)).resolves.toMatchObject({ status: 'claimed' });
+        expect(held('001_a').owner).toEqual(expect.any(String));
     });
 
     it('does not take over one that is merely slow', async () => {
@@ -137,7 +163,7 @@ describe('claiming a migration', () => {
 
         held('001_a').state = 'complete';
         await jest.advanceTimersByTimeAsync(POLL_MS);
-        await expect(claim).resolves.toBe('applied');
+        await expect(claim).resolves.toMatchObject({ status: 'applied' });
     });
 
     it('does not swallow an insert that failed for some other reason', async () => {
@@ -184,6 +210,98 @@ describe('the run that used to abort', () => {
 
         await expect(runMigrations({ dir })).resolves.toBeUndefined();
         expect(mockRecords.rows).toEqual([]);
+    });
+
+    // withTimeout stops *waiting*; it does not stop the migration, which goes on
+    // running against the server. Releasing the claim at that moment would let
+    // another process start the same migration alongside the one still running —
+    // the exact concurrency the claim exists to prevent, reintroduced by its own
+    // cleanup.
+    it('holds the claim while a migration it timed out on is still running', async () => {
+        process.env.MIGRATION_TIMEOUT_MS = '30';
+        writeMigration('001_slow.js', `
+            module.exports = {
+                name: 'slow',
+                up: () => new Promise(resolve => { globalThis.__finishSlow = resolve; }),
+            };
+        `);
+
+        await expect(runMigrations({ dir })).rejects.toThrow(/Timed out after 30ms: slow/);
+
+        // Still held, well past the budget it overran.
+        expect(held('slow')).toMatchObject({ state: 'running' });
+        expect(console.warn.mock.calls.flat().join(' ')).toContain('Holding the claim on slow');
+
+        // And released once the work it could not wait for finally settles.
+        globalThis.__finishSlow();
+        await settle();
+        expect(held('slow')).toBeUndefined();
+    });
+
+    it('releases the claim when the work it timed out on eventually fails', async () => {
+        process.env.MIGRATION_TIMEOUT_MS = '30';
+        writeMigration('001_slow.js', `
+            module.exports = {
+                name: 'slow',
+                up: () => new Promise((resolve, reject) => { globalThis.__failSlow = reject; }),
+            };
+        `);
+
+        await expect(runMigrations({ dir })).rejects.toThrow(/Timed out/);
+        globalThis.__failSlow(new Error('index build refused'));
+        await settle();
+
+        expect(held('slow')).toBeUndefined();
+    });
+
+    it("does not delete the claim of the process that took over from it", async () => {
+        process.env.MIGRATION_TIMEOUT_MS = '30';
+        writeMigration('001_slow.js', `
+            module.exports = {
+                name: 'slow',
+                up: () => new Promise(resolve => { globalThis.__finishSlow = resolve; }),
+            };
+        `);
+
+        await expect(runMigrations({ dir })).rejects.toThrow(/Timed out/);
+        const first = held('slow').owner;
+
+        // The first runner's process is still alive but its claim has aged out,
+        // so a second one takes it over and starts the migration again.
+        held('slow').startedAt = new Date(Date.now() - (30 + GRACE_MS + 1_000));
+        const { owner: second } = await claimMigration('slow', 30);
+        expect(second).not.toBe(first);
+
+        // Now the first runner's migration finally settles and tries to clean up
+        // after itself. The record it would have deleted is no longer its own.
+        globalThis.__finishSlow();
+        await settle();
+
+        expect(held('slow')).toMatchObject({ state: 'running', owner: second });
+    });
+
+    it("does not mark complete a claim that was taken over while it ran", async () => {
+        writeMigration('001_a.js', `
+            module.exports = {
+                name: 'a',
+                up: () => new Promise(resolve => { globalThis.__finishA = resolve; }),
+            };
+        `);
+
+        const run = runMigrations({ dir });
+        await settle();
+        expect(held('a').state).toBe('running');
+
+        // Taken over mid-run: another process now owns this record and is
+        // running the migration itself.
+        held('a').owner = 'the-successor';
+        globalThis.__finishA();
+        await run;
+
+        // Marking it complete here would announce as applied a migration the
+        // successor is still part-way through.
+        expect(held('a')).toMatchObject({ state: 'running', owner: 'the-successor' });
+        expect(console.warn.mock.calls.flat().join(' ')).toContain('claim had already');
     });
 
     // waitForMigrations polls this; a claimed-but-unfinished record reading as

--- a/tests/migrationRollback.test.js
+++ b/tests/migrationRollback.test.js
@@ -11,16 +11,11 @@ const path = require('path');
 // every shipped migration declares down() or irreversible: true, and a
 // mongodump is attempted before anything irreversible runs.
 
-const records = [];
-jest.mock('../src/models/MigrationRecord', () => ({
-    find: () => ({ lean: async () => records.map(r => ({ name: r.name })) }),
-    create: async doc => { records.push(doc); return doc; },
-    deleteOne: async ({ name }) => {
-        const i = records.findIndex(r => r.name === name);
-        if (i !== -1) records.splice(i, 1);
-        return { deletedCount: i === -1 ? 0 : 1 };
-    },
-}));
+const { fakeMigrationRecords } = require('./helpers/fakeMigrationRecords');
+
+const mockRecords = fakeMigrationRecords();
+jest.mock('../src/models/MigrationRecord', () => mockRecords.model);
+const records = mockRecords.rows;
 
 jest.mock('child_process', () => ({ spawnSync: jest.fn() }));
 

--- a/tests/migrationRunner.test.js
+++ b/tests/migrationRunner.test.js
@@ -86,7 +86,14 @@ describe('timeout budget', () => {
         process.env.MIGRATION_TIMEOUT_MS = '60';
         writeMigration('001_slow.js', "module.exports = { name: 'slow', up: () => new Promise(() => {}) };");
         await expect(runMigrations({ dir })).rejects.toThrow(/Timed out after 60ms: slow/);
-        expect(records).toEqual([]);
+
+        // Nothing is recorded as applied. The claim is still held, though, and
+        // deliberately: the timeout stopped the runner waiting, not the
+        // migration, so releasing it would let another process start the same
+        // migration alongside the one still running. tests/migrationClaim.test.js
+        // covers that, and the claim ageing out afterwards.
+        expect(records.filter(r => r.state !== 'running')).toEqual([]);
+        expect(records.map(r => [r.name, r.state])).toEqual([['slow', 'running']]);
     });
 });
 

--- a/tests/migrationRunner.test.js
+++ b/tests/migrationRunner.test.js
@@ -6,11 +6,11 @@ const path = require('path');
 
 // The runner reaches for the MigrationRecord model at require time, so the
 // model is replaced with an in-memory stand-in before anything loads it.
-const records = [];
-jest.mock('../src/models/MigrationRecord', () => ({
-    find: () => ({ lean: async () => records.map(r => ({ name: r.name })) }),
-    create: async doc => { records.push(doc); return doc; },
-}));
+const { fakeMigrationRecords } = require('./helpers/fakeMigrationRecords');
+
+const mockRecords = fakeMigrationRecords();
+jest.mock('../src/models/MigrationRecord', () => mockRecords.model);
+const records = mockRecords.rows;
 
 const { runMigrations } = require('../src/migrations/runner');
 

--- a/tests/migrationShardWait.test.js
+++ b/tests/migrationShardWait.test.js
@@ -10,18 +10,11 @@ const fs   = require('fs');
 const os   = require('os');
 const path = require('path');
 
-const records = [];
-jest.mock('../src/models/MigrationRecord', () => ({
-    find: (filter = {}) => ({
-        lean: async () => {
-            const wanted = filter?.name?.$in;
-            return records
-                .filter(r => !wanted || wanted.includes(r.name))
-                .map(r => ({ name: r.name }));
-        },
-    }),
-    create: async doc => { records.push(doc); return doc; },
-}));
+const { fakeMigrationRecords } = require('./helpers/fakeMigrationRecords');
+
+const mockRecords = fakeMigrationRecords();
+jest.mock('../src/models/MigrationRecord', () => mockRecords.model);
+const records = mockRecords.rows;
 
 const { pendingMigrationNames, waitForMigrations, isRecordableMigration } = require('../src/migrations/runner');
 

--- a/tests/rankTextEquivalent.test.js
+++ b/tests/rankTextEquivalent.test.js
@@ -1,0 +1,152 @@
+'use strict';
+
+/**
+ * #672. `/rank` reported level, XP and server position by drawing them onto a
+ * PNG. In the common branch — no active boosters, no prestige or ranked
+ * history, no XP-excluded channels — it replied with that PNG and no embed at
+ * all, so the three numbers the command exists to report were nowhere a screen
+ * reader, a failed image fetch, or a channel search could reach them.
+ *
+ * The card is now an illustration of an embed that carries the numbers, and it
+ * ships with alt text of its own. These drive the command through
+ * tests/helpers/fakeInteraction.js and read what a player is actually sent.
+ */
+
+const { fakeCollection } = require('./helpers/fakeCollection');
+const { makeInteraction } = require('./helpers/fakeInteraction');
+
+const mockUsers = fakeCollection('User', { level: 0, xp: 0, activeEffects: [] });
+const mockGuilds = fakeCollection('Guild');
+
+jest.mock('../src/models/User', () => mockUsers.model);
+jest.mock('../src/models/Guild', () => mockGuilds.model);
+jest.mock('../src/utils/grindProfile', () => ({ attachGrind: jest.fn(async user => user) }));
+// The canvas render is the one part of this that needs fonts and a GPU-free
+// encode; what it draws is cardGenerator's business, not this file's.
+jest.mock('../src/utils/cardGenerator', () => ({
+    createRankCard: jest.fn(async () => Buffer.from('rank-card-png')),
+}));
+
+const rank = require('../src/commands/leveling/rank');
+
+const GUILD_ID = 'guild-1';
+const USER_ID = 'user-1';
+
+const seedUser = (fields = {}) => mockUsers.seed({
+    userId: USER_ID, guildId: GUILD_ID, level: 7, xp: 250,
+    activeEffects: [], streak: { current: 3 },
+    ...fields,
+});
+
+/** Runs the command and returns the single payload it replied with. */
+async function run(interaction = makeInteraction({ guildId: GUILD_ID, userId: USER_ID })) {
+    await rank.execute(interaction);
+    expect(interaction.replies).toHaveLength(1);
+    return interaction.replies[0];
+}
+
+const fieldsOf = payload => payload.embeds[0].data.fields.map(f => [f.name, f.value]);
+const flatten = payload => JSON.stringify(payload.embeds[0].data);
+
+beforeEach(() => {
+    mockUsers.reset();
+    mockGuilds.reset();
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockGuilds.seed({ guildId: GUILD_ID });
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('the numbers exist in text', () => {
+    it('sends an embed alongside the card even with nothing else to report', async () => {
+        seedUser();
+        const payload = await run();
+
+        expect(payload.files).toHaveLength(1);
+        expect(payload.embeds).toHaveLength(1);
+    });
+
+    it('carries level, XP and rank position as fields', async () => {
+        seedUser({ level: 7, xp: 250 });
+        const payload = await run();
+
+        // requiredXp is level * 100 + 100, and the only seeded user is rank 1.
+        expect(fieldsOf(payload)).toEqual([
+            ['📊 Level', '7'],
+            ['⭐ XP', '250 / 800'],
+            ['🏆 Server rank', '#1'],
+        ]);
+    });
+
+    it('names the player and their position in the embed author line', async () => {
+        seedUser();
+        const payload = await run();
+        expect(payload.embeds[0].data.author.name).toBe('player — rank #1');
+    });
+
+    it('counts the players ahead, so the reported rank is the real one', async () => {
+        seedUser({ level: 7, xp: 250 });
+        mockUsers.seed({ userId: 'ahead-1', guildId: GUILD_ID, level: 9, xp: 0, activeEffects: [] });
+        mockUsers.seed({ userId: 'ahead-2', guildId: GUILD_ID, level: 7, xp: 900, activeEffects: [] });
+        mockUsers.seed({ userId: 'behind', guildId: GUILD_ID, level: 2, xp: 0, activeEffects: [] });
+
+        const payload = await run();
+        expect(fieldsOf(payload)).toContainEqual(['🏆 Server rank', '#3']);
+    });
+});
+
+describe('the card describes itself', () => {
+    it('gives the attachment alt text with the same numbers on it', async () => {
+        seedUser({ level: 7, xp: 250 });
+        const { description } = (await run()).files[0];
+
+        expect(description).toContain('player');
+        expect(description).toContain('level 7');
+        expect(description).toContain('250 of 800 XP');
+        expect(description).toContain('#1');
+    });
+
+    it('stays inside Discord\'s 1024-character cap on alt text', async () => {
+        seedUser({ level: 999, xp: 99_999 });
+        expect((await run()).files[0].description.length).toBeLessThanOrEqual(1024);
+    });
+});
+
+describe('what used to need a branch of its own', () => {
+    it('still reports active boosters, now on the one embed', async () => {
+        seedUser({
+            activeEffects: [{ type: 'xp_booster_2x', expiresAt: new Date(Date.now() + 3_600_000), charges: -1 }],
+        });
+        const payload = await run();
+
+        expect(flatten(payload)).toContain('Active Boosters');
+        // And the numbers are still there, which is the regression the old
+        // four-branch reply invited: each branch built a different embed.
+        expect(fieldsOf(payload)).toContainEqual(['📊 Level', '7']);
+    });
+
+    it('still reports prestige, and still keeps the numbers', async () => {
+        seedUser({ accountPrestige: { rank: 2 } });
+        const payload = await run();
+
+        expect(flatten(payload)).toContain('Identity');
+        expect(fieldsOf(payload)).toContainEqual(['📊 Level', '7']);
+    });
+
+    it('still footnotes XP exclusions', async () => {
+        seedUser();
+        mockGuilds.reset();
+        mockGuilds.seed({ guildId: GUILD_ID, leveling: { noXpChannelIds: ['c1'], noXpRoleIds: [] } });
+
+        const payload = await run();
+        expect(payload.embeds[0].data.footer.text).toMatch(/xpinfo/);
+        expect(fieldsOf(payload)).toContainEqual(['📊 Level', '7']);
+    });
+
+    it('says so in text when the player has no XP yet', async () => {
+        const interaction = makeInteraction({ guildId: GUILD_ID, userId: USER_ID });
+        await rank.execute(interaction);
+        expect(interaction.replies[0].content).toMatch(/hasn't earned any XP/);
+    });
+});


### PR DESCRIPTION
This PR addresses three accessibility and reliability issues across the dashboard, migrations, and image attachments.

## Summary

Fixes accessibility violations for icon-only buttons, implements migration claim locking to prevent concurrent execution, adds alt text to all image attachments, and corrects broken landing page links.

## Key Changes

**Accessibility - Icon-only buttons (#670)**
- Added comprehensive test suite (`dashboardIconButtons.test.js`) that validates every icon-only button across all dashboard panels has an accessible name via `aria-label` or `aria-labelledby`
- Enforces that button labels name the thing acted on (e.g., "Remove chip" not just "Remove")
- Updated all dashboard panel templates to add proper `aria-label` attributes to close buttons, chip removes, and other icon-only controls
- Updated runtime button generation in `guild-settings.js` to include accessible names

**Migration concurrency control (#654)**
- Implemented `claimMigration()` function in `runner.js` that uses the unique `name` index as a distributed lock
- Records are now created *before* migration execution, preventing duplicate runs during rolling updates or multi-replica deployments
- Added `state` field to `MigrationRecord` schema to distinguish claimed-but-unfinished from completed migrations
- Includes stale claim detection (60s grace period) to recover from crashed processes
- Added comprehensive test suite (`migrationClaim.test.js`) covering claim acquisition, waiting, timeout, and takeover scenarios
- Updated integration tests to verify concurrent execution works correctly

**Image attachment alt text (#672)**
- Added test suite (`attachmentAltText.test.js`) that scans all source files for `AttachmentBuilder` calls and validates they include `description` for alt text
- Updated all image attachment creation sites to include descriptive alt text:
  - Rank cards: includes level, XP, and rank position
  - Welcome cards, achievement popups, shop banners, pet sprites, war banners, etc.
  - Alt text respects Discord's 1024-character limit
- Updated `/rank` command to include text embed with the same numbers alongside the card image

**Landing page links (#673)**
- Added test suite (`landingLinks.test.js`) validating all footer and nav links resolve to real destinations
- Fixed duplicate "Features" link in navigation (one now points to "#modules")
- Removed dead links to non-existent Discord server, sponsorship page, privacy policy, and terms
- Centralized repository URL in `index.ejs` for easier maintenance
- Verified all in-page anchors match actual section IDs
- Verified all repository links point to files that exist

**Test infrastructure**
- Added `fakeMigrationRecords.js` helper that properly simulates MongoDB duplicate key errors for testing claim logic
- Updated existing migration tests to use the new helper
- Updated `buildIndexes` export in mongo helper for integration tests

## Implementation Details

- Migration claiming uses optimistic locking with `findOneAndUpdate` to ensure only one process takes over a stale claim
- Icon button validation uses Unicode property escapes to detect actual glyphs vs. words, and decodes HTML entities for accurate detection
- Alt text generation includes context-specific information (item names, player names, etc.) rather than generic descriptions
- All changes maintain backward compatibility with existing migrations and records

https://claude.ai/code/session_01AGV96VKQxZG1iuecdcTWGb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added descriptive alt text to generated images and item attachments.
  * Improved screen-reader labels for dashboard controls and modal buttons.
  * Added visible keyboard focus indicators for footer links.

* **Improvements**
  * Rank displays now consistently include level, XP, and server ranking details.
  * Landing-page navigation and repository links were updated and validated.

* **Reliability**
  * Improved migration handling when multiple processes run migrations concurrently.

* **Tests**
  * Added coverage for image descriptions, accessible controls, links, rank details, and migration concurrency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->