### PR TITLE
Give expired market listings a grace period before MongoDB deletes them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,52 @@ whose schema predates a migration that has already run.
 `npm test` fails if the newest entry below does not name both the current
 `package.json` version and the highest-numbered migration on disk.
 
+## [4.5.2] - 2026-09-01
+
+Migrations through `021_market_listing_ttl_grace`.
+
+Expired market listings no longer lose their items on the ordinary expiry path
+(#867). The `marketlistings` TTL index carried `expireAfterSeconds: 0`, and
+MongoDB's TTL monitor wakes about once a minute, so a listing was hard-deleted
+within roughly a minute of expiring — while `returnExpiredMarketListings`, the
+job that gives the seller their items back and the only thing that does, runs
+every ten minutes. The monitor won that race for nearly every expiry, and a TTL
+delete fires no Mongoose hook: no items returned, no owed-payout record, nothing
+in the logs. The seller's stock simply ceased to exist, on the success path.
+The grace is now seven days, sized against a backlog rather than a single tick
+(the sweep claims 50 listings a tick), and the sweep's `expiresAt <= now` filter
+is unchanged so it still claims a listing the moment it expires, hours before
+the TTL monitor is entitled to look at it. `021` applies the same figure to
+databases that already built the index, with `collMod` so the index is never
+absent and never rebuilt, verified before the boot continues. A capped sweep
+tick now says so in the log — that backlog was invisible, and it is what the
+grace is sized against. The remaining TTL indexes were reviewed as a set:
+`ActiveLock` and `McpOAuthState` are zero-grace by design, both comparing the
+timestamp in code and using the TTL only to reclaim space, and the rest are
+retention windows well clear of any job that reads them.
+
+Casino settlement math is testable and tested (#883). The arithmetic that turns
+an outcome and a stake into the number that goes into `$inc: { balance }` — the
+3:2 natural, insurance, the split and double-down credit, roulette's table odds,
+poker's five payout sites — sat inline behind button collectors at 10-27%
+statement coverage, the largest block of untested code in the repo that decides
+what a player is paid. It is now `src/games/casino/settlement.js`, pure and at
+100%, and the games call it. No payout changed: where the three games disagreed
+they still disagree, and the disagreements are the tested part. Blackjack boosts
+a whole profit unguarded; poker boosts only what is above the stake and only
+above 1x, which is what stops an admin-set `serverBoost.multiplier` below 1 from
+cutting payouts; roulette takes no multiplier at all, because its odds are the
+wheel's. The natural's `Math.floor` runs before the booster and not after —
+worth a coin a hand on an odd bet, and the ordering a refactor would most
+plausibly have changed.
+
+The timezone picker uses canonical IANA names (#942). `Asia/Kolkata` was listed
+twice, `Europe/Kiev` and `Asia/Rangoon` have been superseded by `Europe/Kyiv`
+and `Asia/Yangon`, and `America/Honolulu` was never a zone — canonical
+`Pacific/Honolulu` was already in the list, so that entry is dropped rather than
+renamed. Cosmetic: the old names survive as backward-compatibility links, so
+nothing a guild had saved stopped resolving.
+
 ## [4.5.1] - 2026-08-31
 
 Migrations through `020_narrow_failed_job_ttl`.

--- a/coverage-floors.json
+++ b/coverage-floors.json
@@ -227,7 +227,6 @@
         "src/dashboard/public/guild-settings.js",
         "src/deploy-commands.js",
         "src/index.js",
-        "src/models/AuditLog.js",
         "src/shard.js"
     ],
     "coveredOnlyByIntegration": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clawdia",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawdia",
-      "version": "4.5.1",
+      "version": "4.5.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.120.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawdia",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "Clawdia — a chill, self-hosted Discord bot with a full-featured admin dashboard",
   "main": "src/index.js",
   "scripts": {

--- a/src/dashboard/views/guild-settings.ejs
+++ b/src/dashboard/views/guild-settings.ejs
@@ -219,7 +219,6 @@
         <option value="America/Los_Angeles">
         <option value="America/Phoenix">
         <option value="America/Anchorage">
-        <option value="America/Honolulu">
         <option value="America/Toronto">
         <option value="America/Vancouver">
         <option value="America/Mexico_City">
@@ -247,7 +246,7 @@
         <option value="Europe/Athens">
         <option value="Europe/Bucharest">
         <option value="Europe/Istanbul">
-        <option value="Europe/Kiev">
+        <option value="Europe/Kyiv">
         <option value="Europe/Moscow">
         <option value="Africa/Cairo">
         <option value="Africa/Johannesburg">
@@ -260,7 +259,7 @@
         <option value="Asia/Kolkata">
         <option value="Asia/Colombo">
         <option value="Asia/Dhaka">
-        <option value="Asia/Rangoon">
+        <option value="Asia/Yangon">
         <option value="Asia/Bangkok">
         <option value="Asia/Ho_Chi_Minh">
         <option value="Asia/Jakarta">
@@ -272,7 +271,6 @@
         <option value="Asia/Seoul">
         <option value="Asia/Tokyo">
         <option value="Asia/Manila">
-        <option value="Asia/Kolkata">
         <option value="Australia/Perth">
         <option value="Australia/Darwin">
         <option value="Australia/Brisbane">

--- a/src/games/casino/blackjack.js
+++ b/src/games/casino/blackjack.js
@@ -22,6 +22,14 @@ const {
     settleHand,
     isNaturalBlackjack,
 } = require('./blackjackHands');
+const {
+    naturalBlackjackProfit,
+    blackjackWinProfit,
+    blackjackHandCredit,
+    insuranceCredit,
+    insuranceProfit,
+    insuranceCost: halfBet,
+} = require('./settlement');
 const { ownedBy } = require('../../utils/collectorOwner');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f0cf.png';
@@ -237,7 +245,7 @@ module.exports = {
             }
             const bjCoinMult   = getCoinMultiplier(user);
             const bjServerMult = getServerCoinMultiplier(guildSettings);
-            const payout = Math.round(Math.floor(bet * 1.5) * bjCoinMult * bjServerMult);
+            const payout = naturalBlackjackProfit(bet, bjCoinMult * bjServerMult);
             const bjWinUser = await User.findOneAndUpdate(
                 { userId: interaction.user.id, guildId: interaction.guild.id },
                 { $inc: { balance: bet + payout } },
@@ -262,7 +270,7 @@ module.exports = {
         }
 
         const dealerShowsAce  = dealerHand[0].value === 'A';
-        const insuranceCost   = Math.floor(bet / 2);
+        const insuranceCost   = halfBet(bet);
 
         // Dealer peek: if dealer shows Ace and has natural blackjack, resolve before player acts
         if (dealerShowsAce && isNaturalBlackjack(dealerHand)) {
@@ -306,8 +314,8 @@ module.exports = {
             let peekStatus = `❌ Dealer Blackjack! -${currency}${bet.toLocaleString()}`;
             let peekCredit = 0;
             if (peekInsuranceBet > 0) {
-                peekCredit = peekInsuranceBet * 3;
-                peekStatus += `\n🛡️ Insurance paid! +${currency}${(peekInsuranceBet * 2).toLocaleString()}`;
+                peekCredit = insuranceCredit(peekInsuranceBet);
+                peekStatus += `\n🛡️ Insurance paid! +${currency}${insuranceProfit(peekInsuranceBet).toLocaleString()}`;
             }
             if (peekCredit > 0) {
                 await User.updateOne(
@@ -517,12 +525,12 @@ module.exports = {
                 if (insuranceBet > 0 && isNaturalBlackjack(dealerHand.slice(0, 2))) {
                     await User.updateOne(
                         { userId: interaction.user.id, guildId: interaction.guild.id },
-                        { $inc: { balance: insuranceBet * 3 } },
+                        { $inc: { balance: insuranceCredit(insuranceBet) } },
                     );
                     const insUser = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
                     const embed = buildFinalEmbed(interaction, dealerHand, playerHand, null, currency, activeBet,
                         '🃏 Blackjack — Bust',
-                        `Went over. The house collects.\n🛡️ Insurance paid! +${currency}${(insuranceBet * 2).toLocaleString()}`,
+                        `Went over. The house collects.\n🛡️ Insurance paid! +${currency}${insuranceProfit(insuranceBet).toLocaleString()}`,
                         '#e74c3c', insUser?.balance ?? 0);
                     await interaction.editReply({ embeds: [embed], components: buildButtons(gameId, true) }).catch(() => {});
                 }
@@ -567,18 +575,18 @@ module.exports = {
                     if (outcome === 'bust') {
                         handResults.push(`Hand ${h + 1}: 💥 Bust (-${currency}${hBet.toLocaleString()})`);
                     } else if (outcome === 'win') {
-                        const netProfit = Math.round(hBet * totalCoinMult);
-                        totalCredit += hBet + netProfit;
+                        const netProfit = blackjackWinProfit(hBet, totalCoinMult);
+                        totalCredit += blackjackHandCredit('win', hBet, totalCoinMult);
                         const boostNote = totalCoinMult > 1.0 ? ` *(🚀 ${totalCoinMult.toFixed(1)}x)*` : '';
                         handResults.push(`Hand ${h + 1}: ✅ Win (+${currency}${netProfit.toLocaleString()}${boostNote})`);
                     } else if (outcome === 'push') {
-                        totalCredit += hBet;
+                        totalCredit += blackjackHandCredit('push', hBet, totalCoinMult);
                         handResults.push(`Hand ${h + 1}: 🤝 Push`);
                     } else if (luckySaveEligible(hBet) && luckyActive && Math.random() < 0.20) {
-                        totalCredit += hBet;
+                        totalCredit += blackjackHandCredit('lose', hBet, totalCoinMult, true);
                         handResults.push(`Hand ${h + 1}: 🍀 Lucky Push`);
                     } else if (luckySaveEligible(hBet) && luckyStreakBonus > 0 && Math.random() < luckyStreakBonus) {
-                        totalCredit += hBet;
+                        totalCredit += blackjackHandCredit('lose', hBet, totalCoinMult, true);
                         handResults.push(`Hand ${h + 1}: 🎯 Lucky Push`);
                     } else {
                         handResults.push(`Hand ${h + 1}: ❌ Loss (-${currency}${hBet.toLocaleString()})`);
@@ -596,23 +604,23 @@ module.exports = {
                 const outcome     = settleHand(playerTotal, dealerTotal);
 
                 if (outcome === 'win') {
-                    const netProfit = Math.round(activeBet * totalCoinMult);
-                    totalCredit = activeBet + netProfit;
+                    const netProfit = blackjackWinProfit(activeBet, totalCoinMult);
+                    totalCredit = blackjackHandCredit('win', activeBet, totalCoinMult);
                     title       = '🃏 Blackjack — You Win';
                     description = `${randomFrom(BJ_WIN_LINES)}\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  💰 Payout: ${currency}${(activeBet + netProfit).toLocaleString()}  (+${currency}${netProfit.toLocaleString()} net)${boostNote}\n━━━━━━━━━━━━━━━━━━━━━━━━━━`;
                     color       = '#2ecc71';
                 } else if (outcome === 'push') {
-                    totalCredit = activeBet;
+                    totalCredit = blackjackHandCredit('push', activeBet, totalCoinMult);
                     title       = '🃏 Blackjack — Push';
                     description = `${randomFrom(BJ_PUSH_LINES)}\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  🤝 Returned: ${currency}${activeBet.toLocaleString()}\n━━━━━━━━━━━━━━━━━━━━━━━━━━`;
                     color       = '#f39c12';
                 } else if (luckySaveEligible(activeBet) && luckyActive && Math.random() < 0.20) {
-                    totalCredit = activeBet;
+                    totalCredit = blackjackHandCredit('lose', activeBet, totalCoinMult, true);
                     title       = '🃏 Blackjack — Lucky Push';
                     description = `🍀 Lucky Charm saved you. Bet returned.\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  🤝 Returned: ${currency}${activeBet.toLocaleString()}\n━━━━━━━━━━━━━━━━━━━━━━━━━━`;
                     color       = '#f39c12';
                 } else if (luckySaveEligible(activeBet) && luckyStreakBonus > 0 && Math.random() < luckyStreakBonus) {
-                    totalCredit = activeBet;
+                    totalCredit = blackjackHandCredit('lose', activeBet, totalCoinMult, true);
                     title       = '🃏 Blackjack — Lucky Push';
                     description = `🎯 Lucky Streak saved you. Bet returned.\n\n━━━━━━━━━━━━━━━━━━━━━━━━━━\n  🤝 Returned: ${currency}${activeBet.toLocaleString()}\n━━━━━━━━━━━━━━━━━━━━━━━━━━`;
                     color       = '#f39c12';
@@ -627,8 +635,8 @@ module.exports = {
             if (insuranceBet > 0) {
                 const dealerNaturalBJ = isNaturalBlackjack(dealerHand.slice(0, 2));
                 if (dealerNaturalBJ) {
-                    totalCredit += insuranceBet * 3;
-                    description += `\n🛡️ Insurance paid! +${currency}${(insuranceBet * 2).toLocaleString()}`;
+                    totalCredit += insuranceCredit(insuranceBet);
+                    description += `\n🛡️ Insurance paid! +${currency}${insuranceProfit(insuranceBet).toLocaleString()}`;
                 } else {
                     description += `\n🛡️ Insurance lost (-${currency}${insuranceBet.toLocaleString()})`;
                 }

--- a/src/games/casino/poker.js
+++ b/src/games/casino/poker.js
@@ -21,6 +21,11 @@ const {
     bestHand,
     compareHands,
 } = require('./pokerHands');
+const {
+    pokerFoldWinPayout,
+    pokerPotPayout,
+    pokerShowdownPayout,
+} = require('./settlement');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f0cf.png';
 const MIN_BET = 10;
@@ -137,9 +142,9 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
             const coinMult   = getCoinMultiplier(debited);
             const serverMult = getServerCoinMultiplier(guildSettings);
             const totalMult  = coinMult * serverMult;
-            const baseWin    = Math.floor(bet * 1.5); // small early-exit bonus
-            let winAmount    = baseWin;
-            if (totalMult > 1.0) winAmount = bet + Math.round((baseWin - bet) * totalMult);
+            // A flat 3:2 on the opening bet — a small consolation for a hand
+            // that ended before it started.
+            const winAmount  = pokerFoldWinPayout(bet, totalMult);
 
             const updated = await User.findOneAndUpdate(userFilter, { $inc: { balance: winAmount } }, { new: true });
             releaseLock?.();
@@ -274,8 +279,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
             const coinMult   = getCoinMultiplier(debited);
             const serverMult = getServerCoinMultiplier(guildSettings);
             const totalMult  = coinMult * serverMult;
-            let winPayout    = pot;
-            if (totalMult > 1.0) winPayout = playerStake + Math.round((pot - playerStake) * totalMult);
+            const winPayout  = pokerPotPayout(playerStake, pot, totalMult);
 
             await User.findOneAndUpdate(userFilter, { $inc: { balance: winPayout } }, { new: true });
             releaseLock?.();
@@ -403,8 +407,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
             const coinMult   = getCoinMultiplier(debited);
             const serverMult = getServerCoinMultiplier(guildSettings);
             const totalMult  = coinMult * serverMult;
-            let winPayout    = pot;
-            if (totalMult > 1.0) winPayout = playerStake + Math.round((pot - playerStake) * totalMult);
+            const winPayout  = pokerPotPayout(playerStake, pot, totalMult);
             await User.findOneAndUpdate(userFilter, { $inc: { balance: winPayout } }, { new: true });
             releaseLock?.();
             return interaction.editReply({
@@ -524,8 +527,7 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
             const coinMult   = getCoinMultiplier(debited);
             const serverMult = getServerCoinMultiplier(guildSettings);
             const totalMult  = coinMult * serverMult;
-            let winPayout    = pot;
-            if (totalMult > 1.0) winPayout = playerStake + Math.round((pot - playerStake) * totalMult);
+            const winPayout  = pokerPotPayout(playerStake, pot, totalMult);
             await User.findOneAndUpdate(userFilter, { $inc: { balance: winPayout } }, { new: true });
             releaseLock?.();
             return interaction.editReply({
@@ -637,20 +639,15 @@ async function playPoker(interaction, bet, releaseLock, onWager) {
         const totalCoinMult = coinMult * serverMult;
         const streakBonus   = getLuckyStreakBonus(debited);
 
-        let grossPayout = 0;
-        let outcome     = result;
-
-        if (result === 'win')  grossPayout = playerStake * 2;
-        if (result === 'push') grossPayout = playerStake;
+        // The lucky streak turns a loss into a push before the payout is
+        // computed, so the settled outcome is what both the money and the embed
+        // are read off.
+        let outcome = result;
         if (result === 'lose' && luckySaveEligible(playerStake) && streakBonus > 0 && Math.random() < streakBonus) {
-            grossPayout = playerStake;
             outcome = 'push';
         }
 
-        let adjustedPayout = grossPayout;
-        if (grossPayout > playerStake && totalCoinMult > 1.0) {
-            adjustedPayout = playerStake + Math.round((grossPayout - playerStake) * totalCoinMult);
-        }
+        const adjustedPayout = pokerShowdownPayout(outcome, playerStake, totalCoinMult);
 
         let updated = debited;
         if (adjustedPayout > 0) {

--- a/src/games/casino/roulette.js
+++ b/src/games/casino/roulette.js
@@ -12,6 +12,7 @@ const { confirmBet } = require('../../utils/confirmBet');
 const { hasEffect, luckySaveEligible } = require('../../services/effectsService');
 const COLORS = require('../../utils/embedColors');
 const { ownedBy } = require('../../utils/collectorOwner');
+const { rouletteSettlement } = require('./settlement');
 
 const THUMB   = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/1f3a1.png';
 const MIN_BET = 10;
@@ -253,8 +254,7 @@ async function playRoulette(interaction, betKey, bet, target, releaseLock, onWag
             won    = betDef.matches(result, target);
             charmTriggered = true;
         }
-        const profit   = won ? bet * betDef.payout : -bet;
-        const credit   = won ? bet + profit : 0;
+        const { profit, credit } = rouletteSettlement(bet, betDef.payout, won);
         const delay    = ms => new Promise(r => setTimeout(r, ms));
 
         // Spinning animation

--- a/src/games/casino/settlement.js
+++ b/src/games/casino/settlement.js
@@ -1,0 +1,223 @@
+'use strict';
+
+/**
+ * The arithmetic that decides how many coins a settled casino hand credits.
+ *
+ * Hand ranking was extracted here long ago (`blackjackHands`, `pokerHands`) and
+ * is tested to 100%. The step *after* it — turning an outcome and a stake into
+ * the number that goes into `$inc: { balance }` — stayed inline in the game
+ * files, buried behind button collectors that no unit test can drive, at 10-27%
+ * statement coverage (#883). It is the largest block of untested code in the
+ * repo that decides how many coins a player receives, in a subsystem whose
+ * history (#785, #807, the balanceDelta/payoutKey work) says money bugs are the
+ * recurring failure mode. Rounding order and multiplier stacking are exactly
+ * where those hide, and neither is visible from the outside.
+ *
+ * So the numbers live here, as functions of their inputs and nothing else. The
+ * games keep the coin writes, the embeds and the collectors; this keeps the
+ * arithmetic.
+ *
+ * Every function here reproduces what the games already did, rounding order
+ * included. Where two games disagree — and they do — the disagreement is
+ * preserved and documented rather than tidied into one rule, because tidying it
+ * would change what players are paid.
+ *
+ * The three shapes, and where each is used:
+ *
+ *   profit-boosted  the stake returns unmultiplied and only the winnings are
+ *                   boosted, guarded on the multiplier exceeding 1. Poker, at
+ *                   every one of its five payout sites.
+ *   fully boosted   the whole profit is multiplied with no guard. Blackjack.
+ *   unboosted       no coin multiplier reaches the payout at all. Roulette,
+ *                   whose odds are fixed by the wheel.
+ */
+
+/**
+ * A payout where the stake comes back untouched and only the profit is boosted.
+ *
+ * `Math.round` sits outside the multiplication and inside the addition, so the
+ * stake is never rounded — a 2x booster on a 150-coin win over a 100-coin stake
+ * pays 100 + round(50 * 2) = 200, not round(150 * 2) = 300.
+ *
+ * The `> 1` guard is load-bearing rather than an optimisation: a guild's
+ * `serverBoost.multiplier` is admin-set and nothing clamps it to 1 or more, so
+ * without the guard a booster configured below 1 would quietly *cut* payouts.
+ *
+ * @param {number} stake        what the player has already put in
+ * @param {number} grossPayout  what the hand pays before any booster
+ * @param {number} coinMultiplier  combined personal x server multiplier
+ * @returns {number} coins to credit
+ */
+function boostedPayout(stake, grossPayout, coinMultiplier) {
+    if (!(grossPayout > stake) || !(coinMultiplier > 1)) return grossPayout;
+    return stake + Math.round((grossPayout - stake) * coinMultiplier);
+}
+
+// ── Blackjack ────────────────────────────────────────────────────────────────
+
+/**
+ * Profit on a natural 21, which pays 3:2.
+ *
+ * The floor runs first and the multiplier second: an odd bet loses its half
+ * coin to the 3:2 rate before any booster sees it, so a 25-coin natural at 2x
+ * pays round(floor(37.5) * 2) = 74 and not round(37.5 * 2) = 75. That ordering
+ * is the house's, and it is what the game has always done.
+ *
+ * Unlike poker, the whole profit is boosted with no `> 1` guard — the natural's
+ * profit *is* the boosted quantity, and the bet is credited separately by the
+ * caller.
+ */
+function naturalBlackjackProfit(bet, coinMultiplier) {
+    return Math.round(Math.floor(bet * 1.5) * coinMultiplier);
+}
+
+/** Total credit on a natural: the bet back, plus the 3:2 profit. */
+function naturalBlackjackCredit(bet, coinMultiplier) {
+    return bet + naturalBlackjackProfit(bet, coinMultiplier);
+}
+
+/**
+ * Profit on an ordinary blackjack win, which pays even money.
+ *
+ * Boosted whole and unguarded, matching the natural above rather than poker.
+ */
+function blackjackWinProfit(bet, coinMultiplier) {
+    return Math.round(bet * coinMultiplier);
+}
+
+/** Total credit on an ordinary win: the bet back, plus even-money profit. */
+function blackjackWinCredit(bet, coinMultiplier) {
+    return bet + blackjackWinProfit(bet, coinMultiplier);
+}
+
+/**
+ * What insurance credits when the dealer turns over a natural.
+ *
+ * Insurance costs half the bet and pays 2:1, so the credit is the insurance
+ * stake back plus twice it — three times the stake, and `insuranceProfit` is
+ * the two-thirds of that the player is up on the side bet.
+ *
+ * No coin multiplier: insurance is a side bet against the dealer's hole card at
+ * fixed odds, and no booster has ever touched it. Deliberate, and the reason it
+ * takes no multiplier argument at all rather than one that is ignored.
+ */
+function insuranceCredit(insuranceStake) {
+    return insuranceStake * 3;
+}
+
+/** The winnings on insurance, which is what the embed reports. */
+function insuranceProfit(insuranceStake) {
+    return insuranceStake * 2;
+}
+
+/** Half the bet, rounded down — what insurance costs, and 0 for a bet of 1. */
+function insuranceCost(bet) {
+    return Math.floor(bet / 2);
+}
+
+/**
+ * What one settled blackjack hand credits, for `settleHand`'s four outcomes
+ * plus the lucky-charm save.
+ *
+ * A split plays two of these against one dealer hand and sums them, which is
+ * why it is per-hand: the two halves can carry different bets once one has been
+ * doubled.
+ *
+ * @param {'win'|'push'|'lose'|'bust'} outcome  from blackjackHands.settleHand
+ * @param {number} bet  this hand's stake, after any double down
+ * @param {number} coinMultiplier
+ * @param {boolean} luckySaved  a loss the lucky charm or streak turned into a push
+ * @returns {number} coins to credit for this hand
+ */
+function blackjackHandCredit(outcome, bet, coinMultiplier, luckySaved = false) {
+    if (outcome === 'win')  return blackjackWinCredit(bet, coinMultiplier);
+    if (outcome === 'push') return bet;
+    // A bust is a loss the player caused and the charm does not save; only an
+    // ordinary loss to the dealer is eligible, which is what the games check.
+    if (outcome === 'bust') return 0;
+    return luckySaved ? bet : 0;
+}
+
+// ── Roulette ─────────────────────────────────────────────────────────────────
+
+/**
+ * Profit and credit on a roulette spin, at the table odds for the bet placed.
+ *
+ * No coin multiplier reaches this, unlike every other game in the casino. That
+ * is preserved rather than corrected: roulette's odds are the wheel's — 35:1 on
+ * a straight number against a 1-in-37 chance — and a 2x booster on top of that
+ * is a different game, not a bug in this one. Recorded here because the absence
+ * is invisible at the call site and reads like an oversight.
+ *
+ * `profit` is signed (it is what the embed shows) and `credit` is what goes
+ * into the balance: 0 on a loss, because the stake was debited when the bet was
+ * placed and is not being returned.
+ *
+ * @param {number} bet
+ * @param {number} payoutOdds  the `payout` of the BETS entry: 1, 2 or 35
+ * @param {boolean} won
+ */
+function rouletteSettlement(bet, payoutOdds, won) {
+    const profit = won ? bet * payoutOdds : -bet;
+    return { profit, credit: won ? bet + profit : 0 };
+}
+
+// ── Poker ────────────────────────────────────────────────────────────────────
+
+/**
+ * What the player is credited when the dealer folds before the flop.
+ *
+ * The gross is a flat 3:2 on the opening bet — a small consolation for a hand
+ * that ended before it started — and the boost applies to the half-bet of
+ * profit only, not to the whole 1.5x.
+ */
+function pokerFoldWinPayout(bet, coinMultiplier) {
+    return boostedPayout(bet, Math.floor(bet * 1.5), coinMultiplier);
+}
+
+/**
+ * What the player is credited when the dealer folds on the flop, turn or river:
+ * the pot, with only the part of it above their own stake boosted.
+ *
+ * The pot opens at twice the bet and every raise the player makes adds at least
+ * as much to the pot as to their stake, so the pot always exceeds the stake and
+ * this is always a win.
+ */
+function pokerPotPayout(playerStake, pot, coinMultiplier) {
+    return boostedPayout(playerStake, pot, coinMultiplier);
+}
+
+/**
+ * The showdown payout before any booster, for a compared hand.
+ *
+ * A win returns double the stake, a push returns it, a loss returns nothing —
+ * unless the lucky streak saved it, which the caller decides (it is a random
+ * roll) and passes in as an already-resolved outcome of 'push'.
+ */
+function pokerShowdownGross(outcome, playerStake) {
+    if (outcome === 'win')  return playerStake * 2;
+    if (outcome === 'push') return playerStake;
+    return 0;
+}
+
+/** The showdown payout with the booster applied to the winnings. */
+function pokerShowdownPayout(outcome, playerStake, coinMultiplier) {
+    return boostedPayout(playerStake, pokerShowdownGross(outcome, playerStake), coinMultiplier);
+}
+
+module.exports = {
+    boostedPayout,
+    naturalBlackjackProfit,
+    naturalBlackjackCredit,
+    blackjackWinProfit,
+    blackjackWinCredit,
+    blackjackHandCredit,
+    insuranceCredit,
+    insuranceProfit,
+    insuranceCost,
+    rouletteSettlement,
+    pokerFoldWinPayout,
+    pokerPotPayout,
+    pokerShowdownGross,
+    pokerShowdownPayout,
+};

--- a/src/migrations/021_market_listing_ttl_grace.js
+++ b/src/migrations/021_market_listing_ttl_grace.js
@@ -1,0 +1,88 @@
+const mongoose = require('mongoose');
+
+// Kept in step with `EXPIRED_LISTING_GRACE_SECONDS` in models/MarketListing.js
+// by tests/migrationIndexes.test.js — a migration that sets a different grace
+// from the one the model declares would be undone by the next createIndex.
+const GRACE_SECONDS = 7 * 24 * 60 * 60;
+
+/**
+ * Gives the marketlistings TTL a grace period, so the sweep that returns items
+ * to sellers gets to run before MongoDB destroys the listing.
+ *
+ * `expiresAt_1` was built with `expireAfterSeconds: 0` (#867). MongoDB's TTL
+ * monitor wakes roughly once a minute, so an expired listing was hard-deleted
+ * within about a minute. `returnExpiredMarketListings` — which returns the
+ * seller's items and is the only thing that does — runs every ten minutes. The
+ * TTL monitor won that race for nearly every expiry, and a TTL delete fires no
+ * Mongoose hook: no items back, no owed-payout record, nothing in the logs. On
+ * the *normal* expiry path, sellers lost their stock silently.
+ *
+ * collMod rather than drop-and-recreate. `expireAfterSeconds` is the one index
+ * option MongoDB can change in place, it is the only thing changing here, and
+ * doing it in place means there is never an instant with no TTL on the
+ * collection and never an index rebuild over every listing. The index keeps its
+ * name and key, so the model's declaration matches it afterwards and autoIndex
+ * has nothing to reconcile.
+ *
+ * Listings already deleted are gone and are not recoverable from here; this
+ * stops the next ones going.
+ */
+module.exports = {
+    name: '021_market_listing_ttl_grace',
+
+    async up() {
+        const db = mongoose.connection.db;
+
+        // A fresh install has no marketlistings collection — the first `/market
+        // list` creates it, and the model's declaration builds the index with
+        // the grace already on it. Nothing to convert.
+        const [existing] = await db.listCollections({ name: 'marketlistings' }).toArray();
+        if (!existing) return;
+
+        const listings = db.collection('marketlistings');
+        const before = (await listings.indexes()).find(i => i.name === 'expiresAt_1');
+
+        if (!before) {
+            // The collection exists but the index does not — a database that
+            // predates it, or one where it was dropped by hand. Build it here
+            // rather than leave it to autoIndex, which runs unawaited in the
+            // background and would leave the sweep's `expiresAt` query
+            // unindexed in the meantime.
+            await listings.createIndex({ expiresAt: 1 }, { expireAfterSeconds: GRACE_SECONDS });
+        } else if (before.expireAfterSeconds !== GRACE_SECONDS) {
+            await db.command({
+                collMod: 'marketlistings',
+                index: { name: 'expiresAt_1', expireAfterSeconds: GRACE_SECONDS },
+            });
+        }
+
+        // A TTL still at zero after this would keep deleting listings out from
+        // under the sweep, which is the entire reason the migration exists — so
+        // it fails the boot rather than reporting a swap that did not happen.
+        const after = (await listings.indexes()).find(i => i.name === 'expiresAt_1');
+        if (after?.expireAfterSeconds !== GRACE_SECONDS) {
+            throw new Error(
+                `marketlistings expiresAt_1 still expires after ${after?.expireAfterSeconds}s, not ${GRACE_SECONDS}s — ` +
+                'expired listings would be destroyed before their items are returned, so startup must not continue.',
+            );
+        }
+    },
+
+    // The inverse is the zero-grace index this replaces. It is a rollback to a
+    // state that loses items, which is what a rollback to the previous release
+    // is: the code being rolled back to is the code that shipped the zero.
+    async down() {
+        const db = mongoose.connection.db;
+
+        const [existing] = await db.listCollections({ name: 'marketlistings' }).toArray();
+        if (!existing) return;
+
+        const listings = db.collection('marketlistings');
+        if (!(await listings.indexes()).some(i => i.name === 'expiresAt_1')) return;
+
+        await db.command({
+            collMod: 'marketlistings',
+            index: { name: 'expiresAt_1', expireAfterSeconds: 0 },
+        });
+    },
+};

--- a/src/models/MarketListing.js
+++ b/src/models/MarketListing.js
@@ -26,8 +26,39 @@ const marketListingSchema = new Schema({
     slot:         { type: Number, min: 1 },
 });
 
-// TTL index for automatic expiry cleanup (MongoDB removes docs after expiresAt)
-marketListingSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+// How long an expired listing survives past `expiresAt` before MongoDB removes
+// the document outright. It is not a cleanup schedule — it is the margin the
+// sweep gets to run first.
+//
+// This was 0 (#867), and 0 loses items on the ordinary expiry path. MongoDB's
+// TTL monitor wakes about once a minute, so a listing was hard-deleted within
+// roughly a minute of expiring. `returnExpiredMarketListings` — the job that
+// gives the seller their items back, and the only thing that does — runs every
+// ten minutes and selects on `expiresAt <= now`. The TTL monitor therefore won
+// the race for almost every expiry, and a TTL delete fires no Mongoose hook: no
+// items returned, no owed-payout record, nothing logged. The seller's stock
+// simply ceased to exist, on the success path, silently.
+//
+// Seven days rather than something just over the sweep interval. The sweep
+// claims at most 50 listings per tick (7,200 a day), so a deployment that
+// expires faster than that builds a backlog, and the grace has to outlast the
+// backlog and not merely one tick. Nothing is kept alive by this that the sweep
+// would have deleted anyway: the sweep deletes each listing itself as it claims
+// it, so in normal operation the TTL monitor finds nothing left to remove. What
+// it removes is what the sweep never reached — and a week is long enough that
+// the sweep's own dead-letter alarms fire well before this destroys anything.
+//
+// The sweep's `expiresAt <= now` filter is deliberately left alone: it is what
+// makes the sweep claim a listing the moment it expires, hours before the TTL
+// monitor is entitled to look at it.
+const EXPIRED_LISTING_GRACE_SECONDS = 7 * 24 * 60 * 60;
+
+// Changing `expireAfterSeconds` on an index that already exists is not
+// something declaring it here does — Mongoose issues a createIndex that comes
+// back IndexOptionsConflict, leaving the old zero-grace index in place, still
+// deleting listings. Migration 021_market_listing_ttl_grace applies it with
+// collMod to databases that already built it.
+marketListingSchema.index({ expiresAt: 1 }, { expireAfterSeconds: EXPIRED_LISTING_GRACE_SECONDS });
 marketListingSchema.index({ guildId: 1, itemId: 1, pricePerUnit: 1 });
 marketListingSchema.index({ guildId: 1, sellerId: 1 });
 
@@ -44,3 +75,4 @@ marketListingSchema.index(
 );
 
 module.exports = model('MarketListing', marketListingSchema);
+module.exports.EXPIRED_LISTING_GRACE_SECONDS = EXPIRED_LISTING_GRACE_SECONDS;

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -1478,19 +1478,34 @@ async function returnExpiredMarketListings() {
     let failed = 0;
     let unrecordedReturns = 0;
 
-    // Process in batches of 50 to avoid large memory spikes
-    const expired = await MarketListing.find({ expiresAt: { $lte: now } }).limit(BATCH_SIZE).lean();
+    // Batched to avoid large memory spikes, and oldest first.
+    //
+    // The sort is not cosmetic. Without one MongoDB returns natural order,
+    // which is an implementation detail and not insertion order — so a capped
+    // tick took an arbitrary 50 of the expired listings, and a listing could be
+    // passed over tick after tick while newer ones went ahead of it. Every
+    // listing has a deadline now (#867): the TTL grace deletes it seven days
+    // after it expires, whether or not the sweep ever chose it. Oldest first is
+    // what turns "the backlog drains" into "no individual listing starves",
+    // which is the claim the grace period is sized against.
+    //
+    // Free, as it happens: the sort key is the TTL index, so this walks that
+    // index in order rather than sorting anything in memory.
+    const expired = await MarketListing.find({ expiresAt: { $lte: now } })
+        .sort({ expiresAt: 1 })
+        .limit(BATCH_SIZE)
+        .lean();
 
-    // A full batch means the tick was capped, not that it cleared the queue —
-    // the rest wait for the next one, and the one after that if it is full too.
-    // That backlog used to be invisible and harmless-looking; since #867 it is
-    // the thing the TTL grace is sized against, so it says so. Sustained, it
-    // means listings are expiring faster than 50 per ten minutes and the batch
-    // needs raising before the grace runs out and MongoDB deletes the tail.
+    // A full batch means the tick hit its cap — there may be more behind it, or
+    // there may have been exactly fifty. Either way it is the state worth
+    // saying out loud, because a *sustained* cap means listings are expiring
+    // faster than 50 per ten minutes, and the backlog that builds is the thing
+    // the TTL grace is sized against. It used to be invisible.
     if (expired.length === BATCH_SIZE) {
         console.warn(
-            `[scheduler] returnExpiredMarketListings: batch capped at ${BATCH_SIZE} — more expired listings are ` +
-            'waiting. Items are returned on later ticks; a backlog that persists for days outlives the TTL grace.',
+            `[scheduler] returnExpiredMarketListings: batch capped at ${BATCH_SIZE} — there may be more expired ` +
+            'listings waiting. Any are returned on later ticks, oldest first; a cap that persists for days is a ' +
+            'backlog outliving the TTL grace, and the batch needs raising.',
         );
     }
 

--- a/src/services/schedulerService.js
+++ b/src/services/schedulerService.js
@@ -1461,17 +1461,38 @@ async function applyBankInterest(client) {
  * whose listing expired unclaimed would vanish from the economy permanently.
  * The one job here that needs no client: it posts nothing.
  *
+ * "Before the TTL index deletes them" was not achievable until #867: the index
+ * carried no grace period, MongoDB's TTL monitor wakes about once a minute, and
+ * this runs every ten — so the monitor won nearly every race and the items were
+ * gone before this job ever saw the listing. The grace is now a week
+ * (models/MarketListing.js), which is what makes selecting on `expiresAt <= now`
+ * here the claim it reads as rather than a hope.
+ *
  * @returns {Promise<void>}
  */
 async function returnExpiredMarketListings() {
     const MarketListing = require('../models/MarketListing');
+    const BATCH_SIZE = 50;
     const now = new Date();
     let processed = 0;
     let failed = 0;
     let unrecordedReturns = 0;
 
     // Process in batches of 50 to avoid large memory spikes
-    const expired = await MarketListing.find({ expiresAt: { $lte: now } }).limit(50).lean();
+    const expired = await MarketListing.find({ expiresAt: { $lte: now } }).limit(BATCH_SIZE).lean();
+
+    // A full batch means the tick was capped, not that it cleared the queue —
+    // the rest wait for the next one, and the one after that if it is full too.
+    // That backlog used to be invisible and harmless-looking; since #867 it is
+    // the thing the TTL grace is sized against, so it says so. Sustained, it
+    // means listings are expiring faster than 50 per ten minutes and the batch
+    // needs raising before the grace runs out and MongoDB deletes the tail.
+    if (expired.length === BATCH_SIZE) {
+        console.warn(
+            `[scheduler] returnExpiredMarketListings: batch capped at ${BATCH_SIZE} — more expired listings are ` +
+            'waiting. Items are returned on later ticks; a backlog that persists for days outlives the TTL grace.',
+        );
+    }
 
     for (const listing of expired) {
         try {

--- a/tests/casinoSettlement.test.js
+++ b/tests/casinoSettlement.test.js
@@ -1,0 +1,314 @@
+'use strict';
+
+/**
+ * #883. The arithmetic that decides how many coins a settled hand credits.
+ *
+ * The pure hand-ranking modules were already at 100% while the settlement math
+ * sitting right after them — the numbers that actually go into
+ * `$inc: { balance }` — was at 10-27%, unreachable behind button collectors.
+ * That is the largest block of untested code in the repo that decides what a
+ * player is paid, and rounding order and multiplier stacking are where money
+ * bugs in this codebase have historically lived (#785, #807).
+ *
+ * These cases are written as the payouts a dealer would state, not as
+ * re-derivations of the implementation: a 3:2 natural on 10 pays 15, insurance
+ * pays 2:1, a straight number pays 35:1. Where the code does something a dealer
+ * would not — floor before the booster, no booster on roulette at all — the
+ * case says so explicitly, because that is the behaviour a refactor would
+ * otherwise "fix" and change what players receive.
+ */
+
+const s = require('../src/games/casino/settlement');
+
+// A 2x personal booster on a guild running a 1.5x server boost. The stack is
+// multiplicative, so this is 3x, and it is the case where an implementation
+// that rounds in the wrong place is visibly wrong rather than off by one.
+const STACKED = 2 * 1.5;
+
+describe('boostedPayout — the stake is not part of the winnings', () => {
+    it('pays the gross unchanged when there is no booster', () => {
+        expect(s.boostedPayout(100, 150, 1)).toBe(150);
+    });
+
+    it('boosts the profit only, never the stake', () => {
+        // 100 staked, 150 gross, so 50 of profit. At 2x that is 100 of profit,
+        // not a 300 payout.
+        expect(s.boostedPayout(100, 150, 2)).toBe(200);
+    });
+
+    it('stacks the personal and server multipliers into one', () => {
+        expect(s.boostedPayout(100, 150, STACKED)).toBe(250);
+    });
+
+    it('rounds the boosted profit, leaving the stake exact', () => {
+        // 33 of profit at 1.5x is 49.5. Rounded once, at the end: 100 + 50.
+        expect(s.boostedPayout(100, 133, 1.5)).toBe(150);
+    });
+
+    it('never reduces a payout when a guild sets a multiplier below 1', () => {
+        // serverBoost.multiplier is admin-set and nothing clamps it, so a 0.5
+        // must not turn a 150 win into a 125 one. The `> 1` guard is what
+        // stops that, and it is behaviour rather than an optimisation.
+        expect(s.boostedPayout(100, 150, 0.5)).toBe(150);
+    });
+
+    it('leaves a push alone at any multiplier', () => {
+        // Nothing above the stake, so nothing to boost: a returned bet is
+        // returned, not multiplied.
+        expect(s.boostedPayout(100, 100, STACKED)).toBe(100);
+    });
+
+    it('leaves a loss at zero rather than crediting a boosted negative', () => {
+        expect(s.boostedPayout(100, 0, STACKED)).toBe(0);
+    });
+});
+
+describe('blackjack — a natural pays 3:2', () => {
+    it('pays half again on the bet', () => {
+        expect(s.naturalBlackjackProfit(10, 1)).toBe(15);
+        expect(s.naturalBlackjackCredit(10, 1)).toBe(25);
+    });
+
+    it('rounds the half coin down to the house on an odd bet', () => {
+        // 25 at 3:2 is 37.5. The player gets 37.
+        expect(s.naturalBlackjackProfit(25, 1)).toBe(37);
+    });
+
+    it('floors the 3:2 before the booster, not after', () => {
+        // The ordering that a refactor would most plausibly change, and it is
+        // worth a coin per hand: floor(37.5) * 2 = 74, where 37.5 * 2 = 75.
+        expect(s.naturalBlackjackProfit(25, 2)).toBe(74);
+    });
+
+    it('boosts the whole 3:2 profit, unlike poker', () => {
+        // Blackjack multiplies the entire profit with no `> 1` guard — 15 of
+        // profit at 3x is 45 — where poker would boost only what is above the
+        // stake. The two games genuinely differ; this pins which is which.
+        expect(s.naturalBlackjackProfit(10, STACKED)).toBe(45);
+        expect(s.naturalBlackjackCredit(10, STACKED)).toBe(55);
+    });
+});
+
+describe('blackjack — an ordinary win pays even money', () => {
+    it('returns the bet and the same again', () => {
+        expect(s.blackjackWinProfit(100, 1)).toBe(100);
+        expect(s.blackjackWinCredit(100, 1)).toBe(200);
+    });
+
+    it('boosts the profit, so the credit is the bet plus the boosted profit', () => {
+        expect(s.blackjackWinProfit(100, STACKED)).toBe(300);
+        expect(s.blackjackWinCredit(100, STACKED)).toBe(400);
+    });
+
+    it('rounds a fractional boosted profit rather than truncating it', () => {
+        expect(s.blackjackWinProfit(33, 1.5)).toBe(50); // 49.5
+    });
+});
+
+describe('blackjack — insurance is a fixed 2:1 side bet', () => {
+    it('costs half the bet, rounded down', () => {
+        expect(s.insuranceCost(100)).toBe(50);
+        expect(s.insuranceCost(25)).toBe(12);
+    });
+
+    it('costs nothing on a bet of 1, which is why the button is hidden there', () => {
+        expect(s.insuranceCost(1)).toBe(0);
+    });
+
+    it('credits the stake back plus twice it when the dealer has a natural', () => {
+        expect(s.insuranceCredit(50)).toBe(150);
+        expect(s.insuranceProfit(50)).toBe(100);
+    });
+
+    it('takes no coin multiplier at all', () => {
+        // Deliberate: no booster has ever applied to insurance, and the
+        // functions take no multiplier argument rather than ignoring one.
+        expect(s.insuranceCredit).toHaveLength(1);
+        expect(s.insuranceProfit).toHaveLength(1);
+    });
+
+    it('is a whole side bet — the credit is always three times the profit-and-a-half', () => {
+        for (const stake of [1, 7, 50, 12_345]) {
+            expect(s.insuranceCredit(stake)).toBe(stake + s.insuranceProfit(stake));
+        }
+    });
+});
+
+describe('blackjack — credit per settled hand', () => {
+    it('pays a win at even money', () => {
+        expect(s.blackjackHandCredit('win', 100, 1)).toBe(200);
+        expect(s.blackjackHandCredit('win', 100, STACKED)).toBe(400);
+    });
+
+    it('returns exactly the bet on a push, at any multiplier', () => {
+        expect(s.blackjackHandCredit('push', 100, 1)).toBe(100);
+        expect(s.blackjackHandCredit('push', 100, STACKED)).toBe(100);
+    });
+
+    it('credits nothing on a loss', () => {
+        expect(s.blackjackHandCredit('lose', 100, STACKED)).toBe(0);
+    });
+
+    it('returns the bet when the lucky charm saves a loss, and does not boost it', () => {
+        expect(s.blackjackHandCredit('lose', 100, STACKED, true)).toBe(100);
+    });
+
+    it('credits nothing on a bust, saved or not', () => {
+        // A bust is the player's own doing and the charm does not cover it —
+        // the games only offer the save on an ordinary loss to the dealer.
+        expect(s.blackjackHandCredit('bust', 100, 1)).toBe(0);
+        expect(s.blackjackHandCredit('bust', 100, 1, true)).toBe(0);
+    });
+
+    it('settles a split as two hands against one dealer, each on its own bet', () => {
+        // The case the split/double-down `totalCredit` covers: hand 1 doubled
+        // to 200 and won, hand 2 left at 100 and pushed.
+        const credit = s.blackjackHandCredit('win', 200, 1) + s.blackjackHandCredit('push', 100, 1);
+        expect(credit).toBe(500);
+        // Staked 300 across the two, so the player is up 200.
+        expect(credit - 300).toBe(200);
+    });
+
+    it('is never worse than losing', () => {
+        for (const outcome of ['win', 'push', 'lose', 'bust']) {
+            expect(s.blackjackHandCredit(outcome, 100, 1)).toBeGreaterThanOrEqual(0);
+        }
+    });
+});
+
+describe('roulette — the wheel pays table odds and nothing else', () => {
+    it('pays even money on the outside bets', () => {
+        expect(s.rouletteSettlement(100, 1, true)).toEqual({ profit: 100, credit: 200 });
+    });
+
+    it('pays 2:1 on a dozen or a column', () => {
+        expect(s.rouletteSettlement(100, 2, true)).toEqual({ profit: 200, credit: 300 });
+    });
+
+    it('pays 35:1 on a straight number', () => {
+        expect(s.rouletteSettlement(100, 35, true)).toEqual({ profit: 3_500, credit: 3_600 });
+    });
+
+    it('credits nothing on a loss and reports the stake as the loss', () => {
+        // The stake left the balance when the bet was placed, so a loss credits
+        // zero rather than debiting again. `profit` is signed because it is
+        // what the embed prints.
+        expect(s.rouletteSettlement(100, 35, false)).toEqual({ profit: -100, credit: 0 });
+    });
+
+    it('takes no coin multiplier, unlike every other game in the casino', () => {
+        // Preserved rather than corrected: the odds are the wheel's. Pinned
+        // because the absence is invisible at the call site and reads like an
+        // oversight — a booster here would be a deliberate change, not a fix.
+        expect(s.rouletteSettlement).toHaveLength(3);
+    });
+});
+
+describe('poker — the dealer folding pays a flat 3:2', () => {
+    it('pays half again on the opening bet', () => {
+        expect(s.pokerFoldWinPayout(100, 1)).toBe(150);
+    });
+
+    it('boosts only the half-bet of profit, not the whole 1.5x', () => {
+        // 50 of profit at 3x is 150, so 250 — where boosting the gross would
+        // pay 450.
+        expect(s.pokerFoldWinPayout(100, STACKED)).toBe(250);
+    });
+
+    it('floors the 3:2 on an odd bet before anything else', () => {
+        expect(s.pokerFoldWinPayout(25, 1)).toBe(37);
+    });
+});
+
+describe('poker — the dealer folding later pays the pot', () => {
+    it('pays the pot when there is no booster', () => {
+        // Pot opens at twice the bet; the player has staked the bet.
+        expect(s.pokerPotPayout(100, 200, 1)).toBe(200);
+    });
+
+    it('boosts the pot above the stake only', () => {
+        expect(s.pokerPotPayout(100, 200, 2)).toBe(300);
+    });
+
+    it('handles a raised hand, where the stake and the pot both grew', () => {
+        // Player raised 100 into a pot that took 200 from the raise round.
+        expect(s.pokerPotPayout(200, 400, 1)).toBe(400);
+        expect(s.pokerPotPayout(200, 400, 2)).toBe(600);
+    });
+});
+
+describe('poker — showdown', () => {
+    it('doubles the stake on a win', () => {
+        expect(s.pokerShowdownGross('win', 100)).toBe(200);
+        expect(s.pokerShowdownPayout('win', 100, 1)).toBe(200);
+    });
+
+    it('returns the stake on a split pot', () => {
+        expect(s.pokerShowdownGross('push', 100)).toBe(100);
+        expect(s.pokerShowdownPayout('push', 100, STACKED)).toBe(100);
+    });
+
+    it('credits nothing on a loss', () => {
+        expect(s.pokerShowdownGross('lose', 100)).toBe(0);
+        expect(s.pokerShowdownPayout('lose', 100, STACKED)).toBe(0);
+    });
+
+    it('boosts a win over the stake', () => {
+        expect(s.pokerShowdownPayout('win', 100, STACKED)).toBe(400);
+    });
+
+    it('treats a lucky-streak save as the push it is resolved to', () => {
+        // The games resolve the random roll first and pass the settled outcome
+        // in, so the save returns the stake and is not boosted.
+        expect(s.pokerShowdownPayout('push', 250, STACKED)).toBe(250);
+    });
+});
+
+describe('across the games, a stake is never multiplied', () => {
+    // The single invariant behind every case above, stated once: whatever the
+    // booster, a returned bet is the bet. A rounding or ordering slip that
+    // multiplied the stake would mint coins on every push in the casino.
+    it.each([
+        ['blackjack push', mult => s.blackjackHandCredit('push', 500, mult)],
+        ['blackjack lucky save', mult => s.blackjackHandCredit('lose', 500, mult, true)],
+        ['poker split pot', mult => s.pokerShowdownPayout('push', 500, mult)],
+        ['boostedPayout at break-even', mult => s.boostedPayout(500, 500, mult)],
+    ])('%s returns exactly the stake', (_label, credit) => {
+        for (const mult of [1, 1.5, 2, STACKED, 10]) {
+            expect(credit(mult)).toBe(500);
+        }
+    });
+});
+
+/**
+ * The extraction is only worth anything if the games route through it. These
+ * are source checks in the spirit of tests/migrationIndexes.test.js: the
+ * arithmetic above is tested, and nothing that credits coins is allowed to keep
+ * a second copy of it that no test can reach.
+ */
+describe('the games settle through this module', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const read = game => fs.readFileSync(path.join(__dirname, '..', 'src', 'games', 'casino', `${game}.js`), 'utf8');
+
+    it.each(['blackjack', 'poker', 'roulette'])('%s requires it', game => {
+        expect(read(game)).toContain("require('./settlement')");
+    });
+
+    it('blackjack no longer computes a 3:2 payout or an insurance credit inline', () => {
+        const source = read('blackjack');
+        expect(source).not.toMatch(/Math\.round\(Math\.floor\(bet \* 1\.5\)/);
+        expect(source).not.toMatch(/insuranceBet \* 3/);
+        expect(source).not.toMatch(/Math\.round\((activeBet|hBet) \* totalCoinMult\)/);
+    });
+
+    it('poker no longer computes the profit-only boost inline, at any of its five payout sites', () => {
+        // Five copies of the same expression, one per site, was how a rounding
+        // change could reach four of them and miss the fifth.
+        expect(read('poker')).not.toMatch(/playerStake \+ Math\.round\(\(/);
+    });
+
+    it('roulette no longer computes its credit inline', () => {
+        expect(read('roulette')).not.toMatch(/won \? bet \+ profit : 0/);
+    });
+});

--- a/tests/dashboardTimezoneList.test.js
+++ b/tests/dashboardTimezoneList.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+/**
+ * #942. The timezone picker's datalist is hand-maintained, which is how it came
+ * to list `Asia/Kolkata` twice and three zones under names IANA superseded years
+ * ago (`Europe/Kiev`, `Asia/Rangoon`, and `America/Honolulu`, which was never a
+ * zone at all — the canonical name is `Pacific/Honolulu`, already in the list).
+ *
+ * Nothing broke: the old names survive as backward-compatibility links, so a
+ * guild that saved one still resolves. The cost was cosmetic — a duplicate row
+ * in the picker and names that read as dated to anyone living in those regions.
+ *
+ * These are the two failures a hand-maintained list drifts back into, so they
+ * are checked rather than fixed once: no entry appears twice, and every entry
+ * is a name Node's own tz database calls canonical.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const VIEW = path.join(__dirname, '..', 'src', 'dashboard', 'views', 'guild-settings.ejs');
+
+function datalistZones() {
+    const source = fs.readFileSync(VIEW, 'utf8');
+    const start = source.indexOf('<datalist id="tz-datalist">');
+    const end = source.indexOf('</datalist>', start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    return [...source.slice(start, end).matchAll(/<option value="([^"]+)">/g)].map(m => m[1]);
+}
+
+describe('the timezone datalist', () => {
+    const zones = datalistZones();
+
+    test('is not empty, so a broken parse cannot pass the checks below', () => {
+        expect(zones.length).toBeGreaterThan(50);
+    });
+
+    test('lists no zone twice', () => {
+        const seen = new Set();
+        const duplicates = zones.filter(zone => (seen.has(zone) ? true : (seen.add(zone), false)));
+        expect(duplicates).toEqual([]);
+    });
+
+    test('every entry is a zone the runtime accepts', () => {
+        const rejected = zones.filter(zone => {
+            try {
+                new Intl.DateTimeFormat('en-US', { timeZone: zone });
+                return false;
+            } catch {
+                return true;
+            }
+        });
+        expect(rejected).toEqual([]);
+    });
+
+    test('no two entries are the same zone under different names', () => {
+        // The check that actually caught #942, and the one that survives an ICU
+        // bump: `America/Honolulu` and `Pacific/Honolulu` were both listed and
+        // are one zone, as were `Europe/Kiev` and `Europe/Kyiv` had the rename
+        // been added rather than applied.
+        //
+        // Deliberately not an assertion that each name IS its canonical form:
+        // `resolvedOptions().timeZone` maps a name to whichever of the pair the
+        // bundled tz database calls canonical, and which one that is has flipped
+        // between ICU releases — Node resolves `Europe/Kyiv` to `Europe/Kiev`
+        // here. Comparing entries to each other asks a question whose answer does
+        // not depend on that.
+        const byZone = new Map();
+        for (const zone of zones) {
+            const canonical = new Intl.DateTimeFormat('en-US', { timeZone: zone }).resolvedOptions().timeZone;
+            byZone.set(canonical, [...(byZone.get(canonical) ?? []), zone]);
+        }
+        const collisions = [...byZone.values()].filter(names => names.length > 1);
+        expect(collisions).toEqual([]);
+    });
+
+    test('lists none of the superseded names #942 replaced', () => {
+        // The renames themselves. Each still resolves — they are backward links,
+        // not removals — so nothing above would fail if one came back on its own.
+        for (const dated of ['Europe/Kiev', 'Asia/Rangoon', 'America/Honolulu']) {
+            expect(zones).not.toContain(dated);
+        }
+        // ...and what each was replaced by is present, so a fix by deletion
+        // would not pass either.
+        for (const current of ['Europe/Kyiv', 'Asia/Yangon', 'Pacific/Honolulu']) {
+            expect(zones).toContain(current);
+        }
+    });
+});

--- a/tests/integration/migrations.test.js
+++ b/tests/integration/migrations.test.js
@@ -38,6 +38,12 @@ const {
     runMigrations, rollbackMigration, pendingMigrationNames, waitForMigrations,
 } = require('../../src/migrations/runner');
 const MigrationRecord = require('../../src/models/MigrationRecord');
+// Required for its exported grace period, and so that `marketlistings` is
+// registered on the connection: useMongo's afterEach clears the collections
+// Mongoose knows about, and `seed()` creates this one through the raw driver,
+// which does not register anything. Without this the seeded listing and its TTL
+// index would survive into the next test.
+const { EXPIRED_LISTING_GRACE_SECONDS } = require('../../src/models/MarketListing');
 
 const MIGRATIONS_DIR = path.resolve(__dirname, '..', '..', 'src', 'migrations');
 
@@ -263,6 +269,15 @@ describe('the data migrations, over pre-migration documents', () => {
         // The single-field index 016 exists to drop.
         await db().collection('fishingtournaments').insertOne({ guildId: 'g1', status: 'ended' });
         await db().collection('fishingtournaments').createIndex({ guildId: 1 }, { name: 'guildId_1' });
+
+        // The zero-grace TTL 021 exists to widen, on a listing that has already
+        // expired — the state in which the old index destroyed the seller's
+        // items before the sweep could return them (#867).
+        await db().collection('marketlistings').insertOne({
+            guildId: 'g1', sellerId: 'u1', itemId: 'sword', quantity: 2,
+            pricePerUnit: 10, listedAt: new Date('2024-01-01T00:00:00Z'), expiresAt: new Date('2024-01-03T00:00:00Z'),
+        });
+        await db().collection('marketlistings').createIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 });
     }
 
     const user = id => db().collection('users').findOne({ userId: id });
@@ -384,6 +399,25 @@ describe('the data migrations, over pre-migration documents', () => {
         expect(names).toContain('idx_tournament_guild_status');
     }, 60_000);
 
+    test('021 widens the market TTL in place, without dropping the listing it protects', async () => {
+        await seed();
+
+        expect((await db().collection('marketlistings').indexes())
+            .find(i => i.name === 'expiresAt_1').expireAfterSeconds).toBe(0);
+
+        await runMigrations({ dir: MIGRATIONS_DIR });
+
+        // collMod, so the index keeps its name and key and there is never an
+        // instant with no TTL on the collection at all.
+        const ttl = (await db().collection('marketlistings').indexes()).find(i => i.name === 'expiresAt_1');
+        expect(ttl.key).toEqual({ expiresAt: 1 });
+        expect(ttl.expireAfterSeconds).toBe(EXPIRED_LISTING_GRACE_SECONDS);
+
+        // And the already-expired listing is still there for the sweep to
+        // claim, which is the entire point.
+        expect(await db().collection('marketlistings').countDocuments({})).toBe(1);
+    }, 60_000);
+
     // The claim every one of the above rests on: applying twice is applying
     // once. Here the second pass is forced past the MigrationRecord skip, so
     // the migrations themselves have to be idempotent rather than merely
@@ -404,6 +438,7 @@ describe('the data migrations, over pre-migration documents', () => {
             profiles: await db().collection('grindprofiles').find({}).sort({ system: 1 }).toArray(),
             analytics: await db().collection('guildanalytics').find({}).toArray(),
             images: await db().collection('itemimages').find({}).toArray(),
+            listings: await db().collection('marketlistings').find({}).toArray(),
         });
 
         const before = await snapshot();

--- a/tests/marketListingReturn.test.js
+++ b/tests/marketListingReturn.test.js
@@ -27,12 +27,17 @@ function listing(over = {}) {
     return { _id: 'l1', guildId: 'g1', sellerId: 'u1', itemId: 'sword', quantity: 2, expiresAt: new Date(0), ...over };
 }
 
-/** Records the `limit` the sweep asked for alongside the docs it gets back. */
+/** Records the `sort` and `limit` the sweep asked for, alongside the docs it gets back. */
 function stubFind(docs) {
     const seen = {};
     MarketListing.find.mockImplementation(filter => {
         seen.filter = filter;
-        return { limit: n => { seen.limit = n; return { lean: async () => docs }; } };
+        return {
+            sort: order => {
+                seen.sort = order;
+                return { limit: n => { seen.limit = n; return { lean: async () => docs }; } };
+            },
+        };
     });
     return seen;
 }
@@ -66,6 +71,21 @@ describe('returnExpiredMarketListings', () => {
         expect(seen.limit).toBe(50);
     });
 
+    test('takes the oldest expiries first, so a capped tick cannot starve one', async () => {
+        // Without a sort MongoDB returns natural order, which is not insertion
+        // order and not stable — so a capped tick took an arbitrary 50 and a
+        // listing could be passed over indefinitely while newer ones went
+        // ahead. Since #867 every listing has a deadline: the TTL grace deletes
+        // it seven days after it expires whether the sweep chose it or not.
+        // Oldest first is what makes "the backlog drains" true of each listing
+        // rather than only of the queue.
+        const seen = stubFind([]);
+
+        await returnExpiredMarketListings();
+
+        expect(seen.sort).toEqual({ expiresAt: 1 });
+    });
+
     test('says so when the batch cap leaves listings behind', async () => {
         // Before #867 a capped tick was invisible and looked harmless: the rest
         // waited for the next one. Now the TTL grace is what those stragglers
@@ -75,7 +95,12 @@ describe('returnExpiredMarketListings', () => {
 
         await returnExpiredMarketListings();
 
-        expect(warnLog.mock.calls.flat().join(' ')).toMatch(/batch capped at 50/);
+        const warned = warnLog.mock.calls.flat().join(' ');
+        expect(warned).toMatch(/batch capped at 50/);
+        // Hitting the cap does not prove anything is behind it — fifty expiries
+        // and an empty queue look identical from here — so the wording says
+        // "may" rather than asserting a backlog it has not observed.
+        expect(warned).toMatch(/there may be more/);
     });
 
     test('says nothing about a backlog on a tick that cleared the queue', async () => {

--- a/tests/marketListingReturn.test.js
+++ b/tests/marketListingReturn.test.js
@@ -39,6 +39,7 @@ function stubFind(docs) {
 
 let errorLog;
 let infoLog;
+let warnLog;
 
 beforeEach(() => {
     jest.clearAllMocks();
@@ -47,9 +48,10 @@ beforeEach(() => {
     recordOwedPayout.mockResolvedValue(true);
     errorLog = jest.spyOn(console, 'error').mockImplementation(() => {});
     infoLog  = jest.spyOn(console, 'log').mockImplementation(() => {});
+    warnLog  = jest.spyOn(console, 'warn').mockImplementation(() => {});
 });
 
-afterEach(() => { errorLog.mockRestore(); infoLog.mockRestore(); });
+afterEach(() => { errorLog.mockRestore(); infoLog.mockRestore(); warnLog.mockRestore(); });
 
 describe('returnExpiredMarketListings', () => {
     test('sweeps expired listings in bounded batches', async () => {
@@ -62,6 +64,26 @@ describe('returnExpiredMarketListings', () => {
         // Unbounded, one backlog of expiries pulls the whole collection into
         // the process at once.
         expect(seen.limit).toBe(50);
+    });
+
+    test('says so when the batch cap leaves listings behind', async () => {
+        // Before #867 a capped tick was invisible and looked harmless: the rest
+        // waited for the next one. Now the TTL grace is what those stragglers
+        // are living on, so a backlog is something an operator has to be able
+        // to see coming.
+        stubFind(Array.from({ length: 50 }, (_, i) => listing({ _id: `l${i}` })));
+
+        await returnExpiredMarketListings();
+
+        expect(warnLog.mock.calls.flat().join(' ')).toMatch(/batch capped at 50/);
+    });
+
+    test('says nothing about a backlog on a tick that cleared the queue', async () => {
+        stubFind(Array.from({ length: 49 }, (_, i) => listing({ _id: `l${i}` })));
+
+        await returnExpiredMarketListings();
+
+        expect(warnLog.mock.calls.flat().join(' ')).not.toMatch(/batch capped/);
     });
 
     test('claims the listing by deleting it before it credits anything', async () => {

--- a/tests/migrationIndexes.test.js
+++ b/tests/migrationIndexes.test.js
@@ -77,3 +77,40 @@ describe('014_scope_item_images_per_guild', () => {
         expect(source).toContain("codeName !== 'IndexNotFound'");
     });
 });
+
+// 021 gives the marketlistings TTL a grace period so `returnExpiredMarketListings`
+// can claim an expired listing and return its items before MongoDB destroys the
+// document (#867). Two numbers have to agree and neither file can see the other:
+// the migration's collMod sets the grace on the index that exists, and the
+// model's declaration is what a fresh database — and any later createIndex —
+// builds. A migration that set a different figure would be quietly undone.
+describe('021_market_listing_ttl_grace', () => {
+    const source = read('021_market_listing_ttl_grace.js');
+    const model = fs.readFileSync(path.join(__dirname, '..', 'src', 'models', 'MarketListing.js'), 'utf8');
+    const { EXPIRED_LISTING_GRACE_SECONDS } = require('../src/models/MarketListing');
+
+    // Read off the migration rather than required from it: requiring it pulls in
+    // mongoose, and the value is the thing under test.
+    const migrationGrace = Number(
+        source.match(/const GRACE_SECONDS = ([\d\s*]+);/)[1].split('*').reduce((a, b) => a * Number(b), 1),
+    );
+
+    test('sets the same grace the model declares', () => {
+        expect(migrationGrace).toBe(EXPIRED_LISTING_GRACE_SECONDS);
+    });
+
+    test('the model no longer declares the zero-grace TTL that lost the items', () => {
+        expect(model).not.toContain('expireAfterSeconds: 0');
+        expect(model).toContain('expireAfterSeconds: EXPIRED_LISTING_GRACE_SECONDS');
+    });
+
+    test('the grace far outlasts the sweep that has to win the race', () => {
+        // The sweep runs every ten minutes and takes 50 listings a tick, so the
+        // margin has to cover a backlog rather than a single tick. Asserted
+        // against the schedule itself so a change to either is caught here.
+        const { JOBS } = require('../src/services/scheduler');
+        const sweep = JOBS.find(j => j.name === 'returnExpiredMarketListings');
+        expect(sweep.schedule).toBe('*/10 * * * *');
+        expect(EXPIRED_LISTING_GRACE_SECONDS).toBeGreaterThan(100 * 10 * 60);
+    });
+});

--- a/tests/migrationMarketTtlGrace.test.js
+++ b/tests/migrationMarketTtlGrace.test.js
@@ -1,0 +1,158 @@
+'use strict';
+
+/**
+ * #867. Migration 021, driven against a fake driver.
+ *
+ * tests/integration/migrations.test.js applies it against a real mongod, which
+ * is where "does MongoDB accept this collMod" is answered. What that suite
+ * cannot reach cheaply is the branches either side of the happy path: a fresh
+ * install with no collection, a database whose index was dropped by hand, an
+ * already-migrated one, and the verification that refuses to let the boot
+ * continue if the TTL is still deleting listings afterwards. Those are decided
+ * entirely by what comes back from `indexes()`, so they are stated here.
+ *
+ * The command shape matters as much as the outcome: `collMod` rather than a
+ * drop and recreate is what keeps the collection from spending an interval with
+ * no TTL on it at all, and keeps the index from being rebuilt over every
+ * listing on a large install.
+ */
+
+// The real mongoose, with only `connection.db` swapped for a fake. Mocking the
+// module outright would take `Schema` and `model` with it, and the grace under
+// test is exported by a model.
+const mongoose = require('mongoose');
+const migration = require('../src/migrations/021_market_listing_ttl_grace');
+const { EXPIRED_LISTING_GRACE_SECONDS: GRACE } = require('../src/models/MarketListing');
+
+/**
+ * A `mongoose.connection.db` with just the surface the migration touches.
+ *
+ * `indexes` is a list the fake mutates, so a call after a collMod sees what the
+ * collMod did — which is the whole point of the verification step.
+ */
+function fakeDb({ collectionExists = true, indexes = [] } = {}) {
+    // Copied per index, not just per array: the collMod fake mutates what it
+    // finds, and the fixtures below are shared between tests.
+    const state = { indexes: indexes.map(i => ({ ...i })), commands: [], created: [] };
+
+    state.db = {
+        listCollections: () => ({ toArray: async () => (collectionExists ? [{ name: 'marketlistings' }] : []) }),
+        collection: name => {
+            expect(name).toBe('marketlistings');
+            return {
+                indexes: async () => state.indexes.map(i => ({ ...i })),
+                createIndex: async (key, options) => {
+                    state.created.push({ key, options });
+                    state.indexes.push({ name: 'expiresAt_1', key, expireAfterSeconds: options.expireAfterSeconds });
+                },
+            };
+        },
+        command: async cmd => {
+            state.commands.push(cmd);
+            const target = state.indexes.find(i => i.name === cmd.index.name);
+            if (target) target.expireAfterSeconds = cmd.index.expireAfterSeconds;
+            return { ok: 1 };
+        },
+    };
+    mongoose.connection.db = state.db;
+    return state;
+}
+
+const zeroGrace = { name: 'expiresAt_1', key: { expiresAt: 1 }, expireAfterSeconds: 0 };
+const withGrace = { name: 'expiresAt_1', key: { expiresAt: 1 }, expireAfterSeconds: GRACE };
+
+afterEach(() => { mongoose.connection.db = null; });
+
+describe('021_market_listing_ttl_grace, up', () => {
+    test('widens the zero-grace TTL in place', async () => {
+        const state = fakeDb({ indexes: [zeroGrace] });
+
+        await migration.up();
+
+        expect(state.commands).toEqual([{
+            collMod: 'marketlistings',
+            index: { name: 'expiresAt_1', expireAfterSeconds: GRACE },
+        }]);
+    });
+
+    test('does not drop and recreate the index', async () => {
+        // A drop-and-recreate leaves the collection with no TTL in between and
+        // rebuilds the index over every listing on a large install. collMod is
+        // the reason neither happens, so it is asserted rather than assumed.
+        const state = fakeDb({ indexes: [zeroGrace] });
+
+        await migration.up();
+
+        expect(state.created).toEqual([]);
+    });
+
+    test('does nothing on a database that has already been migrated', async () => {
+        const state = fakeDb({ indexes: [withGrace] });
+
+        await migration.up();
+
+        expect(state.commands).toEqual([]);
+        expect(state.created).toEqual([]);
+    });
+
+    test('does nothing on a fresh install with no listings collection', async () => {
+        // The model's own declaration builds the index with the grace already
+        // on it the first time someone lists an item.
+        const state = fakeDb({ collectionExists: false });
+
+        await migration.up();
+
+        expect(state.commands).toEqual([]);
+        expect(state.created).toEqual([]);
+    });
+
+    test('builds the index when the collection exists without one', async () => {
+        // A database that predates the index, or one where it was dropped by
+        // hand. Built here and awaited rather than left to autoIndex, which
+        // runs unawaited and would leave the sweep's `expiresAt` query
+        // unindexed until it caught up.
+        const state = fakeDb({ indexes: [] });
+
+        await migration.up();
+
+        expect(state.created).toEqual([{ key: { expiresAt: 1 }, options: { expireAfterSeconds: GRACE } }]);
+        expect(state.commands).toEqual([]);
+    });
+
+    test('refuses to let the boot continue if the TTL is still zero afterwards', async () => {
+        // The failure this migration exists to prevent, verified rather than
+        // assumed: a TTL left at zero goes on destroying listings before the
+        // sweep can return the seller's items, and a boot that carried on would
+        // do it silently.
+        const state = fakeDb({ indexes: [zeroGrace] });
+        state.db.command = async () => ({ ok: 1 }); // accepted, changed nothing
+
+        await expect(migration.up()).rejects.toThrow(/still expires after 0s/);
+    });
+});
+
+describe('021_market_listing_ttl_grace, down', () => {
+    test('puts the zero-grace TTL back', async () => {
+        // A rollback to a state that loses items, which is what a rollback to
+        // the previous release is — the code being rolled back to is the code
+        // that shipped the zero.
+        const state = fakeDb({ indexes: [withGrace] });
+
+        await migration.down();
+
+        expect(state.commands).toEqual([{
+            collMod: 'marketlistings',
+            index: { name: 'expiresAt_1', expireAfterSeconds: 0 },
+        }]);
+    });
+
+    test('is a no-op where there is nothing to put back', async () => {
+        const noCollection = fakeDb({ collectionExists: false });
+        await migration.down();
+        expect(noCollection.commands).toEqual([]);
+
+        const noIndex = fakeDb({ indexes: [] });
+        await migration.down();
+        expect(noIndex.commands).toEqual([]);
+    });
+});

--- a/tests/ttlIndexes.test.js
+++ b/tests/ttlIndexes.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+/**
+ * #867, and the note it ends on: review every TTL index as a set rather than
+ * patching the one that was found.
+ *
+ * A TTL index is a delete nobody wrote and nobody watches. It fires no Mongoose
+ * hook, so a `pre('remove')` cannot compensate for it, and it leaves nothing in
+ * the logs. That is fine for a row that is only a record of something that
+ * already happened, and it is data loss for a row that some job still has to
+ * act on — which is exactly what marketlistings was: a zero-second TTL racing a
+ * ten-minute sweep for the document that said a seller was owed their items.
+ * The TTL monitor won, and the items ceased to exist.
+ *
+ * Two properties separate the safe ones from that, and both are checked here
+ * over whatever indexes the models happen to declare, so a TTL added later is
+ * caught by a test rather than by a player.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MODELS = path.join(__dirname, '..', 'src', 'models');
+
+/**
+ * Every TTL index the models declare, as { model, key, seconds, partial }.
+ *
+ * Read off the compiled schemas rather than grepped, so an index built from a
+ * field-level `expires` or assembled at require time counts the same as a
+ * literal `expireAfterSeconds:` in the source.
+ */
+function ttlIndexes() {
+    return fs.readdirSync(MODELS)
+        .filter(file => file.endsWith('.js'))
+        .flatMap(file => {
+            const model = require(path.join(MODELS, file));
+            return (model.schema?.indexes?.() ?? [])
+                .filter(([, options]) => options?.expireAfterSeconds !== undefined)
+                .map(([key, options]) => ({
+                    model: file.replace(/\.js$/, ''),
+                    key: Object.keys(key).join(','),
+                    seconds: options.expireAfterSeconds,
+                    partial: options.partialFilterExpression ?? null,
+                }));
+        });
+}
+
+/**
+ * The TTLs allowed to delete the instant their field comes due.
+ *
+ * A zero-grace TTL is only safe where expiry means the row is *already* dead to
+ * the code — where nothing is owed, nothing has to run first, and the code does
+ * not rely on the TTL for correctness because it compares the timestamp itself.
+ * Both entries here are that: a lock is taken over by comparing `expiresAt` at
+ * acquire time (utils/activeGameLock.js), and an expired OAuth state is refused
+ * on the same comparison. In both cases MongoDB is only reclaiming space behind
+ * code that already treats the row as gone.
+ *
+ * The list is a statement, not a waiver: adding to it means having made that
+ * argument for the new row.
+ */
+const ZERO_GRACE_BY_DESIGN = new Set(['ActiveLock:expiresAt', 'McpOAuthState:expiresAt']);
+
+/**
+ * The longest interval any sweep that has to beat a TTL runs at, in seconds.
+ * `returnExpiredMarketListings` is the one that does, at every ten minutes.
+ */
+const SWEEP_INTERVAL_SECONDS = 10 * 60;
+
+describe('every TTL index in the models', () => {
+    const indexes = ttlIndexes();
+
+    test('there are some, so a broken enumeration cannot pass silently', () => {
+        expect(indexes.length).toBeGreaterThanOrEqual(8);
+        expect(indexes.map(i => i.model)).toContain('MarketListing');
+    });
+
+    test.each(ttlIndexes().map(i => [`${i.model}:${i.key}`, i]))(
+        '%s deletes rows nothing is still waiting to act on',
+        (id, index) => {
+            if (ZERO_GRACE_BY_DESIGN.has(id)) {
+                expect(index.seconds).toBe(0);
+                return;
+            }
+
+            // Everything else is a retention window. It has to clear the
+            // interval of any job that reads the row before it can be deleted,
+            // and clear it by enough to survive a backlog or an outage rather
+            // than by a single tick — the margin marketlistings had none of.
+            expect(index.seconds).toBeGreaterThan(100 * SWEEP_INTERVAL_SECONDS);
+        },
+    );
+
+    test('the market listing TTL outlives the sweep that returns the items', () => {
+        // The regression itself. This was 0 while the sweep ran every ten
+        // minutes, so MongoDB destroyed the listing — and with it the only
+        // record that the seller was owed anything — first, on the ordinary
+        // expiry path.
+        const listings = indexes.find(i => i.model === 'MarketListing');
+        expect(listings.key).toBe('expiresAt');
+        expect(listings.seconds).toBeGreaterThan(SWEEP_INTERVAL_SECONDS);
+    });
+
+    test('the failed-job TTL still expires only settled records', () => {
+        // #896's fix, pinned here alongside the rest of the set: `exhausted` is
+        // an outstanding debt a human has to settle, and an outstanding debt
+        // does not expire. Only `resolved` — paid, and now history — does.
+        const failedJobs = indexes.find(i => i.model === 'FailedJob');
+        expect(failedJobs.partial).toEqual({ status: 'resolved' });
+    });
+});


### PR DESCRIPTION
The marketlistings TTL index carried expireAfterSeconds: 0. MongoDB's TTL
monitor wakes about once a minute, so an expired listing was hard-deleted
within roughly a minute of expiring, while returnExpiredMarketListings — the
job that returns the seller's items, and the only thing that does — runs every
ten minutes and selects on expiresAt <= now.

The monitor won that race for nearly every expiry. A TTL delete fires no
Mongoose hook, so there was no return, no owed-payout record and nothing in the
logs: on the ordinary expiry path, sellers lost their stock silently.

The grace is now seven days, sized against a backlog rather than a single tick
(the sweep claims 50 listings per tick), and the sweep's expiresAt <= now filter
is unchanged so it still claims a listing the moment it expires. Migration 021
applies the same figure to databases that already built the index, using collMod
so the index is never absent and never rebuilt.

The sweep also takes the oldest expiries first now. Without a sort MongoDB
returns natural order, so a capped tick took an arbitrary 50 and an individual
listing could be passed over indefinitely — survivable when nothing had a
deadline, not once the grace period gives every listing one.

A capped sweep tick now says so. That backlog was invisible, and it is what the
grace is sized against.

The remaining TTL indexes were reviewed as a set: ActiveLock and McpOAuthState
are zero-grace by design — both compare the timestamp in code and use the TTL
only to reclaim space — and the rest are retention windows well clear of any job
that reads them. tests/ttlIndexes.test.js pins that division so a TTL added
later is caught by a test rather than by a player.

Fixes #867

Extract casino settlement math into a pure module and test it

The pure hand-ranking modules sit at 100% while the arithmetic immediately after
them — the numbers that go into $inc: { balance } — was inline in the game files
at 10-27% statement coverage, unreachable behind button collectors. That was the
largest block of untested code in the repo deciding how many coins a player
receives, and rounding order and multiplier stacking are exactly where money
bugs in this codebase have historically lived.

src/games/casino/settlement.js now holds it, pure and at 100%: the 3:2 natural,
insurance, per-hand blackjack credit (which is what a split sums), roulette's
table odds, and poker's five payout sites.

No payout changed. Where the three games disagreed they still disagree, and the
disagreements are the tested part: blackjack boosts a whole profit unguarded,
poker boosts only what is above the stake and only above 1x — which is what
stops an admin-set serverBoost.multiplier below 1 from cutting payouts — and
roulette takes no multiplier at all because its odds are the wheel's. The
natural's Math.floor runs before the booster and not after, worth a coin a hand
on an odd bet and the ordering a refactor would most plausibly have changed.

Fixes #883

Use canonical IANA names in the timezone picker

Asia/Kolkata was listed twice, Europe/Kiev and Asia/Rangoon have been superseded
by Europe/Kyiv and Asia/Yangon, and America/Honolulu was never a zone at all —
the canonical Pacific/Honolulu was already in the list, so the entry is dropped
rather than renamed.

Nothing was broken: the old names survive as backward-compatibility links, so a
guild that saved one still resolves. The duplicate showed twice in the picker
and the dated names read as dated.

The new test compares entries to each other rather than to their canonical
forms. resolvedOptions().timeZone maps a name to whichever of a pair the bundled
tz database calls canonical, and which one that is has flipped between ICU
releases — Node resolves Europe/Kyiv to Europe/Kiev here.

Fixes #942

---

Why coverage-floors.json changes

The one-line removal of src/models/AuditLog.js from the neverExecuted list is
required by this PR, not incidental to it. tests/ttlIndexes.test.js reviews the
TTL indexes as a set, which it does by loading every model and reading the
indexes each schema declares — so AuditLog.js is now executed by the suite.

scripts/check-coverage.js treats a stale neverExecuted entry as an error in its
own right ("a stale entry is permission to un-cover it again"), so leaving the
line in place fails `npm run coverage:check`:

    [coverage] the per-subsystem ratchet failed:
      - src/models/AuditLog.js is covered now — move it to coveredOnlyByIntegration
        if only tests/integration/ reaches it, or drop it

Dropping it is the correct branch of that instruction rather than
coveredOnlyByIntegration, because a plain `npx jest` reaches the file — no
mongod required. Nothing else in the file is touched: the directory floors are
left exactly as they were, deliberately, since several are stale in this
repo's favour and raising them is not this PR's business.