### PR TITLE
Make gifting pickable, and cap the value it moves

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -486,12 +486,34 @@ right now — each entry shows its display name, how many are held and its rarit
 — so nobody has to know that the Pet Slot Expansion is stored as
 `pet_slot_expansion`. The list already excludes anything the command would
 refuse: soulbound items, items whose effect is currently running, and empty
-stacks. Coin gifts are capped at 10,000 sent and 25,000 received per account per
-day, and accounts under 7 days old can neither send nor receive.
+stacks. Accounts under 7 days old can neither send nor receive, and a gift at or
+above the confirmation threshold asks the sender to confirm before anything
+moves, since a gift cannot be reversed.
+
+Four daily budgets bound how much value one account can hand another, all
+configurable per server on the dashboard (Economy → Settings & Store → Gifting
+limits), with **0** meaning no limit:
+
+| Limit | Default | What it bounds |
+|---|---|---|
+| Coins sent per day | 10,000 | One member's outgoing coin gifts |
+| Coins received per day | 25,000 | Funnelling into a single account |
+| Item value sent per day | 250,000 | Outgoing item gifts, valued at your shop prices |
+| Item value received per day | 500,000 | Funnelling items into a single account |
+| Confirm gifts at or above | 5,000 | Where the "are you sure" prompt starts |
+
+Item gifts are valued at the guild's own shop price, or the relic payout, or
+what the rarity cost to forge — so "buy the item, gift the item, sell it on the
+market" is bounded by the same kind of budget the coin caps apply. An item worth
+more than the whole daily cap cannot be gifted at all until an admin raises the
+limit.
 
 **Market:** 5 listings per user, 48-hour listing TTL, 5% sale fee, 10-coin
 minimum unit price, and a confirmation prompt above 500 coins. `lifesaver` and
-`streak_shield` are soulbound and cannot be listed or gifted.
+`streak_shield` are soulbound and cannot be listed or gifted. Every option is
+autocompleted: `item` on `list` from the seller's inventory, `item` on `browse`
+from the items actually listed, and `listing_id` on `buy` and `cancel` from the
+listings the caller can act on.
 
 **Districts** are server-wide goals funded collectively. Each has a 1,000,000
 coin goal and, once funded, activates its benefit for **7 days**:

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -481,9 +481,17 @@ evolution track.
 /invest status             - District funding progress and active benefits
 ```
 
+**Gifting:** the `item` option is autocompleted from what the sender is holding
+right now — each entry shows its display name, how many are held and its rarity
+— so nobody has to know that the Pet Slot Expansion is stored as
+`pet_slot_expansion`. The list already excludes anything the command would
+refuse: soulbound items, items whose effect is currently running, and empty
+stacks. Coin gifts are capped at 10,000 sent and 25,000 received per account per
+day, and accounts under 7 days old can neither send nor receive.
+
 **Market:** 5 listings per user, 48-hour listing TTL, 5% sale fee, 10-coin
 minimum unit price, and a confirmation prompt above 500 coins. `lifesaver` and
-`streak_shield` are soulbound and cannot be listed.
+`streak_shield` are soulbound and cannot be listed or gifted.
 
 **Districts** are server-wide goals funded collectively. Each has a 1,000,000
 coin goal and, once funded, activates its benefit for **7 days**:

--- a/src/commands/economy/gift.js
+++ b/src/commands/economy/gift.js
@@ -1,27 +1,40 @@
-const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
+const {
+    SlashCommandBuilder, EmbedBuilder, ActionRowBuilder,
+    ButtonBuilder, ButtonStyle, MessageFlags,
+} = require('discord.js');
 const User  = require('../../models/User');
 const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { logTransaction } = require('../../utils/logTransaction');
 const { grantInventoryItem } = require('../../utils/inventoryGrant');
+const { getItemImageAttachment } = require('../../utils/itemImageHelper');
 const { describeItem } = require('../../utils/itemDisplay');
+const { ownedBy } = require('../../utils/collectorOwner');
+const {
+    giftLimits, budgetState, spendBudget, spendBudgetPipeline,
+    refundBudget, refundBudgetPipeline,
+} = require('../../utils/giftCaps');
 const { isSoulbound } = require('../../data/soulboundItems');
 const { resolveEffectType } = require('../../services/effectsService');
 const COLORS = require('../../utils/embedColors');
 
-const DAILY_COIN_CAP = 10_000;
-// Incoming cap is higher than the outgoing cap (several friends can legitimately
-// gift one person) but low enough that funneling from a farm of alts is capped.
-const DAILY_RECEIVE_CAP = 25_000;
 // Fresh Discord accounts can't send gifts — blocks throwaway-alt funnels.
 const MIN_ACCOUNT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
-const DAY_MS = 86_400_000;
+
+// The four rolling budgets, by the fields that hold them. Paired here so a call
+// site names a budget rather than restating a pair of field names each time.
+const BUDGETS = {
+    coinSend:         { usedField: 'dailyGiftSent',                  resetField: 'dailyGiftReset' },
+    coinReceive:      { usedField: 'dailyGiftReceived',              resetField: 'dailyGiftReceivedReset' },
+    itemValueSend:    { usedField: 'dailyGiftItemValueSent',         resetField: 'dailyGiftItemValueReset' },
+    itemValueReceive: { usedField: 'dailyGiftItemValueReceived',     resetField: 'dailyGiftItemValueReceivedReset' },
+};
 
 // Add `qty` of `itemId` to a user's inventory without reading it first. The
 // three-step bump/guarded-push/bump dance this used to spell out is now one
-// atomic pipeline update shared with every other credit site.
-// Returns the updated document, or null if the user document does not exist.
-const addInventoryItem = (userId, guildId, itemId, qty) =>
-    grantInventoryItem(userId, guildId, itemId, qty);
+// atomic pipeline update shared with every other credit site. `options` is
+// passed through so a budget can be spent in the same write.
+const addInventoryItem = (userId, guildId, itemId, qty, options = {}) =>
+    grantInventoryItem(userId, guildId, itemId, qty, options);
 
 /**
  * Load the AiItem rows for whichever of `itemIds` are forged (`ai_`) ids.
@@ -73,6 +86,55 @@ function toChoice(item) {
         name: `${item.emoji} ${item.name} — ${item.quantity} held${rarity}`.slice(0, 100),
         value: item.itemId.slice(0, 100),
     };
+}
+
+/** `💰1,234`, or `no limit` for a budget that is switched off. */
+function formatRemaining(remaining, currency) {
+    return Number.isFinite(remaining) ? `${currency}${remaining.toLocaleString()}` : 'no limit';
+}
+
+/**
+ * Ask the sender to confirm before an irreversible transfer, on an interaction
+ * that has already been deferred ephemerally.
+ *
+ * A gift has no undo and no counterparty to dispute it with — unlike a market
+ * purchase, which at least prompts above 500 coins. Written against an already
+ * deferred interaction rather than reusing `utils/confirmBet`, which sends its
+ * own reply and so cannot be used once the interaction is acknowledged.
+ *
+ * Returns true only on an explicit confirmation; a cancel and a timeout both
+ * leave the ephemeral message explaining what happened.
+ */
+async function confirmGift(interaction, { description, footer }) {
+    const row = new ActionRowBuilder().addComponents(
+        new ButtonBuilder().setCustomId('gift_confirm').setLabel('Send it').setStyle(ButtonStyle.Success),
+        new ButtonBuilder().setCustomId('gift_cancel').setLabel('Cancel').setStyle(ButtonStyle.Danger),
+    );
+    const embed = new EmbedBuilder()
+        .setColor(COLORS.WARN)
+        .setTitle('⚠️ Confirm this gift')
+        .setDescription(description)
+        .setFooter({ text: footer ?? 'Gifts cannot be reversed. This prompt expires in 30 seconds.' });
+
+    const prompt = await interaction.editReply({ content: '', embeds: [embed], components: [row] });
+
+    try {
+        const press = await prompt.awaitMessageComponent({
+            time: 30_000,
+            filter: ownedBy(interaction.user.id, "This isn't your gift."),
+        });
+        if (press.customId === 'gift_confirm') {
+            await press.update({ content: '✅ Confirmed — sending…', embeds: [], components: [] });
+            return true;
+        }
+        await press.update({ content: '❌ Gift cancelled. Nothing was sent.', embeds: [], components: [] });
+        return false;
+    } catch {
+        await interaction
+            .editReply({ content: '⏱️ Confirmation timed out. Nothing was sent.', embeds: [], components: [] })
+            .catch(() => {});
+        return false;
+    }
 }
 
 module.exports = {
@@ -151,32 +213,35 @@ module.exports = {
     },
 
     async execute(interaction) {
+        // Deferred before anything else, and ephemerally.
+        //
+        // Everything below is database work — up to four reads and three writes
+        // on the item path — against Discord's three-second acknowledgement
+        // window, and a slow database turned that into "the application did not
+        // respond" with the gift already half applied. Ephemeral because most of
+        // what this reply carries is a refusal or the sender's own wallet;
+        // the gift itself is announced publicly by a followUp at the end.
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+        const deny = content => interaction.editReply({ content, embeds: [], components: [] });
+
         const guildSettings = await getGuildSettings(interaction.guild.id);
         if (guildSettings?.economy?.enabled === false) {
-            return interaction.reply({ content: 'The economy is disabled on this server.', flags: MessageFlags.Ephemeral });
+            return deny('The economy is disabled on this server.');
         }
 
         const currency = guildSettings?.economy?.currency || '💰';
+        const limits   = giftLimits(guildSettings);
         const target   = interaction.options.getUser('user');
         const type     = interaction.options.getString('type');
+        const guildId  = interaction.guild.id;
 
-        if (target.id === interaction.user.id) {
-            return interaction.reply({ content: "You can't gift yourself.", flags: MessageFlags.Ephemeral });
-        }
-        if (target.bot) {
-            return interaction.reply({ content: "You can't gift a bot.", flags: MessageFlags.Ephemeral });
-        }
+        if (target.id === interaction.user.id) return deny("You can't gift yourself.");
+        if (target.bot)                        return deny("You can't gift a bot.");
         if (Date.now() - interaction.user.createdTimestamp < MIN_ACCOUNT_AGE_MS) {
-            return interaction.reply({
-                content: 'Your Discord account is too new to send gifts. Try again in a few days.',
-                flags: MessageFlags.Ephemeral,
-            });
+            return deny('Your Discord account is too new to send gifts. Try again in a few days.');
         }
         if (Date.now() - target.createdTimestamp < MIN_ACCOUNT_AGE_MS) {
-            return interaction.reply({
-                content: `${target.username}'s Discord account is too new to receive gifts.`,
-                flags: MessageFlags.Ephemeral,
-            });
+            return deny(`${target.username}'s Discord account is too new to receive gifts.`);
         }
 
         // The two halves of this command each ignore the other's options, and
@@ -187,75 +252,60 @@ module.exports = {
             : (interaction.options.getInteger('amount') ? 'amount' : null);
         if (mismatched) {
             const wanted = type === 'coins' ? 'amount' : 'item';
-            return interaction.reply({
-                content: `You picked **${type}** but filled in \`${mismatched}\`. Use \`${wanted}\` for that, or switch \`type\`.`,
-                flags: MessageFlags.Ephemeral,
-            });
+            return deny(`You picked **${type}** but filled in \`${mismatched}\`. Use \`${wanted}\` for that, or switch \`type\`.`);
         }
 
         if (type === 'coins') {
-            const amount  = interaction.options.getInteger('amount');
-            const guildId = interaction.guild.id;
+            const amount = interaction.options.getInteger('amount');
+            if (!amount) return deny('Specify an `amount` when gifting coins.');
 
-            if (!amount) {
-                return interaction.reply({ content: 'Specify an `amount` when gifting coins.', flags: MessageFlags.Ephemeral });
-            }
+            // Read both sides for the user-facing balance and cap feedback. The
+            // atomic filters below are what actually enforce either.
+            const [senderNow, receiverNow] = await Promise.all([
+                User.findOne({ userId: interaction.user.id, guildId }),
+                User.findOne({ userId: target.id, guildId }),
+            ]);
 
-            // Read current state to provide user-facing balance/cap feedback before the atomic update
-            const senderNow = await User.findOne({ userId: interaction.user.id, guildId });
             if (!senderNow || senderNow.balance < amount) {
-                return interaction.reply({
-                    content: `You only have **${currency}${(senderNow?.balance ?? 0).toLocaleString()}** in your wallet.`,
-                    flags: MessageFlags.Ephemeral,
-                });
+                return deny(`You only have **${currency}${(senderNow?.balance ?? 0).toLocaleString()}** in your wallet.`);
             }
 
-            const capResetAge = senderNow.dailyGiftReset
-                ? Date.now() - new Date(senderNow.dailyGiftReset).getTime()
-                : Infinity;
-            const currentSent = capResetAge >= DAY_MS ? 0 : (senderNow.dailyGiftSent ?? 0);
-            const remaining   = DAILY_COIN_CAP - currentSent;
+            const sendState = budgetState(senderNow,   { ...BUDGETS.coinSend,    cap: limits.coinSend });
+            const rxState   = budgetState(receiverNow, { ...BUDGETS.coinReceive, cap: limits.coinReceive });
 
-            if (amount > remaining) {
-                return interaction.reply({
-                    content: `Daily gift cap reached. You can still gift up to **${currency}${remaining.toLocaleString()}** today.`,
-                    flags: MessageFlags.Ephemeral,
-                });
+            if (amount > sendState.remaining) {
+                return deny(`Daily gift cap reached. You can still gift up to **${currency}${sendState.remaining.toLocaleString()}** today.`);
+            }
+            if (amount > rxState.remaining) {
+                return deny(`<@${target.id}> has reached their daily gift-receiving cap. They can receive up to **${currency}${rxState.remaining.toLocaleString()}** more today.`);
             }
 
-            // Receiver-side daily cap — limits how much one account can be funneled per day
-            const receiverNow  = await User.findOne({ userId: target.id, guildId });
-            const rxResetAge   = receiverNow?.dailyGiftReceivedReset
-                ? Date.now() - new Date(receiverNow.dailyGiftReceivedReset).getTime()
-                : Infinity;
-            const currentReceived = rxResetAge >= DAY_MS ? 0 : (receiverNow?.dailyGiftReceived ?? 0);
-            if (currentReceived + amount > DAILY_RECEIVE_CAP) {
-                return interaction.reply({
-                    content: `<@${target.id}> has reached their daily gift-receiving cap. They can receive up to **${currency}${Math.max(0, DAILY_RECEIVE_CAP - currentReceived).toLocaleString()}** more today.`,
-                    flags: MessageFlags.Ephemeral,
+            // A gift is irreversible, so a large one asks first — the same
+            // courtesy /market buy extends above 500 coins.
+            if (limits.confirmThreshold > 0 && amount >= limits.confirmThreshold) {
+                const pct = senderNow.balance > 0 ? Math.round((amount / senderNow.balance) * 100) : 100;
+                const ok = await confirmGift(interaction, {
+                    description: [
+                        `You're about to send **${currency}${amount.toLocaleString()}** to <@${target.id}>.`,
+                        `That is **${pct}%** of your wallet, and it cannot be taken back.`,
+                    ].join('\n'),
                 });
+                if (!ok) return;
             }
 
-            // Atomic deduction: filter enforces balance and daily cap atomically so concurrent
-            // gifts can't race past either check. Reset cap counter if the 24h window expired.
-            const capFilter = capResetAge >= DAY_MS
-                ? {}
-                : { $expr: { $lte: [{ $add: ['$dailyGiftSent', amount] }, DAILY_COIN_CAP] } };
-
-            const capUpdate = capResetAge >= DAY_MS
-                ? { $inc: { balance: -amount }, $set: { dailyGiftSent: amount, dailyGiftReset: new Date() } }
-                : { $inc: { balance: -amount, dailyGiftSent: amount } };
-
+            // Atomic deduction: the filter enforces the balance and the daily cap
+            // in the same write, so concurrent gifts can't race past either.
+            const sendSpend = spendBudget({ ...BUDGETS.coinSend, cap: limits.coinSend, expired: sendState.expired, amount });
             const deducted = await User.findOneAndUpdate(
-                { userId: interaction.user.id, guildId, balance: { $gte: amount }, ...capFilter },
-                capUpdate,
+                { userId: interaction.user.id, guildId, balance: { $gte: amount }, ...sendSpend.filter },
+                {
+                    $inc: { balance: -amount, ...sendSpend.inc },
+                    ...(Object.keys(sendSpend.set).length ? { $set: sendSpend.set } : {}),
+                },
                 { new: true }
             );
             if (!deducted) {
-                return interaction.reply({
-                    content: 'Could not complete the transfer — your balance or daily gift cap may have changed.',
-                    flags: MessageFlags.Ephemeral,
-                });
+                return deny('Could not complete the transfer — your balance or daily gift cap may have changed.');
             }
 
             // Ensure the receiver document exists, then credit with the receive-cap
@@ -263,16 +313,13 @@ module.exports = {
             // would try to insert a duplicate userId+guildId document).
             await User.updateOne({ userId: target.id, guildId }, {}, { upsert: true });
 
-            const rxCapFilter = rxResetAge >= DAY_MS
-                ? {}
-                : { $expr: { $lte: [{ $add: [{ $ifNull: ['$dailyGiftReceived', 0] }, amount] }, DAILY_RECEIVE_CAP] } };
-            const rxCapUpdate = rxResetAge >= DAY_MS
-                ? { $inc: { balance: amount }, $set: { dailyGiftReceived: amount, dailyGiftReceivedReset: new Date() } }
-                : { $inc: { balance: amount, dailyGiftReceived: amount } };
-
+            const rxSpend = spendBudget({ ...BUDGETS.coinReceive, cap: limits.coinReceive, expired: rxState.expired, amount });
             const credited = await User.findOneAndUpdate(
-                { userId: target.id, guildId, ...rxCapFilter },
-                rxCapUpdate,
+                { userId: target.id, guildId, ...rxSpend.filter },
+                {
+                    $inc: { balance: amount, ...rxSpend.inc },
+                    ...(Object.keys(rxSpend.set).length ? { $set: rxSpend.set } : {}),
+                },
                 { new: true }
             );
             if (!credited) {
@@ -280,32 +327,28 @@ module.exports = {
                 try {
                     await User.updateOne(
                         { userId: interaction.user.id, guildId },
-                        { $inc: { balance: amount, dailyGiftSent: -amount } }
+                        { $inc: { balance: amount, ...refundBudget({ ...BUDGETS.coinSend, cap: limits.coinSend, amount }) } }
                     );
                 } catch (rollbackErr) {
                     console.error(`[gift] CRITICAL: sender rollback failed — sender=${interaction.user.id} guild=${guildId} amount=${amount}:`, rollbackErr);
-                    return interaction.reply({
-                        content: 'Something went wrong returning your coins — please contact a server admin.',
-                        flags: MessageFlags.Ephemeral,
-                    });
+                    return deny('Something went wrong returning your coins — please contact a server admin.');
                 }
-                return interaction.reply({
-                    content: `Could not complete the transfer — <@${target.id}> just reached their daily gift-receiving cap. Your coins were returned.`,
-                    flags: MessageFlags.Ephemeral,
-                });
+                return deny(`Could not complete the transfer — <@${target.id}> just reached their daily gift-receiving cap. Your coins were returned.`);
             }
 
             logTransaction({ userId: interaction.user.id, guildId, type: 'gift_send',    amount: -amount, balance: deducted.balance, relatedUserId: target.id, note: 'Coin gift' });
             logTransaction({ userId: target.id,           guildId, type: 'gift_receive', amount,          balance: credited.balance, relatedUserId: interaction.user.id, note: 'Coin gift' });
 
-            const newRemaining = Math.max(0, DAILY_COIN_CAP - (deducted.dailyGiftSent ?? 0));
+            const capLeft = limits.coinSend
+                ? Math.max(0, limits.coinSend - (deducted.dailyGiftSent ?? 0))
+                : Infinity;
 
-            // One message, not two. The gift used to post a "Gift Sent!" embed
-            // and then immediately follow it with a near-identical "You Received
-            // a Gift!" embed, so every gift cost the channel two posts saying the
-            // same thing. The recipient still gets pinged — that is what the
-            // `content` mention is for — and everything either side wanted to
-            // know is in the one embed.
+            // One public message, not two. The gift used to post a "Gift Sent!"
+            // embed and then immediately follow it with a near-identical "You
+            // Received a Gift!", so every gift cost the channel two posts saying
+            // the same thing. The recipient is still pinged; the sender's own
+            // numbers stay in the ephemeral receipt below, where only they need
+            // them.
             const embed = new EmbedBuilder()
                 .setColor(COLORS.PRIZE)
                 .setAuthor({
@@ -315,26 +358,32 @@ module.exports = {
                 .setTitle('🎁 Gift Delivered')
                 .setDescription(`<@${target.id}> received **${currency}${amount.toLocaleString()}** from <@${interaction.user.id}>.`)
                 .setThumbnail(target.displayAvatarURL())
-                .setFooter({ text: `Your wallet: ${currency}${deducted.balance.toLocaleString()} · Daily gift cap left: ${currency}${newRemaining.toLocaleString()}` })
                 .setTimestamp();
 
-            return interaction.reply({ content: `<@${target.id}>`, embeds: [embed] });
+            await interaction.editReply({
+                content: `✅ Sent **${currency}${amount.toLocaleString()}** to **${target.username}**.\n`
+                       + `Wallet: **${currency}${deducted.balance.toLocaleString()}** · `
+                       + `Daily coin gift cap left: **${formatRemaining(capLeft, currency)}**`,
+                embeds: [],
+                components: [],
+            });
+            return interaction.followUp({ content: `<@${target.id}>`, embeds: [embed] });
         }
 
         // ── Gift an item ──────────────────────────────────────────────────────
         const typedItem = interaction.options.getString('item');
         const qty       = interaction.options.getInteger('quantity') ?? 1;
-        const guildId   = interaction.guild.id;
 
         if (!typedItem) {
-            return interaction.reply({ content: 'Specify an `item` when gifting an item — start typing and pick from your inventory.', flags: MessageFlags.Ephemeral });
+            return deny('Specify an `item` when gifting an item — start typing and pick from your inventory.');
         }
 
         // Both documents must exist before the transfer; the sender doc is also
-        // read here for the pre-flight checks below.
-        const [sender] = await Promise.all([
+        // read here for the pre-flight checks below, and the receiver for theirs.
+        const [sender, , receiver] = await Promise.all([
             User.findOneAndUpdate({ userId: interaction.user.id, guildId }, {}, { upsert: true, new: true }),
             User.updateOne({ userId: target.id, guildId }, {}, { upsert: true }),
+            User.findOne({ userId: target.id, guildId }),
         ]);
 
         // Resolve what was typed against the inventory before anything is checked
@@ -352,10 +401,7 @@ module.exports = {
         const heldTotal = owned.reduce((n, i) => n + i.quantity, 0);
 
         if (!owned.length) {
-            return interaction.reply({
-                content: `You don't have **${typedItem}** in your inventory. Start typing in the \`item\` box to pick from what you're holding.`,
-                flags: MessageFlags.Ephemeral,
-            });
+            return deny(`You don't have **${typedItem}** in your inventory. Start typing in the \`item\` box to pick from what you're holding.`);
         }
 
         // Canonical casing, for every DB match and every label from here down.
@@ -369,7 +415,7 @@ module.exports = {
         const label   = `${meta.emoji} **${meta.name}**`;
 
         if (isSoulbound(itemId)) {
-            return interaction.reply({ content: `${label} is soulbound and cannot be gifted.`, flags: MessageFlags.Ephemeral });
+            return deny(`${label} is soulbound and cannot be gifted.`);
         }
 
         if (!slot) {
@@ -377,44 +423,75 @@ module.exports = {
             // one stack the total is the answer, and with several the total is
             // not, because a gift comes out of a single stack.
             const biggest = owned.reduce((n, i) => Math.max(n, i.quantity), 0);
-            return interaction.reply({
-                content: owned.length > 1
-                    ? `You have **${heldTotal}×** ${label}, but no single stack holds ${qty} — the largest holds **${biggest}×**.`
-                    : `You only have **${heldTotal}×** ${label} — not enough to gift ${qty}.`,
-                flags: MessageFlags.Ephemeral,
-            });
+            return deny(owned.length > 1
+                ? `You have **${heldTotal}×** ${label}, but no single stack holds ${qty} — the largest holds **${biggest}×**.`
+                : `You only have **${heldTotal}×** ${label} — not enough to gift ${qty}.`);
         }
 
         // Cannot gift actively equipped effects
         const effectType = resolveEffectType(itemId);
         if (effectType && (sender.activeEffects || []).some(e => e.type === effectType)) {
-            return interaction.reply({
-                content: `You can't gift ${label} while it's active as an effect. Wait for it to expire first.`,
-                flags: MessageFlags.Ephemeral,
+            return deny(`You can't gift ${label} while it's active as an effect. Wait for it to expire first.`);
+        }
+
+        // Items move value, and the coin caps did not see any of it — so "buy the
+        // item, gift the item, sell it on the market" was the coin cap with one
+        // extra step. Valued at what the guild's own shop charges (or the relic
+        // payout, or what the rarity cost to forge).
+        const giftValue    = Math.max(0, meta.value ?? 0) * qty;
+        const sendState    = budgetState(sender,   { ...BUDGETS.itemValueSend,    cap: limits.itemValueSend });
+        const rxValueState = budgetState(receiver, { ...BUDGETS.itemValueReceive, cap: limits.itemValueReceive });
+
+        if (giftValue > sendState.remaining) {
+            return deny(
+                `That's **${currency}${giftValue.toLocaleString()}** of items, and you can still gift `
+                + `**${currency}${sendState.remaining.toLocaleString()}** worth today. `
+                + `${sendState.used > 0 ? 'The window resets 24 hours after your first item gift of the day.' : 'A single item over the cap can never be gifted — ask an admin to raise it.'}`
+            );
+        }
+        if (giftValue > rxValueState.remaining) {
+            return deny(
+                `<@${target.id}> can only receive **${currency}${rxValueState.remaining.toLocaleString()}** more in item value today, `
+                + `and this gift is worth **${currency}${giftValue.toLocaleString()}**.`
+            );
+        }
+
+        // High-value items get the same confirmation coins do. The threshold is
+        // read against the item's worth, not its count, so ten pet foods do not
+        // prompt and one Prestige Accelerator does.
+        if (limits.confirmThreshold > 0 && giftValue >= limits.confirmThreshold) {
+            const ok = await confirmGift(interaction, {
+                description: [
+                    `You're about to send **${qty}× ${meta.emoji} ${meta.name}** to <@${target.id}>.`,
+                    `That's worth about **${currency}${giftValue.toLocaleString()}**, and it cannot be taken back.`,
+                ].join('\n'),
             });
+            if (!ok) return;
         }
 
         // Debit the sender atomically first, then credit the recipient and roll
         // the debit back if the credit fails — the same shape as the coin path
         // above. Saving both documents in parallel would duplicate the item
         // whenever the sender's write lost and the recipient's won.
+        const sendSpend = spendBudget({ ...BUDGETS.itemValueSend, cap: limits.itemValueSend, expired: sendState.expired, amount: giftValue });
         const debited = await User.findOneAndUpdate(
             {
                 userId: interaction.user.id,
                 guildId,
                 inventory: { $elemMatch: { itemId, quantity: { $gte: qty } } },
+                ...sendSpend.filter,
             },
             // Positional `$`, not an arrayFilter: `$[slot]` would decrement
             // every slot carrying this itemId, and duplicate slots are
             // reachable — several writers $push without checking for one.
-            { $inc: { 'inventory.$.quantity': -qty } },
+            {
+                $inc: { 'inventory.$.quantity': -qty, ...sendSpend.inc },
+                ...(Object.keys(sendSpend.set).length ? { $set: sendSpend.set } : {}),
+            },
             { new: true }
         );
         if (!debited) {
-            return interaction.reply({
-                content: `You don't have ${qty}× ${label} in your inventory.`,
-                flags: MessageFlags.Ephemeral,
-            });
+            return deny(`You don't have ${qty}× ${label} in your inventory, or your daily item-gift value would be exceeded.`);
         }
         // Drop the slot once it is empty so inventory listings stay clean. A
         // failure here leaves a zero-quantity slot, which is cosmetic only.
@@ -423,26 +500,27 @@ module.exports = {
             { $pull: { inventory: { itemId, quantity: { $lte: 0 } } } }
         ).catch(() => null);
 
+        const rxSpend = spendBudgetPipeline({ ...BUDGETS.itemValueReceive, cap: limits.itemValueReceive, expired: rxValueState.expired, amount: giftValue });
+
         let credited = null;
         try {
-            credited = await addInventoryItem(target.id, guildId, itemId, qty);
+            credited = await addInventoryItem(target.id, guildId, itemId, qty, {
+                guard:    rxSpend.filter,
+                extraSet: rxSpend.set,
+            });
         } catch (creditErr) {
             console.error(`[gift] item credit failed — recipient=${target.id} guild=${guildId} item=${itemId} qty=${qty}:`, creditErr);
         }
         if (!credited) {
             try {
-                await addInventoryItem(interaction.user.id, guildId, itemId, qty);
+                await addInventoryItem(interaction.user.id, guildId, itemId, qty, {
+                    extraSet: refundBudgetPipeline({ ...BUDGETS.itemValueSend, cap: limits.itemValueSend, amount: giftValue }),
+                });
             } catch (rollbackErr) {
                 console.error(`[gift] CRITICAL: item rollback failed — sender=${interaction.user.id} guild=${guildId} item=${itemId} qty=${qty}:`, rollbackErr);
-                return interaction.reply({
-                    content: 'Something went wrong returning your item — please contact a server admin.',
-                    flags: MessageFlags.Ephemeral,
-                });
+                return deny('Something went wrong returning your item — please contact a server admin.');
             }
-            return interaction.reply({
-                content: 'Could not complete the transfer — your item was returned.',
-                flags: MessageFlags.Ephemeral,
-            });
+            return deny(`Could not complete the transfer — <@${target.id}> may have reached their daily item-gift cap. Your item was returned.`);
         }
 
         logTransaction({ userId: interaction.user.id, guildId, type: 'gift_item_send',    amount: 0, balance: debited.balance,  relatedUserId: target.id,           note: `Gifted ${qty}x ${itemId}` });
@@ -465,14 +543,34 @@ module.exports = {
                 `<@${target.id}> received **${qty}× ${meta.emoji} ${meta.name}** from <@${interaction.user.id}>.`
                 + (meta.lore ? `\n\n> *${meta.lore}*` : '')
             )
-            .setThumbnail(target.displayAvatarURL())
             .setTimestamp();
 
         if (meta.rarity) {
             embed.addFields({ name: 'Rarity', value: `${meta.rarityEmoji} ${meta.rarity}`, inline: true });
         }
-        embed.addFields({ name: 'You have left', value: `${senderLeft}×`, inline: true });
 
-        return interaction.reply({ content: `<@${target.id}>`, embeds: [embed] });
+        // The item's own artwork where the server has uploaded some — /shop
+        // already shows it on a purchase, and a gift is the other moment an item
+        // changes hands. The recipient's avatar keeps the slot otherwise, so the
+        // embed is never left with an empty corner.
+        const art = await getItemImageAttachment(itemId, guildId, { label: meta.name }).catch(() => null);
+        embed.setThumbnail(art ? art.url : target.displayAvatarURL());
+
+        const valueLeft = limits.itemValueSend
+            ? Math.max(0, limits.itemValueSend - (debited.dailyGiftItemValueSent ?? 0))
+            : Infinity;
+
+        await interaction.editReply({
+            content: `✅ Sent **${qty}× ${meta.name}** to **${target.username}**.\n`
+                   + `You have **${senderLeft}×** left · `
+                   + `Daily item gift value left: **${formatRemaining(valueLeft, currency)}**`,
+            embeds: [],
+            components: [],
+        });
+        return interaction.followUp({
+            content: `<@${target.id}>`,
+            embeds: [embed],
+            ...(art ? { files: [art.attachment] } : {}),
+        });
     },
 };

--- a/src/commands/economy/gift.js
+++ b/src/commands/economy/gift.js
@@ -1,9 +1,11 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const User  = require('../../models/User');
 const { getGuildSettings } = require('../../utils/guildSettingsCache');
-const { getItemLore } = require('../../data/defaultShopItems');
 const { logTransaction } = require('../../utils/logTransaction');
 const { grantInventoryItem } = require('../../utils/inventoryGrant');
+const { describeItem } = require('../../utils/itemDisplay');
+const { isSoulbound } = require('../../data/soulboundItems');
+const { resolveEffectType } = require('../../services/effectsService');
 const COLORS = require('../../utils/embedColors');
 
 const DAILY_COIN_CAP = 10_000;
@@ -12,9 +14,7 @@ const DAILY_COIN_CAP = 10_000;
 const DAILY_RECEIVE_CAP = 25_000;
 // Fresh Discord accounts can't send gifts — blocks throwaway-alt funnels.
 const MIN_ACCOUNT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
-
-// Items that cannot be gifted (soulbound — matches market.js)
-const SOULBOUND_ITEMS = new Set(['lifesaver', 'streak_shield']);
+const DAY_MS = 86_400_000;
 
 // Add `qty` of `itemId` to a user's inventory without reading it first. The
 // three-step bump/guarded-push/bump dance this used to spell out is now one
@@ -22,6 +22,58 @@ const SOULBOUND_ITEMS = new Set(['lifesaver', 'streak_shield']);
 // Returns the updated document, or null if the user document does not exist.
 const addInventoryItem = (userId, guildId, itemId, qty) =>
     grantInventoryItem(userId, guildId, itemId, qty);
+
+/**
+ * Load the AiItem rows for whichever of `itemIds` are forged (`ai_`) ids.
+ *
+ * Returns a plain `itemId -> doc` map, `{}` when there is nothing to look up or
+ * the query fails. A missing name is cosmetic — `describeItem` falls back to the
+ * id — so this must never be the reason a gift is refused.
+ */
+async function loadAiItems(itemIds) {
+    const forged = [...new Set(itemIds.filter(id => id.startsWith('ai_')))];
+    if (!forged.length) return {};
+    try {
+        const AiItem = require('../../models/AiItem');
+        const docs = await AiItem.find({ itemId: { $in: forged } }, 'itemId name emoji rarity lore').lean();
+        return Object.fromEntries(docs.map(d => [d.itemId, d]));
+    } catch (err) {
+        console.error('[gift] AiItem lookup failed:', err);
+        return {};
+    }
+}
+
+/**
+ * Every inventory entry the sender is actually allowed to hand over, described
+ * for display.
+ *
+ * The three exclusions are the same ones `execute` enforces, kept together so
+ * the autocomplete list and the command agree: an item offered in the dropdown
+ * and then refused on submit is worse than one that was never offered.
+ */
+function giftableEntries(user, { shopItems = [], aiItems = {} } = {}) {
+    const activeTypes = new Set((user?.activeEffects ?? []).map(e => e.type));
+    return (user?.inventory ?? [])
+        .filter(e => e.quantity > 0)
+        .filter(e => !isSoulbound(e.itemId))
+        .filter(e => {
+            const type = resolveEffectType(e.itemId);
+            return !(type && activeTypes.has(type));
+        })
+        .map(e => ({
+            quantity: e.quantity,
+            ...describeItem(e.itemId, { shopItems, aiItem: aiItems[e.itemId] }),
+        }));
+}
+
+/** `Name (3 held)` → an autocomplete choice, both halves clipped to Discord's 100. */
+function toChoice(item) {
+    const rarity = item.rarity ? ` · ${item.rarityEmoji} ${item.rarity}` : '';
+    return {
+        name: `${item.emoji} ${item.name} — ${item.quantity} held${rarity}`.slice(0, 100),
+        value: item.itemId.slice(0, 100),
+    };
+}
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -45,12 +97,58 @@ module.exports = {
                 .setMinValue(1))
         .addStringOption(o =>
             o.setName('item')
-                .setDescription('Item ID to gift (if gifting an item).')
-                .setAutocomplete(false))
+                // Autocompleted from what you are holding right now — nobody
+                // should have to know that the Pet Slot Expansion is spelled
+                // `pet_slot_expansion`, or retype a relic's name exactly.
+                .setDescription('Item to gift — start typing to pick from your inventory.')
+                .setAutocomplete(true))
         .addIntegerOption(o =>
             o.setName('quantity')
                 .setDescription('How many of the item to gift (default 1).')
                 .setMinValue(1)),
+
+    async autocomplete(interaction) {
+        try {
+            if (interaction.options.getFocused(true)?.name !== 'item') {
+                return interaction.respond([]);
+            }
+            const focused = interaction.options.getFocused()?.toLowerCase() ?? '';
+
+            const [user, guildSettings] = await Promise.all([
+                User.findOne(
+                    { userId: interaction.user.id, guildId: interaction.guild.id },
+                    'inventory activeEffects'
+                ).lean(),
+                getGuildSettings(interaction.guild.id),
+            ]);
+
+            const inventory = (user?.inventory ?? []).filter(e => e.quantity > 0);
+            const aiItems = await loadAiItems(inventory.map(e => e.itemId));
+            const items = giftableEntries(user, { shopItems: guildSettings?.shop ?? [], aiItems });
+
+            // Matched on the display name *and* the raw id: a player who knows
+            // the id can still type it, and one who only knows the label gets
+            // there too.
+            const matches = focused
+                ? items.filter(i => i.name.toLowerCase().includes(focused) || i.itemId.toLowerCase().includes(focused))
+                : items;
+
+            // Prefix matches first, then substring — same ranking /shop buy uses,
+            // so typing "pet" surfaces "Pet Food" ahead of "Carpet".
+            const ranked = focused
+                ? [...matches].sort((a, b) => {
+                    const aPre = a.name.toLowerCase().startsWith(focused) ? 0 : 1;
+                    const bPre = b.name.toLowerCase().startsWith(focused) ? 0 : 1;
+                    return aPre - bPre || a.name.localeCompare(b.name);
+                })
+                : [...matches].sort((a, b) => a.name.localeCompare(b.name));
+
+            await interaction.respond(ranked.slice(0, 25).map(toChoice));
+        } catch (err) {
+            console.error('[gift] autocomplete error:', err);
+            await interaction.respond([]).catch(() => {});
+        }
+    },
 
     async execute(interaction) {
         const guildSettings = await getGuildSettings(interaction.guild.id);
@@ -81,6 +179,20 @@ module.exports = {
             });
         }
 
+        // The two halves of this command each ignore the other's options, and
+        // silently: `/gift type:item amount:500` used to move nothing and say
+        // nothing about the 500. Say so instead of guessing which one was meant.
+        const mismatched = type === 'coins'
+            ? (interaction.options.getString('item')   ? 'item'   : null)
+            : (interaction.options.getInteger('amount') ? 'amount' : null);
+        if (mismatched) {
+            const wanted = type === 'coins' ? 'amount' : 'item';
+            return interaction.reply({
+                content: `You picked **${type}** but filled in \`${mismatched}\`. Use \`${wanted}\` for that, or switch \`type\`.`,
+                flags: MessageFlags.Ephemeral,
+            });
+        }
+
         if (type === 'coins') {
             const amount  = interaction.options.getInteger('amount');
             const guildId = interaction.guild.id;
@@ -101,7 +213,7 @@ module.exports = {
             const capResetAge = senderNow.dailyGiftReset
                 ? Date.now() - new Date(senderNow.dailyGiftReset).getTime()
                 : Infinity;
-            const currentSent = capResetAge >= 86_400_000 ? 0 : (senderNow.dailyGiftSent ?? 0);
+            const currentSent = capResetAge >= DAY_MS ? 0 : (senderNow.dailyGiftSent ?? 0);
             const remaining   = DAILY_COIN_CAP - currentSent;
 
             if (amount > remaining) {
@@ -116,7 +228,7 @@ module.exports = {
             const rxResetAge   = receiverNow?.dailyGiftReceivedReset
                 ? Date.now() - new Date(receiverNow.dailyGiftReceivedReset).getTime()
                 : Infinity;
-            const currentReceived = rxResetAge >= 86_400_000 ? 0 : (receiverNow?.dailyGiftReceived ?? 0);
+            const currentReceived = rxResetAge >= DAY_MS ? 0 : (receiverNow?.dailyGiftReceived ?? 0);
             if (currentReceived + amount > DAILY_RECEIVE_CAP) {
                 return interaction.reply({
                     content: `<@${target.id}> has reached their daily gift-receiving cap. They can receive up to **${currency}${Math.max(0, DAILY_RECEIVE_CAP - currentReceived).toLocaleString()}** more today.`,
@@ -126,11 +238,11 @@ module.exports = {
 
             // Atomic deduction: filter enforces balance and daily cap atomically so concurrent
             // gifts can't race past either check. Reset cap counter if the 24h window expired.
-            const capFilter = capResetAge >= 86_400_000
+            const capFilter = capResetAge >= DAY_MS
                 ? {}
                 : { $expr: { $lte: [{ $add: ['$dailyGiftSent', amount] }, DAILY_COIN_CAP] } };
 
-            const capUpdate = capResetAge >= 86_400_000
+            const capUpdate = capResetAge >= DAY_MS
                 ? { $inc: { balance: -amount }, $set: { dailyGiftSent: amount, dailyGiftReset: new Date() } }
                 : { $inc: { balance: -amount, dailyGiftSent: amount } };
 
@@ -151,10 +263,10 @@ module.exports = {
             // would try to insert a duplicate userId+guildId document).
             await User.updateOne({ userId: target.id, guildId }, {}, { upsert: true });
 
-            const rxCapFilter = rxResetAge >= 86_400_000
+            const rxCapFilter = rxResetAge >= DAY_MS
                 ? {}
                 : { $expr: { $lte: [{ $add: [{ $ifNull: ['$dailyGiftReceived', 0] }, amount] }, DAILY_RECEIVE_CAP] } };
-            const rxCapUpdate = rxResetAge >= 86_400_000
+            const rxCapUpdate = rxResetAge >= DAY_MS
                 ? { $inc: { balance: amount }, $set: { dailyGiftReceived: amount, dailyGiftReceivedReset: new Date() } }
                 : { $inc: { balance: amount, dailyGiftReceived: amount } };
 
@@ -186,140 +298,181 @@ module.exports = {
             logTransaction({ userId: interaction.user.id, guildId, type: 'gift_send',    amount: -amount, balance: deducted.balance, relatedUserId: target.id, note: 'Coin gift' });
             logTransaction({ userId: target.id,           guildId, type: 'gift_receive', amount,          balance: credited.balance, relatedUserId: interaction.user.id, note: 'Coin gift' });
 
-            const newRemaining = DAILY_COIN_CAP - (deducted.dailyGiftSent ?? 0);
+            const newRemaining = Math.max(0, DAILY_COIN_CAP - (deducted.dailyGiftSent ?? 0));
 
+            // One message, not two. The gift used to post a "Gift Sent!" embed
+            // and then immediately follow it with a near-identical "You Received
+            // a Gift!" embed, so every gift cost the channel two posts saying the
+            // same thing. The recipient still gets pinged — that is what the
+            // `content` mention is for — and everything either side wanted to
+            // know is in the one embed.
             const embed = new EmbedBuilder()
-                .setColor('#f1c40f')
-                .setTitle('🎁 Gift Sent!')
-                .setDescription(`**${interaction.user.username}** gifted **${currency}${amount.toLocaleString()}** to <@${target.id}>!`)
-                .addFields(
-                    { name: 'Your Wallet',         value: `${currency}${deducted.balance.toLocaleString()}`, inline: true },
-                    { name: 'Daily Cap Remaining', value: `${currency}${Math.max(0, newRemaining).toLocaleString()}`, inline: true },
-                )
+                .setColor(COLORS.PRIZE)
+                .setAuthor({
+                    name: `${interaction.user.username} → ${target.username}`,
+                    iconURL: interaction.user.displayAvatarURL(),
+                })
+                .setTitle('🎁 Gift Delivered')
+                .setDescription(`<@${target.id}> received **${currency}${amount.toLocaleString()}** from <@${interaction.user.id}>.`)
+                .setThumbnail(target.displayAvatarURL())
+                .setFooter({ text: `Your wallet: ${currency}${deducted.balance.toLocaleString()} · Daily gift cap left: ${currency}${newRemaining.toLocaleString()}` })
                 .setTimestamp();
 
-            const recipientEmbed = new EmbedBuilder()
-                .setColor(COLORS.SUCCESS)
-                .setTitle('🎁 You Received a Gift!')
-                .setDescription(`**${interaction.user.username}** sent you **${currency}${amount.toLocaleString()}**!`)
-                .setTimestamp();
-
-            await interaction.reply({ embeds: [embed] });
-            await interaction.followUp({ embeds: [recipientEmbed], content: `<@${target.id}>` });
-
-        } else {
-            // Gift item
-            const itemId = interaction.options.getString('item');
-            const qty    = interaction.options.getInteger('quantity') ?? 1;
-
-            if (!itemId) {
-                return interaction.reply({ content: 'Specify an `item` ID when gifting an item.', flags: MessageFlags.Ephemeral });
-            }
-
-            if (SOULBOUND_ITEMS.has(itemId)) {
-                return interaction.reply({ content: `\`${itemId}\` is soulbound and cannot be gifted.`, flags: MessageFlags.Ephemeral });
-            }
-
-            // Both documents must exist before the transfer; the sender doc is also
-            // read here for the pre-flight checks below.
-            const [sender] = await Promise.all([
-                User.findOneAndUpdate({ userId: interaction.user.id, guildId: interaction.guild.id }, {}, { upsert: true, new: true }),
-                User.updateOne({ userId: target.id, guildId: interaction.guild.id }, {}, { upsert: true }),
-            ]);
-
-            // Same predicate as the atomic debit below — `find` on itemId alone
-            // would reject on a small duplicate slot while a later one can cover it.
-            const slot = sender.inventory.find(i => i.itemId === itemId && i.quantity >= qty);
-            if (!slot) {
-                return interaction.reply({
-                    content: `You don't have ${qty}x \`${itemId}\` in your inventory.`,
-                    flags: MessageFlags.Ephemeral,
-                });
-            }
-
-            // Cannot gift actively equipped effects
-            const { resolveEffectType } = require('../../services/effectsService');
-            const effectType = resolveEffectType(itemId);
-            if (effectType && (sender.activeEffects || []).some(e => e.type === effectType)) {
-                return interaction.reply({
-                    content: `You can't gift \`${itemId}\` while it's active as an effect. Deactivate it first.`,
-                    flags: MessageFlags.Ephemeral,
-                });
-            }
-
-            // Debit the sender atomically first, then credit the recipient and roll
-            // the debit back if the credit fails — the same shape as the coin path
-            // above. Saving both documents in parallel would duplicate the item
-            // whenever the sender's write lost and the recipient's won.
-            const debited = await User.findOneAndUpdate(
-                {
-                    userId: interaction.user.id,
-                    guildId: interaction.guild.id,
-                    inventory: { $elemMatch: { itemId, quantity: { $gte: qty } } },
-                },
-                // Positional `$`, not an arrayFilter: `$[slot]` would decrement
-                // every slot carrying this itemId, and duplicate slots are
-                // reachable — several writers $push without checking for one.
-                { $inc: { 'inventory.$.quantity': -qty } },
-                { new: true }
-            );
-            if (!debited) {
-                return interaction.reply({
-                    content: `You don't have ${qty}x \`${itemId}\` in your inventory.`,
-                    flags: MessageFlags.Ephemeral,
-                });
-            }
-            // Drop the slot once it is empty so inventory listings stay clean. A
-            // failure here leaves a zero-quantity slot, which is cosmetic only.
-            await User.updateOne(
-                { userId: interaction.user.id, guildId: interaction.guild.id },
-                { $pull: { inventory: { itemId, quantity: { $lte: 0 } } } }
-            ).catch(() => null);
-
-            let credited = null;
-            try {
-                credited = await addInventoryItem(target.id, interaction.guild.id, itemId, qty);
-            } catch (creditErr) {
-                console.error(`[gift] item credit failed — recipient=${target.id} guild=${interaction.guild.id} item=${itemId} qty=${qty}:`, creditErr);
-            }
-            if (!credited) {
-                try {
-                    await addInventoryItem(interaction.user.id, interaction.guild.id, itemId, qty);
-                } catch (rollbackErr) {
-                    console.error(`[gift] CRITICAL: item rollback failed — sender=${interaction.user.id} guild=${interaction.guild.id} item=${itemId} qty=${qty}:`, rollbackErr);
-                    return interaction.reply({
-                        content: 'Something went wrong returning your item — please contact a server admin.',
-                        flags: MessageFlags.Ephemeral,
-                    });
-                }
-                return interaction.reply({
-                    content: 'Could not complete the transfer — your item was returned.',
-                    flags: MessageFlags.Ephemeral,
-                });
-            }
-
-            logTransaction({ userId: interaction.user.id, guildId: interaction.guild.id, type: 'gift_item_send',    amount: 0, balance: debited.balance,  relatedUserId: target.id,           note: `Gifted ${qty}x ${itemId}` });
-            logTransaction({ userId: target.id,           guildId: interaction.guild.id, type: 'gift_item_receive', amount: 0, balance: credited.balance, relatedUserId: interaction.user.id, note: `Received ${qty}x ${itemId}` });
-
-            const embed = new EmbedBuilder()
-                .setColor('#f1c40f')
-                .setTitle('🎁 Gift Sent!')
-                .setDescription(`**${interaction.user.username}** gifted **${qty}x \`${itemId}\`** to <@${target.id}>!`)
-                .setTimestamp();
-
-            const lore = getItemLore(itemId);
-            const recipientDesc = lore
-                ? `**${interaction.user.username}** sent you **${qty}x \`${itemId}\`**!\n\n> *${lore}*`
-                : `**${interaction.user.username}** sent you **${qty}x \`${itemId}\`**!`;
-
-            const recipientEmbed = new EmbedBuilder()
-                .setColor(COLORS.SUCCESS)
-                .setTitle('🎁 You Received a Gift!')
-                .setDescription(recipientDesc)
-                .setTimestamp();
-
-            await interaction.reply({ embeds: [embed] });
-            await interaction.followUp({ embeds: [recipientEmbed], content: `<@${target.id}>` });
+            return interaction.reply({ content: `<@${target.id}>`, embeds: [embed] });
         }
+
+        // ── Gift an item ──────────────────────────────────────────────────────
+        const typedItem = interaction.options.getString('item');
+        const qty       = interaction.options.getInteger('quantity') ?? 1;
+        const guildId   = interaction.guild.id;
+
+        if (!typedItem) {
+            return interaction.reply({ content: 'Specify an `item` when gifting an item — start typing and pick from your inventory.', flags: MessageFlags.Ephemeral });
+        }
+
+        // Both documents must exist before the transfer; the sender doc is also
+        // read here for the pre-flight checks below.
+        const [sender] = await Promise.all([
+            User.findOneAndUpdate({ userId: interaction.user.id, guildId }, {}, { upsert: true, new: true }),
+            User.updateOne({ userId: target.id, guildId }, {}, { upsert: true }),
+        ]);
+
+        // Resolve what was typed against the inventory before anything is checked
+        // against it. Ids are not uniformly cased — a custom shop item is stored
+        // under its display name and relics under theirs ("The Tenth Owl") — so
+        // an exact `===` refused half of a player's bag unless they matched the
+        // capitalisation exactly. Matching the way /use does also means the
+        // soulbound test below sees the canonical id: `Lifesaver` used to slip
+        // past `SOULBOUND_ITEMS.has()` and only fail later, with the wrong error.
+        const wanted = typedItem.trim().toLowerCase();
+        const owned  = (sender.inventory ?? []).filter(i => i.itemId.toLowerCase() === wanted && i.quantity > 0);
+        // Same predicate as the atomic debit below — a `find` on itemId alone
+        // would reject on a small duplicate slot while a later one can cover it.
+        const slot   = owned.find(i => i.quantity >= qty);
+        const heldTotal = owned.reduce((n, i) => n + i.quantity, 0);
+
+        if (!owned.length) {
+            return interaction.reply({
+                content: `You don't have **${typedItem}** in your inventory. Start typing in the \`item\` box to pick from what you're holding.`,
+                flags: MessageFlags.Ephemeral,
+            });
+        }
+
+        // Canonical casing, for every DB match and every label from here down.
+        // Taken from the stack that will actually be debited, not merely the
+        // first match: two stacks of one item can be stored under different
+        // casings, and an id read off a stack too small to cover the gift would
+        // not match the stack the `$elemMatch` below settles on.
+        const itemId  = (slot ?? owned[0]).itemId;
+        const aiItems = await loadAiItems([itemId]);
+        const meta    = describeItem(itemId, { shopItems: guildSettings?.shop ?? [], aiItem: aiItems[itemId] });
+        const label   = `${meta.emoji} **${meta.name}**`;
+
+        if (isSoulbound(itemId)) {
+            return interaction.reply({ content: `${label} is soulbound and cannot be gifted.`, flags: MessageFlags.Ephemeral });
+        }
+
+        if (!slot) {
+            // Both halves of this are true statements about the same bag: with
+            // one stack the total is the answer, and with several the total is
+            // not, because a gift comes out of a single stack.
+            const biggest = owned.reduce((n, i) => Math.max(n, i.quantity), 0);
+            return interaction.reply({
+                content: owned.length > 1
+                    ? `You have **${heldTotal}×** ${label}, but no single stack holds ${qty} — the largest holds **${biggest}×**.`
+                    : `You only have **${heldTotal}×** ${label} — not enough to gift ${qty}.`,
+                flags: MessageFlags.Ephemeral,
+            });
+        }
+
+        // Cannot gift actively equipped effects
+        const effectType = resolveEffectType(itemId);
+        if (effectType && (sender.activeEffects || []).some(e => e.type === effectType)) {
+            return interaction.reply({
+                content: `You can't gift ${label} while it's active as an effect. Wait for it to expire first.`,
+                flags: MessageFlags.Ephemeral,
+            });
+        }
+
+        // Debit the sender atomically first, then credit the recipient and roll
+        // the debit back if the credit fails — the same shape as the coin path
+        // above. Saving both documents in parallel would duplicate the item
+        // whenever the sender's write lost and the recipient's won.
+        const debited = await User.findOneAndUpdate(
+            {
+                userId: interaction.user.id,
+                guildId,
+                inventory: { $elemMatch: { itemId, quantity: { $gte: qty } } },
+            },
+            // Positional `$`, not an arrayFilter: `$[slot]` would decrement
+            // every slot carrying this itemId, and duplicate slots are
+            // reachable — several writers $push without checking for one.
+            { $inc: { 'inventory.$.quantity': -qty } },
+            { new: true }
+        );
+        if (!debited) {
+            return interaction.reply({
+                content: `You don't have ${qty}× ${label} in your inventory.`,
+                flags: MessageFlags.Ephemeral,
+            });
+        }
+        // Drop the slot once it is empty so inventory listings stay clean. A
+        // failure here leaves a zero-quantity slot, which is cosmetic only.
+        await User.updateOne(
+            { userId: interaction.user.id, guildId },
+            { $pull: { inventory: { itemId, quantity: { $lte: 0 } } } }
+        ).catch(() => null);
+
+        let credited = null;
+        try {
+            credited = await addInventoryItem(target.id, guildId, itemId, qty);
+        } catch (creditErr) {
+            console.error(`[gift] item credit failed — recipient=${target.id} guild=${guildId} item=${itemId} qty=${qty}:`, creditErr);
+        }
+        if (!credited) {
+            try {
+                await addInventoryItem(interaction.user.id, guildId, itemId, qty);
+            } catch (rollbackErr) {
+                console.error(`[gift] CRITICAL: item rollback failed — sender=${interaction.user.id} guild=${guildId} item=${itemId} qty=${qty}:`, rollbackErr);
+                return interaction.reply({
+                    content: 'Something went wrong returning your item — please contact a server admin.',
+                    flags: MessageFlags.Ephemeral,
+                });
+            }
+            return interaction.reply({
+                content: 'Could not complete the transfer — your item was returned.',
+                flags: MessageFlags.Ephemeral,
+            });
+        }
+
+        logTransaction({ userId: interaction.user.id, guildId, type: 'gift_item_send',    amount: 0, balance: debited.balance,  relatedUserId: target.id,           note: `Gifted ${qty}x ${itemId}` });
+        logTransaction({ userId: target.id,           guildId, type: 'gift_item_receive', amount: 0, balance: credited.balance, relatedUserId: interaction.user.id, note: `Received ${qty}x ${itemId}` });
+
+        const senderLeft = (debited.inventory ?? [])
+            .filter(i => i.itemId === itemId)
+            .reduce((n, i) => n + Math.max(0, i.quantity), 0);
+
+        const embed = new EmbedBuilder()
+            // Coloured by what was sent, so a Mythic hand-me-down doesn't look
+            // like a stack of pet food.
+            .setColor(meta.color ?? COLORS.PRIZE)
+            .setAuthor({
+                name: `${interaction.user.username} → ${target.username}`,
+                iconURL: interaction.user.displayAvatarURL(),
+            })
+            .setTitle('🎁 Gift Delivered')
+            .setDescription(
+                `<@${target.id}> received **${qty}× ${meta.emoji} ${meta.name}** from <@${interaction.user.id}>.`
+                + (meta.lore ? `\n\n> *${meta.lore}*` : '')
+            )
+            .setThumbnail(target.displayAvatarURL())
+            .setTimestamp();
+
+        if (meta.rarity) {
+            embed.addFields({ name: 'Rarity', value: `${meta.rarityEmoji} ${meta.rarity}`, inline: true });
+        }
+        embed.addFields({ name: 'You have left', value: `${senderLeft}×`, inline: true });
+
+        return interaction.reply({ content: `<@${target.id}>`, embeds: [embed] });
     },
 };

--- a/src/commands/economy/market.js
+++ b/src/commands/economy/market.js
@@ -15,6 +15,7 @@ const COLORS = require('../../utils/embedColors');
 const { ownedBy } = require('../../utils/collectorOwner');
 const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { isSoulbound } = require('../../data/soulboundItems');
+const { describeItem } = require('../../utils/itemDisplay');
 
 const ITEM_META = Object.fromEntries(DEFAULT_SHOP_ITEMS.map(i => [i.itemId, i]));
 
@@ -42,7 +43,10 @@ module.exports = {
             sub.setName('list')
                 .setDescription('List an item for sale.')
                 .addStringOption(o =>
-                    o.setName('item').setDescription('Item ID to sell.').setRequired(true))
+                    o.setName('item')
+                        .setDescription('Item to sell — start typing to pick from your inventory.')
+                        .setRequired(true)
+                        .setAutocomplete(true))
                 .addIntegerOption(o =>
                     o.setName('quantity').setDescription('How many to sell.').setRequired(true).setMinValue(1))
                 .addIntegerOption(o =>
@@ -51,17 +55,52 @@ module.exports = {
             sub.setName('browse')
                 .setDescription('Browse active listings.')
                 .addStringOption(o =>
-                    o.setName('item').setDescription('Filter by item ID (optional).').setRequired(false)))
+                    o.setName('item')
+                        .setDescription('Filter by item — start typing to pick one that is actually listed.')
+                        .setRequired(false)
+                        .setAutocomplete(true)))
         .addSubcommand(sub =>
             sub.setName('buy')
                 .setDescription('Buy a listing by its ID.')
                 .addStringOption(o =>
-                    o.setName('listing_id').setDescription('Listing ID from /market browse.').setRequired(true)))
+                    o.setName('listing_id')
+                        .setDescription('Listing to buy — start typing to pick one.')
+                        .setRequired(true)
+                        .setAutocomplete(true)))
         .addSubcommand(sub =>
             sub.setName('cancel')
                 .setDescription('Cancel one of your active listings and get your item back.')
                 .addStringOption(o =>
-                    o.setName('listing_id').setDescription('Listing ID to cancel.').setRequired(true))),
+                    o.setName('listing_id')
+                        .setDescription('Which of your listings to cancel — start typing to pick one.')
+                        .setRequired(true)
+                        .setAutocomplete(true))),
+
+    /**
+     * Every option on this command was an id typed from memory.
+     *
+     * `item` is the worse half of that: inventory ids are not uniformly cased —
+     * a relic is stored under its prose name and a custom shop item under its
+     * display name, because shop.js stores an item as `itemId || name` — so
+     * `/market list item:The Tenth Owl` was a spelling test, and the handler's
+     * `.toLowerCase()` meant a relic could not be listed at all. `listing_id` is
+     * a 24-character hex string that had to be copied out of `/market browse`.
+     */
+    async autocomplete(interaction) {
+        try {
+            const sub     = interaction.options.getSubcommand();
+            const focused = interaction.options.getFocused(true);
+            const typed   = (focused?.value ?? '').toLowerCase();
+
+            if (focused?.name === 'item' && sub === 'list')   return interaction.respond(await inventoryChoices(interaction, typed));
+            if (focused?.name === 'item' && sub === 'browse') return interaction.respond(await listedItemChoices(interaction, typed));
+            if (focused?.name === 'listing_id')               return interaction.respond(await listingChoices(interaction, typed, sub));
+            return interaction.respond([]);
+        } catch (err) {
+            console.error('[market] autocomplete error:', err);
+            await interaction.respond([]).catch(() => {});
+        }
+    },
 
     async execute(interaction) {
         const guildSettings = await getGuildSettings(interaction.guild.id);
@@ -79,14 +118,86 @@ module.exports = {
     },
 };
 
-async function handleList(interaction, currency) {
-    const itemId = interaction.options.getString('item').toLowerCase();
-    const qty    = interaction.options.getInteger('quantity');
-    const price  = interaction.options.getInteger('price');
+/** Prefix matches first, then substring, then alphabetical — as /shop buy ranks. */
+function rankByName(items, typed) {
+    if (!typed) return [...items].sort((a, b) => a.name.localeCompare(b.name));
+    return [...items].sort((a, b) => {
+        const aPre = a.name.toLowerCase().startsWith(typed) ? 0 : 1;
+        const bPre = b.name.toLowerCase().startsWith(typed) ? 0 : 1;
+        return aPre - bPre || a.name.localeCompare(b.name);
+    });
+}
 
-    if (isSoulbound(itemId)) {
-        return interaction.reply({ content: `\`${itemId}\` is soulbound and cannot be listed.`, flags: MessageFlags.Ephemeral });
-    }
+/** What the seller is holding and is allowed to list, for `/market list`. */
+async function inventoryChoices(interaction, typed) {
+    const [seller, guildSettings] = await Promise.all([
+        User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id }, 'inventory').lean(),
+        getGuildSettings(interaction.guild.id),
+    ]);
+    const shopItems = guildSettings?.shop ?? [];
+
+    const items = (seller?.inventory ?? [])
+        .filter(e => e.quantity > 0 && !isSoulbound(e.itemId))
+        .map(e => ({ quantity: e.quantity, ...describeItem(e.itemId, { shopItems }) }))
+        .filter(i => !typed || i.name.toLowerCase().includes(typed) || i.itemId.toLowerCase().includes(typed));
+
+    return rankByName(items, typed).slice(0, 25).map(i => ({
+        name: `${i.emoji} ${i.name} — ${i.quantity} held`.slice(0, 100),
+        value: i.itemId.slice(0, 100),
+    }));
+}
+
+/** The items that actually have listings, for the `/market browse` filter. */
+async function listedItemChoices(interaction, typed) {
+    const [itemIds, guildSettings] = await Promise.all([
+        MarketListing.distinct('itemId', { guildId: interaction.guild.id }),
+        getGuildSettings(interaction.guild.id),
+    ]);
+    const shopItems = guildSettings?.shop ?? [];
+
+    const items = itemIds
+        .map(id => describeItem(id, { shopItems }))
+        .filter(i => !typed || i.name.toLowerCase().includes(typed) || i.itemId.toLowerCase().includes(typed));
+
+    return rankByName(items, typed).slice(0, 25).map(i => ({
+        name: `${i.emoji} ${i.name}`.slice(0, 100),
+        value: i.itemId.slice(0, 100),
+    }));
+}
+
+/**
+ * Listings addressable by the caller: their own for `cancel`, everyone else's
+ * for `buy` — the same split the handlers enforce, so the picker never offers a
+ * listing that would be refused on submit.
+ */
+async function listingChoices(interaction, typed, sub) {
+    const query = sub === 'cancel'
+        ? { guildId: interaction.guild.id, sellerId: interaction.user.id }
+        : { guildId: interaction.guild.id, sellerId: { $ne: interaction.user.id } };
+
+    const [listings, guildSettings] = await Promise.all([
+        MarketListing.find(query).sort({ pricePerUnit: 1 }).limit(100).lean(),
+        getGuildSettings(interaction.guild.id),
+    ]);
+    const shopItems = guildSettings?.shop ?? [];
+    const currency  = guildSettings?.economy?.currency ?? '';
+
+    return listings
+        .map(l => ({ listing: l, ...describeItem(l.itemId, { shopItems }) }))
+        .filter(i => !typed
+            || i.name.toLowerCase().includes(typed)
+            || String(i.listing._id).toLowerCase().startsWith(typed))
+        .slice(0, 25)
+        .map(i => ({
+            name: `${i.emoji} ${i.listing.quantity}× ${i.name} — ${currency}${(i.listing.pricePerUnit * i.listing.quantity).toLocaleString()} total`.slice(0, 100),
+            value: String(i.listing._id).slice(0, 100),
+        }));
+}
+
+async function handleList(interaction, currency) {
+    const typedItem = interaction.options.getString('item');
+    const qty       = interaction.options.getInteger('quantity');
+    const price     = interaction.options.getInteger('price');
 
     const seller = await User.findOneAndUpdate(
         { userId: interaction.user.id, guildId: interaction.guild.id },
@@ -94,11 +205,42 @@ async function handleList(interaction, currency) {
         { upsert: true, new: true }
     );
 
+    // Resolve what was typed against the seller's own bag, case-insensitively.
+    //
+    // This used to be `getString('item').toLowerCase()` compared with `===`
+    // against the stored id, which is only ever right for the snake_cased shop
+    // items. Relics are stored under their prose name ("The Tenth Owl") and a
+    // custom guild item under whatever an admin called it, since shop.js stores
+    // an item as `itemId || name` — so neither could be listed at all, whatever
+    // the seller typed. Same resolution /gift and /use do.
+    //
     // `stack`, not `slot`: a slot in this file is one of the seller's five
     // listing slots now, and this is the inventory stack being sold out of.
-    const stack = seller.inventory.find(i => i.itemId === itemId);
-    if (!stack || stack.quantity < qty) {
-        return interaction.reply({ content: `You don't have ${qty}x \`${itemId}\` in your inventory.`, flags: MessageFlags.Ephemeral });
+    const wanted = typedItem.trim().toLowerCase();
+    const owned  = (seller.inventory ?? []).filter(i => i.itemId.toLowerCase() === wanted && i.quantity > 0);
+    // The same predicate as the atomic debit below: a duplicate stack too small
+    // to cover the sale must not reject one that can.
+    const stack  = owned.find(i => i.quantity >= qty);
+
+    if (!owned.length) {
+        return interaction.reply({
+            content: `You don't have **${typedItem}** in your inventory. Start typing in the \`item\` box to pick from what you're holding.`,
+            flags: MessageFlags.Ephemeral,
+        });
+    }
+
+    // Canonical casing, for every database match and every label from here down
+    // — including the soulbound test, which on the raw string let `Lifesaver`
+    // past and refused it several lines later with the wrong reason.
+    const itemId = (stack ?? owned[0]).itemId;
+
+    if (isSoulbound(itemId)) {
+        return interaction.reply({ content: `\`${itemId}\` is soulbound and cannot be listed.`, flags: MessageFlags.Ephemeral });
+    }
+
+    if (!stack) {
+        const held = owned.reduce((n, i) => n + i.quantity, 0);
+        return interaction.reply({ content: `You don't have ${qty}x \`${itemId}\` in your inventory — you hold ${held}.`, flags: MessageFlags.Ephemeral });
     }
 
     // The friendly refusal, before any stock moves: a seller who is already full
@@ -315,10 +457,14 @@ function formatLine(l, currency, repMap, tagMap) {
 }
 
 async function handleBrowse(interaction, currency) {
-    const filterItem = interaction.options.getString('item')?.toLowerCase() ?? null;
+    const filterItem = interaction.options.getString('item')?.trim() || null;
 
     const query = { guildId: interaction.guild.id };
-    if (filterItem) query.itemId = filterItem;
+    // Anchored and case-insensitive rather than an equality on the lowercased
+    // string: a listed relic's itemId is "The Tenth Owl", so the old filter
+    // matched nothing for exactly the items hardest to type. Escaped because the
+    // value is whatever the member sent, and a stray `(` would otherwise throw.
+    if (filterItem) query.itemId = new RegExp(`^${filterItem.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'i');
 
     const total = await MarketListing.countDocuments(query);
     if (total === 0) {

--- a/src/commands/economy/market.js
+++ b/src/commands/economy/market.js
@@ -14,6 +14,7 @@ const { recordOwedPayout } = require('../../utils/owedPayout');
 const COLORS = require('../../utils/embedColors');
 const { ownedBy } = require('../../utils/collectorOwner');
 const { getGuildSettings } = require('../../utils/guildSettingsCache');
+const { isSoulbound } = require('../../data/soulboundItems');
 
 const ITEM_META = Object.fromEntries(DEFAULT_SHOP_ITEMS.map(i => [i.itemId, i]));
 
@@ -27,8 +28,6 @@ const MARKET_FEE_RATE       = 0.05;
 const MIN_PRICE_PER_ITEM    = 10;
 const PAGE_SIZE             = 10;
 const CONFIRM_BUY_THRESHOLD = 500;
-
-const SOULBOUND_ITEMS = new Set(['lifesaver', 'streak_shield']);
 
 const SORT_RARITY = 'rarity';
 const SORT_PRICE  = 'price';
@@ -85,7 +84,7 @@ async function handleList(interaction, currency) {
     const qty    = interaction.options.getInteger('quantity');
     const price  = interaction.options.getInteger('price');
 
-    if (SOULBOUND_ITEMS.has(itemId)) {
+    if (isSoulbound(itemId)) {
         return interaction.reply({ content: `\`${itemId}\` is soulbound and cannot be listed.`, flags: MessageFlags.Ephemeral });
     }
 

--- a/src/dashboard/public/settings-payload.js
+++ b/src/dashboard/public/settings-payload.js
@@ -135,6 +135,14 @@ function buildSettingsPayload(section, ctx = {}) {
             'economy.quizEnabled': document.getElementById('economy-quiz-enabled').checked,
             'economy.jobsEnabled': document.getElementById('economy-jobs-enabled').checked,
             'economy.announcementChannelId': document.getElementById('economy-announcement-channel').value || null,
+            // Gifting limits. `safeInt` keeps a blank or unparseable box on the
+            // schema default rather than on 0, which here would mean "no limit"
+            // and quietly remove the anti-funnel cap.
+            'economy.giftCoinCapDaily': safeInt('economy-gift-coin-cap', 10000),
+            'economy.giftCoinReceiveCapDaily': safeInt('economy-gift-coin-receive-cap', 25000),
+            'economy.giftItemValueCapDaily': safeInt('economy-gift-item-cap', 250000),
+            'economy.giftItemValueReceiveCapDaily': safeInt('economy-gift-item-receive-cap', 500000),
+            'economy.giftConfirmThreshold': safeInt('economy-gift-confirm', 5000),
             shop: storeItems,
             jobs: jobsList,
             jobTiers: jobTiersList

--- a/src/dashboard/public/styles.css
+++ b/src/dashboard/public/styles.css
@@ -616,6 +616,12 @@ body {
 .field { margin-bottom: 1.4rem; }
 .field .field-label { display: block; font-weight: 600; font-size: 0.88rem; margin-bottom: 0.5rem; color: var(--text); }
 .field small { display: block; margin-top: 0.4rem; color: var(--text-mute); font-size: 0.8rem; }
+/* Two inputs that belong together on one row. Was retyped as an inline
+   `style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem"` at each use;
+   inline styles are what keep `style-src 'unsafe-inline'` in the CSP, and
+   tests/dashboardInlineAttributes.test.js only lets their number fall. */
+.field-pair { display: grid; grid-template-columns: 1fr 1fr; gap: .75rem; }
+@media (max-width: 620px) { .field-pair { grid-template-columns: 1fr; } }
 
 input[type="text"],
 input[type="number"],
@@ -826,6 +832,9 @@ textarea { resize: vertical; min-height: 80px; }
     border-bottom: 1px solid var(--border);
 }
 .eco-section-head .toggle { margin: 0; flex: 1; }
+/* A section head that opens a new group below an existing one. */
+.eco-section-head.eco-section-gap { margin-top: 1.5rem; }
+.eco-section-head .eco-section-title { flex: 1; }
 .store-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));

--- a/src/dashboard/views/partials/panels/economy.ejs
+++ b/src/dashboard/views/partials/panels/economy.ejs
@@ -30,7 +30,7 @@
                             <label class="field-label" for="economy-daily">Daily reward amount</label>
                             <input type="number" id="economy-daily" value="<%= settings.economy.dailyAmount %>" min="0">
                         </div>
-                        <div class="field" style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;">
+                        <div class="field field-pair">
                             <div><label class="field-label" for="economy-work-min">Work payout (min)</label><input type="number" id="economy-work-min" value="<%= settings.economy.workMin %>" min="0"></div>
                             <div><label class="field-label" for="economy-work-max">Work payout (max)</label><input type="number" id="economy-work-max" value="<%= settings.economy.workMax %>" min="0"></div>
                         </div>
@@ -38,6 +38,40 @@
                             <label class="field-label" for="economy-announcement-channel">Announcements channel</label>
                             <%- include('../channel-select', { id: 'economy-announcement-channel', placeholder: 'None (no announcements)', selected: settings.economy.announcementChannelId }) %>
                             <small>Channel where shop purchases and economy events are announced</small>
+                        </div>
+
+                        <!-- Gifting -->
+                        <div class="eco-section-head eco-section-gap">
+                            <div class="toggle-text eco-section-title"><strong>Gifting limits</strong><span>How much value one member can hand another per day with /gift. Set any limit to 0 to turn it off.</span></div>
+                        </div>
+                        <div class="field field-pair">
+                            <div>
+                                <label class="field-label" for="economy-gift-coin-cap">Coins sent per day</label>
+                                <input type="number" id="economy-gift-coin-cap" value="<%= settings.economy.giftCoinCapDaily ?? 10000 %>" min="0">
+                                <small>Most one member can gift away in 24 hours</small>
+                            </div>
+                            <div>
+                                <label class="field-label" for="economy-gift-coin-receive-cap">Coins received per day</label>
+                                <input type="number" id="economy-gift-coin-receive-cap" value="<%= settings.economy.giftCoinReceiveCapDaily ?? 25000 %>" min="0">
+                                <small>Caps how much can be funnelled into one account</small>
+                            </div>
+                        </div>
+                        <div class="field field-pair">
+                            <div>
+                                <label class="field-label" for="economy-gift-item-cap">Item value sent per day</label>
+                                <input type="number" id="economy-gift-item-cap" value="<%= settings.economy.giftItemValueCapDaily ?? 250000 %>" min="0">
+                                <small>Valued at your shop prices — stops the coin cap being routed around by gifting items instead</small>
+                            </div>
+                            <div>
+                                <label class="field-label" for="economy-gift-item-receive-cap">Item value received per day</label>
+                                <input type="number" id="economy-gift-item-receive-cap" value="<%= settings.economy.giftItemValueReceiveCapDaily ?? 500000 %>" min="0">
+                                <small>An item worth more than this can never be gifted</small>
+                            </div>
+                        </div>
+                        <div class="field">
+                            <label class="field-label" for="economy-gift-confirm">Confirm gifts at or above</label>
+                            <input type="number" id="economy-gift-confirm" value="<%= settings.economy.giftConfirmThreshold ?? 5000 %>" min="0">
+                            <small>Gifts worth this much ask the sender to confirm first, since a gift cannot be reversed</small>
                         </div>
 
                         <!-- Store -->
@@ -403,7 +437,7 @@
                         </label>
 
                         <div class="panel-head" style="margin-top:1.25rem"><h3>Timing &amp; Limits</h3></div>
-                        <div class="field" style="display:grid;grid-template-columns:1fr 1fr;gap:.75rem;">
+                        <div class="field field-pair">
                             <div>
                                 <label class="field-label" for="heist-cooldown">Cooldown between heists <small>(hours, 1–168)</small></label>
                                 <input type="number" id="heist-cooldown" value="<%= settings.heist?.cooldownHours ?? 6 %>" min="1" max="168">

--- a/src/data/soulboundItems.js
+++ b/src/data/soulboundItems.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * Items that cannot leave the account that earned them.
+ *
+ * Both player-to-player transfer routes — `/gift` and `/market list` — refuse
+ * these, and they used to each carry their own copy of the list. Two copies of
+ * a security rule is one copy too many: an item added to market.js and missed
+ * in gift.js is a hole nobody would notice until it was used.
+ *
+ * `lifesaver` and `streak_shield` are here because both are consumed
+ * automatically by a background check rather than by an explicit `/use`, so a
+ * traded one cannot be distinguished from an earned one after the fact.
+ */
+const SOULBOUND_ITEMS = new Set(['lifesaver', 'streak_shield']);
+
+/**
+ * Case-insensitive membership test.
+ *
+ * The comparison has to be case-insensitive because inventory itemIds are not
+ * uniformly cased: a custom guild shop item is stored under its display name
+ * (`shop.js` falls back to `item.name` when no itemId is set) and relics are
+ * stored under theirs. A bare `SOULBOUND_ITEMS.has(typed)` would let
+ * `Lifesaver` through the check.
+ */
+const isSoulbound = itemId => SOULBOUND_ITEMS.has(String(itemId ?? '').toLowerCase());
+
+module.exports = { SOULBOUND_ITEMS, isSoulbound };

--- a/src/models/Guild.js
+++ b/src/models/Guild.js
@@ -194,6 +194,32 @@ const guildSchema = new Schema({
         duelHouseCut: { type: Number, default: 0.05, min: 0, max: 0.5 },
         betConfirmThreshold: { type: Number, default: 10000, min: 0 },
         casinoMaxBet: { type: Number, default: 0, min: 0 },
+
+        // ── /gift limits ─────────────────────────────────────────────────────
+        // All four were hardcoded constants in commands/economy/gift.js. They
+        // are the anti-funnel budget — how much value one account can hand to
+        // another in a day — and what the right number is depends entirely on
+        // how fast a given server's economy runs, which is exactly the sort of
+        // thing every other economy dial here is already configurable for.
+        //
+        // 0 means unlimited on all four, matching betConfirmThreshold's
+        // convention for "turn this off".
+        giftCoinCapDaily:             { type: Number, default: 10_000,  min: 0 },
+        // Higher than the outgoing cap because several friends can legitimately
+        // gift one person, but low enough to bound a farm of alts.
+        giftCoinReceiveCapDaily:      { type: Number, default: 25_000,  min: 0 },
+        // Items were capped by nothing at all, which made "buy an item, gift the
+        // item, sell it on the market" the coin cap with one extra step. Valued
+        // at the guild's own shop price (or the relic payout / forge cost), so a
+        // server that discounted an item is judged against what it charges.
+        // The default clears every standard and prestige item and stops at the
+        // endgame cosmetics, which are personal trophies rather than presents.
+        giftItemValueCapDaily:        { type: Number, default: 250_000, min: 0 },
+        giftItemValueReceiveCapDaily: { type: Number, default: 500_000, min: 0 },
+        // Coin gifts at or above this ask the sender to confirm first. A gift is
+        // irreversible and there is no undo, which is the same reason
+        // betConfirmThreshold exists for wagers.
+        giftConfirmThreshold:         { type: Number, default: 5_000,   min: 0 },
         announcementChannelId: { type: String, default: null },
         announceRareDrops: { type: Boolean, default: true },
         announceStreakMilestones: { type: Boolean, default: true }

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -336,6 +336,18 @@ const userSchema = new Schema({
     dailyGiftReceived:      { type: Number, default: 0 },
     dailyGiftReceivedReset: { type: Date,   default: null },
 
+    // Gift cap tracking (daily gifted *item* value, in coins, both directions).
+    //
+    // Counted separately from the coin budget rather than folded into it: coins
+    // are printed by the economy and items are bought out of it, so one shared
+    // ceiling would either be too tight to gift a prestige item at all or too
+    // loose to bound coin funneling. Items were previously capped by nothing,
+    // which left the coin cap trivially routed around — buy, gift, sell.
+    dailyGiftItemValueSent:          { type: Number, default: 0 },
+    dailyGiftItemValueReset:         { type: Date,   default: null },
+    dailyGiftItemValueReceived:      { type: Number, default: 0 },
+    dailyGiftItemValueReceivedReset: { type: Date,   default: null },
+
     // Crime syndicate membership
     syndicateId: { type: String, default: null },
 

--- a/src/utils/giftCaps.js
+++ b/src/utils/giftCaps.js
@@ -1,0 +1,200 @@
+'use strict';
+
+/**
+ * The daily budgets `/gift` spends against.
+ *
+ * There are four of them — coins out, coins in, item value out, item value in —
+ * and each is a rolling 24-hour window stored as a counter plus the timestamp it
+ * started. gift.js used to spell every one of those windows out inline: read the
+ * reset date, subtract, branch on whether the window had expired, and build a
+ * different filter and a different update for each branch. Two windows was
+ * already forty lines of near-identical ternaries; four would have been eighty,
+ * and the branch that resets an expired window is exactly where an off-by-one
+ * silently doubles somebody's allowance.
+ *
+ * So the window lives here, once, in two halves:
+ *
+ *   `budgetState`  — what is left right now, for the message shown to the user
+ *                    before anything is written.
+ *   `spendBudget`  — the filter and update fragments that take it, for folding
+ *                    into the same atomic write as the balance change, so the
+ *                    check and the spend cannot be separated by a concurrent
+ *                    gift.
+ *
+ * The pre-flight check is the friendly refusal and the filter is what enforces
+ * the cap; both have to exist, and only the second one is load-bearing.
+ */
+
+const DAY_MS = 86_400_000;
+
+/**
+ * Defaults for every configurable gift limit, used when a guild has no value
+ * stored. These are the constants that used to live at the top of gift.js.
+ */
+const GIFT_LIMIT_DEFAULTS = Object.freeze({
+    coinSend:         10_000,
+    coinReceive:      25_000,
+    itemValueSend:    250_000,
+    itemValueReceive: 500_000,
+    confirmThreshold: 5_000,
+});
+
+/** Guild settings key backing each limit. */
+const LIMIT_KEYS = Object.freeze({
+    coinSend:         'giftCoinCapDaily',
+    coinReceive:      'giftCoinReceiveCapDaily',
+    itemValueSend:    'giftItemValueCapDaily',
+    itemValueReceive: 'giftItemValueReceiveCapDaily',
+    confirmThreshold: 'giftConfirmThreshold',
+});
+
+/**
+ * Resolve all five limits for one guild.
+ *
+ * A stored `0` means "no limit" and has to survive `??` — which it does, and
+ * `||` would not, which is the whole reason this is not a one-liner at each
+ * call site. Anything absent or unparseable falls back to the default rather
+ * than to zero: a corrupt settings document should not quietly remove the
+ * anti-funnel caps.
+ */
+function giftLimits(guildSettings) {
+    const economy = guildSettings?.economy ?? {};
+    const read = name => {
+        const raw = economy[LIMIT_KEYS[name]];
+        const n = Number(raw);
+        return Number.isFinite(n) && n >= 0 ? n : GIFT_LIMIT_DEFAULTS[name];
+    };
+    return {
+        coinSend:         read('coinSend'),
+        coinReceive:      read('coinReceive'),
+        itemValueSend:    read('itemValueSend'),
+        itemValueReceive: read('itemValueReceive'),
+        confirmThreshold: read('confirmThreshold'),
+    };
+}
+
+/**
+ * Where one rolling budget stands on `doc` right now.
+ *
+ * @param {object} doc         the user document (may be null — a user with no
+ *                             document has spent nothing)
+ * @param {object} spec
+ * @param {string} spec.usedField   counter path, e.g. `dailyGiftSent`
+ * @param {string} spec.resetField  window-start path, e.g. `dailyGiftReset`
+ * @param {number} spec.cap         0 for unlimited
+ * @param {number} [spec.now]
+ * @returns {{ expired, used, cap, unlimited, remaining }} `remaining` is
+ *          `Infinity` when the cap is off, so callers can compare against it
+ *          without special-casing.
+ */
+function budgetState(doc, { usedField, resetField, cap, now = Date.now() }) {
+    const startedAt = doc?.[resetField] ? new Date(doc[resetField]).getTime() : null;
+    // A window with no start has never been opened, so it counts as expired and
+    // the first spend opens it.
+    const expired = startedAt === null || Number.isNaN(startedAt) || (now - startedAt) >= DAY_MS;
+    const used = expired ? 0 : Math.max(0, doc?.[usedField] ?? 0);
+    const unlimited = !cap;
+    return {
+        expired,
+        used,
+        cap,
+        unlimited,
+        remaining: unlimited ? Infinity : Math.max(0, cap - used),
+    };
+}
+
+/**
+ * The write fragments that spend `amount` from a budget.
+ *
+ * @returns {{ filter, inc, set }} to be merged into the caller's own query and
+ *          update. `filter` is empty when the window is being opened fresh or
+ *          the cap is off; otherwise it is the `$expr` that makes the update
+ *          match nothing once the cap would be exceeded — which is what stops
+ *          two concurrent gifts from each passing a check the other invalidated.
+ */
+function spendBudget({ usedField, resetField, cap, expired, amount, now = new Date() }) {
+    // Cap off: nothing to enforce and nothing worth counting. The stale counter
+    // left behind is harmless — its window start is old, so re-enabling the cap
+    // finds an expired window and starts from zero.
+    if (!cap) return { filter: {}, inc: {}, set: {} };
+
+    if (expired) {
+        return { filter: {}, inc: {}, set: { [usedField]: amount, [resetField]: now } };
+    }
+
+    return {
+        filter: {
+            $expr: { $lte: [{ $add: [{ $ifNull: [`$${usedField}`, 0] }, amount] }, cap] },
+        },
+        inc: { [usedField]: amount },
+        set: {},
+    };
+}
+
+/**
+ * `spendBudget` for a caller whose update is an aggregation pipeline.
+ *
+ * The recipient's side of an item gift is credited by
+ * `utils/inventoryGrant.grantInventoryItem`, which is a pipeline update — so its
+ * budget has to be written as an aggregation expression rather than a `$inc`,
+ * and returned as `{ filter, set }` for that helper's `guard` and `extraSet`.
+ * Same windows, same arithmetic, different dialect.
+ *
+ * @returns {{ filter, set }} `set` holds aggregation expressions, not operators.
+ */
+function spendBudgetPipeline({ usedField, resetField, cap, expired, amount, now = new Date() }) {
+    if (!cap) return { filter: {}, set: {} };
+
+    if (expired) {
+        return { filter: {}, set: { [usedField]: amount, [resetField]: now } };
+    }
+
+    return {
+        filter: {
+            $expr: { $lte: [{ $add: [{ $ifNull: [`$${usedField}`, 0] }, amount] }, cap] },
+        },
+        set: {
+            [usedField]: { $add: [{ $ifNull: [`$${usedField}`, 0] }, amount] },
+        },
+    };
+}
+
+/**
+ * `refundBudget` in pipeline dialect, for the same reason.
+ *
+ * Clamped at zero rather than trusting the counter: the refund path runs after a
+ * write that may or may not have landed, and a negative counter would hand the
+ * sender back more allowance than they started the day with.
+ */
+function refundBudgetPipeline({ usedField, cap, amount }) {
+    if (!cap) return {};
+    return {
+        [usedField]: {
+            $max: [0, { $subtract: [{ $ifNull: [`$${usedField}`, 0] }, amount] }],
+        },
+    };
+}
+
+/**
+ * Undo a `spendBudget` on the rollback path.
+ *
+ * Always a `$inc` of the negative, whichever branch was taken: a window the
+ * spend opened was `$set` to exactly `amount`, so decrementing it lands on zero
+ * and leaves the (now correct) window start alone.
+ */
+function refundBudget({ usedField, cap, amount }) {
+    if (!cap) return {};
+    return { [usedField]: -amount };
+}
+
+module.exports = {
+    DAY_MS,
+    GIFT_LIMIT_DEFAULTS,
+    LIMIT_KEYS,
+    giftLimits,
+    budgetState,
+    spendBudget,
+    spendBudgetPipeline,
+    refundBudget,
+    refundBudgetPipeline,
+};

--- a/src/utils/itemDisplay.js
+++ b/src/utils/itemDisplay.js
@@ -23,19 +23,40 @@ const { getRelicMeta } = require('../data/exploreData');
 // Matches /shop's rarity swatches so an item wears the same colour wherever it
 // is named.
 const RARITY_EMOJIS = {
-    Common:   '⚪',
-    Uncommon: '🟢',
-    Rare:     '🔵',
-    Epic:     '🟣',
-    Mythic:   '🟠',
+    Common:    '⚪',
+    Uncommon:  '🟢',
+    Rare:      '🔵',
+    Epic:      '🟣',
+    Mythic:    '🟠',
+    // The forge mints a sixth tier above Mythic that the shop has no equivalent
+    // for, so a forged Legendary would otherwise render with no swatch at all.
+    Legendary: '⭐',
 };
 
 const RARITY_HEX = {
-    Common:   '#95a5a6',
-    Uncommon: '#2ecc71',
-    Rare:     '#3498db',
-    Epic:     '#9b59b6',
-    Mythic:   '#e67e22',
+    Common:    '#95a5a6',
+    Uncommon:  '#2ecc71',
+    Rare:      '#3498db',
+    Epic:      '#9b59b6',
+    Mythic:    '#e67e22',
+    Legendary: '#ffd700',
+};
+
+/**
+ * What a forged item is worth.
+ *
+ * There is no price on an AiItem — it was forged, not sold — so its worth is
+ * what it cost to forge, which is the one figure the economy has already
+ * committed to for that rarity. Kept in step with RARITY_CONFIG in
+ * commands/economy/forge.js.
+ */
+const FORGE_COST_BY_RARITY = {
+    Common:    500,
+    Uncommon:  1_000,
+    Rare:      2_500,
+    Epic:      5_000,
+    Mythic:    10_000,
+    Legendary: 25_000,
 };
 
 // Relic rarities are lowercase and only span three tiers; map them onto the
@@ -56,8 +77,11 @@ function leadingEmoji(str) {
  * @param {object} [options]
  * @param {Array}  [options.shopItems] the guild's `shop` array, for custom items
  * @param {object} [options.aiItem]    the AiItem document, for an `ai_` id
- * @returns {{ itemId, name, emoji, rarity, rarityEmoji, color, lore, kind }}
+ * @returns {{ itemId, name, emoji, rarity, rarityEmoji, color, lore, value, kind }}
  *          `name` always falls back to the id, so this never renders empty.
+ *          `value` is the item's worth in coins — the guild's shop price, the
+ *          relic's payout, or what the rarity cost to forge — and is 0 for an
+ *          item nothing in the game puts a number on.
  */
 function describeItem(itemId, { shopItems = [], aiItem = null } = {}) {
     const id = String(itemId ?? '');
@@ -73,6 +97,7 @@ function describeItem(itemId, { shopItems = [], aiItem = null } = {}) {
             rarityEmoji: RARITY_EMOJIS[rarity] ?? '',
             color: RARITY_HEX[rarity],
             lore: relic.lore ?? '',
+            value: relic.value ?? 0,
             kind: 'relic',
         };
     }
@@ -89,6 +114,7 @@ function describeItem(itemId, { shopItems = [], aiItem = null } = {}) {
             rarityEmoji: rarity ? (RARITY_EMOJIS[rarity] ?? '✨') : '',
             color: (rarity && RARITY_HEX[rarity]) ?? '#f1c40f',
             lore: aiItem?.lore ?? '',
+            value: FORGE_COST_BY_RARITY[rarity] ?? FORGE_COST_BY_RARITY.Legendary,
             kind: 'forged',
         };
     }
@@ -120,8 +146,11 @@ function describeItem(itemId, { shopItems = [], aiItem = null } = {}) {
         rarityEmoji: RARITY_EMOJIS[rarity] ?? '',
         color: RARITY_HEX[rarity],
         lore: shopItem?.lore ?? getItemLore(lower) ?? '',
+        // The guild's own price when it has one, so a server that discounted an
+        // item is judged against the price its players actually pay.
+        value: Math.max(0, Number(shopItem?.price) || 0),
         kind: 'shop',
     };
 }
 
-module.exports = { describeItem, RARITY_EMOJIS, RARITY_HEX };
+module.exports = { describeItem, RARITY_EMOJIS, RARITY_HEX, FORGE_COST_BY_RARITY };

--- a/src/utils/itemDisplay.js
+++ b/src/utils/itemDisplay.js
@@ -1,0 +1,127 @@
+'use strict';
+
+/**
+ * One place that turns an inventory `itemId` into something worth showing a
+ * player.
+ *
+ * An inventory entry is only ever an id, and the id is not a label: shop items
+ * are stored snake_cased (`coin_booster_2x`), forged items as an opaque
+ * `ai_<hex>`, relics under their prose name. `/inventory` already resolved all
+ * three inline; anything else that named an item — `/gift` most visibly —
+ * printed the raw id and left the player to work out that `pet_slot_expansion`
+ * was the Pet Slot Expansion they bought.
+ *
+ * Nothing here touches the database: pass in the guild's shop list (which
+ * `getGuildSettings` already has) and, for `ai_` ids, the AiItem document the
+ * caller looked up. That keeps this usable inside an autocomplete handler,
+ * where Discord gives you three seconds and a per-item query is not affordable.
+ */
+
+const { DEFAULT_SHOP_ITEMS, getItemLore, getItemRarity } = require('../data/defaultShopItems');
+const { getRelicMeta } = require('../data/exploreData');
+
+// Matches /shop's rarity swatches so an item wears the same colour wherever it
+// is named.
+const RARITY_EMOJIS = {
+    Common:   '⚪',
+    Uncommon: '🟢',
+    Rare:     '🔵',
+    Epic:     '🟣',
+    Mythic:   '🟠',
+};
+
+const RARITY_HEX = {
+    Common:   '#95a5a6',
+    Uncommon: '#2ecc71',
+    Rare:     '#3498db',
+    Epic:     '#9b59b6',
+    Mythic:   '#e67e22',
+};
+
+// Relic rarities are lowercase and only span three tiers; map them onto the
+// shop's five so one embed doesn't have to know which vocabulary it was handed.
+const RELIC_RARITY_LABELS = { common: 'Common', uncommon: 'Uncommon', rare: 'Rare', epic: 'Epic', legendary: 'Mythic' };
+
+/** The leading emoji of a shop description (`'🔒 Protects…'` → `'🔒'`), if any. */
+function leadingEmoji(str) {
+    if (!str) return '';
+    const m = String(str).match(/^(\p{Emoji_Presentation}|\p{Extended_Pictographic})/u);
+    return m ? m[0] : '';
+}
+
+/**
+ * Describe one inventory item.
+ *
+ * @param {string} itemId    the id as stored in `user.inventory`
+ * @param {object} [options]
+ * @param {Array}  [options.shopItems] the guild's `shop` array, for custom items
+ * @param {object} [options.aiItem]    the AiItem document, for an `ai_` id
+ * @returns {{ itemId, name, emoji, rarity, rarityEmoji, color, lore, kind }}
+ *          `name` always falls back to the id, so this never renders empty.
+ */
+function describeItem(itemId, { shopItems = [], aiItem = null } = {}) {
+    const id = String(itemId ?? '');
+
+    const relic = getRelicMeta(id);
+    if (relic) {
+        const rarity = RELIC_RARITY_LABELS[relic.rarity] ?? 'Rare';
+        return {
+            itemId: id,
+            name: id,
+            emoji: relic.emoji ?? '🏺',
+            rarity,
+            rarityEmoji: RARITY_EMOJIS[rarity] ?? '',
+            color: RARITY_HEX[rarity],
+            lore: relic.lore ?? '',
+            kind: 'relic',
+        };
+    }
+
+    if (id.startsWith('ai_')) {
+        const rarity = aiItem?.rarity ?? null;
+        return {
+            itemId: id,
+            // A forged item whose AiItem document is missing renders as the id
+            // rather than as nothing — the same fallback /inventory uses.
+            name: aiItem?.name ?? id,
+            emoji: aiItem?.emoji ?? '✨',
+            rarity,
+            rarityEmoji: rarity ? (RARITY_EMOJIS[rarity] ?? '✨') : '',
+            color: (rarity && RARITY_HEX[rarity]) ?? '#f1c40f',
+            lore: aiItem?.lore ?? '',
+            kind: 'forged',
+        };
+    }
+
+    // Custom guild items are matched on either field: shop.js stores an item
+    // under `itemId || name`, so an admin-made item can be sitting in the
+    // inventory under its display name.
+    //
+    // The built-in catalogue is the fallback rather than the first lookup: a
+    // guild's own row for a default item carries that guild's price and any
+    // renaming an admin has done, and should win. It is only consulted when the
+    // caller had no shop list to give (a stale cache, or a code path that never
+    // loads guild settings), so a default item still reads as "Pet Food" there
+    // instead of `pet_food`.
+    const lower = id.toLowerCase();
+    const shopItem = shopItems.find(s =>
+        (s.itemId ?? '').toLowerCase() === lower || (s.name ?? '').toLowerCase() === lower)
+        ?? DEFAULT_SHOP_ITEMS.find(s => s.itemId.toLowerCase() === lower || s.name.toLowerCase() === lower);
+
+    const rarity = shopItem
+        ? getItemRarity(shopItem.itemId ?? id, shopItem.price ?? 0)
+        : getItemRarity(id, 0);
+
+    return {
+        itemId: id,
+        name: shopItem?.name ?? id,
+        emoji: leadingEmoji(shopItem?.description) || '🎁',
+        rarity,
+        rarityEmoji: RARITY_EMOJIS[rarity] ?? '',
+        color: RARITY_HEX[rarity],
+        lore: shopItem?.lore ?? getItemLore(lower) ?? '',
+        kind: 'shop',
+    };
+}
+
+module.exports = { describeItem, RARITY_EMOJIS, RARITY_HEX };

--- a/tests/dashboardInlineAttributes.test.js
+++ b/tests/dashboardInlineAttributes.test.js
@@ -41,7 +41,7 @@ const BASELINE = {
     'partials/panels/bibleverses.ejs': [4, 2],
     'partials/panels/birthdays.ejs': [0, 2],
     'partials/panels/commandpolicies.ejs': [21, 11],
-    'partials/panels/economy.ejs': [42, 22],
+    'partials/panels/economy.ejs': [40, 22],
     'partials/panels/eventlog.ejs': [6, 1],
     'partials/panels/exploration.ejs': [5, 1],
     'partials/panels/farewell.ejs': [0, 2],

--- a/tests/economyMarketCommand.test.js
+++ b/tests/economyMarketCommand.test.js
@@ -81,6 +81,10 @@ beforeEach(() => {
     mockListings.reset();
     mockTransactions.reset();
     jest.clearAllMocks();
+    // `/market browse` renders a seller-reputation column from a Transaction
+    // aggregation. Nothing here is about reputation, and the fake collections
+    // do not run pipelines, so it answers empty.
+    mockTransactions.model.aggregate = jest.fn(async () => []);
     // The default: the credit lands. Individual tests make it fail.
     grantInventoryItem.mockImplementation(async (userId, guildId, itemId, quantity) => {
         const doc = mockUsers.get(userId);
@@ -307,6 +311,137 @@ describe('listing an item', () => {
         // The stock is back, so there is nothing owed to write down.
         expect(recordOwedPayout).not.toHaveBeenCalled();
         console.error.mockRestore();
+    });
+});
+
+describe('naming the item', () => {
+    // Inventory ids are not uniformly cased. Relics are stored under their prose
+    // name and a custom guild item under whatever an admin called it, because
+    // shop.js stores an item as `itemId || name`. `handleList` lowercased what
+    // was typed and compared it with `===`, so those items could not be listed
+    // at all, whatever the seller wrote.
+    it('lists a relic despite its capitalisation', async () => {
+        seedGuild();
+        seedUser(BUYER_ID, { inventory: [{ itemId: 'The Tenth Owl', quantity: 1 }] });
+
+        await run({ subcommand: 'list', options: { item: 'the tenth owl', quantity: 1, price: 5000 } });
+
+        expect(mockUsers.get(BUYER_ID).inventory).toEqual([]);
+        expect(await mockListings.model.countDocuments({})).toBe(1);
+    });
+
+    it('stores the canonical id, so the item comes back as itself', async () => {
+        // A listing that recorded the lowercased spelling handed the stock back
+        // into a second stack under a name the player never had.
+        seedGuild();
+        seedUser(BUYER_ID, { inventory: [{ itemId: 'The Tenth Owl', quantity: 1 }] });
+
+        await run({ subcommand: 'list', options: { item: 'THE TENTH OWL', quantity: 1, price: 5000 } });
+
+        const listing = await mockListings.model.findOne({});
+        expect(listing.itemId).toBe('The Tenth Owl');
+    });
+
+    it('refuses a soulbound item however it is typed', async () => {
+        // The check ran on the raw string, so `Lifesaver` missed it and was
+        // refused several lines later as "you don't have it".
+        seedGuild();
+        seedUser(BUYER_ID, { inventory: [{ itemId: 'lifesaver', quantity: 1 }] });
+
+        const interaction = await run({ subcommand: 'list', options: { item: 'LifeSaver', quantity: 1, price: 5000 } });
+
+        expect(repliedText(interaction)).toContain('soulbound');
+        expect(await mockListings.model.countDocuments({})).toBe(0);
+    });
+
+    it('browses for a relic without exact capitalisation', async () => {
+        seedGuild();
+        seedListing({ itemId: 'The Tenth Owl', quantity: 1, pricePerUnit: 5000 });
+
+        const interaction = await run({ subcommand: 'browse', options: { item: 'the tenth owl' } });
+
+        expect(repliedText(interaction)).not.toContain('No listings found');
+    });
+
+    it('a regex metacharacter in the browse filter is matched literally', async () => {
+        seedGuild();
+        seedListing({ itemId: 'lucky_charm' });
+
+        const interaction = await run({ subcommand: 'browse', options: { item: 'lucky_charm)' } });
+
+        expect(repliedText(interaction)).toContain('No listings found');
+    });
+});
+
+describe('the option pickers', () => {
+    const autocomplete = async (subcommand, name, value = '') => {
+        const responses = [];
+        await market.autocomplete({
+            guild: { id: GUILD_ID },
+            user: { id: BUYER_ID },
+            options: {
+                getSubcommand: () => subcommand,
+                getFocused: (withDetail) => (withDetail ? { name, value } : value),
+            },
+            respond: async (choices) => { responses.push(choices); },
+        });
+        return responses[0];
+    };
+
+    it('offers what the seller is holding, by name and count', async () => {
+        seedGuild();
+        seedUser(BUYER_ID, { inventory: [
+            { itemId: 'lucky_charm', quantity: 5 },
+            { itemId: 'lifesaver',   quantity: 1 },   // soulbound
+            { itemId: 'padlock',     quantity: 0 },   // an emptied stack
+        ] });
+
+        const choices = await autocomplete('list', 'item');
+
+        expect(choices.map(c => c.value)).toEqual(['lucky_charm']);
+        expect(choices[0].name).toContain('Lucky Charm');
+        expect(choices[0].name).toContain('5 held');
+    });
+
+    it('offers only items that are actually listed, for browse', async () => {
+        seedGuild();
+        seedListing({ _id: 'l1', itemId: 'lucky_charm' });
+        seedListing({ _id: 'l2', itemId: 'lucky_charm' });
+        seedListing({ _id: 'l3', itemId: 'pet_food' });
+
+        const choices = await autocomplete('browse', 'item');
+
+        expect(choices.map(c => c.value).sort()).toEqual(['lucky_charm', 'pet_food']);
+    });
+
+    it('offers other people listings to buy, and never your own', async () => {
+        // The picker must not offer what handleBuy would refuse on submit.
+        seedGuild();
+        seedListing({ _id: 'theirs', sellerId: SELLER_ID });
+        seedListing({ _id: 'mine',   sellerId: BUYER_ID });
+
+        const choices = await autocomplete('buy', 'listing_id');
+
+        expect(choices.map(c => c.value)).toEqual(['theirs']);
+        expect(choices[0].name).toContain('Lucky Charm');
+    });
+
+    it('offers your own listings to cancel, and only yours', async () => {
+        seedGuild();
+        seedListing({ _id: 'theirs', sellerId: SELLER_ID });
+        seedListing({ _id: 'mine',   sellerId: BUYER_ID });
+
+        const choices = await autocomplete('cancel', 'listing_id');
+
+        expect(choices.map(c => c.value)).toEqual(['mine']);
+    });
+
+    it('an empty response, not a crash, when the lookup fails', async () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        mockListings.model.distinct.mockRejectedValueOnce(new Error('db down'));
+
+        expect(await autocomplete('browse', 'item')).toEqual([]);
+        errorSpy.mockRestore();
     });
 });
 

--- a/tests/giftCaps.test.js
+++ b/tests/giftCaps.test.js
@@ -1,0 +1,146 @@
+'use strict';
+
+// The rolling 24-hour budgets /gift spends against, and the three things that
+// used to be hardcoded: the coin caps, the item-value cap that did not exist at
+// all, and the confirmation a gift never asked for.
+
+const {
+    GIFT_LIMIT_DEFAULTS, giftLimits, budgetState,
+    spendBudget, spendBudgetPipeline, refundBudget, refundBudgetPipeline,
+} = require('../src/utils/giftCaps');
+const { applyPipelineUpdate, evaluate } = require('./helpers/pipelineUpdate');
+
+const WINDOW = { usedField: 'used', resetField: 'reset' };
+
+describe('giftLimits', () => {
+    test('falls back to the defaults when a guild has stored nothing', () => {
+        expect(giftLimits(undefined)).toEqual(GIFT_LIMIT_DEFAULTS);
+        expect(giftLimits({ economy: {} })).toEqual(GIFT_LIMIT_DEFAULTS);
+    });
+
+    test('a stored zero means unlimited and survives the fallback', () => {
+        // `||` would read 0 as "not set" and quietly reinstate the cap the admin
+        // just turned off, which is the whole reason this is not a one-liner.
+        const limits = giftLimits({ economy: { giftCoinCapDaily: 0, giftItemValueCapDaily: 0 } });
+        expect(limits.coinSend).toBe(0);
+        expect(limits.itemValueSend).toBe(0);
+        expect(limits.coinReceive).toBe(GIFT_LIMIT_DEFAULTS.coinReceive);
+    });
+
+    test('a corrupt value falls back to the default rather than to zero', () => {
+        // Zero is "no limit", so parsing junk as zero would silently remove the
+        // anti-funnel cap instead of leaving it in place.
+        const limits = giftLimits({ economy: { giftCoinCapDaily: 'lots', giftCoinReceiveCapDaily: -5 } });
+        expect(limits.coinSend).toBe(GIFT_LIMIT_DEFAULTS.coinSend);
+        expect(limits.coinReceive).toBe(GIFT_LIMIT_DEFAULTS.coinReceive);
+    });
+});
+
+describe('budgetState', () => {
+    const now = Date.UTC(2026, 0, 2, 12);
+
+    test('a window that has never been opened counts as expired', () => {
+        expect(budgetState(null, { ...WINDOW, cap: 100, now })).toMatchObject({ expired: true, used: 0, remaining: 100 });
+        expect(budgetState({ used: 40 }, { ...WINDOW, cap: 100, now })).toMatchObject({ expired: true, used: 0 });
+    });
+
+    test('an open window reports what is left of it', () => {
+        const doc = { used: 40, reset: new Date(now - 3_600_000) };
+        expect(budgetState(doc, { ...WINDOW, cap: 100, now })).toMatchObject({ expired: false, used: 40, remaining: 60 });
+    });
+
+    test('a window older than 24h has expired and starts from zero', () => {
+        const doc = { used: 100, reset: new Date(now - 86_400_001) };
+        expect(budgetState(doc, { ...WINDOW, cap: 100, now })).toMatchObject({ expired: true, used: 0, remaining: 100 });
+    });
+
+    test('an overspent window floors at zero rather than going negative', () => {
+        const doc = { used: 250, reset: new Date(now) };
+        expect(budgetState(doc, { ...WINDOW, cap: 100, now }).remaining).toBe(0);
+    });
+
+    test('cap 0 is unlimited, and remaining compares as such', () => {
+        const state = budgetState({ used: 9_999, reset: new Date(now) }, { ...WINDOW, cap: 0, now });
+        expect(state.unlimited).toBe(true);
+        expect(state.remaining).toBe(Infinity);
+        expect(1e9 > state.remaining).toBe(false);
+    });
+});
+
+describe('spendBudget', () => {
+    test('an expired window is opened by the same write that spends from it', () => {
+        const at = new Date();
+        const { filter, inc, set } = spendBudget({ ...WINDOW, cap: 100, expired: true, amount: 30, now: at });
+        expect(filter).toEqual({});
+        expect(inc).toEqual({});
+        expect(set).toEqual({ used: 30, reset: at });
+    });
+
+    test('an open window carries the cap as a filter, not just a prior check', () => {
+        // The pre-flight check is the friendly message; this expression is what
+        // stops two concurrent gifts from each passing a check the other made
+        // stale.
+        const { filter, inc } = spendBudget({ ...WINDOW, cap: 100, expired: false, amount: 30 });
+        expect(inc).toEqual({ used: 30 });
+        expect(evaluate(filter.$expr, { used: 70 })).toBe(true);   // exactly at the cap
+        expect(evaluate(filter.$expr, { used: 71 })).toBe(false);  // one over
+        expect(evaluate(filter.$expr, {})).toBe(true);             // never spent
+    });
+
+    test('an unlimited budget writes and filters nothing', () => {
+        expect(spendBudget({ ...WINDOW, cap: 0, expired: false, amount: 30 })).toEqual({ filter: {}, inc: {}, set: {} });
+    });
+});
+
+describe('refundBudget', () => {
+    test('a refund undoes a spend on either branch', () => {
+        const doc = { used: 0, reset: null };
+        const spend = spendBudget({ ...WINDOW, cap: 100, expired: true, amount: 30 });
+        Object.assign(doc, spend.set);
+        expect(doc.used).toBe(30);
+
+        const refund = refundBudget({ ...WINDOW, cap: 100, amount: 30 });
+        doc.used += refund.used;
+        expect(doc.used).toBe(0);
+    });
+
+    test('nothing is refunded against a budget that never charged', () => {
+        expect(refundBudget({ ...WINDOW, cap: 0, amount: 30 })).toEqual({});
+    });
+});
+
+describe('the pipeline dialect', () => {
+    // The recipient's side of an item gift is credited by a pipeline update, so
+    // its budget has to be an aggregation expression rather than a $inc. Same
+    // arithmetic, and these check it really is the same.
+    test('spending accumulates onto the existing counter', () => {
+        const doc = { used: 40, reset: new Date() };
+        const { set } = spendBudgetPipeline({ ...WINDOW, cap: 100, expired: false, amount: 25 });
+        applyPipelineUpdate(doc, [{ $set: set }]);
+        expect(doc.used).toBe(65);
+    });
+
+    test('spending on an expired window opens it at the amount', () => {
+        const doc = { used: 999, reset: new Date(0) };
+        const at = new Date();
+        const { set } = spendBudgetPipeline({ ...WINDOW, cap: 100, expired: true, amount: 25, now: at });
+        applyPipelineUpdate(doc, [{ $set: set }]);
+        expect(doc.used).toBe(25);
+        expect(doc.reset).toBe(at);
+    });
+
+    test('the guard rejects a credit that would breach the cap', () => {
+        const { filter } = spendBudgetPipeline({ ...WINDOW, cap: 100, expired: false, amount: 25 });
+        expect(evaluate(filter.$expr, { used: 75 })).toBe(true);
+        expect(evaluate(filter.$expr, { used: 76 })).toBe(false);
+    });
+
+    test('a refund never drives the counter below zero', () => {
+        // The refund runs after a write that may or may not have landed, so a
+        // bare subtraction could hand back more allowance than the day started
+        // with.
+        const doc = { used: 10 };
+        applyPipelineUpdate(doc, [{ $set: refundBudgetPipeline({ ...WINDOW, cap: 100, amount: 25 }) }]);
+        expect(doc.used).toBe(0);
+    });
+});

--- a/tests/giftCommandUx.test.js
+++ b/tests/giftCommandUx.test.js
@@ -33,6 +33,7 @@ jest.mock('../src/models/Guild', () => ({
         shop: [{ itemId: 'pet_food', name: 'Pet Food', price: 250, description: '🍖 Feeds any pet.' }],
     })),
 }));
+jest.mock('../src/models/ItemImage', () => ({ findOne: jest.fn(async () => null) }));
 jest.mock('../src/utils/guildSettingsCache', () => require('./helpers/guildSettingsCacheMock')());
 jest.mock('../src/utils/logTransaction', () => ({ logTransaction: jest.fn() }));
 
@@ -55,8 +56,12 @@ function buildAutocomplete(focusedValue = '') {
     };
 }
 
-function buildExecute({ item = null, type = 'item', quantity = null, amount = null } = {}) {
-    const state = { replies: [] };
+/**
+ * `confirm` decides what the sender does with the confirmation prompt a
+ * high-value gift raises — press Send it, press Cancel, or let it expire.
+ */
+function buildExecute({ item = null, type = 'item', quantity = null, amount = null, confirm = 'confirm' } = {}) {
+    const state = { replies: [], followUps: [], prompted: false };
     return {
         state,
         interaction: {
@@ -79,8 +84,22 @@ function buildExecute({ item = null, type = 'item', quantity = null, amount = nu
                 getString: (name) => (name === 'type' ? type : name === 'item' ? item : null),
                 getInteger: (name) => (name === 'quantity' ? quantity : name === 'amount' ? amount : null),
             },
+            deferReply: jest.fn(async () => {}),
+            editReply: jest.fn(async (p) => {
+                state.replies.push(p);
+                return {
+                    awaitMessageComponent: async () => {
+                        state.prompted = true;
+                        if (confirm === 'timeout') throw new Error('collector ended');
+                        return {
+                            customId: confirm === 'cancel' ? 'gift_cancel' : 'gift_confirm',
+                            update: async (payload) => { state.replies.push(payload); },
+                        };
+                    },
+                };
+            }),
             reply: jest.fn(async (p) => { state.replies.push(p); }),
-            followUp: jest.fn(async () => {}),
+            followUp: jest.fn(async (p) => { state.followUps.push(p); }),
         },
     };
 }
@@ -229,7 +248,6 @@ describe('mismatched options', () => {
         const { interaction, state } = buildExecute({ type: 'item', item: 'pet_food', amount: 500 });
         await giftCommand.execute(interaction);
         expect(state.replies.at(-1).content).toContain('`amount`');
-        expect(state.replies.at(-1).flags).toBeDefined();
     });
 
     test('an item filled in on a coin gift is called out, not ignored', async () => {

--- a/tests/giftCommandUx.test.js
+++ b/tests/giftCommandUx.test.js
@@ -1,0 +1,240 @@
+'use strict';
+
+// The parts of /gift a player actually touches: the item picker, the way a
+// typed id is resolved against the bag, and the refusals that have to survive
+// that resolution. The transfer mechanics themselves are covered by
+// tests/giftItemTransfer.test.js.
+
+let mockStore;
+
+function mockFindDoc(query) {
+    const doc = mockStore[query.userId];
+    if (!doc || doc.guildId !== query.guildId) return null;
+    return doc;
+}
+
+jest.mock('../src/models/User', () => ({
+    findOne: jest.fn((query) => {
+        const doc = mockFindDoc(query);
+        return { lean: async () => doc, then: (res, rej) => Promise.resolve(doc).then(res, rej) };
+    }),
+    findOneAndUpdate: jest.fn(async (query) => mockFindDoc(query)),
+    updateOne: jest.fn(async () => ({})),
+}));
+
+jest.mock('../src/models/AiItem', () => ({
+    find: jest.fn(() => ({ lean: async () => [{ itemId: 'ai_beta', name: 'Sunspike', emoji: '🌞', rarity: 'Mythic' }] })),
+}));
+
+jest.mock('../src/models/Guild', () => ({
+    findOne: jest.fn(async () => ({
+        guildId: 'g1',
+        economy: { currency: '💰', enabled: true },
+        shop: [{ itemId: 'pet_food', name: 'Pet Food', price: 250, description: '🍖 Feeds any pet.' }],
+    })),
+}));
+jest.mock('../src/utils/guildSettingsCache', () => require('./helpers/guildSettingsCacheMock')());
+jest.mock('../src/utils/logTransaction', () => ({ logTransaction: jest.fn() }));
+
+const giftCommand = require('../src/commands/economy/gift.js');
+
+const OLD_ACCOUNT = Date.now() - 365 * 24 * 60 * 60 * 1000;
+
+function buildAutocomplete(focusedValue = '') {
+    const responses = [];
+    return {
+        responses,
+        interaction: {
+            guild: { id: 'g1' },
+            user: { id: 'sender' },
+            options: {
+                getFocused: (withDetail) => (withDetail ? { name: 'item', value: focusedValue } : focusedValue),
+            },
+            respond: jest.fn(async (choices) => { responses.push(choices); }),
+        },
+    };
+}
+
+function buildExecute({ item = null, type = 'item', quantity = null, amount = null } = {}) {
+    const state = { replies: [] };
+    return {
+        state,
+        interaction: {
+            guild: { id: 'g1' },
+            guildId: 'g1',
+            user: {
+                id: 'sender',
+                username: 'sender',
+                createdTimestamp: OLD_ACCOUNT,
+                displayAvatarURL: () => 'https://cdn.example/sender.png',
+            },
+            options: {
+                getUser: () => ({
+                    id: 'recipient',
+                    username: 'recipient',
+                    bot: false,
+                    createdTimestamp: OLD_ACCOUNT,
+                    displayAvatarURL: () => 'https://cdn.example/recipient.png',
+                }),
+                getString: (name) => (name === 'type' ? type : name === 'item' ? item : null),
+                getInteger: (name) => (name === 'quantity' ? quantity : name === 'amount' ? amount : null),
+            },
+            reply: jest.fn(async (p) => { state.replies.push(p); }),
+            followUp: jest.fn(async () => {}),
+        },
+    };
+}
+
+beforeEach(() => {
+    mockStore = {
+        sender: {
+            userId: 'sender',
+            guildId: 'g1',
+            balance: 0,
+            inventory: [
+                { itemId: 'pet_food',      quantity: 3 },
+                { itemId: 'lifesaver',     quantity: 1 },
+                { itemId: 'The Tenth Owl', quantity: 1 },
+                { itemId: 'ai_beta',       quantity: 2 },
+                { itemId: 'lucky_charm',   quantity: 1 },
+                { itemId: 'padlock',       quantity: 0 },
+            ],
+            activeEffects: [{ type: 'lucky_charm' }],
+        },
+        recipient: { userId: 'recipient', guildId: 'g1', balance: 0, inventory: [], activeEffects: [] },
+    };
+    jest.clearAllMocks();
+});
+
+describe('the item picker', () => {
+    test('offers what you hold, by display name and count', async () => {
+        const { interaction, responses } = buildAutocomplete();
+        await giftCommand.autocomplete(interaction);
+
+        const choices = responses[0];
+        expect(choices.map(c => c.value)).toEqual(
+            expect.arrayContaining(['pet_food', 'The Tenth Owl', 'ai_beta'])
+        );
+        const petFood = choices.find(c => c.value === 'pet_food');
+        // The label is what the player recognises, not the id they would
+        // otherwise have had to guess, and it says how many they have.
+        expect(petFood.name).toContain('Pet Food');
+        expect(petFood.name).toContain('3 held');
+    });
+
+    test('resolves a forged item to its name instead of its ai_ id', async () => {
+        const { interaction, responses } = buildAutocomplete();
+        await giftCommand.autocomplete(interaction);
+        expect(responses[0].find(c => c.value === 'ai_beta').name).toContain('Sunspike');
+    });
+
+    test('never offers something the command would refuse', async () => {
+        const { interaction, responses } = buildAutocomplete();
+        await giftCommand.autocomplete(interaction);
+
+        const ids = responses[0].map(c => c.value);
+        expect(ids).not.toContain('lifesaver');    // soulbound
+        expect(ids).not.toContain('lucky_charm');  // its effect is running
+        expect(ids).not.toContain('padlock');      // an empty slot
+    });
+
+    test('matches on the display name, not only on the id', async () => {
+        const { interaction, responses } = buildAutocomplete('pet f');
+        await giftCommand.autocomplete(interaction);
+        expect(responses[0].map(c => c.value)).toEqual(['pet_food']);
+    });
+
+    test('stays silent on any option other than item', async () => {
+        const { interaction, responses } = buildAutocomplete();
+        interaction.options.getFocused = (withDetail) => (withDetail ? { name: 'quantity', value: '' } : '');
+        await giftCommand.autocomplete(interaction);
+        expect(responses[0]).toEqual([]);
+    });
+
+    test('an empty response, not a crash, when the lookup fails', async () => {
+        const User = require('../src/models/User');
+        User.findOne.mockImplementationOnce(() => { throw new Error('db down'); });
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const { interaction, responses } = buildAutocomplete();
+        await giftCommand.autocomplete(interaction);
+
+        expect(responses[0]).toEqual([]);
+        errorSpy.mockRestore();
+    });
+});
+
+describe('resolving what was typed', () => {
+    // Inventory ids are not uniformly cased — relics are stored under their
+    // prose name and a custom shop item under its display name — so an exact
+    // match refused items the player was plainly holding.
+    test('a differently-cased id still finds the item', async () => {
+        const { interaction, state } = buildExecute({ item: 'PET_FOOD', quantity: 1 });
+        await giftCommand.execute(interaction);
+        expect(state.replies.at(-1).content ?? '').not.toContain("don't have");
+    });
+
+    test('a relic name is matched without exact capitalisation', async () => {
+        const { interaction, state } = buildExecute({ item: 'the tenth owl', quantity: 1 });
+        await giftCommand.execute(interaction);
+        expect(state.replies.at(-1).content ?? '').not.toContain("don't have");
+    });
+
+    test('a soulbound item is refused as soulbound however it is typed', async () => {
+        const { interaction, state } = buildExecute({ item: 'LifeSaver', quantity: 1 });
+        await giftCommand.execute(interaction);
+        // Not "you don't have it" — the old exact-match check let the wrong
+        // refusal answer for the right one.
+        expect(state.replies.at(-1).content).toContain('soulbound');
+    });
+
+    test('an item whose effect is running is refused by name', async () => {
+        const { interaction, state } = buildExecute({ item: 'lucky_charm', quantity: 1 });
+        await giftCommand.execute(interaction);
+        expect(state.replies.at(-1).content).toContain('Lucky Charm');
+        expect(state.replies.at(-1).content).toContain('active as an effect');
+    });
+
+    test('asking for more than you hold says how many you have', async () => {
+        const { interaction, state } = buildExecute({ item: 'pet_food', quantity: 9 });
+        await giftCommand.execute(interaction);
+        expect(state.replies.at(-1).content).toContain('3×');
+        expect(state.replies.at(-1).content).toContain('Pet Food');
+    });
+
+    test('several stacks that only add up together say so', async () => {
+        // Duplicate stacks for one item are a reachable legacy state, and a
+        // gift comes out of one stack — so "you have 4" would be true and
+        // useless here.
+        mockStore.sender.inventory = [
+            { itemId: 'pet_food', quantity: 2 },
+            { itemId: 'pet_food', quantity: 2 },
+        ];
+        const { interaction, state } = buildExecute({ item: 'pet_food', quantity: 3 });
+        await giftCommand.execute(interaction);
+
+        expect(state.replies.at(-1).content).toContain('no single stack holds 3');
+        expect(state.replies.at(-1).content).toContain('largest holds **2×**');
+    });
+
+    test('an item you do not hold points at the picker', async () => {
+        const { interaction, state } = buildExecute({ item: 'shield', quantity: 1 });
+        await giftCommand.execute(interaction);
+        expect(state.replies.at(-1).content).toContain('Start typing in the `item` box');
+    });
+});
+
+describe('mismatched options', () => {
+    test('an amount filled in on an item gift is called out, not ignored', async () => {
+        const { interaction, state } = buildExecute({ type: 'item', item: 'pet_food', amount: 500 });
+        await giftCommand.execute(interaction);
+        expect(state.replies.at(-1).content).toContain('`amount`');
+        expect(state.replies.at(-1).flags).toBeDefined();
+    });
+
+    test('an item filled in on a coin gift is called out, not ignored', async () => {
+        const { interaction, state } = buildExecute({ type: 'coins', item: 'pet_food', amount: null });
+        await giftCommand.execute(interaction);
+        expect(state.replies.at(-1).content).toContain('`item`');
+    });
+});

--- a/tests/giftItemTransfer.test.js
+++ b/tests/giftItemTransfer.test.js
@@ -133,9 +133,20 @@ function buildInteraction({ itemId = 'pet_food', quantity = 1 } = {}) {
     const interaction = {
         guild: { id: 'g1' },
         guildId: 'g1',
-        user: { id: 'sender', username: 'sender', createdTimestamp: OLD_ACCOUNT },
+        user: {
+            id: 'sender',
+            username: 'sender',
+            createdTimestamp: OLD_ACCOUNT,
+            displayAvatarURL: () => 'https://cdn.example/sender.png',
+        },
         options: {
-            getUser: () => ({ id: 'recipient', username: 'recipient', bot: false, createdTimestamp: OLD_ACCOUNT }),
+            getUser: () => ({
+                id: 'recipient',
+                username: 'recipient',
+                bot: false,
+                createdTimestamp: OLD_ACCOUNT,
+                displayAvatarURL: () => 'https://cdn.example/recipient.png',
+            }),
             getString: (name) => (name === 'type' ? 'item' : name === 'item' ? itemId : null),
             getInteger: (name) => (name === 'quantity' ? quantity : null),
         },
@@ -222,7 +233,7 @@ test('gifting more than you hold moves nothing', async () => {
     expect(mockWrites).toEqual([]);
     expect(mockStore.sender.inventory).toEqual([{ itemId: 'pet_food', quantity: 3 }]);
     expect(mockStore.recipient.inventory).toEqual([]);
-    expect(state.replies.at(-1).content).toContain("don't have 9x");
+    expect(state.replies.at(-1).content).toContain('not enough to gift 9');
 });
 
 test('a duplicate slot for the same item is not double-debited', async () => {

--- a/tests/giftItemTransfer.test.js
+++ b/tests/giftItemTransfer.test.js
@@ -70,6 +70,11 @@ function mockApplyUpdate(doc, update, options = {}) {
             }
         }
     }
+    if (update.$set) {
+        // The daily gift-value budget opens its 24h window with a `$set` on the
+        // same write as the inventory decrement, so the mock has to apply one.
+        for (const [path, value] of Object.entries(update.$set)) doc[path] = value;
+    }
     if (update.$push?.inventory) {
         const { itemId, quantity } = update.$push.inventory;
         doc.inventory.push({ itemId, quantity });
@@ -122,6 +127,11 @@ jest.mock('../src/models/Guild', () => ({
     findOne: jest.fn(async () => ({ guildId: 'g1', economy: { currency: '💰', enabled: true } })),
 }));
 
+// The gift embed shows the item's artwork where a server has uploaded some.
+// No image in these fixtures — the point here is that the lookup does not reach
+// for a database connection the suite does not have.
+jest.mock('../src/models/ItemImage', () => ({ findOne: jest.fn(async () => null) }));
+
 jest.mock('../src/utils/logTransaction', () => ({ logTransaction: jest.fn() }));
 
 const giftCommand = require('../src/commands/economy/gift.js');
@@ -150,6 +160,11 @@ function buildInteraction({ itemId = 'pet_food', quantity = 1 } = {}) {
             getString: (name) => (name === 'type' ? 'item' : name === 'item' ? itemId : null),
             getInteger: (name) => (name === 'quantity' ? quantity : null),
         },
+        // /gift defers ephemerally before touching the database, so every
+        // refusal and the sender's receipt arrive through editReply and only
+        // the public announcement through followUp.
+        deferReply: jest.fn(async () => {}),
+        editReply: jest.fn(async (p) => { state.replies.push(p); return { awaitMessageComponent: async () => { throw new Error('no component'); } }; }),
         reply: jest.fn(async (p) => { state.replies.push(p); }),
         followUp: jest.fn(async (p) => { state.followUps.push(p); }),
     };
@@ -214,7 +229,7 @@ test('a failed credit rolls the debit back instead of duplicating the item', asy
     expect(mockStore.recipient.inventory).toEqual([]);
     expect(mockStore.sender.inventory).toEqual([{ itemId: 'pet_food', quantity: 3 }]);
     expect(mockTotalHeld('pet_food')).toBe(3); // no duplication, no loss
-    expect(state.replies.at(-1).content).toContain('your item was returned');
+    expect(state.replies.at(-1).content).toContain('Your item was returned');
 });
 
 test('a rolled-back gift of a whole stack restores the slot', async () => {

--- a/tests/giftValueCaps.test.js
+++ b/tests/giftValueCaps.test.js
@@ -1,0 +1,308 @@
+'use strict';
+
+// /gift end to end against the limits: the item-value budget that did not exist
+// before, the coin caps now that they come from guild settings rather than from
+// constants, and the confirmation an irreversible transfer asks for.
+//
+// The store here understands the `$expr` guards these paths carry, so a cap is
+// tested as the atomic filter that enforces it and not only as the message shown
+// before the write.
+
+const { applyPipelineUpdate, evaluate } = require('./helpers/pipelineUpdate');
+
+let mockStore;
+let mockEconomy;
+
+function mockFindDoc(query) {
+    const doc = mockStore[query.userId];
+    if (!doc || doc.guildId !== query.guildId) return null;
+    return doc;
+}
+
+function mockMatches(doc, query) {
+    if (!doc) return false;
+    const elem = query.inventory?.$elemMatch;
+    if (elem) {
+        const idx = doc.inventory.findIndex(s => s.itemId === elem.itemId && s.quantity >= elem.quantity.$gte);
+        if (idx === -1) return false;
+        doc._matchedIndex = idx;
+    }
+    if (query.balance?.$gte !== undefined && (doc.balance ?? 0) < query.balance.$gte) return false;
+    // The cap guards. Evaluated for real — a mock that waved these through would
+    // report every cap as working.
+    if (query.$expr && !evaluate(query.$expr, doc)) return false;
+    return true;
+}
+
+function mockApplyUpdate(doc, update) {
+    if (Array.isArray(update)) return applyPipelineUpdate(doc, update);
+    if (update.$inc) {
+        for (const [path, delta] of Object.entries(update.$inc)) {
+            if (path === 'inventory.$.quantity') doc.inventory[doc._matchedIndex].quantity += delta;
+            else doc[path] = (doc[path] ?? 0) + delta;
+        }
+    }
+    if (update.$set) for (const [path, value] of Object.entries(update.$set)) doc[path] = value;
+    if (update.$pull?.inventory) {
+        const { itemId, quantity } = update.$pull.inventory;
+        doc.inventory = doc.inventory.filter(s => !(s.itemId === itemId && s.quantity <= quantity.$lte));
+    }
+    return doc;
+}
+
+jest.mock('../src/models/User', () => ({
+    findOne: jest.fn((query) => {
+        const doc = mockFindDoc(query);
+        return { lean: async () => doc, then: (res, rej) => Promise.resolve(doc).then(res, rej) };
+    }),
+    findOneAndUpdate: jest.fn(async (query, update, options = {}) => {
+        let doc = mockFindDoc(query);
+        if (!doc && options.upsert) {
+            doc = { userId: query.userId, guildId: query.guildId, balance: 0, inventory: [], activeEffects: [] };
+            mockStore[query.userId] = doc;
+        }
+        if (!mockMatches(doc, query)) return null;
+        mockApplyUpdate(doc, update);
+        return doc;
+    }),
+    updateOne: jest.fn(async (query, update, options = {}) => {
+        let doc = mockFindDoc(query);
+        if (!doc && options.upsert) {
+            doc = { userId: query.userId, guildId: query.guildId, balance: 0, inventory: [], activeEffects: [] };
+            mockStore[query.userId] = doc;
+        }
+        if (doc && mockMatches(doc, query)) mockApplyUpdate(doc, update);
+        return {};
+    }),
+}));
+
+jest.mock('../src/models/Guild', () => ({
+    findOne: jest.fn(async () => ({ guildId: 'g1', economy: { currency: '💰', enabled: true, ...mockEconomy } })),
+}));
+jest.mock('../src/models/ItemImage', () => ({ findOne: jest.fn(async () => null) }));
+jest.mock('../src/utils/guildSettingsCache', () => require('./helpers/guildSettingsCacheMock')());
+jest.mock('../src/utils/logTransaction', () => ({ logTransaction: jest.fn() }));
+
+const giftCommand = require('../src/commands/economy/gift.js');
+
+const OLD_ACCOUNT = Date.now() - 365 * 24 * 60 * 60 * 1000;
+
+function buildExecute({ type = 'item', item = null, quantity = null, amount = null, confirm = 'confirm' } = {}) {
+    const state = { replies: [], followUps: [], prompted: false };
+    return {
+        state,
+        interaction: {
+            guild: { id: 'g1' },
+            guildId: 'g1',
+            user: { id: 'sender', username: 'sender', createdTimestamp: OLD_ACCOUNT, displayAvatarURL: () => 'https://cdn.example/sender.png' },
+            options: {
+                getUser: () => ({ id: 'recipient', username: 'recipient', bot: false, createdTimestamp: OLD_ACCOUNT, displayAvatarURL: () => 'https://cdn.example/recipient.png' }),
+                getString: (name) => (name === 'type' ? type : name === 'item' ? item : null),
+                getInteger: (name) => (name === 'quantity' ? quantity : name === 'amount' ? amount : null),
+            },
+            deferReply: jest.fn(async () => {}),
+            editReply: jest.fn(async (p) => {
+                state.replies.push(p);
+                return {
+                    awaitMessageComponent: async () => {
+                        state.prompted = true;
+                        if (confirm === 'timeout') throw new Error('collector ended');
+                        return {
+                            customId: confirm === 'cancel' ? 'gift_cancel' : 'gift_confirm',
+                            update: async (payload) => { state.replies.push(payload); },
+                        };
+                    },
+                };
+            }),
+            reply: jest.fn(async (p) => { state.replies.push(p); }),
+            followUp: jest.fn(async (p) => { state.followUps.push(p); }),
+        },
+    };
+}
+
+const lastContent = state => state.replies.map(r => r.content).filter(Boolean).at(-1) ?? '';
+
+beforeEach(() => {
+    mockEconomy = {};
+    mockStore = {
+        sender: {
+            userId: 'sender', guildId: 'g1', balance: 100_000, activeEffects: [],
+            inventory: [
+                { itemId: 'pet_food',           quantity: 40 },     //     250 each
+                { itemId: 'prestige_accelerator', quantity: 2 },    // 200,000 each
+                { itemId: 'grand_master_badge', quantity: 1 },      // 25,000,000
+            ],
+        },
+        recipient: { userId: 'recipient', guildId: 'g1', balance: 0, inventory: [], activeEffects: [] },
+    };
+    jest.clearAllMocks();
+});
+
+describe('the daily item-value budget', () => {
+    test('an item worth more than the whole daily cap can never be gifted', async () => {
+        // "Buy the item, gift the item, sell it on the market" was the coin cap
+        // with one extra step, and a 25,000,000-coin badge moved freely.
+        const { interaction, state } = buildExecute({ item: 'grand_master_badge', quantity: 1 });
+        await giftCommand.execute(interaction);
+
+        expect(mockStore.recipient.inventory).toEqual([]);
+        expect(mockStore.sender.inventory.find(i => i.itemId === 'grand_master_badge').quantity).toBe(1);
+        expect(lastContent(state)).toContain('can never be gifted');
+    });
+
+    test('gifts accumulate against the budget until it refuses the next one', async () => {
+        const first = buildExecute({ item: 'prestige_accelerator', quantity: 1 });
+        await giftCommand.execute(first.interaction);
+        expect(mockStore.sender.dailyGiftItemValueSent).toBe(200_000);
+        expect(mockStore.recipient.inventory).toEqual([{ itemId: 'prestige_accelerator', quantity: 1 }]);
+
+        // 200,000 spent of 250,000 — the second one does not fit.
+        const second = buildExecute({ item: 'prestige_accelerator', quantity: 1 });
+        await giftCommand.execute(second.interaction);
+        expect(mockStore.sender.dailyGiftItemValueSent).toBe(200_000);
+        expect(mockStore.recipient.inventory).toEqual([{ itemId: 'prestige_accelerator', quantity: 1 }]);
+        expect(lastContent(second.state)).toContain('worth today');
+    });
+
+    test('the recipient has a budget of their own', async () => {
+        mockStore.recipient.dailyGiftItemValueReceived = 499_000;
+        mockStore.recipient.dailyGiftItemValueReceivedReset = new Date();
+
+        const { interaction, state } = buildExecute({ item: 'prestige_accelerator', quantity: 1 });
+        await giftCommand.execute(interaction);
+
+        expect(mockStore.recipient.inventory).toEqual([]);
+        expect(lastContent(state)).toContain('can only receive');
+    });
+
+    test('an admin can switch the cap off entirely', async () => {
+        mockEconomy = { giftItemValueCapDaily: 0, giftItemValueReceiveCapDaily: 0, giftConfirmThreshold: 0 };
+        const { interaction } = buildExecute({ item: 'grand_master_badge', quantity: 1 });
+        await giftCommand.execute(interaction);
+
+        expect(mockStore.recipient.inventory).toEqual([{ itemId: 'grand_master_badge', quantity: 1 }]);
+    });
+
+    test('a cheap stack still moves without touching the ceiling', async () => {
+        mockEconomy = { giftConfirmThreshold: 0 };
+        const { interaction } = buildExecute({ item: 'pet_food', quantity: 4 });
+        await giftCommand.execute(interaction);
+
+        expect(mockStore.recipient.inventory).toEqual([{ itemId: 'pet_food', quantity: 4 }]);
+        expect(mockStore.sender.dailyGiftItemValueSent).toBe(1_000);
+    });
+});
+
+describe('configurable coin caps', () => {
+    test('a guild that raises the cap allows the bigger gift', async () => {
+        // 20,000 is over the default send cap of 10,000 and under the default
+        // receive cap of 25,000, so only the raised limit is under test here.
+        mockEconomy = { giftCoinCapDaily: 50_000, giftConfirmThreshold: 0 };
+        const { interaction } = buildExecute({ type: 'coins', amount: 20_000 });
+        await giftCommand.execute(interaction);
+
+        expect(mockStore.recipient.balance).toBe(20_000);
+        expect(mockStore.sender.balance).toBe(80_000);
+        expect(mockStore.sender.dailyGiftSent).toBe(20_000);
+    });
+
+    test('the default cap still refuses what it always refused', async () => {
+        const { interaction, state } = buildExecute({ type: 'coins', amount: 30_000 });
+        await giftCommand.execute(interaction);
+
+        expect(mockStore.recipient.balance).toBe(0);
+        expect(lastContent(state)).toContain('Daily gift cap reached');
+    });
+
+    test('a cap of 0 removes the limit', async () => {
+        mockEconomy = { giftCoinCapDaily: 0, giftCoinReceiveCapDaily: 0, giftConfirmThreshold: 0 };
+        const { interaction } = buildExecute({ type: 'coins', amount: 90_000 });
+        await giftCommand.execute(interaction);
+
+        expect(mockStore.recipient.balance).toBe(90_000);
+        // Nothing is counted against a budget that is switched off.
+        expect(mockStore.sender.dailyGiftSent).toBeUndefined();
+    });
+});
+
+describe('the confirmation prompt', () => {
+    test('a gift at the threshold asks before it moves anything', async () => {
+        const { interaction, state } = buildExecute({ type: 'coins', amount: 5_000 });
+        await giftCommand.execute(interaction);
+
+        expect(state.prompted).toBe(true);
+        expect(mockStore.recipient.balance).toBe(5_000);
+    });
+
+    test('cancelling moves nothing', async () => {
+        const { interaction, state } = buildExecute({ type: 'coins', amount: 8_000, confirm: 'cancel' });
+        await giftCommand.execute(interaction);
+
+        expect(state.prompted).toBe(true);
+        expect(mockStore.sender.balance).toBe(100_000);
+        expect(mockStore.recipient.balance).toBe(0);
+        expect(state.followUps).toEqual([]);
+    });
+
+    test('a prompt left to expire moves nothing', async () => {
+        const { interaction, state } = buildExecute({ type: 'coins', amount: 8_000, confirm: 'timeout' });
+        await giftCommand.execute(interaction);
+
+        expect(mockStore.sender.balance).toBe(100_000);
+        expect(lastContent(state)).toContain('timed out');
+    });
+
+    test('a small gift is not interrupted', async () => {
+        const { interaction, state } = buildExecute({ type: 'coins', amount: 100 });
+        await giftCommand.execute(interaction);
+
+        expect(state.prompted).toBe(false);
+        expect(mockStore.recipient.balance).toBe(100);
+    });
+
+    test('the threshold reads an item gift by its worth, not its count', async () => {
+        // Ten pet foods are 2,500 coins and pass; one accelerator is 200,000
+        // and does not.
+        const cheap = buildExecute({ item: 'pet_food', quantity: 10 });
+        await giftCommand.execute(cheap.interaction);
+        expect(cheap.state.prompted).toBe(false);
+
+        const dear = buildExecute({ item: 'prestige_accelerator', quantity: 1 });
+        await giftCommand.execute(dear.interaction);
+        expect(dear.state.prompted).toBe(true);
+    });
+
+    test('an admin can switch the prompt off', async () => {
+        mockEconomy = { giftConfirmThreshold: 0 };
+        const { interaction, state } = buildExecute({ type: 'coins', amount: 9_000 });
+        await giftCommand.execute(interaction);
+
+        expect(state.prompted).toBe(false);
+        expect(mockStore.recipient.balance).toBe(9_000);
+    });
+});
+
+describe('the deferred reply', () => {
+    test('the interaction is acknowledged before any database work', async () => {
+        // Up to four reads and three writes used to run inside Discord's
+        // three-second window, and a slow database turned that into "the
+        // application did not respond" with the gift already half applied.
+        const { interaction } = buildExecute({ type: 'coins', amount: 100 });
+        await giftCommand.execute(interaction);
+
+        expect(interaction.deferReply).toHaveBeenCalled();
+        expect(interaction.deferReply.mock.invocationCallOrder[0])
+            .toBeLessThan(interaction.editReply.mock.invocationCallOrder[0]);
+        expect(interaction.reply).not.toHaveBeenCalled();
+    });
+
+    test('the sender gets a private receipt and the channel gets the announcement', async () => {
+        const { interaction, state } = buildExecute({ type: 'coins', amount: 100 });
+        await giftCommand.execute(interaction);
+
+        expect(lastContent(state)).toContain('Sent');
+        expect(state.followUps).toHaveLength(1);
+        expect(state.followUps[0].content).toBe('<@recipient>');
+        expect(state.followUps[0].embeds).toHaveLength(1);
+    });
+});

--- a/tests/helpers/fakeCollection.js
+++ b/tests/helpers/fakeCollection.js
@@ -107,6 +107,12 @@ function matchesField(doc, field, condition, state) {
         return true;
     }
     const value = getPath(doc, field);
+    // A RegExp condition tests the string, the way Mongo matches a field against
+    // a regex literal. Falling through to `equals` compared the regex object
+    // with the string and answered false for every document.
+    if (condition instanceof RegExp) {
+        return anyMatch(value, v => typeof v === 'string' && condition.test(v));
+    }
     // An array-crossing path matches when any element does; a scalar `null`
     // condition also matches a field that is simply absent, as Mongo's does.
     if (Array.isArray(value) && field.includes('.')) return value.some(v => equals(v, condition ?? null));
@@ -348,6 +354,19 @@ function fakeCollection(name, defaults = {}, { unique = ['userId', 'guildId'] } 
 
         countDocuments: jest.fn(async (query = {}) =>
             docs.filter(doc => matches(doc, query, { positional: {} })).length),
+
+        // The distinct values of one field across the matching documents, in
+        // first-seen order. Autocomplete handlers use it to offer only the
+        // values a collection actually holds.
+        distinct: jest.fn(async (field, query = {}) => {
+            const seen = [];
+            for (const doc of docs) {
+                if (!matches(doc, query, { positional: {} })) continue;
+                const value = doc[field];
+                if (value !== undefined && !seen.includes(value)) seen.push(value);
+            }
+            return seen;
+        }),
 
         create: jest.fn(async fields => {
             const stored = { _id: `id-${docs.length + 1}`, ...defaults, ...fields };


### PR DESCRIPTION
A review of `/gift` and the follow-ups it turned up. Two commits: the first makes the command usable, the second closes what the review found behind it.

## The picker

`/gift`'s `item` option had `.setAutocomplete(false)` set explicitly. It was the only inventory-facing option in the economy without a picker — `/use`, `/shop buy`, `/craft` and `/pet feed` all have one — so gifting meant typing a raw itemId from memory. A guess for `pet_slot_expansion`; effectively impossible for the rest:

- relics are stored under their prose name (`The Tenth Owl`, `Curator's Brass Key`)
- forged items under an opaque `ai_` plus hex
- custom guild shop items under whatever an admin typed, since `shop.js` stores an item as `itemId || name`

It is autocompleted now, from live inventory, as `🍖 Pet Food — 3 held · ⚪ Common`. The list is filtered by the same three rules `execute` enforces — soulbound items, items whose effect is running, empty stacks — so nothing offered is refused on submit.

## Two bugs behind it

1. **Item lookup used exact `===`** while `/use` resolves case-insensitively. `/gift item:Padlock` failed, and so did every relic unless the capitalisation was exact.
2. **The soulbound check ran on the raw typed string**, so `/gift item:Lifesaver` sailed past `SOULBOUND_ITEMS.has()` and failed several lines later as "you don't have it" — the wrong refusal for the right reason. Fixing (1) makes this reachable, so both had to move together.

## Item gifting had no cap at all

Coins are capped at 10,000 out and 25,000 in per account per day, specifically to bound alt-farm funnelling. Items were capped by nothing — so "buy the item, gift the item, sell it on the market" was the coin cap with one extra step, and a 25,000,000-coin Grand Master Badge moved freely and unlimited.

Item gifts now spend from their own daily budget in both directions, valued at the guild's own shop price (or the relic payout, or what the rarity cost to forge, for the two kinds of item no shop prices). The default clears every standard and prestige item and stops at the endgame cosmetics, which read as personal trophies rather than presents.

## Five limits, now guild settings

They were constants at the top of `gift.js`, and what the right number is depends entirely on how fast a server's economy runs. All five are on the dashboard beside the other economy dials, with `0` meaning unlimited — the convention `betConfirmThreshold` already uses.

| Setting | Default | What it bounds |
|---|---|---|
| Coins sent per day | 10,000 | One member's outgoing coin gifts |
| Coins received per day | 25,000 | Funnelling into a single account |
| Item value sent per day | 250,000 | Outgoing item gifts, at your shop prices |
| Item value received per day | 500,000 | Funnelling items into a single account |
| Confirm gifts at or above | 5,000 | Where the "are you sure" prompt starts |

## Confirmation, and a deferred reply

`/market buy` prompts above 500 coins and a casino bet above 10,000. A gift is more irreversible than either and prompted at nothing. It does now, reading an item gift by its *worth* — ten pet foods pass, one Prestige Accelerator does not.

`/gift` also defers before touching the database. The item path runs up to four reads and three writes inside Discord's three-second acknowledgement window, and a slow database turned that into "the application did not respond" with the gift already half applied. Deferred ephemerally, so refusals and the sender's own wallet figures stay private and the gift is announced by a public followUp — which is also what makes the confirmation prompt possible at all.

## Presentation

Every message used to print the raw id: the recipient of a Pet Slot Expansion was told they'd received `pet_slot_expansion`. And each gift posted **two** near-identical embeds — "🎁 Gift Sent!" immediately followed by "🎁 You Received a Gift!".

Now one public embed, coloured by the item's rarity, carrying the item's own artwork where the server has uploaded some (as `/shop` already does on a purchase), with the recipient's avatar keeping the slot otherwise. New `src/utils/itemDisplay.js` holds the id → name/emoji/rarity/colour/lore/worth resolution `/inventory` was doing inline.

Also: `/gift type:item amount:500` used to move nothing and say nothing about the 500. It now says which option it did not use.

## /market had every one of these problems

`list` lowercased the typed id and compared with `===`, so a relic could not be listed **at all**, and the listing recorded the lowercased spelling — which would have handed the stock back into a second stack under a name the player never had. `browse` filtered the same way and so could never find one.

Both resolve case-insensitively now, and all four options are autocompleted: `item` on list from the seller's bag, `item` on browse from what is actually listed, `listing_id` on buy and cancel from the listings the caller can act on — buy offers other people's, cancel only your own, matching what each handler accepts.

## Supporting pieces

- `src/utils/giftCaps.js` holds the rolling 24-hour window once, in both the operator and aggregation-pipeline dialects, rather than four near-identical reset branches inline.
- `src/data/soulboundItems.js` — the list was duplicated in `gift.js` and `market.js`. Two copies of a transfer restriction is one too many: an item added to one and missed in the other is a hole nobody would see until it was used.
- The dashboard's new field rows use a `.field-pair` class and convert two pre-existing inline styles on the way past, so the panel's inline-style budget in `tests/dashboardInlineAttributes.test.js` **falls** 42 → 40 rather than rising.
- `fakeCollection` gained `distinct` and RegExp query matching, both of which the new code paths genuinely use.

## Testing

Lint clean. 334 suites / 6,669 tests pass on the rebased tree. Coverage floors pass, and the numbers rose (50.75 / 40.72 / 52.61 / 51.99 against floors of 49 / 39 / 50 / 50).

New: `tests/giftCaps.test.js` (17), `tests/giftValueCaps.test.js` (16, end to end with the `$expr` cap guards actually evaluated), `tests/giftCommandUx.test.js` (15), plus 10 in `tests/economyMarketCommand.test.js`. `tests/giftItemTransfer.test.js` updated for the deferred flow.

The three `tests/integration/*` suites could not run in the authoring environment — `mongodb-memory-server` gets a 403 fetching its MongoDB binary through the proxy. Untouched by this change, and green here in CI.

## One thing worth a manual check

The item debit now carries the value-budget guard as an `$expr` alongside the existing `inventory: { $elemMatch }` and the positional `inventory.$.quantity` update. The positional operator needs an array-field predicate in the query, which `$elemMatch` supplies, and `$expr` is a document-level filter that does not participate in path matching — so it should compose. The logic is covered (the second item gift of a day exercises exactly that branch), but it could not be confirmed against a live MongoDB. **Two `/gift` item transfers in a row on staging** would settle it.