### PR TITLE
Fix three economy coin-loss paths and two accessibility failures

### DIFF
--- a/src/commands/economy/bank.js
+++ b/src/commands/economy/bank.js
@@ -3,7 +3,7 @@ const User = require('../../models/User');
 const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { logTransaction } = require('../../utils/logTransaction');
 const { giftLimits } = require('../../utils/giftCaps');
-const { accountAgeRefusal, coinBudgets, commitCoinTransfer } = require('../../utils/coinTransfer');
+const { accountAgeRefusal, coinBudgets, commitCoinTransfer, transferRefusal } = require('../../utils/coinTransfer');
 const COLORS = require('../../utils/embedColors');
 
 async function getCurrency(guildId) {
@@ -144,7 +144,16 @@ async function handleTransfer(interaction) {
         return interaction.reply({ content: 'You cannot transfer coins to yourself!', flags: MessageFlags.Ephemeral });
     }
 
-    const deny = content => interaction.reply({ content, flags: MessageFlags.Ephemeral });
+    // Deferred before any database work, and ephemerally. Everything below is
+    // up to two reads and three writes against Discord's three-second
+    // acknowledgement window, and a slow database turned that into "the
+    // application did not respond" with the coins already moved. gift.js
+    // defers first for exactly this reason; the public announcement is a
+    // followUp at the end, so the transfer is still posted in the channel the
+    // way it always was, and the refusals stay private the way they always
+    // were.
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+    const deny = content => interaction.editReply({ content, embeds: [], components: [] });
 
     const guildSettings = await getGuildSettings(guildId);
     const currency = guildSettings?.economy?.currency ?? '💰';
@@ -178,20 +187,11 @@ async function handleTransfer(interaction) {
         refundKey: interaction.id, service: 'bank', jobName: 'bankTransfer',
     });
 
-    if (moved.status === 'debit_failed') {
-        return deny('Could not complete the transfer — your balance or daily transfer cap may have changed.');
-    }
-    if (moved.status !== 'ok') {
-        const why = moved.status === 'receive_cap'
-            ? `<@${recipient.id}> just reached their daily receiving cap`
-            : 'something went wrong sending your coins';
-        if (moved.refunded) return deny(`Could not complete the transfer — ${why}. Your coins were returned.`);
-        // The case that used to destroy the coins in silence. They are neither
-        // sent nor returned, so say that, and say it is recoverable.
-        return deny(moved.owed
-            ? `Could not complete the transfer — ${why}, and returning your **${currency}${amount.toLocaleString()}** failed too. It is recorded and an admin can restore it.`
-            : `Could not complete the transfer — ${why}, and returning your coins failed. Please contact a server admin.`);
-    }
+    const refusal = transferRefusal(moved, {
+        mention: `<@${recipient.id}>`, currency, amount,
+        sendCapLabel: 'daily transfer cap', receiveCapLabel: 'daily receiving cap',
+    });
+    if (refusal) return deny(refusal);
 
     const { sender, receiver } = moved;
 
@@ -222,7 +222,11 @@ async function handleTransfer(interaction) {
         )
         .setTimestamp();
 
-    await interaction.reply({ embeds: [embed] });
+    await interaction.editReply({
+        content: `✅ Sent **${currency}${amount.toLocaleString()}** to **${recipient.username}**.`,
+        embeds: [], components: [],
+    });
+    return interaction.followUp({ embeds: [embed] });
 }
 
 module.exports = {

--- a/src/commands/economy/bank.js
+++ b/src/commands/economy/bank.js
@@ -2,6 +2,8 @@ const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js'
 const User = require('../../models/User');
 const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { logTransaction } = require('../../utils/logTransaction');
+const { giftLimits } = require('../../utils/giftCaps');
+const { accountAgeRefusal, coinBudgets, commitCoinTransfer } = require('../../utils/coinTransfer');
 const COLORS = require('../../utils/embedColors');
 
 async function getCurrency(guildId) {
@@ -117,9 +119,23 @@ async function handleWithdraw(interaction) {
     await interaction.reply({ embeds: [embed] });
 }
 
+/**
+ * `/bank transfer` — the same coin movement `/gift type:coins` performs, and now
+ * literally the same code (#897).
+ *
+ * It used to be its own implementation and a poorer one: no daily cap, no
+ * account-age gate, no accounting, so the anti-alt caps `/gift` enforces were
+ * decorative — anyone who hit the gift cap simply transferred instead. It also
+ * debited the sender and then credited the receiver with nothing watching the
+ * second write, so a credit that threw destroyed the coins outright (#868).
+ *
+ * Both are properties of moving coins rather than of having typed `/gift`, so
+ * they live in utils/coinTransfer.js and this is the wording around them.
+ */
 async function handleTransfer(interaction) {
     const recipient = interaction.options.getUser('user');
     const amount = interaction.options.getInteger('amount');
+    const guildId = interaction.guild.id;
 
     if (recipient.bot) {
         return interaction.reply({ content: 'You cannot transfer coins to bots!', flags: MessageFlags.Ephemeral });
@@ -128,51 +144,85 @@ async function handleTransfer(interaction) {
         return interaction.reply({ content: 'You cannot transfer coins to yourself!', flags: MessageFlags.Ephemeral });
     }
 
-    // Standalone MongoDB doesn't support multi-doc transactions; use atomic $inc
-    // to debit only if the sender has the funds, then credit the receiver.
-    try {
-        const sender = await User.findOneAndUpdate(
-            { userId: interaction.user.id, guildId: interaction.guild.id, balance: { $gte: amount } },
-            { $inc: { balance: -amount } },
-            { new: true }
-        );
+    const deny = content => interaction.reply({ content, flags: MessageFlags.Ephemeral });
 
-        if (!sender) {
-            const existing = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
-            const currentBal = existing ? existing.balance : 0;
-            return interaction.reply({
-                content: `You don't have enough coins! Your balance: ${currentBal.toLocaleString()} coins`,
-                flags: MessageFlags.Ephemeral
-            });
-        }
+    const guildSettings = await getGuildSettings(guildId);
+    const currency = guildSettings?.economy?.currency ?? '💰';
+    const limits = giftLimits(guildSettings);
 
-        const receiver = await User.findOneAndUpdate(
-            { userId: recipient.id, guildId: interaction.guild.id },
-            { $inc: { balance: amount }, $setOnInsert: { userId: recipient.id, guildId: interaction.guild.id } },
-            { upsert: true, new: true }
-        );
+    const tooNew = accountAgeRefusal(interaction.user, recipient);
+    if (tooNew) return deny(tooNew);
 
-        logTransaction({
-            userId: interaction.user.id, guildId: interaction.guild.id, type: 'transfer_send',
-            amount: -amount, balance: sender.balance, relatedUserId: recipient.id
-        });
-        logTransaction({
-            userId: recipient.id, guildId: interaction.guild.id, type: 'transfer_receive',
-            amount, balance: receiver.balance, relatedUserId: interaction.user.id
-        });
+    // Read both sides for the refusal messages below. The atomic filters inside
+    // commitCoinTransfer are what actually enforce the balance and the caps.
+    const [senderNow, receiverNow] = await Promise.all([
+        User.findOne({ userId: interaction.user.id, guildId }),
+        User.findOne({ userId: recipient.id, guildId }),
+    ]);
 
-        const embed = new EmbedBuilder()
-            .setColor(COLORS.SUCCESS)
-            .setTitle('Transfer Successful')
-            .setDescription(`You transferred **${amount.toLocaleString()}** coins to ${recipient}`)
-            .addFields({ name: 'Your New Balance', value: `${sender.balance.toLocaleString()} coins` })
-            .setTimestamp();
-
-        await interaction.reply({ embeds: [embed] });
-    } catch (error) {
-        console.error('Transfer error:', error);
-        await interaction.reply({ content: 'Failed to transfer coins.', flags: MessageFlags.Ephemeral }).catch(() => {});
+    if (!senderNow || senderNow.balance < amount) {
+        return deny(`You don't have enough coins! Your balance: ${(senderNow?.balance ?? 0).toLocaleString()} coins`);
     }
+
+    const budgets = coinBudgets(senderNow, receiverNow, limits);
+    if (amount > budgets.send.remaining) {
+        return deny(`Daily transfer cap reached. You can still send up to **${currency}${budgets.send.remaining.toLocaleString()}** today.`);
+    }
+    if (amount > budgets.receive.remaining) {
+        return deny(`<@${recipient.id}> has reached their daily receiving cap. They can receive up to **${currency}${budgets.receive.remaining.toLocaleString()}** more today.`);
+    }
+
+    const moved = await commitCoinTransfer({
+        senderId: interaction.user.id, receiverId: recipient.id, guildId,
+        amount, limits, budgets,
+        refundKey: interaction.id, service: 'bank', jobName: 'bankTransfer',
+    });
+
+    if (moved.status === 'debit_failed') {
+        return deny('Could not complete the transfer — your balance or daily transfer cap may have changed.');
+    }
+    if (moved.status !== 'ok') {
+        const why = moved.status === 'receive_cap'
+            ? `<@${recipient.id}> just reached their daily receiving cap`
+            : 'something went wrong sending your coins';
+        if (moved.refunded) return deny(`Could not complete the transfer — ${why}. Your coins were returned.`);
+        // The case that used to destroy the coins in silence. They are neither
+        // sent nor returned, so say that, and say it is recoverable.
+        return deny(moved.owed
+            ? `Could not complete the transfer — ${why}, and returning your **${currency}${amount.toLocaleString()}** failed too. It is recorded and an admin can restore it.`
+            : `Could not complete the transfer — ${why}, and returning your coins failed. Please contact a server admin.`);
+    }
+
+    const { sender, receiver } = moved;
+
+    logTransaction({
+        userId: interaction.user.id, guildId, type: 'transfer_send',
+        amount: -amount, balance: sender.balance, relatedUserId: recipient.id
+    });
+    logTransaction({
+        userId: recipient.id, guildId, type: 'transfer_receive',
+        amount, balance: receiver.balance, relatedUserId: interaction.user.id
+    });
+
+    const capLeft = limits.coinSend
+        ? Math.max(0, limits.coinSend - (sender.dailyGiftSent ?? 0))
+        : Infinity;
+
+    const embed = new EmbedBuilder()
+        .setColor(COLORS.SUCCESS)
+        .setTitle('Transfer Successful')
+        .setDescription(`You transferred **${amount.toLocaleString()}** coins to ${recipient}`)
+        .addFields(
+            { name: 'Your New Balance', value: `${currency}${sender.balance.toLocaleString()}`, inline: true },
+            {
+                name: 'Daily Cap Left',
+                value: Number.isFinite(capLeft) ? `${currency}${capLeft.toLocaleString()}` : 'no limit',
+                inline: true,
+            },
+        )
+        .setTimestamp();
+
+    await interaction.reply({ embeds: [embed] });
 }
 
 module.exports = {

--- a/src/commands/economy/gift.js
+++ b/src/commands/economy/gift.js
@@ -10,24 +10,13 @@ const { getItemImageAttachment } = require('../../utils/itemImageHelper');
 const { describeItem } = require('../../utils/itemDisplay');
 const { ownedBy } = require('../../utils/collectorOwner');
 const {
-    giftLimits, budgetState, spendBudget, spendBudgetPipeline,
-    refundBudget, refundBudgetPipeline,
+    BUDGETS, giftLimits, budgetState, spendBudget, spendBudgetPipeline,
+    refundBudgetPipeline,
 } = require('../../utils/giftCaps');
+const { accountAgeRefusal, coinBudgets, commitCoinTransfer } = require('../../utils/coinTransfer');
 const { isSoulbound } = require('../../data/soulboundItems');
 const { resolveEffectType } = require('../../services/effectsService');
 const COLORS = require('../../utils/embedColors');
-
-// Fresh Discord accounts can't send gifts — blocks throwaway-alt funnels.
-const MIN_ACCOUNT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
-
-// The four rolling budgets, by the fields that hold them. Paired here so a call
-// site names a budget rather than restating a pair of field names each time.
-const BUDGETS = {
-    coinSend:         { usedField: 'dailyGiftSent',                  resetField: 'dailyGiftReset' },
-    coinReceive:      { usedField: 'dailyGiftReceived',              resetField: 'dailyGiftReceivedReset' },
-    itemValueSend:    { usedField: 'dailyGiftItemValueSent',         resetField: 'dailyGiftItemValueReset' },
-    itemValueReceive: { usedField: 'dailyGiftItemValueReceived',     resetField: 'dailyGiftItemValueReceivedReset' },
-};
 
 // Add `qty` of `itemId` to a user's inventory without reading it first. The
 // three-step bump/guarded-push/bump dance this used to spell out is now one
@@ -237,12 +226,8 @@ module.exports = {
 
         if (target.id === interaction.user.id) return deny("You can't gift yourself.");
         if (target.bot)                        return deny("You can't gift a bot.");
-        if (Date.now() - interaction.user.createdTimestamp < MIN_ACCOUNT_AGE_MS) {
-            return deny('Your Discord account is too new to send gifts. Try again in a few days.');
-        }
-        if (Date.now() - target.createdTimestamp < MIN_ACCOUNT_AGE_MS) {
-            return deny(`${target.username}'s Discord account is too new to receive gifts.`);
-        }
+        const tooNew = accountAgeRefusal(interaction.user, target, { noun: 'gifts' });
+        if (tooNew) return deny(tooNew);
 
         // The two halves of this command each ignore the other's options, and
         // silently: `/gift type:item amount:500` used to move nothing and say
@@ -270,14 +255,13 @@ module.exports = {
                 return deny(`You only have **${currency}${(senderNow?.balance ?? 0).toLocaleString()}** in your wallet.`);
             }
 
-            const sendState = budgetState(senderNow,   { ...BUDGETS.coinSend,    cap: limits.coinSend });
-            const rxState   = budgetState(receiverNow, { ...BUDGETS.coinReceive, cap: limits.coinReceive });
+            const budgets = coinBudgets(senderNow, receiverNow, limits);
 
-            if (amount > sendState.remaining) {
-                return deny(`Daily gift cap reached. You can still gift up to **${currency}${sendState.remaining.toLocaleString()}** today.`);
+            if (amount > budgets.send.remaining) {
+                return deny(`Daily gift cap reached. You can still gift up to **${currency}${budgets.send.remaining.toLocaleString()}** today.`);
             }
-            if (amount > rxState.remaining) {
-                return deny(`<@${target.id}> has reached their daily gift-receiving cap. They can receive up to **${currency}${rxState.remaining.toLocaleString()}** more today.`);
+            if (amount > budgets.receive.remaining) {
+                return deny(`<@${target.id}> has reached their daily gift-receiving cap. They can receive up to **${currency}${budgets.receive.remaining.toLocaleString()}** more today.`);
             }
 
             // A gift is irreversible, so a large one asks first — the same
@@ -293,48 +277,29 @@ module.exports = {
                 if (!ok) return;
             }
 
-            // Atomic deduction: the filter enforces the balance and the daily cap
-            // in the same write, so concurrent gifts can't race past either.
-            const sendSpend = spendBudget({ ...BUDGETS.coinSend, cap: limits.coinSend, expired: sendState.expired, amount });
-            const deducted = await User.findOneAndUpdate(
-                { userId: interaction.user.id, guildId, balance: { $gte: amount }, ...sendSpend.filter },
-                {
-                    $inc: { balance: -amount, ...sendSpend.inc },
-                    ...(Object.keys(sendSpend.set).length ? { $set: sendSpend.set } : {}),
-                },
-                { new: true }
-            );
-            if (!deducted) {
+            // The move itself, and every guard on it, in utils/coinTransfer.js —
+            // shared with `/bank transfer`, which used to do the same thing with
+            // none of them (#897).
+            const moved = await commitCoinTransfer({
+                senderId: interaction.user.id, receiverId: target.id, guildId,
+                amount, limits, budgets,
+                refundKey: interaction.id, service: 'gift', jobName: 'giftCoins',
+            });
+
+            if (moved.status === 'debit_failed') {
                 return deny('Could not complete the transfer — your balance or daily gift cap may have changed.');
             }
-
-            // Ensure the receiver document exists, then credit with the receive-cap
-            // enforced atomically (no upsert here — an unmatched conditional upsert
-            // would try to insert a duplicate userId+guildId document).
-            await User.updateOne({ userId: target.id, guildId }, {}, { upsert: true });
-
-            const rxSpend = spendBudget({ ...BUDGETS.coinReceive, cap: limits.coinReceive, expired: rxState.expired, amount });
-            const credited = await User.findOneAndUpdate(
-                { userId: target.id, guildId, ...rxSpend.filter },
-                {
-                    $inc: { balance: amount, ...rxSpend.inc },
-                    ...(Object.keys(rxSpend.set).length ? { $set: rxSpend.set } : {}),
-                },
-                { new: true }
-            );
-            if (!credited) {
-                // Receiver hit their cap in a race — roll the sender back
-                try {
-                    await User.updateOne(
-                        { userId: interaction.user.id, guildId },
-                        { $inc: { balance: amount, ...refundBudget({ ...BUDGETS.coinSend, cap: limits.coinSend, amount }) } }
-                    );
-                } catch (rollbackErr) {
-                    console.error(`[gift] CRITICAL: sender rollback failed — sender=${interaction.user.id} guild=${guildId} amount=${amount}:`, rollbackErr);
-                    return deny('Something went wrong returning your coins — please contact a server admin.');
-                }
-                return deny(`Could not complete the transfer — <@${target.id}> just reached their daily gift-receiving cap. Your coins were returned.`);
+            if (moved.status !== 'ok') {
+                const why = moved.status === 'receive_cap'
+                    ? `<@${target.id}> just reached their daily gift-receiving cap`
+                    : 'something went wrong sending your coins';
+                if (moved.refunded) return deny(`Could not complete the transfer — ${why}. Your coins were returned.`);
+                return deny(moved.owed
+                    ? `Could not complete the transfer — ${why}, and returning your **${currency}${amount.toLocaleString()}** failed too. It is recorded and an admin can restore it.`
+                    : `Could not complete the transfer — ${why}, and returning your coins failed. Please contact a server admin.`);
             }
+
+            const { sender: deducted, receiver: credited } = moved;
 
             logTransaction({ userId: interaction.user.id, guildId, type: 'gift_send',    amount: -amount, balance: deducted.balance, relatedUserId: target.id, note: 'Coin gift' });
             logTransaction({ userId: target.id,           guildId, type: 'gift_receive', amount,          balance: credited.balance, relatedUserId: interaction.user.id, note: 'Coin gift' });

--- a/src/commands/economy/gift.js
+++ b/src/commands/economy/gift.js
@@ -13,7 +13,9 @@ const {
     BUDGETS, giftLimits, budgetState, spendBudget, spendBudgetPipeline,
     refundBudgetPipeline,
 } = require('../../utils/giftCaps');
-const { accountAgeRefusal, coinBudgets, commitCoinTransfer } = require('../../utils/coinTransfer');
+const {
+    accountAgeRefusal, coinBudgets, commitCoinTransfer, transferRefusal,
+} = require('../../utils/coinTransfer');
 const { isSoulbound } = require('../../data/soulboundItems');
 const { resolveEffectType } = require('../../services/effectsService');
 const COLORS = require('../../utils/embedColors');
@@ -286,18 +288,11 @@ module.exports = {
                 refundKey: interaction.id, service: 'gift', jobName: 'giftCoins',
             });
 
-            if (moved.status === 'debit_failed') {
-                return deny('Could not complete the transfer — your balance or daily gift cap may have changed.');
-            }
-            if (moved.status !== 'ok') {
-                const why = moved.status === 'receive_cap'
-                    ? `<@${target.id}> just reached their daily gift-receiving cap`
-                    : 'something went wrong sending your coins';
-                if (moved.refunded) return deny(`Could not complete the transfer — ${why}. Your coins were returned.`);
-                return deny(moved.owed
-                    ? `Could not complete the transfer — ${why}, and returning your **${currency}${amount.toLocaleString()}** failed too. It is recorded and an admin can restore it.`
-                    : `Could not complete the transfer — ${why}, and returning your coins failed. Please contact a server admin.`);
-            }
+            const refusal = transferRefusal(moved, {
+                mention: `<@${target.id}>`, currency, amount,
+                sendCapLabel: 'daily gift cap', receiveCapLabel: 'daily gift-receiving cap',
+            });
+            if (refusal) return deny(refusal);
 
             const { sender: deducted, receiver: credited } = moved;
 

--- a/src/commands/economy/market.js
+++ b/src/commands/economy/market.js
@@ -11,6 +11,7 @@ const { EFFECT_CONFIGS } = require('../../services/effectsService');
 const { logTransaction } = require('../../utils/logTransaction');
 const { grantInventoryItem } = require('../../utils/inventoryGrant');
 const { recordOwedPayout } = require('../../utils/owedPayout');
+const { creditCoinsOnce, marketSalePayoutKey } = require('../../utils/payoutKey');
 const COLORS = require('../../utils/embedColors');
 const { ownedBy } = require('../../utils/collectorOwner');
 const { getGuildSettings } = require('../../utils/guildSettingsCache');
@@ -613,24 +614,94 @@ async function handleBuy(interaction, currency) {
             return editReply({ content: 'Something went wrong crediting the item. Your coins have been refunded.', embeds: [], components: [] });
         }
 
-        // Credit seller and capture their new balance for accurate logging
-        const updatedSeller = await User.findOneAndUpdate(
-            { userId: listing.sellerId, guildId: interaction.guild.id },
-            { $inc: { balance: sellerReceives } },
-            { new: true }
-        );
+        // The seller's proceeds, and the one credit in this flow nothing was
+        // watching (#869). By the time it runs the buyer has paid, the item has
+        // moved and the listing is deleted, so there is nothing left to retry
+        // against — and it was an unguarded write whose two failure modes were
+        // both swallowed. A `null` return (a seller with no user document) was
+        // ignored, and logged as `balance: 0` for good measure; a throw escaped
+        // the purchase entirely, with the buyer already charged.
+        //
+        // Keyed by the listing, which this flow has just deleted and so cannot
+        // be reused, making the credit exactly-once: a write that committed
+        // without its response arriving is not paid a second time by
+        // `npm run payouts:replay`. Anything that still will not land is written
+        // down as owed, which is what the expiry sweep does with a return it
+        // cannot make.
+        const saleKey = marketSalePayoutKey(listing._id);
+        let sellerStatus = null;
+        let sellerDoc    = null;
+        let sellerErr    = null;
+        try {
+            ({ status: sellerStatus, doc: sellerDoc } = await creditCoinsOnce(
+                { userId: listing.sellerId, guildId: interaction.guild.id },
+                sellerReceives,
+                saleKey,
+                { projection: { balance: 1 } },
+            ));
+        } catch (err) {
+            sellerErr = err;
+        }
 
-        logTransaction({ userId: listing.sellerId, guildId: interaction.guild.id, type: 'market_sell', amount: sellerReceives, balance: updatedSeller?.balance ?? 0, note: listing.itemId });
+        // 'duplicate' is a success whose response was lost on an earlier attempt
+        // — the coins are there. It comes back with no document though, and a
+        // failure has none either, so in both cases the balance for the audit
+        // log is read rather than assumed. `balance` is required on the
+        // Transaction schema, so guessing is not an option and neither is
+        // leaving it out: the row simply would not be written.
+        const sellerPaid = sellerStatus === 'paid' || sellerStatus === 'duplicate';
+        const sellerBalance = sellerDoc?.balance ?? (await User.findOne(
+            { userId: listing.sellerId, guildId: interaction.guild.id }, { balance: 1 },
+        ).lean().catch(() => null))?.balance ?? 0;
+
+        if (!sellerPaid) {
+            const reason = sellerErr?.message
+                ?? `credit for ${listing.sellerId} in ${interaction.guild.id} matched nothing (${sellerStatus})`;
+            const recorded = await recordOwedPayout({
+                service: 'market',
+                jobName: 'buyListing',
+                guildId: interaction.guild.id,
+                payload: {
+                    kind:      'coins',
+                    userId:    listing.sellerId,
+                    guildId:   interaction.guild.id,
+                    amount:    sellerReceives,
+                    listingId: String(listing._id),
+                    payoutKey: saleKey,
+                },
+                error: sellerErr ?? new Error(reason),
+            });
+            console.error(
+                `[market buy] listing ${listing._id} sold but crediting ${sellerReceives} to ` +
+                `${listing.sellerId} failed — ${recorded ? 'recorded as owed' : 'NOT RECORDED'}:`, reason,
+            );
+        }
+
+        // Logged either way: the sale happened, and a row that only appears when
+        // the credit lands leaves the coins unaccounted for exactly when someone
+        // goes looking for them. The note says which it was, so an operator
+        // reading a `market_sell` whose balance did not move has the reason in
+        // front of them rather than a discrepancy to work out.
+        logTransaction({
+            userId: listing.sellerId, guildId: interaction.guild.id, type: 'market_sell',
+            amount: sellerReceives, balance: sellerBalance,
+            note: sellerPaid ? listing.itemId : `${listing.itemId} — payout owed (${saleKey})`,
+        });
         logTransaction({ userId: interaction.user.id, guildId: interaction.guild.id, type: 'market_buy', amount: -totalCost, balance: buyer.balance, note: listing.itemId });
 
+        // The buyer's side of the trade is complete whatever happened above, so
+        // this is still a success — but the receipt does not claim the seller
+        // was paid when they were not.
         return editReply({
             embeds: [new EmbedBuilder()
                 .setColor(COLORS.SUCCESS)
                 .setTitle('✅ Purchase Complete!')
                 .setDescription(`You bought **${listing.quantity}x \`${listing.itemId}\`** for **${currency}${totalCost.toLocaleString()}**.`)
                 .addFields(
-                    { name: 'Fee Burned',      value: `${currency}${feeAmount.toLocaleString()}`, inline: true },
-                    { name: 'Seller Received', value: `${currency}${sellerReceives.toLocaleString()}`, inline: true },
+                    { name: 'Fee Burned', value: `${currency}${feeAmount.toLocaleString()}`, inline: true },
+                    sellerPaid
+                        ? { name: 'Seller Received', value: `${currency}${sellerReceives.toLocaleString()}`, inline: true }
+                        : { name: 'Seller Payout',   value: `${currency}${sellerReceives.toLocaleString()} — delayed, recorded as owed`, inline: true },
                 )
                 .setTimestamp()
             ],

--- a/src/commands/economy/market.js
+++ b/src/commands/economy/market.js
@@ -654,10 +654,11 @@ async function handleBuy(interaction, currency) {
             { userId: listing.sellerId, guildId: interaction.guild.id }, { balance: 1 },
         ).lean().catch(() => null))?.balance ?? 0;
 
+        let owedRecorded = false;
         if (!sellerPaid) {
             const reason = sellerErr?.message
                 ?? `credit for ${listing.sellerId} in ${interaction.guild.id} matched nothing (${sellerStatus})`;
-            const recorded = await recordOwedPayout({
+            owedRecorded = await recordOwedPayout({
                 service: 'market',
                 jobName: 'buyListing',
                 guildId: interaction.guild.id,
@@ -673,7 +674,7 @@ async function handleBuy(interaction, currency) {
             });
             console.error(
                 `[market buy] listing ${listing._id} sold but crediting ${sellerReceives} to ` +
-                `${listing.sellerId} failed — ${recorded ? 'recorded as owed' : 'NOT RECORDED'}:`, reason,
+                `${listing.sellerId} failed — ${owedRecorded ? 'recorded as owed' : 'NOT RECORDED'}:`, reason,
             );
         }
 
@@ -691,7 +692,9 @@ async function handleBuy(interaction, currency) {
 
         // The buyer's side of the trade is complete whatever happened above, so
         // this is still a success — but the receipt does not claim the seller
-        // was paid when they were not.
+        // was paid when they were not, nor that the payout is recorded when the
+        // queue write failed too: `recordOwedPayout` returns false for that, and
+        // an unrecorded payout is the one case a human has to be told about.
         return editReply({
             embeds: [new EmbedBuilder()
                 .setColor(COLORS.SUCCESS)
@@ -701,7 +704,13 @@ async function handleBuy(interaction, currency) {
                     { name: 'Fee Burned', value: `${currency}${feeAmount.toLocaleString()}`, inline: true },
                     sellerPaid
                         ? { name: 'Seller Received', value: `${currency}${sellerReceives.toLocaleString()}`, inline: true }
-                        : { name: 'Seller Payout',   value: `${currency}${sellerReceives.toLocaleString()} — delayed, recorded as owed`, inline: true },
+                        : {
+                            name: 'Seller Payout',
+                            value: owedRecorded
+                                ? `${currency}${sellerReceives.toLocaleString()} — delayed, recorded as owed`
+                                : `${currency}${sellerReceives.toLocaleString()} — delayed and not recorded, please contact a server admin`,
+                            inline: true,
+                        },
                 )
                 .setTimestamp()
             ],

--- a/src/dashboard/public/guild-settings.js
+++ b/src/dashboard/public/guild-settings.js
@@ -3914,12 +3914,17 @@ function initGettingStarted() {
 }
 onPanel('overview', initGettingStarted);
 function toggleGettingStarted() {
-    const body = document.getElementById('getting-started-body');
-    const icon = document.getElementById('gs-toggle-icon');
+    const body   = document.getElementById('getting-started-body');
+    const toggle = document.getElementById('gs-toggle');
+    const icon   = document.getElementById('gs-toggle-icon');
     if (!body) return;
-    const isHidden = body.style.display === 'none';
-    body.style.display = isHidden ? '' : 'none';
-    if (icon) icon.textContent = isHidden ? '▾' : '▸';
+    const open = body.style.display === 'none';
+    body.style.display = open ? '' : 'none';
+    // The glyph is decorative (aria-hidden in the view), so aria-expanded is the
+    // only thing reporting the state to anyone not looking at it (#882). The two
+    // move together or the button lies.
+    if (toggle) toggle.setAttribute('aria-expanded', String(open));
+    if (icon) icon.textContent = open ? '▾' : '▸';
 }
 function dismissGettingStarted() {
     const guildId = BOOT.guildId;

--- a/src/dashboard/public/styles.css
+++ b/src/dashboard/public/styles.css
@@ -1510,7 +1510,12 @@ textarea.auto-resize {
 .gs-toggle { display: flex; width: 100%; align-items: center; justify-content: space-between; gap: 16px;
              background: none; border: 0; padding: 0; margin: 0; cursor: pointer;
              font: inherit; color: inherit; text-align: left; }
-.gs-toggle-icon { font-size: 1.2rem; line-height: 1; }
+.gs-toggle-text { display: flex; flex-direction: column; align-items: flex-start; gap: 4px; min-width: 0; }
+/* The subtitle is inside the button now, and the button inherits the h2's
+   serif display face — which is not what this line is. Put the body font back
+   on it, and drop the margin the flex `gap` above already provides. */
+.gs-toggle .dash-card-sub { font-family: 'Inter Tight', Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin-top: 0; }
+.gs-toggle-icon { font-size: 1.2rem; line-height: 1; flex: none; }
 .gs-toggle:focus-visible { outline: 2px solid var(--claw-500); outline-offset: 4px; border-radius: 4px; }
 .dash-pill { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: 999px; background: var(--ink-850); font-size: 12px; color: var(--ink-200); border: 1px solid var(--ink-800); font-family: 'JetBrains Mono', monospace; }
 

--- a/src/dashboard/public/styles.css
+++ b/src/dashboard/public/styles.css
@@ -1246,11 +1246,14 @@ textarea.auto-resize {
 .cw-show-stat .delta { font-size: 11.5px; color: var(--good); margin-top: 6px; font-family: 'JetBrains Mono', monospace; }
 .cw-show-stat .delta.bad { color: var(--bad); }
 
-/* Compare table */
-.cw-compare { display: grid; grid-template-columns: 1.4fr 1fr 1fr 1fr; border: 1px solid rgba(20,17,13,.1); border-radius: 22px; overflow: hidden; background: #fff; }
-.cw-compare > div { padding: 18px 22px; border-bottom: 1px solid rgba(20,17,13,.06); font-size: 14.5px; }
-.cw-compare > div:nth-child(4n) { border-right: none; }
-.cw-compare > div:nth-child(-n+4) { background: var(--cream-100); font-family: 'JetBrains Mono', monospace; font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--ink-600); }
+/* Compare table (#912). The markup is a real <table>; the grid keeps the look
+   it had as a pile of divs. `display: contents` on the row groups and rows
+   drops them out of the box tree so the cells become grid items of the table
+   itself, which is what lets one four-column track list span every row. */
+.cw-compare { display: grid; grid-template-columns: 1.4fr 1fr 1fr 1fr; border: 1px solid rgba(20,17,13,.1); border-radius: 22px; overflow: hidden; background: #fff; border-collapse: collapse; width: 100%; }
+.cw-compare thead, .cw-compare tbody, .cw-compare tr { display: contents; }
+.cw-compare th, .cw-compare td { padding: 18px 22px; border-bottom: 1px solid rgba(20,17,13,.06); font-size: 14.5px; text-align: left; font-weight: 400; vertical-align: top; }
+.cw-compare thead th { background: var(--cream-100); font-family: 'JetBrains Mono', monospace; font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--ink-600); }
 .cw-compare .hi { background: rgba(217,119,66,.06); border-left: 2px solid var(--claw-500); }
 .cw-compare-yes { color: var(--good); font-weight: 600; }
 .cw-compare-no { color: var(--ink-400); }
@@ -1497,6 +1500,18 @@ textarea.auto-resize {
 .dash-card-header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 18px; gap: 16px; }
 .dash-card-title { font-family: 'Instrument Serif', serif; font-size: 22px; margin: 0; line-height: 1.1; color: var(--cream-50); }
 .dash-card-sub { font-size: 13px; color: var(--ink-400); margin-top: 4px; }
+
+/* Getting Started collapse (#882). The header is a heading with a full-width
+   button inside it, so the click target is the row it always was while the
+   keyboard and the accessibility tree get a control they can actually use.
+   `display: block` undoes .dash-card-header's flex row — the button does the
+   title/glyph spacing itself now. */
+.gs-header { display: block; }
+.gs-toggle { display: flex; width: 100%; align-items: center; justify-content: space-between; gap: 16px;
+             background: none; border: 0; padding: 0; margin: 0; cursor: pointer;
+             font: inherit; color: inherit; text-align: left; }
+.gs-toggle-icon { font-size: 1.2rem; line-height: 1; }
+.gs-toggle:focus-visible { outline: 2px solid var(--claw-500); outline-offset: 4px; border-radius: 4px; }
 .dash-pill { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: 999px; background: var(--ink-850); font-size: 12px; color: var(--ink-200); border: 1px solid var(--ink-800); font-family: 'JetBrains Mono', monospace; }
 
 /* Modules grid */
@@ -1705,10 +1720,12 @@ textarea.auto-resize {
 .analytics-rec-link:hover { text-decoration: underline; }
 .analytics-chart-card { background: var(--surface-2, #1a1510); border: 1px solid var(--border); border-radius: 8px; padding: .85rem 1rem; }
 .analytics-chart-title { font-size: .8rem; font-weight: 600; color: var(--text-dim); margin-bottom: .5rem; text-transform: uppercase; letter-spacing: .04em; }
-/* #669. The numbers behind each chart, as a real table beside the canvas.
+/* Text for a screen reader and no one else — the numbers behind each chart
+   beside the canvas (#669), the compare table's caption (#912).
    Clipped rather than `display: none` — a hidden element is dropped from the
    accessibility tree along with everything in it, which is the very thing this
    is here to avoid. */
+.sr-only,
 .chart-a11y-data {
     position: absolute;
     width: 1px;

--- a/src/dashboard/views/index.ejs
+++ b/src/dashboard/views/index.ejs
@@ -262,47 +262,70 @@
                 <h2 class="cw-section-title">Things other bots<br>charge $9/mo for.</h2>
             </div>
         </div>
-        <div class="cw-compare">
-            <div>Feature</div>
-            <div class="hi">Clawdia</div>
-            <div>MEE6 Pro</div>
-            <div>Carl-bot Premium</div>
+        <%# A real table, because the comparison is the page's main argument and a
+            grid of bare divs reads as a flat run of disconnected words: nothing
+            ties "● included" to either its feature row or its bot column (#912).
 
-            <div>Self-hosted, your data</div>
-            <div class="hi"><span class="cw-compare-yes">● included</span></div>
-            <div><span class="cw-compare-no">— not available</span></div>
-            <div><span class="cw-compare-no">— not available</span></div>
-
-            <div>AI chat (OpenAI / Gemini / Ollama)</div>
-            <div class="hi"><span class="cw-compare-yes">● included</span></div>
-            <div><span class="cw-compare-warn">◐ limited</span></div>
-            <div><span class="cw-compare-no">— not available</span></div>
-
-            <div>Insights &amp; retention cohorts</div>
-            <div class="hi"><span class="cw-compare-yes">● included</span></div>
-            <div><span class="cw-compare-no">— not available</span></div>
-            <div><span class="cw-compare-no">— not available</span></div>
-
-            <div>Daily news digest from multi-feed</div>
-            <div class="hi"><span class="cw-compare-yes">● included</span></div>
-            <div><span class="cw-compare-no">— not available</span></div>
-            <div><span class="cw-compare-no">— not available</span></div>
-
-            <div>Custom welcome cards</div>
-            <div class="hi"><span class="cw-compare-yes">● included</span></div>
-            <div><span class="cw-compare-yes">● included</span></div>
-            <div><span class="cw-compare-yes">● included</span></div>
-
-            <div>Source code · MIT</div>
-            <div class="hi"><span class="cw-compare-yes">● included</span></div>
-            <div><span class="cw-compare-no">— not available</span></div>
-            <div><span class="cw-compare-no">— not available</span></div>
-
-            <div>Monthly cost</div>
-            <div class="hi"><b>free</b></div>
-            <div><b>$11.95</b></div>
-            <div><b>$5</b></div>
-        </div>
+            The explicit `role` on every part is not belt and braces. The layout
+            is still CSS grid — `display: grid` on the table, `display: contents`
+            on its rows — and a browser that is not laying an element out as a
+            table stops reporting it as one. The elements are what a reader of the
+            markup sees; the roles are what keep that true after the CSS. %>
+        <table class="cw-compare" role="table">
+            <caption class="sr-only">Clawdia compared with MEE6 Pro and Carl-bot Premium, feature by feature.</caption>
+            <thead role="rowgroup">
+                <tr role="row">
+                    <th scope="col" role="columnheader">Feature</th>
+                    <th scope="col" role="columnheader" class="hi">Clawdia</th>
+                    <th scope="col" role="columnheader">MEE6 Pro</th>
+                    <th scope="col" role="columnheader">Carl-bot Premium</th>
+                </tr>
+            </thead>
+            <tbody role="rowgroup">
+                <tr role="row">
+                    <th scope="row" role="rowheader">Self-hosted, your data</th>
+                    <td role="cell" class="hi"><span class="cw-compare-yes">● included</span></td>
+                    <td role="cell"><span class="cw-compare-no">— not available</span></td>
+                    <td role="cell"><span class="cw-compare-no">— not available</span></td>
+                </tr>
+                <tr role="row">
+                    <th scope="row" role="rowheader">AI chat (OpenAI / Gemini / Ollama)</th>
+                    <td role="cell" class="hi"><span class="cw-compare-yes">● included</span></td>
+                    <td role="cell"><span class="cw-compare-warn">◐ limited</span></td>
+                    <td role="cell"><span class="cw-compare-no">— not available</span></td>
+                </tr>
+                <tr role="row">
+                    <th scope="row" role="rowheader">Insights &amp; retention cohorts</th>
+                    <td role="cell" class="hi"><span class="cw-compare-yes">● included</span></td>
+                    <td role="cell"><span class="cw-compare-no">— not available</span></td>
+                    <td role="cell"><span class="cw-compare-no">— not available</span></td>
+                </tr>
+                <tr role="row">
+                    <th scope="row" role="rowheader">Daily news digest from multi-feed</th>
+                    <td role="cell" class="hi"><span class="cw-compare-yes">● included</span></td>
+                    <td role="cell"><span class="cw-compare-no">— not available</span></td>
+                    <td role="cell"><span class="cw-compare-no">— not available</span></td>
+                </tr>
+                <tr role="row">
+                    <th scope="row" role="rowheader">Custom welcome cards</th>
+                    <td role="cell" class="hi"><span class="cw-compare-yes">● included</span></td>
+                    <td role="cell"><span class="cw-compare-yes">● included</span></td>
+                    <td role="cell"><span class="cw-compare-yes">● included</span></td>
+                </tr>
+                <tr role="row">
+                    <th scope="row" role="rowheader">Source code &middot; MIT</th>
+                    <td role="cell" class="hi"><span class="cw-compare-yes">● included</span></td>
+                    <td role="cell"><span class="cw-compare-no">— not available</span></td>
+                    <td role="cell"><span class="cw-compare-no">— not available</span></td>
+                </tr>
+                <tr role="row">
+                    <th scope="row" role="rowheader">Monthly cost</th>
+                    <td role="cell" class="hi"><b>free</b></td>
+                    <td role="cell"><b>$11.95</b></td>
+                    <td role="cell"><b>$5</b></td>
+                </tr>
+            </tbody>
+        </table>
     </section>
 
     <!-- SELF-HOST -->

--- a/src/dashboard/views/partials/panels/economy.ejs
+++ b/src/dashboard/views/partials/panels/economy.ejs
@@ -42,13 +42,13 @@
 
                         <!-- Gifting -->
                         <div class="eco-section-head eco-section-gap">
-                            <div class="toggle-text eco-section-title"><strong>Gifting limits</strong><span>How much value one member can hand another per day with /gift. Set any limit to 0 to turn it off.</span></div>
+                            <div class="toggle-text eco-section-title"><strong>Gifting limits</strong><span>How much value one member can hand another per day. The coin limits cover /gift and /bank transfer together, so neither is a way around the other. Set any limit to 0 to turn it off.</span></div>
                         </div>
                         <div class="field field-pair">
                             <div>
                                 <label class="field-label" for="economy-gift-coin-cap">Coins sent per day</label>
                                 <input type="number" id="economy-gift-coin-cap" value="<%= settings.economy.giftCoinCapDaily ?? 10000 %>" min="0">
-                                <small>Most one member can gift away in 24 hours</small>
+                                <small>Most one member can hand away in 24 hours, by gift or transfer</small>
                             </div>
                             <div>
                                 <label class="field-label" for="economy-gift-coin-receive-cap">Coins received per day</label>

--- a/src/dashboard/views/partials/panels/overview.ejs
+++ b/src/dashboard/views/partials/panels/overview.ejs
@@ -22,12 +22,22 @@
             %>
             <div id="getting-started-wrap" style="margin-bottom:1.5rem;<%= setupDone ? 'display:none' : '' %>">
                 <div class="dash-card" id="getting-started-card">
-                    <div class="dash-card-header" style="cursor:pointer" onclick="toggleGettingStarted()">
-                        <div>
-                            <h2 class="dash-card-title">Getting started</h2>
-                            <div class="dash-card-sub" id="gs-subtitle">Complete these steps to finish setting up Clawdia</div>
-                        </div>
-                        <span id="gs-toggle-icon" style="font-size:1.2rem;line-height:1">▾</span>
+                    <%# The collapse is a real button, not a div with a click handler
+                        (#882): a keyboard user could not reach the old one at all, and
+                        the only sign it was expanded was the ▾/▸ glyph, which a screen
+                        reader has no reason to read out. The glyph is decorative now
+                        and aria-expanded carries the state. The button stretches across
+                        the header so the click target stays the whole row it was. %>
+                    <div class="dash-card-header gs-header">
+                        <h2 class="dash-card-title">
+                            <button type="button" id="gs-toggle" class="gs-toggle"
+                                    aria-expanded="true" aria-controls="getting-started-body"
+                                    onclick="toggleGettingStarted()">
+                                <span>Getting started</span>
+                                <span id="gs-toggle-icon" class="gs-toggle-icon" aria-hidden="true">▾</span>
+                            </button>
+                        </h2>
+                        <div class="dash-card-sub" id="gs-subtitle">Complete these steps to finish setting up Clawdia</div>
                     </div>
                     <div id="getting-started-body">
                         <div class="dash-module-list" style="display:flex;flex-direction:column;gap:.35rem;padding-top:.25rem">

--- a/src/dashboard/views/partials/panels/overview.ejs
+++ b/src/dashboard/views/partials/panels/overview.ejs
@@ -33,11 +33,18 @@
                             <button type="button" id="gs-toggle" class="gs-toggle"
                                     aria-expanded="true" aria-controls="getting-started-body"
                                     onclick="toggleGettingStarted()">
-                                <span>Getting started</span>
+                                <%# The subtitle sits inside the button, not beside it: the whole
+                                    header used to be the click target and a subtitle left outside
+                                    would be the one part of it that stopped working. It joins the
+                                    button's accessible name, which reads well for a disclosure —
+                                    "Getting started, 2 of 5 steps complete". %>
+                                <span class="gs-toggle-text">
+                                    <span>Getting started</span>
+                                    <span class="dash-card-sub" id="gs-subtitle">Complete these steps to finish setting up Clawdia</span>
+                                </span>
                                 <span id="gs-toggle-icon" class="gs-toggle-icon" aria-hidden="true">▾</span>
                             </button>
                         </h2>
-                        <div class="dash-card-sub" id="gs-subtitle">Complete these steps to finish setting up Clawdia</div>
                     </div>
                     <div id="getting-started-body">
                         <div class="dash-module-list" style="display:flex;flex-direction:column;gap:.35rem;padding-top:.25rem">

--- a/src/utils/coinTransfer.js
+++ b/src/utils/coinTransfer.js
@@ -171,11 +171,20 @@ async function commitCoinTransfer({
     const status = creditError ? 'credit_failed' : 'receive_cap';
     let rollbackError;
     try {
-        await Model.updateOne(
+        const refund = await Model.updateOne(
             { userId: senderId, guildId },
             { $inc: { balance: amount, ...refundBudget({ ...BUDGETS.coinSend, cap: limits.coinSend, amount }) } },
         );
-        return { status, refunded: true, owed: false, error: creditError ?? null };
+        // A filter that matches nothing resolves without rejecting, so the
+        // result has to be read rather than the absence of a throw taken as
+        // success: if the sender's document went away between the debit and
+        // here, an unchecked `updateOne` refunds nothing and still looks like
+        // it worked. That is the silent loss this module exists to prevent, so
+        // an unmatched refund is treated exactly like a rejected one.
+        if ((refund?.matchedCount ?? refund?.n ?? 0) > 0) {
+            return { status, refunded: true, owed: false, error: creditError ?? null };
+        }
+        rollbackError = new Error(`refund for ${senderId} in ${guildId} matched no document`);
     } catch (err) {
         rollbackError = err;
     }
@@ -206,4 +215,47 @@ async function commitCoinTransfer({
     return { status, refunded: false, owed, error: creditError ?? rollbackError };
 }
 
-module.exports = { MIN_ACCOUNT_AGE_MS, accountAgeRefusal, coinBudgets, commitCoinTransfer };
+/**
+ * What to tell the sender when `commitCoinTransfer` did not move the coins.
+ *
+ * Both commands had their own copy of this decision tree over `status`,
+ * `refunded` and `owed`, differing only in what they call the two caps and who
+ * they name as the recipient. A status added to `commitCoinTransfer` would have
+ * had to be handled in both, and one of them would have been missed — which
+ * matters here more than it usually does, because the branch most likely to be
+ * forgotten is the one that says the coins are neither sent nor returned.
+ *
+ * Returns null for a successful transfer, so a caller can treat a string as
+ * "there is something to say".
+ *
+ * @param {object} moved   the `commitCoinTransfer` result
+ * @param {object} opts
+ * @param {string} opts.mention          how to name the recipient, already formatted
+ * @param {string} opts.currency
+ * @param {number} opts.amount
+ * @param {string} opts.sendCapLabel     e.g. 'daily gift cap'
+ * @param {string} opts.receiveCapLabel  e.g. 'daily gift-receiving cap'
+ */
+function transferRefusal(moved, { mention, currency, amount, sendCapLabel, receiveCapLabel }) {
+    if (moved.status === 'ok') return null;
+
+    if (moved.status === 'debit_failed') {
+        return `Could not complete the transfer — your balance or ${sendCapLabel} may have changed.`;
+    }
+
+    const why = moved.status === 'receive_cap'
+        ? `${mention} just reached their ${receiveCapLabel}`
+        : 'something went wrong sending your coins';
+
+    if (moved.refunded) return `Could not complete the transfer — ${why}. Your coins were returned.`;
+
+    // Neither sent nor returned. `owed` decides whether that is recoverable,
+    // and the two must not be worded the same.
+    return moved.owed
+        ? `Could not complete the transfer — ${why}, and returning your **${currency}${amount.toLocaleString()}** failed too. It is recorded and an admin can restore it.`
+        : `Could not complete the transfer — ${why}, and returning your coins failed. Please contact a server admin.`;
+}
+
+module.exports = {
+    MIN_ACCOUNT_AGE_MS, accountAgeRefusal, coinBudgets, commitCoinTransfer, transferRefusal,
+};

--- a/src/utils/coinTransfer.js
+++ b/src/utils/coinTransfer.js
@@ -1,0 +1,209 @@
+'use strict';
+
+/**
+ * Moving coins from one player to another, once, for every command that does it.
+ *
+ * There were two of these. `/gift type:coins` enforced the anti-alt daily caps
+ * — 10k out, 25k in — atomically, gated on account age, and rolled the sender
+ * back when the credit missed. `/bank transfer` moved coins between the same two
+ * parties with none of it: no cap, no age gate, no daily accounting, and no
+ * rollback at all, so a failed credit simply destroyed the sender's coins
+ * (#868) while the caps next door were decorative — anyone who hit the gift cap
+ * used transfer instead (#897).
+ *
+ * Two implementations of one operation is what made that possible, so there is
+ * one now, and the caps are a property of moving coins rather than a property of
+ * having typed `/gift`. What is left at each call site is its own wording and
+ * its own confirmation prompt, which is the part that genuinely differs.
+ *
+ * The order of operations is the one gift.js established, and each step is here
+ * for a failure it prevents:
+ *
+ *   1. Debit the sender, with the balance check and the send-cap `$expr` in the
+ *      same filter. A concurrent transfer cannot slip past a check it
+ *      invalidated, because there is no gap between the check and the spend.
+ *   2. Credit the receiver, with the receive cap in *that* filter.
+ *   3. If the credit does not land — a cap reached in the race, a transient
+ *      error, an E11000 on the upsert — roll the debit back, budget and all.
+ *   4. If the rollback does not land either, write the refund down as an owed
+ *      payout so `npm run payouts:replay` can settle it. That is the case that
+ *      used to destroy coins outright.
+ *
+ * There is no transaction to reach for: the deployment is a standalone mongod
+ * and PR #520 removed the transactions this codebase had. Atomic filters plus a
+ * rollback plus a durable record of a rollback that failed is the shape the rest
+ * of the economy already uses.
+ */
+
+const DEFAULT_USER = require('../models/User');
+const { BUDGETS, budgetState, spendBudget, refundBudget } = require('./giftCaps');
+const { recordOwedPayout } = require('./owedPayout');
+const { transferRefundPayoutKey, isDuplicateKeyError } = require('./payoutKey');
+
+/**
+ * Fresh Discord accounts can't send or receive coins — blocks throwaway-alt
+ * funnels, which is the same thing the daily caps are for and is worth applying
+ * wherever they are.
+ */
+const MIN_ACCOUNT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Whether either party's Discord account is too new, as the sentence to show
+ * them, or null when both are old enough.
+ *
+ * Returned as a message rather than a boolean because which of the two it is
+ * changes what the user can do about it, and a caller that had to work that out
+ * again from a boolean would get it wrong in one of the two commands. `noun` is
+ * what the command calls the thing being moved, so `/gift` keeps saying "gifts".
+ */
+function accountAgeRefusal(sender, receiver, { now = Date.now(), noun = 'coins' } = {}) {
+    if (now - sender.createdTimestamp < MIN_ACCOUNT_AGE_MS) {
+        return `Your Discord account is too new to send ${noun}. Try again in a few days.`;
+    }
+    if (now - receiver.createdTimestamp < MIN_ACCOUNT_AGE_MS) {
+        return `${receiver.username}'s Discord account is too new to receive ${noun}.`;
+    }
+    return null;
+}
+
+/**
+ * Where both coin budgets stand for a particular pair of users.
+ *
+ * Split out from the transfer itself because the pre-flight refusal has to name
+ * the number that is left, and the confirmation prompt has to be shown before
+ * anything is written. The states it returns are then handed back to
+ * `commitCoinTransfer`, so the message the user saw and the filter that enforces
+ * it were computed from the same reading.
+ */
+function coinBudgets(senderDoc, receiverDoc, limits) {
+    return {
+        send:    budgetState(senderDoc,   { ...BUDGETS.coinSend,    cap: limits.coinSend }),
+        receive: budgetState(receiverDoc, { ...BUDGETS.coinReceive, cap: limits.coinReceive }),
+    };
+}
+
+/**
+ * Move `amount` coins from one user to another.
+ *
+ * @param {object}  opts
+ * @param {string}  opts.senderId
+ * @param {string}  opts.receiverId
+ * @param {string}  opts.guildId
+ * @param {number}  opts.amount        positive; the caller has already validated it
+ * @param {object}  opts.limits        from `giftLimits(guildSettings)`
+ * @param {object}  opts.budgets       from `coinBudgets`, taken before the confirm prompt
+ * @param {string}  opts.refundKey     names *this* transfer, so a replayed refund
+ *                                     cannot pay twice — `interaction.id` is what
+ *                                     both callers use
+ * @param {string}  [opts.service]     for the owed-payout record and the logs
+ * @param {string}  [opts.jobName]
+ * @param {object}  [opts.Model]
+ *
+ * @returns {Promise<object>} one of
+ *   `{ status: 'ok', sender, receiver }`             both documents, post-write
+ *   `{ status: 'debit_failed' }`                     balance or send cap moved under it
+ *   `{ status: 'receive_cap', refunded, owed }`      receiver hit their cap in the race
+ *   `{ status: 'credit_failed', refunded, owed, error }`
+ *
+ * `refunded` false with `owed` true means the coins are neither with the sender
+ * nor the receiver but are written down for an operator to settle — the caller
+ * has to say so rather than reporting a plain failure.
+ */
+async function commitCoinTransfer({
+    senderId, receiverId, guildId, amount, limits, budgets,
+    refundKey, service = 'economy', jobName = 'coinTransfer', Model = DEFAULT_USER,
+}) {
+    const sendSpend = spendBudget({
+        ...BUDGETS.coinSend, cap: limits.coinSend, expired: budgets.send.expired, amount,
+    });
+
+    // The balance guard and the cap guard in one filter: if either has moved
+    // since the pre-flight read, this matches nothing and no coins leave.
+    const sender = await Model.findOneAndUpdate(
+        { userId: senderId, guildId, balance: { $gte: amount }, ...sendSpend.filter },
+        {
+            $inc: { balance: -amount, ...sendSpend.inc },
+            ...(Object.keys(sendSpend.set).length ? { $set: sendSpend.set } : {}),
+        },
+        { new: true },
+    );
+    if (!sender) return { status: 'debit_failed' };
+
+    const rxSpend = spendBudget({
+        ...BUDGETS.coinReceive, cap: limits.coinReceive, expired: budgets.receive.expired, amount,
+    });
+
+    // Two attempts, and only for E11000. The receiver's document is created by
+    // an upsert that races every other command they are running, and losing that
+    // race raises a duplicate-key error on the unique { userId, guildId } index
+    // — which means the document now exists, so the second pass finds it and
+    // needs no insert. Any other error is a real failure and is not retried:
+    // repeating a write whose outcome is unknown is how a credit lands twice.
+    let receiver = null;
+    let creditError = null;
+    for (let attempt = 0; attempt < 2; attempt++) {
+        try {
+            // No conditional upsert on the credit itself: an upsert whose filter
+            // misses because of the cap `$expr` would try to *insert* a second
+            // document for this user, which the unique index rejects.
+            await Model.updateOne({ userId: receiverId, guildId }, {}, { upsert: true });
+            receiver = await Model.findOneAndUpdate(
+                { userId: receiverId, guildId, ...rxSpend.filter },
+                {
+                    $inc: { balance: amount, ...rxSpend.inc },
+                    ...(Object.keys(rxSpend.set).length ? { $set: rxSpend.set } : {}),
+                },
+                { new: true },
+            );
+            creditError = null;
+            break;
+        } catch (err) {
+            creditError = err;
+            if (!isDuplicateKeyError(err)) break;
+        }
+    }
+
+    if (receiver) return { status: 'ok', sender, receiver };
+
+    // Nothing reached the receiver, so the sender's coins have to come back —
+    // balance and the send budget both, or a failed transfer would quietly eat
+    // the sender's allowance for the day.
+    const status = creditError ? 'credit_failed' : 'receive_cap';
+    let rollbackError;
+    try {
+        await Model.updateOne(
+            { userId: senderId, guildId },
+            { $inc: { balance: amount, ...refundBudget({ ...BUDGETS.coinSend, cap: limits.coinSend, amount }) } },
+        );
+        return { status, refunded: true, owed: false, error: creditError ?? null };
+    } catch (err) {
+        rollbackError = err;
+    }
+
+    // The debit committed and the refund will not. This is the point at which
+    // coins used to simply cease to exist: written down instead, keyed so the
+    // replay cannot pay it a second time, and reported to the caller as
+    // unrefunded so nobody is told their coins came back when they did not.
+    const owed = await recordOwedPayout({
+        service,
+        jobName,
+        guildId,
+        payload: {
+            kind:      'coins',
+            userId:    senderId,
+            guildId,
+            amount,
+            payoutKey: transferRefundPayoutKey(refundKey),
+        },
+        error: rollbackError,
+    });
+
+    console.error(
+        `[${service}] CRITICAL: ${amount} coins debited from ${senderId} in ${guildId} could not be ` +
+        `credited or refunded — ${owed ? 'recorded as owed' : 'NOT RECORDED'}:`, rollbackError,
+    );
+
+    return { status, refunded: false, owed, error: creditError ?? rollbackError };
+}
+
+module.exports = { MIN_ACCOUNT_AGE_MS, accountAgeRefusal, coinBudgets, commitCoinTransfer };

--- a/src/utils/giftCaps.js
+++ b/src/utils/giftCaps.js
@@ -28,6 +28,23 @@
 const DAY_MS = 86_400_000;
 
 /**
+ * The four rolling budgets, by the fields that hold them. Paired here so a call
+ * site names a budget rather than restating a pair of field names each time.
+ *
+ * They live in this module rather than in gift.js because the coin pair is no
+ * longer gift.js's alone: `/bank transfer` spends against the same two windows
+ * through utils/coinTransfer.js (#897), and two tables of field names is exactly
+ * the arrangement in which one of them ends up naming `dailyGiftReset` for the
+ * receive window.
+ */
+const BUDGETS = Object.freeze({
+    coinSend:         { usedField: 'dailyGiftSent',              resetField: 'dailyGiftReset' },
+    coinReceive:      { usedField: 'dailyGiftReceived',          resetField: 'dailyGiftReceivedReset' },
+    itemValueSend:    { usedField: 'dailyGiftItemValueSent',     resetField: 'dailyGiftItemValueReset' },
+    itemValueReceive: { usedField: 'dailyGiftItemValueReceived', resetField: 'dailyGiftItemValueReceivedReset' },
+});
+
+/**
  * Defaults for every configurable gift limit, used when a guild has no value
  * stored. These are the constants that used to live at the top of gift.js.
  */
@@ -189,6 +206,7 @@ function refundBudget({ usedField, cap, amount }) {
 
 module.exports = {
     DAY_MS,
+    BUDGETS,
     GIFT_LIMIT_DEFAULTS,
     LIMIT_KEYS,
     giftLimits,

--- a/src/utils/payoutKey.js
+++ b/src/utils/payoutKey.js
@@ -259,8 +259,35 @@ function listingPayoutKey(listingId) {
     return `listing:${listingId}`;
 }
 
+/**
+ * The seller's proceeds from a completed sale (#869), as opposed to the stock
+ * `listingPayoutKey` returns when the listing expires unsold.
+ *
+ * Two credits against one listing id, and only one of them can ever happen —
+ * `/market buy` and the expiry sweep both delete the listing to claim it. They
+ * are still keyed apart rather than sharing a key, because the guard is a string
+ * comparison on the user document and nothing there records which of the two
+ * wrote it; a shared key would let a replay of one silently satisfy the other.
+ */
+function marketSalePayoutKey(listingId) {
+    return `listing:${listingId}:sale`;
+}
+
+/**
+ * The sender's refund when a coin transfer could not be completed (#868).
+ *
+ * Keyed by the interaction, which is the one identifier that names *this*
+ * transfer: the same two users moving the same amount a second later is a
+ * different transfer and must refund separately, so a key built from the pair
+ * and the amount would collide and drop the second one.
+ */
+function transferRefundPayoutKey(interactionId) {
+    return `transfer:${interactionId}:refund`;
+}
+
 module.exports = {
     weeklyChampionPayoutKey, hourlyPayoutKey, listingPayoutKey,
+    marketSalePayoutKey, transferRefundPayoutKey,
     payoutKeyGuard, payoutKeyAppendExpr, classifyUnmatchedPayout,
     creditCoinsOnce, grantItemOnce, isDuplicateKeyError,
     RETENTION_DAYS, RETENTION_MS, KEY_CAP,

--- a/tests/coinTransfer.test.js
+++ b/tests/coinTransfer.test.js
@@ -56,6 +56,15 @@ beforeEach(() => {
     jest.clearAllMocks();
 });
 
+// Some tests below replace a method on the model outright — the only way to make
+// a specific write reject. `jest.clearAllMocks()` clears call history but leaves
+// the replacement in place, so a patch that outlives its test (a failed assertion
+// skipping an in-body restore, or a stub that never had one) is inherited by
+// everything after it. That is an order-dependent failure which reproduces only
+// in a full run, so the whole method table is snapshotted and put back.
+const pristineUserModel = { ...mockUsers.model };
+afterEach(() => { Object.assign(mockUsers.model, pristineUserModel); });
+
 describe('a transfer that works', () => {
     it('moves the coins and opens both daily windows', async () => {
         seed(SENDER, { balance: 5_000 });
@@ -156,7 +165,10 @@ describe('the daily caps', () => {
 });
 
 describe('a credit that will not land', () => {
-    /** Make the receiver's guarded credit fail, leaving every other write alone. */
+    /**
+     * Make the receiver's guarded credit fail, leaving every other write alone.
+     * The afterEach above puts the method back, so no test has to remember to.
+     */
     const breakCredit = (error, { times = Infinity } = {}) => {
         const real = mockUsers.model.findOneAndUpdate;
         let left = times;
@@ -164,7 +176,6 @@ describe('a credit that will not land', () => {
             if (query.userId === RECEIVER && left > 0) { left -= 1; throw error; }
             return real(query, update, options);
         });
-        return () => { mockUsers.model.findOneAndUpdate = real; };
     };
 
     beforeEach(() => { jest.spyOn(console, 'error').mockImplementation(() => {}); });
@@ -173,7 +184,7 @@ describe('a credit that will not land', () => {
     it('rolls the sender back rather than destroying their coins', async () => {
         seed(SENDER, { balance: 5_000 });
         seed(RECEIVER, { balance: 0 });
-        const restore = breakCredit(new Error('connection reset'));
+        breakCredit(new Error('connection reset'));
 
         const result = await transfer(1_000);
 
@@ -182,7 +193,6 @@ describe('a credit that will not land', () => {
         expect(mockUsers.get(SENDER).dailyGiftSent).toBe(0);
         expect(mockUsers.get(RECEIVER).balance).toBe(0);
         expect(recordOwedPayout).not.toHaveBeenCalled();
-        restore();
     });
 
     it('retries once on the duplicate-key error an upsert race raises', async () => {
@@ -191,26 +201,24 @@ describe('a credit that will not land', () => {
         seed(SENDER, { balance: 5_000 });
         seed(RECEIVER, { balance: 0 });
         const e11000 = Object.assign(new Error('E11000 duplicate key'), { code: 11000 });
-        const restore = breakCredit(e11000, { times: 1 });
+        breakCredit(e11000, { times: 1 });
 
         const result = await transfer(1_000);
 
         expect(result.status).toBe('ok');
         expect(mockUsers.get(RECEIVER).balance).toBe(1_000);
-        restore();
     });
 
     it('does not retry an error that is not a duplicate key', async () => {
         // Repeating a write whose outcome is unknown is how a credit lands twice.
         seed(SENDER, { balance: 5_000 });
         seed(RECEIVER, { balance: 0 });
-        const restore = breakCredit(new Error('connection reset'), { times: 1 });
+        breakCredit(new Error('connection reset'), { times: 1 });
 
         const result = await transfer(1_000);
 
         expect(result.status).toBe('credit_failed');
         expect(mockUsers.get(RECEIVER).balance).toBe(0);
-        restore();
     });
 
     it('records the refund as owed when the rollback fails too', async () => {
@@ -218,7 +226,7 @@ describe('a credit that will not land', () => {
         // credit did not, and the refund could not be written either.
         seed(SENDER, { balance: 5_000 });
         seed(RECEIVER, { balance: 0 });
-        const restore = breakCredit(new Error('connection reset'));
+        breakCredit(new Error('connection reset'));
         mockUsers.model.updateOne = jest.fn(async () => { throw new Error('still down'); });
 
         const result = await transfer(1_000, { refundKey: 'interaction-77' });
@@ -235,7 +243,32 @@ describe('a credit that will not land', () => {
                 payoutKey: 'transfer:interaction-77:refund',
             },
         }));
-        restore();
+    });
+
+    it('records the refund as owed when the rollback matches no document', async () => {
+        // `updateOne` resolves without rejecting when its filter matches nothing,
+        // so an unchecked refund is indistinguishable from one that landed. If
+        // the sender's document went away between the debit and the rollback,
+        // reporting `refunded: true` would tell them their coins came back and
+        // leave the replay job with nothing to settle — the silent loss this
+        // module exists to prevent, one layer further in.
+        seed(SENDER, { balance: 5_000 });
+        seed(RECEIVER, { balance: 0 });
+        breakCredit(new Error('connection reset'));
+        const real = mockUsers.model.updateOne;
+        mockUsers.model.updateOne = jest.fn(async (query, update, options) => {
+            if (query.userId === SENDER) return { matchedCount: 0, modifiedCount: 0 };
+            return real(query, update, options);
+        });
+
+        const result = await transfer(1_000, { refundKey: 'interaction-88' });
+
+        expect(result).toMatchObject({ status: 'credit_failed', refunded: false, owed: true });
+        expect(recordOwedPayout).toHaveBeenCalledWith(expect.objectContaining({
+            payload: expect.objectContaining({
+                amount: 1_000, payoutKey: 'transfer:interaction-88:refund',
+            }),
+        }));
     });
 
     it('reports the payout unrecorded when even the queue write fails', async () => {
@@ -243,14 +276,13 @@ describe('a credit that will not land', () => {
         // "recoverable" from "gone", and only one of the two is worth promising.
         seed(SENDER, { balance: 5_000 });
         seed(RECEIVER, { balance: 0 });
-        const restore = breakCredit(new Error('connection reset'));
+        breakCredit(new Error('connection reset'));
         mockUsers.model.updateOne = jest.fn(async () => { throw new Error('still down'); });
         recordOwedPayout.mockResolvedValueOnce(false);
 
         const result = await transfer(1_000);
 
         expect(result).toMatchObject({ refunded: false, owed: false });
-        restore();
     });
 });
 

--- a/tests/coinTransfer.test.js
+++ b/tests/coinTransfer.test.js
@@ -1,0 +1,284 @@
+'use strict';
+
+/**
+ * #868 and #897, the two halves of one problem: `/gift type:coins` and
+ * `/bank transfer` moved coins between the same two players through two
+ * different implementations, and only one of them was any good.
+ *
+ * `/gift` enforced the anti-alt daily caps atomically and rolled the sender back
+ * when the credit missed. `/bank transfer` had no cap, no account-age gate and
+ * no accounting — so the caps were decorative, anyone who hit the gift cap
+ * simply transferred instead — and it debited the sender before crediting the
+ * receiver with nothing watching the second write. A credit that threw left the
+ * sender poorer, the receiver no richer, and no record for an operator to
+ * replay: the coins were gone.
+ *
+ * These drive utils/coinTransfer.js, which both commands now go through, against
+ * a store that evaluates the cap `$expr` for real — a mock that waved the guards
+ * through would report every cap as working.
+ */
+
+const { fakeCollection } = require('./helpers/fakeCollection');
+const { GIFT_LIMIT_DEFAULTS } = require('../src/utils/giftCaps');
+
+const mockUsers = fakeCollection('User', { balance: 0, bank: 0, inventory: [] });
+
+jest.mock('../src/models/User', () => mockUsers.model);
+jest.mock('../src/utils/owedPayout', () => ({ recordOwedPayout: jest.fn(async () => true) }));
+
+const { accountAgeRefusal, coinBudgets, commitCoinTransfer, MIN_ACCOUNT_AGE_MS } =
+    require('../src/utils/coinTransfer');
+const { recordOwedPayout } = require('../src/utils/owedPayout');
+
+const GUILD = 'guild-1';
+const SENDER = 'sender-1';
+const RECEIVER = 'receiver-1';
+
+const LIMITS = { ...GIFT_LIMIT_DEFAULTS };
+
+const seed = (userId, fields = {}) => mockUsers.seed({ userId, guildId: GUILD, ...fields });
+
+/** The transfer, with the pre-flight read the callers do folded in. */
+async function transfer(amount, { limits = LIMITS, refundKey = 'interaction-1' } = {}) {
+    const [senderDoc, receiverDoc] = await Promise.all([
+        mockUsers.model.findOne({ userId: SENDER, guildId: GUILD }),
+        mockUsers.model.findOne({ userId: RECEIVER, guildId: GUILD }),
+    ]);
+    return commitCoinTransfer({
+        senderId: SENDER, receiverId: RECEIVER, guildId: GUILD, amount, limits,
+        budgets: coinBudgets(senderDoc, receiverDoc, limits),
+        refundKey, service: 'test', jobName: 'testTransfer',
+    });
+}
+
+beforeEach(() => {
+    mockUsers.reset();
+    jest.clearAllMocks();
+});
+
+describe('a transfer that works', () => {
+    it('moves the coins and opens both daily windows', async () => {
+        seed(SENDER, { balance: 5_000 });
+        seed(RECEIVER, { balance: 0 });
+
+        const result = await transfer(1_000);
+
+        expect(result.status).toBe('ok');
+        expect(mockUsers.get(SENDER).balance).toBe(4_000);
+        expect(mockUsers.get(RECEIVER).balance).toBe(1_000);
+        // The accounting the transfer path used to have none of.
+        expect(mockUsers.get(SENDER).dailyGiftSent).toBe(1_000);
+        expect(mockUsers.get(RECEIVER).dailyGiftReceived).toBe(1_000);
+        expect(mockUsers.get(SENDER).dailyGiftReset).toBeInstanceOf(Date);
+    });
+
+    it('creates the receiver a document when they have none', async () => {
+        seed(SENDER, { balance: 5_000 });
+
+        const result = await transfer(500);
+
+        expect(result.status).toBe('ok');
+        expect(mockUsers.get(RECEIVER).balance).toBe(500);
+    });
+
+    it('accumulates against the same window rather than reopening it', async () => {
+        seed(SENDER, { balance: 20_000 });
+        seed(RECEIVER, { balance: 0 });
+
+        await transfer(1_000);
+        const openedAt = mockUsers.get(SENDER).dailyGiftReset;
+        await transfer(2_000);
+
+        expect(mockUsers.get(SENDER).dailyGiftSent).toBe(3_000);
+        expect(mockUsers.get(SENDER).dailyGiftReset).toEqual(openedAt);
+    });
+});
+
+describe('the daily caps', () => {
+    it('refuses a send past the cap in the write itself, not just in the check', async () => {
+        // The pre-flight message is the friendly refusal; the `$expr` in the
+        // filter is what actually stops two concurrent transfers each passing a
+        // check the other invalidated. Driven with a stale budget reading so
+        // only the filter can refuse it.
+        seed(SENDER, { balance: 100_000, dailyGiftSent: 9_500, dailyGiftReset: new Date() });
+        seed(RECEIVER, { balance: 0 });
+
+        const result = await commitCoinTransfer({
+            senderId: SENDER, receiverId: RECEIVER, guildId: GUILD, amount: 1_000,
+            limits: LIMITS,
+            budgets: { send: { expired: false }, receive: { expired: true } },
+            refundKey: 'interaction-1', service: 'test', jobName: 'testTransfer',
+        });
+
+        expect(result.status).toBe('debit_failed');
+        expect(mockUsers.get(SENDER).balance).toBe(100_000);
+        expect(mockUsers.get(RECEIVER).balance).toBe(0);
+    });
+
+    it("refunds the sender when the receiver's cap is reached in the race", async () => {
+        seed(SENDER, { balance: 100_000 });
+        seed(RECEIVER, { balance: 0, dailyGiftReceived: 24_500, dailyGiftReceivedReset: new Date() });
+
+        const result = await commitCoinTransfer({
+            senderId: SENDER, receiverId: RECEIVER, guildId: GUILD, amount: 1_000,
+            limits: LIMITS,
+            budgets: { send: { expired: true }, receive: { expired: false } },
+            refundKey: 'interaction-1', service: 'test', jobName: 'testTransfer',
+        });
+
+        expect(result).toMatchObject({ status: 'receive_cap', refunded: true, owed: false });
+        expect(mockUsers.get(SENDER).balance).toBe(100_000);
+        expect(mockUsers.get(RECEIVER).balance).toBe(0);
+        // The sender's allowance comes back with their coins — a transfer that
+        // did not happen must not spend their day's budget.
+        expect(mockUsers.get(SENDER).dailyGiftSent).toBe(0);
+    });
+
+    it('enforces nothing when an admin has switched a cap off', async () => {
+        seed(SENDER, { balance: 100_000 });
+        seed(RECEIVER, { balance: 0 });
+
+        const result = await transfer(50_000, { limits: { ...LIMITS, coinSend: 0, coinReceive: 0 } });
+
+        expect(result.status).toBe('ok');
+        expect(mockUsers.get(RECEIVER).balance).toBe(50_000);
+    });
+
+    it('refuses more than the wallet holds, whatever the caps say', async () => {
+        seed(SENDER, { balance: 100 });
+        seed(RECEIVER, { balance: 0 });
+
+        const result = await transfer(500);
+
+        expect(result.status).toBe('debit_failed');
+        expect(mockUsers.get(SENDER).balance).toBe(100);
+    });
+});
+
+describe('a credit that will not land', () => {
+    /** Make the receiver's guarded credit fail, leaving every other write alone. */
+    const breakCredit = (error, { times = Infinity } = {}) => {
+        const real = mockUsers.model.findOneAndUpdate;
+        let left = times;
+        mockUsers.model.findOneAndUpdate = jest.fn(async (query, update, options) => {
+            if (query.userId === RECEIVER && left > 0) { left -= 1; throw error; }
+            return real(query, update, options);
+        });
+        return () => { mockUsers.model.findOneAndUpdate = real; };
+    };
+
+    beforeEach(() => { jest.spyOn(console, 'error').mockImplementation(() => {}); });
+    afterEach(() => { console.error.mockRestore(); });
+
+    it('rolls the sender back rather than destroying their coins', async () => {
+        seed(SENDER, { balance: 5_000 });
+        seed(RECEIVER, { balance: 0 });
+        const restore = breakCredit(new Error('connection reset'));
+
+        const result = await transfer(1_000);
+
+        expect(result).toMatchObject({ status: 'credit_failed', refunded: true, owed: false });
+        expect(mockUsers.get(SENDER).balance).toBe(5_000);
+        expect(mockUsers.get(SENDER).dailyGiftSent).toBe(0);
+        expect(mockUsers.get(RECEIVER).balance).toBe(0);
+        expect(recordOwedPayout).not.toHaveBeenCalled();
+        restore();
+    });
+
+    it('retries once on the duplicate-key error an upsert race raises', async () => {
+        // Losing the race to create the receiver's document means the document
+        // now exists, so the second pass finds it and needs no insert.
+        seed(SENDER, { balance: 5_000 });
+        seed(RECEIVER, { balance: 0 });
+        const e11000 = Object.assign(new Error('E11000 duplicate key'), { code: 11000 });
+        const restore = breakCredit(e11000, { times: 1 });
+
+        const result = await transfer(1_000);
+
+        expect(result.status).toBe('ok');
+        expect(mockUsers.get(RECEIVER).balance).toBe(1_000);
+        restore();
+    });
+
+    it('does not retry an error that is not a duplicate key', async () => {
+        // Repeating a write whose outcome is unknown is how a credit lands twice.
+        seed(SENDER, { balance: 5_000 });
+        seed(RECEIVER, { balance: 0 });
+        const restore = breakCredit(new Error('connection reset'), { times: 1 });
+
+        const result = await transfer(1_000);
+
+        expect(result.status).toBe('credit_failed');
+        expect(mockUsers.get(RECEIVER).balance).toBe(0);
+        restore();
+    });
+
+    it('records the refund as owed when the rollback fails too', async () => {
+        // The case that used to destroy coins outright: the debit committed, the
+        // credit did not, and the refund could not be written either.
+        seed(SENDER, { balance: 5_000 });
+        seed(RECEIVER, { balance: 0 });
+        const restore = breakCredit(new Error('connection reset'));
+        mockUsers.model.updateOne = jest.fn(async () => { throw new Error('still down'); });
+
+        const result = await transfer(1_000, { refundKey: 'interaction-77' });
+
+        expect(result).toMatchObject({ status: 'credit_failed', refunded: false, owed: true });
+        expect(recordOwedPayout).toHaveBeenCalledWith(expect.objectContaining({
+            service: 'test',
+            jobName: 'testTransfer',
+            guildId: GUILD,
+            payload: {
+                kind: 'coins', userId: SENDER, guildId: GUILD, amount: 1_000,
+                // Keyed by the interaction, so a replay of this refund cannot
+                // pay it a second time.
+                payoutKey: 'transfer:interaction-77:refund',
+            },
+        }));
+        restore();
+    });
+
+    it('reports the payout unrecorded when even the queue write fails', async () => {
+        // Not a distinction anyone enjoys, but the caller has to be able to tell
+        // "recoverable" from "gone", and only one of the two is worth promising.
+        seed(SENDER, { balance: 5_000 });
+        seed(RECEIVER, { balance: 0 });
+        const restore = breakCredit(new Error('connection reset'));
+        mockUsers.model.updateOne = jest.fn(async () => { throw new Error('still down'); });
+        recordOwedPayout.mockResolvedValueOnce(false);
+
+        const result = await transfer(1_000);
+
+        expect(result).toMatchObject({ refunded: false, owed: false });
+        restore();
+    });
+});
+
+describe('the account-age gate', () => {
+    const old = { username: 'old', createdTimestamp: Date.now() - 365 * 24 * 3_600_000 };
+    const fresh = { username: 'fresh', createdTimestamp: Date.now() - 3_600_000 };
+
+    it('turns a brand-new sender away', () => {
+        expect(accountAgeRefusal(fresh, old)).toMatch(/too new to send coins/);
+    });
+
+    it('turns a brand-new receiver away, and names them', () => {
+        expect(accountAgeRefusal(old, fresh)).toMatch(/fresh's Discord account is too new to receive coins/);
+    });
+
+    it('lets a command keep its own word for what is moving', () => {
+        expect(accountAgeRefusal(fresh, old, { noun: 'gifts' })).toMatch(/too new to send gifts/);
+    });
+
+    it('passes a pair of established accounts', () => {
+        expect(accountAgeRefusal(old, old)).toBeNull();
+    });
+
+    it('sits exactly on seven days', () => {
+        const now = Date.now();
+        const justOld = { username: 'x', createdTimestamp: now - MIN_ACCOUNT_AGE_MS };
+        const justNew = { username: 'x', createdTimestamp: now - MIN_ACCOUNT_AGE_MS + 1 };
+        expect(accountAgeRefusal(justOld, justOld, { now })).toBeNull();
+        expect(accountAgeRefusal(justNew, justOld, { now })).toMatch(/too new/);
+    });
+});

--- a/tests/dashboardAccessibility.test.js
+++ b/tests/dashboardAccessibility.test.js
@@ -500,6 +500,20 @@ describe('the Getting Started collapse', () => {
         expect([btn.getAttribute('aria-expanded'), body.style.display]).toEqual(['true', '']);
     });
 
+    it('toggles from a click anywhere in the header, subtitle included', () => {
+        // The whole header was the click target before this was a button, so a
+        // subtitle left outside it would be the one part of the header that
+        // silently stopped working.
+        const btn = toggle();
+        const subtitle = document.getElementById('gs-subtitle');
+        expect(subtitle).not.toBeNull();
+        expect(btn.contains(subtitle)).toBe(true);
+
+        subtitle.click();
+        expect(btn.getAttribute('aria-expanded')).toBe('false');
+        expect(document.getElementById('getting-started-body').style.display).toBe('none');
+    });
+
     it('leaves the glyph to the eye only', () => {
         // ▾/▸ is the state for a sighted reader and noise for everyone else —
         // aria-expanded above is what carries it now, so the glyph is hidden

--- a/tests/dashboardAccessibility.test.js
+++ b/tests/dashboardAccessibility.test.js
@@ -445,6 +445,73 @@ describe('analytics charts', () => {
     });
 });
 
+// #882. The Getting Started collapse was a `.dash-card-header` div with
+// `cursor:pointer` and an onclick: not focusable, not announced as a control,
+// and its open/closed state carried only by a ▾/▸ glyph. Keyboard users could
+// not toggle it at all (WCAG 2.1.1), and a screen reader had nothing to report
+// (4.1.2).
+describe('the Getting Started collapse', () => {
+    beforeEach(() => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        document.body.innerHTML = '';
+        bootPage();
+    });
+
+    afterEach(async () => {
+        await settle();
+        forgetDocumentListeners();
+        jest.restoreAllMocks();
+    });
+
+    const toggle = () => document.getElementById('gs-toggle');
+
+    it('is a button that owns the section it opens', () => {
+        const btn = toggle();
+        expect(btn).not.toBeNull();
+        expect([btn.tagName, btn.getAttribute('type')]).toEqual(['BUTTON', 'button']);
+        // A button is focusable and activated by Enter and Space for free; the
+        // runtime role/tabindex patch-up the sidebar had to shed must not
+        // reappear here.
+        expect(btn.getAttribute('role')).toBeNull();
+        expect(btn.getAttribute('tabindex')).toBeNull();
+
+        expect(btn.getAttribute('aria-controls')).toBe('getting-started-body');
+        expect(document.getElementById('getting-started-body')).not.toBeNull();
+    });
+
+    it('keeps the heading a heading rather than swallowing it into the control', () => {
+        // The card still has to appear in a heading list; the disclosure lives
+        // inside the h2 rather than replacing it.
+        const heading = toggle().closest('h2');
+        expect(heading).not.toBeNull();
+        expect(heading.textContent).toMatch(/Getting started/);
+    });
+
+    it('reports its state with aria-expanded, and moves it on every toggle', () => {
+        const btn = toggle();
+        const body = document.getElementById('getting-started-body');
+
+        expect(btn.getAttribute('aria-expanded')).toBe('true');
+
+        btn.click();
+        expect([btn.getAttribute('aria-expanded'), body.style.display]).toEqual(['false', 'none']);
+
+        btn.click();
+        expect([btn.getAttribute('aria-expanded'), body.style.display]).toEqual(['true', '']);
+    });
+
+    it('leaves the glyph to the eye only', () => {
+        // ▾/▸ is the state for a sighted reader and noise for everyone else —
+        // aria-expanded above is what carries it now, so the glyph is hidden
+        // rather than read out as a symbol with no name.
+        const icon = document.getElementById('gs-toggle-icon');
+        expect(icon.getAttribute('aria-hidden')).toBe('true');
+
+        toggle().click();
+        expect(icon.textContent).toBe('\u25b8');
+    });
+});
+
 // #678. Six avatars were injected without an alt attribute, so a screen reader
 // fell back to reading the CDN URL out beside the username already sitting next
 // to it. They are decorative — the name is the content — which makes `alt=""`

--- a/tests/dashboardInlineAttributes.test.js
+++ b/tests/dashboardInlineAttributes.test.js
@@ -48,7 +48,7 @@ const BASELINE = {
     'partials/panels/leveling.ejs': [28, 14],
     'partials/panels/moderation.ejs': [28, 19],
     'partials/panels/newspaper.ejs': [4, 1],
-    'partials/panels/overview.ejs': [20, 7],
+    'partials/panels/overview.ejs': [18, 7],
     'partials/panels/progressiontracks.ejs': [2, 1],
     'partials/panels/quests.ejs': [5, 1],
     'partials/panels/raiddetection.ejs': [1, 1],

--- a/tests/economyBankTransfer.test.js
+++ b/tests/economyBankTransfer.test.js
@@ -1,0 +1,227 @@
+'use strict';
+
+/**
+ * #897. `/bank transfer` moved coins between two players with none of the guards
+ * `/gift type:coins` puts on the identical operation — no daily cap, no
+ * account-age gate, no accounting. The caps exist to stop alt-account funnelling,
+ * so an unlimited funnel sitting next to them made them decorative: anyone who
+ * hit the gift cap simply used transfer instead.
+ *
+ * It also debited the sender and then credited the receiver with nothing
+ * watching the second write (#868), which is covered against the shared path in
+ * tests/coinTransfer.test.js. These drive the command, which is where the
+ * question "does the cap apply here at all" is actually answered.
+ */
+
+const { fakeCollection } = require('./helpers/fakeCollection');
+const { makeInteraction, repliedText } = require('./helpers/fakeInteraction');
+const { expectNonNegativeBalance } = require('./helpers/balanceInvariant');
+
+const mockUsers = fakeCollection('User', { balance: 0, bank: 0, inventory: [] });
+const mockGuilds = fakeCollection('Guild');
+
+jest.mock('../src/models/User', () => mockUsers.model);
+jest.mock('../src/models/Guild', () => mockGuilds.model);
+jest.mock('../src/utils/guildSettingsCache', () => require('./helpers/guildSettingsCacheMock')());
+jest.mock('../src/utils/logTransaction', () => ({ logTransaction: jest.fn() }));
+jest.mock('../src/utils/owedPayout', () => ({ recordOwedPayout: jest.fn(async () => true) }));
+
+const bank = require('../src/commands/economy/bank');
+const { logTransaction } = require('../src/utils/logTransaction');
+
+const GUILD_ID = 'guild-1';
+const SENDER_ID = 'user-1';        // the harness's own user
+const RECIPIENT_ID = 'friend-1';
+
+const OLD_ACCOUNT = Date.now() - 365 * 24 * 3_600_000;
+
+const seedGuild = (economy = {}) => mockGuilds.seed({
+    guildId: GUILD_ID, economy: { currency: '💰', ...economy },
+});
+
+const seedUser = (userId, fields = {}) => mockUsers.seed({ userId, guildId: GUILD_ID, ...fields });
+
+const recipient = (overrides = {}) => ({
+    id: RECIPIENT_ID, username: 'friend', bot: false,
+    createdTimestamp: OLD_ACCOUNT, ...overrides,
+});
+
+const run = async (options) => {
+    const interaction = makeInteraction({ subcommand: 'transfer', options, userId: SENDER_ID });
+    await bank.execute(interaction);
+    return interaction;
+};
+
+beforeEach(() => {
+    mockUsers.reset();
+    mockGuilds.reset();
+    jest.clearAllMocks();
+});
+
+describe('/bank transfer', () => {
+    it('moves the coins and logs both sides', async () => {
+        seedGuild();
+        seedUser(SENDER_ID, { balance: 5_000 });
+        seedUser(RECIPIENT_ID, { balance: 0 });
+
+        const interaction = await run({ user: recipient(), amount: 1_000 });
+
+        expect(mockUsers.get(SENDER_ID).balance).toBe(4_000);
+        expect(mockUsers.get(RECIPIENT_ID).balance).toBe(1_000);
+        expect(repliedText(interaction)).toContain('Transfer Successful');
+        expect(logTransaction).toHaveBeenCalledWith(expect.objectContaining({ type: 'transfer_send', amount: -1_000 }));
+        expect(logTransaction).toHaveBeenCalledWith(expect.objectContaining({ type: 'transfer_receive', amount: 1_000 }));
+        expectNonNegativeBalance([mockUsers.get(SENDER_ID), mockUsers.get(RECIPIENT_ID)], 'bank transfer');
+    });
+
+    it('spends the same daily budget /gift does, rather than one of its own', async () => {
+        // The whole point: a transfer is not a way around the gift cap, so it
+        // has to write to the counter the gift cap reads.
+        seedGuild();
+        seedUser(SENDER_ID, { balance: 50_000 });
+        seedUser(RECIPIENT_ID, { balance: 0 });
+
+        await run({ user: recipient(), amount: 4_000 });
+
+        expect(mockUsers.get(SENDER_ID).dailyGiftSent).toBe(4_000);
+        expect(mockUsers.get(RECIPIENT_ID).dailyGiftReceived).toBe(4_000);
+    });
+
+    it('refuses a transfer past the daily send cap', async () => {
+        seedGuild();
+        seedUser(SENDER_ID, { balance: 500_000, dailyGiftSent: 9_500, dailyGiftReset: new Date() });
+        seedUser(RECIPIENT_ID, { balance: 0 });
+
+        const interaction = await run({ user: recipient(), amount: 1_000 });
+
+        expect(repliedText(interaction)).toContain('Daily transfer cap reached');
+        expect(mockUsers.get(SENDER_ID).balance).toBe(500_000);
+        expect(mockUsers.get(RECIPIENT_ID).balance).toBe(0);
+    });
+
+    it("refuses a transfer past the recipient's daily receiving cap", async () => {
+        seedGuild();
+        seedUser(SENDER_ID, { balance: 500_000 });
+        seedUser(RECIPIENT_ID, { balance: 0, dailyGiftReceived: 24_500, dailyGiftReceivedReset: new Date() });
+
+        const interaction = await run({ user: recipient(), amount: 1_000 });
+
+        expect(repliedText(interaction)).toContain('daily receiving cap');
+        expect(mockUsers.get(SENDER_ID).balance).toBe(500_000);
+    });
+
+    it('honours a guild that has raised or removed the cap', async () => {
+        seedGuild({ giftCoinCapDaily: 0, giftCoinReceiveCapDaily: 0 });
+        seedUser(SENDER_ID, { balance: 500_000 });
+        seedUser(RECIPIENT_ID, { balance: 0 });
+
+        await run({ user: recipient(), amount: 400_000 });
+
+        expect(mockUsers.get(RECIPIENT_ID).balance).toBe(400_000);
+    });
+
+    it('turns away an account too new to be sending coins', async () => {
+        seedGuild();
+        seedUser(SENDER_ID, { balance: 5_000 });
+
+        const interaction = makeInteraction({
+            subcommand: 'transfer',
+            options: { user: recipient(), amount: 1_000 },
+            userId: SENDER_ID,
+            user: { createdTimestamp: Date.now() - 3_600_000 },
+        });
+        await bank.execute(interaction);
+
+        expect(repliedText(interaction)).toMatch(/too new to send/);
+        expect(mockUsers.get(SENDER_ID).balance).toBe(5_000);
+    });
+
+    it('turns away a recipient too new to be receiving them', async () => {
+        seedGuild();
+        seedUser(SENDER_ID, { balance: 5_000 });
+
+        const interaction = await run({
+            user: recipient({ createdTimestamp: Date.now() - 3_600_000 }),
+            amount: 1_000,
+        });
+
+        expect(repliedText(interaction)).toMatch(/too new to receive/);
+        expect(mockUsers.get(SENDER_ID).balance).toBe(5_000);
+    });
+
+    it('refuses more than the wallet holds', async () => {
+        seedGuild();
+        seedUser(SENDER_ID, { balance: 100 });
+        seedUser(RECIPIENT_ID, { balance: 0 });
+
+        const interaction = await run({ user: recipient(), amount: 500 });
+
+        expect(repliedText(interaction)).toContain("don't have enough coins");
+        expect(mockUsers.get(SENDER_ID).balance).toBe(100);
+        expect(mockUsers.get(RECIPIENT_ID).balance).toBe(0);
+    });
+
+    it('refuses a bot and refuses yourself', async () => {
+        seedGuild();
+        seedUser(SENDER_ID, { balance: 5_000 });
+
+        const toBot = await run({ user: recipient({ bot: true }), amount: 100 });
+        expect(repliedText(toBot)).toContain('cannot transfer coins to bots');
+
+        const toSelf = await run({
+            user: recipient({ id: SENDER_ID, username: 'player' }),
+            amount: 100,
+        });
+        expect(repliedText(toSelf)).toContain('cannot transfer coins to yourself');
+
+        expect(mockUsers.get(SENDER_ID).balance).toBe(5_000);
+    });
+
+    it('returns the coins and says so when the credit cannot be made', async () => {
+        // #868: this used to reply "Failed to transfer coins" with the sender
+        // already debited and nothing refunding them.
+        seedGuild();
+        seedUser(SENDER_ID, { balance: 5_000 });
+        seedUser(RECIPIENT_ID, { balance: 0 });
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const real = mockUsers.model.findOneAndUpdate;
+        mockUsers.model.findOneAndUpdate = jest.fn(async (query, update, options) => {
+            if (query.userId === RECIPIENT_ID) throw new Error('connection reset');
+            return real(query, update, options);
+        });
+
+        const interaction = await run({ user: recipient(), amount: 1_000 });
+
+        expect(repliedText(interaction)).toContain('coins were returned');
+        expect(mockUsers.get(SENDER_ID).balance).toBe(5_000);
+        expect(mockUsers.get(SENDER_ID).dailyGiftSent).toBe(0);
+        expect(mockUsers.get(RECIPIENT_ID).balance).toBe(0);
+
+        mockUsers.model.findOneAndUpdate = real;
+        console.error.mockRestore();
+    });
+
+    it('says the coins are recorded when they can be neither sent nor returned', async () => {
+        seedGuild();
+        seedUser(SENDER_ID, { balance: 5_000 });
+        seedUser(RECIPIENT_ID, { balance: 0 });
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const real = mockUsers.model.findOneAndUpdate;
+        mockUsers.model.findOneAndUpdate = jest.fn(async (query, update, options) => {
+            if (query.userId === RECIPIENT_ID) throw new Error('connection reset');
+            return real(query, update, options);
+        });
+        mockUsers.model.updateOne = jest.fn(async () => { throw new Error('still down'); });
+
+        const interaction = await run({ user: recipient(), amount: 1_000 });
+
+        // Not "failed": the sender's coins are somewhere, and telling them so is
+        // the difference between a bug report and a silent loss.
+        expect(repliedText(interaction)).toContain('It is recorded and an admin can restore it');
+
+        mockUsers.model.findOneAndUpdate = real;
+        console.error.mockRestore();
+    });
+});

--- a/tests/economyBankTransfer.test.js
+++ b/tests/economyBankTransfer.test.js
@@ -58,6 +58,15 @@ beforeEach(() => {
     jest.clearAllMocks();
 });
 
+// Some tests below replace a method on the model outright — the only way to make
+// a specific write reject. `jest.clearAllMocks()` clears call history but leaves
+// the replacement in place, so a patch that outlives its test (a failed assertion
+// skipping an in-body restore, or a stub that never had one) is inherited by
+// everything after it. That is an order-dependent failure which reproduces only
+// in a full run, so the whole method table is snapshotted and put back.
+const pristineUserModel = { ...mockUsers.model };
+afterEach(() => { Object.assign(mockUsers.model, pristineUserModel); });
+
 describe('/bank transfer', () => {
     it('moves the coins and logs both sides', async () => {
         seedGuild();
@@ -72,6 +81,25 @@ describe('/bank transfer', () => {
         expect(logTransaction).toHaveBeenCalledWith(expect.objectContaining({ type: 'transfer_send', amount: -1_000 }));
         expect(logTransaction).toHaveBeenCalledWith(expect.objectContaining({ type: 'transfer_receive', amount: 1_000 }));
         expectNonNegativeBalance([mockUsers.get(SENDER_ID), mockUsers.get(RECIPIENT_ID)], 'bank transfer');
+    });
+
+    it('acknowledges the interaction before touching the database', async () => {
+        // Two reads and up to three writes against Discord's three-second
+        // acknowledgement window: without a defer a slow database shows the
+        // member "the application did not respond" with the coins already moved.
+        seedGuild();
+        seedUser(SENDER_ID, { balance: 5_000 });
+        seedUser(RECIPIENT_ID, { balance: 0 });
+
+        const interaction = await run({ user: recipient(), amount: 1_000 });
+
+        expect(interaction.deferReply).toHaveBeenCalledWith(expect.objectContaining({
+            flags: expect.anything(),
+        }));
+        expect(interaction.reply).not.toHaveBeenCalled();
+        // The transfer is still announced in the channel the way it always was;
+        // only the sender's receipt and the refusals are private.
+        expect(interaction.followUp).toHaveBeenCalled();
     });
 
     it('spends the same daily budget /gift does, rather than one of its own', async () => {
@@ -198,7 +226,6 @@ describe('/bank transfer', () => {
         expect(mockUsers.get(SENDER_ID).dailyGiftSent).toBe(0);
         expect(mockUsers.get(RECIPIENT_ID).balance).toBe(0);
 
-        mockUsers.model.findOneAndUpdate = real;
         console.error.mockRestore();
     });
 
@@ -221,7 +248,6 @@ describe('/bank transfer', () => {
         // the difference between a bug report and a silent loss.
         expect(repliedText(interaction)).toContain('It is recorded and an admin can restore it');
 
-        mockUsers.model.findOneAndUpdate = real;
         console.error.mockRestore();
     });
 });

--- a/tests/economyMarketCommand.test.js
+++ b/tests/economyMarketCommand.test.js
@@ -598,6 +598,135 @@ describe('buying a listing', () => {
     });
 });
 
+/**
+ * #869. The seller's proceeds were an unguarded, unretried write with no upsert
+ * and no check on its result. It ran last — after the buyer had paid, after the
+ * item had moved, after the listing was deleted — so both of its failure modes
+ * lost the coins outright: a `null` return was ignored (and logged as
+ * `balance: 0`), and a throw escaped with the trade already done.
+ *
+ * Neither left an owed record, so unlike every other credit in the economy there
+ * was nothing for `npm run payouts:replay` to settle, and unlike `/bank transfer`
+ * there was not even a failure message — the purchase looked successful.
+ */
+describe('paying the seller', () => {
+    const sellerCredit = () => mockUsers.writes.find(w =>
+        w.query?.userId === SELLER_ID && Array.isArray(w.update));
+
+    it('is guarded by a key, so a replay cannot pay it twice', async () => {
+        seedGuild();
+        seedUser(BUYER_ID, { balance: 1000 });
+        seedUser(SELLER_ID, { balance: 0 });
+        seedListing({ quantity: 2, pricePerUnit: 100 });
+
+        await run({ subcommand: 'buy', options: { listing_id: 'listing-1' } });
+
+        // Keyed by the listing, which this flow has just deleted, so the id can
+        // never come round again.
+        expect(sellerCredit().query['paidPayouts.key']).toEqual({ $ne: 'listing:listing-1:sale' });
+        expect(mockUsers.get(SELLER_ID).paidPayouts.map(p => p.key)).toEqual(['listing:listing-1:sale']);
+        expect(mockUsers.get(SELLER_ID).balance).toBe(190);
+    });
+
+    it('moves no coins a second time when the key is already on the document', async () => {
+        // The write that committed without its response arriving, replayed.
+        seedGuild();
+        seedUser(BUYER_ID, { balance: 1000 });
+        seedUser(SELLER_ID, { balance: 190, paidPayouts: [{ key: 'listing:listing-1:sale', at: new Date() }] });
+        seedListing({ quantity: 2, pricePerUnit: 100 });
+
+        const interaction = await run({ subcommand: 'buy', options: { listing_id: 'listing-1' } });
+
+        expect(mockUsers.get(SELLER_ID).balance).toBe(190);
+        // A duplicate is a success, not an owed payout: the coins are there.
+        expect(recordOwedPayout).not.toHaveBeenCalled();
+        expect(repliedText(interaction)).toContain('Purchase Complete');
+    });
+
+    it('records the payout as owed when the seller has no document to credit', async () => {
+        seedGuild();
+        seedUser(BUYER_ID, { balance: 1000 });
+        // No seller document at all — the `null` return that used to be dropped.
+        seedListing({ quantity: 2, pricePerUnit: 100 });
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        await run({ subcommand: 'buy', options: { listing_id: 'listing-1' } });
+
+        expect(recordOwedPayout).toHaveBeenCalledWith(expect.objectContaining({
+            service: 'market',
+            jobName: 'buyListing',
+            guildId: GUILD_ID,
+            payload: expect.objectContaining({
+                kind: 'coins', userId: SELLER_ID, guildId: GUILD_ID,
+                amount: 190, payoutKey: 'listing:listing-1:sale',
+            }),
+        }));
+        // No document is created for them: crediting a user who has never
+        // played would resurrect a pruned account.
+        expect(mockUsers.get(SELLER_ID)).toBeNull();
+        console.error.mockRestore();
+    });
+
+    it('records the payout as owed when the credit throws', async () => {
+        seedGuild();
+        seedUser(BUYER_ID, { balance: 1000 });
+        seedUser(SELLER_ID, { balance: 0 });
+        seedListing({ quantity: 2, pricePerUnit: 100 });
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const real = mockUsers.model.findOneAndUpdate;
+        mockUsers.model.findOneAndUpdate = jest.fn(async (query, update, options) => {
+            if (query.userId === SELLER_ID) throw new Error('connection reset');
+            return real(query, update, options);
+        });
+
+        const interaction = await run({ subcommand: 'buy', options: { listing_id: 'listing-1' } });
+
+        expect(recordOwedPayout).toHaveBeenCalledWith(expect.objectContaining({
+            payload: expect.objectContaining({ amount: 190, payoutKey: 'listing:listing-1:sale' }),
+            error: expect.objectContaining({ message: 'connection reset' }),
+        }));
+        // The buyer's side stands — they paid and they have the item — so the
+        // throw must not take the whole purchase with it.
+        expect(mockUsers.get(BUYER_ID).balance).toBe(800);
+        expect(mockUsers.get(BUYER_ID).inventory).toEqual([{ itemId: 'lucky_charm', quantity: 2 }]);
+        expect(repliedText(interaction)).toContain('Purchase Complete');
+
+        mockUsers.model.findOneAndUpdate = real;
+        console.error.mockRestore();
+    });
+
+    it('does not tell the buyer the seller was paid when they were not', async () => {
+        seedGuild();
+        seedUser(BUYER_ID, { balance: 1000 });
+        seedListing({ quantity: 2, pricePerUnit: 100 });
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const interaction = await run({ subcommand: 'buy', options: { listing_id: 'listing-1' } });
+
+        expect(repliedText(interaction)).toContain('recorded as owed');
+        expect(repliedText(interaction)).not.toContain('Seller Received');
+        console.error.mockRestore();
+    });
+
+    it('still writes the sale to the audit log, saying the payout is owed', async () => {
+        // A row that only appears when the credit lands leaves the coins
+        // unaccounted for exactly when someone goes looking for them.
+        seedGuild();
+        seedUser(BUYER_ID, { balance: 1000 });
+        seedListing({ quantity: 2, pricePerUnit: 100 });
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        await run({ subcommand: 'buy', options: { listing_id: 'listing-1' } });
+
+        expect(logTransaction).toHaveBeenCalledWith(expect.objectContaining({
+            type: 'market_sell', amount: 190,
+            note: expect.stringContaining('payout owed'),
+        }));
+        console.error.mockRestore();
+    });
+});
+
 describe('cancelling a listing', () => {
     it('returns the stock and removes the listing', async () => {
         seedGuild();

--- a/tests/economyMarketCommand.test.js
+++ b/tests/economyMarketCommand.test.js
@@ -96,6 +96,15 @@ beforeEach(() => {
     });
 });
 
+// Some tests below replace a method on the model outright — the only way to make
+// a specific write reject. `jest.clearAllMocks()` clears call history but leaves
+// the replacement in place, so a patch that outlives its test (a failed assertion
+// skipping an in-body restore, or a stub that never had one) is inherited by
+// everything after it. That is an order-dependent failure which reproduces only
+// in a full run, so the whole method table is snapshotted and put back.
+const pristineUserModel = { ...mockUsers.model };
+afterEach(() => { Object.assign(mockUsers.model, pristineUserModel); });
+
 describe('listing an item', () => {
     it('takes the stock out of the bag and creates the listing', async () => {
         seedGuild();
@@ -692,7 +701,6 @@ describe('paying the seller', () => {
         expect(mockUsers.get(BUYER_ID).inventory).toEqual([{ itemId: 'lucky_charm', quantity: 2 }]);
         expect(repliedText(interaction)).toContain('Purchase Complete');
 
-        mockUsers.model.findOneAndUpdate = real;
         console.error.mockRestore();
     });
 
@@ -706,6 +714,23 @@ describe('paying the seller', () => {
 
         expect(repliedText(interaction)).toContain('recorded as owed');
         expect(repliedText(interaction)).not.toContain('Seller Received');
+        console.error.mockRestore();
+    });
+
+    it('does not claim the payout is recorded when the queue write failed too', async () => {
+        // recordOwedPayout returns false when the FailedJob write fails. Saying
+        // "recorded as owed" then would tell the buyer the seller's coins are
+        // tracked when nothing is tracking them.
+        seedGuild();
+        seedUser(BUYER_ID, { balance: 1000 });
+        seedListing({ quantity: 2, pricePerUnit: 100 });
+        recordOwedPayout.mockResolvedValueOnce(false);
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const interaction = await run({ subcommand: 'buy', options: { listing_id: 'listing-1' } });
+
+        expect(repliedText(interaction)).toContain('not recorded');
+        expect(repliedText(interaction)).not.toContain('recorded as owed');
         console.error.mockRestore();
     });
 

--- a/tests/helpers/fakeCollection.js
+++ b/tests/helpers/fakeCollection.js
@@ -23,7 +23,7 @@
  * own declarations and refuses a factory that closes over anything else.
  */
 
-const { applyPipelineUpdate } = require('./pipelineUpdate');
+const { applyPipelineUpdate, evaluate } = require('./pipelineUpdate');
 
 const isPlainObject = v => v !== null && typeof v === 'object' && !Array.isArray(v) && !(v instanceof Date);
 
@@ -128,6 +128,13 @@ function matches(doc, query, state) {
             if (!condition.every(clause => matches(doc, clause, state))) return false;
         } else if (field === '$nor') {
             if (condition.some(clause => matches(doc, clause, state))) return false;
+        } else if (field === '$expr') {
+            // Evaluated for real, with the same evaluator that applies a
+            // pipeline update. `$expr` is how the daily gift and transfer caps
+            // are enforced — the cap check lives in the write's own filter so a
+            // concurrent transfer cannot slip past a check it invalidated — so a
+            // mock that waved it through would report every cap as working.
+            if (!evaluate(condition, doc)) return false;
         } else if (field.startsWith('$')) {
             throw new Error(`fakeCollection: unsupported top-level operator ${field}`);
         } else if (!matchesField(doc, field, condition, state)) {

--- a/tests/helpers/fakeCollection.js
+++ b/tests/helpers/fakeCollection.js
@@ -134,7 +134,12 @@ function matches(doc, query, state) {
             // are enforced — the cap check lives in the write's own filter so a
             // concurrent transfer cannot slip past a check it invalidated — so a
             // mock that waved it through would report every cap as working.
-            if (!evaluate(condition, doc)) return false;
+            //
+            // `$$NOW` is bound the way applyPipelineUpdate binds it, because
+            // the real server resolves it in an `$expr` filter too — without it
+            // a cap filter that reached for the clock would throw "unbound
+            // variable" here and match on the server.
+            if (!evaluate(condition, doc, { NOW: new Date() })) return false;
         } else if (field.startsWith('$')) {
             throw new Error(`fakeCollection: unsupported top-level operator ${field}`);
         } else if (!matchesField(doc, field, condition, state)) {

--- a/tests/helpers/fakeCollection.js
+++ b/tests/helpers/fakeCollection.js
@@ -222,6 +222,14 @@ function fakeCollection(name, defaults = {}, { unique = ['userId', 'guildId'] } 
     let docs = [];
     const writes = [];
 
+    // A fresh copy of the defaults per document. `{ ...defaults }` is shallow,
+    // so every document that did not name its own `inventory` shared one array
+    // — and a flow that pushes an item into a user's bag was pushing into every
+    // other seeded user's bag as well, across tests, since the defaults outlive
+    // reset(). It surfaced as a stray quantity in an unrelated assertion, which
+    // is the worst way for it to surface.
+    const freshDefaults = () => structuredClone(defaults);
+
     const uniqueKey = doc => (unique.length ? unique.map(field => getPath(doc, field)).join('\u0000') : null);
 
     /** A document as the caller gets it: a deep copy, plus a save() that writes back. */
@@ -252,7 +260,7 @@ function fakeCollection(name, defaults = {}, { unique = ['userId', 'guildId'] } 
      * E11000 the real server answers with rather than as a silent second row.
      */
     function insert(query, update) {
-        const stored = { ...defaults };
+        const stored = freshDefaults();
         for (const [field, condition] of Object.entries(query)) {
             if (!field.startsWith('$') && !isPlainObject(condition)) setPath(stored, field, condition);
         }
@@ -369,7 +377,7 @@ function fakeCollection(name, defaults = {}, { unique = ['userId', 'guildId'] } 
         }),
 
         create: jest.fn(async fields => {
-            const stored = { _id: `id-${docs.length + 1}`, ...defaults, ...fields };
+            const stored = { _id: `id-${docs.length + 1}`, ...freshDefaults(), ...fields };
             docs.push(stored);
             writes.push({ op: 'create', doc: stored._id });
             return hydrate(stored);
@@ -384,7 +392,7 @@ function fakeCollection(name, defaults = {}, { unique = ['userId', 'guildId'] } 
         writes,
         /** Put documents in. Each is merged over `defaults`. */
         seed(...seeded) {
-            for (const doc of seeded.flat()) docs.push({ ...defaults, ...doc });
+            for (const doc of seeded.flat()) docs.push({ ...freshDefaults(), ...doc });
             return this;
         },
         /** The stored document, by userId — the live one, not a copy. */

--- a/tests/helpers/pipelineUpdate.js
+++ b/tests/helpers/pipelineUpdate.js
@@ -172,6 +172,22 @@ function evaluate(expr, doc, vars = {}) {
         }
         case '$size':
             return (args()[0] ?? []).length;
+        case '$filter': {
+            const input = evaluate(arg.input, doc, vars) ?? [];
+            const as = arg.as ?? 'this';
+            return input.filter(el => Boolean(evaluate(arg.cond, doc, { ...vars, [as]: el })));
+        }
+        // `{ $slice: [<array>, <n>] }` and the three-argument form. A negative
+        // `n` in the two-argument form counts from the end, which is what the
+        // payout-key cap in src/utils/payoutKey.js relies on to evict the
+        // oldest keys rather than the newest.
+        case '$slice': {
+            const [array, a, b] = args();
+            const list = array ?? [];
+            if (b === undefined) return a < 0 ? list.slice(a) : list.slice(0, a);
+            const from = a < 0 ? Math.max(0, list.length + a) : a;
+            return list.slice(from, from + b);
+        }
         default:
             throw new Error(`pipelineUpdate: unsupported operator ${op}`);
     }
@@ -188,12 +204,18 @@ function sameValue(a, b) {
  * accumulate in a single update.
  */
 function applyPipelineUpdate(doc, stages) {
+    // `$$NOW` is the server's clock, and Mongo holds it fixed for the whole
+    // update — every stage of one update sees the same instant. Bound once here
+    // for the same reason: the payout-key append stamps an entry with it and
+    // prunes by it in the same expression, and two clocks there would be a
+    // window, however small, in which an entry could be written already expired.
+    const vars = { NOW: new Date() };
     for (const stage of stages) {
         const set = stage.$set ?? stage.$addFields;
         if (!set) throw new Error(`pipelineUpdate: unsupported stage ${Object.keys(stage).join(', ')}`);
         // Every field of one stage reads the document as it was before that
         // stage, so the values are computed first and written afterwards.
-        const computed = Object.entries(set).map(([path, expr]) => [path, evaluate(expr, doc)]);
+        const computed = Object.entries(set).map(([path, expr]) => [path, evaluate(expr, doc, vars)]);
         for (const [path, value] of computed) setPath(doc, path, value);
     }
     return doc;

--- a/tests/landingCompareTable.test.js
+++ b/tests/landingCompareTable.test.js
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"customExportConditions": ["node"]}
+ */
+process.env.SUPPRESS_JEST_WARNINGS = 'true';
+
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = global.TextEncoder || TextEncoder;
+global.TextDecoder = global.TextDecoder || TextDecoder;
+
+/**
+ * #912. The bot comparison was twenty-eight `<div>`s in a CSS grid — no table,
+ * no rows, no headers. Sighted readers got a table; everyone else got a flat run
+ * of words and symbols with nothing tying "● included" to either the feature it
+ * describes or the bot it describes it for (WCAG 1.3.1). It is the landing
+ * page's main argument, so it is the part a screen-reader user most needs.
+ *
+ * The visual design did not have to change and did not: the layout is still one
+ * four-column grid. That is what makes the roles below load-bearing rather than
+ * decoration — `display: grid` on the table and `display: contents` on its rows
+ * take the elements out of table layout, and a browser that is not laying an
+ * element out as a table stops reporting it as one.
+ */
+const fs = require('fs');
+const path = require('path');
+const ejs = require('ejs');
+const { asset } = require('../src/dashboard/lib/assets');
+
+const ROOT = path.join(__dirname, '..');
+const VIEWS = path.join(ROOT, 'src', 'dashboard', 'views');
+const STYLES = path.join(ROOT, 'src', 'dashboard', 'public', 'styles.css');
+
+function compareTable() {
+    const file = path.join(VIEWS, 'index.ejs');
+    const html = ejs.render(
+        fs.readFileSync(file, 'utf8'),
+        { user: null, stats: { servers: 4, members: 120, uptime: '3d' }, version: '1.2.3', asset },
+        { filename: file },
+    );
+    document.documentElement.innerHTML = html;
+    return document.querySelector('.cw-compare');
+}
+
+describe('the landing page comparison', () => {
+    let table;
+    beforeEach(() => { table = compareTable(); });
+
+    it('is a real table, not a pile of divs in a grid', () => {
+        expect(table).not.toBeNull();
+        expect(table.tagName).toBe('TABLE');
+        // The shape the old markup could not express at all.
+        expect(table.querySelector('thead')).not.toBeNull();
+        expect(table.querySelector('tbody')).not.toBeNull();
+        expect(table.querySelectorAll('tbody tr').length).toBeGreaterThan(0);
+        expect(table.querySelectorAll(':scope > div').length).toBe(0);
+    });
+
+    it('names itself, so the table is findable rather than just present', () => {
+        const caption = table.querySelector('caption');
+        expect(caption).not.toBeNull();
+        expect(caption.textContent).toMatch(/Clawdia/);
+        // Clipped, not `display: none` — a hidden caption is no caption.
+        expect(caption.className).toBe('sr-only');
+    });
+
+    it('scopes a header to every column and every row', () => {
+        const columns = [...table.querySelectorAll('thead th')];
+        expect(columns.map(th => th.textContent.trim()))
+            .toEqual(['Feature', 'Clawdia', 'MEE6 Pro', 'Carl-bot Premium']);
+        expect(columns.every(th => th.getAttribute('scope') === 'col')).toBe(true);
+
+        // The feature name leads its row as a header of its own, which is what
+        // gives "● included" something to be announced against on both axes.
+        for (const row of table.querySelectorAll('tbody tr')) {
+            const [first, ...cells] = [...row.children];
+            expect([first.tagName, first.getAttribute('scope')]).toEqual(['TH', 'row']);
+            expect(first.textContent.trim()).not.toBe('');
+            expect(cells.map(c => c.tagName)).toEqual(['TD', 'TD', 'TD']);
+        }
+    });
+
+    it('states the roles the grid layout would otherwise take away', () => {
+        // Not belt and braces: the CSS below re-lays this out as a grid, and
+        // browsers compute table semantics from the layout they perform.
+        expect(table.getAttribute('role')).toBe('table');
+        expect([...table.querySelectorAll('thead, tbody')].map(el => el.getAttribute('role')))
+            .toEqual(['rowgroup', 'rowgroup']);
+        expect([...table.querySelectorAll('tr')].every(tr => tr.getAttribute('role') === 'row')).toBe(true);
+        expect([...table.querySelectorAll('thead th')].every(th => th.getAttribute('role') === 'columnheader')).toBe(true);
+        expect([...table.querySelectorAll('tbody th')].every(th => th.getAttribute('role') === 'rowheader')).toBe(true);
+        expect([...table.querySelectorAll('td')].every(td => td.getAttribute('role') === 'cell')).toBe(true);
+    });
+
+    it('keeps Clawdia flagged as the highlighted column in every row', () => {
+        // The `.hi` column tint used to be hand-placed on every fourth div, so
+        // an inserted row shifted it. Now it is one cell per row and countable.
+        const rows = [...table.querySelectorAll('tr')];
+        expect(rows.map(tr => [...tr.children].findIndex(c => c.classList.contains('hi'))))
+            .toEqual(rows.map(() => 1));
+    });
+
+    it('still lays out as the four-column grid it looked like before', () => {
+        const styles = fs.readFileSync(STYLES, 'utf8');
+        const rule = /\.cw-compare\s*\{([^}]*)\}/.exec(styles);
+        expect(rule).not.toBeNull();
+        expect(rule[1]).toMatch(/display:\s*grid/);
+        expect(rule[1]).toMatch(/grid-template-columns:\s*1\.4fr 1fr 1fr 1fr/);
+        // Rows and row groups have to drop out of the box tree for the cells to
+        // become grid items of the table itself.
+        expect(styles).toMatch(/\.cw-compare thead,\s*\.cw-compare tbody,\s*\.cw-compare tr\s*\{[^}]*display:\s*contents/);
+    });
+});


### PR DESCRIPTION
Five issues, four commits — #868 and #897 share one, because the fix the latter asks for is what delivers the former.

Closes #912
Closes #882
Closes #869
Closes #897
Closes #868

## Landing-page comparison is a real table (#912)

The bot comparison was twenty-eight divs in a CSS grid. Nothing tied "● included" to either its feature row or its bot column, so the page's main persuasive argument read as a flat run of disconnected words and symbols (WCAG 1.3.1).

It is a `<table>` now — `thead` column headers, a `<th scope="row">` leading each feature, a clipped `<caption>` naming what is being compared. The visual design is untouched: the same four-column grid, with `display: contents` on the rows so the cells stay grid items of the table.

That last part is why every element also carries its role explicitly. A browser laying an element out as a grid rather than a table stops reporting it as a table, which would have swapped one silent failure for another.

## Getting Started collapse is a control anyone can operate (#882)

The header was a div with `cursor:pointer` and an `onclick` — no role, no tabindex, no `aria-expanded`, no `aria-controls`. Keyboard users could not toggle it at all (2.1.1), and its state was carried only by a ▾/▸ glyph a screen reader has no reason to read out (4.1.2).

It is a button inside the existing `h2` now, stretched across the header so the click target stays the whole row it was. `toggleGettingStarted` moves `aria-expanded` alongside the class change, and the glyph is `aria-hidden`: it is the state for the eye, and `aria-expanded` is the state for everyone else.

Two inline styles go with the rewrite, so the `dashboardInlineAttributes` baseline drops to match, as its own comment asks.

## /market buy no longer loses the seller's proceeds (#869)

The seller was credited by an unguarded, unretried `findOneAndUpdate` with no upsert and no check on its result — and it ran last, after the buyer had paid, after the item had moved, after the listing was deleted. Both failure modes lost the coins: a `null` return (a seller with no user document) was ignored and logged as `balance: 0`, and a throw escaped with the trade already complete. Nothing recorded the payout as owed, so unlike every other credit in the economy there was nothing for `payouts:replay` to settle, and unlike `/bank transfer` there was not even a failure message.

It goes through `creditCoinsOnce` now, keyed by the listing — which this flow has just deleted, so the id cannot come round again — and a credit that will not land is written down as owed with that key, the way `returnExpiredMarketListings` already handles a return it cannot make. The buyer's receipt says the payout is delayed rather than claiming the seller was paid, and the sale reaches the audit log either way with the reason in the note.

## One coin-transfer path, so /bank transfer cannot dodge the caps (#897, #868)

`/gift type:coins` and `/bank transfer` moved coins between the same two players through two implementations, and only one of them was any good.

`/gift` enforced the anti-alt daily caps in the write's own filter, gated on account age, and rolled the sender back when the credit missed. `/bank transfer` had none of it — no cap, no age gate, no accounting — so the caps next door were decorative: anyone who hit the gift cap simply transferred instead (#897). It also debited the sender and credited the receiver with nothing watching the second write, so a credit that threw replied "Failed to transfer coins" and left the sender simply poorer, with no refund and no record for an operator to replay (#868).

#897 suggested folding the two into one shared path as the tidier option, noting it would have prevented #868 as well. That is what this does. `utils/coinTransfer.js` holds the operation; each command keeps only its own wording and its own confirmation prompt. The rollback #868 asked for is part of that path rather than duplicated into it:

- the credit retries once on the E11000 an upsert race raises, and only on that — repeating a write whose outcome is unknown is how a credit lands twice;
- a credit that still will not land rolls the debit back, balance and daily budget both, so a failed transfer does not quietly eat the sender's allowance;
- a rollback that fails writes the refund down as an owed payout keyed by the interaction id, so `payouts:replay` can settle it and cannot pay it twice.

The sender is told which of the three happened. "Your coins were returned" is never said when they were not.

The budget table moves from `gift.js` into `giftCaps.js`, since the coin windows are no longer `gift.js`'s alone and two tables of field names is how one of them ends up naming the wrong reset field. The dashboard's gifting-limits copy now says the coin caps cover both commands, because it does — leaving it would have misled admins about what they are configuring.

## Test-helper bugs found along the way

Three, all fixed in-tree, each of which was hiding real behaviour rather than merely being inconvenient:

- `pipelineUpdate.js` could not evaluate `$filter`, `$slice` or `$$NOW`, so the payout-key append had never been exercised by any mock despite being live since #807.
- `fakeCollection.js` could not evaluate `$expr`, so the daily caps were testable only as the message shown before the write and not as the atomic filter that enforces them.
- `fakeCollection.js` shallow-spread one `defaults` object into every seeded document, so they shared its `inventory` array — an item pushed into one user's bag landed in every other seeded user's bag, across tests, since the defaults outlive `reset()`.

## Verification

`npx eslint .` clean. 345 suites / 6817 tests pass; coverage floors (`coverage:check`) pass.

The three `tests/integration/*` suites fail in my environment, but they fail identically on untouched `main` — `mongodb-memory-server` gets a 403 fetching a mongod binary here. I confirmed that by stashing rather than assuming it; they need a real check in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_015YqcutCs5k2G8jLV2R1cTo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `/bank transfer` now follows the same account-age and daily coin limits as `/gift`.
  * Transfers safely roll back when processing fails, helping preserve balances.
  * Market sellers receive reliable, duplicate-safe payouts; delayed payouts are clearly reported.
  * Added a collapsible, keyboard-accessible “Getting started” dashboard card.
  * Rebuilt the bot comparison section as an accessible table for improved screen-reader support.
* **Documentation**
  * Updated economy dashboard text to clarify shared gifting and transfer limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->