### PR TITLE
Move Discord sends outside user lock to prevent deadlocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,11 +194,30 @@ jobs:
     # than seconds; a warm one is a small fraction of that. Matches the publish
     # job's budget, since it is the same build.
     timeout-minutes: 30
+    outputs:
+      # Read by `publish` so both builds carry the same value — see the step
+      # that computes it, and the note on the publish build.
+      apk-refresh: ${{ steps.apk.outputs.key }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      # The cache key for the Dockerfile's `apk upgrade` layer (#961). Without
+      # one, `cache-from: type=gha` restores that layer instead of running it,
+      # and the upgrade the runtime stage exists to perform is frozen at
+      # whatever Alpine was serving when the layer was first built — a package
+      # with a published fix stays vulnerable in the image, and the scan below
+      # is what eventually says so.
+      #
+      # A UTC date rather than the commit SHA or `github.run_id`: those change
+      # every build, which would mean a cold apk layer on every push for a
+      # freshness nobody needs. A day is well inside the window that matters and
+      # keeps the cache doing its job the rest of the time.
+      - name: Compute the apk refresh key
+        id: apk
+        run: echo "key=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
@@ -207,6 +226,8 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
+          build-args: |
+            APK_REFRESH=${{ steps.apk.outputs.key }}
           # The whole point of this job. A pull request has no credentials worth
           # using and no tag anything deploys.
           push: false
@@ -353,6 +374,14 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
+          # Taken from the `image` job rather than recomputed, for the same
+          # reason that job's cache is reused here: a different value is a
+          # different build, so this would publish an image the scan never
+          # looked at — and it would miss the cache and rebuild to do it. Two
+          # `date` calls in one run normally agree; the one run that straddles
+          # midnight UTC is exactly the case worth not leaving to chance.
+          build-args: |
+            APK_REFRESH=${{ needs.image.outputs.apk-refresh }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -367,9 +396,12 @@ jobs:
           # CI rather than from someone's laptop with push access.
           #
           # mode=max records the full build definition, including build
-          # arguments. Nothing secret goes through build args here (the
-          # Dockerfile takes none), which is the condition for max being safe;
-          # if one is ever added, drop this back to mode=min before it lands.
+          # arguments. The condition for max being safe is that no build
+          # argument carries a secret. The Dockerfile takes exactly one,
+          # APK_REFRESH, and it is a UTC date — recording it is a small gain,
+          # since the provenance then says which day's Alpine packages the
+          # image resolved against. Adding a build argument that carries
+          # anything sensitive means dropping this back to mode=min first.
           provenance: mode=max
           sbom: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,26 @@ FROM node:24-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a
 # upstream, neither yet in a node:24-alpine rebuild). Upgrading here takes the
 # fixes without waiting, and costs no more determinism than the `apk add` below
 # already does: both resolve against whatever Alpine is serving at build time.
+#
+# What that reasoning missed is the layer cache. CI builds with
+# `cache-from: type=gha`, so this `RUN` is *restored* rather than executed
+# whenever the Dockerfile text at or above it is unchanged — and the base above
+# it is digest-pinned, so it changes only when someone edits this file. The
+# upgrade was therefore frozen at whatever Alpine was serving the day the layer
+# was first cached, which is how the scan came to fail on a libexpat with a
+# published fix (#961). `--no-cache` is apk's own index cache and does nothing
+# about this.
+#
+# APK_REFRESH is the cache key that unfreezes it: CI passes the current UTC
+# date, so the layer is rebuilt once a day and the upgrade actually re-resolves.
+# It is declared here, inside the runtime stage, so a new day costs one `apk`
+# layer and not a fresh `canvas` compile up in the build stage.
+#
+# It costs no determinism that `apk add` had not already spent — both resolve
+# against whatever Alpine is serving at build time, which is exactly what the
+# paragraph above says this layer is for. The default keeps a local
+# `docker build` with no build argument working and cacheable.
+ARG APK_REFRESH=unset
 RUN apk upgrade --no-cache && apk add --no-cache \
     cairo \
     jpeg \

--- a/src/dashboard/lib/assets.js
+++ b/src/dashboard/lib/assets.js
@@ -68,4 +68,40 @@ function asset(urlPath, publicDir = PUBLIC_DIR) {
     return version ? `${urlPath}?v=${version}` : urlPath;
 }
 
-module.exports = { asset, assetVersion, PUBLIC_DIR };
+/**
+ * How long an asset reached without a matching `?v=` may be cached.
+ *
+ * Short enough that a regenerated file — a font rewritten under the same name
+ * by scripts/fetch-fonts.sh, say — is picked up the same day, long enough that
+ * a page's own assets are not re-fetched while a user clicks around it.
+ */
+const UNVERSIONED_MAX_AGE = 300;
+
+/**
+ * The `Cache-Control` express.static should send for one file.
+ *
+ * `express.static` cannot tell a hashed URL from a bare one, so an
+ * unconditional `immutable` year covers URLs that carry no hash to bust —
+ * public/fonts/fonts.css names every face by plain filename (#903). This
+ * grants the year only to a request whose `v` matches what the file hashes to
+ * right now, which is exactly the case asset() produces.
+ *
+ * @param {object} req - the Express request being served
+ * @param {string} filePath - absolute path of the file about to be sent
+ * @param {string} [publicDir] - the root it was resolved under
+ * @returns {string} the Cache-Control header value
+ */
+function staticCacheControl(req, filePath, publicDir = PUBLIC_DIR) {
+    const requested = req && req.query ? req.query.v : undefined;
+    const relative = path.relative(publicDir, filePath);
+    const versioned = typeof requested === 'string'
+        && Boolean(relative)
+        && !relative.startsWith('..')
+        && requested === assetVersion(`/${relative.split(path.sep).join('/')}`, publicDir);
+
+    return versioned
+        ? 'public, max-age=31536000, immutable'
+        : `public, max-age=${UNVERSIONED_MAX_AGE}`;
+}
+
+module.exports = { asset, assetVersion, staticCacheControl, UNVERSIONED_MAX_AGE, PUBLIC_DIR };

--- a/src/dashboard/public/guild-settings.js
+++ b/src/dashboard/public/guild-settings.js
@@ -1697,13 +1697,6 @@ function updateTierField(el) {
     jobTiersList[idx][field] = field === 'minShifts' ? (parseInt(el.value, 10) || 0) : el.value;
 }
 
-var JOB_TIER_META = [
-    { tier: 1, label: 'Tier 1 · Intern',            color: '#2ecc71', badge: '🟢' },
-    { tier: 2, label: 'Tier 2 · Skilled Worker',    color: '#3498db', badge: '🔵' },
-    { tier: 3, label: 'Tier 3 · Senior Specialist', color: '#9b59b6', badge: '🟣' },
-    { tier: 4, label: 'Tier 4 · Executive',         color: '#f39c12', badge: '🟡' },
-];
-
 function renderJobs() {
     const list = document.getElementById('jobs-list');
     if (!jobsList.length) {
@@ -1753,13 +1746,35 @@ function renderJobs() {
     list.innerHTML = html;
 }
 
+// The tier select cannot be static markup. The Careers tab lets an admin rename
+// every tier and change how many shifts unlock it, so shipping "Tier 2 — Skilled
+// Worker (10 shifts)" in the view meant the job modal contradicted the
+// configuration the same page had just saved (#911). Built here instead, from
+// the same jobTiersList the Careers tab edits — so an unsaved rename shows up
+// too, rather than only after a round trip.
+function renderJobTierOptions(selectedTier) {
+    const select = document.getElementById('modal-job-tier');
+    select.innerHTML = jobTiersList.map(function(t) {
+        const shifts = t.minShifts || 0;
+        const name = t.name || ('Tier ' + t.tier);
+        return '<option value="' + escHtml(String(t.tier)) + '">' +
+            escHtml('Tier ' + t.tier + ' — ' + name + ' (' + shifts + ' shift' + (shifts === 1 ? '' : 's') + ')') +
+            '</option>';
+    }).join('');
+
+    select.value = String(selectedTier);
+    // Assigning a value no option carries leaves the select on '', which would
+    // then save as tier 1 without the admin ever seeing which tier was picked.
+    if (!select.value && jobTiersList.length) select.value = String(jobTiersList[0].tier);
+}
+
 function openJobModal(idx) {
     editingJobIdx = idx;
     document.getElementById('job-modal-title').textContent = idx === -1 ? 'Add Job' : 'Edit Job';
     const job = idx === -1 ? {} : jobsList[idx];
     document.getElementById('modal-job-name').value = job.name || '';
     document.getElementById('modal-job-emoji').value = job.emoji || '';
-    document.getElementById('modal-job-tier').value = String(job.tier || 1);
+    renderJobTierOptions(job.tier || 1);
     document.getElementById('modal-job-min-pay').value = job.minPay != null ? job.minPay : '';
     document.getElementById('modal-job-max-pay').value = job.maxPay != null ? job.maxPay : '';
     openModal('job-modal', { initialFocus: 'modal-job-name' });

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -248,7 +248,11 @@ function createApp({ client = null, bot: injectedBot, sessionStore, configurePas
         res.locals.asset = asset;
         res.setHeader('X-Content-Type-Options', 'nosniff');
         res.setHeader('X-Frame-Options', 'DENY');
-        res.setHeader('X-XSS-Protection', '1; mode=block');
+        // Explicitly off, not on. The header is deprecated and ignored by
+        // current browsers, and the legacy auditor it enables has itself been
+        // a source of XS-Leaks and injection — `0` is the modern guidance, and
+        // the nonce-based CSP below is what actually does this job (#921).
+        res.setHeader('X-XSS-Protection', '0');
         res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
         res.setHeader('Content-Security-Policy', [
             "default-src 'self'",

--- a/src/dashboard/server.js
+++ b/src/dashboard/server.js
@@ -10,7 +10,7 @@ const { getStatus, httpStatusFor } = require('../health');
 const { withContext: withLogContext, addContext: addLogContext } = require('../utils/logger');
 const { hasManagePermission } = require('./lib/permissions');
 const { jsonForScript } = require('./lib/jsonForScript');
-const { asset } = require('./lib/assets');
+const { asset, staticCacheControl } = require('./lib/assets');
 const { createBotGateway } = require('../bot/gateway');
 const { instanceStats } = require('./lib/instanceStats');
 // The DASHBOARD_URL and SESSION_SECRET rules used to be defined here, which is
@@ -194,9 +194,22 @@ function createApp({ client = null, bot: injectedBot, sessionStore, configurePas
     // Assets are requested through the asset() helper, which stamps each URL
     // with a hash of the file's contents — a deploy changes the URL, so a long
     // immutable cache never serves stale JavaScript or CSS.
-    app.use(express.static(path.join(__dirname, 'public'), {
-        maxAge: '1y',
-        immutable: true,
+    //
+    // That guarantee only holds for URLs that actually carry the hash, and
+    // express.static knows nothing about `?v=`. Not every request does: fonts
+    // are named by bare filename inside public/fonts/fonts.css, and
+    // scripts/fetch-fonts.sh rewrites those same filenames with new bytes. An
+    // unconditional year of `immutable` would leave a regenerated font stale in
+    // every returning browser with no way to bust it short of a rename (#903).
+    //
+    // So the policy is decided per request: a `v` that matches the file's
+    // current hash gets the immutable year, and anything else — no `v`, or a
+    // stale one — gets a short cache it can revalidate out of.
+    const staticDir = path.join(__dirname, 'public');
+    app.use(express.static(staticDir, {
+        setHeaders(res, filePath) {
+            res.setHeader('Cache-Control', staticCacheControl(res.req, filePath, staticDir));
+        },
     }));
     app.use(express.json());
     app.use(express.urlencoded({ extended: true }));

--- a/src/dashboard/views/partials/panels/economy.ejs
+++ b/src/dashboard/views/partials/panels/economy.ejs
@@ -514,12 +514,12 @@
                             </div>
                             <div class="field">
                                 <label class="field-label" for="modal-job-tier">Career tier *</label>
-                                <select id="modal-job-tier">
-                                    <option value="1">Tier 1 — Intern (0 shifts)</option>
-                                    <option value="2">Tier 2 — Skilled Worker (10 shifts)</option>
-                                    <option value="3">Tier 3 — Senior Specialist (25 shifts)</option>
-                                    <option value="4">Tier 4 — Executive (50 shifts)</option>
-                                </select>
+                                <!-- Options are built by renderJobTierOptions() when the
+                                     modal opens. They cannot be static markup: the Careers
+                                     tab above lets an admin rename every tier and change its
+                                     shift threshold, and stock names here contradicted the
+                                     configuration the same page had just saved (#911). -->
+                                <select id="modal-job-tier"></select>
                                 <small>Members unlock this job when they reach the required shift count.</small>
                             </div>
                             <div style="display:flex;gap:.75rem">

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -186,12 +186,23 @@ module.exports = {
             // from the same user overlapping in that window is one message's worth of
             // XP, quest progress and streak state written back to what it was before.
             // See utils/userMutex.js for why an in-process lock is the right size here.
-            const { blocked, sideWork } = await withUserLock(
+            //
+            // What the lock must not contain is a Discord REST call. The lock
+            // exists to serialise this user's document writes; awaiting a
+            // `channel.send` inside it makes the hold time include Discord's
+            // rate-limit queueing, and a holder stuck behind a 429 can reach
+            // the 15-second timeout override — which exists to break deadlocks,
+            // so hitting it reintroduces the very lost update the lock is here
+            // to prevent (#894). Level-up embeds, quest notifications and
+            // streak messages are therefore *queued* under the lock and sent
+            // after it, the way `sideWork` already settles outside it.
+            const { blocked, sideWork, announcements } = await withUserLock(
                 `${message.guild.id}:${message.author.id}`,
                 async () => {
+                    const announcements = [];
                     let sharedUser = null;
                     if (guildSettings?.leveling.enabled) {
-                        sharedUser = await handleLeveling(message, guildSettings);
+                        sharedUser = await handleLeveling(message, guildSettings, announcements);
                     }
 
                     if (guildSettings?.moderation.enabled) {
@@ -200,7 +211,10 @@ module.exports = {
                         // XP handleLeveling applied has nothing to ride along on.
                         if (stopped) {
                             await flushPendingUser(sharedUser);
-                            return { blocked: true, sideWork: [] };
+                            // Any level-up queued above still goes out: it did
+                            // before this message was blocked, and blocking the
+                            // message is not a reason to swallow the promotion.
+                            return { blocked: true, sideWork: [], announcements };
                         }
                     }
 
@@ -227,15 +241,19 @@ module.exports = {
                     // when it bailed out early or threw before saving, the XP still has
                     // to be persisted.
                     try {
-                        const persisted = await handleStreakAndQuests(message, guildSettings, sharedUser);
+                        const persisted = await handleStreakAndQuests(message, guildSettings, sharedUser, announcements);
                         if (!persisted) await flushPendingUser(sharedUser);
                     } catch (err) {
                         console.error('Error in messageCreate:', err);
                     }
 
-                    return { blocked: false, sideWork };
+                    return { blocked: false, sideWork, announcements };
                 },
             );
+
+            // The lock is released by here, so a slow or rate-limited Discord
+            // response delays only these messages — not this user's next one.
+            await sendAnnouncements(announcements);
 
             for (const outcome of await Promise.all(sideWork)) {
                 if (outcome.status === 'rejected') console.error('Error in messageCreate:', outcome.reason);
@@ -251,6 +269,24 @@ module.exports = {
     }
 };
 
+// Dispatches the Discord sends collected while the user lock was held, in the
+// order they were queued — which is the order they were awaited in before they
+// moved out of the lock, so a level-up embed still precedes the quest
+// completion it triggered.
+//
+// Sequential rather than parallel for the same reason: these land in one
+// channel, and firing them together lets Discord order them however it likes.
+// One failing send must not skip the rest, so each is guarded.
+async function sendAnnouncements(announcements) {
+    for (const announce of announcements ?? []) {
+        try {
+            await announce();
+        } catch (err) {
+            console.error('Announcement error:', err);
+        }
+    }
+}
+
 // Backstop for the paths that never reach the streak/quest write: the XP applied
 // by handleLeveling lives only in memory until something saves the document.
 // Only called when that write is known not to have happened, so it can never race
@@ -264,7 +300,7 @@ async function flushPendingUser(user) {
     }
 }
 
-async function handleStreakAndQuests(message, guildSettings, existingUser = null) {
+async function handleStreakAndQuests(message, guildSettings, existingUser = null, announcements = []) {
     // Reported back to the caller so it knows whether the XP handleLeveling
     // applied has been persisted. Set only once the write has actually landed —
     // a failure after that point still leaves the document saved.
@@ -354,25 +390,31 @@ async function handleStreakAndQuests(message, guildSettings, existingUser = null
             announceAchievements(message.client, guildSettings, user, message.member, newlyEarned).catch(() => null);
         }
 
-        await notifyQuestComplete(guildSettings, message.member, completedQuests, message.channel, user);
-        await notifyQuestNearComplete(guildSettings, message.member, nearCompleteQuests, message.channel);
+        // Everything below is a Discord send. Queued in the order it used to be
+        // awaited in, and dispatched by the caller once the user lock is
+        // released — see the note at the withUserLock call (#894). The message
+        // text is built here, while the values it reports are the ones this
+        // pass computed, rather than read back at send time.
+        announcements.push(
+            () => notifyQuestComplete(guildSettings, message.member, completedQuests, message.channel, user),
+            () => notifyQuestNearComplete(guildSettings, message.member, nearCompleteQuests, message.channel),
+        );
         if (assignedNewDaily) {
-            await notifyDailyQuestReset(guildSettings, message.member, user, message.channel);
+            announcements.push(() => notifyDailyQuestReset(guildSettings, message.member, user, message.channel));
         }
 
         if (shieldActivated) {
-            await message.channel.send(
-                `🔥🛡️ <@${message.author.id}> Your **Streak Shield** protected your streak! (consumed)`
-            ).catch(() => {});
+            const text = `🔥🛡️ <@${message.author.id}> Your **Streak Shield** protected your streak! (consumed)`;
+            announcements.push(() => message.channel.send(text).catch(() => {}));
         }
 
         for (const milestone of newMilestones) {
             const multiplier = getStreakMultiplier(user.streak.current);
-            await message.channel.send(
+            const text =
                 `🔥 <@${message.author.id}> **${milestone.days}-day streak milestone!** ` +
                 `You earned **${milestone.coins.toLocaleString()} coins** and the **${milestone.badge}** badge! ` +
-                `You're now earning **${multiplier}x** coins and XP.`
-            ).catch(() => {});
+                `You're now earning **${multiplier}x** coins and XP.`;
+            announcements.push(() => message.channel.send(text).catch(() => {}));
         }
     } catch (err) {
         console.error('Streak/quest error:', err);
@@ -384,7 +426,7 @@ async function handleStreakAndQuests(message, guildSettings, existingUser = null
 // The caller hands the same document to handleStreakAndQuests, which mutates it
 // further and issues the one write that covers both — a second fetch and a second
 // save of the same user on every message is what this avoids.
-async function handleLeveling(message, guildSettings) {
+async function handleLeveling(message, guildSettings, announcements = []) {
     if (!guildSettings?.leveling?.rewardsEnabled) return null;
     if (guildSettings.leveling?.noXpChannelIds?.includes(message.channel.id)) return null;
     if (message.member?.roles?.cache?.some(role => guildSettings.leveling?.noXpRoleIds?.includes(role.id))) return null;
@@ -436,7 +478,10 @@ async function handleLeveling(message, guildSettings) {
         user.messages += 1;
         user.lastXpGain = new Date();
         if (leveled) {
-            await announceLevelUp(user, guildSettings, message.member, message.guild, message.channel);
+            // Queued, not awaited: the embed and the level-role grant are both
+            // REST calls, and the caller sends them once the lock is released.
+            announcements.push(() =>
+                announceLevelUp(user, guildSettings, message.member, message.guild, message.channel));
         }
 
         // Standings are computed from the in-memory values, so they do not need

--- a/tests/ciSupplyChainGates.test.js
+++ b/tests/ciSupplyChainGates.test.js
@@ -142,6 +142,64 @@ describe('#646 — the Dockerfile is built on pull requests', () => {
     });
 });
 
+describe('#961 — the apk upgrade layer is not frozen by the cache', () => {
+    // The runtime stage runs `apk upgrade` so the image carries Alpine's
+    // published fixes without waiting for a node:24-alpine rebuild. With
+    // `cache-from: type=gha` and a digest-pinned base, that RUN is restored
+    // rather than executed until someone edits the Dockerfile — so the upgrade
+    // was pinned to whatever Alpine served the day the layer was first built,
+    // and the scan above eventually failed on a libexpat that had a fix. The
+    // ARG is the cache key that unfreezes it, and it is worth nothing unless
+    // both builds actually pass it.
+    const dockerfile = fs.readFileSync(path.join(ROOT, 'Dockerfile'), 'utf8');
+    const buildArgsOf = job => {
+        const step = stepsOf(job).find(s => /build-push-action/.test(s.uses || ''));
+        return String((step.with || {})['build-args'] || '');
+    };
+
+    test('the Dockerfile declares the refresh argument', () => {
+        expect(dockerfile).toMatch(/^ARG APK_REFRESH=/m);
+    });
+
+    test('it sits above the upgrade, which is the layer it is there to bust', () => {
+        const arg = dockerfile.search(/^ARG APK_REFRESH=/m);
+        const upgrade = dockerfile.search(/^RUN apk upgrade\b/m);
+        expect(arg).toBeGreaterThan(-1);
+        expect(upgrade).toBeGreaterThan(arg);
+    });
+
+    test('and inside the runtime stage, so a new day is not a fresh canvas compile', () => {
+        // Declared before the first FROM it would be a global argument, which
+        // invalidates the build stage too — and that stage compiles the native
+        // canvas binding from source. Minutes a day, for an upgrade that only
+        // affects the runtime stage's packages.
+        const lastFrom = dockerfile.lastIndexOf('\nFROM ');
+        expect(dockerfile.search(/^ARG APK_REFRESH=/m)).toBeGreaterThan(lastFrom);
+    });
+
+    test('the build job passes it, and not as a constant', () => {
+        // A literal would be a key that never moves, which is the bug with an
+        // ARG in front of it.
+        expect(buildArgsOf(buildJob)).toMatch(/APK_REFRESH=\$\{\{\s*steps\./);
+    });
+
+    test('from a UTC date, so two jobs in one run agree on the day', () => {
+        expect(runScript(buildJob)).toMatch(/date -u\b/);
+    });
+
+    test('the publish build takes the build job\'s value rather than its own', () => {
+        // Recomputing it here would publish an image built from different
+        // inputs than the one the scan passed — and miss the cache to do it.
+        const outputs = jobs[buildJob].outputs || {};
+        const names = Object.keys(outputs);
+        expect(names).not.toEqual([]);
+
+        const published = buildArgsOf(publishJob);
+        expect(published).toMatch(/APK_REFRESH=/);
+        expect(names.some(name => published.includes(`needs.${buildJob}.outputs.${name}`))).toBe(true);
+    });
+});
+
 describe('#651 — publishing is serialized', () => {
     test('the workflow that publishes declares a concurrency group', () => {
         // The publish job lives in this workflow, so the workflow-level group

--- a/tests/dashboardAssetCaching.test.js
+++ b/tests/dashboardAssetCaching.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+/**
+ * #903. `express.static` was configured with `maxAge: '1y', immutable` for
+ * every URL, but it knows nothing about the `?v=` hash that `lib/assets.js`
+ * stamps on — so an asset reached without `asset()` got the same immutable
+ * year with nothing to bust it. The clearest case is the fonts:
+ * public/fonts/fonts.css names each face by bare filename, and
+ * scripts/fetch-fonts.sh rewrites those files under the same names, so a
+ * regenerated font stayed stale in every returning browser for up to a year.
+ *
+ * The policy is now decided per request, and these tests hold both halves:
+ * a URL carrying the current hash still gets the immutable year, and a bare
+ * one gets a short cache it can revalidate out of.
+ */
+
+const path = require('path');
+const request = require('supertest');
+const session = require('express-session');
+const { assetVersion, staticCacheControl, UNVERSIONED_MAX_AGE, PUBLIC_DIR } = require('../src/dashboard/lib/assets');
+
+const SAVED_ENV = { ...process.env };
+
+beforeEach(() => {
+    process.env.SESSION_SECRET = 'x'.repeat(48);
+    process.env.MONGODB_URI = 'mongodb://127.0.0.1:27017/clawdia-test';
+    process.env.NODE_ENV = 'test';
+});
+
+afterEach(() => {
+    for (const key of ['SESSION_SECRET', 'MONGODB_URI', 'NODE_ENV']) {
+        if (SAVED_ENV[key] === undefined) delete process.env[key];
+        else process.env[key] = SAVED_ENV[key];
+    }
+});
+
+const { createApp } = require('../src/dashboard/server');
+
+function buildApp() {
+    return createApp({
+        bot: { hasGuild: () => false },
+        sessionStore: new session.MemoryStore(),
+        configurePassport: () => {},
+    });
+}
+
+const IMMUTABLE = 'public, max-age=31536000, immutable';
+const SHORT = `public, max-age=${UNVERSIONED_MAX_AGE}`;
+
+describe('staticCacheControl()', () => {
+    const file = path.join(PUBLIC_DIR, 'styles.css');
+
+    test('grants the immutable year to a URL carrying the current hash', () => {
+        const version = assetVersion('/styles.css');
+        expect(staticCacheControl({ query: { v: version } }, file)).toBe(IMMUTABLE);
+    });
+
+    test('gives a bare URL a short cache instead', () => {
+        expect(staticCacheControl({ query: {} }, file)).toBe(SHORT);
+    });
+
+    test('gives a stale hash a short cache — the bytes moved on without it', () => {
+        expect(staticCacheControl({ query: { v: 'deadbeef00' } }, file)).toBe(SHORT);
+    });
+
+    // `?v=a&v=b` parses to an array, and `?v[x]=1` to an object. Neither is a
+    // hash, and neither should be compared as one.
+    test('ignores a v that is not a single string', () => {
+        expect(staticCacheControl({ query: { v: ['a', 'b'] } }, file)).toBe(SHORT);
+        expect(staticCacheControl({ query: { v: { x: '1' } } }, file)).toBe(SHORT);
+        expect(staticCacheControl({}, file)).toBe(SHORT);
+    });
+
+    test('never trusts a hash for a file outside the root it was resolved under', () => {
+        const outside = path.join(PUBLIC_DIR, '..', 'server.js');
+        expect(staticCacheControl({ query: { v: assetVersion('/styles.css') } }, outside)).toBe(SHORT);
+    });
+});
+
+describe('the static handler', () => {
+    test('caches a hashed asset URL for a year', async () => {
+        const version = assetVersion('/styles.css');
+        const res = await request(buildApp()).get(`/styles.css?v=${version}`);
+
+        expect(res.status).toBe(200);
+        expect(res.headers['cache-control']).toBe(IMMUTABLE);
+    });
+
+    // The bare-filename case that started this: fonts.css itself goes through
+    // asset(), but the woff2 URLs inside it do not.
+    test('does not freeze an un-versioned font for a year', async () => {
+        const res = await request(buildApp()).get('/fonts/fonts.css');
+
+        expect(res.status).toBe(200);
+        expect(res.headers['cache-control']).toBe(SHORT);
+        expect(res.headers['cache-control']).not.toContain('immutable');
+    });
+});
+
+describe('public/fonts/fonts.css', () => {
+    // Why the un-versioned branch has to exist at all — if this ever stops
+    // being true the short cache is still correct, just no longer load-bearing.
+    test('references its faces by bare filename', () => {
+        const css = require('fs').readFileSync(path.join(PUBLIC_DIR, 'fonts', 'fonts.css'), 'utf8');
+        expect(css).toMatch(/src: url\('\/fonts\/[a-z0-9-]+\.woff2'\)/);
+    });
+});

--- a/tests/dashboardJobTierOptions.test.js
+++ b/tests/dashboardJobTierOptions.test.js
@@ -1,0 +1,129 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"customExportConditions": ["node"]}
+ */
+process.env.SUPPRESS_JEST_WARNINGS = 'true';
+
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = global.TextEncoder || TextEncoder;
+global.TextDecoder = global.TextDecoder || TextDecoder;
+
+// #911. The job modal's "Career tier" select shipped its four options as static
+// markup — "Tier 2 — Skilled Worker (10 shifts)" and so on — while the Careers
+// tab in the same panel lets an admin rename every tier and change its shift
+// threshold. Opening the modal only set `.value` on the select, so an admin who
+// renamed their tiers still read the stock names, and the shift counts shown
+// were wrong for their server: the dashboard contradicting configuration the
+// same dashboard had just saved.
+//
+// The options are rebuilt from the live tier list when the modal opens now.
+
+const fs = require('fs');
+const path = require('path');
+const { VIEWS, bootPage, clickTab, settle, forgetDocumentListeners } = require('./helpers/guildSettingsPage');
+const DEFAULT_TIERS = require('../src/data/defaultTiers');
+
+const options = () => [...document.getElementById('modal-job-tier').options]
+    .map(o => ({ value: o.value, text: o.textContent }));
+
+/** Rename a tier and change its threshold the way the Careers tab does. */
+function editTier(index, { name, minShifts }) {
+    const set = (field, value) => {
+        const input = document.querySelector(`[data-tier-idx="${index}"][data-field="${field}"]`);
+        input.value = String(value);
+        input.dispatchEvent(new window.Event('input', { bubbles: true }));
+    };
+    if (name !== undefined) set('name', name);
+    if (minShifts !== undefined) set('minShifts', minShifts);
+}
+
+describe('the job modal\'s career-tier select', () => {
+    beforeEach(async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        document.body.innerHTML = '';
+        bootPage();
+        clickTab('economy');
+        await settle();
+    });
+
+    afterEach(() => {
+        forgetDocumentListeners();
+        jest.restoreAllMocks();
+    });
+
+    test('ships no options in the markup — they are not the page\'s to hardcode', () => {
+        const panel = fs.readFileSync(path.join(VIEWS, 'partials', 'panels', 'economy.ejs'), 'utf8');
+        const select = /<select id="modal-job-tier"[^>]*>([\s\S]*?)<\/select>/.exec(panel);
+
+        expect(select).not.toBeNull();
+        expect(select[1].trim()).toBe('');
+        // The stock names in particular — the thing an admin can rename.
+        expect(panel).not.toContain('Skilled Worker');
+    });
+
+    test('is built from the configured tiers when the modal opens', () => {
+        window.openJobModal(-1);
+
+        expect(options()).toEqual(DEFAULT_TIERS.map(t => ({
+            value: String(t.tier),
+            text: `Tier ${t.tier} — ${t.name} (${t.minShifts} shift${t.minShifts === 1 ? '' : 's'})`,
+        })));
+    });
+
+    test('shows a renamed tier and its new threshold, not the stock ones', () => {
+        editTier(1, { name: 'Deckhand', minShifts: 7 });
+
+        window.openJobModal(-1);
+
+        const second = options()[1];
+        expect(second.text).toBe('Tier 2 — Deckhand (7 shifts)');
+        expect(options().some(o => o.text.includes('Skilled Worker'))).toBe(false);
+    });
+
+    test('picks up a rename made after the modal was last opened', () => {
+        window.openJobModal(-1);
+        window.closeJobModal();
+
+        editTier(0, { name: 'Rookie' });
+        window.openJobModal(-1);
+
+        expect(options()[0].text).toBe('Tier 1 — Rookie (0 shifts)');
+    });
+
+    test('says "1 shift", not "1 shifts"', () => {
+        editTier(1, { minShifts: 1 });
+
+        window.openJobModal(-1);
+
+        expect(options()[1].text).toBe('Tier 2 — Skilled Worker (1 shift)');
+    });
+
+    test('escapes a tier name rather than letting it write markup', () => {
+        editTier(2, { name: '<img src=x onerror=alert(1)>' });
+
+        window.openJobModal(-1);
+
+        const select = document.getElementById('modal-job-tier');
+        expect(select.querySelector('img')).toBeNull();
+        expect(options()[2].text).toContain('<img src=x onerror=alert(1)>');
+    });
+
+    test('selects the tier the job being edited is on', () => {
+        // A job on tier 3, added through the modal itself so the page's own
+        // list is what is read back.
+        window.openJobModal(-1);
+        document.getElementById('modal-job-name').value = 'Astronaut';
+        document.getElementById('modal-job-tier').value = '3';
+        document.getElementById('modal-job-min-pay').value = '50';
+        document.getElementById('modal-job-max-pay').value = '150';
+        window.saveJobModal();
+
+        // The list is grouped by tier, so DOM order is not list order — take the
+        // index the edit button itself would pass.
+        const idx = window.jobsList.findIndex(job => job.name === 'Astronaut');
+        expect(idx).toBeGreaterThan(-1);
+        window.openJobModal(idx);
+
+        expect(document.getElementById('modal-job-tier').value).toBe('3');
+    });
+});

--- a/tests/dashboardSecurityHeaders.test.js
+++ b/tests/dashboardSecurityHeaders.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+/**
+ * The baseline response headers every dashboard route carries.
+ *
+ * #921: `X-XSS-Protection: 1; mode=block` used to read as a protection the
+ * site does not actually have. The header is deprecated and ignored by current
+ * browsers, and in the legacy ones that do honour it the auditor has itself
+ * been a source of XS-Leaks and injection — so it is now set to `0`, and the
+ * nonce-based CSP is what does the job.
+ */
+
+const request = require('supertest');
+const session = require('express-session');
+
+const SAVED_ENV = { ...process.env };
+
+beforeEach(() => {
+    process.env.SESSION_SECRET = 'x'.repeat(48);
+    process.env.MONGODB_URI = 'mongodb://127.0.0.1:27017/clawdia-test';
+    process.env.NODE_ENV = 'test';
+});
+
+afterEach(() => {
+    for (const key of ['SESSION_SECRET', 'MONGODB_URI', 'NODE_ENV']) {
+        if (SAVED_ENV[key] === undefined) delete process.env[key];
+        else process.env[key] = SAVED_ENV[key];
+    }
+});
+
+const { createApp } = require('../src/dashboard/server');
+
+function buildApp() {
+    return createApp({
+        bot: { hasGuild: () => false },
+        sessionStore: new session.MemoryStore(),
+        configurePassport: () => {},
+    });
+}
+
+describe('baseline security headers', () => {
+    test('the deprecated XSS auditor is switched off, not switched on', async () => {
+        const res = await request(buildApp()).get('/');
+
+        expect(res.headers['x-xss-protection']).toBe('0');
+    });
+
+    test('the headers that do carry weight are still set', async () => {
+        const res = await request(buildApp()).get('/');
+
+        expect(res.headers['x-content-type-options']).toBe('nosniff');
+        expect(res.headers['x-frame-options']).toBe('DENY');
+        expect(res.headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+        // What actually replaces the auditor.
+        expect(res.headers['content-security-policy']).toMatch(/script-src 'self' 'nonce-/);
+    });
+});

--- a/tests/messageCreateAnnouncementsOutsideLock.test.js
+++ b/tests/messageCreateAnnouncementsOutsideLock.test.js
@@ -1,0 +1,261 @@
+'use strict';
+
+// #894. The level-up embed and the quest/streak notifications were awaited
+// *inside* `withUserLock`, so the lock's hold time included Discord API latency
+// and rate-limit queueing rather than just the database work it exists to
+// serialise. A holder stuck behind a 429 can reach the mutex's 15-second
+// timeout override — and that override exists to break deadlocks, so reaching
+// it lets the next flow run alongside this one and reintroduces the lost update
+// the lock was built to prevent.
+//
+// They are collected under the lock now and sent after it. These pin that:
+// nothing announces while the lock is held, everything still announces, the
+// order is unchanged, and one failing send does not swallow the rest.
+
+jest.mock('../src/models/User',     () => ({ findOne: jest.fn(), create: jest.fn() }));
+jest.mock('../src/models/Guild',    () => ({ create: jest.fn() }));
+jest.mock('../src/models/Case',     () => ({ findOne: jest.fn().mockResolvedValue(null), countDocuments: jest.fn().mockResolvedValue(0) }));
+jest.mock('../src/models/Reminder', () => ({ create: jest.fn() }));
+
+jest.mock('../src/services/aiService',      () => ({ handleAIChat: jest.fn() }));
+jest.mock('../src/services/moderationLogService', () => ({ logModeration: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../src/services/rivalryService', () => ({ checkRivalry: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../src/services/chatEventService', () => ({ maybeTriggerChatEvent: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../src/utils/wealthMilestone',   () => ({ checkAndBroadcastWealthMilestone: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../src/services/achievementService', () => ({
+    checkAndAward: jest.fn().mockResolvedValue([]),
+    announceAchievements: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../src/utils/streakMultiplier', () => ({
+    getStreakMultiplier: jest.fn(() => 1),
+    checkNewMilestones: jest.fn(() => []),
+}));
+jest.mock('../src/services/effectsService', () => ({
+    hasEffect: jest.fn(() => false),
+    consumeEffect: jest.fn(),
+    getXpMultiplier: jest.fn(() => 1),
+    getServerXpMultiplier: jest.fn(() => 1),
+}));
+jest.mock('../src/services/questService', () => ({
+    ensureQuests: jest.fn().mockResolvedValue({ assignedNewDaily: false }),
+    onMessage: jest.fn().mockResolvedValue({ completed: [], nearComplete: [] }),
+    onStreakUpdate: jest.fn().mockResolvedValue({ completed: [], nearComplete: [] }),
+    notifyQuestComplete: jest.fn().mockResolvedValue(undefined),
+    notifyQuestNearComplete: jest.fn().mockResolvedValue(undefined),
+    notifyDailyQuestReset: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../src/services/levelingService', () => ({
+    applyXpGain: jest.fn((user, amount) => {
+        user.xp = (user.xp || 0) + amount;
+        return { leveled: true, newLevel: (user.level || 0) + 1, gained: amount };
+    }),
+    announceLevelUp: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../src/utils/guildSettingsCache', () => ({ getGuildSettings: jest.fn() }));
+jest.mock('../src/utils/balanceDelta', () => ({
+    saveWithBalanceDelta: jest.fn(async (Model, user) => {
+        await user.save();
+        return { credited: true, balance: user.balance ?? 0 };
+    }),
+}));
+
+const User = require('../src/models/User');
+const { getGuildSettings } = require('../src/utils/guildSettingsCache');
+const { announceLevelUp } = require('../src/services/levelingService');
+const { notifyQuestComplete, notifyQuestNearComplete, notifyDailyQuestReset, ensureQuests } = require('../src/services/questService');
+const { checkNewMilestones } = require('../src/utils/streakMultiplier');
+const { hasEffect } = require('../src/services/effectsService');
+const { pendingLocks } = require('../src/utils/userMutex');
+const messageCreate = require('../src/events/messageCreate');
+const { useFixedClock } = require('./helpers/fixedClock');
+
+function makeUserDoc(overrides = {}) {
+    const doc = {
+        _id: 'doc1',
+        userId: 'author1',
+        guildId: 'guild1',
+        xp: 0,
+        level: 4,
+        messages: 0,
+        balance: 0,
+        dailyMessages: 0,
+        lastXpGain: null,
+        streak: { current: 3, longest: 3, lastActive: new Date('2020-01-01'), claimedMilestones: [] },
+        pets: [],
+        isModified() { return false; },
+        ...overrides,
+    };
+    doc.save = jest.fn().mockResolvedValue(undefined);
+    return doc;
+}
+
+function makeSettings(overrides = {}) {
+    return {
+        ai: { enabled: false },
+        leveling: { enabled: true, rewardsEnabled: true, xpRate: 1, noXpChannelIds: [], noXpRoleIds: [] },
+        moderation: { enabled: false },
+        suggestions: { enabled: false },
+        bibleVerse: { autoRespond: false },
+        ...overrides,
+    };
+}
+
+function makeMessage(content = 'hello there') {
+    return {
+        id: 'msg1',
+        url: 'https://discord.com/channels/guild1/chan1/msg1',
+        content,
+        author: { id: 'author1', bot: false, toString: () => '<@author1>' },
+        attachments: new Map(),
+        mentions: { has: () => false },
+        member: {
+            id: 'author1',
+            permissions: { has: () => false },
+            roles: { cache: { some: () => false } },
+            bannable: false, kickable: false, moderatable: false,
+        },
+        guild: { id: 'guild1', name: 'Guild One' },
+        channel: { id: 'chan1', send: jest.fn().mockResolvedValue({ delete: jest.fn().mockResolvedValue(undefined) }) },
+        client: { user: { id: 'bot1' } },
+        delete: jest.fn().mockResolvedValue(undefined),
+    };
+}
+
+const run = message => messageCreate.execute(message, { user: { id: 'bot1' } });
+
+// The mutex has no "is this key held" accessor, and it should not grow one for
+// a test — but it does report how many keys have work in flight, and this suite
+// runs one message at a time. Zero means the lock has been released.
+const lockHeld = () => pendingLocks() > 0;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    getGuildSettings.mockResolvedValue(makeSettings());
+    User.findOne.mockResolvedValue(makeUserDoc());
+});
+
+describe('Discord sends and the user lock', () => {
+    useFixedClock();
+
+    test('the level-up embed is sent after the lock is released, not inside it', async () => {
+        let heldWhenAnnouncing = null;
+        announceLevelUp.mockImplementation(async () => { heldWhenAnnouncing = lockHeld(); });
+
+        await run(makeMessage());
+
+        expect(announceLevelUp).toHaveBeenCalledTimes(1);
+        expect(heldWhenAnnouncing).toBe(false);
+    });
+
+    test('the quest notifications are too', async () => {
+        const held = [];
+        notifyQuestComplete.mockImplementation(async () => { held.push(lockHeld()); });
+        notifyQuestNearComplete.mockImplementation(async () => { held.push(lockHeld()); });
+        ensureQuests.mockResolvedValue({ assignedNewDaily: true });
+        notifyDailyQuestReset.mockImplementation(async () => { held.push(lockHeld()); });
+
+        await run(makeMessage());
+
+        expect(held).toEqual([false, false, false]);
+    });
+
+    test('so are the streak-shield and milestone messages', async () => {
+        // A shield consumed after a missed day, and a milestone crossed on the
+        // same message — the two paths that call channel.send directly.
+        hasEffect.mockReturnValue(true);
+        checkNewMilestones.mockReturnValue([{ days: 30, coins: 5000, badge: '🔥' }]);
+        User.findOne.mockResolvedValue(makeUserDoc({
+            streak: {
+                current: 29,
+                longest: 29,
+                // 60 hours ago: past the 48h break, inside the shield's 72h window.
+                lastActive: new Date(Date.now() - 60 * 60 * 60 * 1000),
+                claimedMilestones: [],
+            },
+        }));
+
+        const message = makeMessage();
+        const held = [];
+        message.channel.send.mockImplementation(async () => {
+            held.push(lockHeld());
+            return { delete: jest.fn().mockResolvedValue(undefined) };
+        });
+
+        await run(message);
+
+        const texts = message.channel.send.mock.calls.map(([arg]) => arg);
+        expect(texts.some(t => typeof t === 'string' && t.includes('Streak Shield'))).toBe(true);
+        expect(texts.some(t => typeof t === 'string' && t.includes('30-day streak milestone'))).toBe(true);
+        expect(held).toEqual(held.map(() => false));
+        expect(held.length).toBeGreaterThan(0);
+    });
+
+    test('a level-up still announces even when automod then blocks the message', async () => {
+        // It did before the sends moved out of the lock — the announcement is
+        // queued before the automod gate is reached — and blocking the message
+        // is not a reason to swallow the promotion.
+        //
+        // Fake timers because the warning the automod path posts schedules its
+        // own deletion five seconds out, which would otherwise outlive the run.
+        jest.useFakeTimers();
+        try {
+            getGuildSettings.mockResolvedValue(makeSettings({
+                moderation: { enabled: true, autoModEnabled: true, linkFilter: true },
+            }));
+            User.findOne
+                .mockResolvedValueOnce(makeUserDoc())
+                .mockResolvedValue(makeUserDoc({ _id: 'doc2', behaviorScore: 0, lastScoreDecay: null }));
+
+            await run(makeMessage('look at https://example.com'));
+
+            expect(announceLevelUp).toHaveBeenCalledTimes(1);
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    test('the level-up is announced before the quest notification it rides with', async () => {
+        const order = [];
+        announceLevelUp.mockImplementation(async () => { order.push('level'); });
+        notifyQuestComplete.mockImplementation(async () => { order.push('quest'); });
+
+        await run(makeMessage());
+
+        expect(order).toEqual(['level', 'quest']);
+    });
+
+    test('one failing send does not skip the ones queued behind it', async () => {
+        const errors = jest.spyOn(console, 'error').mockImplementation(() => {});
+        announceLevelUp.mockRejectedValue(new Error('429 from Discord'));
+
+        await run(makeMessage());
+
+        expect(notifyQuestComplete).toHaveBeenCalledTimes(1);
+        expect(notifyQuestNearComplete).toHaveBeenCalledTimes(1);
+        expect(errors).toHaveBeenCalled();
+        errors.mockRestore();
+    });
+
+    test('a rate-limited send does not delay the same user\'s next message', async () => {
+        // The shape of the bug: with the send inside the lock, the second
+        // message's document read queues behind Discord's response.
+        let releaseSend;
+        announceLevelUp.mockImplementation(() => new Promise(resolve => { releaseSend = resolve; }));
+
+        const first = run(makeMessage('one'));
+        // Let the first flow reach its (now post-lock) announcement.
+        await new Promise(resolve => setImmediate(resolve));
+        await new Promise(resolve => setImmediate(resolve));
+
+        User.findOne.mockClear();
+        const second = run(makeMessage('two'));
+        await new Promise(resolve => setImmediate(resolve));
+
+        // Held inside the lock, this would still be 0: the second flow would be
+        // waiting on a Discord call that has not answered.
+        expect(User.findOne).toHaveBeenCalled();
+
+        releaseSend();
+        await Promise.all([first, second]);
+    });
+});

--- a/tests/messageCreateAnnouncementsOutsideLock.test.js
+++ b/tests/messageCreateAnnouncementsOutsideLock.test.js
@@ -239,8 +239,16 @@ describe('Discord sends and the user lock', () => {
     test('a rate-limited send does not delay the same user\'s next message', async () => {
         // The shape of the bug: with the send inside the lock, the second
         // message's document read queues behind Discord's response.
-        let releaseSend;
-        announceLevelUp.mockImplementation(() => new Promise(resolve => { releaseSend = resolve; }));
+        //
+        // Every resolver is kept, not just the last one. Only one send is
+        // queued as this stands — both flows are handed the same document
+        // object, so the `lastXpGain` the first stamps puts the second inside
+        // handleLeveling's 60-second XP cooldown, which returns before a
+        // level-up can be queued. A fixture that ever gave each flow its own
+        // document would queue two, and holding a single `releaseSend` would
+        // then leave one promise pending and hang the test rather than fail it.
+        const releaseSends = [];
+        announceLevelUp.mockImplementation(() => new Promise(resolve => { releaseSends.push(resolve); }));
 
         const first = run(makeMessage('one'));
         // Let the first flow reach its (now post-lock) announcement.
@@ -255,7 +263,8 @@ describe('Discord sends and the user lock', () => {
         // waiting on a Discord call that has not answered.
         expect(User.findOne).toHaveBeenCalled();
 
-        releaseSend();
+        expect(releaseSends).not.toEqual([]);
+        for (const releaseSend of releaseSends) releaseSend();
         await Promise.all([first, second]);
     });
 });


### PR DESCRIPTION
## Summary

Fixes three separate issues where Discord API calls were being made while holding the user-level mutex lock, causing rate-limit delays to block subsequent messages from the same user and potentially trigger deadlock detection.

## Changes

### Core Fix: Message Create Event (#894)
- **Problem**: Level-up embeds and quest/streak notifications were awaited inside `withUserLock`, causing the lock's hold time to include Discord API latency and rate-limit queueing. A holder stuck behind a 429 response could reach the 15-second timeout override meant to break deadlocks, reintroducing the lost update the lock was designed to prevent.
- **Solution**: Announcements are now collected in an array while the lock is held, then sent sequentially after the lock is released via new `sendAnnouncements()` function
- **Details**:
  - Modified `handleLeveling()` and `handleStreakAndQuests()` to accept an `announcements` array parameter
  - Announcements are queued as async functions and executed in order after the lock releases
  - Sequential execution preserves the original order (level-up before quest completion)
  - Error handling ensures one failing send doesn't skip subsequent announcements
  - Level-up announcements still fire even if the message is later blocked by automod

### Dashboard Asset Caching (#903)
- **Problem**: `express.static` was configured with unconditional `maxAge: '1y', immutable` for all URLs, but it doesn't understand the `?v=` hash that `asset()` adds. Bare URLs (like fonts referenced in `fonts.css`) got the same immutable year with no way to bust the cache when files are regenerated.
- **Solution**: Cache policy is now decided per-request based on whether the `v` parameter matches the file's current hash
- **Details**:
  - Added `staticCacheControl()` function that grants immutable year only to requests with matching hash
  - Bare URLs or stale hashes get short 5-minute cache for revalidation
  - Updated `express.static` configuration to use the new per-request policy
  - Prevents regenerated fonts from staying stale in browsers for up to a year

### Dashboard Job Tier Select (#911)
- **Problem**: The job modal's career tier select shipped with static markup ("Tier 2 — Skilled Worker (10 shifts)") while the Careers tab allows admins to rename tiers and change shift thresholds. The modal only set `.value`, so renamed tiers still showed stock names and wrong shift counts.
- **Solution**: Options are now rebuilt from the live tier list when the modal opens
- **Details**:
  - Removed hardcoded `JOB_TIER_META` array from `guild-settings.js`
  - Added `renderJobTierOptions()` function that builds options from `jobTiersList`
  - Options reflect unsaved changes immediately (before round-trip to server)
  - Proper HTML escaping prevents tier names from injecting markup
  - Removed static option markup from `economy.ejs` view

### Security Headers (#921)
- **Problem**: `X-XSS-Protection: 1; mode=block` header was misleading—the deprecated XSS auditor is a source of XS-Leaks and injection in legacy browsers, and current browsers ignore it.
- **Solution**: Changed header to `X-XSS-Protection: 0` to disable the auditor, relying on nonce-based CSP instead
- **Details**: Added test to verify the header is set to `0` and other security headers remain in place

## Testing

Added comprehensive test suites:
- `messageCreateAnnouncementsOutsideLock.test.js`: Verifies announcements fire after lock release, in correct order, with proper error handling
- `dashboardAssetCaching.test.js`: Tests cache control logic for versioned vs unversioned assets
- `dashboardJobTierOptions.test.js`: Ensures tier options reflect current configuration and handle renames
- `dashboardSecurityHeaders.test.js`: Validates security header configuration

https://claude.ai/code/session_01YA7sqYfeVRSYUWxmiB4Hms

---

## Added while driving this PR to green

Two commits beyond the four fixes above, which is why the diff touches `Dockerfile`, `.github/workflows/ci.yml` and `tests/ciSupplyChainGates.test.js`:

- **f916dae — test hardening.** The rate-limit test in `messageCreateAnnouncementsOutsideLock.test.js` held a single mock resolver in one variable. Only one send is ever queued today (both flows share a document object, so the second hits `handleLeveling`'s 60-second XP cooldown), but a fixture change would queue two and the test would then hang rather than fail. It collects and releases every resolver now, with the reason recorded. Raised by CodeRabbit; the specific failure it described does not occur, and the thread has the detail.

- **c7c0632 — the image scan fix, cherry-picked from [#962](https://github.com/TheShield2594/clawdia/pull/962).** `Build, boot and scan Docker image` was red here and on `main` on two HIGH `libexpat` findings, which nothing in this PR's diff can reach. The cause is that `cache-from: type=gha` restores the runtime stage's `apk upgrade` layer instead of executing it, so the upgrade was frozen at whatever Alpine served when the layer was first cached. #962 adds an `ARG APK_REFRESH` keyed on the UTC date; its scan came back green, which also proves Alpine had the fixed package all along. Ported here rather than waiting on #962 to merge — the two copies are the same commit, so whichever merges first, the other no-ops.

## Summary by CodeRabbit

- **New Features**
  - Career tier options now reflect current configured names and shift thresholds.
  - Level-up, streak, and quest notifications are delivered sequentially without blocking subsequent messages.

- **Bug Fixes**
  - Static assets now receive appropriate caching based on URL versioning.
  - Notification failures no longer prevent later announcements from being sent.
  - Deprecated XSS protection behavior has been disabled while other security protections remain active.

- **Tests**
  - Added coverage for asset caching, career tier updates, security headers, and notification delivery.