### PR TITLE
Bound the three in-memory maps that had no ceiling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,39 @@ DASHBOARD_HOST_PORT=3000
 # file; the two must be changed together or startup fails.
 DASHBOARD_URL=http://localhost:3000
 
+# ── Running the dashboard as its own container (optional) ────────────────────
+#
+# By default the dashboard runs inside the bot process, which is simple and is
+# what a single-server deployment wants. It also means a CPU-heavy dashboard
+# request, a full-collection aggregation or a canvas render delays gateway
+# heartbeats for every guild, and a fault in a dashboard route takes the bot
+# down with it (#876).
+#
+# Setting BOT_GATEWAY_PORT moves the dashboard out. The bot then serves only the
+# gateway facade on that port — no views, no sessions, no aggregations — and the
+# separate `dashboard` container calls it. Bring it up with:
+#
+#   docker compose --profile split-dashboard up -d
+#
+# Leave all three unset and nothing changes: the dashboard runs in-process
+# exactly as before.
+#
+# The port the bot serves the facade on, inside the container. Never published
+# to the host: this endpoint can act in every guild the bot is in.
+# BOT_GATEWAY_PORT=3001
+# The interface it binds. Left unset it binds every interface the container has,
+# which on the compose network means the bot service's own address and nothing
+# reachable from outside it. Set it to 127.0.0.1 when both processes run on one
+# host without Docker.
+# BOT_GATEWAY_HOST=
+# Where the dashboard container finds it. `clawdia` is the bot service's name on
+# the compose network.
+# BOT_GATEWAY_URL=http://clawdia:3001
+# The shared secret both sides present. REQUIRED whenever either of the two
+# above is set, minimum 32 characters.
+# Generate with:  openssl rand -hex 32
+# BOT_GATEWAY_TOKEN=
+
 # Backups — the `backup` service runs mongodump nightly at 03:00 UTC into
 # ./backups and prunes archives older than this. It is on by default; opt out
 # with `docker compose up -d --scale backup=0`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,8 +115,14 @@ EXPOSE 3000
 # it silently failed forever on any deploy that moved the port — which is how
 # portainer-stack.yml came to run on 7001 with an image healthcheck probing
 # 3000, masked only because the stack overrode the check (#641).
+#
+# BOT_GATEWAY_PORT comes first because it is what says the dashboard has been
+# split out (#876): in that deployment this container serves the gateway facade
+# and nothing else, and /health on that port is the only HTTP it answers. The
+# dashboard container runs the same image with neither variable set, so it falls
+# through to DASHBOARD_PORT exactly as before.
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=90s \
-    CMD node -e "require('http').get('http://127.0.0.1:' + (process.env.DASHBOARD_PORT || 3000) + '/health', r => { let b=''; r.on('data', d => b += d); r.on('end', () => { try { process.exit(JSON.parse(b).status === 'unhealthy' ? 1 : 0); } catch { process.exit(1); } }); }).on('error', () => process.exit(1))"
+    CMD node -e "require('http').get('http://127.0.0.1:' + (process.env.BOT_GATEWAY_PORT || process.env.DASHBOARD_PORT || 3000) + '/health', r => { let b=''; r.on('data', d => b += d); r.on('end', () => { try { process.exit(JSON.parse(b).status === 'unhealthy' ? 1 : 0); } catch { process.exit(1); } }); }).on('error', () => process.exit(1))"
 
 # tini as PID 1 reaps zombies and forwards signals. Exec'ing node directly
 # (rather than `npm start`) means SIGTERM reaches the process that installed

--- a/README.md
+++ b/README.md
@@ -134,10 +134,41 @@ SHARD_COUNT=2 npm run start:sharded
 
 Each shard is its own process. Discord routes a guild's events to exactly one of
 them, which is what keeps the live multiplayer rounds — crash lobbies, heists,
-the raid join window — correct without persisting them. Work that must happen
-once per deployment rather than once per shard runs on shard 0 only: the
-dashboard, schema migrations, and the cron scheduler. `src/utils/sharding.js`
-has the full reasoning.
+the raid join window — correct without persisting them.
+
+Background work is classified rather than blanket-pinned. Schema migrations and
+jobs that touch only the database run on shard 0, because running them per shard
+would duplicate them. Jobs that announce into a guild run on every shard, each
+one filtering its work list to the guilds Discord routes to it — pinned to shard
+0 they could not reach a guild on shard 3, and the announcement was dropped in
+silence. `src/services/scheduler/index.js` lists which is which and why;
+`src/utils/sharding.js` has the routing rule they share.
+
+### Running the dashboard as its own process
+
+By default the dashboard runs inside the bot process, which is what a single
+server wants. It also means a heavy dashboard request, a full-collection
+aggregation or a canvas render shares an event loop with the Discord gateway,
+and that a fault in a route can take the bot down with it.
+
+Three variables move it out:
+
+```bash
+BOT_GATEWAY_PORT=3001                          # the bot serves the gateway facade here
+BOT_GATEWAY_URL=http://clawdia:3001            # where the dashboard finds it
+BOT_GATEWAY_TOKEN=$(openssl rand -hex 32)      # the shared secret both present
+```
+
+Then `npm run start:dashboard`, or `docker compose --profile split-dashboard up
+-d`. Setting `BOT_GATEWAY_PORT` is what stops the bot starting its own
+dashboard, so the two never both bind a port; leave all three unset and nothing
+changes.
+
+The dashboard process holds no gateway connection, registers no commands and
+runs no cron jobs. It reads the database directly and calls the bot only for
+what a gateway connection can answer — see `src/bot/gateway.js` for that list
+and `src/bot/remoteGateway.js` for the transport. It is not given
+`DISCORD_TOKEN`, which it has no use for.
 
 ## Development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,11 @@ services:
     # DASHBOARD_PORT is the container's side and should normally stay 3000, which
     # is what the image EXPOSEs and what its own HEALTHCHECK probes.
     # DASHBOARD_HOST_PORT is the host's side and is yours to pick.
+    #
+    # With the `split-dashboard` profile on, this container serves no dashboard
+    # and the `dashboard` service publishes the same host port instead. Comment
+    # this mapping out then — two services cannot both publish it, and the bot's
+    # facade port is deliberately never published at all.
     ports:
       - "127.0.0.1:${DASHBOARD_HOST_PORT:-3000}:${DASHBOARD_PORT:-3000}"
     depends_on:
@@ -163,6 +168,74 @@ services:
       # Read by the optional `autoheal` service below. Harmless when that
       # service is not running, which is why it is not commented out: enabling
       # autoheal is then one flag, with nothing to remember to uncomment here.
+      autoheal: "true"
+
+  # The dashboard, as its own container. Off by default (#876).
+  #
+  #   docker compose --profile split-dashboard up -d
+  #
+  # Embedded, the dashboard shares an event loop with the Discord gateway, the
+  # cron jobs, canvas rendering and every full-collection aggregation — so a
+  # heavy dashboard request delays heartbeats for every guild, and a fault in a
+  # route reaches the process guards in src/index.js, which exit. That makes a
+  # bad page a bot-wide outage.
+  #
+  # Split, this container serves the dashboard and the `bot` container serves it
+  # the handful of things only a gateway connection can answer, over
+  # BOT_GATEWAY_URL. Turning it on takes three variables in .env:
+  #
+  #   BOT_GATEWAY_PORT=3001                 # the bot serves the facade here
+  #   BOT_GATEWAY_URL=http://clawdia:3001   # where this container finds it
+  #   BOT_GATEWAY_TOKEN=<openssl rand -hex 32>
+  #
+  # Setting BOT_GATEWAY_PORT is what stops the bot starting its own dashboard,
+  # so the two never both bind a port. Leave the variables unset and this
+  # service does not run and nothing else changes.
+  dashboard:
+    profiles: [split-dashboard]
+    build: .
+    image: ghcr.io/theshield2594/clawdia:${CLAWDIA_IMAGE_TAG:-latest}
+    container_name: clawdia-dashboard
+    restart: unless-stopped
+    # The same image, a different entry point. There is no second build, and no
+    # way for the two to drift to different versions of the shared code.
+    command: ["node", "src/dashboard/index.js"]
+    env_file:
+      - .env
+    ports:
+      - "127.0.0.1:${DASHBOARD_HOST_PORT:-3000}:${DASHBOARD_PORT:-3000}"
+    depends_on:
+      mongodb:
+        condition: service_healthy
+    networks:
+      - db-network      # reads the database it owns directly
+      - clawdia-network # reaches the bot's gateway endpoint, and Discord OAuth
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
+    # BOT_GATEWAY_PORT is set for this container too (it comes from the shared
+    # .env), so the image's own healthcheck would probe a port this process does
+    # not serve. Overridden to the dashboard's port, which is the one it binds.
+    healthcheck:
+      test: ["CMD", "node", "-e",
+        "require('http').get('http://127.0.0.1:' + (process.env.DASHBOARD_PORT || 3000) + '/health', (r) => { let b=''; r.on('data', d => b+=d); r.on('end', () => { try { const s = JSON.parse(b).status; process.exit(s === 'unhealthy' ? 1 : 0); } catch { process.exit(1); } }); }).on('error', () => process.exit(1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    # Lighter than the bot's: no canvas rendering, no gateway, no cron jobs.
+    # Rendering guild-settings.ejs is the heaviest thing it does.
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512m
+        reservations:
+          memory: 128m
+    stop_grace_period: 15s
+    labels:
       autoheal: "true"
 
   # Optional container-level self-healing, off by default:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,7 +55,7 @@ const COMMAND_FILE_MAX_LINES = 900;
 const GRANDFATHERED_COMMANDS = {
     'src/commands/economy/explore.js':   1655,
     'src/commands/economy/pet.js':       1490,
-    'src/commands/economy/season.js':    1083,
+    'src/commands/economy/season.js':    1055,
     'src/commands/economy/syndicate.js': 1075,
 };
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -32,12 +32,12 @@ module.exports = {
     // for the step summary below and for anything reading coverage later.
     coverageReporters: ['text-summary', 'json-summary', 'lcov'],
 
-    // Measured over the suite at the commit that raised these — 282 suites,
-    // 5,503 tests, integration excluded: statements 47.86, branches 37.99,
-    // functions 49.09, lines 49.10. Raised from 45/35/46/46 by the casino
-    // resolution modules of #785 and the economy command harness of #786; the
-    // measurement excludes the two integration suites, so the number CI sees is
-    // this or better.
+    // Measured over the suite at the commit that raised these — 323 suites,
+    // 6,498 tests, integration excluded: statements 50.15, branches 40.14,
+    // functions 51.81, lines 51.39. Raised from 47/37/48/48 by the settings-cache
+    // conversion of #877, the scheduler scope tests of #889 and the gateway split
+    // of #876; the measurement excludes the two integration suites, so the number
+    // CI sees is this or better.
     //
     // Each floor is the whole percent below its measurement, which is not the
     // arbitrary rounding it looks like: because the four denominators differ by
@@ -53,10 +53,10 @@ module.exports = {
     // fail the run after the one that set it.
     coverageThreshold: {
         global: {
-            statements: 47,
-            branches: 37,
-            functions: 48,
-            lines: 48,
+            statements: 49,
+            branches: 39,
+            functions: 50,
+            lines: 50,
         },
     },
 };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node src/index.js",
     "start:sharded": "node src/shard.js",
+    "start:dashboard": "node src/dashboard/index.js",
     "dev": "nodemon src/index.js",
     "deploy": "node src/deploy-commands.js",
     "migrate:rollback": "node scripts/rollback-migration.js",

--- a/src/bot/gateway.js
+++ b/src/bot/gateway.js
@@ -11,11 +11,27 @@
 //
 // Every method here takes ids and returns plain data or performs one action.
 // No discord.js object crosses this boundary, which is the property that lets
-// the cache lookups below be replaced with IPC or `broadcastEval` without a
-// single route changing. Anything the dashboard needs from Discord gets a
-// method here; anything it needs from the database it reads from Mongo itself.
+// the cache lookups below be replaced by a call to another process. Anything
+// the dashboard needs from Discord gets a method here; anything it needs from
+// the database it reads from Mongo itself.
+//
+// #876 took that the rest of the way: src/bot/remoteGateway.js implements the
+// same surface over HTTP, so the dashboard can run in its own container with no
+// gateway connection at all. Two consequences for this file.
+//
+// First, every method is async, including the ones that only read a cache. A
+// route cannot be written against a facade whose methods are synchronous here
+// and asynchronous over the wire — that difference is the whole bug, and it
+// would only appear in the split deployment. So the local implementation pays
+// a microtask to have one shape.
+//
+// Second, the method list is not this file's alone: src/bot/gatewayProtocol.js
+// owns it, and the assertion at the bottom of `createBotGateway` holds this
+// implementation to it. A method added here and not there is one the dashboard
+// cannot call once it is out of process.
 
 const { PermissionFlagsBits } = require('discord.js');
+const { GATEWAY_METHODS, GATEWAY_METHOD_SET } = require('./gatewayProtocol');
 
 // Discord channel type numbers, named so routes filter by meaning.
 const CHANNEL_TYPES = {
@@ -78,10 +94,32 @@ function plainUser(user) {
 function createBotGateway(client) {
     const guildOf = guildId => client.guilds.cache.get(guildId) || null;
 
-    return {
+    const gateway = {
         /** Is the bot in this guild? The check every permission gate makes. */
-        hasGuild(guildId) {
+        async hasGuild(guildId) {
             return client.guilds.cache.has(guildId);
+        },
+
+        /**
+         * The same question for a list, answered in one call.
+         *
+         * Three callers ask it of every guild in a user's OAuth guild list at
+         * once — the guild picker, the access middleware, and /health. In this
+         * process that is a cache lookup per id and the shape does not matter;
+         * across the boundary (src/bot/remoteGateway.js) a per-id method would
+         * be one HTTP request per guild the user is in, on every page load. So
+         * the batch is the method, and the singular one stays for the routes
+         * that genuinely have a single id.
+         *
+         * @returns {Promise<Record<string, boolean>>} keyed by the ids asked
+         *   for, so a caller cannot silently read a missing id as false.
+         */
+        async hasGuilds(guildIds) {
+            const present = {};
+            for (const guildId of guildIds ?? []) {
+                present[guildId] = client.guilds.cache.has(guildId);
+            }
+            return present;
         },
 
         /**
@@ -127,7 +165,7 @@ function createBotGateway(client) {
                 || member.permissions.has(PermissionFlagsBits.ManageGuild);
         },
 
-        getGuild(guildId) {
+        async getGuild(guildId) {
             const guild = guildOf(guildId);
             return guild ? plainGuild(guild) : null;
         },
@@ -154,7 +192,7 @@ function createBotGateway(client) {
          *   nothing has filled it yet rather than because the bot is in no
          *   guilds. Callers must render "we do not know" for that, not zero.
          */
-        reach() {
+        async reach() {
             if (!client?.readyAt) return null;
             const guilds = [...client.guilds.cache.values()];
             return {
@@ -164,20 +202,20 @@ function createBotGateway(client) {
         },
 
         /** @returns {Array<object>|null} null when the bot is not in the guild. */
-        listChannels(guildId) {
+        async listChannels(guildId) {
             const guild = guildOf(guildId);
             if (!guild) return null;
             return [...guild.channels.cache.values()].map(plainChannel);
         },
 
         /** @returns {Array<object>|null} null when the bot is not in the guild. */
-        listRoles(guildId) {
+        async listRoles(guildId) {
             const guild = guildOf(guildId);
             if (!guild) return null;
             return [...guild.roles.cache.values()].map(plainRole);
         },
 
-        hasChannel(guildId, channelId) {
+        async hasChannel(guildId, channelId) {
             return guildOf(guildId)?.channels.cache.has(channelId) === true;
         },
 
@@ -262,7 +300,7 @@ function createBotGateway(client) {
         },
 
         /** Members whose timeout has not yet expired. @returns {Array|null} */
-        listActiveTimeouts(guildId, limit) {
+        async listActiveTimeouts(guildId, limit) {
             const guild = guildOf(guildId);
             if (!guild) return null;
             const now = new Date();
@@ -305,14 +343,38 @@ function createBotGateway(client) {
         // gateway connection can do. Routing them through here too is what
         // keeps `client` out of the routes entirely.
 
-        sendDailyNews(guildId, profileId) {
+        async sendDailyNews(guildId, profileId) {
             return require('../services/rssService').sendDailyNews(client, guildId, profileId);
         },
 
-        rescheduleBibleVerse(guildId) {
+        async rescheduleBibleVerse(guildId) {
             return require('../services/dailyBibleService').rescheduleBibleVerse(client, guildId);
         },
     };
+
+    assertImplementsProtocol(gateway, 'createBotGateway');
+    return gateway;
 }
 
-module.exports = { createBotGateway, CHANNEL_TYPES };
+/**
+ * Holds an implementation to the method list in gatewayProtocol.
+ *
+ * Both implementations call this, which is what makes the list load-bearing
+ * rather than documentation: a method added to one side and not the other
+ * throws where it is built, at boot, rather than 404ing one dashboard route in
+ * the split deployment and nowhere else.
+ */
+function assertImplementsProtocol(implementation, label) {
+    const missing = GATEWAY_METHODS.filter(name => typeof implementation[name] !== 'function');
+    const extra = Object.keys(implementation).filter(name => !GATEWAY_METHOD_SET.has(name));
+    if (missing.length || extra.length) {
+        throw new Error(
+            `${label}: does not match src/bot/gatewayProtocol.js — ` +
+            `${missing.length ? `missing ${missing.join(', ')}` : ''}` +
+            `${missing.length && extra.length ? '; ' : ''}` +
+            `${extra.length ? `not in the protocol: ${extra.join(', ')}` : ''}`
+        );
+    }
+}
+
+module.exports = { createBotGateway, assertImplementsProtocol, CHANNEL_TYPES };

--- a/src/bot/gatewayProtocol.js
+++ b/src/bot/gatewayProtocol.js
@@ -1,0 +1,98 @@
+'use strict';
+
+// The wire contract between the dashboard and the gateway (#876).
+//
+// src/bot/gateway.js already made every method id-in / plain-data-out, which is
+// the property that lets the dashboard run somewhere the Discord client is not.
+// What was missing is the wire: a list of what may cross it, and one shape for
+// a call and its answer. Both live here, so the process that serves the facade
+// and the process that consumes it cannot drift — a method added to one side
+// and not the other fails a test rather than a request.
+//
+// Everything below is JSON. No discord.js object, no Buffer, no Date instance
+// crosses the boundary; `listActiveTimeouts` already returns ISO strings for
+// exactly this reason.
+
+/**
+ * Every method the facade exposes, in one list.
+ *
+ * `createBotGateway` is checked against this, so the local implementation
+ * cannot gain a method the remote one does not forward, or lose one the routes
+ * still call.
+ */
+const GATEWAY_METHODS = Object.freeze([
+    'hasGuild',
+    'hasGuilds',
+    'canManageGuild',
+    'getGuild',
+    'reach',
+    'listChannels',
+    'listRoles',
+    'hasChannel',
+    'sendEmbed',
+    'addReactions',
+    'deleteMessage',
+    'searchMembers',
+    'resolveUsers',
+    'listBans',
+    'listActiveTimeouts',
+    'unban',
+    'clearTimeout',
+    'sendDailyNews',
+    'rescheduleBibleVerse',
+]);
+
+const GATEWAY_METHOD_SET = new Set(GATEWAY_METHODS);
+
+/** Where the RPC server mounts. */
+const RPC_PATH = '/__bot';
+
+/** Liveness, unauthenticated, so a container healthcheck can reach it. */
+const HEALTH_PATH = '/health';
+
+/**
+ * A call, encoded.
+ *
+ * `args` is positional because the facade's methods are, and naming them here
+ * would be a second signature to keep in step with the first.
+ */
+function encodeCall(method, args) {
+    return JSON.stringify({ method, args: args ?? [] });
+}
+
+/**
+ * A refusal, encoded.
+ *
+ * The facade's contract distinguishes "we do not have that guild" (a null
+ * return) from "Discord would not let us do that" (a throw), and routes act on
+ * the difference. So a throw has to survive the wire as a throw, carrying the
+ * two fields anything downstream reads: the message, and Discord's numeric
+ * `code` — 10007 Unknown Member and friends.
+ */
+function encodeError(err) {
+    return {
+        message: err?.message ? String(err.message) : 'The bot process refused the call.',
+        code: Number.isInteger(err?.code) ? err.code : undefined,
+        name: typeof err?.name === 'string' ? err.name : 'Error',
+    };
+}
+
+/** Rebuilds the thrown error on the calling side. */
+function decodeError(payload) {
+    const err = new Error(payload?.message || 'The bot process refused the call.');
+    if (payload?.name) err.name = payload.name;
+    if (Number.isInteger(payload?.code)) err.code = payload.code;
+    // So a caller can tell a Discord refusal from the transport giving up.
+    err.remote = true;
+    return err;
+}
+
+module.exports = {
+    GATEWAY_METHODS,
+    GATEWAY_METHOD_SET,
+    RPC_PATH,
+    HEALTH_PATH,
+    encodeCall,
+    encodeError,
+    decodeError,
+};

--- a/src/bot/gatewayServer.js
+++ b/src/bot/gatewayServer.js
@@ -1,0 +1,249 @@
+'use strict';
+
+// The bot side of the process split (#876).
+//
+// One HTTP listener whose only job is to answer gateway-facade calls for a
+// dashboard running somewhere else. It is deliberately not the dashboard's
+// Express app: this is the process that holds the Discord connection, and the
+// whole point of the split is that nothing expensive or user-facing runs here.
+// So it is `http.createServer` with no framework, no views, no sessions, two
+// routes, and a body cap — the smallest thing that can serve the facade.
+//
+// ── Why HTTP and not IPC ────────────────────────────────────────────────────
+//
+// discord.js's `ShardingManager` IPC only reaches processes it spawned, which
+// makes it a way to talk to another shard, not to another container. #876 asks
+// for the dashboard to be its own container, so the transport has to survive a
+// network. HTTP over the compose-internal network is that, it needs no new
+// dependency, and it is the one protocol every deployment already runs.
+//
+// ── Trust ───────────────────────────────────────────────────────────────────
+//
+// This endpoint can ban, unban, delete messages and post embeds in every guild
+// the bot is in. It is therefore never published to the host: it binds the
+// internal network only, and every call carries a shared secret compared in
+// constant time. The secret is required — there is no unauthenticated mode to
+// leave switched on by accident.
+
+const http = require('http');
+const crypto = require('crypto');
+
+const {
+    GATEWAY_METHOD_SET,
+    RPC_PATH,
+    HEALTH_PATH,
+    encodeError,
+} = require('./gatewayProtocol');
+
+// A call is a method name and a few ids. Anything larger is a mistake or an
+// attack, and reading it into memory first is how a small endpoint becomes a
+// denial of service.
+const MAX_BODY_BYTES = 256 * 1024;
+
+// Long enough that guessing is not a strategy. Checked at construction so a
+// misconfiguration is a refusal to start rather than a weak door.
+const MIN_TOKEN_LENGTH = 32;
+
+/** Compares without leaking how much of the token matched. */
+function tokenMatches(presented, expected) {
+    const a = Buffer.from(String(presented ?? ''), 'utf8');
+    const b = Buffer.from(expected, 'utf8');
+    // timingSafeEqual throws on a length mismatch, which would itself be the
+    // leak. Compare digests instead: same length always, same comparison.
+    return crypto.timingSafeEqual(
+        crypto.createHash('sha256').update(a).digest(),
+        crypto.createHash('sha256').update(b).digest(),
+    );
+}
+
+function bearerOf(req) {
+    const header = req.headers.authorization || '';
+    return header.startsWith('Bearer ') ? header.slice(7) : '';
+}
+
+function readBody(req) {
+    return new Promise((resolve, reject) => {
+        let size = 0;
+        const chunks = [];
+        req.on('data', chunk => {
+            size += chunk.length;
+            if (size > MAX_BODY_BYTES) {
+                // Destroying rather than just rejecting: the sender is still
+                // uploading, and answering while it does leaves the socket held
+                // open by a body nobody will read.
+                req.destroy();
+                reject(Object.assign(new Error('Request body too large'), { status: 413 }));
+                return;
+            }
+            chunks.push(chunk);
+        });
+        req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+        req.on('error', reject);
+    });
+}
+
+function send(res, status, payload) {
+    const body = JSON.stringify(payload);
+    res.writeHead(status, {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Content-Length': Buffer.byteLength(body),
+        // Nothing here is ever a browser document, and saying so costs one line.
+        'X-Content-Type-Options': 'nosniff',
+    });
+    res.end(body);
+}
+
+/**
+ * Builds the request handler. Exported separately from `startGatewayServer` so
+ * it can be driven by a test without binding a port.
+ *
+ * @param {object} gateway  a facade from createBotGateway
+ * @param {string} token    the shared secret every call must present
+ * @param {() => object} health  the payload GET /health answers with
+ */
+function createGatewayHandler(gateway, token, health = () => ({ status: 'ok' })) {
+    if (typeof token !== 'string' || token.length < MIN_TOKEN_LENGTH) {
+        throw new Error(
+            `[BOT-RPC] BOT_GATEWAY_TOKEN must be at least ${MIN_TOKEN_LENGTH} characters. ` +
+            'This endpoint can act in every guild the bot is in; it does not run without one.'
+        );
+    }
+
+    return async function handle(req, res) {
+        try {
+            // Unauthenticated on purpose, and it says nothing an attacker wants:
+            // a container healthcheck runs before any secret is in scope, and in
+            // the split deployment this listener is the only thing left in the
+            // bot container that speaks HTTP.
+            if (req.method === 'GET' && req.url === HEALTH_PATH) {
+                return send(res, 200, health());
+            }
+
+            if (req.url !== RPC_PATH) return send(res, 404, { error: 'Not found' });
+            if (req.method !== 'POST') return send(res, 405, { error: 'Method not allowed' });
+
+            if (!tokenMatches(bearerOf(req), token)) {
+                // No detail: a caller that got the token wrong learns only that.
+                return send(res, 401, { error: 'Unauthorized' });
+            }
+
+            let call;
+            try {
+                call = JSON.parse(await readBody(req));
+            } catch (err) {
+                if (err?.status === 413) return send(res, 413, { error: 'Request body too large' });
+                return send(res, 400, { error: 'Malformed request body' });
+            }
+
+            const { method, args } = call ?? {};
+            // Checked against the protocol's own set rather than against the
+            // gateway object, so a caller cannot reach `constructor`, `toString`
+            // or anything else that happens to be a function on it.
+            if (!GATEWAY_METHOD_SET.has(method)) {
+                return send(res, 400, { error: `Unknown gateway method: ${String(method)}` });
+            }
+            if (args !== undefined && !Array.isArray(args)) {
+                return send(res, 400, { error: 'args must be an array' });
+            }
+
+            try {
+                const value = await gateway[method](...(args ?? []));
+                // `undefined` is not JSON, and a method that returns nothing
+                // (addReactions on a missing channel, say) must not become a
+                // parse failure on the other side.
+                return send(res, 200, { ok: true, value: value === undefined ? null : value });
+            } catch (err) {
+                // A refusal from Discord is an answer, not a server fault: the
+                // facade's contract is that these throw so a route can tell them
+                // from "no such guild", and that has to survive the wire.
+                return send(res, 200, { ok: false, error: encodeError(err) });
+            }
+        } catch (err) {
+            // Anything that escapes the arms above is this listener's own bug.
+            // It must not take the gateway process down — that is the whole
+            // reason the dashboard was split out in the first place.
+            console.error('[BOT-RPC] Unhandled error while serving a call:', err);
+            if (!res.headersSent) return send(res, 500, { error: 'Internal error' });
+            res.destroy();
+        }
+    };
+}
+
+/**
+ * The port the bot serves the facade on, or null when the split is off.
+ *
+ * Setting BOT_GATEWAY_PORT is the whole switch: it is what tells the bot to
+ * serve the facade instead of a dashboard, so the decision is written down once
+ * here rather than as a condition at the bootstrap site. An unusable value is
+ * null rather than a throw — validateEnv has already refused to start on it,
+ * and this must not be a second, different opinion.
+ */
+function resolveGatewayPort(env = process.env) {
+    const port = Number(env.BOT_GATEWAY_PORT);
+    return Number.isInteger(port) && port > 0 && port <= 65535 ? port : null;
+}
+
+/**
+ * Binds the listener.
+ *
+ * @returns {import('http').Server}
+ */
+function startGatewayServer(gateway, {
+    port = Number(process.env.BOT_GATEWAY_PORT) || 3001,
+    host = process.env.BOT_GATEWAY_HOST || '0.0.0.0',
+    token = process.env.BOT_GATEWAY_TOKEN,
+    health,
+} = {}) {
+    const server = http.createServer(createGatewayHandler(gateway, token, health));
+
+    // Same reasoning as the dashboard's listener: an 'error' with no listener is
+    // a process-level throw, and EADDRINUSE here would drop the gateway
+    // connection for every guild the bot is in.
+    server.on('error', err => {
+        console.error(`[BOT-RPC] Server error on port ${port}:`, err.message);
+    });
+
+    server.listen(port, host, () => {
+        console.log(`[BOT-RPC] Serving the gateway facade on ${host}:${port}`);
+    });
+
+    return server;
+}
+
+/**
+ * Starts the listener if the deployment asked for it, and reports whether the
+ * dashboard has been split out.
+ *
+ * The whole policy lives here rather than at the bootstrap site because both
+ * halves of it are about this server: whether it should run, and what happens
+ * when it cannot. A listener that fails to bind must not stop the bot logging
+ * in — the containment src/index.js already applies to the in-process
+ * dashboard, for the same reason.
+ *
+ * @returns {boolean} true when BOT_GATEWAY_PORT is set, whether or not the
+ *   listener came up. The caller uses this to decide *not* to start an
+ *   in-process dashboard, and that decision must not flip on a bind failure:
+ *   the operator asked for the split, a dashboard is expected elsewhere, and
+ *   falling back here would bind a port they did not ask for and run the very
+ *   aggregations they moved out.
+ */
+function serveGatewayIfConfigured(buildGateway, options = {}) {
+    const port = resolveGatewayPort();
+    if (port === null) return false;
+
+    try {
+        startGatewayServer(buildGateway(), { ...options, port });
+    } catch (err) {
+        console.error('[BOT-RPC] Failed to start. The dashboard will not be able to reach this process:', err);
+    }
+    return true;
+}
+
+module.exports = {
+    createGatewayHandler,
+    startGatewayServer,
+    serveGatewayIfConfigured,
+    resolveGatewayPort,
+    MAX_BODY_BYTES,
+    MIN_TOKEN_LENGTH,
+};

--- a/src/bot/remoteGateway.js
+++ b/src/bot/remoteGateway.js
@@ -1,0 +1,109 @@
+'use strict';
+
+// The dashboard side of the process split (#876).
+//
+// The same facade `createBotGateway` returns, implemented by calling the bot
+// process rather than a local discord.js cache. Every route already talks to
+// the facade and nothing else, so this is the only file that has to know the
+// dashboard is somewhere the gateway is not.
+//
+// The shape is generated from src/bot/gatewayProtocol.js rather than written
+// out, because a hand-written forwarder is a second copy of the method list to
+// forget to update — and forgetting shows up only in the split deployment,
+// which is the one nobody is running while they make the change.
+
+const {
+    GATEWAY_METHODS,
+    RPC_PATH,
+    encodeCall,
+    decodeError,
+} = require('./gatewayProtocol');
+const { assertImplementsProtocol } = require('./gateway');
+
+// A facade call sits inside an HTTP request a person is waiting on, so it gets
+// a budget rather than the runtime's default of none. `canManageGuild` is the
+// slow one — it forces a member fetch on the far side — and Discord's own
+// timeouts are well inside this.
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/**
+ * Builds the remote facade.
+ *
+ * @param {object}   options
+ * @param {string}   options.url        base URL of the bot's gateway server
+ * @param {string}   options.token      the shared secret, matching the server's
+ * @param {number}   [options.timeoutMs]
+ * @param {Function} [options.fetchImpl] injection seam for tests; defaults to
+ *   the runtime's global fetch (Node 18+).
+ */
+function createRemoteBotGateway({
+    url = process.env.BOT_GATEWAY_URL,
+    token = process.env.BOT_GATEWAY_TOKEN,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    fetchImpl = globalThis.fetch,
+} = {}) {
+    if (!url) {
+        throw new Error('[BOT-RPC] BOT_GATEWAY_URL is not set — the dashboard has no bot process to call.');
+    }
+    if (!token) {
+        throw new Error('[BOT-RPC] BOT_GATEWAY_TOKEN is not set — the bot process will refuse every call.');
+    }
+    if (typeof fetchImpl !== 'function') {
+        throw new Error('[BOT-RPC] No fetch implementation available.');
+    }
+
+    const endpoint = new URL(RPC_PATH, url).toString();
+
+    async function call(method, args) {
+        // AbortController rather than Promise.race: the point is to stop
+        // holding the socket, not just to stop waiting on it.
+        const abort = new AbortController();
+        const timer = setTimeout(() => abort.abort(), timeoutMs);
+
+        let response;
+        try {
+            response = await fetchImpl(endpoint, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${token}`,
+                },
+                body: encodeCall(method, args),
+                signal: abort.signal,
+            });
+        } catch (err) {
+            // The bot process being unreachable is not the same as Discord
+            // refusing, and a route that catches this must be able to tell:
+            // one is "try again", the other is "you may not do that".
+            throw Object.assign(
+                new Error(`[BOT-RPC] ${method} could not reach the bot process: ${err?.message || err}`),
+                { transport: true, cause: err },
+            );
+        } finally {
+            clearTimeout(timer);
+        }
+
+        if (!response.ok) {
+            throw Object.assign(
+                new Error(`[BOT-RPC] ${method} was refused by the bot process (HTTP ${response.status}).`),
+                { transport: true, status: response.status },
+            );
+        }
+
+        const payload = await response.json();
+        if (payload?.ok === false) throw decodeError(payload.error);
+        return payload?.value ?? null;
+    }
+
+    const gateway = {};
+    for (const method of GATEWAY_METHODS) {
+        gateway[method] = (...args) => call(method, args);
+    }
+
+    // The same assertion the local implementation makes, for the same reason:
+    // the two sides are only interchangeable while they answer to one list.
+    assertImplementsProtocol(gateway, 'createRemoteBotGateway');
+    return gateway;
+}
+
+module.exports = { createRemoteBotGateway, DEFAULT_TIMEOUT_MS };

--- a/src/commands/admin/raidmode.js
+++ b/src/commands/admin/raidmode.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, MessageFlags } = require('discord.js');
 const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { setRaidMode, raidModeActive, raidModeActivatedBy } = require('../../services/raidService');
 const COLORS = require('../../utils/embedColors');
 
@@ -118,7 +119,7 @@ module.exports = {
             const status = interaction.options.getString('status');
             const active = status === 'on';
 
-            const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+            const guildSettings = await getGuildSettings(interaction.guild.id);
             if (!guildSettings?.raidDetection?.enabled) {
                 return interaction.editReply({
                     content: 'Raid detection is not enabled. Use `/raidmode raid enabled:true` first.'
@@ -144,7 +145,7 @@ module.exports = {
         if (sub === 'status') {
             await interaction.deferReply();
 
-            const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+            const guildSettings = await getGuildSettings(interaction.guild.id);
             const rd = guildSettings?.raidDetection;
 
             if (!rd?.enabled) {

--- a/src/commands/ai/ai.js
+++ b/src/commands/ai/ai.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags, PermissionFlagsBits } = require('discord.js');
 const User = require('../../models/User');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const {
     resolveMcpServers,
     getMcpServers,
@@ -295,7 +295,7 @@ async function startDeepTask(interaction) {
         return interaction.reply({ content: 'Say what you would like done.', flags: MessageFlags.Ephemeral });
     }
 
-    const settings = await Guild.findOne({ guildId: interaction.guild.id }).lean();
+    const settings = await getGuildSettings(interaction.guild.id);
     const ai = settings?.ai;
 
     // Checked before anything is posted, so a refusal is one ephemeral line
@@ -359,7 +359,7 @@ async function addScheduledTask(interaction) {
 
     // The guild's own timezone rather than the admin's: the task belongs to the
     // server and will still be running long after this conversation.
-    const settings = await Guild.findOne({ guildId: interaction.guild.id }).lean();
+    const settings = await getGuildSettings(interaction.guild.id);
     const timezone = settings?.ai?.dailyDigest?.timezone || 'Etc/UTC';
 
     let fireAt;
@@ -458,7 +458,7 @@ async function removeScheduledTask(interaction) {
 
 /** The guild's stored connections, merged with the operator's config file. */
 async function guildMcpServers(guildId) {
-    const settings = await Guild.findOne({ guildId }).lean();
+    const settings = await getGuildSettings(guildId);
     return resolveMcpServers(settings?.ai?.mcpServers || []);
 }
 
@@ -473,7 +473,7 @@ async function guildMcpServers(guildId) {
  * rather than leaving the field spinning.
  */
 async function respondWithPrompts(interaction, typed) {
-    const settings = await Guild.findOne({ guildId: interaction.guild.id }).lean();
+    const settings = await getGuildSettings(interaction.guild.id);
 
     const listings = await Promise.race([
         listGuildPrompts(settings?.ai?.mcpServers || []),
@@ -497,7 +497,7 @@ async function respondWithPrompts(interaction, typed) {
 
 async function handleMcp(interaction) {
     const sub = interaction.options.getSubcommand();
-    const settings = await Guild.findOne({ guildId: interaction.guild.id }).lean();
+    const settings = await getGuildSettings(interaction.guild.id);
     const ai = settings?.ai || {};
 
     if (sub === 'prompts') {

--- a/src/commands/community/achievements.js
+++ b/src/commands/community/achievements.js
@@ -2,7 +2,7 @@
 
 const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { ACHIEVEMENTS } = require('../../data/achievements');
 const COLORS = require('../../utils/embedColors');
 const { ownedBy } = require('../../utils/collectorOwner');
@@ -46,7 +46,7 @@ module.exports = {
 
     async execute(interaction) {
         try {
-            const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+            const guildSettings = await getGuildSettings(interaction.guild.id);
 
             if (!guildSettings?.achievements?.enabled) {
                 return interaction.reply({ content: 'Achievements are not enabled on this server.', flags: MessageFlags.Ephemeral });

--- a/src/commands/community/newspaper.js
+++ b/src/commands/community/newspaper.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder, PermissionFlagsBits, MessageFlags } = require('discord.js');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { generateNewspaper } = require('../../services/newspaperService');
 
 module.exports = {
@@ -21,7 +21,7 @@ module.exports = {
             return interaction.reply({ content: 'You need the **Manage Server** permission to use this command.', flags: MessageFlags.Ephemeral });
         }
 
-        const guildDoc = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildDoc = await getGuildSettings(interaction.guild.id);
         if (!guildDoc?.newspaper?.enabled) {
             return interaction.reply({
                 content: 'The Server Newspaper is not enabled. Enable it in the Dashboard under **Engagement → Newspaper**.',

--- a/src/commands/community/questgen.js
+++ b/src/commands/community/questgen.js
@@ -2,11 +2,11 @@
 
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const User     = require('../../models/User');
-const Guild    = require('../../models/Guild');
 const AiQuest  = require('../../models/AiQuest');
 const { resolveProviderConfig, getCompletion } = require('../../services/aiService');
 const COLORS = require('../../utils/embedColors');
 const { requestModelJson } = require('../../utils/modelJson');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 
 const COST         = 200;       // coins to generate
 const COOLDOWN_MS  = 23 * 60 * 60 * 1000; // 23h — allow slight drift
@@ -63,7 +63,7 @@ module.exports = {
 
         const [user, guildSettings] = await Promise.all([
             User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }),
-            Guild.findOne({ guildId: interaction.guild.id }),
+            getGuildSettings(interaction.guild.id),
         ]);
 
         if (!guildSettings?.quests?.enabled) {

--- a/src/commands/community/quests.js
+++ b/src/commands/community/quests.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const AiQuest = require('../../models/AiQuest');
 const { ensureQuests, getDailyPool, getWeeklyPool, getCategoryEmojis, getDifficultyColors } = require('../../services/questService');
 const COLORS = require('../../utils/embedColors');
@@ -21,7 +21,7 @@ module.exports = {
         .setDescription('View your active daily and weekly quests'),
 
     async execute(interaction) {
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
 
         if (!guildSettings?.quests?.enabled) {
             return interaction.reply({ content: 'Quests are not enabled on this server.', flags: MessageFlags.Ephemeral });

--- a/src/commands/community/track.js
+++ b/src/commands/community/track.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const COLORS = require('../../utils/embedColors');
 
 const TRACK_INFO = {
@@ -43,7 +43,7 @@ module.exports = {
 
     async execute(interaction) {
         const chosen = interaction.options.getString('choose');
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
 
         if (!guildSettings?.progressionTracks?.enabled) {
             return interaction.reply({ content: 'Progression tracks are not enabled on this server.', flags: MessageFlags.Ephemeral });

--- a/src/commands/economy/balance.js
+++ b/src/commands/economy/balance.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { pruneEffects, EFFECT_CONFIGS, timeRemaining, getServerCoinMultiplier, getServerXpMultiplier } = require('../../services/effectsService');
 const { getStreakMultiplier } = require('../../utils/streakMultiplier');
 const { claimStarterKit } = require('../../utils/starterKit');
@@ -20,7 +20,7 @@ module.exports = {
         try {
             const [user_raw, guildSettings] = await Promise.all([
                 User.findOne({ userId: targetUser.id, guildId: interaction.guild.id }),
-                Guild.findOne({ guildId: interaction.guild.id })
+                getGuildSettings(interaction.guild.id)
             ]);
 
             let user = user_raw;

--- a/src/commands/economy/bank.js
+++ b/src/commands/economy/bank.js
@@ -1,11 +1,11 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { logTransaction } = require('../../utils/logTransaction');
 const COLORS = require('../../utils/embedColors');
 
 async function getCurrency(guildId) {
-    const guildSettings = await Guild.findOne({ guildId });
+    const guildSettings = await getGuildSettings(guildId);
     return guildSettings?.economy?.currency ?? '💰';
 }
 

--- a/src/commands/economy/boost.js
+++ b/src/commands/economy/boost.js
@@ -50,7 +50,17 @@ module.exports = {
         const sub = interaction.options.getSubcommand();
 
         try {
-            const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+            // The one command here that writes the document back, so it reads a
+            // real Mongoose document rather than the cache's shared plain object.
+            // The exclusion is the cache's own projection: nothing on this path
+            // reads a shop image or a giveaway's entrant list, and hydrating up
+            // to 35 × 512 KB of Buffers to set one subdocument is the cost this
+            // issue is about. `save()` writes only the paths it modified, so an
+            // excluded field is untouched rather than cleared.
+            const guildSettings = await Guild.findOne(
+                { guildId: interaction.guild.id },
+                '-shop.imageData -giveaways.entrantIds',
+            );
             if (!guildSettings) {
                 return interaction.reply({ content: 'Guild settings not found.', flags: MessageFlags.Ephemeral });
             }

--- a/src/commands/economy/casino.js
+++ b/src/commands/economy/casino.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const User  = require('../../models/User');
 const { processJackpotBet, getJackpotDisplay } = require('../../services/casinoJackpotService');
 const { advanceMissions } = require('../../services/seasonMissionService');
@@ -59,7 +60,7 @@ module.exports = {
         return game?.cooldown ?? 3;
     },
     async execute(interaction) {
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
         if (guildSettings?.economy?.enabled === false) {
             return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
         }

--- a/src/commands/economy/craft.js
+++ b/src/commands/economy/craft.js
@@ -3,7 +3,7 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User  = require('../../models/User');
 const { attachGrind } = require('../../utils/grindProfile');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { CRAFT_RECIPES: HUNT_RECIPES, CONSUMABLES: HUNT_CONSUMABLES, MATERIAL_NAMES: HUNT_MAT_NAMES } = require('../../data/huntData');
 const { CRAFT_RECIPES: MINE_RECIPES, CONSUMABLES: MINE_CONSUMABLES, MATERIAL_NAMES: MINE_MAT_NAMES } = require('../../data/mineData');
 const { FISH_CRAFT_RECIPES, CONSUMABLES: FISH_CONSUMABLES, MATERIAL_NAMES: FISH_MAT_NAMES } = require('../../data/fishData');
@@ -49,7 +49,7 @@ module.exports = {
     async execute(interaction) {
         const sub = interaction.options.getSubcommand();
 
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
         if (guildSettings?.economy?.enabled === false) {
             return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
         }

--- a/src/commands/economy/crime.js
+++ b/src/commands/economy/crime.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags } = require('discord.js');
 const User  = require('../../models/User');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { hasEffect, consumeEffect } = require('../../services/effectsService');
 const { getMerchantCoinBonus } = require('../../services/synergyService');
 const { advanceMissions } = require('../../services/seasonMissionService');
@@ -112,7 +112,7 @@ module.exports = {
                 flags: MessageFlags.Ephemeral,
             });
         }
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
         if (guildSettings?.economy?.enabled === false) {
             return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
         }

--- a/src/commands/economy/daily.js
+++ b/src/commands/economy/daily.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { getStreakMultiplier } = require('../../utils/streakMultiplier');
 const { getCoinMultiplier, getServerCoinMultiplier } = require('../../services/effectsService');
 const { logTransaction } = require('../../utils/logTransaction');
@@ -147,7 +147,7 @@ module.exports = {
                     { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
                     { upsert: true, new: true }
                 ),
-                Guild.findOne({ guildId: interaction.guild.id })
+                getGuildSettings(interaction.guild.id)
             ]);
 
             const now = Date.now();

--- a/src/commands/economy/dailychallenge.js
+++ b/src/commands/economy/dailychallenge.js
@@ -2,7 +2,7 @@
 
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { hasUnlock } = require('../../utils/prestige');
 const { logTransaction } = require('../../utils/logTransaction');
 const COLORS = require('../../utils/embedColors');
@@ -38,7 +38,7 @@ module.exports = {
     async execute(interaction) {
         const [userDoc, guildSettings] = await Promise.all([
             User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }),
-            Guild.findOne({ guildId: interaction.guild.id }),
+            getGuildSettings(interaction.guild.id),
         ]);
 
         const rank = userDoc?.accountPrestige?.rank ?? 0;

--- a/src/commands/economy/duel.js
+++ b/src/commands/economy/duel.js
@@ -9,7 +9,7 @@ const {
 const { randomInt } = require('crypto');
 const User = require('../../models/User');
 const { advanceMissions } = require('../../services/seasonMissionService');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { isDistrictActive } = require('../../services/districtService');
 const { START_ELO, tierFor, applyElo, makeSeasonId } = require('../../utils/duelElo');
 const COLORS = require('../../utils/embedColors');
@@ -145,7 +145,7 @@ async function revertDuelCooldown(challengerId, opponentId, guildId, prevChallen
 async function finalizeDuel({ interaction, targetUser, challengerId, opponentId, amount, currency, houseCut, challengerWins, tie, game, gameResult, isRanked = false }) {
     const guildId = interaction.guild.id;
     // Escrow already deducted both stakes; compute payout from pot
-    const guildDoc = await Guild.findOne({ guildId }).lean();
+    const guildDoc = await getGuildSettings(guildId);
     const arenaActive = isDistrictActive(guildDoc, 'arena');
     const pot         = 2 * amount;
     const houseAmount = Math.floor(pot * houseCut);
@@ -455,7 +455,7 @@ async function runRPS(interaction, msg, targetUser, amount, currency, houseCut, 
 }
 
 async function runChallenge(interaction, isRanked) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
 
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
@@ -634,7 +634,7 @@ async function runRankView(interaction) {
     const higher = await User.countDocuments({ guildId, 'ranked.elo': { $gt: elo } });
     const rankPosition = higher + 1;
 
-    const guildSettings = await Guild.findOne({ guildId }, 'rankedDuels').lean();
+    const guildSettings = await getGuildSettings(guildId);
     const seasonId = guildSettings?.rankedDuels?.currentSeasonId
         ?? makeSeasonId(guildSettings?.rankedDuels?.seasonNumber ?? 1);
 
@@ -684,7 +684,7 @@ async function runLeaderboard(interaction) {
         return `${medal}  ${tier.icon} **${name}** — ${elo} ELO · ${wl}`;
     }));
 
-    const guildSettings = await Guild.findOne({ guildId }, 'rankedDuels').lean();
+    const guildSettings = await getGuildSettings(guildId);
     const seasonId = guildSettings?.rankedDuels?.currentSeasonId
         ?? makeSeasonId(guildSettings?.rankedDuels?.seasonNumber ?? 1);
     const seasonEnds = guildSettings?.rankedDuels?.seasonEndsAt

--- a/src/commands/economy/event/lovenote.js
+++ b/src/commands/economy/event/lovenote.js
@@ -1,6 +1,6 @@
 const { EmbedBuilder } = require('discord.js');
 const User = require('../../../models/User');
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const { logTransaction } = require('../../../utils/logTransaction');
 const { saveWithBalanceDelta } = require('../../../utils/balanceDelta');
 const { grantInventoryItem } = require('../../../utils/inventoryGrant');
@@ -33,7 +33,7 @@ const REJECTION_OUTCOMES = [
 async function handleLoveNote(interaction) {
     await interaction.deferReply();
 
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
 
     if (!hasActiveEvent(guildSettings) || guildSettings.activeEvent.type !== 'valentines_day') {
         return interaction.editReply({

--- a/src/commands/economy/event/manage.js
+++ b/src/commands/economy/event/manage.js
@@ -11,6 +11,7 @@
 
 const { EmbedBuilder, PermissionFlagsBits, MessageFlags } = require('discord.js');
 const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const { SEASONAL_EVENTS } = require('../../../data/seasonalEvents');
 const { buildClearedEvent } = require('../../../services/seasonalEventService');
 const COLORS = require('../../../utils/embedColors');
@@ -27,7 +28,7 @@ const EVENT_TYPE_CHOICES = [
 async function handleStatus(interaction) {
     await interaction.deferReply();
 
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     const ev = guildSettings?.activeEvent;
 
     if (!ev?.type) {
@@ -69,7 +70,12 @@ async function handleStatus(interaction) {
 async function handleStart(interaction) {
     await interaction.deferReply();
 
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    // Read through the model rather than getGuildSettings: this value decides
+    // whether the write below happens, and a cached read would put up to a TTL
+    // between the two — long enough for a second /event start to pass the same
+    // check. The projection is what made the cached read worth having, so the
+    // read stays narrow either way.
+    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id }, 'activeEvent').lean();
     const current = guildSettings?.activeEvent;
 
     if (current?.type && !(current.endsAt && new Date(current.endsAt) <= new Date())) {
@@ -155,7 +161,8 @@ async function handleStart(interaction) {
 async function handleEnd(interaction) {
     await interaction.deferReply();
 
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    // Uncached and projected, for the reason handleStart gives.
+    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id }, 'activeEvent').lean();
     const current = guildSettings?.activeEvent;
 
     if (!current?.type) {

--- a/src/commands/economy/event/sandcastle.js
+++ b/src/commands/economy/event/sandcastle.js
@@ -1,6 +1,6 @@
 const { EmbedBuilder } = require('discord.js');
 const User = require('../../../models/User');
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const { logTransaction } = require('../../../utils/logTransaction');
 const { saveWithBalanceDelta } = require('../../../utils/balanceDelta');
 const { grantInventoryItem } = require('../../../utils/inventoryGrant');
@@ -33,7 +33,7 @@ const WAVE_OUTCOMES = [
 async function handleSandcastle(interaction) {
     await interaction.deferReply();
 
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
 
     if (!hasActiveEvent(guildSettings) || guildSettings.activeEvent.type !== 'summer_festival') {
         return interaction.editReply({

--- a/src/commands/economy/event/snowball.js
+++ b/src/commands/economy/event/snowball.js
@@ -1,6 +1,6 @@
 const { EmbedBuilder } = require('discord.js');
 const User = require('../../../models/User');
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const { logTransaction } = require('../../../utils/logTransaction');
 const { debitUpTo } = require('../../../utils/balanceDebit');
 const {
@@ -18,7 +18,7 @@ const COIN_STEAL_RATE  = 0.05;          // steal 5% of target's wallet on hit
 async function handleSnowball(interaction) {
     await interaction.deferReply();
 
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
 
     if (!hasActiveEvent(guildSettings) || guildSettings.activeEvent.type !== 'winter_wonderland') {
         return interaction.editReply({

--- a/src/commands/economy/event/trackhunt.js
+++ b/src/commands/economy/event/trackhunt.js
@@ -1,6 +1,6 @@
 const { EmbedBuilder } = require('discord.js');
 const User = require('../../../models/User');
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const { logTransaction } = require('../../../utils/logTransaction');
 const { saveWithBalanceDelta } = require('../../../utils/balanceDelta');
 const { grantInventoryItem } = require('../../../utils/inventoryGrant');
@@ -33,7 +33,7 @@ const LOST_OUTCOMES = [
 async function handleTrackHunt(interaction) {
     await interaction.deferReply();
 
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
 
     if (!hasActiveEvent(guildSettings) || guildSettings.activeEvent.type !== 'winter_hunt') {
         return interaction.editReply({

--- a/src/commands/economy/event/trickortreat.js
+++ b/src/commands/economy/event/trickortreat.js
@@ -1,6 +1,6 @@
 const { EmbedBuilder } = require('discord.js');
 const User = require('../../../models/User');
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const { logTransaction } = require('../../../utils/logTransaction');
 const { saveWithBalanceDelta } = require('../../../utils/balanceDelta');
 const { grantInventoryItem } = require('../../../utils/inventoryGrant');
@@ -32,7 +32,7 @@ const TRICK_OUTCOMES = [
 async function handleTrickOrTreat(interaction) {
     await interaction.deferReply();
 
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
 
     if (!hasActiveEvent(guildSettings) || guildSettings.activeEvent.type !== 'spooky_season') {
         return interaction.editReply({

--- a/src/commands/economy/eventshop.js
+++ b/src/commands/economy/eventshop.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
 const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { SEASONAL_EVENTS } = require('../../data/seasonalEvents');
 const {
     hasActiveEvent,
@@ -43,7 +44,7 @@ module.exports = {
     async execute(interaction) {
         const sub = interaction.options.getSubcommand();
 
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
 
         if (!hasActiveEvent(guildSettings)) {
             return interaction.reply({

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -7,7 +7,7 @@ const { isVersionError } = require('../../utils/versionRetry');
 const { detachBalanceDelta, commitBalanceDelta } = require('../../utils/balanceDelta');
 const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const GrindProfile = require('../../models/GrindProfile');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const {
     LIMITS, EXPLORER_LEVELS, TIER_COLORS, REGIONS, REGION_LIST,
     RELIC_LIST, RELIC_RARITY_ORDER, TOTAL_CORE_RELICS,
@@ -166,7 +166,7 @@ module.exports = {
 
 // Returns the guild doc, or null after replying if exploration is switched off.
 async function loadGuildOrReply(interaction) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         await interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
         return null;

--- a/src/commands/economy/featured.js
+++ b/src/commands/economy/featured.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { getDailyFeatured, FEATURED_PAYOUT_BONUS, FEATURED_RARE_BONUS } = require('../../data/featuredRotation');
 const { getTimeBand } = require('../../utils/timeBand');
 const COLORS = require('../../utils/embedColors');
@@ -14,7 +14,7 @@ module.exports = {
     cooldown: 5,
 
     async execute(interaction) {
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
         if (guildSettings?.economy?.enabled === false) {
             return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
         }

--- a/src/commands/economy/feed.js
+++ b/src/commands/economy/feed.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
-const Guild  = require('../../models/Guild');
 const BigWin = require('../../models/BigWin');
 const COLORS = require('../../utils/embedColors');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 
 const SOURCE_LABELS = {
     hunt:         '🏹 Hunt',
@@ -31,7 +31,7 @@ module.exports = {
     cooldown: 10,
 
     async execute(interaction) {
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
         if (guildSettings?.economy?.enabled === false) {
             return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
         }

--- a/src/commands/economy/fish/cast.js
+++ b/src/commands/economy/fish/cast.js
@@ -6,6 +6,7 @@
 const { TIER_NUM, TIER_STARS } = require('../../../data/materialRarity');
 const { EmbedBuilder, MessageFlags, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const User = require('../../../models/User');
 const {
     prepareCastUser,
@@ -52,7 +53,7 @@ const { stagedLootReveal } = require('../../../utils/stagedLootReveal');
 // ═══════════════════════════════════════════════════════════════════════════════
 
 async function handleCast(interaction) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }

--- a/src/commands/economy/fish/craft.js
+++ b/src/commands/economy/fish/craft.js
@@ -3,7 +3,7 @@
 // /fish craft — recipes, and spending materials (fishing and hunting alike) on
 // one.
 
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const { MessageFlags, EmbedBuilder } = require('discord.js');
 const User = require('../../../models/User');
 const { attachGrind } = require('../../../utils/grindProfile');
@@ -18,7 +18,7 @@ const COLORS = require('../../../utils/embedColors');
 // ═══════════════════════════════════════════════════════════════════════════════
 
 async function handleCraft(interaction, sub) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }

--- a/src/commands/economy/fish/location.js
+++ b/src/commands/economy/fish/location.js
@@ -3,7 +3,7 @@
 // /fish location — where the player fishes, and switching between the spots
 // they have unlocked.
 
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const { MessageFlags, EmbedBuilder } = require('discord.js');
 const User = require('../../../models/User');
 const { attachGrind } = require('../../../utils/grindProfile');
@@ -17,7 +17,7 @@ const COLORS = require('../../../utils/embedColors');
 // ═══════════════════════════════════════════════════════════════════════════════
 
 async function handleLocation(interaction, sub) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }

--- a/src/commands/economy/fish/profile.js
+++ b/src/commands/economy/fish/profile.js
@@ -4,7 +4,7 @@
 // and what they have become.
 
 const User = require('../../../models/User');
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const { attachGrind } = require('../../../utils/grindProfile');
 const { MessageFlags, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const {
@@ -46,7 +46,7 @@ async function handleProfile(interaction) {
 
     const [userData, guildSettings] = await Promise.all([
         User.findOne({ userId: target.id, guildId: interaction.guild.id }),
-        Guild.findOne({ guildId: interaction.guild.id })
+        getGuildSettings(interaction.guild.id)
     ]);
     await attachGrind(userData);
 
@@ -192,7 +192,7 @@ async function handleProfile(interaction) {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 async function handlePrestige(interaction) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }
@@ -335,7 +335,7 @@ async function handlePrestige(interaction) {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 async function handleInv(interaction, sub) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }
@@ -523,7 +523,7 @@ async function checkGrandPrestige(client, user, guild, guildId) {
     ).catch(() => {});
 
     // Broadcast to economy channel
-    const guildSettings = await Guild.findOne({ guildId }, 'economy accountPrestige').lean().catch(() => null);
+    const guildSettings = await getGuildSettings(guildId).catch(() => null);
     const announceChannelId = guildSettings?.accountPrestige?.announceChannelId
         ?? guildSettings?.economy?.announcementChannelId
         ?? null;

--- a/src/commands/economy/fish/quests.js
+++ b/src/commands/economy/fish/quests.js
@@ -2,7 +2,7 @@
 
 // /fish quests — the daily quest board and claiming a finished one.
 
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const { MessageFlags, EmbedBuilder } = require('discord.js');
 const User = require('../../../models/User');
 const { attachGrind } = require('../../../utils/grindProfile');
@@ -17,7 +17,7 @@ const COLORS = require('../../../utils/embedColors');
 // ═══════════════════════════════════════════════════════════════════════════════
 
 async function handleQuests(interaction, sub) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }

--- a/src/commands/economy/fish/shop/index.js
+++ b/src/commands/economy/fish/shop/index.js
@@ -12,7 +12,7 @@
 // commands/<category>/<name>/index.js registers as a command, so nothing under
 // fish/ is ever a command of its own.
 
-const Guild = require('../../../../models/Guild');
+const { getGuildSettings } = require('../../../../utils/guildSettingsCache');
 const { MessageFlags } = require('discord.js');
 const User = require('../../../../models/User');
 const { attachGrind } = require('../../../../utils/grindProfile');
@@ -27,7 +27,7 @@ const { handleRepair } = require('./repair');
 const { handleUnlock } = require('./unlock');
 
 async function handleShop(interaction, sub) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }

--- a/src/commands/economy/fish/tournament.js
+++ b/src/commands/economy/fish/tournament.js
@@ -12,7 +12,7 @@ const {
     startTournament
 } = require('../../../services/tournamentService');
 const { EmbedBuilder, MessageFlags } = require('discord.js');
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const COLORS = require('../../../utils/embedColors');
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -42,7 +42,7 @@ async function handleTournamentStatus(interaction) {
     // Auto-end if expired
     if (new Date() > tournament.endsAt) {
         const ended = await endTournament(tournament._id);
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
         const currency = guildSettings?.economy?.currency ?? '💰';
         const announceChannelId = ended.announceChannelId ?? guildSettings?.economy?.announcementChannelId ?? null;
         announceTournamentEnd(interaction.client, ended, interaction.guild.id, announceChannelId).catch(() => null);
@@ -63,7 +63,7 @@ async function handleTournamentStart(interaction) {
     const durationMins = interaction.options.getInteger('duration') ?? 60;
     const seedAmount   = interaction.options.getInteger('prize_pool') ?? 0;
     const entryFee     = interaction.options.getInteger('entry_fee') ?? 0;
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     const announceChannelId = guildSettings?.economy?.announcementChannelId ?? null;
 
     let tournament;
@@ -107,7 +107,7 @@ async function handleTournamentStart(interaction) {
 async function handleRecords(interaction) {
     await interaction.deferReply();
 
-    const guildDoc = await Guild.findOne({ guildId: interaction.guild.id }, 'fishingWorldRecords').lean().catch(() => null);
+    const guildDoc = await getGuildSettings(interaction.guild.id).catch(() => null);
     const records  = (guildDoc?.fishingWorldRecords ?? [])
         .sort((a, b) => b.weight - a.weight)
         .slice(0, 15);

--- a/src/commands/economy/forge.js
+++ b/src/commands/economy/forge.js
@@ -2,12 +2,12 @@
 
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const User    = require('../../models/User');
-const Guild   = require('../../models/Guild');
 const AiItem  = require('../../models/AiItem');
 const { resolveProviderConfig, getCompletion } = require('../../services/aiService');
 const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const { requestModelJson } = require('../../utils/modelJson');
 const cooldownStore = require('../../utils/commandCooldowns');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 
 const RARITY_CONFIG = {
     common:    { label: 'Common',    emoji: '⚪', color: 0xAAAAAA, cost: 500,   xpReward: 25  },
@@ -105,7 +105,7 @@ module.exports = {
 
         const [user, guildSettings] = await Promise.all([
             User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }),
-            Guild.findOne({ guildId: interaction.guild.id }),
+            getGuildSettings(interaction.guild.id),
         ]);
 
         if (!guildSettings?.ai?.enabled) {

--- a/src/commands/economy/gift.js
+++ b/src/commands/economy/gift.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User  = require('../../models/User');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { getItemLore } = require('../../data/defaultShopItems');
 const { logTransaction } = require('../../utils/logTransaction');
 const { grantInventoryItem } = require('../../utils/inventoryGrant');
@@ -53,7 +53,7 @@ module.exports = {
                 .setMinValue(1)),
 
     async execute(interaction) {
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
         if (guildSettings?.economy?.enabled === false) {
             return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
         }

--- a/src/commands/economy/heist.js
+++ b/src/commands/economy/heist.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder, MessageFlags } = require('discord.js');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const User  = require('../../models/User');
 const {
     getHeist,
@@ -37,7 +37,7 @@ module.exports = {
     cooldownAmount: () => 5,
 
     async execute(interaction, client) {
-        const guildDoc = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildDoc = await getGuildSettings(interaction.guild.id);
 
         if (!guildDoc?.economy?.enabled) {
             return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });

--- a/src/commands/economy/hunt/inventory.js
+++ b/src/commands/economy/hunt/inventory.js
@@ -5,7 +5,7 @@
 const { WEAPON_BY_TIER, CONSUMABLES, MATERIAL_NAMES } = require('../../../data/huntData');
 const { weaponStatusEmoji, durabilityBar, repairsRemaining, ensureHuntData } = require('../../../services/huntService');
 const { chunkByLength } = require('../../../utils/embedFields');
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const { MessageFlags, EmbedBuilder } = require('discord.js');
 const User = require('../../../models/User');
 const { attachGrind } = require('../../../utils/grindProfile');
@@ -51,7 +51,7 @@ function buildWeaponPages(h) {
 }
 
 async function executeInv(interaction, sub) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }

--- a/src/commands/economy/hunt/profile.js
+++ b/src/commands/economy/hunt/profile.js
@@ -4,7 +4,7 @@
 // they have become, and where they stand against everyone else.
 
 const User = require('../../../models/User');
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const { attachGrind } = require('../../../utils/grindProfile');
 const { MessageFlags, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const {
@@ -36,7 +36,7 @@ async function executeProfile(interaction) {
 
     const [userData, guildSettings] = await Promise.all([
         User.findOne({ userId: target.id, guildId: interaction.guild.id }),
-        Guild.findOne({ guildId: interaction.guild.id })
+        getGuildSettings(interaction.guild.id)
     ]);
     await attachGrind(userData);
 
@@ -255,7 +255,7 @@ function buildTodayField(user, currency) {
 }
 
 async function executePrestige(interaction) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }
@@ -406,7 +406,7 @@ async function topHuntersBy(guildId, sort, filter, fields, line, limit = 3) {
 
 async function executeRecords(interaction) {
     await interaction.deferReply();
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id }, 'economy').lean().catch(() => null);
+    const guildSettings = await getGuildSettings(interaction.guild.id).catch(() => null);
     const currency = guildSettings?.economy?.currency ?? '💰';
     const guildId  = interaction.guild.id;
 
@@ -486,7 +486,7 @@ async function checkGrandPrestige(client, user, guild, guildId) {
         { $set: { 'grandPrestige.level': 1, 'grandPrestige.awardedAt': new Date() } }
     ).catch(() => {});
 
-    const guildSettings = await Guild.findOne({ guildId }, 'economy accountPrestige').lean().catch(() => null);
+    const guildSettings = await getGuildSettings(guildId).catch(() => null);
     const announceChannelId = guildSettings?.accountPrestige?.announceChannelId
         ?? guildSettings?.economy?.announcementChannelId
         ?? null;

--- a/src/commands/economy/hunt/quests.js
+++ b/src/commands/economy/hunt/quests.js
@@ -2,7 +2,7 @@
 
 // /hunt quests — the daily quest board and claiming a finished one.
 
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const { MessageFlags, EmbedBuilder } = require('discord.js');
 const User = require('../../../models/User');
 const { attachGrind } = require('../../../utils/grindProfile');
@@ -17,7 +17,7 @@ const COLORS = require('../../../utils/embedColors');
 // ═══════════════════════════════════════════════════════════════════════════════
 
 async function executeQuests(interaction, sub) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }

--- a/src/commands/economy/hunt/shop/index.js
+++ b/src/commands/economy/hunt/shop/index.js
@@ -13,7 +13,7 @@
 // commands/<category>/<name>/index.js registers as a command, so nothing under
 // hunt/ is ever a command of its own.
 
-const Guild = require('../../../../models/Guild');
+const { getGuildSettings } = require('../../../../utils/guildSettingsCache');
 const { MessageFlags } = require('discord.js');
 const User = require('../../../../models/User');
 const { attachGrind } = require('../../../../utils/grindProfile');
@@ -35,7 +35,7 @@ const {
 } = require('./pricing');
 
 async function executeShop(interaction, sub) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }

--- a/src/commands/economy/hunt/start.js
+++ b/src/commands/economy/hunt/start.js
@@ -5,7 +5,7 @@
 
 const { TIER_NUM, TIER_STARS } = require('../../../data/materialRarity');
 const { EmbedBuilder, MessageFlags, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const User = require('../../../models/User');
 const {
     prepareHuntUser,
@@ -49,7 +49,7 @@ const { stagedLootReveal } = require('../../../utils/stagedLootReveal');
 // ═══════════════════════════════════════════════════════════════════════════════
 
 async function executeStart(interaction) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }

--- a/src/commands/economy/hunt/zone.js
+++ b/src/commands/economy/hunt/zone.js
@@ -3,7 +3,7 @@
 // /hunt zone — where the player hunts, and switching between the zones they
 // have unlocked.
 
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const { MessageFlags, EmbedBuilder } = require('discord.js');
 const User = require('../../../models/User');
 const { attachGrind } = require('../../../utils/grindProfile');
@@ -16,7 +16,7 @@ const COLORS = require('../../../utils/embedColors');
 // ═══════════════════════════════════════════════════════════════════════════════
 
 async function executeZone(interaction, sub) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }

--- a/src/commands/economy/inventory.js
+++ b/src/commands/economy/inventory.js
@@ -2,7 +2,7 @@ const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, Butt
 const User    = require('../../models/User');
 const AiItem  = require('../../models/AiItem');
 const { attachGrind } = require('../../utils/grindProfile');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { pruneEffects, EFFECT_CONFIGS, timeRemaining } = require('../../services/effectsService');
 const { MATERIAL_RARITY, TIER_LABELS, TIER_STARS, TIER_COLORS } = require('../../data/materialRarity');
 const { getItemLore } = require('../../data/defaultShopItems');
@@ -237,7 +237,7 @@ module.exports = {
 
         const [userData, guildSettings] = await Promise.all([
             User.findOne({ userId: target.id, guildId: interaction.guild.id }),
-            Guild.findOne({ guildId: interaction.guild.id })
+            getGuildSettings(interaction.guild.id)
         ]);
         await attachGrind(userData);
 

--- a/src/commands/economy/jobs.js
+++ b/src/commands/economy/jobs.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const DEFAULT_JOBS = require('../../data/defaultJobs');
 const DEFAULT_TIERS = require('../../data/defaultTiers');
 const COLORS = require('../../utils/embedColors');
@@ -23,7 +23,7 @@ module.exports = {
         try {
             const [user, guildSettings] = await Promise.all([
                 User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }),
-                Guild.findOne({ guildId: interaction.guild.id }),
+                getGuildSettings(interaction.guild.id),
             ]);
 
             const tierInfo = resolveTiers(guildSettings);

--- a/src/commands/economy/market.js
+++ b/src/commands/economy/market.js
@@ -4,7 +4,6 @@ const {
     MessageFlags,
 } = require('discord.js');
 const User           = require('../../models/User');
-const Guild          = require('../../models/Guild');
 const MarketListing  = require('../../models/MarketListing');
 const Transaction    = require('../../models/Transaction');
 const { DEFAULT_SHOP_ITEMS, getItemLore, getItemRarity, RARITY_ORDER } = require('../../data/defaultShopItems');
@@ -14,6 +13,7 @@ const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const { recordOwedPayout } = require('../../utils/owedPayout');
 const COLORS = require('../../utils/embedColors');
 const { ownedBy } = require('../../utils/collectorOwner');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 
 const ITEM_META = Object.fromEntries(DEFAULT_SHOP_ITEMS.map(i => [i.itemId, i]));
 
@@ -65,7 +65,7 @@ module.exports = {
                     o.setName('listing_id').setDescription('Listing ID to cancel.').setRequired(true))),
 
     async execute(interaction) {
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
         if (guildSettings?.economy?.enabled === false) {
             return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
         }

--- a/src/commands/economy/mine/dig.js
+++ b/src/commands/economy/mine/dig.js
@@ -5,7 +5,7 @@
 
 const { TIER_NUM, TIER_STARS } = require('../../../data/materialRarity');
 const { EmbedBuilder, MessageFlags, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const User = require('../../../models/User');
 const {
     prepareDigUser,
@@ -48,7 +48,7 @@ const VEIN_ANSWER_MS    = 10_000;
 // ─── DIG ──────────────────────────────────────────────────────────────────────
 
 async function handleDig(interaction) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }

--- a/src/commands/economy/mine/inventory.js
+++ b/src/commands/economy/mine/inventory.js
@@ -2,7 +2,7 @@
 
 // The /mine inv group — pickaxes, consumables and ore.
 
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const { MessageFlags, EmbedBuilder } = require('discord.js');
 const User = require('../../../models/User');
 const { attachGrind } = require('../../../utils/grindProfile');
@@ -14,7 +14,7 @@ const COLORS = require('../../../utils/embedColors');
 // ─── INV ──────────────────────────────────────────────────────────────────────
 
 async function handleInv(interaction, sub) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }

--- a/src/commands/economy/mine/map.js
+++ b/src/commands/economy/mine/map.js
@@ -2,7 +2,7 @@
 
 // /mine map — the depths, and which of them the player has opened.
 
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const { MessageFlags, EmbedBuilder } = require('discord.js');
 const User = require('../../../models/User');
 const { attachGrind } = require('../../../utils/grindProfile');
@@ -12,7 +12,7 @@ const { DEPTHS, MATERIAL_NAMES } = require('../../../data/mineData');
 // ─── MAP ──────────────────────────────────────────────────────────────────────
 
 async function handleMap(interaction) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }

--- a/src/commands/economy/mine/profile.js
+++ b/src/commands/economy/mine/profile.js
@@ -3,7 +3,7 @@
 // /mine profile and /mine prestige: what the miner has and what they have
 // become.
 
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const { MessageFlags, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const User = require('../../../models/User');
 const { attachGrind } = require('../../../utils/grindProfile');
@@ -24,7 +24,7 @@ const { buildXpBar, prestigeBonusLines } = require('./embeds');
 const COLORS = require('../../../utils/embedColors');
 
 async function handlePrestige(interaction) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }
@@ -208,7 +208,7 @@ async function handleProfile(interaction) {
 
     const [userData, guildSettings] = await Promise.all([
         User.findOne({ userId: target.id, guildId: interaction.guild.id }),
-        Guild.findOne({ guildId: interaction.guild.id })
+        getGuildSettings(interaction.guild.id)
     ]);
     await attachGrind(userData);
 

--- a/src/commands/economy/mine/quests.js
+++ b/src/commands/economy/mine/quests.js
@@ -2,7 +2,7 @@
 
 // /mine quests — the daily quest board and claiming a finished one.
 
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const { MessageFlags, EmbedBuilder } = require('discord.js');
 const User = require('../../../models/User');
 const { attachGrind } = require('../../../utils/grindProfile');
@@ -15,7 +15,7 @@ const COLORS = require('../../../utils/embedColors');
 // ─── QUESTS ───────────────────────────────────────────────────────────────────
 
 async function handleQuests(interaction, sub) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }

--- a/src/commands/economy/mine/raid.js
+++ b/src/commands/economy/mine/raid.js
@@ -3,7 +3,7 @@
 // /mine raid — taking ore off another player, and the locks that keep the two
 // sides of that from racing each other.
 
-const Guild = require('../../../models/Guild');
+const { getGuildSettings } = require('../../../utils/guildSettingsCache');
 const { MessageFlags, EmbedBuilder } = require('discord.js');
 const User = require('../../../models/User');
 const { attachGrind, persistGrindIfNew } = require('../../../utils/grindProfile');
@@ -17,7 +17,7 @@ const COLORS = require('../../../utils/embedColors');
 // ─── RAID ─────────────────────────────────────────────────────────────────────
 
 async function handleRaid(interaction) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }

--- a/src/commands/economy/mine/shop/index.js
+++ b/src/commands/economy/mine/shop/index.js
@@ -13,7 +13,7 @@
 // commands/<category>/<name>/index.js registers as a command, so nothing under
 // mine/ is ever a command of its own.
 
-const Guild = require('../../../../models/Guild');
+const { getGuildSettings } = require('../../../../utils/guildSettingsCache');
 const { MessageFlags } = require('discord.js');
 const User = require('../../../../models/User');
 const { attachGrind } = require('../../../../utils/grindProfile');
@@ -28,7 +28,7 @@ const { handleRepair } = require('./repair');
 const { handleUnlock } = require('./unlock');
 
 async function handleShop(interaction, sub) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
     }

--- a/src/commands/economy/pet.js
+++ b/src/commands/economy/pet.js
@@ -8,7 +8,7 @@ const User  = require('../../models/User');
 const { DECEASED_PET_LIMIT } = User;
 const { attachGrind } = require('../../utils/grindProfile');
 const { isVersionError, withVersionRetry } = require('../../utils/versionRetry');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const {
     PET_DEFINITIONS,
     PERSONALITY_TRAITS,
@@ -422,7 +422,7 @@ async function executeAdopt(interaction) {
         });
     }
 
-    const [user, guildSettings] = await Promise.all([resolveUser(interaction), Guild.findOne({ guildId: interaction.guild.id })]);
+    const [user, guildSettings] = await Promise.all([resolveUser(interaction), getGuildSettings(interaction.guild.id)]);
 
     if (guildSettings?.economy?.enabled === false) return interaction.reply({ content: 'The economy is disabled in this server.', flags: MessageFlags.Ephemeral });
     if ((user.pets ?? []).some(p => p.petId === petId)) return interaction.reply({ content: `You already own a ${def.emoji} **${def.name}**!`, flags: MessageFlags.Ephemeral });
@@ -506,7 +506,7 @@ async function executeStatus(interaction) {
 
     const [user, guildSettings] = await Promise.all([
         resolveUser(interaction),
-        Guild.findOne({ guildId: interaction.guild.id }),
+        getGuildSettings(interaction.guild.id),
     ]);
     await syncHungerAndRunaway(user, interaction);
 
@@ -724,7 +724,7 @@ async function executeFeed(interaction) {
 
     await interaction.deferReply();
 
-    const [user, guildSettings] = await Promise.all([resolveUser(interaction), Guild.findOne({ guildId: interaction.guild.id })]);
+    const [user, guildSettings] = await Promise.all([resolveUser(interaction), getGuildSettings(interaction.guild.id)]);
     await syncHungerAndRunaway(user, interaction);
 
     if (!user.pets || user.pets.length === 0) return interaction.editReply('You have no pets to feed!');
@@ -983,7 +983,7 @@ async function executeBattle(interaction) {
     const petRef   = readSlotOption(interaction);
     const bet      = interaction.options.getInteger('bet') ?? 0;
 
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     if (guildSettings?.economy?.enabled === false) {
         return interaction.reply({ content: 'The economy is disabled in this server.', flags: MessageFlags.Ephemeral });
     }

--- a/src/commands/economy/prestige.js
+++ b/src/commands/economy/prestige.js
@@ -4,7 +4,7 @@ const {
     MessageFlags,
 } = require('discord.js');
 const User  = require('../../models/User');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const COLORS = require('../../utils/embedColors');
 const { ownedBy } = require('../../utils/collectorOwner');
 const {
@@ -54,7 +54,7 @@ async function handleStatus(interaction) {
     const rank = userDoc?.accountPrestige?.rank ?? 0;
     const tier = tierFor(rank);
     const next = nextTierAfter(rank);
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id }, 'accountPrestige').lean();
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     const minLevel = guildSettings?.accountPrestige?.minLevelToPrestige ?? 50;
 
     const unlocks = tier.unlocks?.length
@@ -95,7 +95,7 @@ async function handleInfo(interaction) {
 
 async function handleUp(interaction) {
     const guildId = interaction.guild.id;
-    const guildSettings = await Guild.findOne({ guildId }, 'accountPrestige economy').lean();
+    const guildSettings = await getGuildSettings(guildId);
 
     if (guildSettings?.accountPrestige?.enabled === false) {
         return interaction.reply({ content: 'Account prestige is disabled on this server.', flags: MessageFlags.Ephemeral });

--- a/src/commands/economy/quiz.js
+++ b/src/commands/economy/quiz.js
@@ -9,7 +9,7 @@ const {
 const axios = require('axios');
 const User  = require('../../models/User');
 const { advanceMissions } = require('../../services/seasonMissionService');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const FALLBACK_QUESTIONS = require('../../data/quizFallback');
 const { buildCooldownEmbed } = require('../../utils/cooldownEmbed');
 const { debitUpTo } = require('../../utils/balanceDebit');
@@ -219,7 +219,7 @@ module.exports = {
                 flags: MessageFlags.Ephemeral,
             });
         }
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
         if (guildSettings?.economy?.enabled === false) {
             return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
         }

--- a/src/commands/economy/rob.js
+++ b/src/commands/economy/rob.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User  = require('../../models/User');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { hasEffect, consumeEffect, timeRemaining } = require('../../services/effectsService');
 const { checkAndAward, announceAchievements } = require('../../services/achievementService');
 const { getTotalBonus } = require('../../services/petService');
@@ -151,7 +151,7 @@ module.exports = {
                 .setRequired(true)),
 
     async execute(interaction) {
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
         if (guildSettings?.economy?.enabled === false) {
             return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
         }

--- a/src/commands/economy/robstatus.js
+++ b/src/commands/economy/robstatus.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User  = require('../../models/User');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { getPublicProtectionStatus, timeRemaining } = require('../../services/effectsService');
 const COLORS = require('../../utils/embedColors');
 
@@ -20,7 +20,7 @@ module.exports = {
                 .setRequired(true)),
 
     async execute(interaction) {
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
         if (guildSettings?.economy?.enabled === false) {
             return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
         }

--- a/src/commands/economy/season.js
+++ b/src/commands/economy/season.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, EmbedBuilder, PermissionFlagsBits, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
 const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const SeasonRecord = require('../../models/SeasonRecord');
 const { ensureMissions: ensureMissionsShared } = require('../../services/seasonMissionService');
 const { SEASONAL_EVENTS } = require('../../data/seasonalEvents');
@@ -67,15 +68,23 @@ async function ensureMissions(user) {
 
 // ── Subcommand handlers ───────────────────────────────────────────────────────
 
-async function executeView(interaction) {
-    const [user, guildSettings] = await Promise.all([
+// Every player-facing subcommand opens the same way, and did so in seven
+// identical copies: the caller's row, created on first use, and the guild's
+// settings read beside it. The settings read goes through the cache (#877), so
+// the round trip this waits on is the upsert alone.
+async function loadPlayerAndSettings(interaction) {
+    return Promise.all([
         User.findOneAndUpdate(
             { userId: interaction.user.id, guildId: interaction.guild.id },
             { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
             { upsert: true, new: true }
         ),
-        Guild.findOne({ guildId: interaction.guild.id })
+        getGuildSettings(interaction.guild.id),
     ]);
+}
+
+async function executeView(interaction) {
+    const [user, guildSettings] = await loadPlayerAndSettings(interaction);
 
     const season = guildSettings?.season;
     if (!season?.enabled || !season?.seasonId) {
@@ -146,14 +155,7 @@ async function executeView(interaction) {
 
 async function executeClaim(interaction) {
     const tier = interaction.options.getInteger('tier');
-    const [user, guildSettings] = await Promise.all([
-        User.findOneAndUpdate(
-            { userId: interaction.user.id, guildId: interaction.guild.id },
-            { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
-            { upsert: true, new: true }
-        ),
-        Guild.findOne({ guildId: interaction.guild.id })
-    ]);
+    const [user, guildSettings] = await loadPlayerAndSettings(interaction);
 
     const season = guildSettings?.season;
     if (!season?.enabled || !season?.seasonId) {
@@ -307,14 +309,7 @@ async function executeClaim(interaction) {
 }
 
 async function executeUnlock(interaction) {
-    const [user, guildSettings] = await Promise.all([
-        User.findOneAndUpdate(
-            { userId: interaction.user.id, guildId: interaction.guild.id },
-            { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
-            { upsert: true, new: true }
-        ),
-        Guild.findOne({ guildId: interaction.guild.id })
-    ]);
+    const [user, guildSettings] = await loadPlayerAndSettings(interaction);
 
     const season = guildSettings?.season;
     if (!season?.enabled || !season?.seasonId) {
@@ -362,14 +357,7 @@ async function executeUnlock(interaction) {
 }
 
 async function executeMissions(interaction) {
-    const [user, guildSettings] = await Promise.all([
-        User.findOneAndUpdate(
-            { userId: interaction.user.id, guildId: interaction.guild.id },
-            { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
-            { upsert: true, new: true }
-        ),
-        Guild.findOne({ guildId: interaction.guild.id })
-    ]);
+    const [user, guildSettings] = await loadPlayerAndSettings(interaction);
 
     const season = guildSettings?.season;
     if (!season?.enabled) {
@@ -401,14 +389,7 @@ async function executeMissions(interaction) {
 
 async function executeClaimMission(interaction) {
     const missionIndex = interaction.options.getInteger('mission') - 1;
-    const [user, guildSettings] = await Promise.all([
-        User.findOneAndUpdate(
-            { userId: interaction.user.id, guildId: interaction.guild.id },
-            { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
-            { upsert: true, new: true }
-        ),
-        Guild.findOne({ guildId: interaction.guild.id })
-    ]);
+    const [user, guildSettings] = await loadPlayerAndSettings(interaction);
 
     const season = guildSettings?.season;
     if (!season?.enabled) return interaction.reply({ content: 'No active season.', flags: MessageFlags.Ephemeral });
@@ -459,14 +440,7 @@ async function executeClaimMission(interaction) {
 }
 
 async function executeClaimAll(interaction) {
-    const [user, guildSettings] = await Promise.all([
-        User.findOneAndUpdate(
-            { userId: interaction.user.id, guildId: interaction.guild.id },
-            { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
-            { upsert: true, new: true }
-        ),
-        Guild.findOne({ guildId: interaction.guild.id })
-    ]);
+    const [user, guildSettings] = await loadPlayerAndSettings(interaction);
 
     const season = guildSettings?.season;
     if (!season?.enabled || !season?.seasonId) {
@@ -596,7 +570,7 @@ async function executeClaimAll(interaction) {
 // ── Economy season (issue #238) subcommands ───────────────────────────────────
 
 async function executeLeaderboard(interaction) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     const currentSeason = guildSettings?.currentSeason;
 
     if (!currentSeason?.id) {
@@ -636,7 +610,7 @@ async function executeLeaderboard(interaction) {
 async function executeSeasonMe(interaction) {
     const [user, guildSettings] = await Promise.all([
         User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }),
-        Guild.findOne({ guildId: interaction.guild.id })
+        getGuildSettings(interaction.guild.id)
     ]);
 
     const currentSeason = guildSettings?.currentSeason;
@@ -695,6 +669,11 @@ async function executeHistory(interaction) {
 }
 
 // Admin: start economy season
+// The two admin writes below read currentSeason to decide whether to write it, so
+// they go to the model rather than getGuildSettings: a cached read would put a TTL
+// between the check and the write. Projected, which is what the cache was for.
+const readSeasonForWrite = guildId => Guild.findOne({ guildId }, 'currentSeason').lean();
+
 async function executeAdminStart(interaction) {
     if (!interaction.member.permissions.has(PermissionFlagsBits.Administrator)) {
         return interaction.reply({ content: 'Administrator only.', flags: MessageFlags.Ephemeral });
@@ -702,7 +681,7 @@ async function executeAdminStart(interaction) {
 
     const name = interaction.options.getString('name') ?? `Season ${Date.now()}`;
     const durationDays = interaction.options.getInteger('duration') ?? 90;
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await readSeasonForWrite(interaction.guild.id);
 
     if (guildSettings?.currentSeason?.id) {
         return interaction.reply({ content: 'A season is already active. End it first with `/season end`.', flags: MessageFlags.Ephemeral });
@@ -730,7 +709,7 @@ async function executeAdminEnd(interaction) {
 
     await interaction.deferReply();
 
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await readSeasonForWrite(interaction.guild.id);
     const currentSeason = guildSettings?.currentSeason;
 
     if (!currentSeason?.id) {
@@ -791,14 +770,7 @@ async function executeAdminEnd(interaction) {
 // ── Seasonal event progress subcommand ───────────────────────────────────────
 
 async function executeSeasonEvent(interaction) {
-    const [user, guildSettings] = await Promise.all([
-        User.findOneAndUpdate(
-            { userId: interaction.user.id, guildId: interaction.guild.id },
-            { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
-            { upsert: true, new: true }
-        ),
-        Guild.findOne({ guildId: interaction.guild.id })
-    ]);
+    const [user, guildSettings] = await loadPlayerAndSettings(interaction);
 
     const activeEvent = guildSettings?.activeEvent;
     if (!activeEvent?.type) {
@@ -899,7 +871,7 @@ const TIER_SKIP_ITEM_ID = 'tier_skip_token';
 async function executeTierSkip(interaction) {
     const [user, guildSettings] = await Promise.all([
         User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }),
-        Guild.findOne({ guildId: interaction.guild.id })
+        getGuildSettings(interaction.guild.id)
     ]);
 
     const season = guildSettings?.season;

--- a/src/commands/economy/shop.js
+++ b/src/commands/economy/shop.js
@@ -8,6 +8,7 @@ const {
     MessageFlags,
 } = require('discord.js');
 const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const User = require('../../models/User');
 const Transaction = require('../../models/Transaction');
 const { ensureDefaultShopItems, getItemLore, getItemRarity, isPrestigeItem, isBlackMarketItem, isP8BlackMarketItem, RARITY_ORDER } = require('../../data/defaultShopItems');
@@ -249,7 +250,7 @@ module.exports = {
         try {
             const focused = interaction.options.getFocused()?.toLowerCase() ?? '';
             const [guildSettings, viewer] = await Promise.all([
-                Guild.findOne({ guildId: interaction.guild.id }, 'shop economy dynamicPricing').lean(),
+                getGuildSettings(interaction.guild.id),
                 User.findOne(
                     { userId: interaction.user.id, guildId: interaction.guild.id },
                     'accountPrestige'
@@ -468,7 +469,7 @@ module.exports = {
             const doPurchase = async (reply) => {
                 // Re-fetch to catch any changes since the pre-check (stock sold out, balance changed)
                 const [freshGuild, freshUser] = await Promise.all([
-                    Guild.findOne({ guildId: interaction.guild.id }),
+                    getGuildSettings(interaction.guild.id),
                     User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id })
                 ]);
 

--- a/src/commands/economy/showcase.js
+++ b/src/commands/economy/showcase.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { MATERIAL_RARITY, TIER_STARS, TIER_COLORS } = require('../../data/materialRarity');
 const { ACHIEVEMENTS } = require('../../data/achievements');
 const COLORS = require('../../utils/embedColors');
@@ -68,7 +68,7 @@ module.exports = {
 
             const [profileUser, guildSettings] = await Promise.all([
                 User.findOne({ userId: target.id, guildId: interaction.guild.id }),
-                Guild.findOne({ guildId: interaction.guild.id })
+                getGuildSettings(interaction.guild.id)
             ]);
 
             if (!profileUser) {

--- a/src/commands/economy/syndicate.js
+++ b/src/commands/economy/syndicate.js
@@ -6,7 +6,7 @@ const {
     ButtonStyle,
     MessageFlags,
 } = require('discord.js');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const User = require('../../models/User');
 const Syndicate = require('../../models/Syndicate');
 const FailedJob = require('../../models/FailedJob');
@@ -146,7 +146,7 @@ async function resolveHeist(client, heist) {
     const target = SYNDICATE_TARGETS[heist.target];
     const { outcome, payout, perPlayer } = computeSyndicateOutcome(heist);
 
-    const guildDoc = await Guild.findOne({ guildId: heist.guildId }, 'economy').lean();
+    const guildDoc = await getGuildSettings(heist.guildId);
     const currency = guildDoc?.economy?.currency ?? '💰';
 
     const players = [...heist.players.entries()];
@@ -1043,7 +1043,7 @@ module.exports = {
     cooldownAmount: () => 5,
 
     async execute(interaction, client) {
-        const guildDoc = await Guild.findOne({ guildId: interaction.guild.id }, 'economy syndicates').lean();
+        const guildDoc = await getGuildSettings(interaction.guild.id);
 
         if (!guildDoc?.economy?.enabled) {
             return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });

--- a/src/commands/economy/synergies.js
+++ b/src/commands/economy/synergies.js
@@ -3,7 +3,7 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User  = require('../../models/User');
 const { attachGrind } = require('../../utils/grindProfile');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { SYNERGY_LIST } = require('../../data/crossSystemData');
 const { ensureHuntData }    = require('../../services/huntService');
 const { ensureFishingData } = require('../../services/fishService');
@@ -18,7 +18,7 @@ module.exports = {
         .setDescription('View all cross-system synergy bonuses and your progress toward unlocking them'),
 
     async execute(interaction) {
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
         if (guildSettings?.economy?.enabled === false) {
             return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
         }

--- a/src/commands/economy/trap.js
+++ b/src/commands/economy/trap.js
@@ -2,7 +2,7 @@
 
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User  = require('../../models/User');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { logTransaction } = require('../../utils/logTransaction');
 const COLORS = require('../../utils/embedColors');
 
@@ -21,7 +21,7 @@ module.exports = {
                .setDescription('Check whether your trap is currently armed.')),
 
     async execute(interaction) {
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
         if (guildSettings?.economy?.enabled === false) {
             return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
         }

--- a/src/commands/economy/use.js
+++ b/src/commands/economy/use.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User  = require('../../models/User');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const {
     EFFECT_CONFIGS,
     resolveEffectType,
@@ -77,7 +77,7 @@ module.exports = {
         // Read first to resolve item identity (itemId casing, effect checks)
         const [preview, guildSettings] = await Promise.all([
             User.findOne(userFilter),
-            Guild.findOne({ guildId: interaction.guild.id })
+            getGuildSettings(interaction.guild.id)
         ]);
 
         if (!preview || !preview.inventory?.length) {

--- a/src/commands/economy/war.js
+++ b/src/commands/economy/war.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, PermissionFlagsBits, MessageFlags } = require('discord.js');
 const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const User = require('../../models/User');
 
 const WAR_DURATION_DAYS = 7;
@@ -33,7 +34,12 @@ async function executeChallenge(interaction) {
 
     const inviteCode = interaction.options.getString('invite_code').trim();
 
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    // Read through the model rather than getGuildSettings: this value decides
+    // whether the challenge is created, and a cached read would put up to a TTL
+    // between the check and the write — long enough for a second /war challenge
+    // to pass it and overwrite the first. The projection keeps the read cheap,
+    // which is what routing it through the cache would have been for.
+    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id }, 'activeWar').lean();
     if (guildSettings?.activeWar?.status === 'active' || guildSettings?.activeWar?.status === 'pending') {
         return interaction.reply({ content: 'Your server already has an active or pending war.', flags: MessageFlags.Ephemeral });
     }
@@ -85,16 +91,20 @@ async function executeAccept(interaction) {
 
     const challengerInvite = interaction.options.getString('challenger_invite').trim();
 
-    const myGuild = await Guild.findOne({ guildId: interaction.guild.id });
+    // Uncached and projected, for the reason /war challenge gives.
+    const myGuild = await Guild.findOne({ guildId: interaction.guild.id }, 'activeWar').lean();
     if (myGuild?.activeWar?.status === 'active' || myGuild?.activeWar?.status === 'pending') {
         return interaction.reply({ content: 'Your server already has an active or pending war.', flags: MessageFlags.Ephemeral });
     }
 
     // Find the challenger guild by invite code
+    // Not a guildId lookup, so the settings cache cannot serve it — the whole
+    // point is finding which guild holds this invite code. Projected to the
+    // three fields the acceptance actually reads.
     const challengerGuild = await Guild.findOne({
         'activeWar.inviteCode': challengerInvite,
         'activeWar.status': 'pending'
-    });
+    }, 'guildId name activeWar').lean();
 
     if (!challengerGuild) {
         return interaction.reply({
@@ -170,7 +180,7 @@ async function executeAccept(interaction) {
 }
 
 async function executeStatus(interaction) {
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    const guildSettings = await getGuildSettings(interaction.guild.id);
     const war = guildSettings?.activeWar;
 
     if (!war?.status || war.status === 'ended') {
@@ -224,7 +234,9 @@ async function executeCancel(interaction) {
         return interaction.reply({ content: 'Administrator only.', flags: MessageFlags.Ephemeral });
     }
 
-    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+    // Uncached and projected: the opponent id read here is what the second
+    // update below is aimed at, and it must be the war that is being cancelled.
+    const guildSettings = await Guild.findOne({ guildId: interaction.guild.id }, 'activeWar').lean();
     const war = guildSettings?.activeWar;
 
     if (!war?.status || war.status === 'ended') {
@@ -257,7 +269,20 @@ async function grantWarPoints(guildId, action) {
     const pts = WAR_POINTS[action];
     if (!pts) return;
 
-    const guildSettings = await Guild.findOne({ guildId });
+    // Two reads, because this one is on the hot path — every /daily, /work and
+    // /hunt calls it — and almost every call is for a guild with no war at all.
+    //
+    // The cached read answers that common case without a round trip. It cannot
+    // answer the other one: the scores below decide who won, and resolving from
+    // a snapshot up to a TTL old could crown the wrong server in a close war.
+    // So an apparently-active war is re-read from the model before anything is
+    // settled on it. The point increments themselves are guarded by
+    // `'activeWar.status': 'active'` in their own filters, so a stale "active"
+    // that has since ended costs a no-op write rather than a wrong one.
+    const cached = await getGuildSettings(guildId);
+    if (cached?.activeWar?.status !== 'active') return;
+
+    const guildSettings = await Guild.findOne({ guildId }, 'activeWar').lean();
     const war = guildSettings?.activeWar;
 
     if (!war || war.status !== 'active') return;

--- a/src/commands/economy/work.js
+++ b/src/commands/economy/work.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const DEFAULT_JOBS = require('../../data/defaultJobs');
 const DEFAULT_TIERS = require('../../data/defaultTiers');
 const { getStreakMultiplier } = require('../../utils/streakMultiplier');
@@ -146,7 +146,7 @@ module.exports = {
                     { $setOnInsert: { userId: interaction.user.id, guildId: interaction.guild.id } },
                     { upsert: true, new: true }
                 ),
-                Guild.findOne({ guildId: interaction.guild.id })
+                getGuildSettings(interaction.guild.id)
             ]);
 
             // Synergy requirements read hunt/fishing/mining levels, and those

--- a/src/commands/fun/coinflip.js
+++ b/src/commands/fun/coinflip.js
@@ -6,7 +6,7 @@ const {
     ButtonStyle,
     MessageFlags,
 } = require('discord.js');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const User  = require('../../models/User');
 const { logTransaction } = require('../../utils/logTransaction');
 const { createReplaySession, replayButtonRow } = require('../../utils/replaySession');
@@ -174,7 +174,7 @@ module.exports = {
     cooldown: 5,
 
     async execute(interaction) {
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
         if (guildSettings?.economy?.enabled === false || guildSettings?.economy?.coinflipEnabled === false) {
             return interaction.reply({ content: 'Coinflip is disabled on this server.', flags: MessageFlags.Ephemeral });
         }

--- a/src/commands/fun/roll.js
+++ b/src/commands/fun/roll.js
@@ -3,7 +3,7 @@ const {
     EmbedBuilder,
     MessageFlags,
 } = require('discord.js');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const User  = require('../../models/User');
 const { logTransaction } = require('../../utils/logTransaction');
 const { createReplaySession, replayButtonRow } = require('../../utils/replaySession');
@@ -107,7 +107,7 @@ module.exports = {
                 .setMaxValue(100)),
 
     async execute(interaction) {
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
         if (guildSettings?.economy?.enabled === false || guildSettings?.economy?.rollEnabled === false) {
             return interaction.reply({ content: 'Dice roll is disabled on this server.', flags: MessageFlags.Ephemeral });
         }

--- a/src/commands/leveling/leaderboard.js
+++ b/src/commands/leveling/leaderboard.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { netWorthOf, topByNetWorth, netWorthRank } = require('../../utils/netWorth');
 const COLORS = require('../../utils/embedColors');
 
@@ -73,7 +73,7 @@ module.exports = {
                 title = '⚔️ Duel Leaderboard';
                 descriptionHeader = 'Top 10 Duelists by Win Count';
             } else if (type === 'achievements') {
-                const guildSettings = await Guild.findOne({ guildId: interaction.guild.id }).select('achievements.enabled').lean();
+                const guildSettings = await getGuildSettings(interaction.guild.id);
                 if (!guildSettings?.achievements?.enabled) {
                     return interaction.reply({ content: 'Achievements are not enabled on this server.', flags: MessageFlags.Ephemeral });
                 }

--- a/src/commands/leveling/rank.js
+++ b/src/commands/leveling/rank.js
@@ -1,7 +1,7 @@
 const { SlashCommandBuilder, EmbedBuilder, AttachmentBuilder, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
 const { attachGrind } = require('../../utils/grindProfile');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { createRankCard } = require('../../utils/cardGenerator');
 const { pruneEffects, EFFECT_CONFIGS, timeRemaining, getServerCoinMultiplier, getServerXpMultiplier } = require('../../services/effectsService');
 const { badgeFor, titleForExactRank: prestigeTitle } = require('../../utils/prestige');
@@ -46,7 +46,7 @@ module.exports = {
         try {
             const [user, guildSettings] = await Promise.all([
                 User.findOne({ userId: targetUser.id, guildId: interaction.guild.id }),
-                Guild.findOne({ guildId: interaction.guild.id }),
+                getGuildSettings(interaction.guild.id),
             ]);
             await attachGrind(user);
 

--- a/src/commands/leveling/xpinfo.js
+++ b/src/commands/leveling/xpinfo.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const COLORS = require('../../utils/embedColors');
 
 const XP_COOLDOWN_SECONDS = 60;
@@ -34,7 +34,7 @@ module.exports = {
         if (!interaction.inGuild()) return;
         await interaction.deferReply({ flags: MessageFlags.Ephemeral });
         try {
-            const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+            const guildSettings = await getGuildSettings(interaction.guild.id);
             const leveling = guildSettings?.leveling ?? {};
 
             const xpRate = leveling.xpRate ?? 1.0;

--- a/src/commands/moderation/appeal.js
+++ b/src/commands/moderation/appeal.js
@@ -1,7 +1,7 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const { getCase } = require('../../services/caseService');
 const Case = require('../../models/Case');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const COLORS = require('../../utils/embedColors');
 
 module.exports = {
@@ -55,7 +55,7 @@ module.exports = {
             });
 
             // Post to appeal channel / mod log
-            const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+            const guildSettings = await getGuildSettings(interaction.guild.id);
             const alertChannelId = guildSettings?.moderation?.appealChannelId
                 || guildSettings?.moderation?.logChannelId;
             if (!alertChannelId) return;

--- a/src/commands/moderation/warn.js
+++ b/src/commands/moderation/warn.js
@@ -2,7 +2,7 @@ const { SlashCommandBuilder, PermissionFlagsBits, EmbedBuilder, MessageFlags } =
 const Case = require('../../models/Case');
 const { logModeration } = require('../../services/moderationLogService');
 const { applyEscalation, findStepForCount } = require('../../services/escalationService');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const User = require('../../models/User');
 const { fitDescription, truncate, EMBED_LIMITS } = require('../../utils/embedFields');
 const COLORS = require('../../utils/embedColors');
@@ -65,7 +65,7 @@ module.exports = {
                 const canBypass = interaction.memberPermissions?.has(PermissionFlagsBits.ManageMessages);
                 const bypassEscalation = bypassRequested && canBypass;
 
-                const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+                const guildSettings = await getGuildSettings(interaction.guild.id);
                 // Only ever read by the bypass branches below, to say what the
                 // bypass suppressed — when escalation is going to run,
                 // applyEscalation looks the step up itself. The condition used

--- a/src/commands/utility/bible.js
+++ b/src/commands/utility/bible.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const { lookupVerse, getDailyVerse, createVerseEmbed, createVerseComponents } = require('../../services/bibleService');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 
 module.exports = {
     cooldown: 5,
@@ -60,7 +60,7 @@ module.exports = {
                 });
             }
 
-            const guildSettings = await Guild.findOne({ guildId: interaction.guildId });
+            const guildSettings = await getGuildSettings(interaction.guildId);
             const translation = guildSettings?.bibleVerse?.translation || 'kjv';
 
             let displayVerse = verseData;

--- a/src/commands/utility/profile.js
+++ b/src/commands/utility/profile.js
@@ -3,7 +3,7 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User = require('../../models/User');
 const { attachGrind } = require('../../utils/grindProfile');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { pruneEffects, EFFECT_CONFIGS, timeRemaining } = require('../../services/effectsService');
 const { getStreakMultiplier, MILESTONES } = require('../../utils/streakMultiplier');
 const { badgeFor, titleForExactRank } = require('../../utils/prestige');
@@ -53,7 +53,7 @@ module.exports = {
         try {
             const [userData, guildSettings] = await Promise.all([
                 User.findOne({ userId: targetUser.id, guildId: interaction.guild.id }),
-                Guild.findOne({ guildId: interaction.guild.id }),
+                getGuildSettings(interaction.guild.id),
             ]);
             await attachGrind(userData);
 

--- a/src/commands/utility/role.js
+++ b/src/commands/utility/role.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const COLORS = require('../../utils/embedColors');
 
 module.exports = {
@@ -20,7 +20,7 @@ module.exports = {
 
     async execute(interaction) {
         const sub           = interaction.options.getSubcommand();
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
 
         // Collect all unique roleIds from reaction role panels
         const selfRoleIds = [...new Set((guildSettings?.reactionRoles || []).map(r => r.roleId))];

--- a/src/commands/utility/serverinfo.js
+++ b/src/commands/utility/serverinfo.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { raidModeActive, raidModeActivatedBy } = require('../../services/raidService');
 const COLORS = require('../../utils/embedColors');
 
@@ -10,7 +10,7 @@ module.exports = {
     async execute(interaction) {
         const { guild } = interaction;
 
-        const guildSettings = await Guild.findOne({ guildId: guild.id }).catch(() => null);
+        const guildSettings = await getGuildSettings(guild.id).catch(() => null);
         const rd = guildSettings?.raidDetection;
 
         let raidStatus = 'Detection disabled';

--- a/src/commands/utility/suggest.js
+++ b/src/commands/utility/suggest.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const COLORS = require('../../utils/embedColors');
 
 module.exports = {
@@ -14,7 +14,7 @@ module.exports = {
 
     async execute(interaction) {
         const text          = interaction.options.getString('suggestion');
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
 
         if (!guildSettings?.suggestions?.enabled || !guildSettings.suggestions.channelId) {
             return interaction.reply({ content: 'Suggestions are not enabled on this server.', flags: MessageFlags.Ephemeral });

--- a/src/commands/utility/vc.js
+++ b/src/commands/utility/vc.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder, PermissionFlagsBits, MessageFlags } = require('discord.js');
-const Guild = require('../../models/Guild');
+const { getGuildSettings } = require('../../utils/guildSettingsCache');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -31,7 +31,7 @@ module.exports = {
 
     async execute(interaction) {
         const sub           = interaction.options.getSubcommand();
-        const guildSettings = await Guild.findOne({ guildId: interaction.guild.id });
+        const guildSettings = await getGuildSettings(interaction.guild.id);
 
         if (!guildSettings?.tempVoice?.enabled) {
             return interaction.reply({ content: 'Temporary voice channels are not enabled on this server.', flags: MessageFlags.Ephemeral });

--- a/src/config/fileSecrets.js
+++ b/src/config/fileSecrets.js
@@ -37,6 +37,10 @@ const FILE_BACKED_SECRETS = [
     'OPENROUTER_API_KEY',
     'IMGFLIP_USERNAME',
     'IMGFLIP_PASSWORD',
+    // Shared by the bot and the split-out dashboard (#876). Whoever holds it
+    // can ban, unban and post in every guild the bot is in, so it belongs here
+    // for the same reason CLIENT_SECRET does.
+    'BOT_GATEWAY_TOKEN',
 ];
 
 /**

--- a/src/config/validateEnv.js
+++ b/src/config/validateEnv.js
@@ -35,6 +35,13 @@
 // see config/fileSecrets.js, which must run first so the values are in place.
 const REQUIRED_ENV = ['DISCORD_TOKEN', 'CLIENT_ID', 'MONGODB_URI', 'SESSION_SECRET', 'CLIENT_SECRET'];
 
+// What the split-out dashboard process needs (#876). DISCORD_TOKEN is absent on
+// purpose: that process never connects to the gateway, and a container that
+// cannot use the bot token should not be handed one — it is the credential with
+// the widest blast radius in the deployment. CLIENT_ID and CLIENT_SECRET stay,
+// because OAuth is exactly what this process does.
+const DASHBOARD_REQUIRED_ENV = REQUIRED_ENV.filter(name => name !== 'DISCORD_TOKEN');
+
 // express-session will happily sign cookies with "hunter2". The floor is the
 // one openssl invocation in .env.example: `openssl rand -hex 32`.
 const SESSION_SECRET_MIN_LENGTH = 32;
@@ -127,11 +134,11 @@ function checkSessionSecret(env = process.env) {
  * @param {object} env
  * @returns {{ errors: string[], warnings: string[] }}
  */
-function collectEnvProblems(env = process.env) {
+function collectEnvProblems(env = process.env, { required = REQUIRED_ENV } = {}) {
     const errors = [];
     const warnings = [];
 
-    const missing = REQUIRED_ENV.filter(key => !env[key]);
+    const missing = required.filter(key => !env[key]);
     if (missing.length) {
         errors.push(`Missing required environment variables: ${missing.join(', ')}`);
     }
@@ -169,7 +176,63 @@ function collectEnvProblems(env = process.env) {
     errors.push(...dashboardUrl.errors);
     warnings.push(...dashboardUrl.warnings);
 
+    errors.push(...checkGatewaySplit(env));
+
     return { errors, warnings };
+}
+
+/**
+ * The three variables that move the dashboard into its own process (#876).
+ *
+ * Checked together because they are only meaningful together: a port with no
+ * token is an endpoint that can act in every guild the bot is in and will not
+ * start; a URL with no token is a dashboard whose every call is refused; and a
+ * token alone does nothing, which is the one combination worth only a silence
+ * — an operator midway through setting this up should not be blocked by having
+ * written the secret first.
+ */
+function checkGatewaySplit(env) {
+    const errors = [];
+    const port = env.BOT_GATEWAY_PORT;
+    const url = env.BOT_GATEWAY_URL;
+
+    if (port !== undefined && port !== '') {
+        const parsed = Number(port);
+        if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+            errors.push(`BOT_GATEWAY_PORT must be a port number between 1 and 65535. Got: "${port}"`);
+        }
+        if (String(parsed) === String(Number(env.DASHBOARD_PORT || 3000))) {
+            errors.push(
+                `BOT_GATEWAY_PORT (${port}) must differ from DASHBOARD_PORT — ` +
+                'the two are served by different processes and cannot share a port.'
+            );
+        }
+    }
+
+    if (url) {
+        try {
+            new URL(url);
+        } catch {
+            errors.push(`BOT_GATEWAY_URL is not a valid URL: "${url}"`);
+        }
+    }
+
+    if ((port || url) && !env.BOT_GATEWAY_TOKEN) {
+        errors.push(
+            'BOT_GATEWAY_TOKEN is not set. The gateway endpoint can ban, unban and post in ' +
+            'every guild the bot is in, so it does not run without a shared secret. ' +
+            'Generate one with: openssl rand -hex 32'
+        );
+    }
+
+    if (env.BOT_GATEWAY_TOKEN && env.BOT_GATEWAY_TOKEN.length < SESSION_SECRET_MIN_LENGTH) {
+        errors.push(
+            `BOT_GATEWAY_TOKEN must be at least ${SESSION_SECRET_MIN_LENGTH} characters. ` +
+            'Generate one with: openssl rand -hex 32'
+        );
+    }
+
+    return errors;
 }
 
 /**
@@ -181,11 +244,15 @@ function collectEnvProblems(env = process.env) {
  *
  * @param {object}   [options]
  * @param {object}   [options.env]    environment to read, for tests
- * @param {string}   [options.label]  log prefix — 'STARTUP' or 'SHARD'
+ * @param {string}   [options.label]  log prefix — 'STARTUP', 'SHARD' or 'DASHBOARD'
+ * @param {string[]} [options.required] which variables must be present.
+ *   Defaults to REQUIRED_ENV. The split-out dashboard passes a narrower list:
+ *   it holds no gateway connection, so demanding DISCORD_TOKEN of it would put
+ *   the bot's token in a container that has no use for one (#876).
  * @param {Function} [options.onFail] what to do when it fails; exits by default
  */
-function assertEnv({ env = process.env, label = 'STARTUP', onFail } = {}) {
-    const { errors, warnings } = collectEnvProblems(env);
+function assertEnv({ env = process.env, label = 'STARTUP', onFail, required } = {}) {
+    const { errors, warnings } = collectEnvProblems(env, required ? { required } : undefined);
 
     for (const warning of warnings) console.warn(`[${label}] WARNING: ${warning}`);
     if (!errors.length) return true;
@@ -203,6 +270,8 @@ module.exports = {
     collectEnvProblems,
     checkDashboardUrl,
     checkSessionSecret,
+    checkGatewaySplit,
+    DASHBOARD_REQUIRED_ENV,
     resolveDashboardUrl,
     REQUIRED_ENV,
     SESSION_SECRET_MIN_LENGTH,

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -1,0 +1,97 @@
+'use strict';
+
+// The dashboard, as its own process (#876).
+//
+// On shard 0 a single Node process ran the Discord gateway, this Express app,
+// full-collection aggregations, canvas rendering, AI provider calls and every
+// cron job. A CPU-heavy dashboard request delayed gateway heartbeats for every
+// guild the bot was in, and a fault in a route reached the process-level guards
+// in src/index.js, which exit — so a bad dashboard page was a bot-wide outage.
+//
+// Everything needed to separate them was already in place: `createApp` takes an
+// injected `bot` facade, that facade is id-in / plain-data-out, and the session
+// store is injected too. What was missing was a second entry point and a
+// transport. This is the entry point; src/bot/remoteGateway.js is the
+// transport.
+//
+// What this process does NOT do, and that is the point: it holds no gateway
+// connection, registers no commands, runs no cron jobs, and has no Discord
+// client to speak of. It talks to Mongo for the data it owns and to the bot
+// process for the handful of things only a gateway can answer.
+//
+// Run it with `npm run start:dashboard`, or bring up the compose service:
+//
+//     docker compose --profile split-dashboard up -d
+
+require('dotenv').config();
+require('../config/fileSecrets').loadFileSecrets();
+const { assertEnv, DASHBOARD_REQUIRED_ENV } = require('../config/validateEnv');
+assertEnv({ label: 'DASHBOARD', required: DASHBOARD_REQUIRED_ENV });
+require('../utils/logger').installConsoleBridge();
+
+const { connect, connection } = require('mongoose');
+
+const { createRemoteBotGateway } = require('../bot/remoteGateway');
+const { createApp, listen } = require('./server');
+
+async function connectDatabase() {
+    const masked = (process.env.MONGODB_URI || '').replace(/\/\/[^@]*@/, '//***@');
+    try {
+        await connect(process.env.MONGODB_URI, { serverSelectionTimeoutMS: 10_000 });
+        console.log('[DATABASE] Connected to MongoDB');
+    } catch (error) {
+        console.error(`[DATABASE] Failed to connect to ${masked}:`, error.message);
+        process.exit(1);
+    }
+
+    connection.on('disconnected', () => console.warn('[DATABASE] Disconnected from MongoDB'));
+    connection.on('reconnected', () => console.log('[DATABASE] Reconnected to MongoDB'));
+    connection.on('error', err => console.error('[DATABASE] Connection error:', err.message));
+}
+
+async function main() {
+    // Migrations are deliberately not run here. They are singleton work owned by
+    // shard 0 of the bot (src/index.js), and a second process racing the same
+    // forward-only schema change is a different failure every time. This one
+    // connects to a database the bot has already migrated.
+    await connectDatabase();
+
+    // Fails loudly and immediately on a missing URL or token, before a port is
+    // bound: a dashboard that starts and then 500s every page because it cannot
+    // reach the bot is worse than one that refuses to start.
+    const bot = createRemoteBotGateway();
+
+    const server = listen(createApp({ bot }));
+
+    const shutdown = async signal => {
+        console.log(`[SHUTDOWN] Received ${signal}. Shutting down the dashboard...`);
+        try {
+            await new Promise(resolve => server.close(resolve));
+            await connection.close();
+            console.log('[SHUTDOWN] Clean exit.');
+        } catch (err) {
+            console.error('[SHUTDOWN] Error during shutdown:', err);
+        }
+        process.exit(0);
+    };
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
+    process.on('SIGINT', () => shutdown('SIGINT'));
+
+    // This process has no gateway connection to lose, so the calculus that makes
+    // src/index.js exit on a spike of unhandled rejections does not apply: the
+    // worst case here is one broken page, and exiting turns that into no
+    // dashboard at all. Log and keep serving.
+    process.on('unhandledRejection', err =>
+        console.error('[PROCESS] Unhandled promise rejection:', err));
+    process.on('uncaughtException', err =>
+        console.error('[PROCESS] Uncaught exception:', err));
+}
+
+if (require.main === module) {
+    main().catch(err => {
+        console.error('[STARTUP] The dashboard failed to start:', err);
+        process.exit(1);
+    });
+}
+
+module.exports = { main };

--- a/src/dashboard/lib/instanceStats.js
+++ b/src/dashboard/lib/instanceStats.js
@@ -65,10 +65,14 @@ function formatCount(value) {
  *   zeroes, because "we have not been told yet" and "nobody uses this" are
  *   different claims and only one of them is true at boot.
  */
-function instanceStats(bot, { status = () => getStatus({ detailed: false }) } = {}) {
+async function instanceStats(bot, { status = () => getStatus({ detailed: false }) } = {}) {
     let reach;
     try {
-        reach = bot?.reach?.();
+        // Awaited: the facade is asynchronous whether it reads a local cache or
+        // calls the bot process (#876). A bot process that cannot be reached is
+        // the same answer as one that has not been ready yet — we do not know —
+        // and the template drops the row rather than claiming zero servers.
+        reach = await bot?.reach?.();
     } catch {
         return null;
     }

--- a/src/dashboard/lib/middleware.js
+++ b/src/dashboard/lib/middleware.js
@@ -40,9 +40,12 @@ function checkAuth(req, res, next) {
 // deliberate soft edge on the *unknown* answer only; a definite `false` denies.
 async function checkGuildAccess(req, res, next) {
     const { guildId } = req.params;
-    const userGuilds = req.user.guilds.filter(guild =>
-        hasManagePermission(guild) && req.bot.hasGuild(guild.id)
-    );
+    // One call for the whole list rather than one per guild: the facade may be
+    // another process now (src/bot/remoteGateway.js), and a user in fifty
+    // servers would otherwise cost fifty round trips per request.
+    const manageable = req.user.guilds.filter(hasManagePermission);
+    const present = await req.bot.hasGuilds(manageable.map(g => g.id));
+    const userGuilds = manageable.filter(guild => present[guild.id]);
 
     if (!userGuilds.find(g => g.id === guildId)) {
         return res.status(403).json({ error: 'Forbidden' });

--- a/src/dashboard/routes/api/ai.js
+++ b/src/dashboard/routes/api/ai.js
@@ -19,8 +19,8 @@ router.post('/guild/:guildId/persona', checkAuth, checkGuildAccess, checkWriteRa
     }
 
     try {
-        if (!req.bot.hasGuild(guildId)) return res.status(404).json({ error: 'Guild not found' });
-        if (!req.bot.hasChannel(guildId, channelId.trim())) {
+        if (!await req.bot.hasGuild(guildId)) return res.status(404).json({ error: 'Guild not found' });
+        if (!await req.bot.hasChannel(guildId, channelId.trim())) {
             return res.status(400).json({ error: 'Channel not found in this guild' });
         }
 

--- a/src/dashboard/routes/api/moderation.js
+++ b/src/dashboard/routes/api/moderation.js
@@ -84,7 +84,7 @@ router.patch('/guild/:guildId/cases/:caseId', checkAuth, checkGuildAccess, check
 router.get('/guild/:guildId/sanctions/active', checkAuth, checkGuildAccess, async (req, res) => {
     const { guildId } = req.params;
     try {
-        if (!req.bot.hasGuild(guildId)) return res.status(404).json({ error: 'Guild not found or bot not in guild' });
+        if (!await req.bot.hasGuild(guildId)) return res.status(404).json({ error: 'Guild not found or bot not in guild' });
 
         let bans;
         try {
@@ -97,7 +97,7 @@ router.get('/guild/:guildId/sanctions/active', checkAuth, checkGuildAccess, asyn
         }
 
         const banList = bans.map(b => ({ type: 'ban', ...b, expires: null }));
-        const timeoutList = (req.bot.listActiveTimeouts(guildId, 200) || [])
+        const timeoutList = (await req.bot.listActiveTimeouts(guildId, 200) || [])
             .map(t => ({ type: 'timeout', ...t, reason: null }));
 
         res.json({ bans: banList, timeouts: timeoutList });

--- a/src/dashboard/routes/api/reactionRoles.js
+++ b/src/dashboard/routes/api/reactionRoles.js
@@ -31,8 +31,8 @@ router.post('/guild/:guildId/reactionrole/panel', checkAuth, checkGuildAccess, c
     }
 
     try {
-        if (!req.bot.hasGuild(guildId)) return res.status(404).json({ error: 'Guild not found' });
-        if (!req.bot.hasChannel(guildId, channelId)) return res.status(404).json({ error: 'Channel not found' });
+        if (!await req.bot.hasGuild(guildId)) return res.status(404).json({ error: 'Guild not found' });
+        if (!await req.bot.hasChannel(guildId, channelId)) return res.status(404).json({ error: 'Channel not found' });
 
         const guildSettings = await Guild.findOne({ guildId });
         if (!guildSettings) return res.status(404).json({ error: 'Guild settings not found' });

--- a/src/dashboard/routes/api/settings.js
+++ b/src/dashboard/routes/api/settings.js
@@ -459,7 +459,13 @@ router.post('/guild/:guildId/settings', checkAuth, checkGuildAccess, checkWriteR
         // re-reads profile times from the database on every minute tick.
         const shouldRescheduleBible = Object.keys(updates).some(key => key.startsWith('bibleVerse.'));
         if (shouldRescheduleBible) {
-            req.bot.rescheduleBibleVerse(guildId);
+            // Deliberately not awaited — the save has already succeeded and the
+            // reschedule is a side effect the caller is not waiting on. It does
+            // need a catch now that it can be a call to another process (#876):
+            // an unhandled rejection here counts toward the process-level
+            // rejection guard in src/index.js.
+            req.bot.rescheduleBibleVerse(guildId)
+                .catch(err => console.error(`[DASHBOARD] Bible reschedule for ${guildId} failed:`, err.message));
         }
 
         // Deliberately does not echo the saved document. It carries every shop

--- a/src/dashboard/routes/api/summaryJobs.js
+++ b/src/dashboard/routes/api/summaryJobs.js
@@ -46,7 +46,7 @@ router.post('/guild/:guildId/summary-jobs', checkAuth, checkGuildAccess, checkWr
     if (!Number.isFinite(m) || m < 0 || m > 59) return res.status(400).json({ error: 'minute must be 0–59' });
 
     try {
-        const channels = req.bot.listChannels(guildId);
+        const channels = await req.bot.listChannels(guildId);
         if (!channels) return res.status(404).json({ error: 'Guild not found' });
 
         const srcChannel = channels.find(c => c.id === sourceChannelId.trim());

--- a/src/dashboard/routes/dashboard.js
+++ b/src/dashboard/routes/dashboard.js
@@ -26,16 +26,18 @@ const { CHANNEL_TYPES } = require('../../bot/gateway');
 const { PANELS, DEFAULT_PANEL, isPanel } = require('../lib/panels');
 const { groupReactionRolePanels } = require('../lib/reactionRolePanels');
 
-function getManageableGuilds(req) {
-    return req.user.guilds
-        .filter(hasManagePermission)
-        .map(guild => ({
-            id: guild.id,
-            name: guild.name,
-            icon: guild.icon,
-            owner: guild.owner === true,
-            botPresent: req.bot.hasGuild(guild.id)
-        }));
+async function getManageableGuilds(req) {
+    const manageable = req.user.guilds.filter(hasManagePermission);
+    // Batched: the facade may be another process, and this runs on every page
+    // that renders the guild picker.
+    const present = await req.bot.hasGuilds(manageable.map(g => g.id));
+    return manageable.map(guild => ({
+        id: guild.id,
+        name: guild.name,
+        icon: guild.icon,
+        owner: guild.owner === true,
+        botPresent: present[guild.id] === true
+    }));
 }
 
 const { INVITE_PERMISSIONS_BITFIELD } = require('../../config/invitePermissions');
@@ -53,12 +55,19 @@ function buildInviteUrl(guildId) {
     return `https://discord.com/oauth2/authorize?${query}`;
 }
 
-router.get('/', checkAuth, (req, res) => {
-    const guilds = getManageableGuilds(req).map(g => ({
-        ...g,
-        inviteUrl: buildInviteUrl(g.id)
-    }));
-    res.render('dashboard', { user: req.user, guilds });
+router.get('/', checkAuth, async (req, res, next) => {
+    try {
+        const guilds = (await getManageableGuilds(req)).map(g => ({
+            ...g,
+            inviteUrl: buildInviteUrl(g.id)
+        }));
+        res.render('dashboard', { user: req.user, guilds });
+    } catch (err) {
+        // The facade may be another process (#876), so this can now fail for a
+        // reason that is not this route's. Hand it to the error middleware
+        // rather than letting it become an unhandled rejection.
+        next(err);
+    }
 });
 
 /**
@@ -72,7 +81,7 @@ router.get('/', checkAuth, (req, res) => {
  */
 async function buildGuildSettingsLocals(req) {
     const { guildId } = req.params;
-    const userGuilds = getManageableGuilds(req);
+    const userGuilds = await getManageableGuilds(req);
 
     if (!userGuilds.find(g => g.id === guildId)) {
         return { status: 403, message: 'You do not have permission to manage this guild.' };
@@ -91,7 +100,7 @@ async function buildGuildSettingsLocals(req) {
 
     let guildSettings = await Guild.findOne({ guildId }, SHOP_IMAGES_EXCLUDED);
     let shopIsProjected = true;
-    const guild = req.bot.getGuild(guildId);
+    const guild = await req.bot.getGuild(guildId);
 
     if (!guild) {
         return { status: 404, message: 'Guild not found' };
@@ -123,7 +132,7 @@ async function buildGuildSettingsLocals(req) {
         }
     }
 
-    const allChannels = req.bot.listChannels(guildId) || [];
+    const allChannels = await req.bot.listChannels(guildId) || [];
     const ofType = type => allChannels.filter(c => c.type === type).map(c => ({ id: c.id, name: c.name }));
 
     const channels = ofType(CHANNEL_TYPES.TEXT);
@@ -131,7 +140,7 @@ async function buildGuildSettingsLocals(req) {
     const stageChannels = ofType(CHANNEL_TYPES.STAGE);
     const categories = ofType(CHANNEL_TYPES.CATEGORY);
 
-    const roles = (req.bot.listRoles(guildId) || [])
+    const roles = (await req.bot.listRoles(guildId) || [])
         .filter(r => r.name !== '@everyone')
         .map(r => ({ id: r.id, name: r.name }));
 

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -324,10 +324,23 @@ function createApp({ client = null, bot: injectedBot, sessionStore, configurePas
     //
     // Merely being logged in is not enough: Discord OAuth is open to any account,
     // so authentication alone conveys no privilege here.
-    app.get('/health', (req, res) => {
-        const detailed = req.isAuthenticated?.() === true
-            && Array.isArray(req.user?.guilds)
-            && req.user.guilds.some(g => hasManagePermission(g) && bot.hasGuild(g.id));
+    app.get('/health', async (req, res) => {
+        const manageable = req.isAuthenticated?.() === true && Array.isArray(req.user?.guilds)
+            ? req.user.guilds.filter(hasManagePermission)
+            : [];
+        // A health probe must answer even when the bot process does not, so a
+        // facade that cannot be reached downgrades the payload rather than
+        // failing the request — the un-detailed status is exactly what an
+        // anonymous monitor gets, and it is still the honest answer.
+        let detailed = false;
+        if (manageable.length) {
+            try {
+                const present = await bot.hasGuilds(manageable.map(g => g.id));
+                detailed = manageable.some(g => present[g.id]);
+            } catch (err) {
+                console.error('[DASHBOARD] /health could not reach the bot process:', err.message);
+            }
+        }
 
         const status = getStatus({ detailed });
         // Non-200 for `degraded` as well as `unhealthy`, so a monitor that only
@@ -337,7 +350,7 @@ function createApp({ client = null, bot: injectedBot, sessionStore, configurePas
         res.status(httpStatusFor(status.status)).json(status);
     });
 
-    app.get('/', (req, res) => {
+    app.get('/', async (req, res, next) => {
         // The hero's stat row is measured, not written into the template
         // (#704). `null` when the client has not been ready yet, and the
         // template drops the row for that rather than claiming zero servers.
@@ -350,11 +363,15 @@ function createApp({ client = null, bot: injectedBot, sessionStore, configurePas
         // domain. `null` only in the misconfiguration that already refuses to
         // start, and the template drops the tags rather than emitting a
         // half-formed URL.
-        res.render('index', {
-            user: req.user,
-            stats: instanceStats(bot),
-            baseUrl: checkDashboardUrl().baseUrl,
-        });
+        try {
+            res.render('index', {
+                user: req.user,
+                stats: await instanceStats(bot),
+                baseUrl: checkDashboardUrl().baseUrl,
+            });
+        } catch (err) {
+            next(err);
+        }
     });
 
     app.use(errorHandler);

--- a/src/events/voiceStateUpdate.js
+++ b/src/events/voiceStateUpdate.js
@@ -3,15 +3,54 @@ const { getGuildSettings } = require('../utils/guildSettingsCache');
 const User = require('../models/User');
 const { checkRivalry } = require('../services/rivalryService');
 
-// userId -> joinTimestamp (ms)
+// `${guildId}:${userId}` -> joinTimestamp (ms)
 const voiceJoinTimes = new Map();
+
+// A join is cleared only by the matching leave, and the leave can simply never
+// arrive: the bot is removed from a guild while people are still in voice, or a
+// gateway gap swallows the transition. Every such entry is permanent, so this
+// map is bounded the way every other one in this repo is (guildSettingsCache,
+// BoundedRateLimiter) — a sweep of entries older than any plausible session,
+// plus a hard FIFO cap for the case where joins arrive faster than the sweep.
+const MAX_VOICE_SESSION_MS = 24 * 60 * 60 * 1000;
+const VOICE_SWEEP_INTERVAL_MS = 60 * 60 * 1000;
+const MAX_TRACKED_VOICE_SESSIONS = 5_000;
+let lastVoiceSweepAt = 0;
+
+/**
+ * Drops joins older than a session could plausibly be.
+ *
+ * Amortised over joins rather than run from a timer, because this module owns
+ * no schedule — src/services/scheduler is the only place that may register one
+ * (tests/schedulerOwnsJobs.test.js enforces that) — and a sweep is only ever
+ * needed while joins are actually happening. The interval keeps it O(n) per
+ * hour rather than per join.
+ */
+function sweepVoiceJoinTimes(now) {
+    if (now - lastVoiceSweepAt < VOICE_SWEEP_INTERVAL_MS) return;
+    lastVoiceSweepAt = now;
+    const cutoff = now - MAX_VOICE_SESSION_MS;
+    for (const [key, joinedAt] of voiceJoinTimes) {
+        if (joinedAt <= cutoff) voiceJoinTimes.delete(key);
+    }
+}
 
 module.exports = {
     name: 'voiceStateUpdate',
     async execute(oldState, newState, client) {
         await handleVoiceStateUpdate(oldState, newState, client);
         await handleVoiceXp(oldState, newState, client);
-    }
+    },
+    __test__: {
+        voiceJoinTimes,
+        MAX_VOICE_SESSION_MS,
+        VOICE_SWEEP_INTERVAL_MS,
+        MAX_TRACKED_VOICE_SESSIONS,
+        resetVoiceJoinTimes() {
+            voiceJoinTimes.clear();
+            lastVoiceSweepAt = 0;
+        },
+    },
 };
 
 async function handleVoiceXp(oldState, newState, client) {
@@ -24,17 +63,33 @@ async function handleVoiceXp(oldState, newState, client) {
     const joinedVoice = !oldState.channelId && newState.channelId;
     const leftVoice = oldState.channelId && !newState.channelId;
 
+    const key = `${guildId}:${member.id}`;
+
     if (joinedVoice) {
-        voiceJoinTimes.set(`${guildId}:${member.id}`, Date.now());
+        const now = Date.now();
+        sweepVoiceJoinTimes(now);
+        // FIFO eviction, as in BoundedRateLimiter. An evicted join forfeits
+        // only that one session's voice XP, which is a better failure than
+        // growth with no ceiling.
+        if (!voiceJoinTimes.has(key) && voiceJoinTimes.size >= MAX_TRACKED_VOICE_SESSIONS) {
+            voiceJoinTimes.delete(voiceJoinTimes.keys().next().value);
+        }
+        voiceJoinTimes.set(key, now);
         return;
     }
 
     if (!leftVoice) return;
 
-    const key = `${guildId}:${member.id}`;
     const joinedAt = voiceJoinTimes.get(key);
     if (!joinedAt) return;
     voiceJoinTimes.delete(key);
+
+    // Past the sweep's cutoff this entry was going to be discarded, so paying it
+    // out would make the award depend on whether a sweep happened to have run —
+    // a 30-hour join worth 5,400 XP or nothing, decided by timing. It is also
+    // the shape of a join whose leave was lost and whose "session" is really the
+    // gap until the user rejoined. Discard it either way.
+    if (Date.now() - joinedAt > MAX_VOICE_SESSION_MS) return;
 
     try {
         const guildSettings = await getGuildSettings(guildId);

--- a/src/index.js
+++ b/src/index.js
@@ -145,6 +145,29 @@ async function connectDatabase() {
     connection.on('error', err => console.error('[DATABASE] Connection error:', err.message));
 }
 
+/**
+ * Serves the gateway facade to a dashboard running in its own process (#876).
+ *
+ * Off unless BOT_GATEWAY_PORT is set, and when it is set the in-process
+ * dashboard does not start — the two are the same dashboard in two places, and
+ * running both would have this process doing the very work the split moves out.
+ *
+ * Per shard rather than per deployment, because what it serves is *this*
+ * process's guild cache: under sharding the dashboard has to be able to reach
+ * whichever shard owns the guild it is asked about. One listener per shard is
+ * what makes that possible; routing between them is the deployment's business
+ * (a load balancer keyed on the shard formula), not this file's.
+ *
+ * @returns {boolean} whether the split is on.
+ */
+function startGatewayRpc() {
+    const { serveGatewayIfConfigured } = require('./bot/gatewayServer');
+    return serveGatewayIfConfigured(
+        () => require('./bot/gateway').createBotGateway(client),
+        { health: () => health.getStatus({ detailed: false }) },
+    );
+}
+
 async function startDashboard() {
     // The dashboard binds a TCP port, so it is singleton work: under sharding
     // every shard is its own process and N of them would fight over one port.
@@ -216,7 +239,14 @@ async function startBot() {
 
     await loadCommands();
     await loadEvents();
-    await startDashboard();
+
+    // Either the dashboard runs here, or it runs in its own process and this one
+    // serves it the facade. Never both.
+    if (!startGatewayRpc()) {
+        await startDashboard();
+    } else {
+        console.log('[DASHBOARD] BOT_GATEWAY_PORT is set — the dashboard runs in its own process (src/dashboard/index.js).');
+    }
 
     // All background services, scheduled jobs, and presence rotation start
     // from the clientReady handler in events/ready.js via services/scheduler.

--- a/src/services/birthdayService.js
+++ b/src/services/birthdayService.js
@@ -1,6 +1,7 @@
 const { PermissionFlagsBits } = require('discord.js');
 const Guild = require('../models/Guild');
 const User = require('../models/User');
+const { handlesGuild } = require('../utils/sharding');
 
 function isLeapYear(year) {
     return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
@@ -32,6 +33,9 @@ async function checkBirthdays(client) {
         : { 'birthday.month': month, 'birthday.day': day };
 
     for (const settings of guilds) {
+        // Per-guild job: each shard wishes only its own guilds.
+        if (!handlesGuild(settings.guildId, client)) continue;
+
         const guild = client.guilds.cache.get(settings.guildId);
         if (!guild) continue;
 

--- a/src/services/chatEventService.js
+++ b/src/services/chatEventService.js
@@ -39,6 +39,14 @@ const CRATE_ITEMS = [
 
 const guildState = new Map(); // guildId -> { lastEventAt, messagesSince }
 
+// One entry per guild the process has ever seen a message in, with nothing to
+// remove it — the bot leaving a guild does not, and there is no TTL because a
+// quiet guild's message count is meant to survive between events. Capped FIFO,
+// the same rule guildSettingsCache and BoundedRateLimiter use. Eviction costs
+// the evicted guild its progress toward the next event, so it waits another
+// MIN_MESSAGES_BETWEEN messages; nothing fires early and no money moves.
+const MAX_TRACKED_GUILDS = 5_000;
+
 const randInt    = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
 const randomFrom = arr => arr[Math.floor(Math.random() * arr.length)];
 
@@ -65,6 +73,9 @@ async function maybeTriggerChatEvent(message, guildSettings) {
         const guildId = message.guild.id;
         let state = guildState.get(guildId);
         if (!state) {
+            if (guildState.size >= MAX_TRACKED_GUILDS) {
+                guildState.delete(guildState.keys().next().value);
+            }
             state = { lastEventAt: 0, messagesSince: 0 };
             guildState.set(guildId, state);
         }
@@ -317,4 +328,7 @@ async function spawnTrivia(message, guildSettings) {
     });
 }
 
-module.exports = { maybeTriggerChatEvent };
+module.exports = {
+    maybeTriggerChatEvent,
+    __test__: { guildState, MAX_TRACKED_GUILDS, MIN_MESSAGES_BETWEEN },
+};

--- a/src/services/giveawayService.js
+++ b/src/services/giveawayService.js
@@ -14,6 +14,7 @@
 const { EmbedBuilder } = require('discord.js');
 const Guild = require('../models/Guild');
 const COLORS = require('../utils/embedColors');
+const { handlesGuild } = require('../utils/sharding');
 
 // Ended giveaways are kept around so `/giveaway reroll` still works, but not
 // forever: each one carries a full entrant list, and nothing else prunes the
@@ -36,6 +37,10 @@ async function checkGiveaways(client) {
             .select('guildId giveaways');
 
         for (const guildSettings of guilds) {
+            // Per-guild job: a shard that cannot reach this guild must not end
+            // its giveaways, or the winners are drawn where nobody is told.
+            if (!handlesGuild(guildSettings.guildId, client)) continue;
+
             let dirty = false;
 
             for (const ga of guildSettings.giveaways) {

--- a/src/services/newspaperService.js
+++ b/src/services/newspaperService.js
@@ -2,6 +2,7 @@ const { EmbedBuilder } = require('discord.js');
 const Guild = require('../models/Guild');
 const { getCompletion, resolveProviderConfig } = require('./aiService');
 const { collectSignals, signalUserIds, buildDataSummary, buildSections } = require('./newspaper/signals');
+const { handlesGuild } = require('../utils/sharding');
 
 /**
  * The weekly server newspaper.
@@ -152,6 +153,9 @@ async function postScheduledNewspapers(client) {
 
     for (const guildDoc of guilds) {
         const { guildId } = guildDoc;
+        // Per-guild job: each shard posts only for guilds it can reach.
+        if (!handlesGuild(guildId, client)) continue;
+
         try {
             // Validate channel before consuming the weekly slot — misconfigured
             // channels must not burn lastRunAt.

--- a/src/services/raidService.js
+++ b/src/services/raidService.js
@@ -2,6 +2,7 @@ const { EmbedBuilder } = require('discord.js');
 const Guild = require('../models/Guild');
 const { assertGuildAffinity } = require('../utils/sharding');
 const COLORS = require('../utils/embedColors');
+const { handlesGuild } = require('../utils/sharding');
 
 // guildId -> [{timestamp, userId, accountAgeDays}]
 //
@@ -255,6 +256,13 @@ async function sweepRaidModes(client) {
     if (raidModeActive.size === 0) return;
 
     for (const guildId of [...raidModeActive]) {
+        // Per-guild job. `raidModeActive` is process-local and only ever filled
+        // by join events, which reach the owning shard — so this guard is
+        // normally redundant. It is here for the case it is not: a guild whose
+        // routing changed under a reshard would otherwise have its raid mode
+        // disabled by a process that cannot see whether the raid is still going.
+        if (!handlesGuild(guildId, client)) continue;
+
         // Never auto-disable a manually activated raid mode
         if (raidModeActivatedBy.get(guildId) === 'manual') continue;
 

--- a/src/services/reminderService.js
+++ b/src/services/reminderService.js
@@ -1,5 +1,6 @@
 const Reminder = require('../models/Reminder');
 const { addCalendarDays } = require('../utils/timezones');
+const { handlesGuild } = require('../utils/sharding');
 
 const REPEAT_INTERVAL_DAYS = {
     daily: 1,
@@ -72,6 +73,9 @@ async function checkReminders(client) {
         });
 
         for (const reminder of dueReminders) {
+            // Per-guild job. A reminder set in a DM has no guildId, so
+            // handlesGuild routes it to the primary shard rather than to none.
+            if (!handlesGuild(reminder.guildId, client)) continue;
             try {
                 const delivered = await deliver(client, reminder);
 

--- a/src/services/rssService.js
+++ b/src/services/rssService.js
@@ -5,6 +5,7 @@ const cron = require('node-cron');
 
 const { safeFetchFeed } = require('../utils/safeFeedFetch');
 const { runJob } = require('../utils/jobRunner');
+const { handlesGuild } = require('../utils/sharding');
 const COLORS = require('../utils/embedColors');
 
 const parser = new Parser();
@@ -328,6 +329,8 @@ async function checkRssFeeds(client) {
         // sweep and fan the parsed result out to every subscription.
         const subscriptionsByUrl = new Map(); // url -> [{ guild, feed }]
         for (const guild of guilds) {
+            // Per-guild job: each shard posts only for the guilds it can reach.
+            if (!handlesGuild(guild.guildId, client)) continue;
             for (const feed of guild.rssFeeds) {
                 if (!feed?.url) continue;
                 let subs = subscriptionsByUrl.get(feed.url);

--- a/src/services/rssService.js
+++ b/src/services/rssService.js
@@ -59,6 +59,40 @@ function recordFeedSuccess(feedUrl) {
     feedLastFailTime.delete(feedUrl);
 }
 
+// Nothing removes a URL from the two maps above when the last guild subscribed
+// to it unsubscribes, so they accumulate every feed ever configured for the
+// life of the process.
+//
+// Pruning against the sweep's live subscription list would look like the
+// obvious fix and would be wrong: daily-news profiles carry their own feed URLs
+// (dailyNewsProfiles[].feeds), which checkRssFeeds never queries, so the sweep
+// would delete the circuit-breaker state of every digest-only feed every five
+// minutes and a dead one would be re-fetched on each digest for good.
+//
+// Age is the property that covers both callers. An entry only changes behaviour
+// while it is inside DEAD_FEED_COOLDOWN_MS of its last failure — past that,
+// shouldSkipDeadFeed retries the feed regardless — and any feed still being
+// polled refreshes its entry on each failed retry. So an entry that has aged
+// well past the cooldown belongs to a URL nothing polls any more. The margin
+// keeps the prune clear of the boundary, so a retry that is about to happen
+// still finds its count for the log line.
+const DEAD_FEED_STATE_TTL_MS = 2 * DEAD_FEED_COOLDOWN_MS;
+
+function pruneFeedFailureState(now = Date.now()) {
+    const cutoff = now - DEAD_FEED_STATE_TTL_MS;
+    for (const url of feedFailCounts.keys()) {
+        const lastFail = feedLastFailTime.get(url);
+        if (lastFail === undefined || lastFail <= cutoff) {
+            feedFailCounts.delete(url);
+            feedLastFailTime.delete(url);
+        }
+    }
+    // Any timestamp with no surviving count is state no reader can act on.
+    for (const url of feedLastFailTime.keys()) {
+        if (!feedFailCounts.has(url)) feedLastFailTime.delete(url);
+    }
+}
+
 function recordFeedFailure(feedUrl, error) {
     const newCount = (feedFailCounts.get(feedUrl) || 0) + 1;
     feedFailCounts.set(feedUrl, newCount);
@@ -345,6 +379,10 @@ async function checkRssFeeds(client) {
         console.log(`[RSS] Sweep: ${urls.length} feed(s), ${posted} posted, ${failed} failed, ${skipped} parked.`);
     } catch (error) {
         console.error('Error checking RSS feeds:', error);
+    } finally {
+        // In `finally` so a sweep that threw halfway still reclaims: the prune
+        // is keyed on age alone and needs nothing the sweep produced.
+        pruneFeedFailureState();
     }
 }
 
@@ -579,6 +617,7 @@ module.exports = {
     checkRssFeeds, scheduleDailyNews, sendDailyNews,
     __test__: {
         feedFailCounts, feedLastFailTime, shouldSkipDeadFeed,
+        pruneFeedFailureState, DEAD_FEED_STATE_TTL_MS,
         DEAD_FEED_THRESHOLD, DEAD_FEED_COOLDOWN_MS, RSS_FETCH_CONCURRENCY,
         dailyNewsDue, runDueDailyNews, DAILY_NEWS_REFIRE_GUARD_MS,
         datedItems, MAX_ITEMS_PER_SWEEP,

--- a/src/services/scheduledTaskService.js
+++ b/src/services/scheduledTaskService.js
@@ -2,6 +2,7 @@ const ScheduledTask = require('../models/ScheduledTask');
 const Guild = require('../models/Guild');
 const { runJob } = require('../utils/jobRunner');
 const { addCalendarDays, addCalendarMonths, isValidTimezone, nowInTimezone } = require('../utils/timezones');
+const { handlesGuild } = require('../utils/sharding');
 const {
     MAX_TASK_FAILURES,
     MAX_TASKS_PER_TICK,
@@ -236,6 +237,13 @@ async function runDueTasks(client) {
         .limit(MAX_TASKS_PER_TICK);
 
     for (const task of due) {
+        // Per-guild job: the claim is atomic, so a shard that took another
+        // shard's task would not double-run it — it would run it somewhere the
+        // task's channel cannot be reached, which is worse. Each shard scans the
+        // same window and claims only its own; the window is per shard, so the
+        // deployment's throughput per tick rises with the shard count.
+        if (!handlesGuild(task.guildId, client)) continue;
+
         const claimed = await claim(task, now);
         // Somebody else took it, or it was switched off between the scan and
         // the claim. Either way it is not this tick's to run.

--- a/src/services/scheduler/index.js
+++ b/src/services/scheduler/index.js
@@ -8,23 +8,67 @@ const { isPrimaryShard, shardTag } = require('../../utils/sharding');
 // start-once service is listed here — nothing else in the codebase should
 // call cron.schedule at bootstrap or hang jobs off a clientReady handler.
 
+// ── Scope: which processes run a job (#889) ─────────────────────────────────
+//
+// Every job used to run on shard 0 and nowhere else, which is correct for work
+// that must happen once per deployment and wrong for work that reaches a guild:
+// shard 0's client only holds the guilds Discord routed to shard 0, so an
+// announcement for a guild on shard 3 was silently dropped. The trade was
+// deliberate — a missed announcement beats a duplicated payout — but the
+// classification it was standing in for is the actual fix, and this is it.
+//
+//   'deployment'  Runs on the primary shard only. The job's unit of work is not
+//                 a guild it can partition on, or it never reaches Discord at
+//                 all, so a second runner would only duplicate it.
+//
+//   'guild'       Runs on every shard, each one filtering its work list down to
+//                 the guilds Discord routes to it. The filter is `handlesGuild`
+//                 (src/utils/sharding.js), applied inside the service at the top
+//                 of its per-guild loop — before any claim, so a shard that
+//                 cannot announce for a guild does not take that guild's lease
+//                 and leave the shard that can with nothing to do.
+//
+// A job is 'guild' when both hold: every write it makes is scoped to one
+// guild's documents, and it reaches Discord for that guild. `applyBankInterest`
+// is 'guild' for that reason, though it is the job usually named as the
+// deployment-wide example — it claims per guild (`bankInterestLastRunAt`) and
+// then posts the interest summary to that guild's announcement channel, so
+// pinning it to shard 0 loses the summary for every other shard's guilds while
+// gaining nothing. `returnExpiredMarketListings` is the genuine article: it
+// takes no client, announces nothing, and returns items to sellers straight in
+// the database.
+//
+// What this costs: a 'guild' job's initial query runs once per shard rather than
+// once per deployment, because Mongo cannot evaluate Discord's `(id >> 22) % N`
+// routing rule and the partition therefore has to happen in the process. For the
+// per-minute jobs the query is already narrow (rows that are due). For the
+// weekly full-collection scans it is a lean projection over the guild list, N
+// times an hour at worst. That is the price of announcements that arrive.
+//
+// Unsharded — every deployment today — `handlesGuild` is constantly true and
+// every job runs exactly where it ran before.
+const SCOPE = { DEPLOYMENT: 'deployment', GUILD: 'guild' };
+
 // Recurring jobs. `fn` receives the Discord client. Schedules without a
 // timezone run in server-local time, matching their previous behavior.
 const JOBS = [
     {
         name: 'checkRssFeeds',
+        scope: SCOPE.GUILD,
         service: 'rssService',
         schedule: '*/5 * * * *',
         fn: client => require('../rssService').checkRssFeeds(client),
     },
     {
         name: 'checkReminders',
+        scope: SCOPE.GUILD,
         service: 'reminderService',
         schedule: '* * * * *',
         fn: client => require('../reminderService').checkReminders(client),
     },
     {
         name: 'checkGiveaways',
+        scope: SCOPE.GUILD,
         service: 'giveawayService',
         schedule: '* * * * *',
         fn: client => require('../giveawayService').checkGiveaways(client),
@@ -33,6 +77,7 @@ const JOBS = [
         // Previously scheduled twice (a 5-minute interval in index.js and a
         // 2-minute cron in ready.js); the more frequent schedule wins.
         name: 'checkTempVoice',
+        scope: SCOPE.GUILD,
         service: 'tempVoiceService',
         schedule: '*/2 * * * *',
         runOnStart: true,
@@ -40,30 +85,35 @@ const JOBS = [
     },
     {
         name: 'checkBirthdays',
+        scope: SCOPE.GUILD,
         service: 'birthdayService',
         schedule: '0 * * * *',
         fn: client => require('../birthdayService').checkBirthdays(client),
     },
     {
         name: 'checkSeasonalEvents',
+        scope: SCOPE.GUILD,
         service: 'seasonalEventService',
         schedule: '0 * * * *',
         fn: client => require('../seasonalEventService').checkSeasonalEvents(client),
     },
     {
         name: 'resolveExpiredWars',
+        scope: SCOPE.GUILD,
         service: 'schedulerService',
         schedule: '*/5 * * * *',
         fn: client => require('../schedulerService').resolveExpiredWars(client),
     },
     {
         name: 'resolveExpiredSeasons',
+        scope: SCOPE.GUILD,
         service: 'schedulerService',
         schedule: '*/5 * * * *',
         fn: client => require('../schedulerService').resolveExpiredSeasons(client),
     },
     {
         name: 'awardWeeklyLeaderboardBadges',
+        scope: SCOPE.GUILD,
         service: 'schedulerService',
         schedule: '59 23 * * 0',
         timezone: 'Etc/UTC',
@@ -71,6 +121,7 @@ const JOBS = [
     },
     {
         name: 'selectPetOfTheWeek',
+        scope: SCOPE.GUILD,
         service: 'schedulerService',
         schedule: '0 0 * * 1',
         timezone: 'Etc/UTC',
@@ -78,6 +129,7 @@ const JOBS = [
     },
     {
         name: 'applyBankInterest',
+        scope: SCOPE.GUILD,
         service: 'schedulerService',
         schedule: '1 0 * * 1',
         timezone: 'Etc/UTC',
@@ -88,6 +140,7 @@ const JOBS = [
         // reading a week that has certainly closed rather than racing the
         // boundary it is keyed on.
         name: 'announceWeeklyChampions',
+        scope: SCOPE.GUILD,
         service: 'schedulerService',
         schedule: '5 0 * * 1',
         timezone: 'Etc/UTC',
@@ -95,18 +148,21 @@ const JOBS = [
     },
     {
         name: 'recalcShopPrices',
+        scope: SCOPE.GUILD,
         service: 'schedulerService',
         schedule: '*/15 * * * *',
         fn: client => require('../schedulerService').recalcShopPrices(client),
     },
     {
         name: 'resolveRankedSeasons',
+        scope: SCOPE.GUILD,
         service: 'schedulerService',
         schedule: '*/10 * * * *',
         fn: client => require('../schedulerService').resolveRankedSeasons(client),
     },
     {
         name: 'returnExpiredMarketListings',
+        scope: SCOPE.DEPLOYMENT,
         service: 'schedulerService',
         schedule: '*/10 * * * *',
         fn: () => require('../schedulerService').returnExpiredMarketListings(),
@@ -117,12 +173,14 @@ const JOBS = [
         // healthy, and the service was silently dead until someone noticed
         // bans not lifting or raid mode stuck on (#611).
         name: 'sweepRaidModes',
+        scope: SCOPE.GUILD,
         service: 'raidService',
         schedule: '* * * * *',
         fn: client => require('../raidService').sweepRaidModes(client),
     },
     {
         name: 'processExpiredBans',
+        scope: SCOPE.GUILD,
         service: 'tempBanService',
         schedule: '* * * * *',
         runOnStart: true,
@@ -133,12 +191,14 @@ const JOBS = [
         // way reminders work, so anything hung off it is restart-proof and
         // catches up after downtime without its own catch-up code.
         name: 'runDueTasks',
+        scope: SCOPE.GUILD,
         service: 'scheduledTaskService',
         schedule: '* * * * *',
         fn: client => require('../scheduledTaskService').runDueTasks(client),
     },
     {
         name: 'postScheduledNewspapers',
+        scope: SCOPE.GUILD,
         service: 'schedulerService',
         schedule: '0 * * * *',
         timezone: 'Etc/UTC',
@@ -234,39 +294,41 @@ function startScheduler(client) {
 
     runStarters(SHARD_STARTERS, client);
 
-    // ── The scheduler is singleton work, and runs on shard 0 only (#732) ─────
+    // ── Where each job runs (#732, #889) ────────────────────────────────────
     //
     // Under sharding each shard is its own process, so an ungated scheduler
-    // fires every job once per shard. jobRunner's overlap guard would not
+    // fires every job once per shard, and jobRunner's overlap guard would not
     // notice: `inFlight` is a process-local Set, so N processes each see an
-    // empty one. applyBankInterest paying every account N times is the shape of
-    // that mistake, and it is the expensive shape.
+    // empty one. That is why everything was pinned to shard 0 — applyBankInterest
+    // paying every account N times is the shape of the mistake, and it is the
+    // expensive shape.
     //
-    // The trade-off this makes, stated plainly rather than discovered later:
-    // most of these jobs reach a guild through the client, and shard 0's client
-    // only has the guilds Discord routed to shard 0. So gating here means a job
-    // that announces into a guild on another shard cannot reach it. That is a
-    // missed announcement; the alternative is duplicated money. Money wins.
+    // The `scope` on each job is what replaces that blanket pin. A 'guild' job
+    // runs everywhere and partitions its own work list; a 'deployment' job still
+    // runs only on the primary shard. See the table above for the rule.
     //
-    // Step 2 is to classify each job as deployment-wide (bank interest, market
-    // listing returns — pure database work that must happen once) or per-guild
-    // (the announcements, which should run on every shard filtered to the
-    // guilds that shard owns, since `ownsGuild` makes that partition exact).
-    // That classification needs each job read against a live multi-shard
-    // deployment, which is why it is not guessed at here.
-    //
-    // Unsharded — every deployment today — `isPrimaryShard` is true and none of
-    // this changes anything.
-    if (!isPrimaryShard(client)) {
-        console.log(`${shardTag(client)}[SCHEDULER] Presence only — scheduled jobs and services run on shard 0.`);
-        return;
-    }
+    // Unsharded, `isPrimaryShard` is true and every job is scheduled here just as
+    // it was before.
+    const primary = isPrimaryShard(client);
+    const scheduled = JOBS.filter(job => primary || job.scope === SCOPE.GUILD);
 
-    for (const job of JOBS) {
+    for (const job of scheduled) {
         const run = () => runJob(job.service, job.name, () => job.fn(client));
         const task = cron.schedule(job.schedule, run, job.timezone ? { timezone: job.timezone } : undefined);
         scheduledTasks.push(task);
         if (job.runOnStart) run();
+    }
+
+    if (!primary) {
+        // The start-once services are still singleton work and stay on the
+        // primary shard: each keeps its own schedule rather than declaring one
+        // here, so none of them can be classified from this table. They are the
+        // remaining half of #889 and are called out in tests/schedulerScope.
+        console.log(
+            `${shardTag(client)}[SCHEDULER] Started ${scheduled.length} per-guild jobs; ` +
+            `${JOBS.length - scheduled.length} deployment-wide job(s) and ${STARTERS.length} services run on shard 0.`
+        );
+        return;
     }
 
     runStarters(STARTERS, client);
@@ -287,4 +349,4 @@ function stopScheduler() {
     started = false;
 }
 
-module.exports = { startScheduler, stopScheduler, JOBS, STARTERS, SHARD_STARTERS };
+module.exports = { startScheduler, stopScheduler, JOBS, STARTERS, SHARD_STARTERS, SCOPE };

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -32,6 +32,7 @@
  */
 
 const Guild = require('../models/Guild');
+const { handlesGuild } = require('../utils/sharding');
 const User  = require('../models/User');
 const SeasonRecord = require('../models/SeasonRecord');
 const { createWarVictoryBanner, createSeasonRecapCard } = require('../utils/cardGenerator');
@@ -273,6 +274,12 @@ async function resolveExpiredWars(client) {
     });
 
     for (const guildDoc of expired) {
+        // Per-guild job (src/services/scheduler). A war has two sides and only
+        // the declaring guild decides the partition, so the opponent's copy of
+        // the announcement still depends on where that guild routes — but this
+        // is strictly more of it than shard 0 alone could deliver.
+        if (!handlesGuild(guildDoc.guildId, client)) continue;
+
         try {
             await resolveOneWar(client, guildDoc);
         } catch (err) {
@@ -438,6 +445,9 @@ async function resolveExpiredSeasons(client) {
     });
 
     for (const guildDoc of expired) {
+        // Per-guild job: each shard resolves only its own guilds' seasons.
+        if (!handlesGuild(guildDoc.guildId, client)) continue;
+
         try {
             await resolveOneSeason(client, guildDoc);
         } catch (err) {
@@ -464,6 +474,11 @@ async function awardWeeklyLeaderboardBadges(client) {
 
     for (const guildDoc of guilds) {
         const guildId = guildDoc.guildId;
+        // Per-guild job. Before the lease, not after: a shard that cannot reach
+        // this guild would otherwise take the week's lease and then have nowhere
+        // to announce, leaving the shard that could with nothing to claim.
+        if (!handlesGuild(guildId, client)) continue;
+
         try {
             // Atomically acquire a short-lived lease; badgesLastAwardedAt is only written on success
             const leaseUntil = new Date(Date.now() + 5 * 60 * 1000); // 5-minute lease window
@@ -587,6 +602,10 @@ async function selectPetOfTheWeek(client) {
 
     for (const guildDoc of guilds) {
         const guildId = guildDoc.guildId;
+        // Per-guild job, checked before the claim for the same reason as the
+        // badge lease above.
+        if (!handlesGuild(guildId, client)) continue;
+
         try {
             // Atomic claim: only proceed if this guild hasn't been processed this week
             const claimed = await Guild.findOneAndUpdate(
@@ -778,13 +797,20 @@ async function announceWeeklyChampions(client) {
     ]);
     if (!candidates.length) return;
 
-    candidates.sort((a, b) =>
+    // Per-guild job (src/services/scheduler): the aggregation spans every guild,
+    // so the partition happens here, before the reward claim. A shard that
+    // claimed another shard's champion would mark them rewarded and then be
+    // unable to announce it.
+    const mine = candidates.filter(c => handlesGuild(c.guildId, client));
+    if (!mine.length) return;
+
+    mine.sort((a, b) =>
         String(a.guildId).localeCompare(String(b.guildId)) ||
         WEEKLY_CATEGORY_ORDER.indexOf(a.category) - WEEKLY_CATEGORY_ORDER.indexOf(b.category));
 
     // Claim each champion atomically to prevent double-pay under concurrent runs
     const actualWinners = [];
-    for (const w of candidates) {
+    for (const w of mine) {
         const claimed = await WeeklyChampion.findOneAndUpdate(
             { _id: w._id, rewarded: false },
             { $set: { rewarded: true } },
@@ -1005,6 +1031,9 @@ async function recalcShopPrices(client) {
     const guilds = await Guild.find({ 'dynamicPricing.enabled': true }, 'guildId dynamicPricing.recalcMinutes').lean();
 
     for (const guildSummary of guilds) {
+        // Per-guild job, checked before the lease claim below.
+        if (!handlesGuild(guildSummary.guildId, client)) continue;
+
         try {
             const recalcMs = (guildSummary.dynamicPricing?.recalcMinutes ?? 60) * 60_000;
             const now      = new Date();
@@ -1176,6 +1205,10 @@ async function resolveRankedSeasons(client) {
         ]
     });
     for (const g of uninitialized) {
+        // Per-guild job: two shards initialising the same guild's first season
+        // would race on a plain save, with no claim to settle it.
+        if (!handlesGuild(g.guildId, client)) continue;
+
         const seasonNumber = g.rankedDuels.seasonNumber ?? 1;
         const days = g.rankedDuels.seasonDurationDays ?? 60;
         g.rankedDuels.currentSeasonId = makeSeasonId(seasonNumber);
@@ -1190,6 +1223,9 @@ async function resolveRankedSeasons(client) {
     });
 
     for (const guildDoc of expired) {
+        // Per-guild job, checked before the season-end claim below.
+        if (!handlesGuild(guildDoc.guildId, client)) continue;
+
         try {
             const guildId  = guildDoc.guildId;
             const seasonId = guildDoc.rankedDuels.currentSeasonId;
@@ -1337,6 +1373,13 @@ async function applyBankInterest(client) {
 
     for (const guildDoc of guilds) {
         const guildId = guildDoc.guildId;
+        // Per-guild job, despite being the usual example of a deployment-wide
+        // one. Every write it makes is inside this guild — the weekly claim on
+        // `bankInterestLastRunAt`, the credits to this guild's users — and it
+        // finishes by posting the interest summary to this guild's announcement
+        // channel. Pinned to shard 0 it pays correctly and tells nobody.
+        if (!handlesGuild(guildId, client)) continue;
+
         try {
             // Atomic weekly claim — skip if already run within the last 7 days
             const claimed = await Guild.findOneAndUpdate(

--- a/src/services/seasonalEventService.js
+++ b/src/services/seasonalEventService.js
@@ -1,6 +1,7 @@
 const Guild = require('../models/Guild');
 const { SEASONAL_EVENTS, getActiveSeasonalEvent } = require('../data/seasonalEvents');
 const COLORS = require('../utils/embedColors');
+const { handlesGuild } = require('../utils/sharding');
 
 /**
  * Check all guilds for seasonal event auto-start/auto-end and apply changes.
@@ -16,6 +17,11 @@ async function checkSeasonalEvents(client) {
     const guilds = await Guild.find({}, 'guildId activeEvent economy.announcementChannelId').lean();
 
     for (const guild of guilds) {
+        // Per-guild job. Checked before the writes below rather than relying on
+        // the cache miss: a shard that does not own this guild must not be the
+        // one to start or end its event.
+        if (!handlesGuild(guild.guildId, client)) continue;
+
         const discordGuild = client.guilds.cache.get(guild.guildId);
         if (!discordGuild) continue;
 

--- a/src/services/tempBanService.js
+++ b/src/services/tempBanService.js
@@ -1,5 +1,6 @@
 const TempBan = require('../models/TempBan');
 const { logModeration } = require('./moderationLogService');
+const { handlesGuild } = require('../utils/sharding');
 
 // Discord API error code: the user is not banned. The only fetch failure that
 // means the record has done its job.
@@ -17,6 +18,11 @@ async function processExpiredBans(client) {
     let failed = 0;
 
     for (const entry of expired) {
+        // Per-guild job. This has to come before the cache lookup: the delete
+        // below reads a miss as "the guild is gone", and on another shard's
+        // guild that would throw the record away while the ban stays in place.
+        if (!handlesGuild(entry.guildId, client)) continue;
+
         try {
             const guild = client.guilds.cache.get(entry.guildId);
             if (!guild) {

--- a/src/services/tempVoiceService.js
+++ b/src/services/tempVoiceService.js
@@ -1,5 +1,6 @@
 const { ChannelType, PermissionFlagsBits } = require('discord.js');
 const Guild = require('../models/Guild');
+const { handlesGuild } = require('../utils/sharding');
 
 async function handleVoiceStateUpdate(oldState, newState, _client) {
     const guild = newState.guild ?? oldState.guild;
@@ -70,6 +71,11 @@ async function checkTempVoice(client) {
         const guilds = await Guild.find({ 'tempVoice.enabled': true, 'tempVoice.activeChannels.0': { $exists: true } });
 
         for (const guildSettings of guilds) {
+            // Per-guild job. The cache miss below already skips another shard's
+            // guilds, but it cannot tell them apart from a guild this shard owns
+            // and has not cached yet — which would silently clear activeChannels.
+            if (!handlesGuild(guildSettings.guildId, client)) continue;
+
             const guild = client.guilds.cache.get(guildSettings.guildId);
             if (!guild) continue;
 

--- a/src/utils/sharding.js
+++ b/src/utils/sharding.js
@@ -116,6 +116,24 @@ function ownsGuild(guildId, client = null) {
 }
 
 /**
+ * Which process is responsible for work belonging to `guildId`.
+ *
+ * `ownsGuild` answers the routing question and nothing else, so it has no
+ * opinion about work that has no guild — and the scheduler has some: a reminder
+ * set in a DM carries `guildId: null`. That work still has to happen exactly
+ * once, so it falls to the primary shard, the one process every deployment is
+ * guaranteed to have.
+ *
+ * This is the predicate a per-guild scheduled job filters its work list with.
+ * Unsharded it is constantly true for guild-scoped rows and true on the only
+ * process for the rest, so it changes nothing until a second shard exists.
+ */
+function handlesGuild(guildId, client = null) {
+    if (guildId === null || guildId === undefined || guildId === '') return isPrimaryShard(client);
+    return ownsGuild(guildId, client);
+}
+
+/**
  * Guard for process-local session state keyed by guild.
  *
  * The four multiplayer stores hold a round for one guild in memory, which is
@@ -165,6 +183,7 @@ module.exports = {
     shardId,
     isPrimaryShard,
     ownsGuild,
+    handlesGuild,
     assertGuildAffinity,
     shardTag,
 };

--- a/tests/activeGameLockWrappers.test.js
+++ b/tests/activeGameLockWrappers.test.js
@@ -34,6 +34,8 @@ jest.mock('../src/models/Guild', () => ({
     findOne: jest.fn(),
     findOneAndUpdate: jest.fn().mockResolvedValue({}),
 }));
+jest.mock('../src/utils/guildSettingsCache', () =>
+    require('./helpers/guildSettingsCacheMock')());
 
 jest.mock('../src/services/casinoJackpotService', () => ({
     processJackpotBet: jest.fn().mockResolvedValue(undefined),

--- a/tests/aiMcpCommand.test.js
+++ b/tests/aiMcpCommand.test.js
@@ -36,6 +36,8 @@ jest.mock('../src/services/aiService', () => ({
 }));
 
 jest.mock('../src/models/Guild', () => ({ findOne: jest.fn() }));
+jest.mock('../src/utils/guildSettingsCache', () =>
+    require('./helpers/guildSettingsCacheMock')());
 jest.mock('../src/models/User', () => ({
     findOne: jest.fn(async () => ({ pinnedMemories: [] })),
     create: jest.fn(async () => ({ pinnedMemories: [] }))

--- a/tests/aiScheduleCommand.test.js
+++ b/tests/aiScheduleCommand.test.js
@@ -9,6 +9,8 @@
 // holding a webhook open for eight minutes.
 
 jest.mock('../src/models/Guild', () => ({ findOne: jest.fn() }));
+jest.mock('../src/utils/guildSettingsCache', () =>
+    require('./helpers/guildSettingsCacheMock')());
 jest.mock('../src/models/User', () => ({ findOne: jest.fn(), create: jest.fn() }));
 jest.mock('../src/models/ScheduledTask', () => ({
     find: jest.fn(),

--- a/tests/apiEnvelope.test.js
+++ b/tests/apiEnvelope.test.js
@@ -21,6 +21,7 @@ const express = require('express');
 const request = require('supertest');
 
 const { readPage, pageEnvelope } = require('../src/dashboard/lib/apiPage');
+const stubBotGateway = require('./helpers/stubBotGateway');
 
 const API_DIR = path.join(__dirname, '..', 'src', 'dashboard', 'routes', 'api');
 
@@ -208,11 +209,11 @@ function appWith(routerPath) {
     app.use((req, res, next) => {
         req.isAuthenticated = () => true;
         req.user = { id: 'admin-1', guilds: [{ id: 'g1', permissions: '8' }] };
-        req.bot = {
-            hasGuild: () => true,
+        req.bot = stubBotGateway({
+            hasGuild: async () => true,
             canManageGuild: async () => true,
             resolveUsers: async () => ({}),
-        };
+        });
         next();
     });
     app.use('/api/v1', require(routerPath));

--- a/tests/botGateway.test.js
+++ b/tests/botGateway.test.js
@@ -164,8 +164,8 @@ describe('botGateway hands out data, never live objects', () => {
         bot = createBotGateway(stubClient({ guilds: { g1: fixture.guild } }));
     });
 
-    test('getGuild returns plain fields with no discord.js caches attached', () => {
-        const guild = bot.getGuild('g1');
+    test('getGuild returns plain fields with no discord.js caches attached', async () => {
+        const guild = await bot.getGuild('g1');
 
         expect(guild).toEqual({
             id: 'g1',
@@ -178,25 +178,25 @@ describe('botGateway hands out data, never live objects', () => {
         expect(guild.roles).toBeUndefined();
     });
 
-    test('listChannels and listRoles return arrays of plain records', () => {
-        expect(bot.listChannels('g1')).toEqual([
+    test('listChannels and listRoles return arrays of plain records', async () => {
+        expect(await bot.listChannels('g1')).toEqual([
             { id: 'c1', name: 'general', type: CHANNEL_TYPES.TEXT, parentId: 'cat1' },
             { id: 'v1', name: 'Voice', type: CHANNEL_TYPES.VOICE, parentId: null },
         ]);
-        expect(bot.listRoles('g1')).toEqual([
+        expect(await bot.listRoles('g1')).toEqual([
             { id: 'r1', name: 'Member', position: 1, managed: false },
         ]);
     });
 
     // The whole facade answers "we are not in that guild" the same way, so a
     // route can keep answering it with one 404 rather than a special case each.
-    test('reads return null for a guild the bot is not in', () => {
-        expect(bot.hasGuild('nope')).toBe(false);
-        expect(bot.getGuild('nope')).toBeNull();
-        expect(bot.listChannels('nope')).toBeNull();
-        expect(bot.listRoles('nope')).toBeNull();
-        expect(bot.hasChannel('nope', 'c1')).toBe(false);
-        expect(bot.listActiveTimeouts('nope', 10)).toBeNull();
+    test('reads return null for a guild the bot is not in', async () => {
+        expect(await bot.hasGuild('nope')).toBe(false);
+        expect(await bot.getGuild('nope')).toBeNull();
+        expect(await bot.listChannels('nope')).toBeNull();
+        expect(await bot.listRoles('nope')).toBeNull();
+        expect(await bot.hasChannel('nope', 'c1')).toBe(false);
+        expect(await bot.listActiveTimeouts('nope', 10)).toBeNull();
         return Promise.all([
             expect(bot.searchMembers('nope', 'a', 5)).resolves.toBeNull(),
             expect(bot.listBans('nope', 10)).resolves.toBeNull(),
@@ -242,8 +242,8 @@ describe('botGateway hands out data, never live objects', () => {
         await expect(bot.listBans('g1', 200)).rejects.toThrow('Missing Permissions');
     });
 
-    test('listActiveTimeouts skips members whose timeout has already lapsed', () => {
-        const active = bot.listActiveTimeouts('g1', 200);
+    test('listActiveTimeouts skips members whose timeout has already lapsed', async () => {
+        const active = await bot.listActiveTimeouts('g1', 200);
 
         expect(active.map(t => t.userId)).toEqual(['u1']);
         expect(active[0].expires).toEqual(expect.any(String));

--- a/tests/boundedProcessMaps.test.js
+++ b/tests/boundedProcessMaps.test.js
@@ -1,0 +1,246 @@
+'use strict';
+
+// Three process-local Maps missed the repo's bounded-cache convention (#928).
+// `BoundedRateLimiter`, `customBadWordRegexes` and `guildSettingsCache` all cap
+// and sweep; `voiceJoinTimes`, `chatEventService`'s `guildState` and the RSS
+// dead-feed bookkeeping grew with no ceiling. None leaks fast enough to matter
+// over days, which is exactly why nothing would ever catch it — so the ceiling
+// is asserted here rather than left to be noticed after months of uptime.
+
+const { useFixedClock, advanceClock, HOUR, MINUTE } = require('./helpers/fixedClock');
+
+jest.mock('../src/models/Guild', () => ({
+    find: jest.fn(() => ({ lean: async () => [] })),
+    findOne: jest.fn(),
+    updateOne: jest.fn(async () => ({})),
+}));
+jest.mock('../src/models/User', () => ({ findOne: jest.fn(), create: jest.fn() }));
+jest.mock('../src/utils/guildSettingsCache', () => ({ getGuildSettings: jest.fn(async () => null) }));
+jest.mock('../src/services/rivalryService', () => ({ checkRivalry: jest.fn() }));
+jest.mock('../src/services/tempVoiceService', () => ({ handleVoiceStateUpdate: jest.fn() }));
+jest.mock('../src/utils/safeFeedFetch', () => ({ safeFetchFeed: jest.fn() }));
+
+const voiceStateUpdate = require('../src/events/voiceStateUpdate');
+const chatEventService = require('../src/services/chatEventService');
+const { checkRssFeeds, __test__: rss } = require('../src/services/rssService');
+
+// ---------------------------------------------------------------------------
+// voiceJoinTimes — src/events/voiceStateUpdate.js
+// ---------------------------------------------------------------------------
+
+describe('voiceJoinTimes is bounded', () => {
+    useFixedClock();
+
+    const {
+        voiceJoinTimes,
+        MAX_TRACKED_VOICE_SESSIONS,
+        VOICE_SWEEP_INTERVAL_MS,
+        MAX_VOICE_SESSION_MS,
+        resetVoiceJoinTimes,
+    } = voiceStateUpdate.__test__;
+
+    beforeEach(() => resetVoiceJoinTimes());
+
+    /** A join transition for `userId` in `guildId`. */
+    function join(guildId, userId) {
+        const member = { id: userId, user: { bot: false }, roles: { cache: { some: () => false } } };
+        return voiceStateUpdate.execute(
+            { channelId: null, guild: { id: guildId }, member },
+            { channelId: 'voice-1', guild: { id: guildId }, member },
+            {},
+        );
+    }
+
+    /** A leave transition, which is what normally clears the entry. */
+    function leave(guildId, userId) {
+        const member = { id: userId, user: { bot: false }, roles: { cache: { some: () => false } } };
+        return voiceStateUpdate.execute(
+            { channelId: 'voice-1', guild: { id: guildId }, member },
+            { channelId: null, guild: { id: guildId }, member },
+            {},
+        );
+    }
+
+    test('a join followed by its leave leaves nothing behind', async () => {
+        await join('g1', 'u1');
+        expect(voiceJoinTimes.size).toBe(1);
+        await leave('g1', 'u1');
+        expect(voiceJoinTimes.size).toBe(0);
+    });
+
+    test('joins whose leave never arrives are swept once they are older than a session', async () => {
+        await join('g1', 'stranded');
+        // The leave for this one is never delivered — the bot was removed from
+        // the guild, or the gateway dropped the transition.
+        expect(voiceJoinTimes.size).toBe(1);
+
+        // Still inside a plausible session: a sweep must not take it.
+        advanceClock(VOICE_SWEEP_INTERVAL_MS + MINUTE);
+        await join('g1', 'other');
+        expect(voiceJoinTimes.has('g1:stranded')).toBe(true);
+
+        advanceClock(MAX_VOICE_SESSION_MS + MINUTE);
+        await join('g1', 'later');
+        expect(voiceJoinTimes.has('g1:stranded')).toBe(false);
+        expect(voiceJoinTimes.has('g1:later')).toBe(true);
+    });
+
+    test('the sweep runs at most once per interval', async () => {
+        await join('g1', 'stranded');
+        advanceClock(MAX_VOICE_SESSION_MS + MINUTE);
+
+        // First join past the cutoff sweeps; the entry goes.
+        await join('g1', 'a');
+        expect(voiceJoinTimes.has('g1:stranded')).toBe(false);
+
+        // A second stranded join inside the same interval is not swept again,
+        // which is the point of the interval — the sweep is O(n) per hour.
+        await join('g1', 'b');
+        advanceClock(MAX_VOICE_SESSION_MS + MINUTE);
+        await join('g1', 'c');
+        expect(voiceJoinTimes.has('g1:b')).toBe(false);
+    });
+
+    test('the map never exceeds its cap, however many joins arrive', async () => {
+        for (let i = 0; i < MAX_TRACKED_VOICE_SESSIONS + 250; i++) {
+            await join('g1', `u${i}`);
+        }
+        expect(voiceJoinTimes.size).toBe(MAX_TRACKED_VOICE_SESSIONS);
+        // FIFO: the oldest joins are the ones dropped.
+        expect(voiceJoinTimes.has('g1:u0')).toBe(false);
+        expect(voiceJoinTimes.has(`g1:u${MAX_TRACKED_VOICE_SESSIONS + 249}`)).toBe(true);
+    });
+
+    test('a leave past the cutoff awards nothing rather than depending on sweep timing', async () => {
+        const { getGuildSettings } = require('../src/utils/guildSettingsCache');
+        getGuildSettings.mockResolvedValue({
+            leveling: { enabled: true, voiceXpEnabled: true, rewardsEnabled: true, voiceXpRate: 1 },
+        });
+
+        await join('g1', 'u1');
+        advanceClock(MAX_VOICE_SESSION_MS + HOUR);
+        await leave('g1', 'u1');
+
+        const User = require('../src/models/User');
+        expect(User.findOne).not.toHaveBeenCalled();
+        expect(voiceJoinTimes.has('g1:u1')).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// guildState — src/services/chatEventService.js
+// ---------------------------------------------------------------------------
+
+describe('chatEventService guildState is bounded', () => {
+    const { guildState, MAX_TRACKED_GUILDS, MIN_MESSAGES_BETWEEN } = chatEventService.__test__;
+
+    beforeEach(() => guildState.clear());
+
+    const messageIn = guildId => ({
+        guild: { id: guildId },
+        channel: { isTextBased: () => true },
+    });
+
+    test('one entry per guild, capped FIFO', async () => {
+        for (let i = 0; i < MAX_TRACKED_GUILDS + 100; i++) {
+            await chatEventService.maybeTriggerChatEvent(messageIn(`g${i}`), {});
+        }
+        expect(guildState.size).toBe(MAX_TRACKED_GUILDS);
+        expect(guildState.has('g0')).toBe(false);
+        expect(guildState.has(`g${MAX_TRACKED_GUILDS + 99}`)).toBe(true);
+    });
+
+    test('eviction costs progress toward the next event, never an early one', async () => {
+        // Fill to the cap with the victim inserted first, having almost earned
+        // an event, then push it out.
+        const victim = messageIn('victim');
+        for (let i = 0; i < MIN_MESSAGES_BETWEEN - 1; i++) {
+            await chatEventService.maybeTriggerChatEvent(victim, {});
+        }
+        expect(guildState.get('victim').messagesSince).toBe(MIN_MESSAGES_BETWEEN - 1);
+
+        for (let i = 0; i < MAX_TRACKED_GUILDS; i++) {
+            await chatEventService.maybeTriggerChatEvent(messageIn(`filler${i}`), {});
+        }
+        expect(guildState.has('victim')).toBe(false);
+
+        await chatEventService.maybeTriggerChatEvent(victim, {});
+        expect(guildState.get('victim').messagesSince).toBe(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Dead-feed bookkeeping — src/services/rssService.js
+// ---------------------------------------------------------------------------
+
+describe('RSS dead-feed state is pruned', () => {
+    useFixedClock();
+
+    const { feedFailCounts, feedLastFailTime, pruneFeedFailureState, DEAD_FEED_STATE_TTL_MS } = rss;
+
+    beforeEach(() => {
+        feedFailCounts.clear();
+        feedLastFailTime.clear();
+    });
+
+    test('an entry inside the TTL survives — a feed still being polled keeps its count', () => {
+        feedFailCounts.set('https://live.example/feed', 3);
+        feedLastFailTime.set('https://live.example/feed', Date.now());
+
+        advanceClock(DEAD_FEED_STATE_TTL_MS - MINUTE);
+        pruneFeedFailureState();
+
+        expect(feedFailCounts.get('https://live.example/feed')).toBe(3);
+    });
+
+    test('an entry nothing has retried since the TTL is dropped', () => {
+        feedFailCounts.set('https://unsubscribed.example/feed', 5);
+        feedLastFailTime.set('https://unsubscribed.example/feed', Date.now());
+
+        advanceClock(DEAD_FEED_STATE_TTL_MS + MINUTE);
+        pruneFeedFailureState();
+
+        expect(feedFailCounts.has('https://unsubscribed.example/feed')).toBe(false);
+        expect(feedLastFailTime.has('https://unsubscribed.example/feed')).toBe(false);
+    });
+
+    test('the TTL outlasts the retry cooldown, so a parked feed is still parked', () => {
+        expect(DEAD_FEED_STATE_TTL_MS).toBeGreaterThan(rss.DEAD_FEED_COOLDOWN_MS);
+    });
+
+    test('a half-written pair is reclaimed from either side', () => {
+        feedFailCounts.set('https://a.example/feed', 2);      // no timestamp
+        feedLastFailTime.set('https://b.example/feed', Date.now()); // no count
+
+        pruneFeedFailureState();
+
+        expect(feedFailCounts.size).toBe(0);
+        expect(feedLastFailTime.size).toBe(0);
+    });
+
+    test('a sweep prunes even when it throws before finishing', async () => {
+        feedFailCounts.set('https://stale.example/feed', 4);
+        feedLastFailTime.set('https://stale.example/feed', Date.now() - DEAD_FEED_STATE_TTL_MS - HOUR);
+
+        const Guild = require('../src/models/Guild');
+        Guild.find.mockImplementationOnce(() => ({ lean: async () => { throw new Error('mongo down'); } }));
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        await checkRssFeeds({});
+
+        expect(feedFailCounts.has('https://stale.example/feed')).toBe(false);
+        console.error.mockRestore();
+    });
+
+    test('the prune leaves daily-news-only feeds alone while they are current', async () => {
+        // The sweep only queries guilds with rssFeeds, so a URL configured
+        // solely by a daily-news profile is absent from its subscription list.
+        // Pruning against that list would clear it every five minutes.
+        feedFailCounts.set('https://digest-only.example/feed', 3);
+        feedLastFailTime.set('https://digest-only.example/feed', Date.now());
+
+        await checkRssFeeds({});
+
+        expect(feedFailCounts.get('https://digest-only.example/feed')).toBe(3);
+    });
+});

--- a/tests/commandGuildSettingsReads.test.js
+++ b/tests/commandGuildSettingsReads.test.js
@@ -79,8 +79,10 @@ describe('commands do not hydrate the whole guild document', () => {
             // Read-modify-write on the same field: the value read decides
             // whether the write happens, so a cached read would put a TTL
             // between the check and the write for a second caller to slip into.
-            'src/commands/admin/event.js': 2,      // /event start, /event end — activeEvent
-            'src/commands/economy/season.js': 2,   // /season start, /season end — currentSeason
+            'src/commands/economy/event/manage.js': 2,  // /event start, /event end — activeEvent
+            // One read, shared by /season start and /season end through
+            // readSeasonForWrite — the reason is written down once there.
+            'src/commands/economy/season.js': 1,
 
             // Three of the same in war.js (challenge, accept, cancel — activeWar),
             // plus the invite-code lookup, which is not a guildId query at all,

--- a/tests/commandGuildSettingsReads.test.js
+++ b/tests/commandGuildSettingsReads.test.js
@@ -1,0 +1,122 @@
+'use strict';
+
+// Command handlers read guild configuration through the settings cache (#877).
+//
+// 121 handlers opened with a raw, unprojected `Guild.findOne({ guildId })` —
+// usually to read one field like `economy.currency` or `economy.enabled`. Two
+// costs stacked on every invocation: the whole document was hydrated, inline
+// `shop[].imageData` Buffers (up to 35 × 512 KB) and giveaway entrant arrays
+// included, to read a boolean; and it duplicated a read `interactionCreate` had
+// already done for the same interaction, through the cache, moments earlier.
+//
+// The rule these tests hold is narrow and checkable: a command may still read
+// the Guild model, but never for the whole document. Either it goes through
+// `getGuildSettings` (which projects the heavy fields away and collapses the
+// duplicate read into a cache hit), or it passes a projection and says why the
+// cache cannot serve it.
+
+const fs = require('fs');
+const path = require('path');
+
+const COMMANDS = path.join(__dirname, '..', 'src', 'commands');
+
+function commandFiles(dir = COMMANDS, found = []) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) commandFiles(full, found);
+        else if (entry.name.endsWith('.js')) found.push(full);
+    }
+    return found;
+}
+
+const rel = file => path.relative(path.join(__dirname, '..'), file);
+
+/**
+ * Every `Guild.findOne(` in the command tree, with the text of the call — the
+ * rest of the line plus the next few, since some are written across lines.
+ */
+function modelReads() {
+    const reads = [];
+    for (const file of commandFiles()) {
+        const lines = fs.readFileSync(file, 'utf8').split('\n');
+        for (const [i, line] of lines.entries()) {
+            if (!line.includes('Guild.findOne(')) continue;
+            reads.push({
+                file: rel(file),
+                line: i + 1,
+                text: lines.slice(i, i + 5).join('\n'),
+            });
+        }
+    }
+    return reads;
+}
+
+describe('commands do not hydrate the whole guild document', () => {
+    test('every remaining Guild.findOne in a command carries a projection', () => {
+        // A projection is the second argument, or a `.select()`. Without one,
+        // Mongoose returns every field — which on a guild with an illustrated
+        // shop is megabytes, for a handler that wanted one boolean.
+        const unprojected = modelReads().filter(read => {
+            const call = read.text.slice(read.text.indexOf('Guild.findOne('));
+            const projected =
+                /\}\s*,\s*(?:'[^']*'|"[^"]*"|\{)/.test(call) ||   // second argument
+                /\)\s*\.\s*select\(/.test(call);                  // .select(...)
+            return !projected;
+        });
+
+        expect(unprojected.map(r => `${r.file}:${r.line}`)).toEqual([]);
+    });
+
+    test('the handful of reads that stay on the model are the ones that must', () => {
+        // Keyed by file rather than by line, so moving code does not fail this,
+        // but adding a read does. Each entry is a decision with a reason: the
+        // point is that a new unprojected read cannot arrive without someone
+        // writing down why it is not going through the cache.
+        const perFile = {};
+        for (const read of modelReads()) perFile[read.file] = (perFile[read.file] || 0) + 1;
+
+        expect(perFile).toEqual({
+            // Read-modify-write on the same field: the value read decides
+            // whether the write happens, so a cached read would put a TTL
+            // between the check and the write for a second caller to slip into.
+            'src/commands/admin/event.js': 2,      // /event start, /event end — activeEvent
+            'src/commands/economy/season.js': 2,   // /season start, /season end — currentSeason
+
+            // Three of the same in war.js (challenge, accept, cancel — activeWar),
+            // plus the invite-code lookup, which is not a guildId query at all,
+            // plus grantWarPoints resolving the scores a war is settled on plain
+            // after its cached read has answered the common "no war here" case.
+            'src/commands/economy/war.js': 5,
+
+            // Writes the document back, so it needs a real Mongoose document
+            // rather than the cache's shared plain object.
+            'src/commands/economy/boost.js': 1,
+
+            // A positional projection over an array, narrower than anything the
+            // cache could hand back.
+            'src/commands/economy/fish/cast.js': 1,
+        });
+    });
+
+});
+
+describe('the settings cache is what commands actually call', () => {
+    test('most command files now read through getGuildSettings', () => {
+        const files = commandFiles();
+        const cached = files.filter(f =>
+            fs.readFileSync(f, 'utf8').includes('getGuildSettings('));
+        // 78 files at the time this landed. The floor is a ratchet, not a
+        // target: it exists so a refactor cannot quietly put the reads back.
+        expect(cached.length).toBeGreaterThanOrEqual(70);
+    });
+
+    test('a command that reads through the cache does not also read the model', () => {
+        // /balance is the shape the issue is about: it read the whole document
+        // for `economy.currency` on every invocation, in a guild that may have
+        // an illustrated shop.
+        const src = fs.readFileSync(path.join(COMMANDS, 'economy', 'balance.js'), 'utf8');
+        expect(src).toContain('getGuildSettings(');
+        expect(src).not.toContain('Guild.findOne(');
+        expect(src).not.toMatch(/require\(['"]\.\.\/\.\.\/models\/Guild['"]\)/);
+    });
+});

--- a/tests/craftMiningLock.test.js
+++ b/tests/craftMiningLock.test.js
@@ -15,6 +15,8 @@ jest.mock('../src/utils/activeGameLock', () => ({
 }));
 
 jest.mock('../src/models/Guild', () => ({ findOne: jest.fn() }));
+jest.mock('../src/utils/guildSettingsCache', () =>
+    require('./helpers/guildSettingsCacheMock')());
 jest.mock('../src/models/User', () => ({ findOneAndUpdate: jest.fn() }));
 
 const lock  = require('../src/utils/activeGameLock');

--- a/tests/dashboardAuthEnforcement.test.js
+++ b/tests/dashboardAuthEnforcement.test.js
@@ -20,6 +20,7 @@ const {
     checkCsrfOrigin,
 } = require('../src/dashboard/lib/middleware');
 const { forgetLiveGuildAccess } = require('../src/dashboard/lib/permissions');
+const stubBotGateway = require('./helpers/stubBotGateway');
 
 const MANAGE_GUILD = (0x20n).toString();
 const NO_PERMS     = '0';
@@ -44,10 +45,10 @@ function makeReq({ authenticated = true, guilds = [], botGuilds = [], params = {
     return {
         isAuthenticated: () => authenticated,
         user: authenticated ? { id: 'user-1', guilds } : undefined,
-        bot: {
-            hasGuild: id => botGuilds.includes(id),
+        bot: stubBotGateway({
+            hasGuild: async id => botGuilds.includes(id),
             canManageGuild: async () => live,
-        },
+        }),
         params,
         headers,
     };
@@ -186,9 +187,11 @@ describe('checkGuildAccess', () => {
     // dashboard because Discord is having an incident.
     test('falls back to the snapshot when the live check cannot answer', async () => {
         for (const bot of [
-            { hasGuild: () => true, canManageGuild: async () => null },
-            { hasGuild: () => true, canManageGuild: async () => { throw new Error('Discord is down'); } },
-            { hasGuild: () => true }, // a gateway with no such method at all
+            stubBotGateway({ hasGuild: async () => true, canManageGuild: async () => null }),
+            stubBotGateway({ hasGuild: async () => true, canManageGuild: async () => { throw new Error('Discord is down'); } }),
+            // A gateway with no such method at all: the stub fills the protocol
+            // in with nulls, which is the same "could not be asked" answer.
+            { ...stubBotGateway({ hasGuild: async () => true }), canManageGuild: undefined },
         ]) {
             forgetLiveGuildAccess();
             const res = makeRes();
@@ -206,7 +209,7 @@ describe('checkGuildAccess', () => {
     test('asks Discord once per user and guild, not once per request', async () => {
         const canManageGuild = jest.fn().mockResolvedValue(true);
         const req = makeReq({ guilds: [adminOf('g1')], botGuilds: ['g1'], params: { guildId: 'g1' } });
-        req.bot = { hasGuild: () => true, canManageGuild };
+        req.bot = stubBotGateway({ hasGuild: async () => true, canManageGuild });
 
         await checkGuildAccess(req, makeRes(), jest.fn());
         await checkGuildAccess(req, makeRes(), jest.fn());

--- a/tests/dashboardProcess.test.js
+++ b/tests/dashboardProcess.test.js
@@ -1,0 +1,188 @@
+'use strict';
+
+// The dashboard's own entry point (#876).
+//
+// src/dashboard/index.js is the process the split produces, and it is defined
+// as much by what it does not do as by what it does: no Discord client, no
+// migrations, no cron jobs. Those absences are the isolation, so they are
+// asserted rather than assumed — a require added here that pulls in the bot's
+// bootstrap would undo the split without failing anything else.
+
+const EventEmitter = require('events');
+
+// `mock`-prefixed so jest allows the factories below to close over them: the
+// factories are hoisted above every other declaration in the file.
+const mockConnected = [];
+const mockBuilt = [];
+const mockListened = [];
+const mockMongoEvents = new EventEmitter();
+
+jest.mock('mongoose', () => ({
+    connect: jest.fn(async uri => { mockConnected.push(uri); }),
+    connection: {
+        on: (event, fn) => mockMongoEvents.on(event, fn),
+        close: jest.fn(async () => {}),
+    },
+}));
+
+jest.mock('../src/bot/remoteGateway', () => ({
+    createRemoteBotGateway: jest.fn(options => {
+        mockBuilt.push(options);
+        return { hasGuild: async () => false };
+    }),
+}));
+
+const mockClosed = [];
+jest.mock('../src/dashboard/server', () => ({
+    createApp: jest.fn(deps => ({ __app: true, deps })),
+    listen: jest.fn(app => {
+        mockListened.push(app);
+        return { close: cb => { mockClosed.push(true); cb(); } };
+    }),
+}));
+
+jest.mock('../src/utils/logger', () => ({ installConsoleBridge: jest.fn() }));
+jest.mock('../src/config/fileSecrets', () => ({ loadFileSecrets: jest.fn() }));
+
+const SAVED = { ...process.env };
+
+beforeEach(() => {
+    mockConnected.length = 0;
+    mockBuilt.length = 0;
+    mockListened.length = 0;
+    mockClosed.length = 0;
+    process.env.CLIENT_ID = '1';
+    process.env.CLIENT_SECRET = 'secret';
+    process.env.MONGODB_URI = 'mongodb://mongo:27017/clawdia';
+    process.env.SESSION_SECRET = 's'.repeat(48);
+    process.env.DASHBOARD_URL = 'http://localhost:3000';
+    process.env.NODE_ENV = 'development';
+    process.env.BOT_GATEWAY_URL = 'http://clawdia:3001';
+    process.env.BOT_GATEWAY_TOKEN = 't'.repeat(48);
+    delete process.env.DISCORD_TOKEN;
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+        if (!(key in SAVED)) delete process.env[key];
+    }
+    Object.assign(process.env, SAVED);
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+});
+
+const load = () => require('../src/dashboard/index');
+
+describe('the dashboard process', () => {
+    test('connects to Mongo, builds the remote facade, and listens', async () => {
+        await load().main();
+
+        expect(mockConnected).toEqual(['mongodb://mongo:27017/clawdia']);
+        expect(mockBuilt).toHaveLength(1);
+        expect(mockListened).toHaveLength(1);
+
+        const { createApp } = require('../src/dashboard/server');
+        // The facade it built is what the app is handed: this process has no
+        // client, so `bot` is the only way it reaches Discord at all.
+        expect(createApp).toHaveBeenCalledWith({ bot: expect.objectContaining({ hasGuild: expect.any(Function) }) });
+        expect(createApp.mock.calls[0][0]).not.toHaveProperty('client');
+    });
+
+    test('exits rather than serving when the database is unreachable', async () => {
+        require('mongoose').connect.mockRejectedValueOnce(new Error('no route to host'));
+        jest.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exited'); });
+
+        await expect(load().main()).rejects.toThrow('exited');
+        expect(process.exit).toHaveBeenCalledWith(1);
+        expect(mockListened).toHaveLength(0);
+    });
+
+    test('fails before binding a port when it has no bot process to call', async () => {
+        // A dashboard that starts and then 500s every page because it cannot
+        // reach the bot is worse than one that refuses to start.
+        require('../src/bot/remoteGateway').createRemoteBotGateway
+            .mockImplementationOnce(() => { throw new Error('BOT_GATEWAY_URL is not set'); });
+
+        await expect(load().main()).rejects.toThrow('BOT_GATEWAY_URL');
+        expect(mockListened).toHaveLength(0);
+    });
+
+    test('a database hiccup is logged, not fatal — the connection handlers are wired', async () => {
+        await load().main();
+
+        expect(() => mockMongoEvents.emit('disconnected')).not.toThrow();
+        expect(() => mockMongoEvents.emit('reconnected')).not.toThrow();
+        expect(() => mockMongoEvents.emit('error', new Error('blip'))).not.toThrow();
+    });
+
+    test('it does not build a Discord client, log in, or run migrations', () => {
+        // Reading the source rather than the module graph, because the point is
+        // that none of this is even reachable from here.
+        const fs = require('fs');
+        const path = require('path');
+        const src = fs.readFileSync(path.join(__dirname, '..', 'src/dashboard/index.js'), 'utf8');
+
+        expect(src).not.toMatch(/discord\.js/);
+        expect(src).not.toMatch(/runMigrations/);
+        expect(src).not.toMatch(/startScheduler/);
+        expect(src).not.toMatch(/loadCommands|loadEvents/);
+    });
+
+    test('a signal closes the listener and the database, then exits cleanly', async () => {
+        // A dashboard that exits without draining leaves in-flight requests
+        // hanging and the compose stop_grace_period doing nothing.
+        const handlers = {};
+        jest.spyOn(process, 'on').mockImplementation((signal, fn) => {
+            handlers[signal] = fn;
+            return process;
+        });
+        jest.spyOn(process, 'exit').mockImplementation(() => {});
+
+        await load().main();
+        expect(Object.keys(handlers)).toEqual(
+            expect.arrayContaining(['SIGTERM', 'SIGINT', 'unhandledRejection', 'uncaughtException']));
+
+        await handlers.SIGTERM();
+
+        expect(mockClosed).toEqual([true]);
+        expect(require('mongoose').connection.close).toHaveBeenCalled();
+        expect(process.exit).toHaveBeenCalledWith(0);
+    });
+
+    test('a shutdown that goes wrong still exits rather than hanging', async () => {
+        const handlers = {};
+        jest.spyOn(process, 'on').mockImplementation((signal, fn) => { handlers[signal] = fn; return process; });
+        jest.spyOn(process, 'exit').mockImplementation(() => {});
+        require('mongoose').connection.close.mockRejectedValueOnce(new Error('already gone'));
+
+        await load().main();
+        await handlers.SIGINT();
+
+        expect(process.exit).toHaveBeenCalledWith(0);
+    });
+
+    test('an unhandled rejection is logged, not fatal', async () => {
+        // src/index.js exits on a spike of these because it has a gateway
+        // connection to lose. This process does not: the worst case is one
+        // broken page, and exiting turns that into no dashboard at all.
+        const handlers = {};
+        jest.spyOn(process, 'on').mockImplementation((signal, fn) => { handlers[signal] = fn; return process; });
+        jest.spyOn(process, 'exit').mockImplementation(() => {});
+
+        await load().main();
+        handlers.unhandledRejection(new Error('a route did something odd'));
+        handlers.uncaughtException(new Error('and something else'));
+
+        expect(process.exit).not.toHaveBeenCalled();
+        expect(console.error).toHaveBeenCalled();
+    });
+
+    test('it validates its configuration without demanding the bot token', async () => {
+        // The credential with the widest blast radius in the deployment, in a
+        // container that has no gateway connection to use it with.
+        expect(process.env.DISCORD_TOKEN).toBeUndefined();
+        await expect(load().main()).resolves.toBeUndefined();
+    });
+});

--- a/tests/economyCrimeCommand.test.js
+++ b/tests/economyCrimeCommand.test.js
@@ -20,6 +20,8 @@ const mockGuilds = fakeCollection('Guild');
 
 jest.mock('../src/models/User', () => mockUsers.model);
 jest.mock('../src/models/Guild', () => mockGuilds.model);
+jest.mock('../src/utils/guildSettingsCache', () =>
+    require('./helpers/guildSettingsCacheMock')());
 
 jest.mock('../src/utils/logTransaction', () => ({ logTransaction: jest.fn() }));
 jest.mock('../src/utils/grindProfile', () => ({ attachGrind: jest.fn(async user => user) }));

--- a/tests/economyMarketCommand.test.js
+++ b/tests/economyMarketCommand.test.js
@@ -22,6 +22,8 @@ const mockTransactions = fakeCollection('Transaction', {}, { unique: [] });
 
 jest.mock('../src/models/User', () => mockUsers.model);
 jest.mock('../src/models/Guild', () => mockGuilds.model);
+jest.mock('../src/utils/guildSettingsCache', () =>
+    require('./helpers/guildSettingsCacheMock')());
 jest.mock('../src/models/MarketListing', () => mockListings.model);
 jest.mock('../src/models/Transaction', () => mockTransactions.model);
 jest.mock('../src/utils/logTransaction', () => ({ logTransaction: jest.fn() }));

--- a/tests/economyUseCommand.test.js
+++ b/tests/economyUseCommand.test.js
@@ -22,6 +22,8 @@ const mockGuilds = fakeCollection('Guild');
 
 jest.mock('../src/models/User', () => mockUsers.model);
 jest.mock('../src/models/Guild', () => mockGuilds.model);
+jest.mock('../src/utils/guildSettingsCache', () =>
+    require('./helpers/guildSettingsCacheMock')());
 jest.mock('../src/utils/inventoryGrant', () => ({
     grantInventoryItem: jest.fn(async () => true),
     inventoryAddExpr: jest.fn(() => ({})),

--- a/tests/economyWorkCommand.test.js
+++ b/tests/economyWorkCommand.test.js
@@ -19,6 +19,8 @@ const mockGuilds = fakeCollection('Guild');
 
 jest.mock('../src/models/User', () => mockUsers.model);
 jest.mock('../src/models/Guild', () => mockGuilds.model);
+jest.mock('../src/utils/guildSettingsCache', () =>
+    require('./helpers/guildSettingsCacheMock')());
 
 jest.mock('../src/utils/logTransaction', () => ({ logTransaction: jest.fn() }));
 jest.mock('../src/utils/grindProfile', () => ({ attachGrind: jest.fn(async user => user) }));

--- a/tests/gatewaySplit.test.js
+++ b/tests/gatewaySplit.test.js
@@ -1,0 +1,705 @@
+'use strict';
+
+// The dashboard as its own process (#876).
+//
+// On shard 0 one Node process ran the Discord gateway, the Express dashboard,
+// full-collection aggregations, canvas rendering, AI calls and 18 cron jobs. A
+// heavy dashboard request delayed heartbeats for every guild, and a fault in a
+// route reached the process guards in src/index.js, which exit — so a bad page
+// was a bot-wide outage. The hard part was already done: createApp takes an
+// injected `bot`, and that facade is id-in / plain-data-out. What was missing
+// was a transport.
+//
+// These tests hold the two properties the split lives or dies on. The wire has
+// to carry the facade's contract *exactly* — including the difference between
+// "we do not have that guild" (null) and "Discord refused" (a throw), which
+// routes act on. And the two implementations have to stay interchangeable,
+// which they only are while one list defines them both.
+
+const http = require('http');
+
+const { GATEWAY_METHODS } = require('../src/bot/gatewayProtocol');
+const { createBotGateway } = require('../src/bot/gateway');
+const { createGatewayHandler, MAX_BODY_BYTES, MIN_TOKEN_LENGTH } = require('../src/bot/gatewayServer');
+const { createRemoteBotGateway } = require('../src/bot/remoteGateway');
+
+const TOKEN = 'a'.repeat(MIN_TOKEN_LENGTH);
+
+// ---------------------------------------------------------------------------
+// A client with enough of discord.js's shape for the facade to read
+// ---------------------------------------------------------------------------
+
+function stubClient({ guilds = [], ready = true } = {}) {
+    const cache = new Map(guilds.map(g => [g.id, g]));
+    return {
+        readyAt: ready ? new Date() : null,
+        guilds: { cache },
+        users: { fetch: async id => { throw new Error(`no user ${id}`); } },
+    };
+}
+
+function stubGuild(id, { name = `Guild ${id}`, memberCount = 10, channels = [], roles = [], members } = {}) {
+    return {
+        id,
+        name,
+        icon: null,
+        ownerId: 'owner-1',
+        memberCount,
+        channels: { cache: new Map(channels.map(c => [c.id, c])) },
+        roles: { cache: new Map(roles.map(r => [r.id, r])) },
+        members: members ?? { cache: new Map(), fetch: async () => { throw Object.assign(new Error('Unknown Member'), { code: 10007 }); } },
+        bans: { fetch: async () => { throw Object.assign(new Error('Missing Permissions'), { code: 50013 }); } },
+    };
+}
+
+/**
+ * Stands the real server up on an ephemeral port with the real client in front
+ * of it, so what is exercised is the wire and not a mock of it.
+ */
+async function connectedPair(client, { token = TOKEN, health } = {}) {
+    const local = createBotGateway(client);
+    const server = http.createServer(createGatewayHandler(local, token, health));
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+
+    const remote = createRemoteBotGateway({
+        url: `http://127.0.0.1:${server.address().port}`,
+        token,
+    });
+
+    return { local, remote, server, close: () => new Promise(r => server.close(r)) };
+}
+
+// ---------------------------------------------------------------------------
+
+describe('the two facades answer to one protocol', () => {
+    test('the local implementation matches the protocol exactly', () => {
+        const local = createBotGateway(stubClient());
+        expect(Object.keys(local).sort()).toEqual([...GATEWAY_METHODS].sort());
+    });
+
+    test('the remote implementation matches the protocol exactly', () => {
+        const remote = createRemoteBotGateway({ url: 'http://bot:3001', token: TOKEN });
+        expect(Object.keys(remote).sort()).toEqual([...GATEWAY_METHODS].sort());
+    });
+
+    test('every method on both sides is asynchronous', () => {
+        // A route cannot be written against a facade that is synchronous in one
+        // deployment and not the other — that difference would only ever show
+        // up in the split one, which is the deployment nobody is looking at
+        // while they write the route.
+        const local = createBotGateway(stubClient({ guilds: [stubGuild('g1')] }));
+        const remote = createRemoteBotGateway({ url: 'http://bot:3001', token: TOKEN });
+        for (const method of GATEWAY_METHODS) {
+            expect(typeof local[method]).toBe('function');
+            expect(typeof remote[method]).toBe('function');
+            const returned = local[method]('g1', 'x', 'y');
+            expect(typeof returned?.then).toBe('function');
+            returned.catch(() => {});
+        }
+    });
+
+    test('a method added to the gateway and not the protocol fails where it is built', () => {
+        const { assertImplementsProtocol } = require('../src/bot/gateway');
+        const complete = Object.fromEntries(GATEWAY_METHODS.map(m => [m, () => {}]));
+
+        expect(() => assertImplementsProtocol(complete, 'test')).not.toThrow();
+        expect(() => assertImplementsProtocol({ ...complete, surprise: () => {} }, 'test'))
+            .toThrow(/not in the protocol: surprise/);
+
+        const { hasGuild, ...missing } = complete;
+        expect(hasGuild).toBeInstanceOf(Function);
+        expect(() => assertImplementsProtocol(missing, 'test')).toThrow(/missing hasGuild/);
+    });
+});
+
+describe('a call over the wire is the same call', () => {
+    let pair;
+    const CHANNEL = { id: 'c1', name: 'general', type: 0, parentId: null };
+    const ROLE = { id: 'r1', name: 'Mods', position: 3, managed: false };
+
+    beforeEach(async () => {
+        pair = await connectedPair(stubClient({
+            guilds: [stubGuild('g1', { name: 'Home', memberCount: 42, channels: [CHANNEL], roles: [ROLE] })],
+        }));
+    });
+    afterEach(() => pair.close());
+
+    test('reads return the same data as the local facade', async () => {
+        for (const [method, args] of [
+            ['hasGuild', ['g1']],
+            ['hasGuild', ['nope']],
+            ['hasGuilds', [['g1', 'nope']]],
+            ['getGuild', ['g1']],
+            ['getGuild', ['nope']],
+            ['reach', []],
+            ['listChannels', ['g1']],
+            ['listChannels', ['nope']],
+            ['listRoles', ['g1']],
+            ['hasChannel', ['g1', 'c1']],
+            ['hasChannel', ['g1', 'nope']],
+            ['listActiveTimeouts', ['g1', 10]],
+        ]) {
+            const near = await pair.local[method](...args);
+            const far = await pair.remote[method](...args);
+            expect({ method, args, far }).toEqual({ method, args, far: near });
+        }
+    });
+
+    test('null survives the wire as null, not as undefined', async () => {
+        // The facade's contract is that a read answers null for a guild the bot
+        // is not in, and routes turn that into a 404. `undefined` is not JSON,
+        // so a naive encoding would drop the key and hand back undefined —
+        // which `?? null` at the call sites papers over right up until one of
+        // them uses `=== null`.
+        await expect(pair.remote.getGuild('nope')).resolves.toBeNull();
+        await expect(pair.remote.listChannels('nope')).resolves.toBeNull();
+        await expect(pair.remote.listActiveTimeouts('nope', 5)).resolves.toBeNull();
+    });
+
+    test('a refusal from Discord arrives as a throw, carrying its code', async () => {
+        // listBans on a guild the bot lacks Ban Members in throws rather than
+        // returning null, precisely so a route can tell it from "no such
+        // guild". That distinction has to survive the wire or the split
+        // silently turns permission errors into 404s.
+        await expect(pair.local.listBans('g1', 10)).rejects.toThrow('Missing Permissions');
+
+        await expect(pair.remote.listBans('g1', 10)).rejects.toThrow('Missing Permissions');
+        await pair.remote.listBans('g1', 10).catch(err => {
+            expect(err.code).toBe(50013);
+            expect(err.remote).toBe(true);
+            // Not a transport failure: the bot process answered, and the answer
+            // was "Discord would not let us".
+            expect(err.transport).toBeUndefined();
+        });
+    });
+
+    test('canManageGuild still answers null for "could not be asked"', async () => {
+        // null is not a denial here — it is the answer during a Discord outage,
+        // and the middleware falls back to the session snapshot for it. Reading
+        // it as false over the wire would lock every operator out.
+        await expect(pair.remote.canManageGuild('nope', 'u1')).resolves.toBeNull();
+    });
+});
+
+describe('the endpoint is not open', () => {
+    test('it refuses to be built without a long enough secret', () => {
+        const gateway = createBotGateway(stubClient());
+        expect(() => createGatewayHandler(gateway, undefined)).toThrow(/BOT_GATEWAY_TOKEN/);
+        expect(() => createGatewayHandler(gateway, 'short')).toThrow(/at least 32 characters/);
+    });
+
+    test('a call with the wrong secret is refused, and told nothing else', async () => {
+        const pair = await connectedPair(stubClient({ guilds: [stubGuild('g1')] }));
+        try {
+            const wrong = createRemoteBotGateway({
+                url: `http://127.0.0.1:${pair.server.address().port}`,
+                token: 'b'.repeat(MIN_TOKEN_LENGTH),
+            });
+            await expect(wrong.hasGuild('g1')).rejects.toThrow(/HTTP 401/);
+        } finally {
+            await pair.close();
+        }
+    });
+
+    test('only protocol methods are callable — not everything on the object', async () => {
+        // The dispatch is checked against the protocol's own set rather than
+        // against the gateway object, so `constructor`, `toString` and anything
+        // else that happens to be a function on it are not reachable.
+        const pair = await connectedPair(stubClient());
+        try {
+            const port = pair.server.address().port;
+            for (const method of ['constructor', 'toString', '__proto__', 'hasOwnProperty']) {
+                const res = await fetch(`http://127.0.0.1:${port}/__bot`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${TOKEN}` },
+                    body: JSON.stringify({ method, args: [] }),
+                });
+                expect(res.status).toBe(400);
+                expect((await res.json()).error).toMatch(/Unknown gateway method/);
+            }
+        } finally {
+            await pair.close();
+        }
+    });
+
+    test('a body larger than the cap is refused rather than read', async () => {
+        const pair = await connectedPair(stubClient());
+        try {
+            // Either the 413 lands or the socket is destroyed mid-upload —
+            // both are the endpoint refusing to buffer it, which is the point.
+            // Checked without `instanceof Error`: undici throws across realms
+            // and the check is unreliable under Jest.
+            const outcome = await fetch(`http://127.0.0.1:${pair.server.address().port}/__bot`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${TOKEN}` },
+                body: JSON.stringify({ method: 'hasGuild', args: ['x'.repeat(MAX_BODY_BYTES + 1024)] }),
+            }).then(res => `status:${res.status}`, () => 'rejected');
+
+            expect(['status:413', 'rejected']).toContain(outcome);
+        } finally {
+            await pair.close();
+        }
+    });
+
+    test('health is answerable without the secret, because a probe has none', async () => {
+        const pair = await connectedPair(stubClient(), { health: () => ({ status: 'ok', uptime: 1 }) });
+        try {
+            const res = await fetch(`http://127.0.0.1:${pair.server.address().port}/health`);
+            expect(res.status).toBe(200);
+            expect(await res.json()).toEqual({ status: 'ok', uptime: 1 });
+        } finally {
+            await pair.close();
+        }
+    });
+});
+
+describe('the endpoint answers badly-formed calls without falling over', () => {
+    let pair;
+    let port;
+
+    beforeEach(async () => {
+        pair = await connectedPair(stubClient({ guilds: [stubGuild('g1')] }));
+        port = pair.server.address().port;
+    });
+    afterEach(() => pair.close());
+
+    const post = (path, body, headers = {}) => fetch(`http://127.0.0.1:${port}${path}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${TOKEN}`, ...headers },
+        body,
+    });
+
+    test('an unknown path is a 404, not a dispatch', async () => {
+        const res = await post('/anything', JSON.stringify({ method: 'hasGuild', args: ['g1'] }));
+        expect(res.status).toBe(404);
+    });
+
+    test('the RPC path answers only POST', async () => {
+        const res = await fetch(`http://127.0.0.1:${port}/__bot`, {
+            headers: { Authorization: `Bearer ${TOKEN}` },
+        });
+        expect(res.status).toBe(405);
+    });
+
+    test('a body that is not JSON is a 400', async () => {
+        const res = await post('/__bot', 'not json at all');
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toMatch(/Malformed/);
+    });
+
+    test('args that are not an array are refused rather than spread', async () => {
+        const res = await post('/__bot', JSON.stringify({ method: 'hasGuild', args: 'g1' }));
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toMatch(/args must be an array/);
+    });
+
+    test('a missing Authorization header is refused like a wrong one', async () => {
+        const res = await fetch(`http://127.0.0.1:${port}/__bot`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ method: 'hasGuild', args: ['g1'] }),
+        });
+        expect(res.status).toBe(401);
+    });
+
+    test('a health probe with no health function still gets an answer', async () => {
+        // The default exists so a container healthcheck works before anything
+        // has been wired up to report detail.
+        const bare = await connectedPair(stubClient());
+        try {
+            const res = await fetch(`http://127.0.0.1:${bare.server.address().port}/health`);
+            expect(res.status).toBe(200);
+            expect(await res.json()).toEqual({ status: 'ok' });
+        } finally {
+            await bare.close();
+        }
+    });
+
+    test('a method that returns nothing crosses the wire as null, not as a parse failure', async () => {
+        // addReactions on a channel that is not there returns undefined-shaped
+        // falsity locally; `undefined` is not JSON.
+        const res = await post('/__bot', JSON.stringify({
+            method: 'addReactions', args: ['nope', 'c1', 'm1', []],
+        }));
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({ ok: true, value: false });
+    });
+});
+
+describe('resolveGatewayPort decides whether the split is on', () => {
+    const { resolveGatewayPort } = require('../src/bot/gatewayServer');
+
+    test('unset is off, which is every deployment that has not opted in', () => {
+        expect(resolveGatewayPort({})).toBeNull();
+        expect(resolveGatewayPort({ BOT_GATEWAY_PORT: '' })).toBeNull();
+    });
+
+    test('a usable port turns it on', () => {
+        expect(resolveGatewayPort({ BOT_GATEWAY_PORT: '3001' })).toBe(3001);
+    });
+
+    test('an unusable value is off rather than a throw', () => {
+        // validateEnv has already refused to start on it; this must not be a
+        // second, different opinion at a later point in the boot.
+        for (const value of ['nonsense', '0', '-1', '70000', '3001.5']) {
+            expect([value, resolveGatewayPort({ BOT_GATEWAY_PORT: value })]).toEqual([value, null]);
+        }
+    });
+});
+
+describe('the remote facade refuses to be built half-configured', () => {
+    test('no URL, no facade', () => {
+        expect(() => createRemoteBotGateway({ url: '', token: TOKEN })).toThrow(/BOT_GATEWAY_URL/);
+    });
+
+    test('no token, no facade — every call would be refused anyway', () => {
+        expect(() => createRemoteBotGateway({ url: 'http://bot:3001', token: '' })).toThrow(/BOT_GATEWAY_TOKEN/);
+    });
+
+    test('a bot process that cannot be reached is a transport failure, not a refusal', async () => {
+        // The two mean different things to a route: one is "try again", the
+        // other is "you may not do that".
+        const remote = createRemoteBotGateway({
+            url: 'http://127.0.0.1:1',   // nothing listens here
+            token: TOKEN,
+            timeoutMs: 500,
+        });
+        await remote.hasGuild('g1').then(
+            () => { throw new Error('expected a rejection'); },
+            err => {
+                expect(err.transport).toBe(true);
+                expect(err.message).toMatch(/could not reach the bot process/);
+            },
+        );
+    });
+});
+
+describe('the configuration that turns the split on', () => {
+    const { collectEnvProblems, DASHBOARD_REQUIRED_ENV, REQUIRED_ENV } = require('../src/config/validateEnv');
+
+    const base = {
+        DISCORD_TOKEN: 't', CLIENT_ID: '1', CLIENT_SECRET: 's',
+        MONGODB_URI: 'mongodb://localhost/x',
+        SESSION_SECRET: 's'.repeat(32),
+        DASHBOARD_URL: 'http://localhost:3000',
+        NODE_ENV: 'development',
+    };
+    const problems = extra => collectEnvProblems({ ...base, ...extra }).errors.join('\n');
+
+    test('all three unset is the default, and is not a problem', () => {
+        expect(problems({})).toBe('');
+    });
+
+    test('a port or a URL without the shared secret refuses to start', () => {
+        // This endpoint can ban, unban and post in every guild the bot is in.
+        // There is no unauthenticated mode to leave switched on by accident.
+        expect(problems({ BOT_GATEWAY_PORT: '3001' })).toMatch(/BOT_GATEWAY_TOKEN is not set/);
+        expect(problems({ BOT_GATEWAY_URL: 'http://clawdia:3001' })).toMatch(/BOT_GATEWAY_TOKEN is not set/);
+    });
+
+    test('a short secret is refused for the same reason SESSION_SECRET is', () => {
+        expect(problems({ BOT_GATEWAY_PORT: '3001', BOT_GATEWAY_TOKEN: 'short' }))
+            .toMatch(/at least 32 characters/);
+    });
+
+    test('the two ports cannot be the same — different processes serve them', () => {
+        expect(problems({ BOT_GATEWAY_PORT: '3000', BOT_GATEWAY_TOKEN: TOKEN }))
+            .toMatch(/must differ from DASHBOARD_PORT/);
+    });
+
+    test('a fully configured split is accepted', () => {
+        expect(problems({
+            BOT_GATEWAY_PORT: '3001',
+            BOT_GATEWAY_URL: 'http://clawdia:3001',
+            BOT_GATEWAY_TOKEN: TOKEN,
+        })).toBe('');
+    });
+
+    test('the secret alone is silent — it is the half-done state worth allowing', () => {
+        expect(problems({ BOT_GATEWAY_TOKEN: TOKEN })).toBe('');
+    });
+
+    test('the dashboard process is not asked for the bot token', () => {
+        // It holds no gateway connection, and the token is the credential with
+        // the widest blast radius in the deployment. A container that cannot
+        // use it should not be handed it.
+        expect(DASHBOARD_REQUIRED_ENV).not.toContain('DISCORD_TOKEN');
+        expect(DASHBOARD_REQUIRED_ENV).toEqual(REQUIRED_ENV.filter(n => n !== 'DISCORD_TOKEN'));
+
+        const { DISCORD_TOKEN, ...withoutToken } = base;
+        expect(DISCORD_TOKEN).toBe('t');
+        expect(collectEnvProblems(withoutToken, { required: DASHBOARD_REQUIRED_ENV }).errors).toEqual([]);
+        expect(collectEnvProblems(withoutToken).errors.join('\n')).toMatch(/DISCORD_TOKEN/);
+    });
+});
+
+describe('the two processes are wired to never both serve the dashboard', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const read = rel => fs.readFileSync(path.join(__dirname, '..', rel), 'utf8');
+
+    test('the bot serves the facade instead of the dashboard, never as well as', () => {
+        // Both would have this process doing the very work the split moves out,
+        // and would bind a port the operator did not ask for.
+        const code = read('src/index.js');
+        expect(code).toMatch(/if \(!startGatewayRpc\(\)\) \{\s*\n\s*await startDashboard\(\);/);
+    });
+
+    test('the dashboard process has an entry point and an npm script', () => {
+        const pkg = JSON.parse(read('package.json'));
+        expect(pkg.scripts['start:dashboard']).toBe('node src/dashboard/index.js');
+        expect(fs.existsSync(path.join(__dirname, '..', 'src/dashboard/index.js'))).toBe(true);
+    });
+
+    test('the dashboard process builds no Discord client and runs no migrations', () => {
+        // It has no gateway connection to hold, and migrations are forward-only
+        // singleton work owned by shard 0 of the bot — a second process racing
+        // the same schema change is a different failure every time.
+        const code = read('src/dashboard/index.js');
+        expect(code).not.toMatch(/new Client\(/);
+        expect(code).not.toMatch(/runMigrations\(\)/);
+        expect(code).not.toMatch(/client\.login/);
+        expect(code).toContain('createRemoteBotGateway');
+    });
+
+    test('the compose service runs the same image behind a profile', () => {
+        // A second build is a second version to drift; a profile keeps the
+        // service off unless it is asked for.
+        const compose = read('docker-compose.yml');
+        expect(compose).toMatch(/dashboard:\s*\n\s*profiles: \[split-dashboard\]/);
+        expect(compose).toContain('command: ["node", "src/dashboard/index.js"]');
+    });
+
+    test('the image healthcheck follows whichever port this container serves', () => {
+        // Split, the bot container answers HTTP only on the facade port. A
+        // healthcheck fixed to DASHBOARD_PORT would report it unhealthy forever.
+        expect(read('Dockerfile')).toContain('process.env.BOT_GATEWAY_PORT || process.env.DASHBOARD_PORT || 3000');
+    });
+});
+
+describe('the dashboard works with the facade in another process', () => {
+    // The claim #876 makes is that no route has to change, because every one of
+    // them already talks to the facade and nothing else. This is that claim,
+    // end to end: the real Express app, built with the real remote facade, in
+    // front of the real RPC server, in front of the real local facade.
+    const request = require('supertest');
+    const session = require('express-session');
+    const { createApp } = require('../src/dashboard/server');
+
+    const SAVED = { ...process.env };
+    let pair;
+    let app;
+
+    beforeEach(async () => {
+        process.env.SESSION_SECRET = 'x'.repeat(48);
+        process.env.MONGODB_URI = 'mongodb://127.0.0.1:27017/clawdia-test';
+        process.env.NODE_ENV = 'test';
+        process.env.DASHBOARD_URL = 'http://localhost:3000';
+
+        pair = await connectedPair(
+            stubClient({ guilds: [stubGuild('g1', { name: 'Home', memberCount: 1_284 })] }),
+            { health: () => ({ status: 'ok', uptime: 90_061 }) },
+        );
+
+        app = createApp({
+            bot: pair.remote,
+            sessionStore: new session.MemoryStore(),
+            configurePassport: () => {},
+        });
+    });
+
+    afterEach(async () => {
+        await pair.close();
+        for (const key of ['SESSION_SECRET', 'MONGODB_URI', 'NODE_ENV', 'DASHBOARD_URL']) {
+            if (SAVED[key] === undefined) delete process.env[key];
+            else process.env[key] = SAVED[key];
+        }
+    });
+
+    test('the landing page renders the instance stats it fetched over the wire', async () => {
+        const res = await request(app).get('/');
+        expect(res.status).toBe(200);
+        expect(res.text).toContain('1,284');
+    });
+
+    test('/health answers even when the bot process cannot be reached', async () => {
+        // A monitor must get an answer about the dashboard whatever the bot is
+        // doing. Closing the far side is the outage this has to survive.
+        await pair.close();
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const res = await request(app).get('/health');
+        expect(res.status).toBeLessThan(600);
+        expect(res.body).toHaveProperty('status');
+
+        console.error.mockRestore();
+    });
+
+    test('the landing page still renders when the bot process is gone', async () => {
+        // instanceStats answers null for "we do not know", and the template
+        // drops the row rather than claiming zero servers — the same behaviour
+        // as a client that has not been ready yet.
+        await pair.close();
+        const res = await request(app).get('/');
+        expect(res.status).toBe(200);
+        expect(res.text).not.toContain('members reached');
+    });
+});
+
+describe('a refusal keeps its shape across the wire', () => {
+    const { encodeError, decodeError } = require('../src/bot/gatewayProtocol');
+
+    test('a Discord error keeps its message, name and numeric code', () => {
+        const err = Object.assign(new TypeError('Missing Permissions'), { code: 50013 });
+        const round = decodeError(encodeError(err));
+
+        expect(round.message).toBe('Missing Permissions');
+        expect(round.name).toBe('TypeError');
+        expect(round.code).toBe(50013);
+        expect(round.remote).toBe(true);
+    });
+
+    test('a code that is not a number is dropped rather than forwarded', () => {
+        // Routes compare it to Discord's numeric codes; a string that looks
+        // like one would compare false and read as an unknown failure.
+        expect(encodeError(Object.assign(new Error('x'), { code: 'ETIMEDOUT' })).code).toBeUndefined();
+        expect(decodeError({ message: 'x', code: 'ETIMEDOUT' }).code).toBeUndefined();
+    });
+
+    test('something thrown that is not an Error still arrives as one', () => {
+        for (const thrown of [undefined, null, 'a string', 42]) {
+            const round = decodeError(encodeError(thrown));
+            expect(round).toBeInstanceOf(Error);
+            expect(round.message).toBe('The bot process refused the call.');
+        }
+        expect(decodeError(undefined).message).toBe('The bot process refused the call.');
+    });
+});
+
+describe('binding the listener', () => {
+    const { startGatewayServer } = require('../src/bot/gatewayServer');
+
+    test('serves health on the port it was given, and can be closed', async () => {
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        const server = startGatewayServer(createBotGateway(stubClient()), {
+            port: 0,
+            host: '127.0.0.1',
+            token: TOKEN,
+            health: () => ({ status: 'ok', uptime: 5 }),
+        });
+        await new Promise(resolve => server.once('listening', resolve));
+
+        try {
+            const res = await fetch(`http://127.0.0.1:${server.address().port}/health`);
+            expect(await res.json()).toEqual({ status: 'ok', uptime: 5 });
+        } finally {
+            await new Promise(r => server.close(r));
+            console.log.mockRestore();
+        }
+    });
+
+    test('a bind failure is logged, not thrown — it must not drop the gateway', async () => {
+        // An 'error' event with no listener is a process-level throw, and
+        // EADDRINUSE here would disconnect every guild the bot is in.
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        const errors = [];
+        jest.spyOn(console, 'error').mockImplementation((...args) => errors.push(args.join(' ')));
+
+        const first = startGatewayServer(createBotGateway(stubClient()), { port: 0, host: '127.0.0.1', token: TOKEN });
+        await new Promise(resolve => first.once('listening', resolve));
+        const taken = first.address().port;
+
+        const second = startGatewayServer(createBotGateway(stubClient()), { port: taken, host: '127.0.0.1', token: TOKEN });
+        await new Promise(resolve => second.once('error', resolve));
+
+        expect(errors.join('\n')).toMatch(/Server error on port/);
+
+        await new Promise(r => first.close(r));
+        second.close();
+        console.log.mockRestore();
+        console.error.mockRestore();
+    });
+});
+
+describe('serveGatewayIfConfigured is the whole switch', () => {
+    const { serveGatewayIfConfigured } = require('../src/bot/gatewayServer');
+    const SAVED = { ...process.env };
+
+    afterEach(() => {
+        for (const key of ['BOT_GATEWAY_PORT', 'BOT_GATEWAY_TOKEN']) {
+            if (SAVED[key] === undefined) delete process.env[key];
+            else process.env[key] = SAVED[key];
+        }
+        jest.restoreAllMocks();
+    });
+
+    test('unset: no listener, and the caller starts its own dashboard', () => {
+        delete process.env.BOT_GATEWAY_PORT;
+        const build = jest.fn();
+        expect(serveGatewayIfConfigured(build)).toBe(false);
+        expect(build).not.toHaveBeenCalled();
+    });
+
+    test('set: the listener comes up and the caller does not start a dashboard', async () => {
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        process.env.BOT_GATEWAY_PORT = '0';   // an ephemeral port, for the test
+        process.env.BOT_GATEWAY_TOKEN = TOKEN;
+
+        // '0' is not a port resolveGatewayPort accepts, so drive the real path
+        // with a real one: bind, read it back, and close.
+        const probe = require('http').createServer();
+        await new Promise(r => probe.listen(0, '127.0.0.1', r));
+        const port = probe.address().port;
+        await new Promise(r => probe.close(r));
+
+        process.env.BOT_GATEWAY_PORT = String(port);
+        let server;
+        const build = jest.fn(() => createBotGateway(stubClient()));
+        try {
+            expect(serveGatewayIfConfigured(build, { host: '127.0.0.1' })).toBe(true);
+            expect(build).toHaveBeenCalledTimes(1);
+        } finally {
+            // startGatewayServer does not hand the server back through this
+            // wrapper, so close by connecting once and letting the test end.
+            server = undefined;
+            await new Promise(r => setTimeout(r, 10));
+        }
+        expect(server).toBeUndefined();
+    });
+
+    test('a listener that cannot be built still counts as split', () => {
+        // The operator asked for the split and a dashboard is running
+        // elsewhere. Falling back to the in-process one here would bind a port
+        // nobody asked for and run the aggregations they moved out.
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        process.env.BOT_GATEWAY_PORT = '3001';
+        delete process.env.BOT_GATEWAY_TOKEN;   // startGatewayServer will refuse
+
+        expect(serveGatewayIfConfigured(() => createBotGateway(stubClient()))).toBe(true);
+        expect(console.error).toHaveBeenCalled();
+    });
+});
+
+describe('the remote facade needs something to fetch with', () => {
+    test('no fetch implementation, no facade', () => {
+        // `null` rather than `undefined`: a default parameter only fills in for
+        // undefined, and the case worth guarding is a runtime with no global
+        // fetch at all, which reads as null here.
+        expect(() => createRemoteBotGateway({ url: 'http://bot:3001', token: TOKEN, fetchImpl: null }))
+            .toThrow(/No fetch implementation/);
+    });
+
+    test('it reads its configuration from the environment when not given any', () => {
+        const saved = { ...process.env };
+        process.env.BOT_GATEWAY_URL = 'http://clawdia:3001';
+        process.env.BOT_GATEWAY_TOKEN = TOKEN;
+        try {
+            expect(() => createRemoteBotGateway()).not.toThrow();
+        } finally {
+            for (const key of ['BOT_GATEWAY_URL', 'BOT_GATEWAY_TOKEN']) {
+                if (saved[key] === undefined) delete process.env[key];
+                else process.env[key] = saved[key];
+            }
+        }
+    });
+});

--- a/tests/helpers/guildSettingsCacheMock.js
+++ b/tests/helpers/guildSettingsCacheMock.js
@@ -1,0 +1,61 @@
+'use strict';
+
+/**
+ * A `getGuildSettings` that answers from whatever the suite already told the
+ * Guild model to return.
+ *
+ * Commands read guild configuration through `utils/guildSettingsCache` instead
+ * of `Guild.findOne` (#877), so a suite that stubs the model no longer stubs
+ * the read the command makes. Rather than have every command suite carry a
+ * second fixture that has to be kept in step with the first, this delegates:
+ * it calls the mocked `Guild.findOne` and unwraps whatever shape that mock
+ * hands back.
+ *
+ * Delegating rather than answering directly is what keeps the existing
+ * assertions meaningful — a suite that parks `Guild.findOne` to hold a command
+ * inside its critical section, or asserts the read never happened, still works
+ * because the read still goes through the model mock.
+ *
+ * Usage, beside the Guild mock:
+ *
+ *     jest.mock('../src/models/Guild', () => ({ findOne: jest.fn() }));
+ *     jest.mock('../src/utils/guildSettingsCache', () =>
+ *         require('./helpers/guildSettingsCacheMock')());
+ *
+ * Nothing here caches. The real cache collapses repeated reads within its TTL;
+ * a test double that did the same would make "how many times was the database
+ * asked" depend on the order tests happen to run in.
+ */
+
+// The projection the real cache reads with. Passed through so a suite can
+// assert the heavy fields are still excluded on this path.
+const HEAVY_FIELDS_PROJECTION = '-shop.imageData -giveaways.entrantIds';
+
+/** Resolves the query-like shapes the model mocks in this repo return. */
+async function unwrap(result) {
+    let value = await result;
+    if (value && typeof value.select === 'function') value = await value.select();
+    if (value && typeof value.lean === 'function') value = await value.lean();
+    value = await value;
+    // The real cache converts a hydrated document; a mock may hand back either.
+    if (value && typeof value.toObject === 'function') value = value.toObject();
+    return value ?? null;
+}
+
+module.exports = function guildSettingsCacheMock() {
+    const getGuildSettings = jest.fn(async guildId => {
+        if (!guildId) return null;
+        const Guild = require('../../src/models/Guild');
+        return unwrap(Guild.findOne({ guildId }, HEAVY_FIELDS_PROJECTION));
+    });
+
+    return {
+        getGuildSettings,
+        invalidateGuildSettings: jest.fn(),
+        clearGuildSettingsCache: jest.fn(),
+        onGuildDocumentSaved: jest.fn(),
+        onGuildQueryWrite: jest.fn(),
+        setGuildSettingsTtl: jest.fn(),
+        getGuildSettingsCacheStats: jest.fn(() => ({ size: 0, hits: 0, misses: 0, ttlMs: 0 })),
+    };
+};

--- a/tests/helpers/stubBotGateway.js
+++ b/tests/helpers/stubBotGateway.js
@@ -1,0 +1,41 @@
+'use strict';
+
+/**
+ * A test double for the bot gateway facade (src/bot/gateway.js).
+ *
+ * Dashboard suites build their app with an injected `bot` and stub only the one
+ * or two methods the route under test calls. That worked while the facade was a
+ * loose object; #876 gave it a protocol, two implementations and a batch method
+ * (`hasGuilds`) that three call sites reach for — so a hand-rolled stub missing
+ * one method now fails as a 500 several layers away from the omission.
+ *
+ * This fills in the rest of the protocol with "no": every method answers null,
+ * every presence check answers false, and whatever the suite passes wins. A
+ * stub that overrides only `hasGuild` also gets a `hasGuilds` derived from it,
+ * because those two must agree and a suite should not have to say so twice.
+ *
+ *     const bot = stubBotGateway({ hasGuild: id => ids.includes(id) });
+ */
+
+const { GATEWAY_METHODS } = require('../../src/bot/gatewayProtocol');
+
+module.exports = function stubBotGateway(overrides = {}) {
+    const stub = {};
+    for (const method of GATEWAY_METHODS) stub[method] = async () => null;
+
+    stub.hasGuild = async () => false;
+    stub.hasChannel = async () => false;
+    stub.hasGuilds = async ids => Object.fromEntries((ids ?? []).map(id => [id, false]));
+
+    Object.assign(stub, overrides);
+
+    if (overrides.hasGuild && !overrides.hasGuilds) {
+        stub.hasGuilds = async ids => {
+            const present = {};
+            for (const id of ids ?? []) present[id] = (await overrides.hasGuild(id)) === true;
+            return present;
+        };
+    }
+
+    return stub;
+};

--- a/tests/itemImageTenancy.test.js
+++ b/tests/itemImageTenancy.test.js
@@ -14,6 +14,7 @@ const express = require('express');
 jest.mock('../src/models/ItemImage');
 
 const ItemImage = require('../src/models/ItemImage');
+const stubBotGateway = require('./helpers/stubBotGateway');
 
 const PNG = Buffer.concat([
     Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]),
@@ -33,10 +34,10 @@ beforeAll(done => {
     app.use((req, res, next) => {
         req.isAuthenticated = () => session.authenticated !== false;
         req.user = { id: session.userId, guilds: session.guilds };
-        req.bot = {
-            hasGuild: id => session.botGuilds.includes(id),
+        req.bot = stubBotGateway({
+            hasGuild: async id => session.botGuilds.includes(id),
             canManageGuild: async () => session.live,
-        };
+        });
         next();
     });
     app.use('/api', require('../src/dashboard/routes/api/itemImages'));

--- a/tests/landingStats.test.js
+++ b/tests/landingStats.test.js
@@ -45,37 +45,37 @@ function stubClient({ ready = true, guilds = [] } = {}) {
 }
 
 describe('the gateway reach() the row is built from', () => {
-    test('counts the guilds the bot is in and sums their members', () => {
+    test('counts the guilds the bot is in and sums their members', async () => {
         const bot = createBotGateway(stubClient({
             guilds: [{ memberCount: 120 }, { memberCount: 8 }, { memberCount: 1_000 }],
         }));
 
-        expect(bot.reach()).toEqual({ guilds: 3, members: 1_128 });
+        expect(await bot.reach()).toEqual({ guilds: 3, members: 1_128 });
     });
 
     // Before READY the cache is empty because nothing has filled it, not
     // because the bot is in no guilds. Reporting 0 there would be the same
     // class of false claim the hardcoded numbers were.
-    test('answers null before the client has been ready', () => {
-        expect(createBotGateway(stubClient({ ready: false, guilds: [{ memberCount: 5 }] })).reach()).toBeNull();
+    test('answers null before the client has been ready', async () => {
+        expect(await createBotGateway(stubClient({ ready: false, guilds: [{ memberCount: 5 }] })).reach()).toBeNull();
     });
 
-    test('reports zero honestly once ready and in no guilds', () => {
-        expect(createBotGateway(stubClient({ guilds: [] })).reach()).toEqual({ guilds: 0, members: 0 });
+    test('reports zero honestly once ready and in no guilds', async () => {
+        expect(await createBotGateway(stubClient({ guilds: [] })).reach()).toEqual({ guilds: 0, members: 0 });
     });
 
     // A guild Discord has not sent a member count for must not turn the whole
     // sum into NaN, which would render as "NaN members reached".
-    test('treats a guild with no member count as contributing none', () => {
+    test('treats a guild with no member count as contributing none', async () => {
         const bot = createBotGateway(stubClient({
             guilds: [{ memberCount: 40 }, { memberCount: undefined }, { memberCount: null }],
         }));
 
-        expect(bot.reach()).toEqual({ guilds: 3, members: 40 });
+        expect(await bot.reach()).toEqual({ guilds: 3, members: 40 });
     });
 
-    test('leaks no discord.js object across the facade', () => {
-        const reach = createBotGateway(stubClient({ guilds: [{ memberCount: 3 }] })).reach();
+    test('leaks no discord.js object across the facade', async () => {
+        const reach = await createBotGateway(stubClient({ guilds: [{ memberCount: 3 }] })).reach();
 
         expect(Object.keys(reach).sort()).toEqual(['guilds', 'members']);
         expect(Object.values(reach).every(v => typeof v === 'number')).toBe(true);
@@ -112,37 +112,37 @@ describe('formatCount', () => {
 describe('instanceStats', () => {
     const status = uptime => () => ({ status: 'healthy', uptime });
 
-    test('formats what the instance reports', () => {
+    test('formats what the instance reports', async () => {
         const bot = { reach: () => ({ guilds: 3, members: 14_200 }) };
 
-        expect(instanceStats(bot, { status: status(90_061) })).toEqual({
+        expect(await instanceStats(bot, { status: status(90_061) })).toEqual({
             servers: '3',
             members: '14,200',
             uptime: '1d 1h',
         });
     });
 
-    test('is null when the client has not been ready', () => {
-        expect(instanceStats({ reach: () => null }, { status: status(10) })).toBeNull();
+    test('is null when the client has not been ready', async () => {
+        expect(await instanceStats({ reach: () => null }, { status: status(10) })).toBeNull();
     });
 
-    test('is null for a facade with no reach() at all', () => {
-        expect(instanceStats({ hasGuild: () => false }, { status: status(10) })).toBeNull();
+    test('is null for a facade with no reach() at all', async () => {
+        expect(await instanceStats({ hasGuild: () => false }, { status: status(10) })).toBeNull();
     });
 
     // The landing page is the one route that renders for anyone. A throw here
     // must cost the row, never the page.
-    test('is null when the facade throws', () => {
+    test('is null when the facade throws', async () => {
         const bot = { reach: () => { throw new Error('no client'); } };
 
-        expect(instanceStats(bot, { status: status(10) })).toBeNull();
+        expect(await instanceStats(bot, { status: status(10) })).toBeNull();
     });
 
-    test('is null when health cannot be read', () => {
+    test('is null when health cannot be read', async () => {
         const bot = { reach: () => ({ guilds: 1, members: 2 }) };
         const broken = () => { throw new Error('no health'); };
 
-        expect(instanceStats(bot, { status: broken })).toBeNull();
+        expect(await instanceStats(bot, { status: broken })).toBeNull();
     });
 });
 

--- a/tests/moderationCommands.test.js
+++ b/tests/moderationCommands.test.js
@@ -31,6 +31,8 @@ jest.mock('../src/models/Case', () => ({
     deleteOne:      jest.fn().mockResolvedValue({ deletedCount: 1 }),
 }));
 jest.mock('../src/models/Guild', () => ({ findOne: jest.fn().mockResolvedValue(null) }));
+jest.mock('../src/utils/guildSettingsCache', () =>
+    require('./helpers/guildSettingsCacheMock')());
 jest.mock('../src/models/User', () => ({ findOneAndUpdate: jest.fn().mockResolvedValue({}) }));
 // findStepForCount is a pure function over the configured ladder and is worth
 // running for real; only the half that touches Discord is stubbed.

--- a/tests/rankTextEquivalent.test.js
+++ b/tests/rankTextEquivalent.test.js
@@ -20,6 +20,8 @@ const mockGuilds = fakeCollection('Guild');
 
 jest.mock('../src/models/User', () => mockUsers.model);
 jest.mock('../src/models/Guild', () => mockGuilds.model);
+jest.mock('../src/utils/guildSettingsCache', () =>
+    require('./helpers/guildSettingsCacheMock')());
 jest.mock('../src/utils/grindProfile', () => ({ attachGrind: jest.fn(async user => user) }));
 // The canvas render is the one part of this that needs fonts and a GPU-free
 // encode; what it draws is cardGenerator's business, not this file's.

--- a/tests/schedulerScope.test.js
+++ b/tests/schedulerScope.test.js
@@ -1,0 +1,210 @@
+'use strict';
+
+// Where each scheduled job runs, and why (#889).
+//
+// Everything used to be pinned to shard 0. For work that must happen once per
+// deployment that is right — jobRunner's overlap guard is a process-local Set,
+// so N processes each see an empty one and the job runs N times. For work that
+// reaches a guild it is wrong in a way that produces no error at all: shard 0's
+// client only holds the guilds Discord routed to shard 0, so an announcement
+// for a guild on shard 3 was dropped in silence. The old comment said so and
+// deferred the classification. This is the classification, and these are the
+// two properties that make it real rather than a label:
+//
+//   1. A 'deployment' job is scheduled only on the primary shard.
+//   2. A 'guild' job is scheduled everywhere AND actually partitions its own
+//      work list — a scope declared and not enforced is worse than the pin it
+//      replaced, because it duplicates the work the pin was protecting.
+
+const cronSchedules = [];
+jest.mock('node-cron', () => ({
+    schedule: jest.fn((expression, fn, options) => {
+        cronSchedules.push({ expression, options });
+        return { stop: jest.fn() };
+    }),
+    validate: jest.requireActual('node-cron').validate,
+}));
+
+// runOnStart jobs fire during bootstrap, and this suite is about what gets
+// scheduled rather than what the jobs do — a real run would reach Mongo.
+jest.mock('../src/utils/jobRunner', () => ({ runJob: jest.fn() }));
+
+const startedStarters = [];
+jest.mock('../src/services/ai/mcp/prewarm', () => ({
+    startMcpPrewarm: jest.fn(() => startedStarters.push('mcpPrewarm')),
+}));
+for (const [module, fn, label] of [
+    ['../src/services/summaryService', 'startSummaryService', 'summaryService'],
+    ['../src/services/caseService', 'startSlaMonitor', 'caseService.slaMonitor'],
+    ['../src/services/questService', 'startQuestService', 'questService'],
+    ['../src/services/pollService', 'scheduleActivePollExpirations', 'poll.expirations'],
+    ['../src/services/dailyBibleService', 'startDailyBibleService', 'dailyBibleService'],
+]) {
+    jest.doMock(module, () => ({
+        ...jest.requireActual(module),
+        [fn]: jest.fn(() => startedStarters.push(label)),
+    }));
+}
+// Only the starter is stubbed: scheduleDailyNews registers a cron of its own,
+// which would land in cronSchedules and be counted as a job. checkRssFeeds stays
+// real, because the enforcement tests below read its source.
+jest.doMock('../src/services/rssService', () => ({
+    ...jest.requireActual('../src/services/rssService'),
+    scheduleDailyNews: jest.fn(() => startedStarters.push('rssService.dailyNews')),
+}));
+
+const scheduler = require('../src/services/scheduler');
+const { JOBS, STARTERS, SCOPE, startScheduler, stopScheduler } = scheduler;
+
+/** A client that reports itself as shard `id` of `count`. */
+function shardedClient(id, count) {
+    return {
+        shard: { ids: [id], count },
+        user: { setPresence: jest.fn().mockResolvedValue(undefined) },
+    };
+}
+
+function unshardedClient() {
+    return { user: { setPresence: jest.fn().mockResolvedValue(undefined) } };
+}
+
+/** Runs startScheduler against `client` and reports what it scheduled. */
+function bootstrap(client) {
+    cronSchedules.length = 0;
+    startedStarters.length = 0;
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+        startScheduler(client);
+    } finally {
+        console.log.mockRestore();
+    }
+    const result = {
+        expressions: cronSchedules.map(c => c.expression),
+        starters: [...startedStarters],
+    };
+    stopScheduler();
+    return result;
+}
+
+const guildJobs = () => JOBS.filter(j => j.scope === SCOPE.GUILD);
+const deploymentJobs = () => JOBS.filter(j => j.scope === SCOPE.DEPLOYMENT);
+
+// ---------------------------------------------------------------------------
+// The table
+// ---------------------------------------------------------------------------
+
+describe('every job declares where it runs', () => {
+    test('each job carries one of the two scopes', () => {
+        for (const job of JOBS) {
+            expect(Object.values(SCOPE)).toContain(job.scope);
+        }
+    });
+
+    test('the classification is not vacuous — both scopes are used', () => {
+        expect(guildJobs().length).toBeGreaterThan(0);
+        expect(deploymentJobs().length).toBeGreaterThan(0);
+    });
+
+    test('returnExpiredMarketListings is deployment-wide: no client, nothing announced', () => {
+        // It takes no client at all, so there is nothing for a second shard to
+        // reach — running it everywhere would only race the listing claim.
+        const job = JOBS.find(j => j.name === 'returnExpiredMarketListings');
+        expect(job.scope).toBe(SCOPE.DEPLOYMENT);
+        expect(job.fn.toString()).not.toContain('client');
+    });
+
+    test('applyBankInterest is per-guild, though it is the usual deployment-wide example', () => {
+        // Its claim (bankInterestLastRunAt) and its credits are both scoped to
+        // one guild, and it finishes by posting the interest summary to that
+        // guild's announcement channel. On shard 0 alone it pays correctly and
+        // tells nobody on every other shard.
+        expect(JOBS.find(j => j.name === 'applyBankInterest').scope).toBe(SCOPE.GUILD);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The enforcement — a scope is a claim about the service, not just a label
+// ---------------------------------------------------------------------------
+
+describe('a per-guild job partitions its own work', () => {
+    /** The function a job's `fn` actually calls, resolved through the require. */
+    function targetOf(job) {
+        const match = /require\('([^']+)'\)\.(\w+)/.exec(job.fn.toString());
+        expect(match).not.toBeNull();
+        const [, modulePath, name] = match;
+        // The job table lives in src/services/scheduler/, so its relative
+        // requires resolve from there.
+        const resolved = require(require('path').join(__dirname, '../src/services/scheduler', modulePath));
+        return resolved[name];
+    }
+
+    test.each(guildJobs().map(j => [j.name, j]))(
+        '%s filters its work list with handlesGuild',
+        (_name, job) => {
+            // Resolved through the export rather than read off the file, so a
+            // job re-exported from another module (postScheduledNewspapers)
+            // cannot pass on a sibling function's guard.
+            expect(targetOf(job).toString()).toContain('handlesGuild(');
+        },
+    );
+
+    test.each(deploymentJobs().map(j => [j.name, j]))(
+        '%s does not filter — it is meant to run once, not once per shard',
+        (_name, job) => {
+            expect(targetOf(job).toString()).not.toContain('handlesGuild(');
+        },
+    );
+});
+
+// ---------------------------------------------------------------------------
+// The bootstrap
+// ---------------------------------------------------------------------------
+
+describe('startScheduler schedules by scope', () => {
+    afterEach(() => stopScheduler());
+
+    test('unsharded: every job and every service, exactly as before', () => {
+        const { expressions, starters } = bootstrap(unshardedClient());
+        expect(expressions).toHaveLength(JOBS.length);
+        expect(starters).toEqual(expect.arrayContaining(STARTERS.map(s => s.name)));
+        expect(starters).toContain('mcpPrewarm');
+    });
+
+    test('the primary shard runs everything, including the deployment-wide jobs', () => {
+        const { expressions, starters } = bootstrap(shardedClient(0, 4));
+        expect(expressions).toHaveLength(JOBS.length);
+        expect(starters).toEqual(expect.arrayContaining(STARTERS.map(s => s.name)));
+    });
+
+    test('a non-primary shard runs the per-guild jobs and only those', () => {
+        const { expressions, starters } = bootstrap(shardedClient(2, 4));
+        expect(expressions).toHaveLength(guildJobs().length);
+        expect(expressions).toHaveLength(JOBS.length - deploymentJobs().length);
+
+        // The start-once services keep their own schedules rather than
+        // declaring one here, so none of them can be classified from the job
+        // table. They stay singleton work until they can be.
+        for (const starter of STARTERS) {
+            expect(starters).not.toContain(starter.name);
+        }
+    });
+
+    test('a non-primary shard still warms its own caches and sets its own presence', () => {
+        // Both are properties of this process rather than of the deployment: a
+        // shard that skipped them would show no activity to the guilds it
+        // serves and answer their first message from a cold cache.
+        const client = shardedClient(3, 4);
+        const { starters } = bootstrap(client);
+        expect(starters).toContain('mcpPrewarm');
+        expect(client.user.setPresence).toHaveBeenCalled();
+    });
+
+    test('runOnStart still fires, on the shards that schedule the job', () => {
+        const runOnStart = JOBS.filter(j => j.runOnStart);
+        expect(runOnStart.length).toBeGreaterThan(0);
+        // Every runOnStart job is per-guild, so every shard runs it at boot.
+        for (const job of runOnStart) {
+            expect(job.scope).toBe(SCOPE.GUILD);
+        }
+    });
+});

--- a/tests/settingsValidators.test.js
+++ b/tests/settingsValidators.test.js
@@ -29,6 +29,7 @@ const Guild = require('../src/models/Guild');
 const { CONFIRM_MODES, MCP_ROUTES } = require('../src/config/mcpServers');
 
 const settings = require('../src/dashboard/routes/api/settings');
+const stubBotGateway = require('./helpers/stubBotGateway');
 const {
     ALLOWED_SETTING_PARENTS,
     isAllowedSettingKey,
@@ -464,7 +465,7 @@ describe('POST /guild/:guildId/settings', () => {
     // The gateway facade lives out here so the reschedule hook is a mock the
     // assertions can read, rather than a fresh one built per request and thrown
     // away inside the middleware.
-    const bot = { rescheduleBibleVerse: jest.fn() };
+    const bot = stubBotGateway({ rescheduleBibleVerse: jest.fn(async () => null) });
 
     function makeApp() {
         const app = express();

--- a/tests/sharding.test.js
+++ b/tests/sharding.test.js
@@ -24,6 +24,7 @@ const {
     shardId,
     isPrimaryShard,
     ownsGuild,
+    handlesGuild,
     assertGuildAffinity,
     shardTag,
 } = require('../src/utils/sharding');
@@ -236,6 +237,44 @@ describe('the four process-bound session stores are covered by affinity', () => 
     });
 });
 
+describe('handlesGuild routes scheduled work', () => {
+    const shardedClient = (id, count) => ({ shard: { ids: [id], count } });
+
+    it('is true everywhere when unsharded, so nothing changes today', () => {
+        for (const guildId of SNOWFLAKES) {
+            expect(handlesGuild(guildId)).toBe(true);
+        }
+        expect(handlesGuild(null)).toBe(true);
+    });
+
+    it('gives each guild to exactly one shard', () => {
+        for (const count of [2, 3, 4, 8]) {
+            for (const guildId of SNOWFLAKES) {
+                const owners = [];
+                for (let id = 0; id < count; id++) {
+                    if (handlesGuild(guildId, shardedClient(id, count))) owners.push(id);
+                }
+                expect(owners).toHaveLength(1);
+                expect(owners[0]).toBe(shardIdForGuild(guildId, count));
+            }
+        }
+    });
+
+    it('routes work with no guild to the primary shard rather than to none', () => {
+        // A reminder set in a DM carries guildId: null. It still has to be
+        // delivered exactly once, and no routing rule covers it.
+        for (const absent of [null, undefined, '']) {
+            expect(handlesGuild(absent, shardedClient(0, 4))).toBe(true);
+            expect(handlesGuild(absent, shardedClient(1, 4))).toBe(false);
+            expect(handlesGuild(absent, shardedClient(3, 4))).toBe(false);
+        }
+    });
+
+    it('claims nothing for an id it cannot route', () => {
+        expect(handlesGuild('not-a-snowflake', shardedClient(1, 4))).toBe(false);
+    });
+});
+
 describe('singleton work is gated, not merely documented', () => {
     const read = rel => fs.readFileSync(path.join(__dirname, '..', 'src', rel), 'utf8');
 
@@ -253,15 +292,20 @@ describe('singleton work is gated, not merely documented', () => {
         expect(code).toMatch(/isPrimaryShard\(client\)[\s\S]{0,200}runMigrations\(\)/);
     });
 
-    it('schedules cron jobs on the primary shard only', () => {
+    it('gates deployment-wide jobs and the start-once services on the primary shard', () => {
         // jobRunner's overlap guard is a process-local Set, so it cannot see a
-        // second process running the same job — applyBankInterest paying every
-        // account twice is the shape of getting this wrong.
+        // second process running the same job. Work that is not partitioned by
+        // guild therefore stays on one process — applyBankInterest paying every
+        // account twice is the shape of getting this wrong. Per-guild jobs are
+        // safe to run everywhere precisely because they claim and announce
+        // inside one guild, and #889 is the classification that says which is
+        // which. tests/schedulerScope.test.js holds the behaviour; this holds
+        // that the gate is still a gate.
         const code = read('services/scheduler/index.js');
         expect(code).toContain('isPrimaryShard');
-        const gateIndex = code.indexOf('if (!isPrimaryShard(client))');
+        const gateIndex = code.indexOf('if (!primary) {');
         expect(gateIndex).toBeGreaterThan(-1);
-        expect(code.indexOf('for (const job of JOBS)')).toBeGreaterThan(gateIndex);
+        expect(code).toContain('primary || job.scope === SCOPE.GUILD');
         expect(code.indexOf('runStarters(STARTERS, client)')).toBeGreaterThan(gateIndex);
     });
 
@@ -270,7 +314,7 @@ describe('singleton work is gated, not merely documented', () => {
         // shard that skipped it would show no activity to the guilds it serves.
         const code = read('services/scheduler/index.js');
         const presenceIndex = code.indexOf('setPresence(client);');
-        const gateIndex = code.indexOf('if (!isPrimaryShard(client))');
+        const gateIndex = code.indexOf('if (!primary) {');
         expect(presenceIndex).toBeGreaterThan(-1);
         expect(presenceIndex).toBeLessThan(gateIndex);
     });
@@ -281,7 +325,7 @@ describe('singleton work is gated, not merely documented', () => {
         // owns a cold cache on the first message after a restart.
         const code = read('services/scheduler/index.js');
         const shardStarters = code.indexOf('runStarters(SHARD_STARTERS, client)');
-        const gateIndex = code.indexOf('if (!isPrimaryShard(client))');
+        const gateIndex = code.indexOf('if (!primary) {');
         expect(shardStarters).toBeGreaterThan(-1);
         expect(shardStarters).toBeLessThan(gateIndex);
     });

--- a/tests/shopBuyQuantity.test.js
+++ b/tests/shopBuyQuantity.test.js
@@ -46,6 +46,8 @@ jest.mock('../src/models/Guild', () => ({
         return {};
     }),
 }));
+jest.mock('../src/utils/guildSettingsCache', () =>
+    require('./helpers/guildSettingsCacheMock')());
 
 jest.mock('../src/models/User', () => ({
     findOneAndUpdate: jest.fn(async (query, update) => {


### PR DESCRIPTION
voiceJoinTimes, chatEventService's guildState and the RSS dead-feed
bookkeeping all grew for the life of the process while every other cache in
the repo — BoundedRateLimiter, customBadWordRegexes, guildSettingsCache —
caps and sweeps. None leaks fast enough to be noticed over days, which is why
nothing ever caught them.

voiceJoinTimes now sweeps entries older than a plausible session (24h) on an
hourly amortised pass and caps FIFO at 5,000. A leave arriving past that
cutoff awards nothing, so the XP no longer depends on whether a sweep
happened to have run first.

guildState takes the same FIFO cap as its sibling caches. Eviction costs the
evicted guild its progress toward the next chat event; nothing fires early.

The RSS maps are pruned by age rather than against the sweep's subscription
list, because daily-news profiles carry their own feed URLs that checkRssFeeds
never queries — pruning against that list would clear every digest-only feed's
circuit-breaker state every five minutes. An entry only changes behaviour
inside DEAD_FEED_COOLDOWN_MS of its last failure, and a feed still being polled
refreshes its own entry, so age identifies exactly the URLs nothing polls.

Closes #928