### PR TITLE
Fix the build context, the pre-migration backup, silent hook typos and clipped tab strips

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,41 @@
-node_modules
-npm-debug.log*
-.env
-.env.local
-.env.*.local
-logs
-.git
-.gitignore
-*.md
-tests
-.github
-backups
+# The build context is a separate list from .gitignore, and this is the file
+# that governs it. A path git ignores is still sent to the daemon and still
+# lands in the image through `COPY . .` — which is how ./secrets/, the
+# directory docker-compose.yml tells you to put your live Discord token,
+# session secret and provider keys in, would have been baked into a locally
+# built image and published by the documented `docker compose push` (#871).
+#
+# So this is an allowlist rather than a denylist: everything is excluded, and
+# the few paths the build actually needs are added back below. The next
+# directory of credentials someone adds is then out of the image because it was
+# never named here, rather than because whoever added it remembered to come and
+# name it — which is the half that failed.
+#
+# tests/dockerignoreContext.test.js holds the shape: it fails if this file
+# stops being an allowlist, if an exception names something sensitive, or if
+# the Dockerfile starts copying a path from the context that is not listed.
+*
+
+# The install in the build and asset stages, and the version string
+# services/ai/mcp/client.js and dashboard/server.js read at runtime.
+!package.json
+!package-lock.json
+
+# The application, and the dashboard assets the asset stage minifies.
+!src
+
+# Runtime config. config/mcp-servers.json is re-excluded below.
+!config
+
+# scripts/build-assets.js is copied by the asset stage; the rest is here so a
+# Portainer deploy with no checkout can still run the operational ones
+# (`docker exec clawdia node scripts/rollback-migration.js …`).
+!scripts
+
+# After the allowlist, because `!config` would otherwise bring it back: this
+# file can hold MCP OAuth tokens, and both stack files mount it from the host.
 config/mcp-servers.json
+
+# A node_modules under an allowlisted directory would be sent as-is; the build
+# stage installs its own from the lockfile.
+**/node_modules

--- a/.env.example
+++ b/.env.example
@@ -180,8 +180,10 @@ AUDIT_LOG_RETENTION_DAYS=90
 #   unset      attempt it; warn loudly and continue if mongodump is missing
 #   require    a failed or impossible backup aborts startup instead
 #   skip       do not attempt one
-# `require` is the right setting for a production deploy that has mongodump in
-# the image or on the host.
+# `require` is the right setting for a production deploy, and both stack files
+# already set it — the image ships mongodb-tools, so mongodump is there. Set it
+# here only to override that (or to get the guarantee on a bare checkout, where
+# it depends on mongodump being on the host's PATH).
 # MIGRATION_BACKUP=require
 # Where that archive lands (default ./backups, the same directory the nightly
 # backup service prunes). Named pre-migration-<timestamp>.gz, and aged out on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,8 +145,10 @@ land a change.
 `src/migrations/` in order before the bot logs in and before the dashboard opens
 its port. There is no separate migrate step and no way to start without them.
 Some are irreversible and none roll back on their own, so the runner takes a
-`mongodump` before an irreversible one — set `MIGRATION_BACKUP=require` to make
-a failed backup abort startup rather than warn. Writing one:
+`mongodump` before an irreversible one. Both stack files set
+`MIGRATION_BACKUP=require`, which makes a failed backup abort startup rather
+than warn; a bare checkout defaults to the warning and needs `mongodump` on
+your PATH. Writing one:
 [docs/EXTENDING.md](docs/EXTENDING.md#schema-migrations).
 
 **The bot registers its own slash commands.** It publishes the command set to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,13 +189,14 @@ before your first command is
 [the full module contract](docs/EXTENDING.md#the-full-module-contract).
 
 A command is one object. `data` and `execute` are required and the loader
-refuses to start without them. Four optional hooks are read by name and
-validated by nothing: `cooldownAmount`, `cooldownKey`, `autocomplete` and
-`requiredPermissions`. A typo in any of them is not an error — it is a key
-nobody reads, so the command loads, deploys, runs, and your hook never fires.
-On `requiredPermissions` that is a security bug rather than an annoyance,
-because `setDefaultMemberPermissions` on the builder is only a default that a
-guild admin can reassign.
+refuses to start without them. Four optional hooks are read by exact name:
+`cooldownAmount`, `cooldownKey`, `autocomplete` and `requiredPermissions`. A
+typo in one of those used to be invisible — a key nobody reads, so the command
+loaded, deployed and ran with your hook never firing, and on
+`requiredPermissions` that meant a gate that silently stopped existing. The
+loader now fails startup on a key that is a near miss of a contract one and
+tells you which it thinks you meant; prefix a deliberate extra field with an
+underscore to keep it out of that check.
 
 ### New features ship as subcommands
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,21 @@ RUN apk upgrade --no-cache && apk add --no-cache \
     freetype \
     ttf-dejavu \
     font-noto-emoji \
-    tini
+    tini \
+    mongodb-tools
+
+# mongodb-tools is the odd one out above: nothing this image *runs* links
+# against it. It is there for `mongodump`, which src/migrations/runner.js shells
+# out to immediately before an irreversible migration — the dump into
+# /app/backups that both stack files present as the only way back from one, and
+# that migrations here are forward-only makes it the only way back there is.
+#
+# Without the package that dump could never be taken in this image. The runner
+# would log a warning that mongodump was not on PATH and apply the destructive
+# migration anyway, which is precisely the sequence an operator reading either
+# stack file believes cannot happen (#872). It also brings mongorestore, so
+# scripts/restore.sh works from inside the container on a Portainer deploy that
+# has no checkout to run it from.
 
 # npm ships inside the Node base image and this one never runs it: the build
 # stage does the install, and the runtime entrypoint is `node src/index.js`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,31 +63,43 @@ services:
     restart: unless-stopped
     env_file:
       - .env
-    # Everything in .env arrives as a plain container environment variable, and
-    # those are readable by anyone who can reach the Docker API: `docker inspect
-    # clawdia` prints the bot token and every provider key in full, no shell in
-    # the container required. To keep them out of it, deliver each secret as a
-    # file instead — every secret variable also accepts a <NAME>_FILE form
-    # naming a file to read the value from (src/config/fileSecrets.js).
-    #
-    # To switch over: create ./secrets/discord_token (etc.), remove the plain
-    # variable from .env, and uncomment the matching lines here and the
-    # top-level `secrets:` block at the bottom of this file. If both forms are
-    # set the plain variable wins and the file is ignored, so the migration can
-    # be done one secret at a time.
-    # environment:
-    #   DISCORD_TOKEN_FILE: /run/secrets/discord_token
-    #   CLIENT_SECRET_FILE: /run/secrets/client_secret
-    #   SESSION_SECRET_FILE: /run/secrets/session_secret
-    #   # The `backup` service reads MONGODB_URI too; uncomment the matching
-    #   # lines on it so both sides come from the same secret.
-    #   MONGODB_URI_FILE: /run/secrets/mongodb_uri
-    #   # Opens the per-guild AI provider keys stored in the database (#564).
-    #   SECRET_ENCRYPTION_KEY_FILE: /run/secrets/secret_encryption_key
-    #   ANTHROPIC_API_KEY_FILE: /run/secrets/anthropic_api_key
-    #   OPENAI_API_KEY_FILE: /run/secrets/openai_api_key
-    #   GEMINI_API_KEY_FILE: /run/secrets/gemini_api_key
-    #   OPENROUTER_API_KEY_FILE: /run/secrets/openrouter_api_key
+    environment:
+      # An irreversible migration is forward-only, so the mongodump the runner
+      # takes immediately before one is the only way back from it — which is
+      # what the `backups` mount below is for. Unset, that dump is best-effort:
+      # a failure is a warning and the destructive step runs anyway. `require`
+      # makes a failed or impossible backup abort the boot instead, which is
+      # the setting to want when the dump is your rollback plan.
+      #
+      # Defaulted here rather than in .env.example so an operator who never
+      # opened that section still gets it. Set MIGRATION_BACKUP in .env to
+      # override — including back to the warn-and-continue behaviour.
+      MIGRATION_BACKUP: ${MIGRATION_BACKUP:-require}
+      # Everything in .env arrives as a plain container environment variable,
+      # and those are readable by anyone who can reach the Docker API: `docker
+      # inspect clawdia` prints the bot token and every provider key in full,
+      # no shell in the container required. To keep them out of it, deliver
+      # each secret as a file instead — every secret variable also accepts a
+      # <NAME>_FILE form naming a file to read the value from
+      # (src/config/fileSecrets.js).
+      #
+      # To switch over: create ./secrets/discord_token (etc.), remove the plain
+      # variable from .env, and uncomment the matching lines here and the
+      # top-level `secrets:` block at the bottom of this file. If both forms
+      # are set the plain variable wins and the file is ignored, so the
+      # migration can be done one secret at a time.
+      # DISCORD_TOKEN_FILE: /run/secrets/discord_token
+      # CLIENT_SECRET_FILE: /run/secrets/client_secret
+      # SESSION_SECRET_FILE: /run/secrets/session_secret
+      # The `backup` service reads MONGODB_URI too; uncomment the matching
+      # lines on it so both sides come from the same secret.
+      # MONGODB_URI_FILE: /run/secrets/mongodb_uri
+      # Opens the per-guild AI provider keys stored in the database (#564).
+      # SECRET_ENCRYPTION_KEY_FILE: /run/secrets/secret_encryption_key
+      # ANTHROPIC_API_KEY_FILE: /run/secrets/anthropic_api_key
+      # OPENAI_API_KEY_FILE: /run/secrets/openai_api_key
+      # GEMINI_API_KEY_FILE: /run/secrets/gemini_api_key
+      # OPENROUTER_API_KEY_FILE: /run/secrets/openrouter_api_key
     # secrets:
     #   - discord_token
     #   - client_secret

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -121,18 +121,33 @@ refuses to come up with an incomplete set, because the deploy publishes exactly
 the collection startup builds, and a command that quietly failed to load would
 otherwise *unregister* itself from Discord on the next boot.
 
-#### A typo in an optional key fails silently
+#### A typo in an optional key stops startup
 
-Nothing validates the optional keys. They are read as `command.cooldownKey`,
-`command.autocomplete` and so on, so `cooldownkey` or `autoComplete` is not an
-error — it is a key nobody reads. The command loads, deploys and runs, and the
-hook you wrote never fires. `requiredPermissions` is the one where that is a
-security bug rather than an annoyance, so grep an existing user of the key and
-copy the spelling:
+The optional keys are read by exact name — `command.cooldownKey`,
+`command.autocomplete` and so on — so `cooldownkey` or `autoComplete` is not an
+error at the language level, it is a key nobody reads. Left to itself the
+command would load, deploy and run with the hook you wrote never firing, and on
+`requiredPermissions` that is a security bug rather than an annoyance: the gate
+silently stops existing, and `setDefaultMemberPermissions` on the builder is
+only a default a guild admin can reassign (#874).
+
+So the loader checks. `contractKeyTypos` in `utils/commandLoader.js` compares
+every exported key against the table above and fails startup on a near miss —
+within two edits of one of the longer names, one of the shorter — naming the
+key it thinks you meant:
 
 ```
-cooldownAmount   cooldownKey   autocomplete   requiredPermissions
+[STARTUP] 1 command file(s) failed to load:
+  - moderation/ban.js exports `requiredPermissons`, which nothing reads — did
+    you mean `requiredPermissions`? (rename it, or prefix it with _ if it is
+    deliberate)
 ```
+
+A command is free to export anything else beside the contract; several export
+the button and modal handlers their own `interactionCreate` branch imports, and
+those are nowhere near a contract key. When something deliberate *is* close to
+one, give it a leading underscore — `_meta`, `__test__` — and the check leaves
+it alone.
 
 #### Cooldowns
 

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -732,8 +732,9 @@ Two things happen on that first boot without being asked for, and both are worth
 knowing about before an upgrade rather than during one:
 
 - **Schema migrations run**, before the dashboard opens its port. Some are
-  irreversible. See [Schema migrations](#schema-migrations) — in particular
-  `MIGRATION_BACKUP=require`, which is the setting you want here.
+  irreversible. See [Schema migrations](#schema-migrations) — the
+  `MIGRATION_BACKUP=require` both stack files set is what makes the
+  pre-migration dump a guarantee rather than an attempt.
 - **Slash commands re-register** if the command set changed, so a release that
   adds or renames a command needs no separate step. Newly registered global
   commands can take up to an hour to appear.
@@ -893,13 +894,15 @@ That matters more than it usually would, because of what these migrations do:
   marked `optional` (a performance index, not a schema change): that one is
   logged, left unapplied, and retried next boot.
 
-**Before the first upgrade of a deployment that has data in it, set
-`MIGRATION_BACKUP=require`.** Immediately before any irreversible migration the
-runner takes a `mongodump` into `MIGRATION_BACKUP_DIR` (default `./backups`,
-which both stack files mount) named `pre-migration-<timestamp>.gz` — and with
-`MIGRATION_BACKUP` unset, a `mongodump` that is missing from `PATH` or fails is
-a loud warning and the destructive step runs anyway. `require` turns that into
-an aborted startup instead. `skip` does not attempt one.
+**Both stack files set `MIGRATION_BACKUP=require` for you.** Immediately before
+any irreversible migration the runner takes a `mongodump` into
+`MIGRATION_BACKUP_DIR` (default `./backups`, which both stack files mount) named
+`pre-migration-<timestamp>.gz`. Under `require` a backup that fails or cannot be
+taken aborts the startup, so the destructive step never runs unprotected; the
+image ships `mongodb-tools`, so `mongodump` is on `PATH` there. With
+`MIGRATION_BACKUP` unset — which is what a bare checkout gets — a missing or
+failing `mongodump` is a loud warning and the migration proceeds anyway, so set
+it yourself if you run outside Docker. `skip` does not attempt one.
 
 Restore it with `scripts/restore.sh`, the same as any nightly archive. These
 dumps are pruned on the same `BACKUP_RETENTION_DAYS` schedule as the rest.

--- a/portainer-stack.yml
+++ b/portainer-stack.yml
@@ -160,6 +160,15 @@ services:
       - DASHBOARD_PORT=${DASHBOARD_PORT:-3000}
       - AUDIT_LOG_RETENTION_DAYS=${AUDIT_LOG_RETENTION_DAYS:-90}
       - NODE_ENV=${NODE_ENV:-production}
+      # An irreversible migration is forward-only, so the mongodump the runner
+      # takes immediately before one is the only way back from it — which is
+      # what the `backups` volume below is for, and what the note on it says it
+      # is for. Unset, that dump is best-effort: a failure is a warning in the
+      # log and the destructive step runs anyway, which leaves this stack
+      # promising a recovery path it did not take. `require` makes a failed or
+      # impossible backup abort the boot instead. Override to `skip` only if
+      # you are taking the dump yourself.
+      - MIGRATION_BACKUP=${MIGRATION_BACKUP:-require}
       #
       # --- Secrets as files (recommended) ---------------------------------
       # Uncomment these *and* the matching `secrets:` entries below, then leave

--- a/src/dashboard/public/styles.css
+++ b/src/dashboard/public/styles.css
@@ -546,9 +546,26 @@ body {
     to { opacity: 1; transform: translateY(0); }
 }
 
-/* AI inner tabs */
+/* AI inner tabs
+ *
+ * `flex-wrap` here is load-bearing rather than cosmetic. The Economy strip
+ * carries nine tabs, with hunt/fish/mine strips nested inside it, and `body` is
+ * `overflow-x: hidden` — so on a phone a nowrap strip ran its rightmost tabs
+ * (Dynamic Pricing, Economy Health) past the viewport and had them clipped
+ * away. No scroll, no wrap, and no other route to those panels: the settings
+ * behind them were simply unreachable on mobile (#879). Same bug class as the
+ * wide tables in #668.
+ *
+ * Wrapping rather than the `overflow-x: auto` those tables got, because a
+ * second row is reachable by touch, mouse and keyboard as it stands — no
+ * scroll affordance to draw, and no scroll container to make focusable. The
+ * `margin-bottom: -1px` below then lands the last row on the strip's border
+ * and leaves the earlier rows carrying their own underline, which is what a
+ * wrapped tab strip is supposed to look like.
+ */
 .ai-inner-tabs {
     display: flex;
+    flex-wrap: wrap;
     gap: 0.25rem;
     margin-bottom: 1.75rem;
     border-bottom: 1px solid var(--border);

--- a/src/migrations/runner.js
+++ b/src/migrations/runner.js
@@ -191,9 +191,15 @@ function loadMigrations(dir) {
  *   'require'  a failed or impossible backup aborts startup rather than
  *              letting the destructive step run unprotected
  *   unset      attempt it; if mongodump is missing or fails, warn loudly and
- *              carry on, because a bot that cannot boot without a tool its
- *              container may not ship is a worse default than no backup —
- *              operators who want the guarantee set 'require'.
+ *              carry on, because a bot that cannot boot without a tool the
+ *              host may not have is a worse default for a bare checkout than
+ *              no backup — operators who want the guarantee set 'require'.
+ *
+ * That default is for the checkout case only. The published image ships
+ * mongodb-tools and both stack files set MIGRATION_BACKUP=require, so a Docker
+ * deploy gets the guarantee without asking: the image the dump is documented as
+ * the recovery path for used to have no mongodump in it at all, which made the
+ * warn-and-continue default the only branch it could ever take (#872).
  *
  * The archive lands in MIGRATION_BACKUP_DIR (default ./backups, same place as
  * scripts/backup.sh) and is restored with scripts/restore.sh.

--- a/src/utils/commandLoader.js
+++ b/src/utils/commandLoader.js
@@ -73,6 +73,86 @@ function isCommandModule(command) {
 }
 
 /**
+ * Every key a command module may export that something reads. `data` and
+ * `execute` are the two isCommandModule enforces; the rest are the optional
+ * hooks events/interactionCreate.js looks up by exact name, plus `category`,
+ * which the loader stamps on below.
+ *
+ * docs/EXTENDING.md has the table, and tests/commandContractDocs.test.js holds
+ * this list and that table to each other.
+ */
+const CONTRACT_KEYS = [
+    'data',
+    'execute',
+    'cooldown',
+    'cooldownAmount',
+    'cooldownKey',
+    'autocomplete',
+    'requiredPermissions',
+    'category',
+];
+
+// Distance in single-character edits between two strings. Small and iterative
+// rather than recursive, because it runs over every exported key of every
+// command file at startup.
+function editDistance(a, b) {
+    let previous = Array.from({ length: b.length + 1 }, (_, i) => i);
+
+    for (let i = 1; i <= a.length; i++) {
+        const current = [i];
+        for (let j = 1; j <= b.length; j++) {
+            current[j] = a[i - 1] === b[j - 1]
+                ? previous[j - 1]
+                : 1 + Math.min(previous[j - 1], previous[j], current[j - 1]);
+        }
+        previous = current;
+    }
+
+    return previous[b.length];
+}
+
+/**
+ * The optional hooks are read by exact key name and validated by nothing, so a
+ * one-character slip is not an error — it is a key nobody reads. The command
+ * loads, deploys and runs, and the hook never fires. On `requiredPermissions`
+ * that is a security bug rather than an annoyance (#874): the gate silently
+ * stops existing, and `setDefaultMemberPermissions` on the builder is only a
+ * default a guild admin is free to reassign. Nothing surfaces it until someone
+ * notices the command working for a member who should not have it.
+ *
+ * A command may still export whatever else it likes — several export helpers
+ * their own button and modal handlers import — so an unknown key is only a
+ * problem when it is a *near miss* of a contract key. Anything under a leading
+ * underscore is left alone entirely, which is the escape hatch for a deliberate
+ * field that happens to read like one.
+ *
+ * @returns {string[]} one message per suspected typo, empty when there is none
+ */
+function contractKeyTypos(command) {
+    const contract = new Set(CONTRACT_KEYS);
+    const problems = [];
+
+    for (const key of Object.keys(command)) {
+        if (contract.has(key) || key.startsWith('_')) continue;
+
+        for (const valid of CONTRACT_KEYS) {
+            // Two edits on the longer names, one on the short ones: `execute`
+            // and up are long enough that a transposition (two edits, in this
+            // metric) is a likelier explanation than a deliberate export, while
+            // on `data` that budget would start flagging ordinary words.
+            const budget = valid.length >= 7 ? 2 : 1;
+            if (editDistance(key.toLowerCase(), valid.toLowerCase()) > budget) continue;
+
+            problems.push(`exports \`${key}\`, which nothing reads — did you mean \`${valid}\`? `
+                + '(rename it, or prefix it with _ if it is deliberate)');
+            break;
+        }
+    }
+
+    return problems;
+}
+
+/**
  * Require every command once and hand back both the loaded modules and the
  * files that would not load. Callers decide what a failure means: startup logs
  * and carries on with the rest, the deploy refuses to publish a truncated set.
@@ -98,6 +178,18 @@ function loadCommandModules(foldersPath = COMMANDS_ROOT) {
             continue;
         }
 
+        // A failure rather than a warning, for the same reason the check above
+        // is one: a permission gate that is not spelled the way the handler
+        // reads it does not exist, and a line in the startup log is not what
+        // stands between a reassigned /ban and an ordinary member. Startup
+        // refuses to come up, which is a deploy that never happens rather than
+        // a command that quietly runs ungated.
+        const typos = contractKeyTypos(command);
+        if (typos.length) {
+            for (const typo of typos) failures.push(`${entry.rel} ${typo}`);
+            continue;
+        }
+
         // The folder a command lives in is its category, and it is the only
         // record of that: `client.commands` is keyed by name, so by the time
         // /help reads the collection the directory walk is long gone. Stamping
@@ -112,4 +204,11 @@ function loadCommandModules(foldersPath = COMMANDS_ROOT) {
     return { commands, failures };
 }
 
-module.exports = { listCommandFiles, loadCommandModules, isCommandModule, COMMANDS_ROOT };
+module.exports = {
+    listCommandFiles,
+    loadCommandModules,
+    isCommandModule,
+    contractKeyTypos,
+    CONTRACT_KEYS,
+    COMMANDS_ROOT,
+};

--- a/tests/commandContractDocs.test.js
+++ b/tests/commandContractDocs.test.js
@@ -14,6 +14,8 @@
 const fs = require('fs');
 const path = require('path');
 
+const { CONTRACT_KEYS } = require('../src/utils/commandLoader');
+
 const GUIDE = path.join(__dirname, '../docs/EXTENDING.md');
 const SOURCES = [
     path.join(__dirname, '../src/events/interactionCreate.js'),
@@ -71,4 +73,12 @@ describe('command-module contract', () => {
         'documents %s',
         key => expect(documentedKeys().has(key)).toBe(true),
     );
+
+    // The loader's typo check (#874) is an allowlist, and an allowlist that has
+    // drifted from the table is worse than none: a key missing from it fails
+    // startup on a spelling the guide says is correct, and a key wrongly on it
+    // waves through the typo the check exists to catch.
+    test('the loader allowlist is exactly the documented table', () => {
+        expect([...CONTRACT_KEYS].sort()).toEqual([...documentedKeys()].sort());
+    });
 });

--- a/tests/commandContractTypos.test.js
+++ b/tests/commandContractTypos.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+// #874. The optional hooks are read by exact key name and were validated by
+// nothing, so `requiredPermissons` was not an error — it was a key nobody read.
+// The command loaded, deployed and ran, and the permission gate it was supposed
+// to declare silently did not exist. `setDefaultMemberPermissions` on the
+// builder is only a default a guild admin can reassign, so that gate is the
+// whole check: a one-character slip turned a moderation command into an open
+// one, with no error, no warning and no failing test.
+//
+// The loader compares exported keys against the contract now and fails startup
+// on a near miss. This covers both halves of that: the typos it has to catch,
+// and the deliberate extra exports it must not — several commands export their
+// own button and modal handlers, and a check that broke those would be reverted
+// rather than fixed.
+
+const { contractKeyTypos, loadCommandModules, CONTRACT_KEYS } = require('../src/utils/commandLoader');
+
+const stub = extra => ({
+    data: { toJSON: () => ({}) },
+    execute: async () => {},
+    ...extra,
+});
+
+describe('contractKeyTypos', () => {
+    test.each([
+        ['requiredPermissons', 'requiredPermissions'],   // dropped letter, the #874 case
+        ['requiredpermissions', 'requiredPermissions'],  // wrong case
+        ['cooldownkey', 'cooldownKey'],
+        ['autoComplete', 'autocomplete'],
+        ['cooldwonAmount', 'cooldownAmount'],
+        ['exceute', 'execute'],                          // transposition
+    ])('catches %s and names %s', (typo, intended) => {
+        const [problem] = contractKeyTypos(stub({ [typo]: () => {} }));
+
+        expect(problem).toContain(`\`${typo}\``);
+        expect(problem).toContain(`\`${intended}\``);
+    });
+
+    test.each(CONTRACT_KEYS)('leaves the contract key %s alone', key => {
+        expect(contractKeyTypos(stub({ [key]: 1 }))).toEqual([]);
+    });
+
+    test.each([
+        'handleSyndicateButton',
+        'grantWarPoints',
+        'isEightBallButton',
+        'handleMap',
+    ])('leaves the deliberate export %s alone', key => {
+        expect(contractKeyTypos(stub({ [key]: () => {} }))).toEqual([]);
+    });
+
+    test('leaves anything under a leading underscore alone', () => {
+        // The escape hatch, for a deliberate field that does read like a near
+        // miss. Without one the check would have no answer for a command that
+        // genuinely wants `_cooldowns`.
+        expect(contractKeyTypos(stub({ __test__: {}, _cooldowns: {} }))).toEqual([]);
+    });
+
+    test('reports every typo on a module, not just the first', () => {
+        expect(contractKeyTypos(stub({ cooldownkey: () => {}, autoComplete: () => {} })))
+            .toHaveLength(2);
+    });
+});
+
+describe('the shipped commands', () => {
+    // The check is only worth having if the tree it guards is clean, and this
+    // is where a near miss introduced by a new command surfaces in CI rather
+    // than at the boot that would have deployed it.
+    test('load with no suspected typos', () => {
+        expect(loadCommandModules().failures).toEqual([]);
+    });
+});

--- a/tests/dashboardAccessibility.test.js
+++ b/tests/dashboardAccessibility.test.js
@@ -212,6 +212,38 @@ describe('toast', () => {
     });
 });
 
+// #879. `.ai-inner-tabs` was a nowrap flex row and `body` is
+// `overflow-x: hidden`, so the Economy panel's nine tabs ran past a phone's
+// viewport and the rightmost ones were clipped away — no scroll, no wrap, and
+// no other route to the panels behind them. Same bug class as the wide tables
+// below; a different fix, because a wrapped row needs no scroll affordance.
+describe('inner tab strips', () => {
+    const styles = fs.readFileSync(path.join(PUBLIC, 'styles.css'), 'utf8');
+
+    it('wraps rather than running off the side of the screen', () => {
+        const rule = /\.ai-inner-tabs\s*\{([^}]*)\}/.exec(styles);
+        expect(rule).not.toBeNull();
+        expect(rule[1]).toMatch(/flex-wrap:\s*wrap/);
+    });
+
+    it.each(['economy', 'moderation', 'ai', 'rss'])(
+        'puts every tab in the %s panel inside one of those strips',
+        panel => {
+            document.body.innerHTML = renderPanel(panel);
+
+            const strips = [...document.querySelectorAll('.ai-inner-tabs')];
+            expect(strips.length).toBeGreaterThan(0);
+
+            // A strip that reaches for its own layout instead of the class is
+            // back outside the rule above, which is how the clipping got in.
+            for (const tab of document.querySelectorAll('[class*="-inner-tab"]:not(.ai-inner-tabs)')) {
+                expect([tab.textContent.trim(), tab.closest('.ai-inner-tabs') !== null])
+                    .toEqual([tab.textContent.trim(), true]);
+            }
+        },
+    );
+});
+
 // #668. `.cases-table` is up to seven columns wide and `body` is
 // `overflow-x: hidden`, so on a narrow screen the right-hand columns — the
 // Actions column on three of these four — were clipped with nothing that could

--- a/tests/dockerignoreContext.test.js
+++ b/tests/dockerignoreContext.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+// `.dockerignore` is the only thing standing between a file on disk and the
+// published image: `COPY . .` in the Dockerfile sends whatever the context
+// still holds, and .gitignore has no say in it. The list used to be a denylist,
+// so ./secrets/ — the directory docker-compose.yml documents for the live
+// Discord token, session secret and provider keys — was in the context and
+// would have been baked into any locally built image (#871).
+//
+// It is an allowlist now. This test is what keeps it one: the failure mode is
+// not a wrong pattern but a *missing* one, and a missing pattern in an
+// allowlist excludes rather than leaks. So the things worth asserting are the
+// shape (does it still start by excluding everything?), the exceptions (does
+// one of them name something sensitive?) and the Dockerfile's side of the
+// contract (is every path it copies from the context still reachable?).
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const IGNORE = path.join(ROOT, '.dockerignore');
+const DOCKERFILE = path.join(ROOT, 'Dockerfile');
+
+// Anything whose whole point is to hold a credential, plus the two directories
+// that accumulate copies of the database. None of these belongs in an image.
+const SENSITIVE = [
+    'secrets',
+    '.env',
+    '.env.local',
+    'config/mcp-servers.json',
+    'backups',
+    'logs',
+];
+
+function patterns() {
+    return fs.readFileSync(IGNORE, 'utf8')
+        .split('\n')
+        .map(line => line.trim())
+        .filter(line => line && !line.startsWith('#'));
+}
+
+function exceptions() {
+    return patterns().filter(p => p.startsWith('!')).map(p => p.slice(1));
+}
+
+// Every COPY that reads from the build context. `--from=<stage>` copies out of
+// an earlier stage instead and the context has no say in those.
+function contextCopySources() {
+    const dockerfile = fs.readFileSync(DOCKERFILE, 'utf8');
+    const sources = [];
+
+    for (const line of dockerfile.split('\n')) {
+        const match = /^COPY\s+(.*)$/.exec(line.trim());
+        if (!match) continue;
+
+        const args = match[1].split(/\s+/).filter(Boolean);
+        if (args.some(arg => arg.startsWith('--from='))) continue;
+
+        // Drop the flags and the destination; what is left is the source list.
+        const operands = args.filter(arg => !arg.startsWith('--'));
+        sources.push(...operands.slice(0, -1));
+    }
+
+    return sources;
+}
+
+// `COPY package*.json ./` names two real files, and it is those the allowlist
+// has to cover — a glob is only ever as good as what it currently matches.
+function expandGlob(source) {
+    if (!source.includes('*')) return [source];
+
+    const dir = path.dirname(source);
+    const pattern = new RegExp(`^${path.basename(source).split('*').map(part =>
+        part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('[^/]*')}$`);
+
+    return fs.readdirSync(path.join(ROOT, dir))
+        .filter(entry => pattern.test(entry))
+        .map(entry => (dir === '.' ? entry : `${dir}/${entry}`));
+}
+
+describe('.dockerignore', () => {
+    test('is an allowlist: the first pattern excludes everything', () => {
+        expect(patterns()[0]).toBe('*');
+    });
+
+    test('re-includes only paths that exist', () => {
+        for (const allowed of exceptions()) {
+            expect(fs.existsSync(path.join(ROOT, allowed))).toBe(true);
+        }
+    });
+
+    test('re-includes nothing sensitive', () => {
+        // An exception is a prefix: `!config` would carry config/mcp-servers.json
+        // back in with it, so a sensitive path counts as re-included when the
+        // exception names it or any directory above it — unless a later pattern
+        // excludes it again, which is what the mcp-servers.json line does.
+        const laterExclusions = new Set(patterns().filter(p => !p.startsWith('!')));
+
+        for (const secret of SENSITIVE) {
+            if (laterExclusions.has(secret)) continue;
+
+            const covering = exceptions().filter(allowed =>
+                secret === allowed || secret.startsWith(`${allowed}/`),
+            );
+
+            expect({ secret, covering }).toEqual({ secret, covering: [] });
+        }
+    });
+
+    test('re-includes every path the Dockerfile copies out of the context', () => {
+        for (const source of contextCopySources()) {
+            // `COPY . .` takes the context as a whole; the allowlist above is
+            // exactly what decides what that means.
+            if (source === '.') continue;
+
+            for (const file of expandGlob(source)) {
+                const covered = exceptions().some(allowed =>
+                    file === allowed || file.startsWith(`${allowed}/`),
+                );
+
+                expect({ file, covered }).toEqual({ file, covered: true });
+            }
+        }
+    });
+});

--- a/tests/migrationBackupTooling.test.js
+++ b/tests/migrationBackupTooling.test.js
@@ -1,0 +1,69 @@
+/**
+ * #872. Three things had to be true together for the pre-migration backup to
+ * work, and only two of them were.
+ *
+ * The runner shells out to `mongodump` before an irreversible migration, and
+ * both stack files present the archive it writes as *the* way back from a bad
+ * one — migrations here are forward-only, so it is the only way back there is.
+ * But the runtime image installed cairo, pango and friends and no
+ * mongodb-tools, so mongodump was not in it; and MIGRATION_BACKUP was unset
+ * everywhere, which is the mode where a failed dump is a warning and the
+ * destructive migration runs anyway. The dump could not be taken and nothing
+ * stopped on its absence: operators had a recovery path that consisted of one
+ * line in a startup log.
+ *
+ * This holds the three together. Any one of them going back to how it was is a
+ * silent regression in the others.
+ */
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const ROOT = path.join(__dirname, '..');
+const read = name => fs.readFileSync(path.join(ROOT, name), 'utf8');
+const load = name => yaml.load(read(name));
+
+// The runtime stage is the last one in the file: it is what ships, and the
+// packages the earlier stages install are left behind with them.
+function runtimeStage() {
+    const dockerfile = read('Dockerfile');
+    const stages = dockerfile.split(/^FROM /m);
+    return stages[stages.length - 1];
+}
+
+// The commands the runner spawns for the dump. Read out of the source so that
+// swapping mongodump for something else fails here rather than at the boot
+// that needed it.
+function spawnedBinaries() {
+    const runner = read('src/migrations/runner.js');
+    return [...runner.matchAll(/spawnSync\(\s*'([^']+)'/g)].map(m => m[1]);
+}
+
+describe('pre-migration backup', () => {
+    it('is taken with mongodump', () => {
+        expect(spawnedBinaries()).toContain('mongodump');
+    });
+
+    it('has that binary in the image it runs in', () => {
+        // mongodb-tools is the apk that carries mongodump (and mongorestore,
+        // which is what scripts/restore.sh needs to read the archive back).
+        expect(runtimeStage()).toMatch(/\bmongodb-tools\b/);
+    });
+
+    it.each([['docker-compose.yml'], ['portainer-stack.yml']])(
+        '%s defaults MIGRATION_BACKUP to require',
+        name => {
+            const env = load(name).services.bot.environment;
+
+            // compose takes a mapping, the Portainer stack a NAME=value list.
+            const value = Array.isArray(env)
+                ? env.map(String).find(entry => entry.startsWith('MIGRATION_BACKUP='))?.slice('MIGRATION_BACKUP='.length)
+                : env?.MIGRATION_BACKUP;
+
+            // `${MIGRATION_BACKUP:-require}` rather than a bare `require`, so an
+            // operator who wants the old warn-and-continue can still say so
+            // without editing the stack file.
+            expect([name, value]).toEqual([name, '${MIGRATION_BACKUP:-require}']);
+        },
+    );
+});


### PR DESCRIPTION
Four independent fixes from the specialist review, one commit each.

## #871 — `.dockerignore` omitted `secrets/`

`.gitignore` covered `secrets/`; the build context is a separate list and did not. A maintainer following the file-secrets migration documented in `docker-compose.yml` and then the `docker compose build` / `push` flow documented a few lines above it published an image holding their Discord token, session secret and provider keys.

Adding one line would have fixed this instance and left the next one to memory, so the file is an allowlist now: `*`, then back in come `package.json`, `package-lock.json`, `src`, `config` and `scripts` — with `config/mcp-servers.json` excluded again underneath, because `!config` would otherwise carry it in.

`tests/dockerignoreContext.test.js` keeps the shape: it fails if the file stops starting with `*`, if an exception names a credential path, or if the Dockerfile starts copying something from the context the allowlist does not reach.

## #872 — the pre-migration backup could never be taken

The runner shells out to `mongodump` before an irreversible migration and both stack files present that archive as the recovery path from a bad one. The runtime image installed cairo, pango, giflib and freetype and no `mongodb-tools`, and `MIGRATION_BACKUP` was unset everywhere — the warn-and-continue branch. The dump failed, the warning scrolled past, and the destructive migration ran anyway.

Three changes, none of which works alone:

- the runtime stage installs `mongodb-tools` (also `mongorestore`, so `scripts/restore.sh` works from inside a Portainer deploy with no checkout);
- both stack files default `MIGRATION_BACKUP` to `require`, written as `${MIGRATION_BACKUP:-require}` so it stays overridable;
- the runner comment, `.env.example`, SETUP_GUIDE and CONTRIBUTING stop telling operators to set `require` themselves against an image that might not ship the tool.

In `docker-compose.yml` the commented-out `# environment:` block is merged into the now-real one — leaving both would make uncommenting it a duplicate YAML key.

`tests/migrationBackupTooling.test.js` holds the three together.

## #874 — a typoed `requiredPermissions` never enforced

The optional hooks are read by exact key name, so `requiredPermissons` was not an error but a key nobody read: the command loaded, deployed and ran, and the permission gate it declared did not exist. `setDefaultMemberPermissions` is only a default a guild admin can reassign, so that gate is the whole check.

`contractKeyTypos` now compares every exported key against the contract and fails startup on a near miss — two edits on the longer names, one on the shorter — naming the key it thinks was meant. Unrelated exports pass untouched, which matters because several commands export the button and modal handlers their own handler branch imports; a deliberate field that *is* close to a contract key takes a leading underscore, the escape hatch the existing `__test__` exports already use.

A failure rather than a warning, matching the loader's existing stance: a startup that refuses is a deploy that never happens, where a warning is a command running ungated behind a log line. `tests/commandContractDocs.test.js` now asserts the allowlist equals the table in `docs/EXTENDING.md`, so neither can drift into waving through the typo the check exists to catch.

## #879 — inner tab strips clipped on narrow screens

`.ai-inner-tabs` was a nowrap flex row with no overflow handling and `body` is `overflow-x: hidden`, so the Economy panel's nine tabs ran past a phone's viewport and the rightmost — Dynamic Pricing, Economy Health — were clipped, with no route to the panels behind them.

`flex-wrap: wrap` rather than the `overflow-x: auto` the wide tables got in #668: a wrapped row is already reachable by touch, mouse and keyboard, so there is no affordance to draw and no scroll container to make focusable. The existing `margin-bottom: -1px` puts the last row on the strip's border and leaves earlier rows carrying their own underline.

## Testing

`npx eslint src tests scripts` is clean. Full suite: 6773 passed, 97 failed — every failure is in `tests/integration/*`, which need `mongodb-memory-server` to download a mongod binary from `fastdl.mongodb.org`, blocked by this environment's egress proxy. Nothing these changes touch; they run in CI.

Two things I could not verify locally and that CI is the check for:

- No Docker daemon here, so the image was not built. `mongodb-tools 100.12.0-r0` in Alpine 3.22 community is confirmed by package listings only. The `image` job builds, smoke-tests and Trivy-scans it; the scan is HIGH/CRITICAL with `ignore-unfixed`, and a Go-built toolset is the one plausible way this turns red.
- The `.dockerignore` allowlist relies on the standard `*` + `!path` exception semantics; the smoke test that boots the image to its config validator is what proves the context still carries everything the runtime needs.

Closes #871
Closes #872
Closes #874
Closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BW2YTgH4BFBEEVCjHvoimS

---
_Generated by [Claude Code](https://claude.ai/code/session_01BW2YTgH4BFBEEVCjHvoimS)_