### PR TITLE
Make every achievement measure what its description claims

### DIFF
--- a/src/commands/community/achievements.js
+++ b/src/commands/community/achievements.js
@@ -6,6 +6,7 @@ const { getGuildSettings } = require('../../utils/guildSettingsCache');
 const { ACHIEVEMENTS } = require('../../data/achievements');
 const COLORS = require('../../utils/embedColors');
 const { ownedBy } = require('../../utils/collectorOwner');
+const { attachGrind } = require('../../utils/grindProfile');
 
 const CATEGORY_ORDER = ['economy', 'leveling', 'hunt', 'fishing', 'exploration', 'community', 'moderation', 'custom'];
 
@@ -64,6 +65,16 @@ module.exports = {
                 if (!user) {
                     user = await User.create({ userId: target.id, guildId: interaction.guild.id });
                 }
+                // Hunt, fishing, mining and exploration stats live in GrindProfile
+                // now, not on the user document. Thirty-three of the definitions below
+                // read them through the legacy `user.hunt` / `user.fishing` /
+                // `user.mining` / `user.exploration` names, so without this every
+                // one of their progress bars rendered a flat 0/N no matter how
+                // much the player had hunted — the numbers the grind commands
+                // award off were simply not on the document being measured.
+                await attachGrind(user).catch(err => {
+                    console.error('[achievements] grind profile load failed:', err);
+                });
 
                 const disabled = new Set(guildSettings.achievements?.disabledAchievements || []);
                 const earnedMap = new Map((user.achievements || []).map(a => [a.id, a]));

--- a/src/commands/economy/casino.js
+++ b/src/commands/economy/casino.js
@@ -5,6 +5,7 @@ const User  = require('../../models/User');
 const { processJackpotBet, getJackpotDisplay } = require('../../services/casinoJackpotService');
 const { advanceMissions } = require('../../services/seasonMissionService');
 const { tryAcquire, release } = require('../../utils/activeGameLock');
+const { checkAndAwardAtomic, announceAchievements } = require('../../services/achievementService');
 const { economyLockKey, busyMessage } = require('../../utils/economyLock');
 
 const games = [
@@ -17,6 +18,28 @@ const games = [
     require('../../games/casino/roulette'),
     require('../../games/casino/slots'),
 ];
+
+/**
+ * Award and announce whatever the coins just staked unlocked.
+ *
+ * Split out of `onWager` so the async work is one awaited chain the caller can
+ * attach a single `.catch` to. `guildSettings` is re-read rather than closed
+ * over so a crash lobby's joiner — who may be in a different guild's cache
+ * entry than the invoker was when the lobby opened — is judged against the
+ * settings that apply to them.
+ */
+async function awardWagerAchievements(doc, better, source) {
+    const settings = await getGuildSettings(doc.guildId);
+    if (!settings?.achievements?.enabled) return;
+
+    const earned = await checkAndAwardAtomic(
+        User, { userId: doc.userId, guildId: doc.guildId }, doc, settings,
+    );
+    if (!earned.length) return;
+
+    const member = source?.guild?.members?.cache?.get(better.id) ?? null;
+    await announceAchievements(source.client, settings, doc, member, earned);
+}
 
 // Discord rejects a command description longer than this.
 const DESCRIPTION_LIMIT = 100;
@@ -167,7 +190,7 @@ module.exports = {
         // not another game played. `user` and `source` are the player and the
         // interaction to announce through, which differ from the invoker for a
         // crash lobby: joiners stake their own coins on someone else's command.
-        const onWager = ({ amount, user = null, source = null }) => {
+        const onWager = ({ amount, user = null, source = null, doc = null }) => {
             const better = user ?? interaction.user;
 
             // Fire-and-forget — the service handles pool reset, user credit, and logging.
@@ -185,6 +208,22 @@ module.exports = {
                 { userId: better.id, guildId: interaction.guild.id },
                 'casino', 1, guildSettings,
             ).catch(err => console.error('[casino] season mission error:', err));
+
+            // The wagering achievements. `doc` is the document placeWager's own
+            // `$inc` returned, so `lifetimeGambled` on it already includes this
+            // stake — nothing else has to be read back.
+            //
+            // Without this the casino awarded nothing at all: the only checks
+            // that ran were the ones on the grind commands and on messageCreate,
+            // so crossing a million coins wagered unlocked High Roller whenever
+            // the player next happened to type in chat, which is a strange place
+            // for a casino achievement to appear. The award is atomic (see
+            // checkAndAwardAtomic) precisely because this document was read
+            // mid-hand and must not be saved back wholesale.
+            if (doc) {
+                awardWagerAchievements(doc, better, source ?? interaction)
+                    .catch(err => console.error('[casino] achievement check error:', err));
+            }
         };
 
         try {

--- a/src/commands/economy/duel.js
+++ b/src/commands/economy/duel.js
@@ -54,30 +54,43 @@ function drawCard() {
 
 // Atomically deduct wagers from both players. Returns { success, reason }.
 // If opponent deduction fails after challenger succeeded, challenger is refunded.
+//
+// The stake also advances `lifetimeGambled`, the counter behind Lucky, Gambler,
+// High Roller and the three Wager badges. A duel is a coin bet on a coin flip
+// dressed up as rock-paper-scissors, and it is the only wager outside the
+// casino that puts a player's own coins at risk on an outcome — leaving it out
+// meant those achievements measured "coins staked at /casino" while claiming to
+// measure coins gambled. Every path that hands a stake back (both branches
+// here, and refundEscrow) takes the counter back with it, so a duel that never
+// resolved — declined, expired, errored — counts for nothing.
 async function takeEscrow(challengerId, opponentId, guildId, amount) {
     const challenger = await User.findOneAndUpdate(
         { userId: challengerId, guildId, balance: { $gte: amount } },
-        { $inc: { balance: -amount } },
+        { $inc: { balance: -amount, lifetimeGambled: amount } },
         { new: true }
     );
     if (!challenger) return { success: false, reason: 'challenger' };
 
     const opponent = await User.findOneAndUpdate(
         { userId: opponentId, guildId, balance: { $gte: amount } },
-        { $inc: { balance: -amount } },
+        { $inc: { balance: -amount, lifetimeGambled: amount } },
         { new: true }
     );
     if (!opponent) {
-        await User.updateOne({ userId: challengerId, guildId }, { $inc: { balance: amount } });
+        await User.updateOne(
+            { userId: challengerId, guildId },
+            { $inc: { balance: amount, lifetimeGambled: -amount } },
+        );
         return { success: false, reason: 'opponent' };
     }
     return { success: true };
 }
 
 async function refundEscrow(challengerId, opponentId, guildId, amount) {
+    const give = { $inc: { balance: amount, lifetimeGambled: -amount } };
     await Promise.all([
-        User.updateOne({ userId: challengerId, guildId }, { $inc: { balance: amount } }),
-        User.updateOne({ userId: opponentId,   guildId }, { $inc: { balance: amount } }),
+        User.updateOne({ userId: challengerId, guildId }, give),
+        User.updateOne({ userId: opponentId,   guildId }, give),
     ]);
 }
 
@@ -752,3 +765,10 @@ module.exports = {
         if (sub === 'leaderboard') return runLeaderboard(interaction);
     },
 };
+
+// The escrow pair is the whole of /duel's money handling, and the
+// `lifetimeGambled` bookkeeping it carries has to stay exactly inverse between
+// them or a declined duel would leave a player credited for coins they got
+// straight back. Exported so tests can hold the two against each other without
+// driving a full challenge through its button collectors.
+module.exports.__test__ = { takeEscrow, refundEscrow };

--- a/src/data/achievements.js
+++ b/src/data/achievements.js
@@ -18,6 +18,17 @@ const { CORE_REGION_IDS, TOTAL_CORE_SECRETS } = require('./exploreData');
 // never re-checked and never taken back.
 const RARE_COMPANION_IDS = ['eagle', 'shark', 'crystal_fox', 'lantern_owl'];
 
+// Days a member has gone without a warning: since their last one, or since the
+// account was first recorded when they have never had one. Returns 0 when
+// neither date is available, so a document without either stays locked rather
+// than unlocking on an epoch-zero timestamp.
+function daysSinceLastWarning(user) {
+    const since = user.lastWarnedAt ?? user.createdAt;
+    if (!since) return 0;
+    const ms = Date.now() - new Date(since).getTime();
+    return ms > 0 ? ms / 864e5 : 0;
+}
+
 const ACHIEVEMENTS = [
     // ── Economy ──────────────────────────────────────────────────────────────
     {
@@ -462,16 +473,17 @@ const ACHIEVEMENTS = [
         category: 'moderation',
         xpReward: 150,
         coinReward: 500,
-        check: (user) => {
-            if (!user.lastWarnedAt) return false;
-            const daysSince = (Date.now() - new Date(user.lastWarnedAt).getTime()) / 864e5;
-            return daysSince >= 30;
-        },
-        progress: (user) => {
-            if (!user.lastWarnedAt) return [0, 30];
-            const daysSince = Math.min(Math.floor((Date.now() - new Date(user.lastWarnedAt).getTime()) / 864e5), 30);
-            return [daysSince, 30];
-        }
+        // The clock runs from the last warning, or from when the account was
+        // first seen if there has never been one. It used to `return false` on a
+        // missing `lastWarnedAt`, which made the achievement unreachable for
+        // exactly the players it describes: a member who has never been warned
+        // has, self-evidently, gone 30 days without receiving a warning, but
+        // could only earn Clean Record by first being warned and then waiting.
+        // `createdAt` is schema-defaulted to now on insert, so a brand-new
+        // member still has to serve the 30 days rather than earning it on their
+        // first message.
+        check: (user) => daysSinceLastWarning(user) >= 30,
+        progress: (user) => [Math.min(Math.floor(daysSinceLastWarning(user)), 30), 30]
     },
 
     // ── Pets ─────────────────────────────────────────────────────────────────

--- a/src/games/casino/blackjack.js
+++ b/src/games/casino/blackjack.js
@@ -217,7 +217,7 @@ module.exports = {
         const debited = await placeWager(
             { userId: interaction.user.id, guildId: interaction.guild.id },
             bet,
-            { extraInc: { lifetimeGambled: bet }, onWager },
+            { onWager },
         );
         if (!debited) {
             releaseLock?.();
@@ -303,7 +303,6 @@ module.exports = {
                     const peekUpdated = await placeWager(
                         { userId: interaction.user.id, guildId: interaction.guild.id },
                         insuranceCost,
-                        { extraInc: { lifetimeGambled: insuranceCost } },
                     );
                     if (peekUpdated) peekInsuranceBet = insuranceCost;
                 } catch {
@@ -372,7 +371,6 @@ module.exports = {
                 const updated = await placeWager(
                     { userId: interaction.user.id, guildId: interaction.guild.id },
                     insuranceCost,
-                    { extraInc: { lifetimeGambled: insuranceCost } },
                 );
                 if (updated) insuranceBet = insuranceCost;
                 const statusMsg = updated
@@ -389,7 +387,6 @@ module.exports = {
                 const updated = await placeWager(
                     { userId: interaction.user.id, guildId: interaction.guild.id },
                     bet,
-                    { extraInc: { lifetimeGambled: bet } },
                 );
                 if (!updated) {
                     const embed = buildEmbed(interaction, playerHand, dealerHand, activeBet, currency, `⚠️ Not enough balance for double down · Your turn`, '#5865F2', true);
@@ -419,7 +416,6 @@ module.exports = {
                 const updated = await placeWager(
                     { userId: interaction.user.id, guildId: interaction.guild.id },
                     bet,
-                    { extraInc: { lifetimeGambled: bet } },
                 );
                 if (!updated) {
                     const embed = buildEmbed(interaction, playerHand, dealerHand, activeBet, currency, `⚠️ Not enough balance for split · Your turn`, '#5865F2', true);

--- a/src/games/casino/crash.js
+++ b/src/games/casino/crash.js
@@ -364,9 +364,12 @@ async function openLobby(interaction, bet, hostAutoCashout, releaseLock, onWager
 
         const joined = addPlayer(channelId, i.user.id, null, i.user.username); // no auto cash-out for non-host joiners
         if (!joined) {
+            // The stake goes back, and so does the `lifetimeGambled` placeWager
+            // counted with the debit: coins handed straight back were never
+            // risked, and the wagering achievements must not count them.
             await User.findOneAndUpdate(
                 { userId: i.user.id, guildId: interaction.guild.id },
-                { $inc: { balance: bet, pendingCrashRefund: -bet } }
+                { $inc: { balance: bet, pendingCrashRefund: -bet, lifetimeGambled: -bet } }
             ).catch(err => console.error('[crash] join refund failed:', err));
             return i.reply({ content: 'Could not join the lobby (it may have just filled up). Your coins have been refunded.', flags: MessageFlags.Ephemeral });
         }
@@ -598,7 +601,9 @@ async function startCrashGame(interaction, lobby, lobbyId) {
                 if (unresolvedIds.length > 0) {
                     await User.updateMany(
                         { userId: { $in: unresolvedIds }, guildId, pendingCrashRefund: { $gt: 0 } },
-                        { $inc: { balance: bet }, $set: { pendingCrashRefund: 0 } }
+                        // As with the join refund: a returned stake is an
+                        // uncounted one, so the wager counter comes back too.
+                        { $inc: { balance: bet, lifetimeGambled: -bet }, $set: { pendingCrashRefund: 0 } }
                     ).catch(e => console.error('[crash] emergency refund failed:', e));
                 }
                 deleteLobby(channelId);

--- a/src/services/achievementService.js
+++ b/src/services/achievementService.js
@@ -9,6 +9,15 @@ const COLORS = require('../utils/embedColors');
  * Check all applicable achievements for a user and award any newly earned ones.
  * Call this after any stat-changing operation, before user.save().
  *
+ * The scan repeats until a pass awards nothing. One achievement reads what the
+ * others have earned — Completionist wants 20 non-secret unlocks — and a single
+ * ordered pass only sees the ones defined *above* it in the list. The tiered
+ * hunt/angler/miner/gambler badges were appended below Completionist, so a
+ * player whose twentieth unlock was Hunter Gold stayed locked out of it until
+ * some later, unrelated check happened to run. Iterating to a fixed point makes
+ * the award independent of where a definition sits in the array, which is not a
+ * property anything should have to remember when adding one.
+ *
  * @param {object} user           - Mongoose user document (already modified, not yet saved)
  * @param {object} guildSettings  - Mongoose guild document
  * @returns {Array} newly earned achievement definitions (built-in + custom)
@@ -22,28 +31,80 @@ async function checkAndAward(user, guildSettings) {
     const newlyEarned = [];
 
     // ── Built-in achievements ─────────────────────────────────────────────
-    for (const def of ACHIEVEMENTS) {
-        if (disabled.has(def.id)) continue;
-        if (earnedIds.has(def.id)) continue;
+    // Bounded by the definition count: every pass after the first is entered
+    // only because the one before it awarded something, and nothing is awarded
+    // twice, so this cannot run more times than there are achievements.
+    let awardedThisPass = true;
+    while (awardedThisPass) {
+        awardedThisPass = false;
 
-        let earned = false;
-        try {
-            earned = def.check(user, guildSettings);
-        } catch {
-            // silently skip a broken check
+        for (const def of ACHIEVEMENTS) {
+            if (disabled.has(def.id)) continue;
+            if (earnedIds.has(def.id)) continue;
+
+            let earned = false;
+            try {
+                earned = def.check(user, guildSettings);
+            } catch {
+                // silently skip a broken check
+            }
+
+            if (!earned) continue;
+
+            user.achievements = user.achievements || [];
+            user.achievements.push({ id: def.id, earnedAt: new Date(), claimed: false });
+            user.achievementsCount = (user.achievementsCount || 0) + 1;
+            earnedIds.add(def.id);
+            newlyEarned.push(def);
+            awardedThisPass = true;
         }
-
-        if (!earned) continue;
-
-        user.achievements = user.achievements || [];
-        user.achievements.push({ id: def.id, earnedAt: new Date(), claimed: false });
-        user.achievementsCount = (user.achievementsCount || 0) + 1;
-        earnedIds.add(def.id);
-        newlyEarned.push(def);
     }
 
     // Announcement is deferred — callers must call announceAchievements after user.save()
     return newlyEarned;
+}
+
+/**
+ * checkAndAward for a caller that must not save the whole user document.
+ *
+ * The casino is the case this exists for. A hand's stake is debited with an
+ * atomic `$inc` while the player's balance is moving under several other
+ * writers, and `user.save()` writes `balance` back as an absolute `$set` — so
+ * saving the document a wager was read from is exactly the "a casino debit
+ * landing between this read and that save would simply be erased" hazard
+ * messageCreate already guards against. Awarding through a targeted update
+ * writes the two achievement fields and nothing else.
+ *
+ * The filter refuses to write if any of the ids are already on the document, so
+ * two hands settling at once cannot both award the same achievement; the loser
+ * of that race gets an empty array back and announces nothing.
+ *
+ * `user` is still mutated by the checkAndAward inside, so the caller must not
+ * also save it — the whole point is that this write is the only one.
+ *
+ * @param {object} User           the User model
+ * @param {object} filter         `{ userId, guildId }` for the update
+ * @param {object} user           the document to evaluate (not saved)
+ * @param {object} guildSettings
+ * @returns {Promise<Array>} newly earned definitions that this call persisted
+ */
+async function checkAndAwardAtomic(User, filter, user, guildSettings) {
+    const newlyEarned = await checkAndAward(user, guildSettings);
+    if (!newlyEarned.length) return [];
+
+    const ids = newlyEarned.map(def => def.id);
+    const entries = ids.map(id => ({ id, earnedAt: new Date(), claimed: false }));
+
+    const res = await User.updateOne(
+        { ...filter, 'achievements.id': { $nin: ids } },
+        {
+            $push: { achievements: { $each: entries } },
+            $inc:  { achievementsCount: entries.length },
+        },
+    );
+
+    const wrote = res?.modifiedCount ?? res?.nModified ?? 0;
+    return wrote > 0 ? newlyEarned : [];
 }
 
 // XP → embed color tier
@@ -213,4 +274,4 @@ async function grantCustomAchievement(user, achievementId) {
     return true;
 }
 
-module.exports = { checkAndAward, announceAchievements, grantCustomAchievement };
+module.exports = { checkAndAward, checkAndAwardAtomic, announceAchievements, grantCustomAchievement };

--- a/src/utils/placeWager.js
+++ b/src/utils/placeWager.js
@@ -28,13 +28,28 @@ const User = require('../models/User');
  * without it, because they are more money on a hand already counted — not
  * another game played.
  *
+ * The third thing is that nothing counted the coins. `lifetimeGambled` is what
+ * the six wagering achievements (Lucky, Gambler, High Roller and the three
+ * Wager tiers) read, and only blackjack ever wrote it — the other seven games
+ * debited a stake through this helper and left the counter untouched, so a
+ * player could lose a million coins at slots and still show 0 progress toward
+ * High Roller. It is written here now, for the same reason the debit
+ * lives here: a stake that moved is a stake that was gambled, and there is
+ * exactly one place that knows the coins moved.
+ *
+ * Unlike `onWager`, it counts *every* stake and not just the opening one — a
+ * double-down, an insurance side bet, a poker raise and a keno reroll are all
+ * more coins put at risk, which is what the achievement measures, even though
+ * they are not another game played. That is the same rule blackjack already
+ * applied to its own five sites, kept and extended rather than narrowed.
+ *
  * @param {object} filter          the user's `{ userId, guildId }`
  * @param {number} amount          coins to take
  * @param {object} [opts]
  * @param {object} [opts.extraInc] further `$inc` fields for the same write, so a
  *                                 stake and its bookkeeping commit together
- * @param {Function} [opts.onWager] called with `{ amount, user, source }` when
- *                                 this debit opened a hand and landed
+ * @param {Function} [opts.onWager] called with `{ amount, user, source, doc }`
+ *                                 when this debit opened a hand and landed
  * @param {object} [opts.user]     who placed it, if not the command's invoker —
  *                                 a crash lobby takes bets from joiners too
  * @param {object} [opts.source]   the interaction to announce a jackpot through
@@ -47,14 +62,15 @@ async function placeWager(filter, amount, { extraInc = {}, onWager = null, user 
 
     const debited = await User.findOneAndUpdate(
         { ...filter, balance: { $gte: wager } },
-        { $inc: { balance: -wager, ...extraInc } },
+        { $inc: { balance: -wager, lifetimeGambled: wager, ...extraInc } },
         { new: true },
     );
 
     // Fire-and-forget by contract: the caller is mid-hand and the jackpot and
     // mission writes are both best-effort, so a slow round trip must not hold
-    // up dealing the cards.
-    if (debited && onWager) onWager({ amount: wager, user, source });
+    // up dealing the cards. The debited document rides along so a listener can
+    // read the counters this write just advanced without a second round trip.
+    if (debited && onWager) onWager({ amount: wager, user, source, doc: debited });
 
     return debited;
 }

--- a/tests/achievementTracking.test.js
+++ b/tests/achievementTracking.test.js
@@ -1,0 +1,348 @@
+'use strict';
+
+/**
+ * Do the achievements actually measure what they claim to?
+ *
+ * An achievement has two halves and either can rot on its own: a `check` that
+ * reads a field, and somewhere in the bot that writes it. The definitions were
+ * fine — every one of them reads a real field with a sensible threshold — but
+ * three of the wirings between them were not:
+ *
+ *   1. `lifetimeGambled` backs six achievements and only blackjack wrote it.
+ *      The other seven casino games took a stake through the same helper and
+ *      left the counter at zero, so High Roller measured "coins staked at
+ *      blackjack" while promising "coins gambled". /duel, the one wager outside
+ *      the casino, counted for nothing at all.
+ *   2. Clean Record was unreachable for a member who has never been warned —
+ *      the only people it describes.
+ *   3. Completionist counts the other achievements, and a single ordered pass
+ *      could only see the ones defined above it.
+ *
+ * This suite pins the wiring rather than the thresholds: the counter moves when
+ * coins are staked, comes back when they are handed back, and the award is
+ * independent of where a definition sits in the list.
+ */
+
+const { ACHIEVEMENTS } = require('../src/data/achievements');
+
+const byId = id => ACHIEVEMENTS.find(a => a.id === id);
+const DAY = 86400000;
+
+// ── the counter behind the six wagering achievements ─────────────────────────
+
+describe('placeWager counts every stake as gambled', () => {
+    let User, placeWager;
+
+    beforeEach(() => {
+        jest.resetModules();
+        jest.doMock('../src/models/User', () => ({ findOneAndUpdate: jest.fn() }));
+        User = require('../src/models/User');
+        ({ placeWager } = require('../src/utils/placeWager'));
+    });
+
+    afterEach(() => {
+        jest.dontMock('../src/models/User');
+        jest.resetModules();
+    });
+
+    test('the stake and the counter commit in the one write', async () => {
+        User.findOneAndUpdate.mockResolvedValue({ userId: 'u', lifetimeGambled: 100 });
+
+        await placeWager({ userId: 'u', guildId: 'g' }, 100);
+
+        const [filter, update] = User.findOneAndUpdate.mock.calls[0];
+        expect(filter).toEqual({ userId: 'u', guildId: 'g', balance: { $gte: 100 } });
+        expect(update).toEqual({ $inc: { balance: -100, lifetimeGambled: 100 } });
+    });
+
+    test('extra bookkeeping rides along without displacing it', async () => {
+        User.findOneAndUpdate.mockResolvedValue({ userId: 'u' });
+
+        await placeWager({ userId: 'u', guildId: 'g' }, 50, { extraInc: { pendingCrashRefund: 50 } });
+
+        expect(User.findOneAndUpdate.mock.calls[0][1]).toEqual({
+            $inc: { balance: -50, lifetimeGambled: 50, pendingCrashRefund: 50 },
+        });
+    });
+
+    test('the fractional part of a stake is counted the way it is charged', async () => {
+        User.findOneAndUpdate.mockResolvedValue({ userId: 'u' });
+
+        await placeWager({ userId: 'u', guildId: 'g' }, 99.9);
+
+        expect(User.findOneAndUpdate.mock.calls[0][1].$inc).toEqual({ balance: -99, lifetimeGambled: 99 });
+    });
+
+    test('a stake the wallet could not cover counts for nothing', async () => {
+        User.findOneAndUpdate.mockResolvedValue(null);
+
+        expect(await placeWager({ userId: 'u', guildId: 'g' }, 100)).toBeNull();
+        // The guard is in the filter, so the write simply matches nothing —
+        // what matters is that no second, unguarded write follows it.
+        expect(User.findOneAndUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    test('a non-positive stake never reaches the database', async () => {
+        expect(await placeWager({ userId: 'u', guildId: 'g' }, 0)).toBeNull();
+        expect(User.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+    test('the debited document rides along so a listener can read the counter it just moved', async () => {
+        const doc = { userId: 'u', guildId: 'g', lifetimeGambled: 1_000_000 };
+        User.findOneAndUpdate.mockResolvedValue(doc);
+        const onWager = jest.fn();
+
+        await placeWager({ userId: 'u', guildId: 'g' }, 100, { onWager });
+
+        expect(onWager).toHaveBeenCalledWith(expect.objectContaining({ amount: 100, doc }));
+    });
+});
+
+describe('/duel — an escrowed stake is gambled, a refunded one is not', () => {
+    let User, duel;
+
+    beforeEach(() => {
+        jest.resetModules();
+        jest.doMock('../src/models/User', () => ({
+            findOneAndUpdate: jest.fn(),
+            updateOne: jest.fn().mockResolvedValue({}),
+        }));
+        User = require('../src/models/User');
+        duel = require('../src/commands/economy/duel').__test__;
+    });
+
+    afterEach(() => {
+        jest.dontMock('../src/models/User');
+        jest.resetModules();
+    });
+
+    const incsFor = mockFn => mockFn.mock.calls.map(([, update]) => update.$inc);
+
+    test('both players are charged and counted when the escrow holds', async () => {
+        User.findOneAndUpdate.mockResolvedValue({ userId: 'x' });
+
+        expect(await duel.takeEscrow('a', 'b', 'g', 250)).toEqual({ success: true });
+        expect(incsFor(User.findOneAndUpdate)).toEqual([
+            { balance: -250, lifetimeGambled: 250 },
+            { balance: -250, lifetimeGambled: 250 },
+        ]);
+        expect(User.updateOne).not.toHaveBeenCalled();
+    });
+
+    test('a challenger refunded because the opponent could not pay is un-counted', async () => {
+        User.findOneAndUpdate
+            .mockResolvedValueOnce({ userId: 'a' })
+            .mockResolvedValueOnce(null);
+
+        expect(await duel.takeEscrow('a', 'b', 'g', 250)).toEqual({ success: false, reason: 'opponent' });
+        expect(incsFor(User.updateOne)).toEqual([{ balance: 250, lifetimeGambled: -250 }]);
+    });
+
+    test('a duel that never resolves gives back the coins and the count', async () => {
+        await duel.refundEscrow('a', 'b', 'g', 250);
+
+        expect(incsFor(User.updateOne)).toEqual([
+            { balance: 250, lifetimeGambled: -250 },
+            { balance: 250, lifetimeGambled: -250 },
+        ]);
+    });
+
+    test('escrow and refund are exactly inverse, so a cancelled duel nets to zero', async () => {
+        User.findOneAndUpdate.mockResolvedValue({ userId: 'x' });
+        await duel.takeEscrow('a', 'b', 'g', 250);
+        await duel.refundEscrow('a', 'b', 'g', 250);
+
+        const net = [...incsFor(User.findOneAndUpdate), ...incsFor(User.updateOne)]
+            .reduce((sum, inc) => sum + inc.lifetimeGambled, 0);
+        expect(net).toBe(0);
+    });
+});
+
+describe.each(require('./helpers/casinoInteraction').GAMES)(
+    '/$name advances the wagering counter',
+    (game) => {
+        // The end-to-end half of the claim. The unit tests above pin what
+        // placeWager writes; this pins that each of the eight games actually
+        // reaches it with the opening stake, against the real helper rather
+        // than a stub — which is the step blackjack alone used to take.
+        const { GUILD_ID, USER_ID, walletDoc, makeInteraction, stakeFor } = require('./helpers/casinoInteraction');
+        const stake = stakeFor(game);
+
+        test('the opening stake lands on lifetimeGambled', async () => {
+            jest.resetModules();
+            jest.doMock('../src/models/User', () => ({
+                findOne: jest.fn(), findOneAndUpdate: jest.fn(), updateOne: jest.fn(), create: jest.fn(),
+            }));
+            jest.doMock('../src/models/Guild', () => ({
+                findOne: jest.fn(), findOneAndUpdate: jest.fn(), updateOne: jest.fn(),
+            }));
+            jest.doMock('../src/models/ActiveLock', () => require('./helpers/fakeActiveLock'));
+
+            const errorSpy   = jest.spyOn(console, 'error').mockImplementation(() => {});
+            const freshUser  = require('../src/models/User');
+            const freshGuild = require('../src/models/Guild');
+
+            freshGuild.findOne.mockReturnValue(Object.assign(
+                Promise.resolve({ guildId: GUILD_ID, economy: { enabled: true, gamesEnabled: true } }),
+                { lean: () => ({ catch: () => Promise.resolve(null) }) },
+            ));
+            freshGuild.findOneAndUpdate.mockResolvedValue(null);
+            freshGuild.updateOne.mockResolvedValue({});
+            freshUser.findOne.mockResolvedValue(walletDoc());
+            freshUser.create.mockResolvedValue(walletDoc());
+            freshUser.updateOne.mockResolvedValue({});
+            // Every *debit* refuses, which stops the hand right after the write
+            // this test is here to inspect — eight games playing themselves out
+            // is not what is being measured. The upsert some games do first is
+            // not a debit and still has to hand back a wallet, or they fall over
+            // before reaching the stake.
+            freshUser.findOneAndUpdate.mockImplementation((_filter, update) =>
+                Promise.resolve(update?.$inc?.balance < 0 ? null : walletDoc()));
+
+            await require(`../src/games/casino/${game.name}`)
+                .execute(makeInteraction(game.options), { releaseLock: jest.fn(), onWager: jest.fn() });
+
+            const opening = freshUser.findOneAndUpdate.mock.calls
+                .find(([, update]) => update?.$inc?.balance === -stake);
+            expect(opening).toBeDefined();
+            expect(opening[0]).toMatchObject({ userId: USER_ID, guildId: GUILD_ID });
+            expect(opening[1].$inc.lifetimeGambled).toBe(stake);
+
+            errorSpy.mockRestore();
+            jest.resetModules();
+        });
+    },
+);
+
+// ── the definitions whose wiring was wrong ───────────────────────────────────
+
+describe('Clean Record', () => {
+    const def = byId('clean_record');
+
+    test('a member who has never been warned earns it once they have been around 30 days', () => {
+        const user = { createdAt: new Date(Date.now() - 31 * DAY) };
+        expect(def.check(user)).toBe(true);
+        expect(def.progress(user)).toEqual([30, 30]);
+    });
+
+    test('a member who joined today has not served the 30 days yet', () => {
+        const user = { createdAt: new Date() };
+        expect(def.check(user)).toBe(false);
+        expect(def.progress(user)).toEqual([0, 30]);
+    });
+
+    test('a warning restarts the clock even on an old account', () => {
+        const user = { createdAt: new Date(Date.now() - 400 * DAY), lastWarnedAt: new Date(Date.now() - DAY) };
+        expect(def.check(user)).toBe(false);
+        expect(def.progress(user)).toEqual([1, 30]);
+    });
+
+    test('30 days after the last warning it comes back', () => {
+        const user = { createdAt: new Date(Date.now() - 400 * DAY), lastWarnedAt: new Date(Date.now() - 31 * DAY) };
+        expect(def.check(user)).toBe(true);
+    });
+
+    test('a document carrying neither date stays locked rather than unlocking on epoch zero', () => {
+        expect(def.check({})).toBe(false);
+        expect(def.progress({})).toEqual([0, 30]);
+    });
+});
+
+describe('checkAndAward runs to a fixed point', () => {
+    const { checkAndAward } = require('../src/services/achievementService');
+    const settings = { achievements: { enabled: true } };
+
+    // Completionist is defined above the tiered hunt/angler/miner/gambler
+    // badges, so a user whose twentieth non-secret unlock is one of those is
+    // exactly the case a single ordered pass missed.
+    const nonSecretIds = ACHIEVEMENTS.filter(a => !a.secret).map(a => a.id);
+    const lateTierId = 'gambler_gold';
+
+    test('Completionist lands in the same pass as the achievement that completes it', async () => {
+        expect(nonSecretIds.indexOf(lateTierId)).toBeGreaterThan(
+            ACHIEVEMENTS.findIndex(a => a.id === 'completionist'),
+        );
+
+        // Nineteen already banked, and a stat that unlocks a twentieth defined
+        // below Completionist.
+        const already = nonSecretIds.filter(id => id !== lateTierId).slice(0, 19);
+        const user = {
+            achievements: already.map(id => ({ id, earnedAt: new Date(), claimed: false })),
+            achievementsCount: already.length,
+            lifetimeGambled: 250_000,
+        };
+
+        const earned = await checkAndAward(user, settings);
+        const earnedIds = earned.map(d => d.id);
+
+        expect(earnedIds).toContain(lateTierId);
+        expect(earnedIds).toContain('completionist');
+    });
+
+    test('nothing is awarded twice, however many passes it takes', async () => {
+        const user = { achievements: [], achievementsCount: 0, balance: 2_000_000, bank: 2_000_000 };
+
+        const earned = await checkAndAward(user, settings);
+        const ids = earned.map(d => d.id);
+
+        expect(new Set(ids).size).toBe(ids.length);
+        expect(user.achievementsCount).toBe(user.achievements.length);
+        expect(await checkAndAward(user, settings)).toEqual([]);
+    });
+
+    test('a disabled achievement is not awarded by a later pass either', async () => {
+        const user = { achievements: [], achievementsCount: 0, balance: 500, bank: 0 };
+        const disabled = { achievements: { enabled: true, disabledAchievements: ['first_steps'] } };
+
+        const earned = await checkAndAward(user, disabled);
+        expect(earned.map(d => d.id)).not.toContain('first_steps');
+    });
+});
+
+describe('checkAndAwardAtomic writes the achievement fields and nothing else', () => {
+    const { checkAndAwardAtomic } = require('../src/services/achievementService');
+    const settings = { achievements: { enabled: true } };
+    const filter = { userId: 'u', guildId: 'g' };
+
+    test('a wager that crosses a threshold is persisted without saving the wallet', async () => {
+        const User = { updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }) };
+        const doc = { ...filter, achievements: [], achievementsCount: 0, lifetimeGambled: 1_000_000, save: jest.fn() };
+
+        const earned = await checkAndAwardAtomic(User, filter, doc, settings);
+
+        expect(earned.map(d => d.id)).toEqual(expect.arrayContaining(['high_roller']));
+        expect(doc.save).not.toHaveBeenCalled();
+
+        const [q, update] = User.updateOne.mock.calls[0];
+        expect(q).toMatchObject(filter);
+        expect(Object.keys(update)).toEqual(['$push', '$inc']);
+        // Only the counter — a balance written back from a mid-hand read is the
+        // hazard this helper exists to avoid.
+        expect(Object.keys(update.$inc)).toEqual(['achievementsCount']);
+    });
+
+    test('the write refuses to run if the document already carries one of the ids', async () => {
+        const User = { updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }) };
+        const doc = { ...filter, achievements: [], achievementsCount: 0, lifetimeGambled: 1_000_000 };
+
+        const earned = await checkAndAwardAtomic(User, filter, doc, settings);
+        const [q] = User.updateOne.mock.calls[0];
+
+        expect(q['achievements.id']).toEqual({ $nin: earned.map(d => d.id) });
+    });
+
+    test('losing the race to a concurrent hand announces nothing', async () => {
+        const User = { updateOne: jest.fn().mockResolvedValue({ modifiedCount: 0 }) };
+        const doc = { ...filter, achievements: [], achievementsCount: 0, lifetimeGambled: 1_000_000 };
+
+        expect(await checkAndAwardAtomic(User, filter, doc, settings)).toEqual([]);
+    });
+
+    test('nothing earned means no write at all', async () => {
+        const User = { updateOne: jest.fn() };
+        const doc = { ...filter, achievements: [], achievementsCount: 0, lifetimeGambled: 0, balance: 0, bank: 0 };
+
+        expect(await checkAndAwardAtomic(User, filter, doc, settings)).toEqual([]);
+        expect(User.updateOne).not.toHaveBeenCalled();
+    });
+});

--- a/tests/casinoBetGuard.test.js
+++ b/tests/casinoBetGuard.test.js
@@ -288,7 +288,8 @@ describe('a stake that is available is taken exactly once', () => {
         const interaction = makeInteraction({ bet: BET });
         await load('slots').execute(interaction, { releaseLock: jest.fn() });
 
-        expect(debits).toEqual([{ $inc: { balance: -BET } }]);
+        // The wagering counter rides in the same write — one debit, still.
+        expect(debits).toEqual([{ $inc: { balance: -BET, lifetimeGambled: BET } }]);
     });
 });
 

--- a/tests/casinoWagerSignal.test.js
+++ b/tests/casinoWagerSignal.test.js
@@ -76,7 +76,10 @@ describe('placeWager — the debit is the signal', () => {
         return placeWager(filter, BET).then(() => {
             expect(User.findOneAndUpdate).toHaveBeenCalledWith(
                 { userId: USER_ID, guildId: GUILD_ID, balance: { $gte: BET } },
-                { $inc: { balance: -BET } },
+                // The wagering counter moved into this write when it turned out
+                // seven of the eight games never wrote it — see
+                // tests/achievementTracking.test.js for what depends on it.
+                { $inc: { balance: -BET, lifetimeGambled: BET } },
                 { new: true },
             );
         });
@@ -84,10 +87,10 @@ describe('placeWager — the debit is the signal', () => {
 
     test('commits a stake and its bookkeeping in one write', async () => {
         User.findOneAndUpdate.mockResolvedValue(walletDoc());
-        await placeWager(filter, BET, { extraInc: { lifetimeGambled: BET } });
+        await placeWager(filter, BET, { extraInc: { pendingCrashRefund: BET } });
 
         const [, update] = User.findOneAndUpdate.mock.calls[0];
-        expect(update).toEqual({ $inc: { balance: -BET, lifetimeGambled: BET } });
+        expect(update).toEqual({ $inc: { balance: -BET, lifetimeGambled: BET, pendingCrashRefund: BET } });
     });
 
     test('reports the wager once the coins have moved', async () => {
@@ -97,7 +100,9 @@ describe('placeWager — the debit is the signal', () => {
         await placeWager(filter, BET, { onWager });
 
         expect(onWager).toHaveBeenCalledTimes(1);
-        expect(onWager).toHaveBeenCalledWith({ amount: BET, user: null, source: null });
+        expect(onWager).toHaveBeenCalledWith(
+            { amount: BET, user: null, source: null, doc: expect.objectContaining({ userId: USER_ID }) },
+        );
     });
 
     test('says nothing when the guard misses — the whole point', async () => {
@@ -120,7 +125,9 @@ describe('placeWager — the debit is the signal', () => {
 
         await placeWager({ userId: joiner.id, guildId: GUILD_ID }, BET, { onWager, user: joiner, source });
 
-        expect(onWager).toHaveBeenCalledWith({ amount: BET, user: joiner, source });
+        expect(onWager).toHaveBeenCalledWith(
+            { amount: BET, user: joiner, source, doc: expect.objectContaining({ userId: USER_ID }) },
+        );
     });
 
     test('refuses a non-positive stake without touching the database', async () => {
@@ -364,7 +371,9 @@ describe('/crash — a joiner is counted only once the seat is theirs', () => {
         // counting a bet nobody ended up making.
         expect(User.findOneAndUpdate).toHaveBeenCalledWith(
             { userId: 'user-2', guildId: GUILD_ID },
-            { $inc: { balance: BET, pendingCrashRefund: -BET } },
+            // The stake was counted as gambled when it was taken, so a refund
+            // that hands it straight back has to un-count it.
+            { $inc: { balance: BET, pendingCrashRefund: -BET, lifetimeGambled: -BET } },
         );
         expect(press.reply).toHaveBeenCalledWith(expect.objectContaining({
             content: expect.stringMatching(/refunded/i),


### PR DESCRIPTION
Audit of all 72 built-in achievements against the code that writes the stats
they read. The definitions were sound — each reads a real field at a sensible
threshold — but four of the wirings between definition and stat were not.

## High Roller and the five other wagering badges

`lifetimeGambled` backs six achievements (Lucky, Gambler, High Roller and the
three Wager tiers) and **only blackjack ever wrote it**. The other seven casino
games took their stake through the same `placeWager` helper and left the counter
at zero, so a player could lose a million coins at slots and show no progress
toward High Roller.

The counter now moves in `placeWager`'s own write, which is the one place that
knows the coins moved, and blackjack's five hand-written copies come out. Unlike
`onWager`, it counts *every* stake and not just the opening one — a double-down,
an insurance side bet, a poker raise and a keno reroll are all more coins at
risk, which is what the achievement measures. That is the rule blackjack already
applied to its own sites, kept and extended rather than narrowed.

`/duel` — the one wager outside the casino — counts too, with both `takeEscrow`
branches and `refundEscrow` exactly inverse, so a duel that never resolves
(declined, expired, errored) counts for nothing. The two crash refund paths give
the counter back with the coins for the same reason.

## The casino never checked achievements at all

The only checks that ran were the ones on the grind commands and on
`messageCreate`, so crossing a threshold unlocked the badge whenever the player
next happened to type in chat — a strange place for a casino achievement to
appear.

A wager that lands now awards on the spot, through a new `checkAndAwardAtomic`
that writes the two achievement fields and nothing else. That matters here
specifically: the document was read mid-hand while balance is moving under
several other writers, and `user.save()` writes `balance` back as an absolute
`$set` — the same hazard `messageCreate` already guards against. The update's
filter refuses to write if any of the ids are already present, so two hands
settling at once cannot both award the same achievement.

## Clean Record was unreachable for the players it describes

It returned `false` on a missing `lastWarnedAt`, so a member who had never been
warned could only earn "30 days without receiving a warning" by first being
warned and then waiting. The clock now runs from the last warning or, absent
one, from when the account was first recorded. `createdAt` is schema-defaulted
on insert, so a brand-new member still serves the 30 days.

## Completionist depended on where a definition sat in the array

`checkAndAward` ran a single ordered pass, and Completionist counts the other
achievements — so a player whose twentieth non-secret unlock was one of the
tiered hunt/angler/miner/gambler badges (all defined *below* it) stayed locked
out until some later, unrelated check happened to run. The scan now repeats
until a pass awards nothing, which makes the award independent of definition
order — not a property anything should have to remember when adding one.

## /achievements view rendered a flat 0/N for 33 of the 72

Hunt, fishing, mining and exploration stats moved to the `GrindProfile`
collection, and the command never attached them. It was measuring a document
that did not carry the numbers the grind commands award off, so those progress
bars were empty no matter how much the player had played.

## What checks out

The other 38 are correctly wired: balance/bank, messages, level, streaks,
quests, successful robs, season tier, hunt trophies and all seven pet
achievements each have a live writer and a check that runs after it.

## Noticed, deliberately not changed

`user.messages` only increments once per 60 seconds, because it sits inside the
XP-cooldown branch of `handleLeveling`. "Send 10,000 messages" is really 10,000
XP-eligible minutes. That reads as deliberate anti-spam rather than a bug, and
changing it would retroactively shift everyone's progress — worth a separate
decision rather than folding into this one.

## Testing

- New `tests/achievementTracking.test.js` (30 tests): what `placeWager` writes
  and that it is inverse to every refund; all eight games driven end-to-end
  against the real helper to prove each reaches it with the opening stake;
  `/duel` escrow and refund netting to zero; Clean Record's four states; the
  fixed-point scan awarding Completionist in the same pass as the badge that
  completes it; and `checkAndAwardAtomic` touching only the achievement fields,
  guarding against duplicates, and announcing nothing when it loses the race.
- `tests/casinoWagerSignal.test.js` and `tests/casinoBetGuard.test.js` updated
  for the new write shape and the `doc` now carried on the `onWager` payload.
- Full suite: 6,851 passing, lint clean, `coverage:check` passing.
- The three `tests/integration/` suites are not included in those numbers —
  they fail identically with and without this change in the sandbox I ran in,
  because `mongodb-memory-server` cannot fetch a `mongod` binary there. CI
  should run them normally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyQFJzpP2tBcM6gXbhv2Bw)_