### PR TITLE
Fix leveling system to properly handle XP adjustments and level derivation

### DIFF
--- a/src/dashboard/public/guild-settings.js
+++ b/src/dashboard/public/guild-settings.js
@@ -2452,7 +2452,13 @@ async function levelAdminAction(action) {
         const data = await resp.json();
         if (!resp.ok) { msgEl.style.color = 'var(--bad)'; msgEl.textContent = data.error || 'Failed.'; return; }
         msgEl.style.color = 'var(--good)';
-        msgEl.textContent = 'Done — level: ' + data.level + ' · XP: ' + Number(data.xp).toLocaleString();
+        // `settled: false` means the XP landed but another writer kept beating
+        // the level fold to the document. Saying "done" with a level the server
+        // has just told us it did not write would be the misreport this whole
+        // path exists to avoid.
+        msgEl.textContent = data.settled === false
+            ? 'XP applied — level is still catching up; reload in a moment.'
+            : 'Done — level: ' + data.level + ' · XP: ' + Number(data.xp).toLocaleString();
         loadLevelLeaderboard(1, true);
     } catch {
         msgEl.style.color = 'var(--bad)'; msgEl.textContent = 'Request failed.';

--- a/src/dashboard/routes/api/leveling.js
+++ b/src/dashboard/routes/api/leveling.js
@@ -5,6 +5,7 @@ const User = require('../../../models/User');
 const { checkAuth, checkGuildAccess, checkWriteRateLimit } = require('../../lib/middleware');
 const { isValidDiscordId, readAdjustAmount, MAX_ADJUST_TOTAL } = require('../../lib/apiHelpers');
 const { readPage, pageEnvelope } = require('../../lib/apiPage');
+const { normalizeLevelProgress } = require('../../../services/levelingService');
 
 // One page of members ranked by level then XP, 25 to a page.
 router.get('/guild/:guildId/leveling/leaderboard', checkAuth, checkGuildAccess, async (req, res) => {
@@ -26,6 +27,46 @@ router.get('/guild/:guildId/leveling/leaderboard', checkAuth, checkGuildAccess, 
         res.status(500).json({ error: 'Internal server error' });
     }
 });
+
+/**
+ * Fold a member's XP into levels after an adjustment, and persist the result.
+ *
+ * The adjustment itself is a pipeline update so the ceiling clamp is atomic, but
+ * a pipeline cannot express the catch-up: working out how many levels a pile of
+ * XP buys is a quadratic solve, not an arithmetic expression over the document.
+ * So the fold is a second write, guarded on the XP this was computed from — a
+ * concurrent adjustment loses the guard rather than being overwritten with a
+ * level derived from a total that is no longer the member's.
+ *
+ * A no-op when the pair is already consistent, which is the ordinary case: a
+ * give that does not cross a threshold writes nothing here.
+ *
+ * @param {object} filter    the `{ userId, guildId }` the adjustment matched
+ * @param {object} user      the document the adjustment returned
+ * @returns {Promise<object>} the document as it now stands
+ */
+async function settleLevel(filter, user) {
+    let current = user;
+    // Bounded rather than a retry-until-won loop: each lost guard means another
+    // writer has since settled the pair itself, so a caller that runs out of
+    // attempts is reporting a consistent document written by someone else.
+    for (let attempt = 0; attempt < 3; attempt++) {
+        const settled = normalizeLevelProgress(current.level, current.xp);
+        if (settled.level === (current.level || 0) && settled.xp === (current.xp || 0)) return current;
+
+        const written = await User.findOneAndUpdate(
+            { ...filter, xp: current.xp },
+            { $set: settled },
+            { new: true },
+        );
+        if (written) return written;
+
+        const reread = await User.findOne(filter).select('userId level xp');
+        if (!reread) return current;
+        current = reread;
+    }
+    return current;
+}
 
 // Gives, takes, resets or sets one member's XP or level.
 router.post('/guild/:guildId/leveling/adjust', checkAuth, checkGuildAccess, checkWriteRateLimit, async (req, res) => {
@@ -63,14 +104,24 @@ router.post('/guild/:guildId/leveling/adjust', checkAuth, checkGuildAccess, chec
         } else if (action === 'reset') {
             update = { $set: { xp: 0, level: 0 } };
         } else {
-            update = { $set: { level: amt } };
+            // XP is progress within the current level, so the level a moderator
+            // sets means "at the start of level N" and its XP is zero (#924).
+            // Leaving the old XP behind is what let the next message re-derive a
+            // different level and undo the adjustment on the spot.
+            update = { $set: { level: amt, xp: 0 } };
         }
         // No upsert (#584) — see the note on the economy adjust route: a mistyped
         // snowflake is still a well-formed one, and upserting turned it into a
         // phantom member document instead of an error the admin could act on.
         const user = await User.findOneAndUpdate(filter, update, options);
         if (!user) return res.status(404).json({ error: 'That member has no leveling record in this server' });
-        res.json({ success: true, level: user.level, xp: user.xp });
+
+        // `give` and `take` move XP without touching the level it implies, and
+        // the leaderboard sorts by `{ level: -1, xp: -1 }` — so until this runs,
+        // a 50,000 XP grant left the member ranked where they were and only
+        // caught up whenever they next happened to speak (#924).
+        const settled = ['give', 'take'].includes(action) ? await settleLevel(filter, user) : user;
+        res.json({ success: true, level: settled.level, xp: settled.xp });
     } catch (err) {
         console.error('Leveling adjust error:', err);
         res.status(500).json({ error: 'Internal server error' });

--- a/src/dashboard/routes/api/leveling.js
+++ b/src/dashboard/routes/api/leveling.js
@@ -5,7 +5,7 @@ const User = require('../../../models/User');
 const { checkAuth, checkGuildAccess, checkWriteRateLimit } = require('../../lib/middleware');
 const { isValidDiscordId, readAdjustAmount, MAX_ADJUST_TOTAL } = require('../../lib/apiHelpers');
 const { readPage, pageEnvelope } = require('../../lib/apiPage');
-const { normalizeLevelProgress } = require('../../../services/levelingService');
+const { normalizeLevelProgress, xpToAdvance } = require('../../../services/levelingService');
 
 // One page of members ranked by level then XP, 25 to a page.
 router.get('/guild/:guildId/leveling/leaderboard', checkAuth, checkGuildAccess, async (req, res) => {
@@ -28,35 +28,53 @@ router.get('/guild/:guildId/leveling/leaderboard', checkAuth, checkGuildAccess, 
     }
 });
 
+// How many times a settle will re-read and try again after losing its guard.
+// Each loss is a real concurrent write to this one member, so the bound is about
+// giving up on a pathologically contended document rather than about retrying a
+// likely race.
+const SETTLE_ATTEMPTS = 5;
+
+/**
+ * Whether a document's XP is where its level says it should be: below the
+ * threshold for advancing out of that level.
+ *
+ * @param {{ level: number, xp: number }} doc
+ * @returns {boolean}
+ */
+function isSettled(doc) {
+    return (doc.xp || 0) < xpToAdvance(doc.level);
+}
+
 /**
  * Fold a member's XP into levels after an adjustment, and persist the result.
  *
  * The adjustment itself is a pipeline update so the ceiling clamp is atomic, but
  * a pipeline cannot express the catch-up: working out how many levels a pile of
  * XP buys is a quadratic solve, not an arithmetic expression over the document.
- * So the fold is a second write, guarded on the XP this was computed from — a
- * concurrent adjustment loses the guard rather than being overwritten with a
- * level derived from a total that is no longer the member's.
+ * So the fold is a second write — a compare-and-set on the whole `(level, xp)`
+ * pair it was computed from.
+ *
+ * The pair, not the XP alone. Guarding on XP is an ABA check: a `set_level`
+ * landing in between moves `level` while a following give can put `xp` back on
+ * the value this read, and the settle would then write a level derived from the
+ * level that has since been replaced, silently undoing it.
  *
  * A no-op when the pair is already consistent, which is the ordinary case: a
  * give that does not cross a threshold writes nothing here.
  *
  * @param {object} filter    the `{ userId, guildId }` the adjustment matched
  * @param {object} user      the document the adjustment returned
- * @returns {Promise<object>} the document as it now stands
+ * @returns {Promise<object>} the document as it now stands, which the caller
+ *                            must check with `isSettled` rather than assume
  */
 async function settleLevel(filter, user) {
     let current = user;
-    // Bounded rather than a retry-until-won loop: each lost guard means another
-    // writer has since settled the pair itself, so a caller that runs out of
-    // attempts is reporting a consistent document written by someone else.
-    for (let attempt = 0; attempt < 3; attempt++) {
-        const settled = normalizeLevelProgress(current.level, current.xp);
-        if (settled.level === (current.level || 0) && settled.xp === (current.xp || 0)) return current;
+    for (let attempt = 0; attempt < SETTLE_ATTEMPTS; attempt++) {
+        if (isSettled(current)) return current;
 
         const written = await User.findOneAndUpdate(
-            { ...filter, xp: current.xp },
-            { $set: settled },
+            { ...filter, level: current.level, xp: current.xp },
+            { $set: normalizeLevelProgress(current.level, current.xp) },
             { new: true },
         );
         if (written) return written;
@@ -96,10 +114,19 @@ router.post('/guild/:guildId/leveling/adjust', checkAuth, checkGuildAccess, chec
         if (action === 'give') {
             // Clamped inside the update rather than after a read, for the reason
             // the economy route's give explains.
-            update = [{ $set: { xp: { $min: [MAX_ADJUST_TOTAL, { $add: [{ $ifNull: ['$xp', 0] }, amt] }] } } }];
+            // `level` is written as itself so a document predating the field
+            // comes back with a number rather than an absent one — the settle's
+            // compare-and-set has to be able to name it.
+            update = [{ $set: {
+                xp:    { $min: [MAX_ADJUST_TOTAL, { $add: [{ $ifNull: ['$xp', 0] }, amt] }] },
+                level: { $ifNull: ['$level', 0] },
+            } }];
             options.updatePipeline = true;
         } else if (action === 'take') {
-            update = [{ $set: { xp: { $max: [0, { $subtract: ['$xp', amt] }] } } }];
+            update = [{ $set: {
+                xp:    { $max: [0, { $subtract: [{ $ifNull: ['$xp', 0] }, amt] }] },
+                level: { $ifNull: ['$level', 0] },
+            } }];
             options.updatePipeline = true;
         } else if (action === 'reset') {
             update = { $set: { xp: 0, level: 0 } };
@@ -121,7 +148,18 @@ router.post('/guild/:guildId/leveling/adjust', checkAuth, checkGuildAccess, chec
         // a 50,000 XP grant left the member ranked where they were and only
         // caught up whenever they next happened to speak (#924).
         const settled = ['give', 'take'].includes(action) ? await settleLevel(filter, user) : user;
-        res.json({ success: true, level: settled.level, xp: settled.xp });
+
+        // `settled: false` only when the compare-and-set lost every attempt, and
+        // it says what is true: the XP moved and is durable, but the level it
+        // implies is not written yet. Reporting that as a plain success would
+        // hand the dashboard a rank the database does not hold. It is not an
+        // error either — answering 4xx here would invite the moderator to grant
+        // the XP a second time — and the pair does converge, since every writer
+        // of this member's XP settles it, the last of them with nobody left to
+        // race.
+        const body = { success: true, level: settled.level, xp: settled.xp };
+        if (!isSettled(settled)) body.settled = false;
+        res.json(body);
     } catch (err) {
         console.error('Leveling adjust error:', err);
         res.status(500).json({ error: 'Internal server error' });

--- a/src/dashboard/routes/api/settings.js
+++ b/src/dashboard/routes/api/settings.js
@@ -27,10 +27,21 @@ const ALLOWED_SETTING_PARENTS = new Set([
     'dynamicPricing'
 ]);
 
+// Segments that must never appear anywhere in a dotted path (#920). The
+// allow-list bounds the *first* segment only, so `ai.__proto__.x` cleared it and
+// reached `guildSettings.set()` with the rest of the path intact. Mongoose's
+// strict schemas reject the unknown nested path today, which is why this was a
+// latent hole rather than a live one — but the check has to bound the whole path
+// for anything to be entitled to rely on its name.
+const FORBIDDEN_SEGMENTS = new Set(['__proto__', 'prototype', 'constructor']);
+
 function isAllowedSettingKey(key) {
     if (typeof key !== 'string') return false;
-    const top = key.split('.')[0];
-    return ALLOWED_SETTING_PARENTS.has(top);
+    const segments = key.split('.');
+    // An empty segment is `a..b` or a leading/trailing dot: not a path the UI
+    // ever sends, and not one worth handing to `.set()` to interpret.
+    if (segments.some(segment => segment === '' || FORBIDDEN_SEGMENTS.has(segment))) return false;
+    return ALLOWED_SETTING_PARENTS.has(segments[0]);
 }
 
 // Field-level validation for welcome settings before they reach Mongoose (fix #12).

--- a/src/dashboard/routes/api/stats.js
+++ b/src/dashboard/routes/api/stats.js
@@ -69,9 +69,10 @@ async function buildGuildStats(guildId) {
         const channelId = item.channelId || 'unknown';
         let channel = bestTimesByChannel.get(channelId);
         if (!channel) {
-            channel = { hours: {}, bestHour: 0, bestCount: 0 };
+            channel = { hours: {}, bestHour: 0, bestCount: 0, total: 0 };
             bestTimesByChannel.set(channelId, channel);
         }
+        channel.total += 1;
         const count = (channel.hours[item.hour] || 0) + 1;
         channel.hours[item.hour] = count;
         // The sort this replaces ran over `Object.entries(hours)`, whose keys are
@@ -89,7 +90,13 @@ async function buildGuildStats(guildId) {
             msgVolMap[day] = (msgVolMap[day] || 0) + 1;
         }
     }
+    // Sorted by volume before the slice (#923). A Map iterates in insertion
+    // order, which here is the order channels first appear in the usage log —
+    // so slicing straight off the front kept whichever eight were logged first
+    // and presented them as the busiest, with a server's loudest channel able to
+    // be missing entirely. Ties keep insertion order, since Array#sort is stable.
     const bestPostingTimes = [...bestTimesByChannel.entries()]
+        .sort((a, b) => b[1].total - a[1].total)
         .slice(0, 8)
         .map(([channelId, channel]) => ({ channelId, hourUtc: Number(channel.bestHour) || 0 }));
 

--- a/src/dashboard/views/index.ejs
+++ b/src/dashboard/views/index.ejs
@@ -99,7 +99,7 @@
         </div>
 
         <!-- Decorative claw mark -->
-        <svg class="cw-hero-art" viewBox="0 0 460 460" fill="none">
+        <svg class="cw-hero-art" viewBox="0 0 460 460" fill="none" aria-hidden="true">
             <ellipse cx="230" cy="320" rx="135" ry="95" fill="#14110d" opacity="0.06"/>
             <ellipse cx="90" cy="170" rx="42" ry="62" fill="#14110d" opacity="0.06" transform="rotate(-18 90 170)"/>
             <ellipse cx="180" cy="115" rx="42" ry="65" fill="#14110d" opacity="0.06" transform="rotate(-6 180 115)"/>
@@ -232,7 +232,10 @@
                     </div>
                     <div style="display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:999px;background:var(--ink-850);font-size:12px;color:var(--ink-200);border:1px solid var(--ink-800);font-family:'JetBrains Mono',monospace;">peak · Sat 21:00</div>
                 </div>
-                <div class="cw-heatmap" id="insights-heatmap"></div>
+                <!-- Illustrative demo data, drawn as 168 coloured cells with no text of
+                     their own. Hidden from assistive tech rather than announced as 168
+                     empty divs: there is nothing in them to read. -->
+                <div class="cw-heatmap" id="insights-heatmap" aria-hidden="true"></div>
                 <div class="cw-show-stats">
                     <div class="cw-show-stat">
                         <div class="v">D7 · 62%</div>

--- a/src/services/levelingService.js
+++ b/src/services/levelingService.js
@@ -19,6 +19,54 @@ const TIER_STYLES = [
 ];
 
 /**
+ * XP needed to leave `level` for the next one.
+ *
+ * `xp` is progress *within* the current level, not a running total: crossing a
+ * threshold spends it. Everything that reads or writes the pair has to agree on
+ * that, which is why the rule is one exported function rather than the same
+ * arithmetic inlined at each site.
+ *
+ * @param {number} level
+ * @returns {number}
+ */
+function xpToAdvance(level) {
+    return (Number(level) || 0) * 100 + 100;
+}
+
+/**
+ * Fold any XP at or past the current threshold into levels.
+ *
+ * Pure, and total: takes a possibly-inconsistent `(level, xp)` pair — the shape
+ * a bulk XP grant leaves behind — and returns the consistent one it stands for,
+ * with `xp` back below `xpToAdvance(level)`.
+ *
+ * Solved rather than looped. Advancing `k` levels from `level` costs
+ * `50k² + (100·level + 50)k`, so the largest affordable `k` is the positive root
+ * of that quadratic; the two correction steps settle the rounding, because at a
+ * fifteen-digit XP total the square root is a float and can land a step either
+ * side of the exact answer. The loop it replaces ran once per level, and the
+ * dashboard's ceiling of 1e15 XP buys about 4.5 million of them (#924).
+ *
+ * @param {number} level
+ * @param {number} xp
+ * @returns {{ level: number, xp: number }}
+ */
+function normalizeLevelProgress(level, xp) {
+    const startLevel = Math.max(0, Math.floor(Number(level) || 0));
+    const pool = Math.max(0, Math.floor(Number(xp) || 0));
+    if (pool < xpToAdvance(startLevel)) return { level: startLevel, xp: pool };
+
+    const b = 100 * startLevel + 50;
+    const costOf = k => 50 * k * k + b * k;
+
+    let levels = Math.max(0, Math.floor((Math.sqrt(b * b + 200 * pool) - b) / 100));
+    while (levels > 0 && costOf(levels) > pool) levels--;
+    while (costOf(levels + 1) <= pool) levels++;
+
+    return { level: startLevel + levels, xp: pool - costOf(levels) };
+}
+
+/**
  * Apply XP in-memory, processing multi-level threshold crossings.
  *
  * Applies any `xp_gain` pet passive (the Bird) here rather than at each call
@@ -32,14 +80,10 @@ function applyXpGain(user, amount) {
     const petBonusPct = getTotalBonus(user?.pets ?? [], 'xp_gain');
     const gained = Math.max(0, Math.floor(amount * (1 + petBonusPct / 100)));
 
-    user.xp = (user.xp || 0) + gained;
-    let leveled = false;
-    while (user.xp >= (user.level || 0) * 100 + 100) {
-        const threshold = (user.level || 0) * 100 + 100;
-        user.xp -= threshold;
-        user.level = (user.level || 0) + 1;
-        leveled = true;
-    }
+    const settled = normalizeLevelProgress(user.level, (user.xp || 0) + gained);
+    const leveled = settled.level > (user.level || 0);
+    user.xp = settled.xp;
+    user.level = settled.level;
     return { leveled, newLevel: user.level, gained, petBonusPct };
 }
 
@@ -82,4 +126,4 @@ async function announceLevelUp(user, guildSettings, member, guild, fallbackChann
     }
 }
 
-module.exports = { applyXpGain, announceLevelUp };
+module.exports = { applyXpGain, announceLevelUp, normalizeLevelProgress, xpToAdvance };

--- a/tests/dashboardAdjustLimits.test.js
+++ b/tests/dashboardAdjustLimits.test.js
@@ -241,6 +241,55 @@ describe('POST leveling/adjust', () => {
         expect(settle.update).toEqual({ $set: { level: 4, xp: 0 } });
     });
 
+    /**
+     * Lets a test land a write between the adjustment and the settle that
+     * follows it. `mutate` runs just before the guarded settle write — the one
+     * whose filter names an XP — so the guard is evaluated against a document
+     * that has moved underneath it, which is the race the guard exists for.
+     */
+    function concurrentlyWriteBeforeSettle(mutate, { times = Infinity } = {}) {
+        const real = mockUsers.model.findOneAndUpdate.getMockImplementation();
+        let landed = 0;
+        mockUsers.model.findOneAndUpdate.mockImplementation(async (query, update, options) => {
+            if ('xp' in query && landed < times) {
+                landed += 1;
+                mutate();
+            }
+            return real(query, update, options);
+        });
+        return () => mockUsers.model.findOneAndUpdate.mockImplementation(real);
+    }
+
+    test('a settle that loses the guard reports the pair the other writer left', async () => {
+        mockUsers.seed({ userId: USER, guildId: GUILD, xp: 40, level: 2 });
+        // One interloper, then the retry sees a consistent pair and stops.
+        const restore = concurrentlyWriteBeforeSettle(() => { mockUsers.get(USER).xp = 55; }, { times: 1 });
+
+        const res = await adjustLeveling({ userId: USER, action: 'give', amount: 660 });
+        restore();
+
+        // The level derived from 700 XP is not written over the 55 the other
+        // writer left, and the response describes the document as it stands.
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ success: true, level: 2, xp: 55 });
+        expect(mockUsers.get(USER)).toMatchObject({ level: 2, xp: 55 });
+    });
+
+    test('a settle that keeps losing the guard gives up rather than spinning', async () => {
+        mockUsers.seed({ userId: USER, guildId: GUILD, xp: 40, level: 2 });
+        // Every attempt is beaten, so the bound is what ends this.
+        let n = 0;
+        const restore = concurrentlyWriteBeforeSettle(() => { mockUsers.get(USER).xp = 1000 + (n += 1); });
+
+        const res = await adjustLeveling({ userId: USER, action: 'give', amount: 660 });
+        restore();
+
+        expect(res.status).toBe(200);
+        // Three attempts, each losing its guard: no settle write landed.
+        expect(mockUsers.writes.filter(write => 'xp' in write.query)).toEqual([]);
+        expect(n).toBe(3);
+    });
+
     test('take runs, and clamps at zero', async () => {
         mockUsers.seed({ userId: USER, guildId: GUILD, xp: 30 });
 

--- a/tests/dashboardAdjustLimits.test.js
+++ b/tests/dashboardAdjustLimits.test.js
@@ -237,7 +237,8 @@ describe('POST leveling/adjust', () => {
 
         const settle = mockUsers.writes.at(-1);
         expect(settle.op).toBe('findOneAndUpdate');
-        expect(settle.query).toMatchObject({ userId: USER, guildId: GUILD, xp: 700 });
+        // The whole pair, not the XP alone — see the ABA test below.
+        expect(settle.query).toMatchObject({ userId: USER, guildId: GUILD, level: 2, xp: 700 });
         expect(settle.update).toEqual({ $set: { level: 4, xp: 0 } });
     });
 
@@ -275,19 +276,56 @@ describe('POST leveling/adjust', () => {
         expect(mockUsers.get(USER)).toMatchObject({ level: 2, xp: 55 });
     });
 
-    test('a settle that keeps losing the guard gives up rather than spinning', async () => {
+    // CodeRabbit on #977: the guard named only `xp`, so it was an ABA check. A
+    // level set between the adjustment and its settle moves `level` while a
+    // following give can put `xp` back to the very value the settle was computed
+    // from — and the settle then wrote a level derived from the *old* level over
+    // the new one.
+    test('a settle does not overwrite a level set while it was in flight', async () => {
         mockUsers.seed({ userId: USER, guildId: GUILD, xp: 40, level: 2 });
-        // Every attempt is beaten, so the bound is what ends this.
+        // Between the give's write and its settle: set_level 7 (which zeroes XP)
+        // and a further give that lands XP back on 300, the value the in-flight
+        // settle read.
+        const restore = concurrentlyWriteBeforeSettle(() => {
+            Object.assign(mockUsers.get(USER), { level: 7, xp: 300 });
+        }, { times: 1 });
+
+        const res = await adjustLeveling({ userId: USER, action: 'give', amount: 260 });
+        restore();
+
+        // Level 7 survives: the settle computed level 3 from the pair it read,
+        // and that pair is no longer the member's.
+        expect(mockUsers.get(USER).level).toBe(7);
+        expect(res.status).toBe(200);
+    });
+
+    // CodeRabbit on #977: giving up used to answer a plain success carrying
+    // whatever the last re-read held — which can be XP still past its threshold,
+    // i.e. a rank the database does not hold, reported as final.
+    test('a settle that keeps losing the guard says so instead of claiming success', async () => {
+        mockUsers.seed({ userId: USER, guildId: GUILD, xp: 40, level: 2 });
+        // Every attempt is beaten, and each interloper leaves XP unsettled.
         let n = 0;
         const restore = concurrentlyWriteBeforeSettle(() => { mockUsers.get(USER).xp = 1000 + (n += 1); });
 
         const res = await adjustLeveling({ userId: USER, action: 'give', amount: 660 });
         restore();
 
+        // Not a 4xx: the XP moved and is durable, so inviting a retry would
+        // invite a second grant. The response says the level has not caught up.
         expect(res.status).toBe(200);
-        // Three attempts, each losing its guard: no settle write landed.
+        expect(res.body).toMatchObject({ success: true, settled: false });
+        // Every attempt lost its guard, so no settle write landed.
         expect(mockUsers.writes.filter(write => 'xp' in write.query)).toEqual([]);
-        expect(n).toBe(3);
+        expect(n).toBe(5);
+    });
+
+    test('an ordinary settled response does not carry the settled flag', async () => {
+        mockUsers.seed({ userId: USER, guildId: GUILD, xp: 40, level: 2 });
+
+        const res = await adjustLeveling({ userId: USER, action: 'give', amount: 660 });
+
+        expect(res.body).toEqual({ success: true, level: 4, xp: 0 });
     });
 
     test('take runs, and clamps at zero', async () => {

--- a/tests/dashboardAdjustLimits.test.js
+++ b/tests/dashboardAdjustLimits.test.js
@@ -192,15 +192,53 @@ describe('POST leveling/adjust', () => {
 
         expect(res.status).toBe(200);
         expect(res.body).toEqual({ success: true, level: 2, xp: 100 });
+        // Level 2 needs 300 to advance, so nothing was folded — and the settle
+        // step wrote nothing rather than rewriting the pair it was handed.
+        expect(mockUsers.writes).toHaveLength(1);
     });
 
-    test('a give onto a maxed-out XP total clamps', async () => {
-        mockUsers.seed({ userId: USER, guildId: GUILD, xp: MAX_ADJUST_TOTAL });
+    // #924: `give` moved XP and left `level` alone, so the member kept their old
+    // rank — the leaderboard sorts by `{ level: -1, xp: -1 }` — until they next
+    // happened to send a message and applyXpGain caught the levels up.
+    test('a give that crosses thresholds levels the member up in the same request', async () => {
+        mockUsers.seed({ userId: USER, guildId: GUILD, xp: 40, level: 2 });
+
+        // 40 + 660 = 700, which buys level 2 → 3 (300) and 3 → 4 (400) exactly.
+        const res = await adjustLeveling({ userId: USER, action: 'give', amount: 660 });
+
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ success: true, level: 4, xp: 0 });
+        expect(mockUsers.get(USER)).toMatchObject({ level: 4, xp: 0 });
+    });
+
+    test('a give onto a maxed-out XP total clamps, then spends the clamped total', async () => {
+        mockUsers.seed({ userId: USER, guildId: GUILD, xp: MAX_ADJUST_TOTAL, level: 0 });
 
         const res = await adjustLeveling({ userId: USER, action: 'give', amount: MAX_ADJUST_AMOUNT });
 
-        expect(res.body.xp).toBe(MAX_ADJUST_TOTAL);
-        expect(Number.isSafeInteger(mockUsers.get(USER).xp)).toBe(true);
+        // The clamp still bites — the ceiling is what bounds the catch-up — and
+        // the ceiling's worth of XP is then folded into levels rather than left
+        // sitting in `xp` as a total no level reflects. XP is progress within a
+        // level, so what is conserved is the cumulative cost of getting there.
+        const { level, xp } = mockUsers.get(USER);
+        expect(50 * level * (level + 1) + xp).toBe(MAX_ADJUST_TOTAL);
+        expect(res.body).toEqual({ success: true, level, xp });
+        expect(Number.isSafeInteger(xp)).toBe(true);
+        expect(Number.isSafeInteger(level)).toBe(true);
+    });
+
+    // The settle is a second write, so it is guarded on the XP it was computed
+    // from: a concurrent adjustment must lose the guard rather than have a level
+    // derived from a total that is no longer the member's written over it.
+    test('the level settle is guarded on the XP it was derived from', async () => {
+        mockUsers.seed({ userId: USER, guildId: GUILD, xp: 40, level: 2 });
+
+        await adjustLeveling({ userId: USER, action: 'give', amount: 660 });
+
+        const settle = mockUsers.writes.at(-1);
+        expect(settle.op).toBe('findOneAndUpdate');
+        expect(settle.query).toMatchObject({ userId: USER, guildId: GUILD, xp: 700 });
+        expect(settle.update).toEqual({ $set: { level: 4, xp: 0 } });
     });
 
     test('take runs, and clamps at zero', async () => {
@@ -242,5 +280,18 @@ describe('POST leveling/adjust', () => {
 
         expect(res.status).toBe(200);
         expect(mockUsers.get(USER).level).toBe(0);
+    });
+
+    // #924: setting a level left the old XP in place. XP is progress *within*
+    // the current level, so a level set beneath a large XP balance was undone by
+    // the member's next message, which re-derived the level the XP implied.
+    test('set_level puts the member at the start of that level', async () => {
+        mockUsers.seed({ userId: USER, guildId: GUILD, level: 2, xp: 250 });
+
+        const res = await adjustLeveling({ userId: USER, action: 'set_level', amount: 7 });
+
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ success: true, level: 7, xp: 0 });
+        expect(mockUsers.get(USER)).toMatchObject({ level: 7, xp: 0 });
     });
 });

--- a/tests/landingDecorativeGraphics.test.js
+++ b/tests/landingDecorativeGraphics.test.js
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"customExportConditions": ["node"]}
+ */
+process.env.SUPPRESS_JEST_WARNINGS = 'true';
+
+const { TextEncoder, TextDecoder } = require('util');
+global.TextEncoder = global.TextEncoder || TextEncoder;
+global.TextDecoder = global.TextDecoder || TextDecoder;
+
+/**
+ * #936. Two graphics on the landing page carry no information a screen reader
+ * can use: the hero's claw mark, and the "active hours" heatmap, whose 168 cells
+ * are illustrative demo data drawn as background colours with no text in them.
+ *
+ * The heatmap is the one that costs something. It is built at runtime, so the
+ * markup check alone would not catch a regression that stopped hiding it — the
+ * script is run here, and what is asserted is that every cell it appends is
+ * inside a subtree assistive tech is told to skip.
+ */
+const fs = require('fs');
+const path = require('path');
+const ejs = require('ejs');
+const { asset } = require('../src/dashboard/lib/assets');
+
+const ROOT = path.join(__dirname, '..');
+const VIEW = path.join(ROOT, 'src', 'dashboard', 'views', 'index.ejs');
+
+/** Renders the landing page, then runs its inline scripts by hand — jsdom does
+ *  not execute a script assigned through `innerHTML`. `window.eval` is how
+ *  tests/helpers/guildSettingsPage.js boots the settings page, for the same
+ *  reason: the script has to see the document it is being run against. */
+function renderLanding() {
+    const html = ejs.render(
+        fs.readFileSync(VIEW, 'utf8'),
+        { user: null, stats: { servers: 4, members: 120, uptime: '3d' }, version: '1.2.3', asset },
+        { filename: VIEW },
+    );
+    document.documentElement.innerHTML = html;
+    for (const script of document.querySelectorAll('script:not([src])')) {
+        window.eval(script.textContent);
+    }
+}
+
+/** True if `el` or any ancestor of it is hidden from assistive technology. */
+const hiddenFromAT = el => !!el.closest('[aria-hidden="true"]');
+
+describe('the landing page\'s decorative graphics', () => {
+    beforeEach(renderLanding);
+
+    test('the hero claw mark is hidden from assistive technology', () => {
+        const art = document.querySelector('.cw-hero-art');
+
+        expect(art).not.toBeNull();
+        expect(art.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    test('the heatmap demo renders its cells, and hides all of them', () => {
+        const heatmap = document.getElementById('insights-heatmap');
+
+        // Seven days by twenty-four hours: the script really did run, so the
+        // assertion below is about the cells rather than about an empty div.
+        const cells = heatmap.querySelectorAll('.cell');
+        expect(cells).toHaveLength(168);
+        expect(heatmap.getAttribute('aria-hidden')).toBe('true');
+        expect([...cells].every(hiddenFromAT)).toBe(true);
+    });
+
+    test('no cell carries text of its own, which is why hiding it loses nothing', () => {
+        const cells = [...document.querySelectorAll('#insights-heatmap .cell')];
+
+        expect(cells.map(cell => cell.textContent.trim()).filter(Boolean)).toEqual([]);
+        expect(cells.every(cell => cell.getAttribute('aria-label') === null)).toBe(true);
+    });
+});

--- a/tests/levelingProgress.test.js
+++ b/tests/levelingProgress.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+// #924: the dashboard's XP adjust route moved `xp` and left `level` alone, so a
+// grant only turned into levels whenever the member next happened to speak. The
+// fix needs the level rule in one place, callable outside a message handler —
+// which is what `normalizeLevelProgress` is. These pin it against the loop it
+// replaces, because the two have to agree exactly: they are the same rule, and
+// a member's level must not depend on which of them last ran.
+
+const { normalizeLevelProgress, xpToAdvance, applyXpGain } = require('../src/services/levelingService');
+
+/** The catch-up loop as `applyXpGain` carried it, one level at a time. */
+function byLoop(level, xp) {
+    let [lvl, rem] = [level, xp];
+    while (rem >= lvl * 100 + 100) {
+        rem -= lvl * 100 + 100;
+        lvl += 1;
+    }
+    return { level: lvl, xp: rem };
+}
+
+describe('xpToAdvance', () => {
+    test('is 100 per level, starting at 100 for level 0', () => {
+        expect([0, 1, 2, 9].map(xpToAdvance)).toEqual([100, 200, 300, 1000]);
+    });
+});
+
+describe('normalizeLevelProgress', () => {
+    test('leaves a pair that is already consistent alone', () => {
+        expect(normalizeLevelProgress(3, 399)).toEqual({ level: 3, xp: 399 });
+        expect(normalizeLevelProgress(0, 0)).toEqual({ level: 0, xp: 0 });
+    });
+
+    test('spends exactly one threshold at the boundary', () => {
+        expect(normalizeLevelProgress(3, 400)).toEqual({ level: 4, xp: 0 });
+        expect(normalizeLevelProgress(3, 401)).toEqual({ level: 4, xp: 1 });
+    });
+
+    test('crosses as many levels as the XP buys', () => {
+        // From level 2: 300 to reach 3, then 400 to reach 4, leaving 60.
+        expect(normalizeLevelProgress(2, 760)).toEqual({ level: 4, xp: 60 });
+    });
+
+    test('agrees with the one-level-at-a-time loop across the ordinary range', () => {
+        const mismatches = [];
+        for (let level = 0; level <= 40; level++) {
+            for (let xp = 0; xp <= 4000; xp += 37) {
+                const solved = normalizeLevelProgress(level, xp);
+                const looped = byLoop(level, xp);
+                if (solved.level !== looped.level || solved.xp !== looped.xp) {
+                    mismatches.push({ level, xp, solved, looped });
+                }
+            }
+        }
+        expect(mismatches).toEqual([]);
+    });
+
+    // The dashboard's ceiling is 1e15 XP, which the loop spent about 4.5 million
+    // iterations on. The solve has to land on the same answer there, where the
+    // square root it uses is a float over an eighteen-digit discriminant.
+    test('is exact at the dashboard ceiling, where the loop was millions of steps', () => {
+        const MAX = 1_000_000_000_000_000;
+        const { level, xp } = normalizeLevelProgress(0, MAX);
+
+        // Cumulative cost of standing at (level, xp) is 50·level·(level+1) + xp.
+        expect(50 * level * (level + 1) + xp).toBe(MAX);
+        expect(xp).toBeLessThan(xpToAdvance(level));
+        expect(xp).toBeGreaterThanOrEqual(0);
+        expect(Number.isSafeInteger(level)).toBe(true);
+    });
+
+    test('never returns XP at or past the level it settles on', () => {
+        for (const [level, xp] of [[0, 1], [0, 1e6], [7, 999_999], [1200, 5e8], [4_000_000, 1e12]]) {
+            const settled = normalizeLevelProgress(level, xp);
+            expect(settled.xp).toBeLessThan(xpToAdvance(settled.level));
+            expect(settled.level).toBeGreaterThanOrEqual(level);
+        }
+    });
+
+    test('treats a missing or negative pair as the start of level 0', () => {
+        expect(normalizeLevelProgress(undefined, undefined)).toEqual({ level: 0, xp: 0 });
+        expect(normalizeLevelProgress(-5, -20)).toEqual({ level: 0, xp: 0 });
+    });
+});
+
+describe('applyXpGain over the shared rule', () => {
+    test('still reports a promotion and leaves the member mid-level', () => {
+        const user = { level: 2, xp: 40 };
+
+        expect(applyXpGain(user, 300)).toMatchObject({ leveled: true, newLevel: 3, gained: 300 });
+        expect(user).toMatchObject({ level: 3, xp: 40 });
+    });
+
+    test('reports no promotion when the gain stays inside the level', () => {
+        const user = { level: 2, xp: 40 };
+
+        expect(applyXpGain(user, 10)).toMatchObject({ leveled: false, newLevel: 2 });
+        expect(user).toMatchObject({ level: 2, xp: 50 });
+    });
+
+    test('credits a member with neither field yet', () => {
+        const user = {};
+
+        expect(applyXpGain(user, 250)).toMatchObject({ leveled: true, newLevel: 1 });
+        expect(user).toMatchObject({ level: 1, xp: 150 });
+    });
+});

--- a/tests/settingsValidators.test.js
+++ b/tests/settingsValidators.test.js
@@ -87,6 +87,33 @@ describe('isAllowedSettingKey', () => {
         expect(ALLOWED_SETTING_PARENTS.has('welcome')).toBe(true);
     });
 
+    // #920: the check read the first segment and nothing else, then the caller
+    // handed the *whole* dotted key to `guildSettings.set()`. So a pollution
+    // segment behind an allowed parent cleared the allow-list and arrived at the
+    // write intact. Mongoose's strict schema is what refused it in the end,
+    // which made this a hole in a named security control rather than a live bug.
+    it('refuses a pollution segment anywhere in the path, not just at the front', () => {
+        for (const key of [
+            'ai.__proto__.x',
+            'ai.constructor.prototype.polluted',
+            'welcome.message.__proto__',
+            'economy.prototype.x',
+        ]) {
+            expect([key, isAllowedSettingKey(key)]).toEqual([key, false]);
+        }
+    });
+
+    it('refuses a path with an empty segment', () => {
+        for (const key of ['welcome.', '.welcome', 'welcome..message']) {
+            expect([key, isAllowedSettingKey(key)]).toEqual([key, false]);
+        }
+    });
+
+    it('still accepts the deep paths the settings page actually sends', () => {
+        expect(isAllowedSettingKey('ai.mcpServers.0.confirmMode')).toBe(true);
+        expect(isAllowedSettingKey('moderation.autoModEnabled')).toBe(true);
+    });
+
     it('is exported as a copy, so a caller cannot widen the writable surface', () => {
         const mine = settings.ALLOWED_SETTING_PARENTS;
         mine.add('casinoJackpot');

--- a/tests/statsResponseCache.test.js
+++ b/tests/statsResponseCache.test.js
@@ -161,6 +161,43 @@ describe('/stats command-log aggregation', () => {
         expect(body.analytics.failedCommands).toEqual({ execution_error: 1, cooldown: 1 });
     });
 
+    // #923: the eight came off the front of a Map, whose iteration order is the
+    // order channels first appear in the log — so the panel showed whichever
+    // eight were logged first and called them the best, with a server's busiest
+    // channel able to be missing entirely.
+    test('ranks channels by volume rather than by which was logged first', async () => {
+        // Nine channels, seen in ascending order of activity: the quietest is
+        // first in the log, so an unsorted slice would drop the busiest.
+        const usage = [];
+        for (let i = 1; i <= 9; i++) {
+            for (let n = 0; n < i; n++) usage.push({ command: 'ping', success: true, channelId: `c${i}`, hour: i });
+        }
+        stubAnalytics({ guildId: 'g1', memberEvents: [], commandUsage: usage });
+
+        const { body } = await get('/guild/g1/stats');
+
+        expect(body.analytics.bestPostingTimes.map(entry => entry.channelId))
+            .toEqual(['c9', 'c8', 'c7', 'c6', 'c5', 'c4', 'c3', 'c2']);
+    });
+
+    test('breaks a volume tie toward the channel seen first', async () => {
+        stubAnalytics({
+            guildId: 'g1',
+            memberEvents: [],
+            commandUsage: [
+                { command: 'ping', success: true, channelId: 'first',  hour: 4 },
+                { command: 'ping', success: true, channelId: 'second', hour: 5 },
+            ],
+        });
+
+        const { body } = await get('/guild/g1/stats');
+
+        expect(body.analytics.bestPostingTimes).toEqual([
+            { channelId: 'first',  hourUtc: 4 },
+            { channelId: 'second', hourUtc: 5 },
+        ]);
+    });
+
     test('picks each channel\'s busiest hour, breaking ties toward the earlier one', async () => {
         const { body } = await get('/guild/g1/stats');
 


### PR DESCRIPTION
## Summary

Fixes four issues found in a ten-agent specialist review: #924 (leveling), #920 (settings key validation), #923 (stats ranking) and #936 (landing-page accessibility). One commit per issue, plus two follow-ups from review.

## Key Changes

### Leveling System Fixes (#924)
- **Extracted level advancement logic**: `normalizeLevelProgress()` turns any `(level, xp)` pair into the consistent one it stands for, folding excess XP into levels. It solves the quadratic rather than looping once per level — the dashboard's 1e15 XP ceiling buys about 4.5 million of them.
- **Exported `xpToAdvance()` helper**: the XP threshold rule now has one definition that every site reads.
- **Updated `applyXpGain()`**: uses `normalizeLevelProgress()` instead of its own inline loop, so the bot and the dashboard cannot disagree about a member's level.
- **Fixed XP adjustment endpoint**: `settleLevel()` folds XP into levels after `give`/`take`, so the leaderboard's `{ level: -1, xp: -1 }` sort is right when the request returns rather than whenever the member next happens to speak.
- **Fixed level setting**: `set_level` now writes `xp: 0`. **Note this departs from the issue's suggested fix**, which was to set XP to that level's threshold — under this schema `xp` is progress *within* a level, so XP at the threshold levels the member up again on their next message, which is the bug being reported. Explained on [#924](https://github.com/TheShield2594/clawdia/issues/924#issuecomment-5525870625).

### Security Fix (#920)
- **`isAllowedSettingKey()` bounds the whole path**: it checked `split('.')[0]` while the caller passed the full dotted key to `guildSettings.set()`, so `ai.__proto__.x` cleared a check named for bounding the path. Now every segment is checked for `__proto__`, `prototype` and `constructor`, and empty segments are rejected.
- Not exploitable today — Mongoose's strict schemas reject the unknown nested path — so this closes a gap between what the control does and what its name claims.

### Stats Ranking Fix (#923)
- **Channels ranked by volume before the slice**: `bestPostingTimes` took the first eight entries a `Map` iterated, which is the order channels first appear in the usage log. A server's busiest channel could be absent while a channel with three messages was shown. Ties keep insertion order, since `Array#sort` is stable.

### Accessibility Fixes (#936)
- **Landing page graphics**: `aria-hidden="true"` on the decorative claw mark and the 168-cell demo heatmap.

## Follow-ups from review

Two defects CodeRabbit found in the settle above. Both were real; the first was a lost update.

- **The guard was an ABA check.** It named `xp` alone, so a `set_level` landing between a give and its settle moved `level` while a following give could put `xp` back on the value the settle had read — and the settle then overwrote the new level with one derived from the old. It is now a compare-and-set on the whole `(level, xp)` pair. The `give`/`take` pipelines also write `level` as `{ $ifNull: ['$level', 0] }`, because Mongoose strips an `undefined` filter value and would otherwise have silently dropped half the guard on legacy documents.
- **Exhaustion reported an unsettled pair as success.** The response now carries `settled: false` in that case, and the dashboard says the level is still catching up rather than printing one the database does not hold. Deliberately not a 4xx: the XP has already moved and is durable, so inviting a retry would invite a second grant.

The retry bound is 5, which is only meaningful now that a lost guard is known to be a real concurrent write rather than possibly an ABA false match.

## Testing

`tests/levelingProgress.test.js` (new) holds `normalizeLevelProgress` against the one-level-at-a-time loop it replaces across the ordinary range, and at the 1e15 ceiling where the loop was millions of steps. `tests/dashboardAdjustLimits.test.js` covers the settle's guard, both concurrency paths, and the ABA interleave — that last one was written as a failing test first, and reproduced the lost update exactly. Also new: `tests/landingDecorativeGraphics.test.js`, which runs the page's inline script and asserts on the cells it appends rather than on an empty container.

Full suite, coverage thresholds, per-subsystem coverage floors and lint all run in CI.

https://claude.ai/code/session_013vUfGRS2wU2q8q8TwxmzNJ

## Summary by CodeRabbit

* **New Features**
  * Level adjustments now immediately reconcile earned XP and levels, with explicit level changes resetting XP.
  * Busiest channels in statistics are ranked by message volume.

* **Bug Fixes**
  * Improved validation blocks unsafe or malformed settings paths while preserving valid nested settings.
  * Level progression handles large XP totals efficiently and consistently.

* **Accessibility**
  * Decorative landing-page graphics are now hidden from assistive technologies.

* **Tests**
  * Added coverage for leveling, settings validation, statistics ranking, and decorative graphic accessibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vUfGRS2wU2q8q8TwxmzNJ