### PR TITLE
Stop the layer cache freezing the image's apk upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,11 +194,30 @@ jobs:
     # than seconds; a warm one is a small fraction of that. Matches the publish
     # job's budget, since it is the same build.
     timeout-minutes: 30
+    outputs:
+      # Read by `publish` so both builds carry the same value — see the step
+      # that computes it, and the note on the publish build.
+      apk-refresh: ${{ steps.apk.outputs.key }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      # The cache key for the Dockerfile's `apk upgrade` layer (#961). Without
+      # one, `cache-from: type=gha` restores that layer instead of running it,
+      # and the upgrade the runtime stage exists to perform is frozen at
+      # whatever Alpine was serving when the layer was first built — a package
+      # with a published fix stays vulnerable in the image, and the scan below
+      # is what eventually says so.
+      #
+      # A UTC date rather than the commit SHA or `github.run_id`: those change
+      # every build, which would mean a cold apk layer on every push for a
+      # freshness nobody needs. A day is well inside the window that matters and
+      # keeps the cache doing its job the rest of the time.
+      - name: Compute the apk refresh key
+        id: apk
+        run: echo "key=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
@@ -207,6 +226,8 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
+          build-args: |
+            APK_REFRESH=${{ steps.apk.outputs.key }}
           # The whole point of this job. A pull request has no credentials worth
           # using and no tag anything deploys.
           push: false
@@ -353,6 +374,14 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
+          # Taken from the `image` job rather than recomputed, for the same
+          # reason that job's cache is reused here: a different value is a
+          # different build, so this would publish an image the scan never
+          # looked at — and it would miss the cache and rebuild to do it. Two
+          # `date` calls in one run normally agree; the one run that straddles
+          # midnight UTC is exactly the case worth not leaving to chance.
+          build-args: |
+            APK_REFRESH=${{ needs.image.outputs.apk-refresh }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -367,9 +396,12 @@ jobs:
           # CI rather than from someone's laptop with push access.
           #
           # mode=max records the full build definition, including build
-          # arguments. Nothing secret goes through build args here (the
-          # Dockerfile takes none), which is the condition for max being safe;
-          # if one is ever added, drop this back to mode=min before it lands.
+          # arguments. The condition for max being safe is that no build
+          # argument carries a secret. The Dockerfile takes exactly one,
+          # APK_REFRESH, and it is a UTC date — recording it is a small gain,
+          # since the provenance then says which day's Alpine packages the
+          # image resolved against. Adding a build argument that carries
+          # anything sensitive means dropping this back to mode=min first.
           provenance: mode=max
           sbom: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,26 @@ FROM node:24-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a
 # upstream, neither yet in a node:24-alpine rebuild). Upgrading here takes the
 # fixes without waiting, and costs no more determinism than the `apk add` below
 # already does: both resolve against whatever Alpine is serving at build time.
+#
+# What that reasoning missed is the layer cache. CI builds with
+# `cache-from: type=gha`, so this `RUN` is *restored* rather than executed
+# whenever the Dockerfile text at or above it is unchanged — and the base above
+# it is digest-pinned, so it changes only when someone edits this file. The
+# upgrade was therefore frozen at whatever Alpine was serving the day the layer
+# was first cached, which is how the scan came to fail on a libexpat with a
+# published fix (#961). `--no-cache` is apk's own index cache and does nothing
+# about this.
+#
+# APK_REFRESH is the cache key that unfreezes it: CI passes the current UTC
+# date, so the layer is rebuilt once a day and the upgrade actually re-resolves.
+# It is declared here, inside the runtime stage, so a new day costs one `apk`
+# layer and not a fresh `canvas` compile up in the build stage.
+#
+# It costs no determinism that `apk add` had not already spent — both resolve
+# against whatever Alpine is serving at build time, which is exactly what the
+# paragraph above says this layer is for. The default keeps a local
+# `docker build` with no build argument working and cacheable.
+ARG APK_REFRESH=unset
 RUN apk upgrade --no-cache && apk add --no-cache \
     cairo \
     jpeg \

--- a/tests/ciSupplyChainGates.test.js
+++ b/tests/ciSupplyChainGates.test.js
@@ -142,6 +142,64 @@ describe('#646 — the Dockerfile is built on pull requests', () => {
     });
 });
 
+describe('#961 — the apk upgrade layer is not frozen by the cache', () => {
+    // The runtime stage runs `apk upgrade` so the image carries Alpine's
+    // published fixes without waiting for a node:24-alpine rebuild. With
+    // `cache-from: type=gha` and a digest-pinned base, that RUN is restored
+    // rather than executed until someone edits the Dockerfile — so the upgrade
+    // was pinned to whatever Alpine served the day the layer was first built,
+    // and the scan above eventually failed on a libexpat that had a fix. The
+    // ARG is the cache key that unfreezes it, and it is worth nothing unless
+    // both builds actually pass it.
+    const dockerfile = fs.readFileSync(path.join(ROOT, 'Dockerfile'), 'utf8');
+    const buildArgsOf = job => {
+        const step = stepsOf(job).find(s => /build-push-action/.test(s.uses || ''));
+        return String((step.with || {})['build-args'] || '');
+    };
+
+    test('the Dockerfile declares the refresh argument', () => {
+        expect(dockerfile).toMatch(/^ARG APK_REFRESH=/m);
+    });
+
+    test('it sits above the upgrade, which is the layer it is there to bust', () => {
+        const arg = dockerfile.search(/^ARG APK_REFRESH=/m);
+        const upgrade = dockerfile.search(/^RUN apk upgrade\b/m);
+        expect(arg).toBeGreaterThan(-1);
+        expect(upgrade).toBeGreaterThan(arg);
+    });
+
+    test('and inside the runtime stage, so a new day is not a fresh canvas compile', () => {
+        // Declared before the first FROM it would be a global argument, which
+        // invalidates the build stage too — and that stage compiles the native
+        // canvas binding from source. Minutes a day, for an upgrade that only
+        // affects the runtime stage's packages.
+        const lastFrom = dockerfile.lastIndexOf('\nFROM ');
+        expect(dockerfile.search(/^ARG APK_REFRESH=/m)).toBeGreaterThan(lastFrom);
+    });
+
+    test('the build job passes it, and not as a constant', () => {
+        // A literal would be a key that never moves, which is the bug with an
+        // ARG in front of it.
+        expect(buildArgsOf(buildJob)).toMatch(/APK_REFRESH=\$\{\{\s*steps\./);
+    });
+
+    test('from a UTC date, so two jobs in one run agree on the day', () => {
+        expect(runScript(buildJob)).toMatch(/date -u\b/);
+    });
+
+    test('the publish build takes the build job\'s value rather than its own', () => {
+        // Recomputing it here would publish an image built from different
+        // inputs than the one the scan passed — and miss the cache to do it.
+        const outputs = jobs[buildJob].outputs || {};
+        const names = Object.keys(outputs);
+        expect(names).not.toEqual([]);
+
+        const published = buildArgsOf(publishJob);
+        expect(published).toMatch(/APK_REFRESH=/);
+        expect(names.some(name => published.includes(`needs.${buildJob}.outputs.${name}`))).toBe(true);
+    });
+});
+
 describe('#651 — publishing is serialized', () => {
     test('the workflow that publishes declares a concurrency group', () => {
         // The publish job lives in this workflow, so the workflow-level group


### PR DESCRIPTION
Found while driving [#961](https://github.com/TheShield2594/clawdia/pull/961) to green: `Build, boot and scan Docker image` is red there, and on `main`, on two HIGH `libexpat` findings in the base layer.

```
clawdia:ci (alpine 3.24.1)
libexpat  CVE-2026-66046  HIGH  fixed  installed 2.8.3-r0  fixed in 2.8.4-r0
libexpat  CVE-2026-76641  HIGH  fixed  installed 2.8.3-r0  fixed in 2.8.4-r0
```

## The bug

The runtime stage opens with `apk upgrade --no-cache`, and the note above it explains why: the digest pin (#644) fixes the *starting point*, which is what makes a rebuild reproducible, but it does not make that starting point *current* — `node:24-alpine` is rebuilt on upstream's schedule, not Alpine's, so between rebuilds the base carries packages with fixes already sitting in Alpine's repo. Upgrading takes them without waiting.

That reasoning is right. The mechanism was broken.

CI builds with `cache-from: type=gha`, so that `RUN` is **restored rather than executed** whenever the Dockerfile text at or above it is unchanged — and the base above it is digest-pinned, so it changes only when someone edits the file. Between Dockerfile edits the upgrade was frozen at whatever Alpine was serving the day the layer was first cached. `--no-cache` is apk's own index cache and does nothing about this.

The 57-second job time on #961 is the visible symptom: that is not a build that compiled `canvas` from source, or ran an `apk` transaction.

This is not only a red scan. `publish` builds from the same cache, so **the image published from `main` carries the same frozen packages** — the scan is telling the truth about what ships.

## The fix

`ARG APK_REFRESH`, declared inside the runtime stage immediately above the upgrade, with CI passing the current UTC date. The layer rebuilds once a day and the upgrade actually re-resolves.

- **A date, not the commit SHA or `run_id`.** Those change every build, which would mean a cold apk layer on every push for a freshness nobody needs. A day is well inside the window that matters and leaves the cache doing its job the rest of the time.
- **Inside the runtime stage, not global.** A global `ARG` invalidates the build stage too, and that stage compiles the native `canvas` binding from source — minutes a day for an upgrade that only touches runtime packages.
- **Defaulted to a literal**, so a local `docker build` with no build argument still works and still caches.
- **`publish` takes the value from `image`'s job output rather than recomputing it.** Two `date` calls in one run normally agree; the run that straddles midnight UTC would otherwise publish an image built from different inputs than the one the scan passed — and miss the cache to do it. That preserves the property the workflow comment already claims: the publish build is a cache hit, and a cache hit is the same layers.

Determinism is unchanged. The `apk add` in this same layer already resolves against whatever Alpine is serving at build time; that is exactly what the digest pin deliberately does not cover, and the existing comment says so.

The provenance note in `publish` said `mode=max` was safe because "the Dockerfile takes none" — that is now false, so it is updated to state the actual condition (no build argument carries a secret). A UTC date does not, and recording it is a small gain: the provenance then says which day's Alpine packages the image resolved against.

## It does clear the libexpat findings — confirmed

This section originally posed it as an open question, because Alpine's package index is not reachable from the environment this was written in and there was no Docker daemon to build against. CI answered it: **the scan on this branch is green.**

So Alpine 3.24 had `expat-2.8.4-r0` available all along, and the frozen layer was the whole story — the upgrade simply never ran. The build time says the same thing independently: 2m11s here against the 57s and 36s of the two frozen-cache runs on #961, which is the signature of a runtime stage that actually rebuilt.

## Testing

Four assertions added to `tests/ciSupplyChainGates.test.js`, which is where this repo keeps the "few lines of YAML that nothing else refers to" gates:

- the Dockerfile declares `APK_REFRESH` and it sits above the upgrade it exists to bust;
- it is inside the runtime stage, so a new day is not a fresh `canvas` compile;
- the build job passes it, and not as a constant;
- the publish build takes the build job's value rather than computing its own.

Each was checked against a deliberately broken variant — publish recomputing its own key, the `ARG` moved to global scope, and `build-args` dropped from the image job — and each fails on the right one. `npx eslint .` is clean; 327 suites / 6587 tests pass (the three `tests/integration/*` suites need a `mongod` binary this sandbox cannot download).

## Relationship to #961

Originally kept separate, and it still deserves its own review. But once the scan here came back green the change became a fix that exists for a PR that is red on it, so it is **also cherry-picked into #961** (c7c0632) rather than leaving that PR waiting on this one to merge. The two copies are the same commit; whichever merges first, the other no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YA7sqYfeVRSYUWxmiB4Hms