### PR TITLE
Improve mobile UX and accessibility: nav toggle, history, motion

### DIFF
--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -649,6 +649,25 @@ Two related conventions worth knowing while writing a panel:
   reaches for the paw mark through `partials/brand-mark.ejs` rather than
   pasting ten ellipses. The cream bar on the landing page and the server
   picker is `partials/nav.ejs`, which takes a `page` local.
+- A settings field gets Enter-saves-the-section for free (#679), and gets it
+  from the same place the unsaved-changes banner gets its answer: the field's
+  save scope, and the `saveSettings()` button in it. So there is nothing to
+  wire — but the two opt-outs are worth knowing. A field that is *not* a
+  setting (a search box, a "pick one to add", a one-shot admin lookup) is
+  marked `data-no-dirty`, which takes it out of the banner and out of Enter
+  together; and a section whose commit is its own POST rather than
+  `saveSettings()` has no save button for Enter to press, so Enter stays inert
+  there on purpose — better than firing a section save at somebody reaching
+  for Add.
+- Anything destructive goes through `showConfirm()` (#677), including the ones
+  that look small. Name the thing in the body — panels put several identical ×
+  buttons in a row, and the one the reader hit is not always the one they
+  meant — and say what the action does not undo.
+- A new animation needs no `prefers-reduced-motion` rule of its own (#675).
+  The block at the end of `public/styles.css` is one universal rule, so it
+  already covers whatever you write. Only add a selector there if stopping the
+  animation mid-flight leaves the element somewhere wrong — the background
+  blobs are the example, since finishing early would strand them off-position.
 
 ### Adding API Endpoints
 

--- a/src/dashboard/public/guild-settings.js
+++ b/src/dashboard/public/guild-settings.js
@@ -15,6 +15,25 @@ function boot(key) {
     return JSON.parse(JSON.stringify(BOOT[key]));
 }
 
+// ── Media queries ────────────────────────────────────────────────────
+// jsdom has no matchMedia, and neither did a handful of browsers this page
+// still loads in. A query nobody can answer reads as "no preference expressed"
+// — the desktop layout, and motion left as authored — which is what the page
+// did before any of this existed.
+function media(query) {
+    return typeof window.matchMedia === 'function' ? window.matchMedia(query) : null;
+}
+
+const REDUCED_MOTION = '(prefers-reduced-motion: reduce)';
+
+// styles.css answers this for everything it can reach, but `scroll-behavior`
+// in CSS does not govern a `behavior: 'smooth'` passed to scrollIntoView (#675)
+// — that argument wins over the stylesheet — so the one call that scrolls the
+// page has to ask as well.
+function scrollBehavior() {
+    return media(REDUCED_MOTION)?.matches ? 'auto' : 'smooth';
+}
+
 // ── Lazily loaded panels ─────────────────────────────────────────────
 // The page ships only the panel that is open on arrival; the other two dozen
 // come down as HTML fragments the first time their tab is clicked. So nothing
@@ -116,11 +135,117 @@ const topbarSection = document.getElementById('topbar-section');
 // button being held down.
 const mainContent = document.getElementById('dash-main-content');
 
+// ── Narrow-viewport nav toggle (#674) ────────────────────────────────
+// Below 768px the sidebar stops being a column beside the content and becomes
+// a block on top of it, so the 25 nav items, the search box and the user
+// footer all sat between the reader and the panel they had just opened — on
+// every visit, in both directions, because picking a section from the top of
+// the page leaves the settings below the fold.
+//
+// So on a narrow viewport the nav starts folded and the reader unfolds it to
+// move. The width is the same 768px the stylesheet stacks at, and it is asked
+// rather than assumed: a tablet turned sideways crosses it mid-session, and
+// the toggle has to disappear again when it does — a hidden nav with no
+// control to open it is the one state this must never leave behind.
+//
+// Nothing here runs without matchMedia: `media()` answers null, `isNarrow`
+// reads false, the button stays `hidden`, and the sidebar keeps the shape it
+// has always had.
+const dashSide = document.querySelector('.dash-side');
+const navToggle = document.getElementById('dash-nav-toggle');
+const narrowViewport = media('(max-width: 768px)');
+
+function isNarrow() {
+    return !!narrowViewport?.matches;
+}
+
+function setNavOpen(open) {
+    if (!dashSide) return;
+    dashSide.classList.toggle('nav-collapsed', !open);
+    if (navToggle) navToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+}
+
+/** Fold the nav away after the reader has chosen where to go. Narrow only. */
+function collapseNavAfterNavigation() {
+    if (!isNarrow() || !dashSide || dashSide.classList.contains('nav-collapsed')) return;
+    setNavOpen(false);
+    // The nav was the top of the page and is now gone, so without this the
+    // reader is left scrolled to where it used to be — which is now somewhere
+    // in the middle of the panel. Focus has already moved to the main content
+    // with preventScroll, precisely so this is the call that decides where the
+    // page lands. jsdom has no scrollIntoView, and neither did the browsers
+    // that would not have got here anyway.
+    if (mainContent && typeof mainContent.scrollIntoView === 'function') {
+        mainContent.scrollIntoView({ behavior: scrollBehavior(), block: 'start' });
+    }
+}
+
+function syncNavToggle() {
+    const narrow = isNarrow();
+    if (navToggle) navToggle.hidden = !narrow;
+    // Widening puts the nav back unconditionally: at desktop width the
+    // collapsed class would hide a column that has no control to restore it.
+    setNavOpen(!narrow);
+}
+
+if (navToggle && dashSide && narrowViewport) {
+    navToggle.addEventListener('click', () => {
+        setNavOpen(dashSide.classList.contains('nav-collapsed'));
+    });
+    // addEventListener where it exists, addListener for the Safari versions
+    // where MediaQueryList is still an EventTarget in name only.
+    if (typeof narrowViewport.addEventListener === 'function') {
+        narrowViewport.addEventListener('change', syncNavToggle);
+    } else if (typeof narrowViewport.addListener === 'function') {
+        narrowViewport.addListener(syncNavToggle);
+    }
+    syncNavToggle();
+}
+
+// The section the server rendered active, which is what a Back press onto the
+// entry the page loaded on has to restore.
+const INITIAL_TAB = document.querySelector('.panel.active')?.id || null;
+
 // The tab the reader last asked for. A panel that is still being fetched when
 // the reader moves on must not steal the view when it finally arrives.
-let requestedTab = document.querySelector('.panel.active')?.id || null;
+let requestedTab = INITIAL_TAB;
 
-async function activateTab(tab) {
+// The hashes that name an inner tab rather than a panel, and the panel each one
+// lives in. '#knowledgebase' is a place in the AI panel, so arriving at it — or
+// coming back to it — has to open 'ai' and then the tab inside it.
+const INNER_TO_PARENT = { knowledgebase: 'ai', aisummaries: 'ai', aipersonas: 'ai', dailynews: 'rss' };
+const AI_INNER_TABS = { knowledgebase: 'ai-knowledgebase', aisummaries: 'ai-summaries', aipersonas: 'ai-personas' };
+const RSS_INNER_TABS = { dailynews: 'rss-tab-dailynews' };
+
+/**
+ * Record a section change in the browser's history.
+ *
+ * Every section change used to be a replaceState (#679), so the whole
+ * dashboard occupied a single history entry: Back from the tenth panel a
+ * reader had opened left the dashboard altogether rather than returning to the
+ * ninth. Pushing gives each section an entry, which is what the button is for.
+ *
+ * Still replaced, not pushed, when the URL would not change — re-clicking the
+ * section already open, or opening the panel that an inner tab's hash already
+ * points into. Neither is a place a reader could come back to, and an entry
+ * that restores what is already on screen is a Back press that does nothing.
+ */
+function writeTabHash(tab, mode) {
+    if (!window.history || !history.pushState) return;
+    const curInner = location.hash.slice(1);
+    const newHash = (INNER_TO_PARENT[curInner] === tab) ? location.hash : '#' + tab;
+    if (mode === 'push' && newHash !== location.hash) history.pushState(null, '', newHash);
+    else history.replaceState(null, '', newHash);
+}
+
+/**
+ * Show a section.
+ *
+ * `historyMode` is 'push' for a section the reader just chose, 'replace' for
+ * the one the URL already named on arrival, and 'none' when the browser is
+ * already doing the navigating and writing to history would fight it.
+ */
+async function activateTab(tab, { historyMode = 'push' } = {}) {
     if (!tab) return null;
     const item = document.querySelector(`.nav-item[data-tab="${CSS.escape(tab)}"]`);
     if (!item) return null;
@@ -132,12 +257,7 @@ async function activateTab(tab) {
     item.classList.add('active');
     item.setAttribute('aria-current', 'page');
     if (topbarSection) topbarSection.textContent = item.querySelector('span:last-child')?.textContent || tab;
-    if (history.replaceState) {
-        const innerToParent = { knowledgebase: 'ai', aisummaries: 'ai', aipersonas: 'ai', dailynews: 'rss' };
-        const curInner = location.hash.slice(1);
-        const newHash = (innerToParent[curInner] === tab) ? location.hash : '#' + tab;
-        history.replaceState(null, '', newHash);
-    }
+    if (historyMode !== 'none') writeTabHash(tab, historyMode);
 
     // Leave the stub on screen while its markup is in flight, so the main area
     // shows "Loading…" rather than going blank.
@@ -163,7 +283,6 @@ async function activateTab(tab) {
 
 navItems.forEach(item => {
     item.addEventListener('click', async () => {
-        await activateTab(item.dataset.tab);
         // Land the reader in the section they just opened. Without this, a
         // keyboard user picking the last item in the sidebar has to tab back
         // through every item below it to reach the settings — 25 stops on
@@ -172,6 +291,13 @@ navItems.forEach(item => {
         if (mainContent && document.activeElement === item) {
             mainContent.focus({ preventScroll: true });
         }
+        // Then fold the sidebar away, on a narrow viewport (#674) — before the
+        // panel is fetched, not after, so the fold is not left waiting on a
+        // network round trip. Strictly after the focus move above: folding
+        // first would hide `item` while it is still the active element, and
+        // the browser would drop focus to the body rather than hand it on.
+        collapseNavAfterNavigation();
+        await activateTab(item.dataset.tab);
     });
 });
 
@@ -257,21 +383,35 @@ document.addEventListener('click', e => {
     }
 });
 
-if (location.hash) {
-    // An inner tab can only be selected once its parent panel has arrived.
-    (async function routeFromHash() {
-        const hash = location.hash.slice(1);
-        const aiInnerMap = { knowledgebase: 'ai-knowledgebase', aisummaries: 'ai-summaries', aipersonas: 'ai-personas' };
-        const rssInnerMap = { dailynews: 'rss-tab-dailynews' };
-        if (aiInnerMap[hash]) {
-            if (await activateTab('ai')) switchAiInnerTab(aiInnerMap[hash]);
-        } else if (rssInnerMap[hash]) {
-            if (await activateTab('rss')) switchRssInnerTab(rssInnerMap[hash]);
-        } else {
-            await activateTab(hash);
-        }
-    })();
+// An inner tab can only be selected once its parent panel has arrived, which is
+// why this awaits the panel before reaching into it.
+async function routeToHash(hash, opts) {
+    if (AI_INNER_TABS[hash]) {
+        if (await activateTab('ai', opts)) switchAiInnerTab(AI_INNER_TABS[hash]);
+    } else if (RSS_INNER_TABS[hash]) {
+        if (await activateTab('rss', opts)) switchRssInnerTab(RSS_INNER_TABS[hash]);
+    } else {
+        await activateTab(hash, opts);
+    }
 }
+
+// The section named in the URL on arrival. Replaced rather than pushed: the
+// reader is already here, and an entry for it would put a Back press between
+// them and the page they actually came from.
+if (location.hash) routeToHash(location.hash.slice(1), { historyMode: 'replace' });
+
+// Back and Forward. The browser has already moved the URL by the time this
+// runs, so the section is read out of it and nothing is written back — a push
+// here would append the entry the reader just stepped off, and Back would
+// stop going anywhere.
+//
+// An entry with no hash is the one the page loaded on, whose section is
+// whatever the server rendered active.
+window.addEventListener('popstate', () => {
+    const hash = location.hash.slice(1);
+    if (hash) routeToHash(hash, { historyMode: 'none' });
+    else if (INITIAL_TAB) activateTab(INITIAL_TAB, { historyMode: 'none' });
+});
 
 // ── Sidebar search ────────────────────────────────────────────────────
 (function() {
@@ -909,10 +1049,30 @@ async function addAutoRole() {
 
 async function removeAutoRole(roleId) {
     const guildId = BOOT.guildId;
+    // Every other destructive action on this page goes through showConfirm;
+    // this one fired the DELETE straight off the click (#677). It is a
+    // one-character × sitting against the role name, so the miss is easy and
+    // the undo is not: re-adding the role restores the setting for people who
+    // join later, but nobody who joined in between gets the role.
+    //
+    // Named, because the chips sit in a row and the × the reader hit is not
+    // necessarily the one they meant. BOOT.roleNames is the server's list;
+    // the chip's own text is the fallback for a role added since the page
+    // loaded, and the id is the last resort for one deleted in Discord.
+    const named = document.querySelector(`#autorole-list [data-role-id="${CSS.escape(roleId)}"]`);
+    const roleName = BOOT.roleNames?.[roleId]
+        || named?.textContent.replace(/[\s\u00d7]+$/, '').replace(/^@/, '')
+        || roleId;
+    const ok = await showConfirm({
+        title: 'Remove auto-role',
+        body: `Stop giving @${roleName} to new members? People who already have it keep it.`,
+        okText: 'Remove role'
+    });
+    if (!ok) return;
     try {
         const response = await fetch(`/api/v1/guild/${guildId}/autorole/${roleId}`, { method: 'DELETE' });
         if (response.ok) {
-            const chip = document.querySelector(`#autorole-list [data-role-id="${roleId}"]`);
+            const chip = document.querySelector(`#autorole-list [data-role-id="${CSS.escape(roleId)}"]`);
             if (chip) chip.remove();
             toast('Role removed', 'success');
         } else toast('Failed to remove role', 'error');
@@ -2995,7 +3155,7 @@ function editMcpServer(name) {
     mcpEl('mcp-save-btn').textContent = 'Save changes';
     mcpEl('mcp-cancel-btn').style.display = '';
     updateMcpFormState();
-    mcpEl('mcp-form-title').scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    mcpEl('mcp-form-title').scrollIntoView({ behavior: scrollBehavior(), block: 'nearest' });
 }
 
 async function saveMcpServer() {
@@ -4798,7 +4958,12 @@ function registerSaveScopes(root) {
         const section = sectionOfSaveButton(btn);
         const scope = saveScopeOf(btn);
         if (!section || !scope || saveScopes.has(scope)) continue;
-        saveScopes.set(scope, { section, baseline: scopeSignature(scope) });
+        // The button is kept, not just the section it saves: Enter in a field
+        // presses it (#679), and pressing the real control means the save goes
+        // through whatever that button does — the in-flight guard, the
+        // re-baseline, the toast — rather than through a second path that
+        // would have to keep up with it.
+        saveScopes.set(scope, { section, baseline: scopeSignature(scope), saveButton: btn });
     }
     refreshUnsavedMarks();
 }
@@ -4868,6 +5033,56 @@ document.addEventListener('change', noteEdit, true);
 document.addEventListener('click', () => {
     if (saveScopes.size) setTimeout(refreshUnsavedMarks, 0);
 }, true);
+
+// ── Enter saves the section (#679) ───────────────────────────────────
+// There is one <form> in the whole dashboard and it answers `return false`, so
+// Enter did nothing in any of the ~130 text fields across the panels — a key
+// every other settings page in the world responds to, in a page whose save
+// button is often several screens down from the field being edited.
+//
+// What Enter saves is exactly what the unsaved-changes banner tracks: the same
+// save scope, the same exclusions. A field the banner would never light up for
+// is not a setting, and Enter in it does nothing — which is what it did
+// before, so nothing that used to be inert becomes surprising.
+//
+// Fields whose scope has no saveSettings button of its own — the RSS feed URL,
+// the member admin lookups, anything committed by its own POST — are left
+// alone deliberately. Enter there would fire the section save rather than the
+// Add the reader was reaching for, and a key that does the wrong thing is
+// worse than a key that does nothing.
+
+// Types where Enter is not a commit: a checkbox and a radio answer to Space, a
+// file input opens a picker, and the rest are dragged or clicked.
+const NO_ENTER_TYPES = new Set(['checkbox', 'radio', 'file', 'color', 'range', 'button', 'submit', 'reset', 'hidden', 'image']);
+
+function enterSavesFrom(target) {
+    // <textarea> keeps Enter — it is a newline there, and always was. <select>
+    // keeps it too: it commits an open dropdown.
+    if (!target || target.tagName !== 'INPUT') return null;
+    if (NO_ENTER_TYPES.has(target.type) || target.disabled || target.readOnly) return null;
+    // The same three exclusions scopeSignature() applies, for the same
+    // reasons: a modal is a scratch editor with its own commit button, and a
+    // data-no-dirty field is a search box or a "pick one to add", not a
+    // setting.
+    if (target.closest('.modal-overlay') || target.matches(NOT_A_SETTING)) return null;
+    const scope = saveScopeOf(target);
+    const entry = scope && saveScopes.get(scope);
+    return entry?.saveButton || null;
+}
+
+document.addEventListener('keydown', event => {
+    if (event.key !== 'Enter' || event.defaultPrevented) return;
+    // A modifier means the reader asked for something else — Ctrl+Enter is the
+    // prompt editor's commit — and `isComposing` is the Enter that closes an
+    // IME candidate list, which must never reach the page as a keystroke.
+    if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey || event.isComposing) return;
+    const button = enterSavesFrom(event.target);
+    if (!button) return;
+    // Stop the implicit submission the one <form> on the page would otherwise
+    // have to keep swallowing.
+    event.preventDefault();
+    button.click();
+});
 
 // The one place edits are genuinely lost. Browsers ignore any message we pass
 // and show their own wording, but returnValue still has to be set for Chrome

--- a/src/dashboard/public/styles.css
+++ b/src/dashboard/public/styles.css
@@ -1359,6 +1359,38 @@ textarea.auto-resize {
 
 /* Sidebar */
 .dash-side { background: var(--ink-900); border-right: 1px solid var(--ink-800); padding: 22px 18px; display: flex; flex-direction: column; min-height: 100vh; position: sticky; top: 0; max-height: 100vh; overflow-y: auto; }
+
+/* Brand row, and the narrow-viewport nav toggle beside it (#674). The padding
+   was an inline style on the brand wrapper; it is a class now so the row can
+   lay two things out, and so guild-settings.ejs spends one less of the inline
+   attributes tests/dashboardInlineAttributes.test.js ratchets down. */
+.dash-side-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 4px 8px 22px; }
+
+/* Never shown by the stylesheet alone: guild-settings.js unhides it once it
+   knows the viewport is narrow, so the collapse cannot strand a reader whose
+   browser never ran the script that would reopen it. */
+.dash-nav-toggle {
+    display: inline-flex; align-items: center; gap: 7px; flex-shrink: 0;
+    padding: 7px 11px; border-radius: 10px;
+    background: var(--ink-850); border: 1px solid var(--ink-800);
+    color: var(--ink-200); font-family: inherit; font-size: 13px; font-weight: 500;
+    cursor: pointer; transition: border-color .15s, color .15s;
+}
+.dash-nav-toggle[hidden] { display: none; }
+.dash-nav-toggle:hover { border-color: var(--ink-600); color: var(--cream-50); }
+.dash-nav-toggle:focus-visible { outline: 2px solid var(--claw-500); outline-offset: 2px; }
+/* Hamburger while the nav is folded away, X while it is open. Both ship in the
+   markup and CSS picks one, so the state never depends on the script having
+   swapped an icon — aria-expanded on the button is what carries it either way. */
+.dash-nav-toggle-icon { flex-shrink: 0; }
+.dash-nav-toggle-close { display: none; }
+.dash-side:not(.nav-collapsed) .dash-nav-toggle-open { display: none; }
+.dash-side:not(.nav-collapsed) .dash-nav-toggle-close { display: inline; }
+
+/* What the toggle folds away. The server switcher stays: it is one row, and it
+   is the way back out of a server you opened by mistake. */
+.dash-side.nav-collapsed .dash-side-nav,
+.dash-side.nav-collapsed .dash-side-footer { display: none; }
 .dash-server-switch { background: var(--ink-850); border: 1px solid var(--ink-800); border-radius: 14px; padding: 10px 12px; display: flex; align-items: center; gap: 10px; cursor: pointer; margin-bottom: 22px; transition: border-color .15s; }
 .dash-server-switch:hover { border-color: var(--ink-600); }
 .dash-server-avatar { width: 36px; height: 36px; border-radius: 10px; background: linear-gradient(135deg, var(--claw-500), var(--plum-500)); display: flex; align-items: center; justify-content: center; font-family: 'Instrument Serif', serif; color: #fff; font-size: 18px; flex-shrink: 0; }
@@ -1530,7 +1562,13 @@ textarea.auto-resize {
    box, five labelled groups and a user footer, none of which read as a row. It
    stacks above the content instead, which is why max-height is lifted — the
    sticky column's scroll cap would otherwise trap the nav in a short box with
-   the page already scrolling behind it. */
+   the page already scrolling behind it.
+
+   Stacked and expanded, though, that column is a long scroll standing between
+   the reader and the settings they just opened, on every visit (#674). This is
+   the breakpoint the nav toggle above turns itself on at, so the column stacks
+   folded and the reader opens it when they want to move. The two rules have to
+   agree on the width: change one and change the other. */
 @media (max-width: 768px) {
     .dash { grid-template-columns: 1fr; }
     .dash-side { min-height: auto; max-height: none; position: static; }
@@ -1698,3 +1736,44 @@ textarea.auto-resize {
    inline-style budget tests/dashboardInlineAttributes.test.js ratchets down. */
 .pager { display: flex; gap: .5rem; align-items: center; justify-content: center; margin-top: .75rem; }
 .pager-info { font-size: .85rem; opacity: .7; }
+
+/* ── Reduced motion ───────────────────────────────────────────────
+   #675. Three decorative blobs drift behind every page on 18–26s infinite
+   loops, every panel and modal fades up through `panel-in`, and the analytics
+   skeletons pulse until their data lands — none of which the reader asked for,
+   and none of which stopped for anybody. WCAG 2.2.2.
+
+   Last in the file, and stated as one rule over everything rather than as a
+   list of the selectors that animate today: the list would be accurate until
+   the next panel is written, and a decorative animation that is missed here is
+   invisible to the person writing it and unavoidable for the person it makes
+   ill. `.01ms` rather than `0s` because a zero-duration animation never fires
+   `animationend` in some engines, and a listener waiting on one would hang;
+   at this length the reader sees a cut, not a transition.
+
+   Movement is what goes, not feedback. Everything here ends in its finished
+   state — panels at full opacity, the toast in place, the toggle knob thrown —
+   so nothing that reported an outcome by moving stops reporting it. */
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: .01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: .01ms !important;
+        scroll-behavior: auto !important;
+    }
+
+    /* The background blobs are the exception to "ends in its finished state":
+       run to completion they would settle 120px off where they were authored,
+       having travelled there in no time at all. `none` leaves each one at the
+       position its own rule gives it — which for .blob-3 is the
+       translate(-50%, -50%) that centres it, so this has to be `animation`
+       rather than a duration override. */
+    .mesh-bg::before,
+    .mesh-bg::after,
+    .mesh-bg .blob-3 { animation: none !important; }
+
+    /* Loading skeletons stop pulsing but must still read as "not the content
+       yet", so they hold the mid-point of the shimmer instead of its faintest
+       frame. The panel they sit in is replaced the moment the data arrives. */
+    .skel-tile, .skel-bar, .skel-chart { animation: none !important; opacity: .5; }
+}

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -18,12 +18,27 @@
     <!-- ── SIDEBAR ───────────────────────────────────────────── -->
     <aside class="dash-side">
 
-        <!-- Brand -->
-        <div style="padding:4px 8px 22px;">
+        <%# Brand, and — narrow only — the control that folds the rest of the
+            sidebar away. Below 768px the whole column stacks *above* the
+            content, so every visit to a panel used to open on a scroll past 25
+            nav items, a search box and the user footer to reach the settings
+            being edited (#674).
+
+            The button ships `hidden` and guild-settings.js unhides it once it
+            has confirmed the viewport is narrow. That way the collapse only
+            ever exists where something can open it again: with no script, or
+            in a browser without matchMedia, the nav stays exactly as it is
+            today rather than folding shut with no way back. %>
+        <div class="dash-side-head">
             <a href="/" class="cw-brand-link">
                 <%- include('partials/brand-mark', { size: 24, fill: '#ece4d2', accent: '#e89163' }) %>
                 <span class="cw-wordmark cw-side-wordmark">Clawdia</span>
             </a>
+            <button type="button" class="dash-nav-toggle" id="dash-nav-toggle" aria-expanded="true" aria-controls="dash-side-nav dash-side-footer" hidden>
+                <svg class="dash-nav-toggle-icon dash-nav-toggle-open" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+                <svg class="dash-nav-toggle-icon dash-nav-toggle-close" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="6" y1="6" x2="18" y2="18"/><line x1="18" y1="6" x2="6" y2="18"/></svg>
+                <span>Menu</span>
+            </button>
         </div>
 
         <!-- Server switcher -->
@@ -43,7 +58,7 @@
         <%# A landmark, so a screen reader can jump to the section list — and
             can skip past it — instead of walking the sidebar from the top.
             The search filters this list, so it lives inside the landmark. %>
-        <nav class="dash-side-nav" aria-label="Dashboard sections">
+        <nav class="dash-side-nav" id="dash-side-nav" aria-label="Dashboard sections">
 
         <!-- Sidebar search -->
         <div class="dash-nav-search-wrap">
@@ -115,7 +130,7 @@
         </nav><!-- /.dash-side-nav -->
 
         <!-- User footer -->
-        <div class="dash-side-footer">
+        <div class="dash-side-footer" id="dash-side-footer">
             <div class="dash-user">
                 <% if (user.avatar) { %>
                     <img src="https://cdn.discordapp.com/avatars/<%= user.id %>/<%= user.avatar %>.png" alt="" style="width:34px;height:34px;border-radius:10px;object-fit:cover;flex-shrink:0;">

--- a/tests/autoroleChipXss.test.js
+++ b/tests/autoroleChipXss.test.js
@@ -145,6 +145,14 @@ describe('autorole chip', () => {
         button.dispatchEvent(new window.Event('click', { bubbles: true }));
         await settle();
 
+        // Removing an auto-role asks first now (#677), like every other
+        // destructive action on the page. The dialog is not what this test is
+        // about — the wiring above is — so it is answered and the DELETE it
+        // releases is what gets checked.
+        expect(document.getElementById('confirm-modal').style.display).toBe('flex');
+        window._confirmResolve(true);
+        await settle();
+
         const removeCall = window.fetch.mock.calls
             .find(c => String(c[0]).includes(`/autorole/${PAYLOAD_ROLE.id}`));
         expect(removeCall).toBeDefined();

--- a/tests/dashboardAutoRoleConfirm.test.js
+++ b/tests/dashboardAutoRoleConfirm.test.js
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"customExportConditions": ["node"]}
+ */
+process.env.SUPPRESS_JEST_WARNINGS = 'true';
+
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = global.TextEncoder || TextEncoder;
+global.TextDecoder = global.TextDecoder || TextDecoder;
+
+// #677. Every other destructive action on the dashboard goes through
+// showConfirm; removing an auto-role fired its DELETE straight off the click.
+// The target is a one-character × sitting against a role name in a row of
+// them, so the miss is easy — and the undo is not: re-adding the role restores
+// the setting for people who join later, but nobody who joined in between ever
+// gets it.
+const { bootPage, renderPanel, clickTab, settle, forgetDocumentListeners } = require('./helpers/guildSettingsPage');
+const { populatedGuildSettingsLocals } = require('./helpers/guildSettingsLocals');
+
+// The populated locals are the ones that seed an auto-role, on the role they
+// call ROLE. The default locals have none, and a panel with no chip in it
+// would pass every assertion below by having nothing to remove.
+const ROLE_ID = '40';
+const ROLE_NAME = 'Member';
+const POPULATED = populatedGuildSettingsLocals();
+
+async function openWelcome() {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    document.body.innerHTML = '';
+    bootPage({
+        panelFetch: name => ({
+            ok: true,
+            status: 200,
+            text: async () => renderPanel(name, { settings: POPULATED.settings }),
+        }),
+    });
+    clickTab('welcome');
+    await settle();
+    expect(removeButton()).not.toBeNull();
+}
+
+const removeButton = () =>
+    document.querySelector(`#autorole-list [data-role-id="${ROLE_ID}"] button[data-action="autorole-remove"]`);
+
+const deleteCalls = () =>
+    window.fetch.mock.calls.filter(([, opts]) => opts && opts.method === 'DELETE');
+
+/** Press the confirm dialog's Confirm or Cancel, once it is up. */
+async function answerConfirm(ok) {
+    const modal = document.getElementById('confirm-modal');
+    expect(modal.style.display).toBe('flex');
+    const body = document.getElementById('confirm-modal-body').textContent;
+    window._confirmResolve(ok);
+    await settle();
+    return body;
+}
+
+afterEach(async () => {
+    await settle();
+    forgetDocumentListeners();
+    jest.restoreAllMocks();
+});
+
+describe('removing an auto-role', () => {
+    beforeEach(openWelcome);
+
+    it('asks before it deletes anything', async () => {
+        removeButton().click();
+        await settle();
+
+        expect(document.getElementById('confirm-modal').style.display).toBe('flex');
+        expect(deleteCalls()).toHaveLength(0);
+    });
+
+    it('names the role, because the chips sit in a row', async () => {
+        removeButton().click();
+        await settle();
+
+        expect(document.getElementById('confirm-modal-title').textContent).toMatch(/auto-role/i);
+        const body = await answerConfirm(false);
+        expect(body).toContain(ROLE_NAME);
+    });
+
+    it('deletes once confirmed, and takes the chip with it', async () => {
+        removeButton().click();
+        await settle();
+        await answerConfirm(true);
+
+        expect(deleteCalls()).toHaveLength(1);
+        expect(deleteCalls()[0][0]).toContain(`/autorole/${ROLE_ID}`);
+        expect(document.querySelector(`#autorole-list [data-role-id="${ROLE_ID}"]`)).toBeNull();
+    });
+
+    it('leaves the role alone when cancelled', async () => {
+        removeButton().click();
+        await settle();
+        await answerConfirm(false);
+
+        expect(deleteCalls()).toHaveLength(0);
+        expect(document.querySelector(`#autorole-list [data-role-id="${ROLE_ID}"]`)).not.toBeNull();
+    });
+
+    // The dialog says people who already have the role keep it, because that
+    // is the part an admin is most likely to be wrong about.
+    it('says what removing it does and does not undo', async () => {
+        removeButton().click();
+        await settle();
+        const body = await answerConfirm(false);
+        expect(body).toMatch(/already have it keep it/i);
+    });
+});

--- a/tests/dashboardEnterToSave.test.js
+++ b/tests/dashboardEnterToSave.test.js
@@ -1,0 +1,205 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"customExportConditions": ["node"]}
+ */
+process.env.SUPPRESS_JEST_WARNINGS = 'true';
+
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = global.TextEncoder || TextEncoder;
+global.TextDecoder = global.TextDecoder || TextDecoder;
+
+// #679. There is one <form> in the whole dashboard and it answers
+// `return false`, so Enter did nothing in any of the ~130 text fields across
+// the panels — in a page whose save button is often several screens down from
+// the field being edited.
+//
+// The rule Enter follows is the one the unsaved-changes banner already
+// follows: same save scope, same exclusions. A field the banner would never
+// light up for is not a setting, and Enter in it does nothing — which is what
+// it did before, so nothing inert becomes surprising.
+const { bootPage, clickTab, settle, forgetDocumentListeners } = require('./helpers/guildSettingsPage');
+
+function press(el, key = 'Enter', init = {}) {
+    const event = new window.KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...init });
+    el.dispatchEvent(event);
+    return event;
+}
+
+/**
+ * Open a panel and put a spy on the button that saves it. Clicking that real
+ * button is what Enter must do — the in-flight guard, the re-baseline and the
+ * toast all hang off it — so the spy sits on the button's own click rather
+ * than standing in for it.
+ *
+ * Starboard by default: one text field, one number field, one checkbox and one
+ * save button, which is the whole shape this behaviour is about.
+ */
+async function openPanel(id = 'starboard') {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    document.body.innerHTML = '';
+    bootPage();
+    clickTab(id);
+    await settle();
+
+    const panel = document.getElementById(id);
+    const save = Array.from(panel.querySelectorAll('[onclick]'))
+        .find(el => /saveSettings\(/.test(el.getAttribute('onclick')));
+    expect(save).toBeTruthy();
+    const clicked = jest.fn();
+    save.addEventListener('click', clicked);
+    return { panel, save, clicked };
+}
+
+const textField = panel => panel.querySelector('input[type="text"]:not([data-no-dirty])');
+
+afterEach(async () => {
+    await settle();
+    forgetDocumentListeners();
+    jest.restoreAllMocks();
+});
+
+describe('Enter in a settings field', () => {
+    it('presses the save button that owns the section', async () => {
+        const { panel, clicked } = await openPanel();
+        const field = textField(panel);
+        expect(field).toBeTruthy();
+
+        const event = press(field);
+        expect(clicked).toHaveBeenCalledTimes(1);
+        // The implicit submission the one <form> on the page would otherwise
+        // have to keep swallowing.
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('does nothing for any other key', async () => {
+        const { panel, clicked } = await openPanel();
+        const field = textField(panel);
+
+        press(field, 'a');
+        press(field, 'Escape');
+        press(field, 'Tab');
+        expect(clicked).not.toHaveBeenCalled();
+    });
+
+    // Ctrl+Enter is the prompt editor's commit, and an Enter that closes an
+    // IME candidate list must never reach the page as a keystroke.
+    it.each([
+        ['ctrlKey', { ctrlKey: true }],
+        ['metaKey', { metaKey: true }],
+        ['altKey', { altKey: true }],
+        ['shiftKey', { shiftKey: true }],
+    ])('stands aside for %s', async (_name, init) => {
+        const { panel, clicked } = await openPanel();
+        const field = textField(panel);
+
+        press(field, 'Enter', init);
+        expect(clicked).not.toHaveBeenCalled();
+    });
+
+    it('stands aside mid-IME-composition', async () => {
+        const { panel, clicked } = await openPanel();
+        const field = textField(panel);
+
+        press(field, 'Enter', { isComposing: true });
+        expect(clicked).not.toHaveBeenCalled();
+    });
+});
+
+describe('Enter where it already means something', () => {
+    it('is still a newline in a textarea', async () => {
+        const { panel, clicked } = await openPanel('welcome');
+        const area = panel.querySelector('textarea');
+        expect(area).toBeTruthy();
+
+        const event = press(area);
+        expect(clicked).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    it('still commits an open dropdown on a select', async () => {
+        const { panel, clicked } = await openPanel('welcome');
+        const select = panel.querySelector('select');
+        expect(select).toBeTruthy();
+
+        const event = press(select);
+        expect(clicked).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    it('leaves a checkbox to the Space bar', async () => {
+        const { panel, clicked } = await openPanel();
+        const box = panel.querySelector('input[type="checkbox"]');
+        expect(box).toBeTruthy();
+
+        press(box);
+        expect(clicked).not.toHaveBeenCalled();
+    });
+});
+
+describe('Enter in something that is not a setting', () => {
+    it('does nothing in the sidebar search', async () => {
+        const { clicked } = await openPanel();
+        const search = document.getElementById('sidebar-search');
+
+        const event = press(search);
+        expect(clicked).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    // data-no-dirty marks the "pick one to add" selects and one-shot admin
+    // fields that live inside a panel but that saveSettings() never reads.
+    it('does nothing in a data-no-dirty field', async () => {
+        const { panel, clicked } = await openPanel('antinuke');
+        const field = panel.querySelector('input[data-no-dirty]');
+        expect(field).toBeTruthy();
+
+        const event = press(field);
+        expect(clicked).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    it('does nothing in a modal, which has its own commit button', async () => {
+        const { clicked } = await openPanel();
+        const input = document.getElementById('confirm-type-input');
+        expect(input.closest('.modal-overlay')).not.toBeNull();
+
+        press(input);
+        expect(clicked).not.toHaveBeenCalled();
+    });
+
+    it('does nothing in a disabled or readonly field', async () => {
+        const { panel, clicked } = await openPanel();
+        const field = textField(panel);
+
+        field.disabled = true;
+        press(field);
+        field.disabled = false;
+        field.readOnly = true;
+        press(field);
+        expect(clicked).not.toHaveBeenCalled();
+    });
+});
+
+// A save scope with no saveSettings button of its own — the RSS feed URL, the
+// member admin lookups, anything committed by its own POST — is left alone
+// deliberately. Enter there would fire a section save rather than the Add the
+// reader was reaching for, and a key that does the wrong thing is worse than a
+// key that does nothing.
+describe('a field whose section has no save button', () => {
+    it('leaves Enter inert rather than guessing at an action', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        document.body.innerHTML = '';
+        bootPage();
+        clickTab('rss');
+        await settle();
+
+        const url = document.getElementById('rss-url');
+        expect(url).toBeTruthy();
+        const fetchesBefore = window.fetch.mock.calls.length;
+
+        const event = press(url);
+        await settle();
+        expect(event.defaultPrevented).toBe(false);
+        expect(window.fetch.mock.calls.length).toBe(fetchesBefore);
+    });
+});

--- a/tests/dashboardInlineAttributes.test.js
+++ b/tests/dashboardInlineAttributes.test.js
@@ -31,7 +31,7 @@ const VIEWS = path.join(__dirname, '..', 'src', 'dashboard', 'views');
 // file (relative to views/) -> [inline style attributes, inline handler attributes]
 const BASELINE = {
     'dashboard.ejs': [4, 0],
-    'guild-settings.ejs': [14, 5],
+    'guild-settings.ejs': [13, 5],
     'index.ejs': [11, 0],
     'partials/game-item-card.ejs': [2, 4],
     'partials/panels/achievements.ejs': [14, 9],

--- a/tests/dashboardMobileNav.test.js
+++ b/tests/dashboardMobileNav.test.js
@@ -1,0 +1,153 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"customExportConditions": ["node"]}
+ */
+process.env.SUPPRESS_JEST_WARNINGS = 'true';
+
+// jsdom omits a few Node globals that mongoose's driver reaches for on require.
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = global.TextEncoder || TextEncoder;
+global.TextDecoder = global.TextDecoder || TextDecoder;
+
+// #674. Below 768px the sidebar stops being a column beside the content and
+// becomes a block on top of it, so 25 nav items, a search box and the user
+// footer sat between the reader and the panel they had just opened — on every
+// visit. It folds away now, and the rules that matter are the ones that keep
+// it openable: the toggle only exists where the viewport is narrow, and it
+// unfolds again the moment the viewport is not.
+const fs = require('fs');
+const path = require('path');
+const { PUBLIC, bootPage, clickTab, settle, forgetDocumentListeners } = require('./helpers/guildSettingsPage');
+
+const NARROW = '(max-width: 768px)';
+
+const side = () => document.querySelector('.dash-side');
+const toggle = () => document.getElementById('dash-nav-toggle');
+const collapsed = () => side().classList.contains('nav-collapsed');
+
+function boot(media) {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    document.body.innerHTML = '';
+    return bootPage({ media });
+}
+
+afterEach(async () => {
+    await settle();
+    forgetDocumentListeners();
+    jest.restoreAllMocks();
+});
+
+describe('on a desktop viewport', () => {
+    beforeEach(() => boot({ [NARROW]: false }));
+
+    it('has no toggle and shows the whole sidebar', () => {
+        expect(toggle().hidden).toBe(true);
+        expect(collapsed()).toBe(false);
+    });
+
+    it('leaves the nav open after a section is chosen', async () => {
+        clickTab('welcome');
+        await settle();
+        expect(collapsed()).toBe(false);
+    });
+});
+
+describe('on a narrow viewport', () => {
+    beforeEach(() => boot({ [NARROW]: true }));
+
+    it('folds the nav away and offers a control to open it', () => {
+        expect(collapsed()).toBe(true);
+        expect(toggle().hidden).toBe(false);
+        expect(toggle().getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('opens and closes on the toggle, reporting the state it is in', () => {
+        toggle().click();
+        expect(collapsed()).toBe(false);
+        expect(toggle().getAttribute('aria-expanded')).toBe('true');
+
+        toggle().click();
+        expect(collapsed()).toBe(true);
+        expect(toggle().getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('names both of the regions it folds away', () => {
+        const controls = toggle().getAttribute('aria-controls').split(/\s+/);
+        expect(controls).toContain('dash-side-nav');
+        expect(controls).toContain('dash-side-footer');
+        for (const id of controls) expect(document.getElementById(id)).not.toBeNull();
+    });
+
+    // The whole point: the reader picked a section, so the nav standing
+    // between them and it has done its job.
+    it('folds away again once a section has been chosen', async () => {
+        toggle().click();
+        expect(collapsed()).toBe(false);
+
+        clickTab('welcome');
+        await settle();
+        expect(collapsed()).toBe(true);
+        expect(toggle().getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('scrolls the panel into view when it folds, since the nav above it just went', async () => {
+        const main = document.getElementById('dash-main-content');
+        main.scrollIntoView = jest.fn();
+        toggle().click();
+
+        clickTab('welcome');
+        await settle();
+        expect(main.scrollIntoView).toHaveBeenCalled();
+    });
+});
+
+// A tablet turned sideways crosses the breakpoint mid-session. A folded nav
+// with no control to open it is the one state this must never leave behind.
+describe('when the viewport changes under it', () => {
+    it('puts the sidebar back and drops the toggle on widening', () => {
+        const page = boot({ [NARROW]: true });
+        expect(collapsed()).toBe(true);
+
+        page.media.set(NARROW, false);
+        expect(collapsed()).toBe(false);
+        expect(toggle().hidden).toBe(true);
+    });
+
+    it('folds it away and offers the toggle on narrowing', () => {
+        const page = boot({ [NARROW]: false });
+        expect(collapsed()).toBe(false);
+
+        page.media.set(NARROW, true);
+        expect(collapsed()).toBe(true);
+        expect(toggle().hidden).toBe(false);
+    });
+});
+
+// The collapse is script-driven precisely so that a browser that never ran the
+// script — or never answered the query — is left with the sidebar it has
+// always had, rather than one folded shut with nothing to open it.
+describe('without matchMedia', () => {
+    it('leaves the nav open and the toggle hidden', () => {
+        boot(false);
+        expect(window.matchMedia).toBeUndefined();
+        expect(collapsed()).toBe(false);
+        expect(toggle().hidden).toBe(true);
+    });
+
+    it('still navigates, so the sidebar is no worse than it was', async () => {
+        boot(false);
+        clickTab('welcome');
+        await settle();
+        expect(document.getElementById('welcome').classList.contains('active')).toBe(true);
+        expect(collapsed()).toBe(false);
+    });
+
+    it('ships the toggle hidden, so the stylesheet alone never reveals it', () => {
+        const markup = fs.readFileSync(
+            path.join(__dirname, '..', 'src', 'dashboard', 'views', 'guild-settings.ejs'), 'utf8');
+        expect(markup).toMatch(/id="dash-nav-toggle"[^>]*\shidden/);
+
+        const css = fs.readFileSync(path.join(PUBLIC, 'styles.css'), 'utf8');
+        expect(css).toMatch(/\.dash-nav-toggle\[hidden\]\s*\{\s*display:\s*none/);
+    });
+});

--- a/tests/dashboardReducedMotion.test.js
+++ b/tests/dashboardReducedMotion.test.js
@@ -1,0 +1,126 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"customExportConditions": ["node"]}
+ */
+process.env.SUPPRESS_JEST_WARNINGS = 'true';
+
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = global.TextEncoder || TextEncoder;
+global.TextDecoder = global.TextDecoder || TextDecoder;
+
+// #675. The stylesheet had no `prefers-reduced-motion` in it anywhere, while
+// three decorative blobs drifted behind every page on 18–26s infinite loops
+// and every panel and modal switch ran `panel-in`. WCAG 2.2.2.
+//
+// The CSS is checked as text because jsdom has no cascade to ask: it parses
+// the stylesheet but resolves nothing, so an assertion about a computed
+// animation would pass whatever the file said. What is worth pinning is that
+// the block exists, that it covers everything rather than a list of today's
+// selectors, and that the things it cannot reach from CSS are handled in the
+// script.
+const fs = require('fs');
+const path = require('path');
+const { PUBLIC, bootPage, settle, forgetDocumentListeners } = require('./helpers/guildSettingsPage');
+
+const REDUCE = '(prefers-reduced-motion: reduce)';
+const css = fs.readFileSync(path.join(PUBLIC, 'styles.css'), 'utf8');
+
+/** The body of the `prefers-reduced-motion: reduce` block, braces balanced. */
+function reduceBlock() {
+    const at = css.indexOf('@media (prefers-reduced-motion: reduce)');
+    expect(at).toBeGreaterThan(-1);
+    let depth = 0;
+    for (let i = css.indexOf('{', at); i < css.length; i++) {
+        if (css[i] === '{') depth++;
+        else if (css[i] === '}' && --depth === 0) return css.slice(at, i + 1);
+    }
+    throw new Error('unterminated @media block');
+}
+
+describe('the stylesheet', () => {
+    const block = reduceBlock();
+
+    it('answers the preference at all', () => {
+        expect(css).toContain(REDUCE);
+    });
+
+    // A list of the selectors that animate today is accurate until the next
+    // panel is written; the universal rule is what makes it stay true.
+    it('reaches every element rather than the ones that animate today', () => {
+        expect(block).toMatch(/\*,\s*\*::before,\s*\*::after/);
+        expect(block).toMatch(/animation-duration:\s*\.01ms\s*!important/);
+        expect(block).toMatch(/animation-iteration-count:\s*1\s*!important/);
+        expect(block).toMatch(/transition-duration:\s*\.01ms\s*!important/);
+    });
+
+    // Not `0s`: a zero-duration animation never fires `animationend` in some
+    // engines, and anything waiting on one would hang.
+    it('never zeroes a duration outright', () => {
+        expect(block).not.toMatch(/animation-duration:\s*0s/);
+        expect(block).not.toMatch(/transition-duration:\s*0s/);
+    });
+
+    // Run to completion the blobs settle 120px from where they were authored,
+    // and .blob-3 loses the translate(-50%, -50%) that centres it.
+    it('stops the three infinite background blobs where they stand', () => {
+        expect(block).toMatch(/\.mesh-bg::before,\s*\.mesh-bg::after,\s*\.mesh-bg \.blob-3\s*\{\s*animation:\s*none\s*!important/);
+    });
+
+    it('leaves the loading skeletons legible once they stop pulsing', () => {
+        expect(block).toMatch(/\.skel-tile,\s*\.skel-bar,\s*\.skel-chart\s*\{[^}]*animation:\s*none\s*!important/);
+        expect(block).toMatch(/\.skel-tile,\s*\.skel-bar,\s*\.skel-chart\s*\{[^}]*opacity:/);
+    });
+
+    it('has all three infinite animations inside its reach', () => {
+        // If a fourth is ever added, the universal rule above already covers
+        // it — this is here so the count in the issue stays checkable.
+        expect(css.match(/animation:\s*float-[abc][^;]*infinite/g)).toHaveLength(3);
+    });
+});
+
+// `scroll-behavior` in CSS does not govern a `behavior: 'smooth'` passed to
+// scrollIntoView — the argument wins over the stylesheet — so the one call on
+// the page that scrolls has to ask the preference itself.
+describe('the script', () => {
+    afterEach(async () => {
+        await settle();
+        forgetDocumentListeners();
+        jest.restoreAllMocks();
+    });
+
+    function bootWith(reduce) {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        document.body.innerHTML = '';
+        return bootPage({ media: { [REDUCE]: reduce } });
+    }
+
+    it('scrolls smoothly when no preference is expressed', () => {
+        bootWith(false);
+        expect(window.scrollBehavior()).toBe('smooth');
+    });
+
+    it('cuts straight there when reduced motion is asked for', () => {
+        bootWith(true);
+        expect(window.scrollBehavior()).toBe('auto');
+    });
+
+    it('follows the preference changing mid-session', () => {
+        const page = bootWith(false);
+        page.media.set(REDUCE, true);
+        expect(window.scrollBehavior()).toBe('auto');
+    });
+
+    it('falls back to smooth where the query cannot be answered', () => {
+        bootWith(false);
+        delete window.matchMedia;
+        expect(window.scrollBehavior()).toBe('smooth');
+    });
+
+    it('is what the one smooth scroll on the page uses', () => {
+        const js = fs.readFileSync(path.join(PUBLIC, 'guild-settings.js'), 'utf8');
+        // The literal survives inside scrollBehavior() itself; what must not
+        // come back is a scroll that hardcodes it at the call site.
+        expect(js).not.toMatch(/scroll(IntoView|To)\([^)]*behavior:\s*'smooth'/);
+        expect(js).toMatch(/scrollIntoView\(\{ behavior: scrollBehavior\(\)/);
+    });
+});

--- a/tests/dashboardSectionHistory.test.js
+++ b/tests/dashboardSectionHistory.test.js
@@ -1,0 +1,165 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"customExportConditions": ["node"]}
+ */
+process.env.SUPPRESS_JEST_WARNINGS = 'true';
+
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = global.TextEncoder || TextEncoder;
+global.TextDecoder = global.TextDecoder || TextDecoder;
+
+// #679. Every section change was a replaceState, so the whole dashboard
+// occupied one history entry: after opening ten panels, Back left the
+// dashboard altogether rather than returning to the ninth. Each section is an
+// entry of its own now, and Back walks them.
+const { bootPage, clickTab, settle, forgetDocumentListeners } = require('./helpers/guildSettingsPage');
+
+const active = () => document.querySelector('.panel.active')?.id || null;
+
+/** Go back one entry and let the popstate handler's panel fetch land. */
+function back() {
+    return new Promise(resolve => {
+        window.addEventListener('popstate', async () => {
+            await settle();
+            resolve();
+        }, { once: true });
+        window.history.back();
+    });
+}
+
+async function boot() {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    // Each test starts from a URL of its own, so the entries one pushes are
+    // never the entries the next one walks back through.
+    window.history.pushState(null, '', `/dashboard/guild/1?t=${Math.random()}`);
+    document.body.innerHTML = '';
+    bootPage();
+    await settle();
+}
+
+afterEach(async () => {
+    await settle();
+    forgetDocumentListeners();
+    jest.restoreAllMocks();
+});
+
+describe('choosing a section', () => {
+    beforeEach(boot);
+
+    it('names it in the URL', async () => {
+        clickTab('welcome');
+        await settle();
+        expect(location.hash).toBe('#welcome');
+    });
+
+    it('adds an entry rather than overwriting the last one', async () => {
+        const before = history.length;
+        clickTab('welcome');
+        await settle();
+        clickTab('farewell');
+        await settle();
+        expect(history.length).toBe(before + 2);
+    });
+
+    // An entry that restores what is already on screen is a Back press that
+    // does nothing, which is worse than no entry at all.
+    it('adds nothing for re-choosing the section already open', async () => {
+        clickTab('welcome');
+        await settle();
+        const before = history.length;
+        clickTab('welcome');
+        await settle();
+        expect(history.length).toBe(before);
+        expect(location.hash).toBe('#welcome');
+    });
+});
+
+describe('the Back button', () => {
+    beforeEach(boot);
+
+    it('returns to the previous section instead of leaving the dashboard', async () => {
+        clickTab('welcome');
+        await settle();
+        clickTab('farewell');
+        await settle();
+        expect(active()).toBe('farewell');
+
+        await back();
+        expect(location.hash).toBe('#welcome');
+        expect(active()).toBe('welcome');
+    });
+
+    it('walks all the way back to the section the page opened on', async () => {
+        const landed = active();
+        clickTab('welcome');
+        await settle();
+        clickTab('farewell');
+        await settle();
+
+        await back();
+        await back();
+        expect(location.hash).toBe('');
+        expect(active()).toBe(landed);
+    });
+
+    // Writing to history from the popstate handler would append the entry the
+    // reader just stepped off, and Back would stop going anywhere.
+    it('does not grow the history it is walking', async () => {
+        clickTab('welcome');
+        await settle();
+        clickTab('farewell');
+        await settle();
+        const length = history.length;
+
+        await back();
+        expect(history.length).toBe(length);
+    });
+
+    it('goes forward again', async () => {
+        clickTab('welcome');
+        await settle();
+        clickTab('farewell');
+        await settle();
+        await back();
+        expect(active()).toBe('welcome');
+
+        await new Promise(resolve => {
+            window.addEventListener('popstate', async () => { await settle(); resolve(); }, { once: true });
+            window.history.forward();
+        });
+        expect(active()).toBe('farewell');
+    });
+});
+
+// '#knowledgebase' is a place inside the AI panel, so arriving at it — or
+// coming back to it — has to open 'ai' and then the tab within it, and must
+// not rewrite the hash to '#ai' on the way.
+describe('a hash that names an inner tab', () => {
+    it('opens the panel and the tab inside it, keeping the hash', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        window.history.pushState(null, '', `/dashboard/guild/1?t=${Math.random()}#knowledgebase`);
+        document.body.innerHTML = '';
+        bootPage();
+        await settle();
+        await settle();
+
+        expect(active()).toBe('ai');
+        expect(location.hash).toBe('#knowledgebase');
+        expect(document.getElementById('ai-knowledgebase').classList.contains('active')).toBe(true);
+    });
+
+    // The reader is already here; an entry for it would put a Back press
+    // between them and the page they actually came from.
+    it('replaces rather than pushes the entry it arrived on', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        window.history.pushState(null, '', `/dashboard/guild/1?t=${Math.random()}#welcome`);
+        const before = history.length;
+        document.body.innerHTML = '';
+        bootPage();
+        await settle();
+        await settle();
+
+        expect(active()).toBe('welcome');
+        expect(history.length).toBe(before);
+    });
+});

--- a/tests/helpers/guildSettingsPage.js
+++ b/tests/helpers/guildSettingsPage.js
@@ -54,7 +54,54 @@ async function settle() {
     await new Promise(resolve => setTimeout(resolve, 0));
 }
 
-function bootPage({ panelFetch } = {}) {
+// jsdom has no matchMedia at all, so the page's own `media()` helper would
+// answer null for every query and the viewport-dependent behaviour (#674) and
+// the motion preference (#675) would be untestable. This is the smallest thing
+// that behaves like one: queries answer from `state`, and `set()` flips a query
+// and notifies its listeners the way a browser does when the window is resized
+// or the preference is changed mid-session.
+function installMatchMedia(initial) {
+    // `false` is "this browser has no matchMedia" — the fail-safe the page's
+    // own `media()` helper is written around, and worth being able to boot.
+    if (initial === false) {
+        delete window.matchMedia;
+        return { set() {} };
+    }
+
+    const state = new Map(Object.entries(initial || {}));
+    const lists = new Map();
+
+    window.matchMedia = query => {
+        if (lists.has(query)) return lists.get(query);
+        const listeners = [];
+        const mql = {
+            media: query,
+            get matches() { return state.get(query) === true; },
+            addEventListener: (type, fn) => { if (type === 'change') listeners.push(fn); },
+            removeEventListener: (type, fn) => {
+                const at = listeners.indexOf(fn);
+                if (at !== -1) listeners.splice(at, 1);
+            },
+            notify: () => listeners.slice().forEach(fn => fn({ matches: mql.matches, media: query })),
+        };
+        lists.set(query, mql);
+        return mql;
+    };
+
+    return {
+        set(query, matches) {
+            state.set(query, matches);
+            lists.get(query)?.notify();
+        },
+    };
+}
+
+/**
+ * Boot the page. `media` seeds the matchMedia stub — `{ '(max-width: 768px)':
+ * true }` for a phone — and the returned handle flips a query afterwards.
+ * `media: false` boots with no matchMedia at all.
+ */
+function bootPage({ panelFetch, media } = {}) {
     const html = renderPage();
     const body = html.slice(html.indexOf('<body'), html.indexOf('</body>'));
     document.body.innerHTML = body.replace(/^<body[^>]*>/, '');
@@ -62,6 +109,8 @@ function bootPage({ panelFetch } = {}) {
     // jsdom has no CSS.escape; every browser that can run this page does.
     window.CSS = window.CSS || {};
     window.CSS.escape = value => String(value).replace(/[^\w-]/g, c => '\\' + c);
+
+    const mediaControl = installMatchMedia(media);
 
     window.fetch = jest.fn(async url => {
         const panel = /\/panel\/([a-z]+)(?:$|\?)/.exec(String(url));
@@ -101,6 +150,8 @@ function bootPage({ panelFetch } = {}) {
     window.eval(bootstrap);
     window.eval(fs.readFileSync(path.join(PUBLIC, 'settings-payload.js'), 'utf8'));
     window.eval(fs.readFileSync(path.join(PUBLIC, 'guild-settings.js'), 'utf8'));
+
+    return { media: mediaControl };
 }
 
 function clickTab(id) {


### PR DESCRIPTION
## Summary

This PR addresses three interconnected UX and accessibility issues on the dashboard:

1. **Mobile navigation collapse** (#674): On narrow viewports (<768px), the sidebar now folds away after navigation, preventing it from blocking access to the panel content. A toggle button appears to reopen it.

2. **Browser history for sections** (#679): Each section change now creates a separate history entry, allowing Back/Forward to navigate between previously viewed panels instead of leaving the dashboard entirely.

3. **Reduced motion support** (#675): Added `prefers-reduced-motion: reduce` media query handling in CSS and script to respect user motion preferences, including smooth scroll behavior.

## Key Changes

- **Mobile nav toggle** (`guild-settings.js`):
  - Added `media()` helper to safely query matchMedia (with fallback for unsupported browsers)
  - Implemented `setNavOpen()`, `isNarrow()`, and `collapseNavAfterNavigation()` to manage sidebar visibility
  - Toggle button only appears on narrow viewports and automatically hides when viewport widens
  - Nav collapses after section selection and scrolls content into view

- **Section history management** (`guild-settings.js`):
  - Refactored `activateTab()` to accept `historyMode` parameter ('push', 'replace', 'none')
  - Extracted `writeTabHash()` function to handle history state updates
  - Added `routeToHash()` for unified hash-based navigation
  - Implemented `popstate` listener for Back/Forward button support
  - Inner tabs (e.g., `#knowledgebase` in AI panel) preserve their hash while opening parent panel

- **Reduced motion support**:
  - Added `scrollBehavior()` function that respects `prefers-reduced-motion: reduce`
  - Updated CSS with `@media (prefers-reduced-motion: reduce)` block that:
    - Reduces animation durations to 0.01ms with single iteration
    - Stops infinite background blob animations
    - Maintains skeleton loader opacity when animations stop
  - Applied to `scrollIntoView()` call when collapsing nav

- **UI/Template updates** (`guild-settings.ejs`, `styles.css`):
  - Added nav toggle button with hamburger/X icons
  - Created `.dash-side-head` class for brand row layout
  - Added `.nav-collapsed` class to hide nav sections
  - Styled toggle button with proper focus states and hover effects
  - Updated responsive breakpoint handling

- **Test coverage** (new test files):
  - `dashboardMobileNav.test.js`: Tests nav toggle visibility, collapse behavior, and viewport changes
  - `dashboardSectionHistory.test.js`: Tests history entry creation, Back/Forward navigation, inner tabs
  - `dashboardEnterToSave.test.js`: Tests Enter key triggering section save (related to #679)
  - `dashboardReducedMotion.test.js`: Tests motion preference handling in CSS and script
  - `dashboardAutoRoleConfirm.test.js`: Tests confirmation dialog for destructive actions (#677)

- **Test helpers** (`tests/helpers/guildSettingsPage.js`):
  - Added `installMatchMedia()` stub to simulate media query behavior in jsdom
  - Supports dynamic query state changes mid-session for testing viewport/preference changes

## Implementation Details

- The nav toggle is always shipped in HTML but hidden via CSS, ensuring it never appears without script support
- Media queries are asked rather than assumed, allowing graceful degradation in unsupported browsers
- History management distinguishes between user-initiated navigation (push), URL-based arrival (replace), and browser navigation (none)
- Inner tab hashes are preserved when opening their parent panels to maintain URL semantics
- Scroll behavior respects user preferences while maintaining fallback for browsers without matchMedia

https://claude.ai/code/session_01QFGVbhdheDBvRbBcQuPEe7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive dashboard navigation with a collapsible sidebar on narrow screens.
  * Added tab history support for browser Back and Forward navigation.
  * Pressing Enter now saves eligible settings sections.
  * Added confirmation dialogs before removing auto-roles.
  * Added reduced-motion support for animations and scrolling.
* **Bug Fixes**
  * Improved focus restoration and role-name handling during dashboard interactions.
* **Documentation**
  * Documented dashboard settings, confirmation, and animation conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->