### PR TITLE
Fix critical data integrity issues in tournaments, events, and admin tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,58 @@ whose schema predates a migration that has already run.
 `npm test` fails if the newest entry below does not name both the current
 `package.json` version and the highest-numbered migration on disk.
 
+## [4.5.1] - 2026-08-31
+
+Migrations through `020_narrow_failed_job_ttl`.
+
+The dead-letter queue stops deleting debts nobody has settled (#896). Its TTL
+expired `resolved` and `exhausted` records alike after 30 days, and an owed
+payout that burns through its three retry attempts is marked `exhausted` and
+left for a human — `scripts/replay-owed-payouts.js` says so, and `retryJob`
+refuses to claim one. So the TTL was the only thing that ever acted on those
+records, and what it did was delete them: a player owed coins by a failed payout
+lost the claim a month later, silently. A resolved record has been paid and is
+history; an exhausted one is an outstanding debt, and a debt does not expire.
+`020` drops the old unnamed `updatedAt_1` index and builds the narrowed one in
+its place, verified before the boot continues — Mongoose never drops an index it
+no longer declares, so the model edit alone would have left the old TTL
+sweeping. The replay script lists exhausted payouts as their own section and
+exits non-zero while any exist; it still never pays one, because settling it is
+a decision about a specific player.
+
+The dashboard's admin adjustments have a ceiling (#925). `Number.isInteger(1e20)`
+is true, so an absurd amount went straight into `$inc`, and past
+`Number.MAX_SAFE_INTEGER` the arithmetic, the stored balance and the amounts the
+Transaction ledger records all stop being exact with nothing reporting a
+problem. Amounts are validated with `Number.isSafeInteger` and bounded at 1e12
+per adjustment, and the give paths clamp the resulting balance, XP or level at
+1e15 inside the update rather than after a read, so two admins adjusting at once
+cannot step over it in between. The XP ceiling does a second job: `applyXpGain`
+spends a total one level at a time, so an unbounded grant was an unbounded loop
+on the member's next message.
+
+Two writes that Mongoose 9 had stopped running are running again. Both dashboard
+adjust routes and `weeklyChampion`'s progress accumulator passed an
+aggregation-pipeline update without the `updatePipeline` opt-in the upgrade
+introduced, which throws rather than executing — `take` on either route answered
+500 to every call, and no weekly champion run had counted since. The static
+check that was supposed to catch this only looked at array literals passed
+inline; it resolves identifiers now, which is how the third one turned up.
+
+The market's per-seller cap is a property of the data rather than a count read a
+moment earlier (#926). Each listing carries the slot it occupies under a unique
+index on `{ guildId, sellerId, slot }`, so two concurrent `/market list` calls
+can no longer both pass the check and leave a seller with six. A slot rides on
+the listing rather than in a counter, so cancelling, selling or expiring one
+frees it by deleting the row — there is nothing to decrement and nothing that
+can drift.
+
+Coverage: the tournament prize split and the seasonal event rewards are tested
+at the service level for the first time (#906) — the 60/25/15 split and its
+payouts, a winner who has left the guild, the claim that stops a second payout,
+the multipliers every earning command scales by, and the hourly sweep that
+writes them.
+
 ## [4.5.0] - 2026-08-28
 
 Migrations through `019_drop_hourly_winners`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clawdia",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawdia",
-      "version": "4.5.0",
+      "version": "4.5.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.120.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawdia",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "Clawdia — a chill, self-hosted Discord bot with a full-featured admin dashboard",
   "main": "src/index.js",
   "scripts": {

--- a/scripts/replay-owed-payouts.js
+++ b/scripts/replay-owed-payouts.js
@@ -98,6 +98,11 @@ async function main() {
         if (!pay) {
             console.log('\nNothing was paid. Re-run with --pay to attempt these.');
             reportExhausted();
+            // Same rule as the no-owed branch above: an exhausted debt is a
+            // non-zero exit however the run reached it, so a listing run in a
+            // monitor answers the same as a paying one. A listing run with
+            // nothing exhausted still exits 0 — it has reported, not failed.
+            if (exhausted.length > 0) process.exitCode = 1;
             return;
         }
 

--- a/scripts/replay-owed-payouts.js
+++ b/scripts/replay-owed-payouts.js
@@ -24,7 +24,10 @@
 // Every attempt goes through retryJob, so the DLQ record carries its own audit
 // trail: attempts, last error, and `resolved`/`exhausted` at the end of it. A
 // record that exhausts its attempts is left for a human — nothing here deletes
-// one.
+// one, and since #896 nothing else does either: the collection's TTL expires
+// `resolved` records only, so an unsettled debt survives until somebody settles
+// it. It is listed separately below, because a debt nobody can see is the same
+// as one that was deleted.
 
 require('dotenv').config();
 require('../src/config/fileSecrets').loadFileSecrets();
@@ -54,8 +57,33 @@ async function main() {
             ...claimableFilter(),
         }).sort({ createdAt: 1 });
 
+        // Exhausted records are not claimable — retryJob refuses one, and the
+        // filter above deliberately excludes them — but they are the entries
+        // that most need looking at: each is a payout that failed every attempt
+        // it had. They are reported, never paid from here; settling one is a
+        // decision about a specific player, taken by the human this queue keeps
+        // it for.
+        const exhausted = await FailedJob.find({
+            jobName: { $regex: `\\${OWED_SUFFIX}$` },
+            status: 'exhausted',
+        }).sort({ createdAt: 1 });
+
+        const reportExhausted = () => {
+            if (exhausted.length === 0) return;
+            console.log(`\n${exhausted.length} exhausted payout(s) — these need a human, ` +
+                `and --pay will not attempt them:\n`);
+            for (const record of exhausted) {
+                console.log(
+                    `  ${record._id}  ${record.jobName}  ${describeOwedPayout(record.payload)}  ` +
+                    `(gave up after ${record.attempts}/${record.maxAttempts}, last error: ${record.errorMessage})`
+                );
+            }
+        };
+
         if (owed.length === 0) {
             console.log('Nothing owed.');
+            reportExhausted();
+            if (exhausted.length > 0) process.exitCode = 1;
             return;
         }
 
@@ -69,6 +97,7 @@ async function main() {
 
         if (!pay) {
             console.log('\nNothing was paid. Re-run with --pay to attempt these.');
+            reportExhausted();
             return;
         }
 
@@ -95,7 +124,8 @@ async function main() {
         }
 
         console.log(`\nPaid ${paid}, still owed ${stillOwed}.`);
-        if (stillOwed > 0) process.exitCode = 1;
+        reportExhausted();
+        if (stillOwed > 0 || exhausted.length > 0) process.exitCode = 1;
     } finally {
         await mongoose.disconnect();
     }

--- a/src/commands/economy/market.js
+++ b/src/commands/economy/market.js
@@ -17,6 +17,10 @@ const { ownedBy } = require('../../utils/collectorOwner');
 const ITEM_META = Object.fromEntries(DEFAULT_SHOP_ITEMS.map(i => [i.itemId, i]));
 
 const MAX_LISTINGS_PER_USER = 5;
+// The slots a seller's listings occupy, 1-based. Each listing carries the one it
+// holds and the unique index on { guildId, sellerId, slot } enforces it — see
+// createListingInFreeSlot and models/MarketListing.js.
+const LISTING_SLOTS = Array.from({ length: MAX_LISTINGS_PER_USER }, (_, i) => i + 1);
 const LISTING_TTL_MS        = 48 * 3_600_000;
 const MARKET_FEE_RATE       = 0.05;
 const MIN_PRICE_PER_ITEM    = 10;
@@ -90,20 +94,26 @@ async function handleList(interaction, currency) {
         { upsert: true, new: true }
     );
 
-    const slot = seller.inventory.find(i => i.itemId === itemId);
-    if (!slot || slot.quantity < qty) {
+    // `stack`, not `slot`: a slot in this file is one of the seller's five
+    // listing slots now, and this is the inventory stack being sold out of.
+    const stack = seller.inventory.find(i => i.itemId === itemId);
+    if (!stack || stack.quantity < qty) {
         return interaction.reply({ content: `You don't have ${qty}x \`${itemId}\` in your inventory.`, flags: MessageFlags.Ephemeral });
     }
 
-    const activeListing = await MarketListing.countDocuments({
-        guildId:  interaction.guild.id,
-        sellerId: interaction.user.id,
-    });
-    if (activeListing >= MAX_LISTINGS_PER_USER) {
+    // The friendly refusal, before any stock moves: a seller who is already full
+    // is told so without their items being taken and handed back. It is not what
+    // enforces the cap — two calls can pass this together — which is what the
+    // slot the insert claims below is for.
+    const openListings = await MarketListing.find(
+        { guildId: interaction.guild.id, sellerId: interaction.user.id },
+        'slot',
+    ).lean();
+    if (openListings.length >= MAX_LISTINGS_PER_USER) {
         return interaction.reply({ content: `You can only have ${MAX_LISTINGS_PER_USER} active listings at a time.`, flags: MessageFlags.Ephemeral });
     }
 
-    // The stock leaves as a compare-and-set, not `slot.quantity -= qty` followed
+    // The stock leaves as a compare-and-set, not `stack.quantity -= qty` followed
     // by a save: the quantity read above is history by now, and two concurrent
     // `/market list` calls for the same stack would each see the full count and
     // both take it — one stack backing two listings. The `$elemMatch` filter
@@ -120,16 +130,24 @@ async function handleList(interaction, currency) {
     if (!debited) {
         return interaction.reply({ content: `You don't have ${qty}x \`${itemId}\` in your inventory.`, flags: MessageFlags.Ephemeral });
     }
-    // Drop slots the decrement above emptied. Advisory: a failure leaves an
-    // empty slot, not wrong quantities.
+    // Drop inventory stacks the decrement above emptied. Advisory: a failure
+    // leaves an empty stack, not wrong quantities.
     await User.updateOne(
         { userId: interaction.user.id, guildId: interaction.guild.id },
         { $pull: { inventory: { quantity: { $lte: 0 } } } },
     ).catch(err => console.error('[market list] inventory cleanup failed:', err));
 
+    // Hand the stock back the same way every other credit lands — one atomic
+    // upsert, so the return can't duplicate an inventory stack a concurrent
+    // credit is creating (src/utils/inventoryGrant.js).
+    const returnStock = () => grantInventoryItem(interaction.user.id, interaction.guild.id, itemId, qty)
+        .catch(restoreErr => console.error(
+            `[market list] returning ${qty}x ${itemId} to ${interaction.user.id} failed — items owed:`, restoreErr,
+        ));
+
     let listing;
     try {
-        listing = await MarketListing.create({
+        listing = await createListingInFreeSlot({
             guildId:      interaction.guild.id,
             sellerId:     interaction.user.id,
             itemId,
@@ -138,15 +156,20 @@ async function handleList(interaction, currency) {
             expiresAt:    new Date(Date.now() + LISTING_TTL_MS),
         });
     } catch (err) {
-        // Hand the stock back the same way every other credit lands — one atomic
-        // upsert, so the return can't duplicate a slot a concurrent credit is
-        // creating (src/utils/inventoryGrant.js).
-        await grantInventoryItem(interaction.user.id, interaction.guild.id, itemId, qty)
-            .catch(restoreErr => console.error(
-                `[market list] returning ${qty}x ${itemId} to ${interaction.user.id} failed — items owed:`, restoreErr,
-            ));
+        await returnStock();
         console.error('[market list] MarketListing.create failed:', err);
         return interaction.reply({ content: 'Failed to create listing. Your item has been returned.', flags: MessageFlags.Ephemeral });
+    }
+
+    // Every slot was taken by the time the insert went in — the check above and
+    // another `/market list` both passed it. The stock is handed straight back,
+    // so losing the race costs the seller nothing but the refusal.
+    if (!listing) {
+        await returnStock();
+        return interaction.reply({
+            content: `You can only have ${MAX_LISTINGS_PER_USER} active listings at a time. Your item has been returned.`,
+            flags: MessageFlags.Ephemeral,
+        });
     }
 
     const embed = new EmbedBuilder()
@@ -161,6 +184,44 @@ async function handleList(interaction, currency) {
         .setTimestamp();
 
     return interaction.reply({ embeds: [embed], flags: MessageFlags.Ephemeral });
+}
+
+/**
+ * Inserts the listing into the seller's first free slot, or answers null when
+ * they have none left.
+ *
+ * The cap used to be a `countDocuments` followed by an insert (#926), which two
+ * concurrent calls could both pass — cosmetic, but the pattern is the same one
+ * that loses money elsewhere, and the fix is the one the rest of the economy
+ * uses: let the write itself be the check. The unique index on
+ * { guildId, sellerId, slot } means only one insert per slot can land, so the
+ * loser of the race is told no rather than quietly making it six.
+ *
+ * Each attempt re-reads the taken slots, because an E11000 means exactly that
+ * they have changed. One attempt per slot plus one is the most that can be
+ * useful: every retry loses a different slot to somebody, and the read after the
+ * last one finds the seller full.
+ */
+async function createListingInFreeSlot(fields) {
+    for (let attempt = 0; attempt <= MAX_LISTINGS_PER_USER; attempt++) {
+        const open = await MarketListing.find(
+            { guildId: fields.guildId, sellerId: fields.sellerId },
+            'slot',
+        ).lean();
+        const taken = new Set(open.map(l => l.slot));
+        const slot = LISTING_SLOTS.find(s => !taken.has(s));
+        if (slot === undefined) return null;
+
+        try {
+            return await MarketListing.create({ ...fields, slot });
+        } catch (err) {
+            // 11000 is the index doing its job: somebody else took this slot
+            // between the read and the insert. Anything else is a real failure
+            // and belongs to the caller, which hands the stock back.
+            if (err?.code !== 11000) throw err;
+        }
+    }
+    return null;
 }
 
 // Batch-fetches seller rep counts and Discord usernames for a page slice.

--- a/src/commands/economy/market.js
+++ b/src/commands/economy/market.js
@@ -11,6 +11,7 @@ const { DEFAULT_SHOP_ITEMS, getItemLore, getItemRarity, RARITY_ORDER } = require
 const { EFFECT_CONFIGS } = require('../../services/effectsService');
 const { logTransaction } = require('../../utils/logTransaction');
 const { grantInventoryItem } = require('../../utils/inventoryGrant');
+const { recordOwedPayout } = require('../../utils/owedPayout');
 const COLORS = require('../../utils/embedColors');
 const { ownedBy } = require('../../utils/collectorOwner');
 
@@ -140,10 +141,51 @@ async function handleList(interaction, currency) {
     // Hand the stock back the same way every other credit lands — one atomic
     // upsert, so the return can't duplicate an inventory stack a concurrent
     // credit is creating (src/utils/inventoryGrant.js).
-    const returnStock = () => grantInventoryItem(interaction.user.id, interaction.guild.id, itemId, qty)
-        .catch(restoreErr => console.error(
-            `[market list] returning ${qty}x ${itemId} to ${interaction.user.id} failed — items owed:`, restoreErr,
-        ));
+    //
+    // The debit has already committed by the time anything calls this, so a
+    // return that does not land is an item the player no longer has and no
+    // listing to show for it. Two ways it fails to land: the update rejects, or
+    // it matches no document and resolves null. Both are failures, and neither
+    // may be reported as a return — the credit is written down as owed instead,
+    // the same shape `replayOwedPayout` pays and `npm run payouts:replay` lists
+    // (src/utils/owedPayout.js), which is what utils/balanceDelta.js does for a
+    // credit that will not land in a command.
+    //
+    // Returns whether the stock is actually back.
+    const returnStock = async () => {
+        let failure;
+        try {
+            if (await grantInventoryItem(interaction.user.id, interaction.guild.id, itemId, qty)) return true;
+            failure = new Error(`no user document for ${interaction.user.id} in ${interaction.guild.id}`);
+        } catch (restoreErr) {
+            failure = restoreErr;
+        }
+
+        console.error(
+            `[market list] returning ${qty}x ${itemId} to ${interaction.user.id} failed — items owed:`, failure,
+        );
+        await recordOwedPayout({
+            service: 'market',
+            jobName: 'listItem',
+            guildId: interaction.guild.id,
+            payload: {
+                kind:     'items',
+                userId:   interaction.user.id,
+                guildId:  interaction.guild.id,
+                itemId,
+                quantity: qty,
+            },
+            error: failure,
+        });
+        return false;
+    };
+
+    // What to tell the seller about their stock. Saying it came back when it did
+    // not is the one thing this must never do: they would have no reason to
+    // mention it to anyone.
+    const stockNote = returned => (returned
+        ? 'Your item has been returned.'
+        : 'Your item could not be returned automatically — it is recorded as owed and an operator can restore it.');
 
     let listing;
     try {
@@ -156,18 +198,18 @@ async function handleList(interaction, currency) {
             expiresAt:    new Date(Date.now() + LISTING_TTL_MS),
         });
     } catch (err) {
-        await returnStock();
+        const returned = await returnStock();
         console.error('[market list] MarketListing.create failed:', err);
-        return interaction.reply({ content: 'Failed to create listing. Your item has been returned.', flags: MessageFlags.Ephemeral });
+        return interaction.reply({ content: `Failed to create listing. ${stockNote(returned)}`, flags: MessageFlags.Ephemeral });
     }
 
     // Every slot was taken by the time the insert went in — the check above and
     // another `/market list` both passed it. The stock is handed straight back,
     // so losing the race costs the seller nothing but the refusal.
     if (!listing) {
-        await returnStock();
+        const returned = await returnStock();
         return interaction.reply({
-            content: `You can only have ${MAX_LISTINGS_PER_USER} active listings at a time. Your item has been returned.`,
+            content: `You can only have ${MAX_LISTINGS_PER_USER} active listings at a time. ${stockNote(returned)}`,
             flags: MessageFlags.Ephemeral,
         });
     }
@@ -208,8 +250,17 @@ async function createListingInFreeSlot(fields) {
             { guildId: fields.guildId, sellerId: fields.sellerId },
             'slot',
         ).lean();
-        const taken = new Set(open.map(l => l.slot));
-        const slot = LISTING_SLOTS.find(s => !taken.has(s));
+        const slotted = open.filter(l => l.slot != null);
+        const taken   = new Set(slotted.map(l => l.slot));
+        const free    = LISTING_SLOTS.filter(s => !taken.has(s));
+
+        // A listing written before the slot field existed carries none, and the
+        // index skips it — but it is still one of the seller's five, and taking
+        // the lowest free number beside it would let a seller with four legacy
+        // listings open five more. The legacy rows stand in for that many free
+        // slots, so the seller has as many places left as they should and the
+        // unique index still decides who gets each remaining number.
+        const slot = free[open.length - slotted.length];
         if (slot === undefined) return null;
 
         try {

--- a/src/dashboard/lib/apiHelpers.js
+++ b/src/dashboard/lib/apiHelpers.js
@@ -72,6 +72,14 @@ const MAX_ADJUST_TOTAL  = 1_000_000_000_000_000;  // 1e15 balance, XP or level
  * @returns {{ value: ?number, error: ?string }} exactly one of the two is set
  */
 function readAdjustAmount(amount, { min = 1, max = MAX_ADJUST_AMOUNT, label = 'amount' } = {}) {
+    // `Number()` answers 0 for null, undefined, '', '  ', [] and false, and a
+    // route whose minimum is 0 — set_level — would take that as "level 0" and
+    // wipe the member's level on a request that named no amount at all. Only a
+    // number or a non-blank string is an amount; everything else is a missing
+    // field, not a zero.
+    const isNumeric = typeof amount === 'number' || (typeof amount === 'string' && amount.trim() !== '');
+    if (!isNumeric) return { value: null, error: `${label} must be an integer` };
+
     const amt = Number(amount);
     // isSafeInteger rather than isInteger: it rejects 1e20, Infinity and NaN in
     // one go, and every value it accepts survives the arithmetic below it.

--- a/src/dashboard/lib/apiHelpers.js
+++ b/src/dashboard/lib/apiHelpers.js
@@ -37,6 +37,50 @@ async function logAuditEvent(req, guildId, action, details = null) {
     }
 }
 
+// Ceilings for the admin adjust routes (#925).
+//
+// `Number.isInteger(1e20)` is true, and 1e20 is a hopeless balance: past
+// `Number.MAX_SAFE_INTEGER` (9.007e15) the `$inc` arithmetic and the amounts
+// the Transaction ledger records stop being exact, so a balance quietly stops
+// reconciling and no layer reports anything. Nothing rejects it today, and the
+// values are awkward to unwind afterwards.
+//
+// Two ceilings, because they answer different things. MAX_ADJUST_AMOUNT bounds
+// the single give or take, which is the shape a mistyped number arrives in.
+// MAX_ADJUST_TOTAL bounds the field afterwards, because a hundred legitimate
+// gives reach the same place one absurd one does; the routes clamp inside the
+// update rather than reading the balance first, so two admins adjusting at once
+// cannot step over it between the read and the write.
+//
+// Both sit far enough under MAX_SAFE_INTEGER that the clamp's own arithmetic is
+// exact: the largest give applied to a balance already at the total is 1.001e15,
+// still an exactly representable integer, so the `$min` sees a true value rather
+// than a rounded one. The totals are also what keeps `applyXpGain`'s catch-up
+// loop (src/services/levelingService.js) finite — it spends XP one level at a
+// time, and an unbounded grant is an unbounded loop on the next message.
+const MAX_ADJUST_AMOUNT = 1_000_000_000_000;      // 1e12 per give/take
+const MAX_ADJUST_TOTAL  = 1_000_000_000_000_000;  // 1e15 balance, XP or level
+
+/**
+ * Validates one `amount` field from an adjust route.
+ *
+ * @param {*} amount raw request value
+ * @param {object} [opts]
+ * @param {number} [opts.min]   smallest accepted value (1 for give/take, 0 for a set)
+ * @param {number} [opts.max]   largest accepted value
+ * @param {string} [opts.label] what to call the field in the error
+ * @returns {{ value: ?number, error: ?string }} exactly one of the two is set
+ */
+function readAdjustAmount(amount, { min = 1, max = MAX_ADJUST_AMOUNT, label = 'amount' } = {}) {
+    const amt = Number(amount);
+    // isSafeInteger rather than isInteger: it rejects 1e20, Infinity and NaN in
+    // one go, and every value it accepts survives the arithmetic below it.
+    if (!Number.isSafeInteger(amt)) return { value: null, error: `${label} must be an integer` };
+    if (amt < min) return { value: null, error: `${label} must be at least ${min.toLocaleString('en-US')}` };
+    if (amt > max) return { value: null, error: `${label} must be at most ${max.toLocaleString('en-US')}` };
+    return { value: amt, error: null };
+}
+
 // Filters memberEvents by calendar date rather than array position so sparse
 // histories (days with no events) don't skew the 7/30-day windows.
 function computeRetention(memberEvents, nowMs = Date.now()) {
@@ -68,6 +112,9 @@ function parseChannelIdFromJumpUrl(url) {
 
 module.exports = {
     isValidDiscordId,
+    MAX_ADJUST_AMOUNT,
+    MAX_ADJUST_TOTAL,
+    readAdjustAmount,
     sanitizeMongoValue,
     logAuditEvent,
     computeRetention,

--- a/src/dashboard/routes/api/economy.js
+++ b/src/dashboard/routes/api/economy.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const GuildAnalytics = require('../../../models/GuildAnalytics');
 const User = require('../../../models/User');
 const { checkAuth, checkGuildAccess, checkWriteRateLimit } = require('../../lib/middleware');
-const { isValidDiscordId, logAuditEvent } = require('../../lib/apiHelpers');
+const { isValidDiscordId, logAuditEvent, readAdjustAmount, MAX_ADJUST_TOTAL } = require('../../lib/apiHelpers');
 const { topByNetWorth } = require('../../../utils/netWorth');
 const { cachedAggregate, invalidatePrefix } = require('../../lib/aggregateCache');
 
@@ -78,21 +78,33 @@ router.post('/guild/:guildId/economy/adjust', checkAuth, checkGuildAccess, check
     if (!action || !['give', 'take', 'reset', 'freeze', 'unfreeze'].includes(action)) {
         return res.status(400).json({ error: 'action must be give, take, reset, freeze, or unfreeze' });
     }
+    let amt = null;
     if (['give', 'take'].includes(action)) {
-        const amt = Number(amount);
-        if (!Number.isFinite(amt) || amt <= 0 || !Number.isInteger(amt)) {
-            return res.status(400).json({ error: 'amount must be a positive integer for give/take' });
-        }
+        const read = readAdjustAmount(amount);
+        if (read.error) return res.status(400).json({ error: `${read.error} for give/take` });
+        amt = read.value;
     }
 
     try {
         const filter = { userId: String(userId), guildId };
         let update;
+        // A pipeline update has to say so under Mongoose 9, or the call throws
+        // rather than running (see tests/updatePipelineOption.test.js).
+        const options = { new: true };
         if (action === 'give') {
-            update = { $inc: { balance: Number(amount) } };
+            // Clamped at MAX_ADJUST_TOTAL inside the update, not by reading the
+            // balance first: the ceiling exists to keep the balance exactly
+            // representable, and a read-then-$inc lets two admins adjusting at
+            // once step over it between the read and the write. `$ifNull` guards
+            // documents written before `balance` had a default — the take below
+            // needs no such guard, since `$max` against 0 already answers 0 for
+            // a missing field.
+            update = [{ $set: { balance: { $min: [MAX_ADJUST_TOTAL, { $add: [{ $ifNull: ['$balance', 0] }, amt] }] } } }];
+            options.updatePipeline = true;
         } else if (action === 'take') {
             // Use aggregation pipeline update to clamp balance at 0 atomically.
-            update = [{ $set: { balance: { $max: [0, { $subtract: ['$balance', Number(amount)] }] } } }];
+            update = [{ $set: { balance: { $max: [0, { $subtract: ['$balance', amt] }] } } }];
+            options.updatePipeline = true;
         } else if (action === 'reset') {
             update = { $set: { balance: 0, bank: 0 } };
         } else if (action === 'freeze') {
@@ -107,12 +119,12 @@ router.post('/guild/:guildId/economy/adjust', checkAuth, checkGuildAccess, check
         // exist — while reporting success, and the admin's coins went nowhere
         // anyone could see. A member with no row has never run a command here,
         // which is a 404, not a row to create.
-        const user = await User.findOneAndUpdate(filter, update, { new: true });
+        const user = await User.findOneAndUpdate(filter, update, options);
         if (!user) return res.status(404).json({ error: 'That member has no economy record in this server' });
         // An admin who has just moved someone's coins expects to see it, and a
         // thirty-second-old total would read as the adjustment not having applied.
         invalidatePrefix(`${guildId}:`);
-        await logAuditEvent(req, guildId, 'economy_adjust', { targetUserId: String(userId), action, amount: amount ?? null });
+        await logAuditEvent(req, guildId, 'economy_adjust', { targetUserId: String(userId), action, amount: amt });
         res.json({ success: true, balance: user.balance, bank: user.bank, economyFrozen: user.economyFrozen });
     } catch (error) {
         console.error('Economy adjust error:', error);

--- a/src/dashboard/routes/api/leveling.js
+++ b/src/dashboard/routes/api/leveling.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const Guild = require('../../../models/Guild');
 const User = require('../../../models/User');
 const { checkAuth, checkGuildAccess, checkWriteRateLimit } = require('../../lib/middleware');
-const { isValidDiscordId } = require('../../lib/apiHelpers');
+const { isValidDiscordId, readAdjustAmount, MAX_ADJUST_TOTAL } = require('../../lib/apiHelpers');
 const { readPage, pageEnvelope } = require('../../lib/apiPage');
 
 // One page of members ranked by level then XP, 25 to a page.
@@ -35,34 +35,40 @@ router.post('/guild/:guildId/leveling/adjust', checkAuth, checkGuildAccess, chec
     if (!action || !['give', 'take', 'reset', 'set_level'].includes(action)) {
         return res.status(400).json({ error: 'action must be give, take, reset, or set_level' });
     }
+    // Same ceilings as the economy route (#925): an XP total or a level past
+    // Number.MAX_SAFE_INTEGER stops being exact, and an unbounded XP grant is an
+    // unbounded catch-up loop in applyXpGain the next time the member speaks.
+    let amt = null;
     if (['give', 'take', 'set_level'].includes(action)) {
-        const amt = Number(amount);
-        if (!Number.isFinite(amt) || !Number.isInteger(amt)) {
-            return res.status(400).json({ error: 'amount must be an integer' });
-        }
-        if (['give', 'take'].includes(action) && amt <= 0) {
-            return res.status(400).json({ error: 'amount must be positive for give/take' });
-        }
-        if (action === 'set_level' && amt < 0) {
-            return res.status(400).json({ error: 'level cannot be negative' });
-        }
+        const read = action === 'set_level'
+            ? readAdjustAmount(amount, { min: 0, max: MAX_ADJUST_TOTAL, label: 'level' })
+            : readAdjustAmount(amount);
+        if (read.error) return res.status(400).json({ error: read.error });
+        amt = read.value;
     }
     try {
         const filter = { userId: String(userId), guildId };
         let update;
+        // Mongoose 9 throws on a pipeline update that does not opt in — see
+        // tests/updatePipelineOption.test.js.
+        const options = { new: true };
         if (action === 'give') {
-            update = { $inc: { xp: Number(amount) } };
+            // Clamped inside the update rather than after a read, for the reason
+            // the economy route's give explains.
+            update = [{ $set: { xp: { $min: [MAX_ADJUST_TOTAL, { $add: [{ $ifNull: ['$xp', 0] }, amt] }] } } }];
+            options.updatePipeline = true;
         } else if (action === 'take') {
-            update = [{ $set: { xp: { $max: [0, { $subtract: ['$xp', Number(amount)] }] } } }];
+            update = [{ $set: { xp: { $max: [0, { $subtract: ['$xp', amt] }] } } }];
+            options.updatePipeline = true;
         } else if (action === 'reset') {
             update = { $set: { xp: 0, level: 0 } };
         } else {
-            update = { $set: { level: Number(amount) } };
+            update = { $set: { level: amt } };
         }
         // No upsert (#584) — see the note on the economy adjust route: a mistyped
         // snowflake is still a well-formed one, and upserting turned it into a
         // phantom member document instead of an error the admin could act on.
-        const user = await User.findOneAndUpdate(filter, update, { new: true });
+        const user = await User.findOneAndUpdate(filter, update, options);
         if (!user) return res.status(404).json({ error: 'That member has no leveling record in this server' });
         res.json({ success: true, level: user.level, xp: user.xp });
     } catch (err) {

--- a/src/migrations/020_narrow_failed_job_ttl.js
+++ b/src/migrations/020_narrow_failed_job_ttl.js
@@ -1,0 +1,79 @@
+const mongoose = require('mongoose');
+
+/**
+ * Replaces the failedjobs TTL so it expires `resolved` records only.
+ *
+ * The old index — `updatedAt_1`, built by Mongoose from the schema — expired
+ * `resolved` **and** `exhausted` records after 30 days (#896). An owed payout
+ * that burns through its three retry attempts is marked `exhausted` and, per
+ * scripts/replay-owed-payouts.js, left for a human; nothing else in the
+ * codebase pays it. Thirty days of nobody looking and the record was gone, and
+ * with it the only record that a player was owed coins. The queue that exists
+ * so a failed credit survives was deleting exactly the entries that had not
+ * been settled.
+ *
+ * Dropping an index is not something Mongoose does on its own — declaring the
+ * narrowed one in the model leaves the old one in place, still deleting
+ * exhausted records — so the drop happens here. The replacement is created here
+ * too rather than left to autoIndex, so the two swap inside one boot step
+ * instead of leaving a window with no TTL at all (the same reasoning as 016).
+ *
+ * Records already deleted are not recoverable; this stops the next ones going.
+ */
+module.exports = {
+    name: '020_narrow_failed_job_ttl',
+
+    async up() {
+        const failedJobs = mongoose.connection.db.collection('failedjobs');
+
+        // A database that never built it — a fresh install, or one already past
+        // this — has nothing to drop. NamespaceNotFound (26) is a failedjobs
+        // collection that does not exist yet, which is the common case: it is
+        // created by the first job failure.
+        await failedJobs.dropIndex('updatedAt_1').catch(err => {
+            if (err?.codeName !== 'IndexNotFound' && err?.code !== 26) throw err;
+        });
+
+        await failedJobs.createIndex(
+            { updatedAt: 1 },
+            {
+                name: 'idx_failedjob_resolved_ttl',
+                expireAfterSeconds: 30 * 24 * 60 * 60,
+                partialFilterExpression: { status: 'resolved' },
+            },
+        );
+
+        const built = (await failedJobs.indexes()).find(i => i.name === 'idx_failedjob_resolved_ttl');
+        // A TTL that came back covering `exhausted` would delete owed payouts on
+        // its next sweep, which is the whole reason this migration exists — so
+        // it fails the boot rather than being left to a background sweep nobody
+        // is watching.
+        if (built?.partialFilterExpression?.status !== 'resolved') {
+            throw new Error(
+                'failedjobs TTL is not restricted to resolved records after createIndex — ' +
+                'exhausted owed payouts would still be deleted, so startup must not continue.',
+            );
+        }
+    },
+
+    // The inverse is the index this replaced, options and unnamed name included.
+    // It is a rollback to a state that loses owed payouts, which is what a
+    // rollback to the previous release is: the code being rolled back to is the
+    // code that wrote the broad filter.
+    async down() {
+        const failedJobs = mongoose.connection.db.collection('failedjobs');
+
+        await failedJobs.dropIndex('idx_failedjob_resolved_ttl').catch(err => {
+            if (err?.codeName !== 'IndexNotFound' && err?.code !== 26) throw err;
+        });
+
+        await failedJobs.createIndex(
+            { updatedAt: 1 },
+            {
+                name: 'updatedAt_1',
+                expireAfterSeconds: 30 * 24 * 60 * 60,
+                partialFilterExpression: { status: { $in: ['resolved', 'exhausted'] } },
+            },
+        );
+    },
+};

--- a/src/models/FailedJob.js
+++ b/src/models/FailedJob.js
@@ -31,7 +31,35 @@ const FailedJobSchema = new Schema({
     claimedBy: { type: String, default: null },
 }, { timestamps: true });
 
-// Auto-expire resolved/exhausted records after 30 days
-FailedJobSchema.index({ updatedAt: 1 }, { expireAfterSeconds: 30 * 24 * 60 * 60, partialFilterExpression: { status: { $in: ['resolved', 'exhausted'] } } });
+// Auto-expire *resolved* records after 30 days.
+//
+// `exhausted` was in this filter too (#896), which meant the TTL deleted
+// precisely the records that most needed a human. An owed payout that burns
+// through its three attempts is marked `exhausted` and, per
+// scripts/replay-owed-payouts.js, "left for a human" — nothing else in the
+// codebase pays it. Thirty days later the record went away and the debt with
+// it: a player owed coins by a failed payout simply lost the claim, silently.
+//
+// This queue is the compensation mechanism behind every money path that cannot
+// use a transaction, so the records have to outlive an operator's attention
+// span. A resolved one has been paid and is history; an exhausted one is an
+// outstanding debt, and an outstanding debt does not expire.
+//
+// `pending` and `retrying` were never covered by the TTL and still are not, for
+// the same reason: they are work that has not been done yet.
+//
+// Named, because the index it replaces was not: Mongoose called that one
+// `updatedAt_1`, and a second index on the same key with different options is
+// an IndexOptionsConflict rather than an update. Migration
+// 020_narrow_failed_job_ttl drops it — declaring this one leaves the old one
+// exactly where it is, still deleting exhausted records.
+FailedJobSchema.index(
+    { updatedAt: 1 },
+    {
+        name: 'idx_failedjob_resolved_ttl',
+        expireAfterSeconds: 30 * 24 * 60 * 60,
+        partialFilterExpression: { status: 'resolved' },
+    },
+);
 
 module.exports = model('FailedJob', FailedJobSchema);

--- a/src/models/MarketListing.js
+++ b/src/models/MarketListing.js
@@ -8,11 +8,39 @@ const marketListingSchema = new Schema({
     pricePerUnit: { type: Number, required: true, min: 1 },
     listedAt:     { type: Date, default: Date.now },
     expiresAt:    { type: Date, required: true },
+
+    // Which of the seller's MAX_LISTINGS_PER_USER slots this listing occupies,
+    // 1-based. It exists so the per-seller cap can be a property of the data
+    // rather than of a count read a moment before the insert (#926): two
+    // concurrent `/market list` calls both passed that count and both inserted.
+    //
+    // A slot is not a counter kept alongside the listings — it is carried by the
+    // listing itself, so cancelling, selling or expiring one frees its slot by
+    // deleting the row. There is nothing to decrement, and so nothing that can
+    // drift and cost a seller a slot they are not using.
+    //
+    // Deliberately not required and with no default: rows written before this
+    // field existed have no slot, and the index below skips them rather than
+    // treating them all as duplicates of one another. They are gone within the
+    // 48-hour listing TTL.
+    slot:         { type: Number, min: 1 },
 });
 
 // TTL index for automatic expiry cleanup (MongoDB removes docs after expiresAt)
 marketListingSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 marketListingSchema.index({ guildId: 1, itemId: 1, pricePerUnit: 1 });
 marketListingSchema.index({ guildId: 1, sellerId: 1 });
+
+// The cap itself. A unique key on the seller's slot is what makes
+// MAX_LISTINGS_PER_USER true under concurrency: the loser of a race gets an
+// E11000 and picks another slot, and a seller with every slot taken has nowhere
+// left to insert. The partial filter keeps it to rows that actually carry a
+// slot — a compound sparse index would still index a legacy row (sparse skips a
+// document only when it has none of the keys, and these rows have guildId and
+// sellerId), and every such row would collide on `slot: null`.
+marketListingSchema.index(
+    { guildId: 1, sellerId: 1, slot: 1 },
+    { name: 'idx_market_seller_slot', unique: true, partialFilterExpression: { slot: { $gte: 1 } } },
+);
 
 module.exports = model('MarketListing', marketListingSchema);

--- a/src/services/tournamentService.js
+++ b/src/services/tournamentService.js
@@ -99,10 +99,18 @@ async function endTournament(tournamentId) {
     const pool   = tournament.prizePool;
 
     tournament.prizes = [];
+    // Each share is rounded on its own, and three independent roundings can add
+    // up to more than there is: a pool of 10 rounds to 6 + 3 + 2 = 11, and the
+    // eleventh coin is minted out of nothing. Tracking what is left and capping
+    // each share against it means the split can never pay out more than the
+    // pool held, whatever the rounding does. A remainder left over by rounding
+    // down stays unpaid, as the places that do not exist always have.
+    let unallocated = pool;
     for (let i = 0; i < Math.min(3, sorted.length); i++) {
         const pct    = PRIZE_SPLITS[i];
-        const amount = Math.round(pool * pct);
+        const amount = Math.min(Math.round(pool * pct), unallocated);
         if (amount > 0) {
+            unallocated -= amount;
             tournament.prizes.push({ place: i + 1, userId: sorted[i].userId, amount, paidOut: false });
         }
     }

--- a/src/utils/weeklyChampion.js
+++ b/src/utils/weeklyChampion.js
@@ -96,14 +96,14 @@ async function addWeeklyChampionProgress({ guildId, category, userId, username, 
     // rather than swallowing it: this is an accumulator, and a swallowed error
     // is a run that silently never counted.
     try {
-        await WeeklyChampion.findOneAndUpdate(filter, update, { upsert: true });
+        await WeeklyChampion.findOneAndUpdate(filter, update, { upsert: true, updatePipeline: true });
     } catch (err) {
         if (err.code !== 11000) {
             console.error('[weekly] progress update failed:', err.message);
             return;
         }
         try {
-            await WeeklyChampion.findOneAndUpdate(filter, update, { upsert: true });
+            await WeeklyChampion.findOneAndUpdate(filter, update, { upsert: true, updatePipeline: true });
         } catch (retryErr) {
             console.error('[weekly] progress update failed on retry:', retryErr.message);
         }

--- a/tests/apiEnvelope.test.js
+++ b/tests/apiEnvelope.test.js
@@ -330,12 +330,11 @@ describe('admin adjust endpoints no longer upsert (#584)', () => {
 
         expect(res.status).toBe(404);
         expect(res.body.error).toMatch(/no economy record/i);
-        expect(User.findOneAndUpdate).toHaveBeenCalledWith(
-            { userId: MISTYPED, guildId: 'g1' },
-            { $inc: { balance: 500 } },
-            { new: true },
-        );
-        const [, , options] = User.findOneAndUpdate.mock.calls[0];
+        // The update itself is a clamped pipeline now (#925) and is asserted in
+        // tests/dashboardAdjustLimits.test.js; what belongs here is that it went
+        // to the member the request named and did not offer to create one.
+        const [filter, , options] = User.findOneAndUpdate.mock.calls[0];
+        expect(filter).toEqual({ userId: MISTYPED, guildId: 'g1' });
         expect(options.upsert).toBeUndefined();
     });
 

--- a/tests/dashboardAdjustLimits.test.js
+++ b/tests/dashboardAdjustLimits.test.js
@@ -1,0 +1,233 @@
+'use strict';
+
+// #925: the two admin adjust routes accepted any integer. `1e20` satisfies
+// `Number.isInteger`, so it went straight into `$inc` — and past
+// `Number.MAX_SAFE_INTEGER` the arithmetic, the balance and the amounts the
+// Transaction ledger records all stop being exact, silently, with nothing at
+// any layer reporting a problem. It takes an admin typing an absurd number, but
+// the values are awkward to unwind once they are in.
+//
+// Two halves have to hold together, so both are driven through the real routers
+// against a fake User collection that applies the update it is handed: the
+// request is refused above the ceiling, and the update the route does issue
+// clamps rather than trusting the number it was given — a read-then-write
+// clamp would let two admins adjusting at once step over it.
+//
+// The routes also grew `updatePipeline: true` here, which is not decoration:
+// Mongoose 9 throws on a pipeline update without it, so `take` on either route
+// was answering 500 to every call.
+
+const express = require('express');
+const request = require('supertest');
+const { fakeCollection } = require('./helpers/fakeCollection');
+
+const mockUsers = fakeCollection('User', { balance: 0, bank: 0, xp: 0, level: 0 });
+
+jest.mock('../src/models/User', () => mockUsers.model);
+jest.mock('../src/models/GuildAnalytics', () => ({ findOne: jest.fn() }));
+jest.mock('../src/models/Guild', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../src/dashboard/lib/middleware', () => ({
+    checkAuth: (req, _res, next) => { req.user = { id: 'admin-1', username: 'admin' }; next(); },
+    checkGuildAccess: (_req, _res, next) => next(),
+    checkWriteRateLimit: (_req, _res, next) => next(),
+}));
+jest.mock('../src/dashboard/lib/apiHelpers', () => ({
+    ...jest.requireActual('../src/dashboard/lib/apiHelpers'),
+    logAuditEvent: jest.fn(async () => {}),
+}));
+
+const { logAuditEvent, MAX_ADJUST_AMOUNT, MAX_ADJUST_TOTAL } = require('../src/dashboard/lib/apiHelpers');
+const economy = require('../src/dashboard/routes/api/economy');
+const leveling = require('../src/dashboard/routes/api/leveling');
+
+const GUILD = '999888777666555444';
+const USER  = '111222333444555666';
+
+let app;
+let errors;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    errors = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockUsers.reset();
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/v1', economy);
+    app.use('/api/v1', leveling);
+});
+
+afterEach(() => errors.mockRestore());
+
+const adjustEconomy = body => request(app).post(`/api/v1/guild/${GUILD}/economy/adjust`).send(body);
+const adjustLeveling = body => request(app).post(`/api/v1/guild/${GUILD}/leveling/adjust`).send(body);
+
+describe('the ceilings themselves', () => {
+    // The clamp's own arithmetic has to be exact, or the ceiling is a rounded
+    // number pretending to be one: the largest give applied to a field already
+    // at the total is the biggest value the routes can ever compute.
+    test('a maximum give onto a maxed-out balance is still an exact integer', () => {
+        expect(Number.isSafeInteger(MAX_ADJUST_TOTAL + MAX_ADJUST_AMOUNT)).toBe(true);
+        expect(MAX_ADJUST_AMOUNT).toBeLessThan(MAX_ADJUST_TOTAL);
+    });
+});
+
+describe('POST economy/adjust', () => {
+    test('refuses an amount past the safe-integer range and writes nothing', async () => {
+        const res = await adjustEconomy({ userId: USER, action: 'give', amount: 1e20 });
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/integer/);
+        expect(mockUsers.writes).toEqual([]);
+        expect(logAuditEvent).not.toHaveBeenCalled();
+    });
+
+    test('refuses an amount over the per-adjustment ceiling', async () => {
+        const res = await adjustEconomy({ userId: USER, action: 'give', amount: MAX_ADJUST_AMOUNT + 1 });
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/at most/);
+        expect(mockUsers.writes).toEqual([]);
+    });
+
+    test.each([0, -5, 1.5, 'lots', null])('refuses %p', async amount => {
+        const res = await adjustEconomy({ userId: USER, action: 'give', amount });
+
+        expect(res.status).toBe(400);
+        expect(mockUsers.writes).toEqual([]);
+    });
+
+    test('an ordinary give still credits the member', async () => {
+        mockUsers.seed({ userId: USER, guildId: GUILD, balance: 500 });
+
+        const res = await adjustEconomy({ userId: USER, action: 'give', amount: 250 });
+
+        expect(res.status).toBe(200);
+        expect(res.body.balance).toBe(750);
+        expect(mockUsers.get(USER).balance).toBe(750);
+        expect(logAuditEvent).toHaveBeenCalledWith(
+            expect.anything(), GUILD, 'economy_adjust',
+            { targetUserId: USER, action: 'give', amount: 250 },
+        );
+    });
+
+    // The ceiling is enforced by the update, not by the validator: a member
+    // already at the top takes a legal give and stays exactly representable.
+    test('a legal give onto a maxed-out balance clamps instead of drifting', async () => {
+        mockUsers.seed({ userId: USER, guildId: GUILD, balance: MAX_ADJUST_TOTAL });
+
+        const res = await adjustEconomy({ userId: USER, action: 'give', amount: MAX_ADJUST_AMOUNT });
+
+        expect(res.status).toBe(200);
+        expect(res.body.balance).toBe(MAX_ADJUST_TOTAL);
+        expect(Number.isSafeInteger(mockUsers.get(USER).balance)).toBe(true);
+    });
+
+    test('repeated maximum gives never climb past the ceiling', async () => {
+        mockUsers.seed({ userId: USER, guildId: GUILD, balance: 0 });
+
+        for (let i = 0; i < 4; i++) {
+            await adjustEconomy({ userId: USER, action: 'give', amount: MAX_ADJUST_AMOUNT });
+        }
+
+        expect(mockUsers.get(USER).balance).toBe(4 * MAX_ADJUST_AMOUNT);
+        expect(Number.isSafeInteger(mockUsers.get(USER).balance)).toBe(true);
+    });
+
+    // A balance written before the field had a default is missing, not 0, and
+    // `$add` over a missing field is null in Mongo — a give would have wiped it.
+    test('a document with no balance field is credited rather than nulled', async () => {
+        mockUsers.seed({ userId: USER, guildId: GUILD, balance: undefined });
+        delete mockUsers.get(USER).balance;
+
+        const res = await adjustEconomy({ userId: USER, action: 'give', amount: 100 });
+
+        expect(res.status).toBe(200);
+        expect(mockUsers.get(USER).balance).toBe(100);
+    });
+
+    // Mongoose 9 throws on a pipeline update that has not opted in, so this
+    // path answered 500 for every take until the option was added.
+    test('take runs, and clamps at zero rather than going negative', async () => {
+        mockUsers.seed({ userId: USER, guildId: GUILD, balance: 100 });
+
+        const res = await adjustEconomy({ userId: USER, action: 'take', amount: 500 });
+
+        expect(res.status).toBe(200);
+        expect(res.body.balance).toBe(0);
+        expect(mockUsers.get(USER).balance).toBe(0);
+    });
+
+    test('a member with no record is a 404, not a row to create', async () => {
+        const res = await adjustEconomy({ userId: USER, action: 'give', amount: 10 });
+
+        expect(res.status).toBe(404);
+        expect(mockUsers.all()).toEqual([]);
+    });
+});
+
+describe('POST leveling/adjust', () => {
+    test('refuses XP past the safe-integer range', async () => {
+        const res = await adjustLeveling({ userId: USER, action: 'give', amount: 1e20 });
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/integer/);
+        expect(mockUsers.writes).toEqual([]);
+    });
+
+    // An XP total is spent one level at a time by applyXpGain's catch-up loop
+    // (src/services/levelingService.js), so an unbounded grant is an unbounded
+    // loop on the member's next message, not merely an inexact number.
+    test('refuses XP over the per-adjustment ceiling', async () => {
+        const res = await adjustLeveling({ userId: USER, action: 'give', amount: MAX_ADJUST_AMOUNT + 1 });
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/at most/);
+    });
+
+    test('an ordinary XP give still credits the member', async () => {
+        mockUsers.seed({ userId: USER, guildId: GUILD, xp: 40, level: 2 });
+
+        const res = await adjustLeveling({ userId: USER, action: 'give', amount: 60 });
+
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ success: true, level: 2, xp: 100 });
+    });
+
+    test('a give onto a maxed-out XP total clamps', async () => {
+        mockUsers.seed({ userId: USER, guildId: GUILD, xp: MAX_ADJUST_TOTAL });
+
+        const res = await adjustLeveling({ userId: USER, action: 'give', amount: MAX_ADJUST_AMOUNT });
+
+        expect(res.body.xp).toBe(MAX_ADJUST_TOTAL);
+        expect(Number.isSafeInteger(mockUsers.get(USER).xp)).toBe(true);
+    });
+
+    test('take runs, and clamps at zero', async () => {
+        mockUsers.seed({ userId: USER, guildId: GUILD, xp: 30 });
+
+        const res = await adjustLeveling({ userId: USER, action: 'take', amount: 500 });
+
+        expect(res.status).toBe(200);
+        expect(res.body.xp).toBe(0);
+    });
+
+    test('refuses a level past the safe-integer range, and one below zero', async () => {
+        const tooBig = await adjustLeveling({ userId: USER, action: 'set_level', amount: 1e20 });
+        const negative = await adjustLeveling({ userId: USER, action: 'set_level', amount: -1 });
+
+        expect(tooBig.status).toBe(400);
+        expect(tooBig.body.error).toMatch(/^level /);
+        expect(negative.status).toBe(400);
+        expect(mockUsers.writes).toEqual([]);
+    });
+
+    test('set_level still accepts a level, including zero', async () => {
+        mockUsers.seed({ userId: USER, guildId: GUILD, level: 9 });
+
+        const res = await adjustLeveling({ userId: USER, action: 'set_level', amount: 0 });
+
+        expect(res.status).toBe(200);
+        expect(mockUsers.get(USER).level).toBe(0);
+    });
+});

--- a/tests/dashboardAdjustLimits.test.js
+++ b/tests/dashboardAdjustLimits.test.js
@@ -90,7 +90,7 @@ describe('POST economy/adjust', () => {
         expect(mockUsers.writes).toEqual([]);
     });
 
-    test.each([0, -5, 1.5, 'lots', null])('refuses %p', async amount => {
+    test.each([0, -5, 1.5, 'lots', null, undefined, '', '   ', [], true])('refuses %p', async amount => {
         const res = await adjustEconomy({ userId: USER, action: 'give', amount });
 
         expect(res.status).toBe(400);
@@ -219,6 +219,19 @@ describe('POST leveling/adjust', () => {
         expect(tooBig.status).toBe(400);
         expect(tooBig.body.error).toMatch(/^level /);
         expect(negative.status).toBe(400);
+        expect(mockUsers.writes).toEqual([]);
+    });
+
+    // `Number(null)`, `Number('')` and `Number([])` are all 0, and set_level's
+    // minimum is 0 — so before the input was type-checked, a request that named
+    // no amount at all wiped the member's level instead of being refused.
+    test.each([null, undefined, '', '  ', []])('refuses set_level with %p rather than setting level 0', async amount => {
+        mockUsers.seed({ userId: USER, guildId: GUILD, level: 9 });
+
+        const res = await adjustLeveling({ userId: USER, action: 'set_level', amount });
+
+        expect(res.status).toBe(400);
+        expect(mockUsers.get(USER).level).toBe(9);
         expect(mockUsers.writes).toEqual([]);
     });
 

--- a/tests/economyMarketCommand.test.js
+++ b/tests/economyMarketCommand.test.js
@@ -29,9 +29,11 @@ jest.mock('../src/utils/inventoryGrant', () => ({
     grantInventoryItem: jest.fn(),
     inventoryAddExpr: jest.fn(() => ({})),
 }));
+jest.mock('../src/utils/owedPayout', () => ({ recordOwedPayout: jest.fn(async () => true) }));
 
 const market = require('../src/commands/economy/market');
 const { grantInventoryItem } = require('../src/utils/inventoryGrant');
+const { recordOwedPayout } = require('../src/utils/owedPayout');
 const { logTransaction } = require('../src/utils/logTransaction');
 
 const GUILD_ID = 'guild-1';
@@ -221,6 +223,71 @@ describe('listing an item', () => {
         expect(mockListings.all().filter(l => l.sellerId === BUYER_ID)).toHaveLength(5);
     });
 
+    // Legacy rows carry no slot and the unique index skips them, so they have to
+    // be counted against the seller's five some other way — otherwise a seller
+    // holding four of them could open five more.
+    it('counts listings written before slots existed against the seller\'s five', async () => {
+        seedGuild();
+        seedUser(BUYER_ID, { inventory: [{ itemId: 'lucky_charm', quantity: 9 }] });
+        for (let i = 0; i < 4; i++) seedListing({ _id: `legacy-${i}`, sellerId: BUYER_ID, slot: undefined });
+
+        await run({ subcommand: 'list', options: { item: 'lucky_charm', quantity: 1, price: 100 } });
+
+        expect(mockListings.all().filter(l => l.sellerId === BUYER_ID)).toHaveLength(5);
+        // The one number the four legacy rows have not reserved.
+        expect(mockListings.all().find(l => l.slot != null).slot).toBe(5);
+    });
+
+    it('refuses the seller a sixth when the race for it is against a legacy listing', async () => {
+        seedGuild();
+        seedUser(BUYER_ID, { inventory: [{ itemId: 'lucky_charm', quantity: 9 }] });
+        for (let i = 0; i < 4; i++) seedListing({ _id: `legacy-${i}`, sellerId: BUYER_ID, slot: undefined });
+        // Four legacy rows pass the pre-check; the one numbered slot they leave
+        // goes to somebody else between that check and this insert.
+        mockListings.model.create.mockImplementationOnce(async () => {
+            seedListing({ _id: 'rival', sellerId: BUYER_ID, slot: 5 });
+            throw Object.assign(new Error('E11000 duplicate key'), { code: 11000 });
+        });
+
+        const interaction = await run({
+            subcommand: 'list',
+            options: { item: 'lucky_charm', quantity: 2, price: 100 },
+        });
+
+        expect(repliedText(interaction)).toContain('only have 5 active listings');
+        expect(mockListings.all().filter(l => l.sellerId === BUYER_ID)).toHaveLength(5);
+        expect(mockUsers.get(BUYER_ID).inventory).toEqual([{ itemId: 'lucky_charm', quantity: 9 }]);
+    });
+
+    // The debit has committed by the time the return runs, so a return that does
+    // not land leaves the player without the item and without a listing. Saying
+    // it came back is the one answer that gives them no reason to mention it.
+    it.each([
+        ['the update rejects', () => grantInventoryItem.mockRejectedValueOnce(new Error('write failed'))],
+        ['the update matches no document', () => grantInventoryItem.mockResolvedValueOnce(false)],
+    ])('records the stock as owed, and says so, when %s', async (_case, breakReturn) => {
+        seedGuild();
+        seedUser(BUYER_ID, { inventory: [{ itemId: 'lucky_charm', quantity: 5 }] });
+        mockListings.model.create.mockRejectedValueOnce(new Error('write failed'));
+        breakReturn();
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const interaction = await run({
+            subcommand: 'list',
+            options: { item: 'lucky_charm', quantity: 2, price: 100 },
+        });
+
+        expect(repliedText(interaction)).toContain('recorded as owed');
+        expect(repliedText(interaction)).not.toContain('has been returned');
+        expect(recordOwedPayout).toHaveBeenCalledWith(expect.objectContaining({
+            service: 'market',
+            payload: {
+                kind: 'items', userId: BUYER_ID, guildId: GUILD_ID, itemId: 'lucky_charm', quantity: 2,
+            },
+        }));
+        console.error.mockRestore();
+    });
+
     it('hands the stock back when the listing cannot be written', async () => {
         seedGuild();
         seedUser(BUYER_ID, { inventory: [{ itemId: 'lucky_charm', quantity: 5 }] });
@@ -235,6 +302,8 @@ describe('listing an item', () => {
         expect(repliedText(interaction)).toContain('item has been returned');
         expect(grantInventoryItem).toHaveBeenCalledWith(BUYER_ID, GUILD_ID, 'lucky_charm', 2);
         expect(mockUsers.get(BUYER_ID).inventory).toEqual([{ itemId: 'lucky_charm', quantity: 5 }]);
+        // The stock is back, so there is nothing owed to write down.
+        expect(recordOwedPayout).not.toHaveBeenCalled();
         console.error.mockRestore();
     });
 });

--- a/tests/economyMarketCommand.test.js
+++ b/tests/economyMarketCommand.test.js
@@ -154,6 +154,73 @@ describe('listing an item', () => {
         expect(mockUsers.get(BUYER_ID).inventory).toEqual([{ itemId: 'lucky_charm', quantity: 9 }]);
     });
 
+    // #926: the cap was a `countDocuments` followed by an insert, which two
+    // concurrent calls could both pass. It is a property of the data now — each
+    // listing claims one of the seller's five slots, and the unique index on
+    // { guildId, sellerId, slot } is what makes a sixth impossible rather than
+    // merely unlikely.
+    it('claims the seller a slot, and the next listing takes the one after it', async () => {
+        seedGuild();
+        seedUser(BUYER_ID, { inventory: [{ itemId: 'lucky_charm', quantity: 9 }] });
+
+        await run({ subcommand: 'list', options: { item: 'lucky_charm', quantity: 1, price: 100 } });
+        await run({ subcommand: 'list', options: { item: 'lucky_charm', quantity: 1, price: 100 } });
+
+        expect(mockListings.all().map(l => l.slot)).toEqual([1, 2]);
+    });
+
+    it('reuses the slot a cancelled or sold listing left behind', async () => {
+        seedGuild();
+        seedUser(BUYER_ID, { inventory: [{ itemId: 'lucky_charm', quantity: 9 }] });
+        seedListing({ _id: 'open-1', sellerId: BUYER_ID, slot: 1 });
+        seedListing({ _id: 'open-3', sellerId: BUYER_ID, slot: 3 });
+
+        await run({ subcommand: 'list', options: { item: 'lucky_charm', quantity: 1, price: 100 } });
+
+        expect(mockListings.all().find(l => l._id === 'id-3').slot).toBe(2);
+    });
+
+    it('takes another slot when it loses the race for the one it picked', async () => {
+        seedGuild();
+        seedUser(BUYER_ID, { inventory: [{ itemId: 'lucky_charm', quantity: 9 }] });
+        // The rival's insert lands first and the index refuses this one, which is
+        // exactly what a lost race looks like from here.
+        mockListings.model.create.mockImplementationOnce(async () => {
+            seedListing({ _id: 'rival', sellerId: BUYER_ID, slot: 1 });
+            throw Object.assign(new Error('E11000 duplicate key'), { code: 11000 });
+        });
+
+        const interaction = await run({
+            subcommand: 'list',
+            options: { item: 'lucky_charm', quantity: 2, price: 100 },
+        });
+
+        expect(repliedText(interaction)).toContain('Item Listed');
+        expect(mockListings.all().find(l => l._id !== 'rival').slot).toBe(2);
+        expect(mockUsers.get(BUYER_ID).inventory).toEqual([{ itemId: 'lucky_charm', quantity: 7 }]);
+    });
+
+    it('refuses, and returns the stock, when the race filled the last slot', async () => {
+        seedGuild();
+        seedUser(BUYER_ID, { inventory: [{ itemId: 'lucky_charm', quantity: 9 }] });
+        for (const slot of [1, 2, 3, 4]) seedListing({ _id: `open-${slot}`, sellerId: BUYER_ID, slot });
+        // Four listings pass the pre-check; the fifth slot goes to somebody else
+        // in the moment between that check and this insert.
+        mockListings.model.create.mockImplementationOnce(async () => {
+            seedListing({ _id: 'rival', sellerId: BUYER_ID, slot: 5 });
+            throw Object.assign(new Error('E11000 duplicate key'), { code: 11000 });
+        });
+
+        const interaction = await run({
+            subcommand: 'list',
+            options: { item: 'lucky_charm', quantity: 2, price: 100 },
+        });
+
+        expect(repliedText(interaction)).toContain('only have 5 active listings');
+        expect(grantInventoryItem).toHaveBeenCalledWith(BUYER_ID, GUILD_ID, 'lucky_charm', 2);
+        expect(mockListings.all().filter(l => l.sellerId === BUYER_ID)).toHaveLength(5);
+    });
+
     it('hands the stock back when the listing cannot be written', async () => {
         seedGuild();
         seedUser(BUYER_ID, { inventory: [{ itemId: 'lucky_charm', quantity: 5 }] });
@@ -375,5 +442,30 @@ describe('the economy switch', () => {
 
         expect(repliedText(interaction)).toContain('economy is disabled');
         expect(mockUsers.writes).toEqual([]);
+    });
+});
+
+// The slot allocation above is only half of the cap: the other half is the
+// unique index that makes two listings in one slot impossible, and an index is
+// not something the command can assert about itself. Read off the compiled
+// schema — the real one, past the mock — so a malformed declaration fails here
+// rather than at autoIndex time in production.
+describe('the MarketListing schema backs the cap', () => {
+    const declared = jest.requireActual('../src/models/MarketListing').schema.indexes();
+    const slotIndex = declared.find(([, opts]) => opts?.name === 'idx_market_seller_slot');
+
+    it('keeps one listing per seller slot', () => {
+        expect(slotIndex).toBeDefined();
+        expect(slotIndex[0]).toEqual({ guildId: 1, sellerId: 1, slot: 1 });
+        expect(slotIndex[1].unique).toBe(true);
+    });
+
+    // Rows written before the field existed carry no slot. A sparse index would
+    // still index them — sparse skips a document only when it has none of the
+    // keys, and these have guildId and sellerId — and every one of a seller's
+    // legacy rows would then collide on `slot: null`, failing the index build.
+    it('indexes only the rows that carry a slot', () => {
+        expect(slotIndex[1].partialFilterExpression).toEqual({ slot: { $gte: 1 } });
+        expect(slotIndex[1].sparse).toBeUndefined();
     });
 });

--- a/tests/failedJobTtl.test.js
+++ b/tests/failedJobTtl.test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+// #896: the dead-letter queue's TTL deleted `exhausted` records alongside
+// `resolved` ones.
+//
+// An owed payout that burns through its three attempts is marked `exhausted`
+// and left for a human — scripts/replay-owed-payouts.js says so, and
+// claimableFilter means the replay itself will not touch one. Nothing else in
+// the codebase pays it. So the TTL was, thirty days on, the only thing that
+// acted on those records, and what it did was delete them: a player owed coins
+// by a failed payout lost the claim with nothing logged and nothing left to
+// find.
+//
+// The index is read off the compiled schema rather than described, so this
+// cannot pass on a filter that is written down but malformed, and the migration
+// that swaps the old index for it is checked against the same spec — the two
+// have to agree or a deployment ends up with one of them.
+
+const fs = require('fs');
+const path = require('path');
+
+const failedJobSchema = require('../src/models/FailedJob').schema;
+const migration = require('../src/migrations/020_narrow_failed_job_ttl');
+
+const TTL_NAME = 'idx_failedjob_resolved_ttl';
+const THIRTY_DAYS = 30 * 24 * 60 * 60;
+
+/** Every declared index as [keys, options], excluding the _id index. */
+const declared = failedJobSchema.indexes();
+const ttl = declared.find(([, opts]) => opts?.expireAfterSeconds !== undefined);
+
+describe('the failedjobs TTL', () => {
+    test('is declared once, on updatedAt, under an explicit name', () => {
+        const expiring = declared.filter(([, opts]) => opts?.expireAfterSeconds !== undefined);
+        expect(expiring).toHaveLength(1);
+        expect(ttl[0]).toEqual({ updatedAt: 1 });
+        expect(ttl[1].name).toBe(TTL_NAME);
+        expect(ttl[1].expireAfterSeconds).toBe(THIRTY_DAYS);
+    });
+
+    // The assertion this file exists for. `{ status: { $in: [...] } }` matching
+    // more than one status is how the old one read, and an `$in` that happens
+    // to list only 'resolved' would pass a looser check while being one edit
+    // away from the bug again.
+    test('expires resolved records and nothing else', () => {
+        expect(ttl[1].partialFilterExpression).toEqual({ status: 'resolved' });
+    });
+
+    // Every other status is an unsettled claim on the bot: pending and retrying
+    // are work not yet done, exhausted is a debt waiting for a human.
+    test('covers no status that still owes someone something', () => {
+        const covered = ttl[1].partialFilterExpression.status;
+        for (const status of ['pending', 'retrying', 'exhausted']) {
+            expect([status, covered === status]).toEqual([status, false]);
+        }
+    });
+
+    test('the schema still knows the statuses the filter reasons about', () => {
+        expect(failedJobSchema.path('status').enumValues)
+            .toEqual(expect.arrayContaining(['pending', 'retrying', 'exhausted', 'resolved']));
+    });
+});
+
+describe('020_narrow_failed_job_ttl', () => {
+    const source = fs.readFileSync(
+        path.join(__dirname, '..', 'src', 'migrations', '020_narrow_failed_job_ttl.js'), 'utf8');
+
+    // Mongoose never drops an index it no longer declares, so a deployment that
+    // only got the model change would keep the old TTL and go on deleting
+    // exhausted records — the model edit is inert without this drop.
+    test('drops the unnamed index Mongoose built from the old declaration', () => {
+        expect(source).toContain("dropIndex('updatedAt_1')");
+    });
+
+    test('creates the index under the name and options the model declares', () => {
+        expect(source).toContain(`name: '${TTL_NAME}'`);
+        expect(source).toContain("partialFilterExpression: { status: 'resolved' }");
+    });
+
+    test('swallows IndexNotFound so a fresh database is not a failure', () => {
+        expect(source).toContain("codeName !== 'IndexNotFound'");
+    });
+
+    test('is reversible, and its rollback restores the index it replaced', () => {
+        expect(typeof migration.down).toBe('function');
+        expect(source).toContain("name: 'updatedAt_1'");
+    });
+
+    test('is not optional — a TTL left half-swapped is not something to boot past', () => {
+        expect(migration.optional).toBeUndefined();
+    });
+});

--- a/tests/helpers/pipelineUpdate.js
+++ b/tests/helpers/pipelineUpdate.js
@@ -129,11 +129,15 @@ function evaluate(expr, doc, vars = {}) {
         }
         case '$max':
             return args().reduce((best, n) => (n === null || n === undefined ? best : Math.max(best, n)), -Infinity);
-        // Mongo's `$min`/`$max` ignore null operands rather than propagating
-        // them, which is what makes `$max: [0, <subtract that went null>]`
-        // answer 0 for a missing field.
-        case '$min':
-            return args().reduce((best, n) => (n === null || n === undefined ? best : Math.min(best, n)), Infinity);
+        // Mongo's `$min` ignores null operands rather than propagating them,
+        // which is what lets `$min: [<cap>, <add that went null>]` answer the
+        // cap — but an expression whose operands are *all* null answers null,
+        // not the identity the fold started from. Returning Infinity there
+        // would write a number no document should ever hold.
+        case '$min': {
+            const usable = args().filter(n => n !== null && n !== undefined);
+            return usable.length ? Math.min(...usable) : null;
+        }
         case '$not':
             return !args()[0];
         case '$and':

--- a/tests/helpers/pipelineUpdate.js
+++ b/tests/helpers/pipelineUpdate.js
@@ -129,6 +129,11 @@ function evaluate(expr, doc, vars = {}) {
         }
         case '$max':
             return args().reduce((best, n) => (n === null || n === undefined ? best : Math.max(best, n)), -Infinity);
+        // Mongo's `$min`/`$max` ignore null operands rather than propagating
+        // them, which is what makes `$max: [0, <subtract that went null>]`
+        // answer 0 for a missing field.
+        case '$min':
+            return args().reduce((best, n) => (n === null || n === undefined ? best : Math.min(best, n)), Infinity);
         case '$not':
             return !args()[0];
         case '$and':

--- a/tests/seasonalEventRewards.test.js
+++ b/tests/seasonalEventRewards.test.js
@@ -1,0 +1,339 @@
+'use strict';
+
+/**
+ * #906. `seasonalEventService` sat at 3.6% statements — the lowest figure of any
+ * service that moves value, and it moves two kinds of it.
+ *
+ * The multipliers are the larger one: `getEventCoinMultiplier` scales what every
+ * earning command in the guild pays out, so an event that is over but still
+ * reads as 1.25x pays a quarter more to everyone, indefinitely, and nothing
+ * about that looks like an error. The event currency is the other — it is the
+ * only thing the event shop takes, so a spend that debits nothing is a free
+ * shop and a grant that overwrites is a player's balance gone.
+ *
+ * `checkSeasonalEvents` is the batch that writes the multipliers in the first
+ * place: hourly, across every guild, out of the calendar. It is driven here
+ * against a pinned clock, because a test that reads the real one asserts a
+ * different branch every month (the same reason tests/seasonalEventWindows.js
+ * pins it).
+ */
+
+const { useFixedClock, setClock } = require('./helpers/fixedClock');
+
+jest.mock('../src/models/Guild', () => ({ find: jest.fn(), findOneAndUpdate: jest.fn() }));
+
+const Guild = require('../src/models/Guild');
+const { SEASONAL_EVENTS } = require('../src/data/seasonalEvents');
+const {
+    checkSeasonalEvents,
+    getEventCoinMultiplier,
+    getEventXpMultiplier,
+    hasActiveEvent,
+    getEventCurrencyId,
+    getEventCrossSystemType,
+    addEventCurrency,
+    getEventCurrencyBalance,
+    spendEventCurrency,
+    buildClearedEvent,
+} = require('../src/services/seasonalEventService');
+
+const GUILD = 'guild-1';
+
+// Inside the summer festival's window (July 1–31), which is the event with a
+// coin multiplier above 1 — the one where getting the end wrong costs coins.
+const IN_SUMMER = '2026-07-15T12:00:00Z';
+// Between every configured window: no month has an event on the 20th of March.
+const NO_SEASON = '2026-03-20T12:00:00Z';
+
+const activeEvent = (fields = {}) => ({
+    type: 'summer_festival', name: 'Summer Festival', emoji: '🏖️',
+    coinMultiplier: 1.25, xpMultiplier: 1.0,
+    startedAt: new Date('2026-07-01T00:00:00Z'),
+    endsAt: new Date('2026-08-01T00:00:00Z'),
+    startedBy: 'auto',
+    ...fields,
+});
+
+describe('the multipliers every payout is scaled by', () => {
+    useFixedClock(IN_SUMMER);
+
+    test('a guild with no event pays exactly what it earned', () => {
+        expect(getEventCoinMultiplier({})).toBe(1.0);
+        expect(getEventXpMultiplier({})).toBe(1.0);
+        expect(getEventCoinMultiplier({ activeEvent: buildClearedEvent() })).toBe(1.0);
+        expect(hasActiveEvent({ activeEvent: buildClearedEvent() })).toBe(false);
+    });
+
+    test('a running event applies its own multipliers', () => {
+        const settings = { activeEvent: activeEvent({ coinMultiplier: 1.25, xpMultiplier: 1.5 }) };
+
+        expect(getEventCoinMultiplier(settings)).toBe(1.25);
+        expect(getEventXpMultiplier(settings)).toBe(1.5);
+        expect(hasActiveEvent(settings)).toBe(true);
+    });
+
+    // The failure that pays a quarter more to everyone forever: an event whose
+    // end date has passed but whose document nobody has cleared yet. The hourly
+    // sweep clears it, and until it runs these have to answer 1.0 on their own.
+    test('an event past its end date stops multiplying, cleared or not', () => {
+        const settings = { activeEvent: activeEvent({ endsAt: new Date('2026-07-14T00:00:00Z') }) };
+
+        expect(getEventCoinMultiplier(settings)).toBe(1.0);
+        expect(getEventXpMultiplier(settings)).toBe(1.0);
+        expect(hasActiveEvent(settings)).toBe(false);
+        expect(getEventCrossSystemType(settings)).toBeNull();
+    });
+
+    test('an event with no end date runs until something clears it', () => {
+        const settings = { activeEvent: activeEvent({ endsAt: null }) };
+
+        expect(getEventCoinMultiplier(settings)).toBe(1.25);
+        expect(hasActiveEvent(settings)).toBe(true);
+    });
+
+    test('an event that declares no multiplier does not multiply', () => {
+        const settings = { activeEvent: activeEvent({ coinMultiplier: undefined, xpMultiplier: undefined }) };
+
+        expect(getEventCoinMultiplier(settings)).toBe(1.0);
+        expect(getEventXpMultiplier(settings)).toBe(1.0);
+    });
+});
+
+describe('which currency an event pays in', () => {
+    useFixedClock(IN_SUMMER);
+
+    test('names the currency the event definition declares', () => {
+        expect(getEventCurrencyId({ activeEvent: activeEvent() })).toBe('shells');
+    });
+
+    // An admin's custom event has no definition behind it, so there is no
+    // currency to credit — commands have to see null rather than a bad id they
+    // would then write balances under.
+    test('a custom or absent event has no currency', () => {
+        expect(getEventCurrencyId({ activeEvent: activeEvent({ type: 'custom' }) })).toBeNull();
+        expect(getEventCurrencyId({})).toBeNull();
+        expect(getEventCurrencyId({ activeEvent: activeEvent({ type: 'not_an_event' }) })).toBeNull();
+    });
+
+    test('only an event that declares a cross-system hook reports one', () => {
+        expect(getEventCrossSystemType({ activeEvent: activeEvent({ type: 'winter_hunt' }) })).toBe('winter_hunt');
+        expect(getEventCrossSystemType({ activeEvent: activeEvent({ type: 'summer_festival' }) })).toBeNull();
+    });
+});
+
+describe('event currency balances', () => {
+    test('a first grant creates the balance and later ones add to it', () => {
+        const user = {};
+
+        addEventCurrency(user, 'shells', 10);
+        addEventCurrency(user, 'shells', 5);
+
+        expect(user.eventCurrency).toEqual([{ currencyId: 'shells', amount: 15 }]);
+        expect(getEventCurrencyBalance(user, 'shells')).toBe(15);
+    });
+
+    test('two events keep separate balances', () => {
+        const user = { eventCurrency: [{ currencyId: 'candy', amount: 40 }] };
+
+        addEventCurrency(user, 'shells', 10);
+
+        expect(getEventCurrencyBalance(user, 'candy')).toBe(40);
+        expect(getEventCurrencyBalance(user, 'shells')).toBe(10);
+    });
+
+    test('a grant of nothing, or to no currency, writes nothing', () => {
+        const user = { eventCurrency: [{ currencyId: 'shells', amount: 10 }] };
+
+        addEventCurrency(user, 'shells', 0);
+        addEventCurrency(user, 'shells', -5);
+        addEventCurrency(user, null, 10);
+
+        expect(user.eventCurrency).toEqual([{ currencyId: 'shells', amount: 10 }]);
+    });
+
+    test('a balance nobody has is zero, not undefined', () => {
+        expect(getEventCurrencyBalance({}, 'shells')).toBe(0);
+        expect(getEventCurrencyBalance({ eventCurrency: [] }, 'shells')).toBe(0);
+        expect(getEventCurrencyBalance({ eventCurrency: [] }, null)).toBe(0);
+    });
+
+    // The event shop's whole guard: it takes the items only if this said yes.
+    test('spending debits exactly what it took', () => {
+        const user = { eventCurrency: [{ currencyId: 'shells', amount: 30 }] };
+
+        expect(spendEventCurrency(user, 'shells', 20)).toBe(true);
+        expect(getEventCurrencyBalance(user, 'shells')).toBe(10);
+    });
+
+    test('a spend it cannot afford takes nothing and says so', () => {
+        const user = { eventCurrency: [{ currencyId: 'shells', amount: 5 }] };
+
+        expect(spendEventCurrency(user, 'shells', 6)).toBe(false);
+        expect(getEventCurrencyBalance(user, 'shells')).toBe(5);
+    });
+
+    test('spending a currency the player has never held is refused', () => {
+        const user = { eventCurrency: [] };
+
+        expect(spendEventCurrency(user, 'shells', 1)).toBe(false);
+        expect(spendEventCurrency({}, 'shells', 1)).toBe(false);
+    });
+
+    test('a spend of nothing is refused rather than treated as a free purchase', () => {
+        const user = { eventCurrency: [{ currencyId: 'shells', amount: 5 }] };
+
+        expect(spendEventCurrency(user, 'shells', 0)).toBe(false);
+        expect(spendEventCurrency(user, 'shells', -10)).toBe(false);
+        expect(getEventCurrencyBalance(user, 'shells')).toBe(5);
+    });
+
+    test('spending all of it leaves the entry at zero, not negative', () => {
+        const user = { eventCurrency: [{ currencyId: 'shells', amount: 5 }] };
+
+        expect(spendEventCurrency(user, 'shells', 5)).toBe(true);
+        expect(user.eventCurrency[0].amount).toBe(0);
+    });
+});
+
+describe('the hourly sweep', () => {
+    useFixedClock(IN_SUMMER);
+
+    const channel = { isTextBased: () => true, send: jest.fn(async () => {}) };
+    let client;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        client = {
+            guilds: {
+                cache: new Map([[GUILD, {
+                    id: GUILD,
+                    channels: { fetch: jest.fn(async () => channel) },
+                }]]),
+            },
+        };
+        Guild.findOneAndUpdate.mockResolvedValue({});
+    });
+
+    const seedGuilds = (...guilds) => Guild.find.mockReturnValue({ lean: async () => guilds });
+    const written = () => Guild.findOneAndUpdate.mock.calls[0]?.[1].$set.activeEvent;
+
+    test('starts the season the calendar says is running, with its multipliers and shop', async () => {
+        seedGuilds({ guildId: GUILD, activeEvent: null, economy: { announcementChannelId: 'chan-1' } });
+
+        await checkSeasonalEvents(client);
+
+        const event = written();
+        expect(event.type).toBe('summer_festival');
+        expect(event.coinMultiplier).toBe(SEASONAL_EVENTS.summer_festival.coinMultiplier);
+        expect(event.xpMultiplier).toBe(SEASONAL_EVENTS.summer_festival.xpMultiplier);
+        expect(event.startedBy).toBe('auto');
+        expect(event.eventShop).toHaveLength(SEASONAL_EVENTS.summer_festival.shop.length);
+        // Unlimited stock, not "none left" — the shop reads -1 as no limit.
+        expect(event.eventShop.every(item => item.stock === -1)).toBe(true);
+    });
+
+    // The end date is the one the multipliers are read against for the rest of
+    // the month, so it has to be the day after the window's last day, not the
+    // day of.
+    test('the event it starts ends after the last day of the window, at midnight UTC', async () => {
+        seedGuilds({ guildId: GUILD, activeEvent: null });
+
+        await checkSeasonalEvents(client);
+
+        expect(written().endsAt.toISOString()).toBe('2026-08-01T00:00:00.000Z');
+    });
+
+    test('leaves a running event alone rather than restarting it every hour', async () => {
+        seedGuilds({ guildId: GUILD, activeEvent: activeEvent() });
+
+        await checkSeasonalEvents(client);
+
+        expect(Guild.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    test('clears an event whose end date has passed, multipliers included', async () => {
+        seedGuilds({
+            guildId: GUILD,
+            activeEvent: activeEvent({ endsAt: new Date('2026-07-14T00:00:00Z') }),
+            economy: { announcementChannelId: 'chan-1' },
+        });
+
+        await checkSeasonalEvents(client);
+
+        const cleared = written();
+        expect(cleared.type).toBeNull();
+        expect(cleared.coinMultiplier).toBe(1.0);
+        expect(cleared.xpMultiplier).toBe(1.0);
+        expect(cleared.eventShop).toEqual([]);
+        // One write: the expired event is cleared and not immediately restarted.
+        expect(Guild.findOneAndUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    test('clears an auto-started event once its season is out of the calendar', async () => {
+        setClock(NO_SEASON);
+        seedGuilds({ guildId: GUILD, activeEvent: activeEvent({ endsAt: null, startedBy: 'auto' }) });
+
+        await checkSeasonalEvents(client);
+
+        expect(written().type).toBeNull();
+    });
+
+    // An admin's event is theirs to end. The seasonal sweep clearing it would
+    // take away a multiplier they turned on deliberately.
+    test('does not clear an admin-started event when no season is running', async () => {
+        setClock(NO_SEASON);
+        seedGuilds({ guildId: GUILD, activeEvent: activeEvent({ endsAt: null, startedBy: 'admin-1' }) });
+
+        await checkSeasonalEvents(client);
+
+        expect(Guild.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    test('starts nothing outside every configured window', async () => {
+        setClock(NO_SEASON);
+        seedGuilds({ guildId: GUILD, activeEvent: null });
+
+        await checkSeasonalEvents(client);
+
+        expect(Guild.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    // The sweep runs over every guild in the database, including the ones this
+    // shard is not connected to. Writing an event to one of those would turn on
+    // a multiplier nobody could see or announce.
+    test('skips a guild this client is not in', async () => {
+        seedGuilds({ guildId: 'elsewhere', activeEvent: null });
+
+        await checkSeasonalEvents(client);
+
+        expect(Guild.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    test('reads only the fields it needs off each guild', async () => {
+        seedGuilds();
+
+        await checkSeasonalEvents(client);
+
+        expect(Guild.find).toHaveBeenCalledWith({}, 'guildId activeEvent economy.announcementChannelId');
+    });
+
+    test('announces the start in the guild economy channel', async () => {
+        seedGuilds({ guildId: GUILD, activeEvent: null, economy: { announcementChannelId: 'chan-1' } });
+
+        await checkSeasonalEvents(client);
+
+        expect(channel.send).toHaveBeenCalledTimes(1);
+        expect(channel.send.mock.calls[0][0].embeds[0].data.title).toContain('Summer Festival');
+    });
+
+    // The write is the part that matters; the announcement is not. A channel
+    // that was deleted must not stop the event starting, or leave the sweep
+    // throwing before it reaches the next guild.
+    test('a failed announcement does not stop the event, or the guilds after it', async () => {
+        client.guilds.cache.get(GUILD).channels.fetch = jest.fn(async () => { throw new Error('unknown channel'); });
+        seedGuilds({ guildId: GUILD, activeEvent: null, economy: { announcementChannelId: 'gone' } });
+
+        await expect(checkSeasonalEvents(client)).resolves.toBeUndefined();
+        expect(written().type).toBe('summer_festival');
+    });
+});

--- a/tests/tournamentPrizePayout.test.js
+++ b/tests/tournamentPrizePayout.test.js
@@ -120,6 +120,57 @@ describe('ending a tournament', () => {
         expect(ended.prizes.every(p => Number.isInteger(p.amount))).toBe(true);
     });
 
+    // Three shares rounded independently can exceed what there is: 60/25/15 of a
+    // pool of 10 rounds to 6 + 3 + 2. The eleventh coin would have been minted
+    // out of nothing, on every small tournament.
+    test('a pool too small to divide cleanly is not overpaid', async () => {
+        mockUsers.seed(
+            { userId: 'a', guildId: GUILD }, { userId: 'b', guildId: GUILD }, { userId: 'c', guildId: GUILD },
+        );
+        const tournament = makeTournament({
+            prizePool: 10,
+            entries: [
+                entry('a', 30, '2026-08-31T10:10:00Z'),
+                entry('b', 20, '2026-08-31T10:11:00Z'),
+                entry('c', 10, '2026-08-31T10:12:00Z'),
+            ],
+        });
+        claimYields(tournament);
+
+        const ended = await tournamentService.endTournament(tournament._id);
+
+        const total = ended.prizes.reduce((sum, p) => sum + p.amount, 0);
+        expect(total).toBeLessThanOrEqual(10);
+        expect(total).toBe(10);
+        expect(ended.prizes.map(p => p.amount)).toEqual([6, 3, 1]);
+        expect(mockUsers.get('a').balance + mockUsers.get('b').balance + mockUsers.get('c').balance).toBe(10);
+    });
+
+    // Every pool the arithmetic can be handed, not just the ones that divide
+    // evenly: no split may hand out more than it was given.
+    test.each([1, 2, 3, 7, 10, 33, 99, 100, 999, 1000, 12_345])(
+        'a pool of %i is never overpaid',
+        async prizePool => {
+            mockUsers.seed(
+                { userId: 'a', guildId: GUILD }, { userId: 'b', guildId: GUILD }, { userId: 'c', guildId: GUILD },
+            );
+            const tournament = makeTournament({
+                prizePool,
+                entries: [
+                    entry('a', 30, '2026-08-31T10:10:00Z'),
+                    entry('b', 20, '2026-08-31T10:11:00Z'),
+                    entry('c', 10, '2026-08-31T10:12:00Z'),
+                ],
+            });
+            claimYields(tournament);
+
+            const ended = await tournamentService.endTournament(tournament._id);
+
+            const total = ended.prizes.reduce((sum, p) => sum + p.amount, 0);
+            expect([prizePool, total <= prizePool]).toEqual([prizePool, true]);
+        },
+    );
+
     test('a tie is broken by whoever caught it first', async () => {
         mockUsers.seed({ userId: 'early', guildId: GUILD }, { userId: 'late', guildId: GUILD });
         const tournament = makeTournament({
@@ -146,7 +197,12 @@ describe('ending a tournament', () => {
         const ended = await tournamentService.endTournament(tournament._id);
 
         expect(ended.prizes).toHaveLength(2);
+        // 60/25 of the pool, not a redistributed 70/30: the third share is not
+        // handed to the two who did turn up. That is the payout this service has
+        // always made, and changing it is an economy decision rather than a
+        // rounding fix — recorded here so a change to it is a deliberate one.
         expect(ended.prizes.map(p => p.amount)).toEqual([600, 250]);
+        expect(ended.prizes.reduce((sum, p) => sum + p.amount, 0)).toBe(850);
     });
 
     test('an empty pool pays nobody and writes no prizes', async () => {

--- a/tests/tournamentPrizePayout.test.js
+++ b/tests/tournamentPrizePayout.test.js
@@ -1,0 +1,353 @@
+'use strict';
+
+/**
+ * #906. `tournamentService` sat at 6.4% statements — the service that splits a
+ * fishing tournament's prize pool and credits it to three players had never had
+ * a line of it executed by a test, and neither had the command layer above it
+ * (#890). A prize payout is a batch: one bad split or one lost credit hits
+ * every winner of that tournament at once, not one player.
+ *
+ * What is driven here is the money: how the pool is divided, who is paid, what
+ * happens when a credit does not land, and the claim that stops a tournament
+ * being paid out twice. The User model is the shared fake rather than a stub
+ * that answers yes, so `$inc` really moves a balance and a missing member
+ * really matches nothing.
+ */
+
+const { fakeCollection } = require('./helpers/fakeCollection');
+
+const mockUsers = fakeCollection('User', { balance: 0, bank: 0 });
+
+jest.mock('../src/models/User', () => mockUsers.model);
+jest.mock('../src/models/FishingTournament', () => ({
+    findOne: jest.fn(),
+    findById: jest.fn(),
+    findOneAndUpdate: jest.fn(),
+    create: jest.fn(),
+}));
+jest.mock('../src/utils/logTransaction', () => ({ logTransaction: jest.fn() }));
+
+const FishingTournament = require('../src/models/FishingTournament');
+const { logTransaction } = require('../src/utils/logTransaction');
+const tournamentService = require('../src/services/tournamentService');
+
+const GUILD = 'guild-1';
+
+/** A claimable tournament document, with the `save()` the service calls. */
+const makeTournament = (fields = {}) => {
+    const doc = {
+        _id: 'tourney-1',
+        guildId: GUILD,
+        status: 'active',
+        prizePool: 1000,
+        entryFee: 0,
+        entries: [],
+        prizes: [],
+        // Relative to now: submitCatch compares the clock against `endsAt` and
+        // ends a tournament that has run out, so a fixed date would make these
+        // assert the expiry path from next week onwards.
+        startedAt: new Date(Date.now() - 60_000),
+        endsAt: new Date(Date.now() + 3_600_000),
+        ...fields,
+    };
+    doc.save = jest.fn(async () => doc);
+    return doc;
+};
+
+const entry = (userId, score, caughtAt, fields = {}) => ({
+    userId, username: userId, fishName: 'Cod', fishEmoji: '🐟',
+    tier: 'common', score, caughtAt: new Date(caughtAt), isBossKill: false, ...fields,
+});
+
+/** The service's claim succeeded and handed back `doc`. */
+const claimYields = doc => FishingTournament.findOneAndUpdate.mockResolvedValue(doc);
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsers.reset();
+});
+
+describe('ending a tournament', () => {
+    test('splits the pool 60/25/15 and credits each winner', async () => {
+        mockUsers.seed(
+            { userId: 'first', guildId: GUILD, balance: 100 },
+            { userId: 'second', guildId: GUILD, balance: 0 },
+            { userId: 'third', guildId: GUILD, balance: 50 },
+        );
+        const tournament = makeTournament({
+            prizePool: 1000,
+            entries: [
+                entry('third', 10, '2026-08-31T10:10:00Z'),
+                entry('first', 90, '2026-08-31T10:30:00Z'),
+                entry('second', 50, '2026-08-31T10:20:00Z'),
+            ],
+        });
+        claimYields(tournament);
+
+        const ended = await tournamentService.endTournament(tournament._id);
+
+        expect(ended.prizes).toEqual([
+            { place: 1, userId: 'first', amount: 600, paidOut: true },
+            { place: 2, userId: 'second', amount: 250, paidOut: true },
+            { place: 3, userId: 'third', amount: 150, paidOut: true },
+        ]);
+        expect(mockUsers.get('first').balance).toBe(700);
+        expect(mockUsers.get('second').balance).toBe(250);
+        expect(mockUsers.get('third').balance).toBe(200);
+        expect(tournament.save).toHaveBeenCalled();
+    });
+
+    // The whole pool is meant to leave: a split that quietly kept a coin, or
+    // handed out more than was in the pool, would do it on every tournament.
+    test('pays out the pool it was given, no more and no less', async () => {
+        mockUsers.seed(
+            { userId: 'a', guildId: GUILD }, { userId: 'b', guildId: GUILD }, { userId: 'c', guildId: GUILD },
+        );
+        const tournament = makeTournament({
+            prizePool: 999,
+            entries: [
+                entry('a', 30, '2026-08-31T10:10:00Z'),
+                entry('b', 20, '2026-08-31T10:11:00Z'),
+                entry('c', 10, '2026-08-31T10:12:00Z'),
+            ],
+        });
+        claimYields(tournament);
+
+        const ended = await tournamentService.endTournament(tournament._id);
+
+        const total = ended.prizes.reduce((sum, p) => sum + p.amount, 0);
+        expect(total).toBe(999);
+        expect(ended.prizes.every(p => Number.isInteger(p.amount))).toBe(true);
+    });
+
+    test('a tie is broken by whoever caught it first', async () => {
+        mockUsers.seed({ userId: 'early', guildId: GUILD }, { userId: 'late', guildId: GUILD });
+        const tournament = makeTournament({
+            entries: [
+                entry('late', 50, '2026-08-31T10:45:00Z'),
+                entry('early', 50, '2026-08-31T10:05:00Z'),
+            ],
+        });
+        claimYields(tournament);
+
+        const ended = await tournamentService.endTournament(tournament._id);
+
+        expect(ended.prizes.map(p => p.userId)).toEqual(['early', 'late']);
+    });
+
+    test('two entrants share the pool between the two places that exist', async () => {
+        mockUsers.seed({ userId: 'a', guildId: GUILD }, { userId: 'b', guildId: GUILD });
+        const tournament = makeTournament({
+            prizePool: 1000,
+            entries: [entry('a', 30, '2026-08-31T10:10:00Z'), entry('b', 20, '2026-08-31T10:11:00Z')],
+        });
+        claimYields(tournament);
+
+        const ended = await tournamentService.endTournament(tournament._id);
+
+        expect(ended.prizes).toHaveLength(2);
+        expect(ended.prizes.map(p => p.amount)).toEqual([600, 250]);
+    });
+
+    test('an empty pool pays nobody and writes no prizes', async () => {
+        mockUsers.seed({ userId: 'a', guildId: GUILD, balance: 10 });
+        const tournament = makeTournament({
+            prizePool: 0,
+            entries: [entry('a', 30, '2026-08-31T10:10:00Z')],
+        });
+        claimYields(tournament);
+
+        const ended = await tournamentService.endTournament(tournament._id);
+
+        expect(ended.prizes).toEqual([]);
+        expect(mockUsers.get('a').balance).toBe(10);
+        expect(logTransaction).not.toHaveBeenCalled();
+    });
+
+    test('a tournament with no entries ends without paying anyone', async () => {
+        const tournament = makeTournament({ entries: [] });
+        claimYields(tournament);
+
+        const ended = await tournamentService.endTournament(tournament._id);
+
+        expect(ended.prizes).toEqual([]);
+        expect(mockUsers.writes).toEqual([]);
+    });
+
+    // The credit is the thing that can fail on its own: a winner who has left
+    // the guild has no member document, so the update matches nothing. That
+    // must not be recorded as paid — `paidOut: false` is what an operator has
+    // to be able to find afterwards.
+    test('a winner with no member document is left unpaid rather than marked paid', async () => {
+        mockUsers.seed({ userId: 'present', guildId: GUILD, balance: 0 });
+        const tournament = makeTournament({
+            prizePool: 1000,
+            entries: [
+                entry('departed', 90, '2026-08-31T10:10:00Z'),
+                entry('present', 50, '2026-08-31T10:11:00Z'),
+            ],
+        });
+        claimYields(tournament);
+
+        const ended = await tournamentService.endTournament(tournament._id);
+
+        expect(ended.prizes[0]).toEqual({ place: 1, userId: 'departed', amount: 600, paidOut: false });
+        expect(ended.prizes[1].paidOut).toBe(true);
+        expect(mockUsers.get('present').balance).toBe(250);
+        // The unpaid winner is not in the ledger either — a ledger row is the
+        // record of coins that moved.
+        expect(logTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    test('each paid prize is written to the ledger with the balance it produced', async () => {
+        mockUsers.seed({ userId: 'a', guildId: GUILD, balance: 400 });
+        const tournament = makeTournament({
+            prizePool: 1000,
+            entries: [entry('a', 30, '2026-08-31T10:10:00Z')],
+        });
+        claimYields(tournament);
+
+        await tournamentService.endTournament(tournament._id);
+
+        expect(logTransaction).toHaveBeenCalledWith({
+            userId: 'a',
+            guildId: GUILD,
+            type: 'tournament_prize',
+            amount: 600,
+            balance: 1000,
+            note: 'Tournament place #1',
+        });
+    });
+
+    // The status flip is the claim: `{ _id, status: 'active' }` matches once, so
+    // a second call — a scheduled sweep and a `/fish` that both notice the clock
+    // has run out — finds nothing to claim and must pay nobody.
+    test('claims the tournament by flipping it out of active in the same write', async () => {
+        const tournament = makeTournament({ entries: [entry('a', 30, '2026-08-31T10:10:00Z')] });
+        claimYields(tournament);
+
+        await tournamentService.endTournament(tournament._id);
+
+        const [filter, update] = FishingTournament.findOneAndUpdate.mock.calls[0];
+        expect(filter).toEqual({ _id: tournament._id, status: 'active' });
+        expect(update.$set.status).toBe('ended');
+        expect(update.$set.winnersAnnouncedAt).toBeInstanceOf(Date);
+    });
+
+    test('a tournament somebody else already ended is read back, not paid again', async () => {
+        mockUsers.seed({ userId: 'a', guildId: GUILD, balance: 100 });
+        const alreadyEnded = makeTournament({
+            status: 'ended',
+            prizes: [{ place: 1, userId: 'a', amount: 600, paidOut: true }],
+        });
+        FishingTournament.findOneAndUpdate.mockResolvedValue(null);
+        FishingTournament.findById.mockResolvedValue(alreadyEnded);
+
+        const ended = await tournamentService.endTournament(alreadyEnded._id);
+
+        expect(ended).toBe(alreadyEnded);
+        expect(mockUsers.get('a').balance).toBe(100);
+        expect(mockUsers.writes).toEqual([]);
+        expect(logTransaction).not.toHaveBeenCalled();
+    });
+});
+
+describe('submitting a catch', () => {
+    test('an entry fee is added to the pool once, on the first catch', async () => {
+        const tournament = makeTournament({ prizePool: 100, entryFee: 25 });
+        FishingTournament.findOne.mockResolvedValue(tournament);
+
+        await tournamentService.submitCatch(GUILD, { userId: 'a', username: 'a', fishName: 'Cod', fishEmoji: '🐟', tier: 'common', score: 10 });
+        await tournamentService.submitCatch(GUILD, { userId: 'a', username: 'a', fishName: 'Cod', fishEmoji: '🐟', tier: 'common', score: 20 });
+
+        expect(tournament.prizePool).toBe(125);
+        expect(tournament.entries).toHaveLength(1);
+    });
+
+    test('only a better catch replaces the one already recorded', async () => {
+        const tournament = makeTournament({
+            entries: [entry('a', 80, '2026-08-31T10:05:00Z', { fishName: 'Marlin' })],
+        });
+        FishingTournament.findOne.mockResolvedValue(tournament);
+
+        await tournamentService.submitCatch(GUILD, { userId: 'a', username: 'a', fishName: 'Cod', fishEmoji: '🐟', tier: 'common', score: 20 });
+
+        expect(tournament.entries[0].score).toBe(80);
+        expect(tournament.entries[0].fishName).toBe('Marlin');
+
+        await tournamentService.submitCatch(GUILD, { userId: 'a', username: 'a', fishName: 'Tuna', fishEmoji: '🐟', tier: 'rare', score: 200 });
+
+        expect(tournament.entries[0].score).toBe(200);
+        expect(tournament.entries[0].fishName).toBe('Tuna');
+    });
+
+    test('a catch after the clock ran out ends the tournament instead of scoring', async () => {
+        const expired = makeTournament({ endsAt: new Date(Date.now() - 60_000), entries: [] });
+        FishingTournament.findOne.mockResolvedValue(expired);
+        claimYields(expired);
+
+        const result = await tournamentService.submitCatch(GUILD, {
+            userId: 'a', username: 'a', fishName: 'Cod', fishEmoji: '🐟', tier: 'common', score: 10,
+        });
+
+        expect(result).toBeNull();
+        expect(FishingTournament.findOneAndUpdate).toHaveBeenCalledWith(
+            { _id: expired._id, status: 'active' }, expect.anything(), expect.anything(),
+        );
+    });
+
+    test('there is nothing to submit to without an active tournament', async () => {
+        FishingTournament.findOne.mockResolvedValue(null);
+
+        const result = await tournamentService.submitCatch(GUILD, {
+            userId: 'a', username: 'a', fishName: 'Cod', fishEmoji: '🐟', tier: 'common', score: 10,
+        });
+
+        expect(result).toBeNull();
+    });
+});
+
+describe('starting a tournament', () => {
+    test('refuses a second one while another is running or scheduled', async () => {
+        FishingTournament.findOne.mockResolvedValue(makeTournament());
+
+        await expect(tournamentService.startTournament(GUILD)).rejects.toThrow(/already running or scheduled/);
+        expect(FishingTournament.create).not.toHaveBeenCalled();
+    });
+
+    test('seeds the pool with the amount it was given', async () => {
+        FishingTournament.findOne.mockResolvedValue(null);
+        FishingTournament.create.mockImplementation(async fields => fields);
+
+        const started = await tournamentService.startTournament(GUILD, { seedAmount: 500, entryFee: 20, durationMs: 30 * 60_000 });
+
+        expect(started.prizePool).toBe(500);
+        expect(started.seedAmount).toBe(500);
+        expect(started.entryFee).toBe(20);
+        expect(started.endsAt.getTime() - started.startedAt.getTime()).toBe(30 * 60_000);
+    });
+});
+
+describe('the winners embed', () => {
+    test('names each winner with the prize the payout actually recorded', () => {
+        const tournament = makeTournament({
+            entries: [entry('a', 90, '2026-08-31T10:10:00Z'), entry('b', 50, '2026-08-31T10:11:00Z')],
+            prizes: [
+                { place: 1, userId: 'a', amount: 600, paidOut: true },
+                { place: 2, userId: 'b', amount: 250, paidOut: true },
+            ],
+        });
+
+        const embed = tournamentService.buildWinnersEmbed(tournament, '🪙');
+
+        expect(embed.data.description).toContain('🪙600');
+        expect(embed.data.description).toContain('🪙250');
+        expect(embed.data.description).toContain('<@a>');
+    });
+
+    test('says so when nobody entered', () => {
+        const embed = tournamentService.buildWinnersEmbed(makeTournament({ entries: [] }));
+
+        expect(embed.data.description).toContain('No participants');
+    });
+});

--- a/tests/updatePipelineOption.test.js
+++ b/tests/updatePipelineOption.test.js
@@ -105,7 +105,16 @@ function pipelineNames(ast) {
     return names;
 }
 
-/** Names the file sets `updatePipeline` on, e.g. `options.updatePipeline = true`. */
+/** True for the literal `true`, which is the only value that opts in. */
+const isTrue = node => node?.type === 'Literal' && node.value === true;
+
+/**
+ * Names the file sets `updatePipeline` on, e.g. `options.updatePipeline = true`.
+ *
+ * Only a literal `true` counts. `updatePipeline: false` is Mongoose's default
+ * spelled out, and a computed value is a promise this scan cannot check — both
+ * would otherwise read as an opt-in on the strength of the property name.
+ */
 function optedInNames(ast) {
     const names = new Set();
     for (const node of walk(ast)) {
@@ -113,7 +122,8 @@ function optedInNames(ast) {
         const target = node.left;
         if (target.type === 'MemberExpression' && !target.computed &&
             target.object.type === 'Identifier' &&
-            target.property.name === 'updatePipeline') {
+            target.property.name === 'updatePipeline' &&
+            isTrue(node.right)) {
             names.add(target.object.name);
         }
     }
@@ -133,7 +143,8 @@ function optsIn(node, optedIn = new Set()) {
     if (node.type === 'ObjectExpression') {
         return node.properties.some(p =>
             p.type === 'Property' && !p.computed &&
-            (p.key.name || p.key.value) === 'updatePipeline');
+            (p.key.name || p.key.value) === 'updatePipeline' &&
+            isTrue(p.value));
     }
     // `cond ? {...} : {...}` — both branches have to opt in.
     if (node.type === 'ConditionalExpression') {

--- a/tests/updatePipelineOption.test.js
+++ b/tests/updatePipelineOption.test.js
@@ -80,8 +80,55 @@ function nativeCollectionNames(ast) {
     return names;
 }
 
-/** True when an options AST node sets `updatePipeline` on every branch it can take. */
-function optsIn(node) {
+/**
+ * Names the file binds to a pipeline at some point — `const u = [{ $set: ... }]`
+ * or `let u; ... u = [{ $set: ... }]`.
+ *
+ * The dashboard's two adjust routes built their pipeline into a `let` and passed
+ * the variable, so the scan below walked past both of them and they shipped
+ * without the opt-in: an admin taking coins or XP got a 500 from a call that
+ * threw before it ran (#925). A pipeline is no less a pipeline for having been
+ * assigned to something first.
+ */
+function pipelineNames(ast) {
+    const names = new Set();
+    for (const node of walk(ast)) {
+        if (node.type === 'VariableDeclarator' && node.id.type === 'Identifier' &&
+            node.init?.type === 'ArrayExpression') {
+            names.add(node.id.name);
+        }
+        if (node.type === 'AssignmentExpression' && node.left.type === 'Identifier' &&
+            node.right.type === 'ArrayExpression') {
+            names.add(node.left.name);
+        }
+    }
+    return names;
+}
+
+/** Names the file sets `updatePipeline` on, e.g. `options.updatePipeline = true`. */
+function optedInNames(ast) {
+    const names = new Set();
+    for (const node of walk(ast)) {
+        if (node.type !== 'AssignmentExpression') continue;
+        const target = node.left;
+        if (target.type === 'MemberExpression' && !target.computed &&
+            target.object.type === 'Identifier' &&
+            target.property.name === 'updatePipeline') {
+            names.add(target.object.name);
+        }
+    }
+    return names;
+}
+
+/**
+ * True when an options AST node sets `updatePipeline` on every branch it can take.
+ *
+ * An options object held in a variable is answered by `optedIn`: the file has to
+ * assign `updatePipeline` to that name somewhere. That is weaker than the
+ * literal case — it cannot tell which branch the assignment sits on — but it is
+ * the difference between noticing a missing opt-in and not looking at all.
+ */
+function optsIn(node, optedIn = new Set()) {
     if (node == null) return false;
     if (node.type === 'ObjectExpression') {
         return node.properties.some(p =>
@@ -90,8 +137,9 @@ function optsIn(node) {
     }
     // `cond ? {...} : {...}` — both branches have to opt in.
     if (node.type === 'ConditionalExpression') {
-        return optsIn(node.consequent) && optsIn(node.alternate);
+        return optsIn(node.consequent, optedIn) && optsIn(node.alternate, optedIn);
     }
+    if (node.type === 'Identifier') return optedIn.has(node.name);
     return false;
 }
 
@@ -101,6 +149,8 @@ function pipelineUpdates() {
         const source = fs.readFileSync(file, 'utf8');
         const ast = espree.parse(source, { ecmaVersion: 2024, sourceType: 'script', loc: true });
         const native = nativeCollectionNames(ast);
+        const pipelines = pipelineNames(ast);
+        const optedIn = optedInNames(ast);
 
         for (const node of walk(ast)) {
             if (node.type !== 'CallExpression') continue;
@@ -109,13 +159,15 @@ function pipelineUpdates() {
             if (!UPDATE_METHODS.has(callee.property.name)) continue;
 
             const update = node.arguments[1];
-            if (!update || update.type !== 'ArrayExpression') continue;
+            const isPipeline = update?.type === 'ArrayExpression' ||
+                (update?.type === 'Identifier' && pipelines.has(update.name));
+            if (!isPipeline) continue;
             if (callee.object.type === 'Identifier' && native.has(callee.object.name)) continue;
 
             found.push({
                 where: `${path.relative(path.join(SRC, '..'), file)}:${node.loc.start.line}`,
                 method: callee.property.name,
-                optedIn: optsIn(node.arguments[2]),
+                optedIn: optsIn(node.arguments[2], optedIn),
             });
         }
     }
@@ -129,6 +181,15 @@ describe('aggregation-pipeline updates opt in to Mongoose 9', () => {
     // call sites going away — a renamed method or a parse that silently failed.
     it('finds the pipeline updates the economy is built on', () => {
         expect(updates.length).toBeGreaterThanOrEqual(8);
+    });
+
+    // The two dashboard adjust routes are the reason the scan resolves
+    // identifiers: each holds its pipeline in a `let` and passes the variable to
+    // a single findOneAndUpdate (#925), so the literal-only scan saw neither.
+    it('sees a pipeline that was assigned to a variable first', () => {
+        const byVariable = updates.map(u => u.where).filter(where =>
+            where.includes('routes/api/economy.js') || where.includes('routes/api/leveling.js'));
+        expect(byVariable.length).toBe(2);
     });
 
     it('sets `updatePipeline: true` on every one of them', () => {

--- a/tests/weeklyChampion.test.js
+++ b/tests/weeklyChampion.test.js
@@ -88,7 +88,8 @@ describe('addWeeklyChampionProgress', () => {
 
             const [filter, update, options] = WeeklyChampion.findOneAndUpdate.mock.calls[0];
             expect(filter).toEqual({ guildId: 'g1', week: '2026-W35', category: 'mine', userId: 'u1' });
-            expect(options).toEqual({ upsert: true });
+            // A pipeline update Mongoose 9 will actually run — see tests/updatePipelineOption.test.js.
+            expect(options).toEqual({ upsert: true, updatePipeline: true });
 
             const set = update[0].$set;
             expect(set.total).toEqual({ $add: [{ $ifNull: ['$total', 0] }, 250] });


### PR DESCRIPTION
This release addresses three critical bugs affecting data integrity and safety across tournament payouts, seasonal events, and admin adjustment tools.

## Summary

Three separate issues are fixed:
1. **Tournament prize payouts** (#906) - Added comprehensive test coverage for `tournamentService.endTournament()` which had zero test coverage, revealing the payout logic works correctly but was untested
2. **Seasonal event multipliers** (#906) - Added test coverage for `seasonalEventService` to verify coin/XP multipliers and event currency handling
3. **Admin adjustment ceilings** (#925) - Added validation and clamping to prevent unsafe integer values from being written to the database
4. **Dead-letter queue TTL** (#896) - Fixed TTL index to only expire resolved payouts, not exhausted ones that represent unsettled debts
5. **Market listing race condition** (#926) - Replaced count-based cap with slot-based enforcement using unique index to prevent concurrent listing overflow

## Key Changes

- **tests/tournamentPrizePayout.test.js** (new) - 353 lines of comprehensive tests for tournament prize distribution, covering the 60/25/15 split, tie-breaking, edge cases (empty pools, missing members), and the claim mechanism that prevents double-payout
- **tests/seasonalEventRewards.test.js** (new) - 339 lines of tests for event multipliers, currency balances, spending, and the hourly sweep that starts seasonal events
- **tests/dashboardAdjustLimits.test.js** (new) - 233 lines of tests for admin economy/leveling adjustments with ceiling enforcement
- **tests/failedJobTtl.test.js** (new) - 92 lines verifying the TTL index only expires resolved records
- **src/migrations/020_narrow_failed_job_ttl.js** (new) - Migration that drops the old `updatedAt_1` index and creates the narrowed `idx_failedjob_resolved_ttl` with partial filter
- **src/models/FailedJob.js** - Updated TTL index to use `partialFilterExpression: { status: 'resolved' }` instead of including `exhausted`
- **src/dashboard/lib/apiHelpers.js** - Added `MAX_ADJUST_AMOUNT` and `MAX_ADJUST_TOTAL` constants with validation helper `readAdjustAmount()`
- **src/dashboard/routes/api/economy.js** - Added ceiling validation and pipeline update clamping using `$min` operator
- **src/dashboard/routes/api/leveling.js** - Added ceiling validation and pipeline update clamping for XP/level adjustments
- **src/commands/economy/market.js** - Replaced count-based listing cap with slot-based system; listings now claim one of 5 slots with unique index enforcement and retry logic for race conditions
- **src/models/MarketListing.js** - Added `slot` field (1-5) with unique compound index on `{ guildId, sellerId, slot }`
- **scripts/replay-owed-payouts.js** - Updated to list exhausted records separately and note that TTL no longer deletes them
- **tests/updatePipelineOption.test.js** - Enhanced to detect pipeline variables assigned in `let`/assignment statements, catching the dashboard routes' missing `updatePipeline: true` option
- **CHANGELOG.md** - Documented all fixes in version 4.5.1
- **package.json** - Bumped version to 4.5.1

## Notable Implementation Details

- The tournament payout tests use a shared fake User collection that applies real `$inc` operations, catching actual balance changes rather than mocking them
- The market listing slot system uses a unique index on `{ guildId, sellerId, slot }` to enforce the cap at the database level; concurrent calls that lose the race for a slot automatically retry with the next available slot
- Admin adjustment ceilings use `$min` in the update pipeline to clamp values atomically, preventing two concurrent adjustments from stepping over the ceiling
- The failed job TTL migration verifies the new index was created correctly before boot continues, ensuring the old TTL is not left in place
- The `updatePipe

https://claude.ai/code/session_01Vg3qfEctc38VdLkyU9HCne

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Market sellers are limited to five active listings, with available slots reused after listings are sold or cancelled.
  * Administrative economy and leveling adjustments now enforce safe limits and prevent balances or XP from exceeding supported maximums or dropping below zero.

* **Bug Fixes**
  * Exhausted payout records are no longer automatically removed, improving recovery and visibility of outstanding payouts.
  * Improved reliability for tournament prizes, seasonal rewards, and marketplace listing conflicts.

* **Release**
  * Updated to version 4.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->