### PR TITLE
Stop paying for a user document when nothing about the user changed

### DIFF
--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -11,7 +11,10 @@ const {
     handleEightBallButton,
     handleEightBallModal,
 } = require('../commands/fun/8ball');
-const { ensureQuests, onCommandUse, notifyQuestComplete, notifyQuestNearComplete } = require('../services/questService');
+const {
+    ensureQuests, onCommandUse, questEventCanProgress, questAssignmentNeeded,
+    notifyQuestComplete, notifyQuestNearComplete,
+} = require('../services/questService');
 const { getGuildSettings } = require('../utils/guildSettingsCache');
 const {
     commandIsFreezeGated, isEconomyFrozen, NOT_FROZEN, FROZEN_NOTICE, FREEZE_UNKNOWN_NOTICE,
@@ -86,9 +89,31 @@ async function trackQuestCommandUse(interaction) {
     const guildSettings = await getGuildSettings(interaction.guild.id);
     if (!guildSettings?.quests?.enabled) return;
 
-    let user = await User.findOne({ userId: interaction.user.id, guildId: interaction.guild.id });
+    const filter = { userId: interaction.user.id, guildId: interaction.guild.id };
+
+    // Cheap read first (#898). This runs after *every* successful command, on
+    // top of whatever the command handler itself already loaded and saved for
+    // the same user — so it was a second full document hydrate and a second
+    // full save each time, for a counter that usually has nothing to move.
+    // Most members hold no live command quest at any given moment: the five ids
+    // are a handful of dailies and weeklies, finished early and then dormant
+    // until they roll over.
+    //
+    // The projection is the quest list and the freeze flag, which is everything
+    // the two questions below need. When they both answer no, the command costs
+    // this one small read and nothing else. When either answers yes, the full
+    // document is fetched as before — one extra tiny read on the rare path, in
+    // exchange for dropping a hydrate and a save from the common one.
+    const snapshot = await User.findOne(filter, { quests: 1, economyFrozen: 1 }).lean();
+    if (snapshot) {
+        if (snapshot.economyFrozen) return;
+        if (!questEventCanProgress(snapshot.quests, 'command')
+            && !questAssignmentNeeded(snapshot.quests, guildSettings)) return;
+    }
+
+    let user = await User.findOne(filter);
     if (!user) {
-        user = await User.create({ userId: interaction.user.id, guildId: interaction.guild.id });
+        user = await User.create(filter);
     }
 
     // A frozen member earns nothing, and a completed quest pays coins (#870).

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -62,6 +62,24 @@ function getCustomBadWordRegexes(guildId, customBadWords) {
     return regexes;
 }
 
+// The bot's own mention token, as a regex.
+//
+// This was rebuilt with `new RegExp` on every mention-triggered message (#930).
+// The id is fixed for the life of the process, but it is only knowable once the
+// client has logged in — hence built on first use rather than at module load,
+// and keyed on the id so a client that logs in as someone else (a test, a token
+// swap) does not keep the stale pattern.
+let mentionPattern = null;
+function getMentionPattern(botId) {
+    if (mentionPattern?.botId !== botId) {
+        mentionPattern = { botId, regex: new RegExp(`<@!?${botId}>`, 'g') };
+    }
+    // Shared and `g`-flagged, so `lastIndex` is state between calls. `replace`
+    // resets it for us; nothing here may switch to `test`/`exec` without
+    // clearing it first.
+    return mentionPattern.regex;
+}
+
 // Leet-speak normalization map
 const LEET_MAP = {
     '4': 'a', '@': 'a', '3': 'e', '€': 'e', '1': 'i', '!': 'i',
@@ -115,6 +133,9 @@ module.exports = {
     name: 'messageCreate',
     // Exported for unit testing only
     _getCustomBadWordRegexes: getCustomBadWordRegexes,
+    // Likewise: the mention pattern is built once per bot id (#930), and the
+    // only way to see that from outside is to ask for it twice.
+    _getMentionPattern: getMentionPattern,
     // The spam window's backing store. Exposed so a test can assert the sweep
     // actually reclaims it (#600) — a leak is invisible from the outside,
     // because a tracker that never forgets behaves identically until it is the
@@ -167,7 +188,7 @@ module.exports = {
                         // the reset command and the raw `<@id>` token went into the
                         // model prompt on every mention-triggered message (#820).
                         const strippedContent = message.content
-                            .replace(new RegExp(`<@!?${client.user.id}>`, 'g'), '')
+                            .replace(getMentionPattern(client.user.id), '')
                             .trim();
                         const reminderHandled = await handleNLReminder(message, strippedContent);
                         if (!reminderHandled) {
@@ -300,6 +321,10 @@ async function flushPendingUser(user) {
     }
 }
 
+// The one path this handler increments on every single message, and so the one
+// it is worth keeping out of the document save.
+const DAILY_COUNTER_PATH = 'dailyMessages';
+
 async function handleStreakAndQuests(message, guildSettings, existingUser = null, announcements = []) {
     // Reported back to the caller so it knows whether the XP handleLeveling
     // applied has been persisted. Set only once the write has actually landed —
@@ -365,7 +390,8 @@ async function handleStreakAndQuests(message, guildSettings, existingUser = null
             user.dailyMessages = 0;
             user.lastDailyReset = now;
         }
-        user.dailyMessages = (user.dailyMessages || 0) + 1;
+        const dailyMessagesAtLoad = user.dailyMessages || 0;
+        user.dailyMessages = dailyMessagesAtLoad + 1;
 
         // Quest progress
         const { assignedNewDaily } = await ensureQuests(user, guildSettings);
@@ -376,11 +402,45 @@ async function handleStreakAndQuests(message, guildSettings, existingUser = null
 
         const newlyEarned = await checkAndAward(user, guildSettings).catch(() => []);
 
-        await saveWithBalanceDelta(User, user, balanceAtLoad, {
-            service: 'messageCreate',
-            jobName: 'streakAndQuestRewards',
-            guildId: message.guild.id,
-        });
+        // The steady-state message changes nothing but the daily counter: same
+        // UTC day, so the streak stands; quests finished for the day or turned
+        // off, so no progress moved; XP on cooldown, so no levelling either.
+        // Writing the whole document back for that `+1` is what made this path
+        // cost a read *and* a write per message per active chatter (#893), so
+        // when the counter is all that is pending it goes out as the `$inc` it
+        // always was, and `save()` is skipped entirely.
+        //
+        // The decision reads `modifiedPaths()` rather than re-deriving "could
+        // anything have changed?" by hand: it is the very list `save()` would
+        // write, so a handler added to this chain later cannot quietly fall
+        // through the gap and stop being persisted. Anything beyond the counter
+        // — a streak rollover, quest progress, a milestone's coins, a fresh
+        // achievement — puts it back on the full save below.
+        //
+        // A document that cannot report its modified paths falls to the full
+        // save: the sentinel matches no path, so the counter-only branch is not
+        // taken. Skipping a write on a guess is how XP goes missing.
+        const pending = user.modifiedPaths?.() ?? ['*'];
+        if (pending.length && pending.every(path => path === DAILY_COUNTER_PATH)) {
+            const delta = (user.dailyMessages || 0) - dailyMessagesAtLoad;
+            await User.updateOne(
+                { userId: user.userId, guildId: user.guildId },
+                { $inc: { [DAILY_COUNTER_PATH]: delta } },
+            );
+            // The in-memory value already counts this message and the `$inc`
+            // has just made the stored one agree, so the path is settled.
+            // Clearing the flag is what stops the caller's backstop flush from
+            // saving the whole document to write a field that is already right.
+            user.unmarkModified?.(DAILY_COUNTER_PATH);
+        } else if (pending.length) {
+            await saveWithBalanceDelta(User, user, balanceAtLoad, {
+                service: 'messageCreate',
+                jobName: 'streakAndQuestRewards',
+                guildId: message.guild.id,
+            });
+        }
+        // Nothing modified at all is also "persisted": there is nothing left
+        // for the caller's flush to write.
         persisted = true;
 
         // Check wealth milestones after any coins may have been awarded (streak rewards, etc.)

--- a/src/events/messageReactionAdd.js
+++ b/src/events/messageReactionAdd.js
@@ -2,7 +2,10 @@ const { EmbedBuilder } = require('discord.js');
 const Guild = require('../models/Guild');
 const User = require('../models/User');
 const { getGuildSettings } = require('../utils/guildSettingsCache');
-const { ensureQuests, onReaction, notifyQuestComplete, notifyQuestNearComplete } = require('../services/questService');
+const {
+    ensureQuests, onReaction, questEventCanProgress, questAssignmentNeeded,
+    notifyQuestComplete, notifyQuestNearComplete,
+} = require('../services/questService');
 const { saveWithBalanceDelta } = require('../utils/balanceDelta');
 const COLORS = require('../utils/embedColors');
 const { MEMORY_CAP, MAX_MEMORY_LENGTH } = require('../utils/memoryLimits');
@@ -28,18 +31,59 @@ module.exports = {
         const guildSettings = await getGuildSettings(guild.id);
         if (!guildSettings) return;
 
-        await handleReactionRole(reaction, user, guild, guildSettings);
-        await handleStarboard(reaction, user, guild, guildSettings);
-        await handleReactionQuests(reaction, user, guild, guildSettings);
+        // Reaction roles and the starboard share no document with each other or
+        // with anything below — one adds a role, the other claims a message in
+        // the guild document — so they run together rather than one behind the
+        // other (#929). Settled, not raced: a handler that throws must not take
+        // the other three down with it, which is what the old sequential awaits
+        // did.
+        const independent = await Promise.allSettled([
+            handleReactionRole(reaction, user, guild, guildSettings),
+            handleStarboard(reaction, user, guild, guildSettings),
+        ]);
+        for (const outcome of independent) {
+            if (outcome.status === 'rejected') console.error('Error in messageReactionAdd:', outcome.reason);
+        }
+
+        // These two stay in sequence, and must. Both load the reacting member's
+        // `User` document and both `save()` it, so running them concurrently
+        // would have each write back the copy it read — the pinned memory or
+        // the quest progress, whichever landed second, silently erasing the
+        // other.
+        try {
+            await handleReactionQuests(reaction, user, guild, guildSettings);
+        } catch (err) {
+            console.error('Error in messageReactionAdd:', err);
+        }
         await handleMemoryPin(reaction, user, guild, client);
     }
 };
 
 async function handleReactionQuests(reaction, discordUser, guild, guildSettings) {
     if (!guildSettings?.quests?.enabled) return;
+
+    const filter = { userId: discordUser.id, guildId: guild.id };
+
+    // Cheap read first (#929). Every reaction used to pay an upsert, a full
+    // user hydrate, a save and a member fetch, for four quest ids that a given
+    // member has usually either finished for the day or never been assigned.
+    // Reaction bursts are what makes that expensive: a message that catches on,
+    // or a starboard-active channel, lands dozens of these in seconds and each
+    // one paid in full.
+    //
+    // A projected quest list answers whether anything could move. When nothing
+    // can, the reaction costs this one small read — and, notably, no upsert, so
+    // a passer-by who reacts once no longer has a document created for them
+    // here. The upsert still runs on the path that has work to do, which is the
+    // path that needs the document to exist.
+    const snapshot = await User.findOne(filter, { quests: 1 }).lean();
+    if (snapshot
+        && !questEventCanProgress(snapshot.quests, 'reaction')
+        && !questAssignmentNeeded(snapshot.quests, guildSettings)) return;
+
     const userDoc = await User.findOneAndUpdate(
-        { userId: discordUser.id, guildId: guild.id },
-        { $setOnInsert: { userId: discordUser.id, guildId: guild.id } },
+        filter,
+        { $setOnInsert: filter },
         { upsert: true, new: true }
     );
     if (!userDoc) return;
@@ -56,6 +100,11 @@ async function handleReactionQuests(reaction, discordUser, guild, guildSettings)
         jobName: 'reactionQuestReward',
         guildId: guild.id,
     });
+    // The member fetch exists only to address the notification, so it is not
+    // worth a REST call — or a cache miss's round trip — on the overwhelming
+    // majority of reactions, which complete nothing and near-complete nothing.
+    if (!completed.length && !nearComplete.length) return;
+
     const member = await guild.members.fetch(discordUser.id).catch(() => null);
     if (member) {
         await notifyQuestComplete(guildSettings, member, completed, reaction.message.channel);

--- a/src/services/questService.js
+++ b/src/services/questService.js
@@ -146,7 +146,16 @@ async function ensureQuests(user, guildSettings) {
     if (!guildSettings?.quests?.enabled) return { assignedNewDaily: false };
 
     const now = new Date();
-    user.quests = (user.quests || []).filter(q => q.expiresAt > now);
+    // Assigning a plain array back over the document array rebuilds it — every
+    // entry re-cast into a subdocument — and this runs on every message, for a
+    // list that actually changes twice a day (#893). Mongoose compares the two
+    // and correctly declines to mark the path modified, so no write was at
+    // stake; the cast itself is what is skipped when nothing expired, along
+    // with the churn of handing the callers below a different array object each
+    // time.
+    const existing = user.quests;
+    const unexpired = (existing || []).filter(q => q.expiresAt > now);
+    if (!Array.isArray(existing) || unexpired.length !== existing.length) user.quests = unexpired;
 
     const dailyCount  = guildSettings.quests.questsPerDay  ?? 3;
     const weeklyCount = guildSettings.quests.questsPerWeek ?? 2;
@@ -190,6 +199,85 @@ async function ensureQuests(user, guildSettings) {
     }
 
     return { assignedNewDaily };
+}
+
+// The quest ids each per-event hook ticks, and the AI-quest mechanic it also
+// advances. Named here rather than inline in the hooks because the hot paths
+// ask a second question of the same lists — "could this event move anything for
+// this user at all?" — before they pay for a full document hydrate and save
+// (#893, #898, #929). Two copies of these ids would drift, and the failure mode
+// of drift is a quest that silently stops progressing.
+const QUEST_EVENTS = {
+    message: {
+        ids: ['daily_messages_5', 'daily_messages_10', 'daily_messages_25', 'daily_messages_50',
+              'weekly_messages_50', 'weekly_messages_150', 'weekly_messages_300'],
+        aiMechanic: 'social',
+    },
+    reaction: {
+        ids: ['daily_reactions_3', 'daily_reactions_5', 'daily_reactions_10', 'daily_reactions_20'],
+        aiMechanic: null,
+    },
+    command: {
+        ids: ['daily_commands_2', 'daily_commands_5', 'daily_commands_10',
+              'weekly_commands_10', 'weekly_commands_25'],
+        aiMechanic: 'explore',
+    },
+    streak: {
+        ids: ['weekly_streak_3', 'weekly_streak_5'],
+        aiMechanic: null,
+    },
+};
+
+// A quest entry this event could still advance: assigned, unfinished, unexpired.
+function isLive(entry, now) {
+    return !entry.completedAt && new Date(entry.expiresAt).getTime() > now;
+}
+
+/**
+ * Whether `on<Event>` could move anything for a user holding `quests`.
+ *
+ * Answers from the quest list alone, so a caller can ask it of a projected
+ * `{ quests: 1 }` read and skip hydrating the whole user document when the
+ * answer is no — which it is for most users most of the time, since the
+ * per-event quests are a handful of ids that are finished early in the day.
+ *
+ * AI legendary quests are matched on the `ai_` prefix rather than on their
+ * mechanic: the mechanic lives in a separate collection, and reading it would
+ * cost the round trip this check exists to avoid. So an active AI quest of any
+ * mechanic answers yes — conservative in the direction that cannot lose
+ * progress, and rare enough not to matter.
+ */
+function questEventCanProgress(quests, event) {
+    const spec = QUEST_EVENTS[event];
+    if (!spec) return true;
+    const now = Date.now();
+    return (quests || []).some(q =>
+        isLive(q, now) && (spec.ids.includes(q.questId) || (spec.aiMechanic && q.questId.startsWith('ai_'))),
+    );
+}
+
+/**
+ * Whether `ensureQuests` would add or remove anything — a fresh daily set, a
+ * topped-up weekly set, or an expired entry to prune.
+ *
+ * Same contract as `questEventCanProgress`: quest list in, boolean out, safe to
+ * ask of a lean projection. Callers pair the two so that a user whose quests
+ * have rolled over still gets the full path even though no event quest is live.
+ */
+function questAssignmentNeeded(quests, guildSettings) {
+    if (!guildSettings?.quests?.enabled) return false;
+
+    const now = Date.now();
+    const entries = quests || [];
+    const unexpired = entries.filter(q => new Date(q.expiresAt).getTime() > now);
+    if (unexpired.length !== entries.length) return true;
+
+    const dailyExpiryMs  = getDailyExpiry().getTime();
+    const weeklyExpiryMs = getWeeklyExpiry().getTime();
+    const countAt = ms => unexpired.filter(q => new Date(q.expiresAt).getTime() === ms).length;
+
+    return countAt(dailyExpiryMs)  < (guildSettings.quests.questsPerDay  ?? 3)
+        || countAt(weeklyExpiryMs) < (guildSettings.quests.questsPerWeek ?? 2);
 }
 
 function getDefById(questId) {
@@ -300,13 +388,12 @@ async function awardSeasonXp(user, xp, guildSettings) {
 async function onMessage(user, guildSettings) {
     if (!guildSettings?.quests?.enabled) return { completed: [], nearComplete: [] };
     const completed = [], nearComplete = [];
-    for (const questId of ['daily_messages_5', 'daily_messages_10', 'daily_messages_25', 'daily_messages_50',
-                           'weekly_messages_50', 'weekly_messages_150', 'weekly_messages_300']) {
+    for (const questId of QUEST_EVENTS.message.ids) {
         const { completed: def, nearComplete: nearDef } = await incrementQuest(user, questId);
         if (def)     completed.push(await awardQuest(user, def, guildSettings));
         if (nearDef) nearComplete.push(nearDef);
     }
-    const ai = await incrementAiQuestsForMechanic(user, 'social', 1, guildSettings);
+    const ai = await incrementAiQuestsForMechanic(user, QUEST_EVENTS.message.aiMechanic, 1, guildSettings);
     completed.push(...ai.completed); nearComplete.push(...ai.nearComplete);
     return { completed, nearComplete };
 }
@@ -314,7 +401,7 @@ async function onMessage(user, guildSettings) {
 async function onReaction(user, guildSettings) {
     if (!guildSettings?.quests?.enabled) return { completed: [], nearComplete: [] };
     const completed = [], nearComplete = [];
-    for (const questId of ['daily_reactions_3', 'daily_reactions_5', 'daily_reactions_10', 'daily_reactions_20']) {
+    for (const questId of QUEST_EVENTS.reaction.ids) {
         const { completed: def, nearComplete: nearDef } = await incrementQuest(user, questId);
         if (def)     completed.push(await awardQuest(user, def, guildSettings));
         if (nearDef) nearComplete.push(nearDef);
@@ -345,13 +432,12 @@ async function incrementAiQuestsForMechanic(user, mechanic, amount, guildSetting
 async function onCommandUse(user, guildSettings) {
     if (!guildSettings?.quests?.enabled) return { completed: [], nearComplete: [] };
     const completed = [], nearComplete = [];
-    for (const questId of ['daily_commands_2', 'daily_commands_5', 'daily_commands_10',
-                           'weekly_commands_10', 'weekly_commands_25']) {
+    for (const questId of QUEST_EVENTS.command.ids) {
         const { completed: def, nearComplete: nearDef } = await incrementQuest(user, questId);
         if (def)     completed.push(await awardQuest(user, def, guildSettings));
         if (nearDef) nearComplete.push(nearDef);
     }
-    const ai = await incrementAiQuestsForMechanic(user, 'explore', 1, guildSettings);
+    const ai = await incrementAiQuestsForMechanic(user, QUEST_EVENTS.command.aiMechanic, 1, guildSettings);
     completed.push(...ai.completed); nearComplete.push(...ai.nearComplete);
     return { completed, nearComplete };
 }
@@ -443,7 +529,7 @@ async function onStreakUpdate(user, guildSettings) {
     const streak       = user.streak?.current || 0;
     const completed    = [];
     const nearComplete = [];
-    for (const questId of ['weekly_streak_3', 'weekly_streak_5']) {
+    for (const questId of QUEST_EVENTS.streak.ids) {
         const def = getDefById(questId);
         if (!def) continue;
         const entry = user.quests?.find(q => q.questId === questId && !q.completedAt && q.expiresAt > new Date());
@@ -584,7 +670,8 @@ function startQuestService() {
 }
 
 module.exports = {
-    ensureQuests, getQuestDefs, getDailyPool, getWeeklyPool,
+    ensureQuests, questEventCanProgress, questAssignmentNeeded,
+    getQuestDefs, getDailyPool, getWeeklyPool,
     getCategoryEmojis, getDifficultyColors,
     onMessage, onReaction, onCommandUse, onEconomyEarn, onHunt, onFish, onMine, onExplore, onPetCare, onStreakUpdate,
     awardSeasonXp, awardQuest, incrementAiQuestsForMechanic,

--- a/tests/aiMentionStripping.test.js
+++ b/tests/aiMentionStripping.test.js
@@ -124,6 +124,36 @@ describe('the event handler', () => {
 
         expect(promptGiven()).toBe('!reset');
     });
+
+    // #930. The token was compiled with `new RegExp` on every mention-triggered
+    // message, for an id that is fixed for the life of the process.
+    describe('the token pattern', () => {
+        test('is compiled once and reused', async () => {
+            await run(mentionMessage(`<@${BOT_ID}> one`));
+            await run(mentionMessage(`<@${BOT_ID}> two`));
+
+            expect(messageCreate._getMentionPattern(BOT_ID))
+                .toBe(messageCreate._getMentionPattern(BOT_ID));
+        });
+
+        test('is rebuilt if the bot logs in as someone else', async () => {
+            const first = messageCreate._getMentionPattern(BOT_ID);
+
+            expect(messageCreate._getMentionPattern('999000111222333444')).not.toBe(first);
+            // And the original id is not still being served the other pattern.
+            expect(messageCreate._getMentionPattern(BOT_ID)).not.toBe(first);
+        });
+
+        test('still strips every token in a message, not just the first', async () => {
+            // The cached pattern is `g`-flagged and therefore carries
+            // `lastIndex` between calls. `replace` resets it; a second
+            // consecutive strip would drop tokens if anything ever did not.
+            await run(mentionMessage(`<@${BOT_ID}> hey <@${BOT_ID}> you`));
+
+            expect(promptGiven()).toBe('hey  you');
+            expect(promptGiven()).not.toContain(BOT_ID);
+        });
+    });
 });
 
 describe('the chat transport', () => {

--- a/tests/commandQuestPrecheck.test.js
+++ b/tests/commandQuestPrecheck.test.js
@@ -1,0 +1,166 @@
+'use strict';
+
+/**
+ * #898 — the second user round trip every command used to pay.
+ *
+ * `trackQuestCommandUse` runs after every successful command, on top of
+ * whatever the command handler itself already loaded and saved for the same
+ * member. It hydrated the whole `User` document and saved it back, for five
+ * quest ids that most members have either finished for the day or are not
+ * holding at all — so every slash command cost two full document round trips
+ * where one would do.
+ *
+ * A projected quest list is read first now. When it says nothing can move, the
+ * command pays that one small read and stops.
+ */
+
+const mockUser = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    findOneAndUpdate: jest.fn(),
+    updateOne: jest.fn(),
+};
+
+jest.mock('../src/models/User', () => mockUser);
+jest.mock('../src/utils/guildSettingsCache', () => ({ getGuildSettings: jest.fn() }));
+jest.mock('../src/utils/balanceDelta', () => ({
+    saveWithBalanceDelta: jest.fn(async () => ({ credited: true, balance: 0 })),
+    detachBalanceDelta: jest.fn(),
+    applyBalanceDelta: jest.fn(),
+    commitBalanceDelta: jest.fn(),
+}));
+jest.mock('../src/services/questService', () => {
+    const actual = jest.requireActual('../src/services/questService');
+    return {
+        // Real predicates: they are the whole decision under test.
+        questEventCanProgress: actual.questEventCanProgress,
+        questAssignmentNeeded: actual.questAssignmentNeeded,
+        ensureQuests: jest.fn(async () => ({ assignedNewDaily: false })),
+        onCommandUse: jest.fn(async () => ({ completed: [], nearComplete: [] })),
+        notifyQuestComplete: jest.fn(async () => {}),
+        notifyQuestNearComplete: jest.fn(async () => {}),
+    };
+});
+
+const { getGuildSettings } = require('../src/utils/guildSettingsCache');
+const { saveWithBalanceDelta } = require('../src/utils/balanceDelta');
+const { ensureQuests, onCommandUse } = require('../src/services/questService');
+const { trackQuestCommandUse } = require('../src/events/interactionCreate');
+
+const QUESTS_PER_DAY = 3;
+const QUESTS_PER_WEEK = 2;
+
+// Real expiry boundaries, minted by `ensureQuests` rather than written down
+// here: the pre-check buckets a quest by exact expiry match, so an invented
+// date lands in neither bucket and the set reads as empty — which would make
+// the "nothing to do" cases pass for the wrong reason. `ensureQuests` mutates
+// synchronously despite being declared async.
+const EXPIRIES = (() => {
+    const seed = { level: 1, quests: [] };
+    jest.requireActual('../src/services/questService')
+        .ensureQuests(seed, { quests: { enabled: true, questsPerDay: QUESTS_PER_DAY, questsPerWeek: QUESTS_PER_WEEK } });
+    const distinct = [...new Set(seed.quests.map(q => q.expiresAt.getTime()))].sort((a, b) => a - b);
+    return { daily: new Date(distinct[0]), weekly: new Date(distinct[distinct.length - 1]) };
+})();
+
+const entry = (questId, expiresAt, extra = {}) =>
+    ({ questId, progress: 0, completedAt: null, expiresAt, ...extra });
+
+// A full, live set with nothing a command can advance.
+const settledQuests = () => [
+    entry('daily_messages_5',  EXPIRIES.daily),
+    entry('daily_messages_10', EXPIRIES.daily),
+    entry('daily_messages_25', EXPIRIES.daily),
+    entry('weekly_messages_50',  EXPIRIES.weekly),
+    entry('weekly_messages_150', EXPIRIES.weekly),
+];
+
+function stubFindOne(doc) {
+    mockUser.findOne.mockImplementation(() => {
+        const query = Promise.resolve(doc);
+        query.lean = async () => doc;
+        return query;
+    });
+}
+
+const interaction = {
+    guild: { id: 'guild-1' },
+    user: { id: 'player-1' },
+    member: {},
+    channel: {},
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    getGuildSettings.mockResolvedValue({
+        quests: { enabled: true, questsPerDay: QUESTS_PER_DAY, questsPerWeek: QUESTS_PER_WEEK },
+    });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('a command with no command quest to move', () => {
+    beforeEach(() => stubFindOne({ userId: 'player-1', guildId: 'guild-1', quests: settledQuests() }));
+
+    test('costs one projected read and no hydrate', async () => {
+        await trackQuestCommandUse(interaction);
+
+        expect(mockUser.findOne).toHaveBeenCalledTimes(1);
+        expect(mockUser.findOne.mock.calls[0][1]).toEqual({ quests: 1, economyFrozen: 1 });
+    });
+
+    test('writes nothing', async () => {
+        await trackQuestCommandUse(interaction);
+
+        expect(saveWithBalanceDelta).not.toHaveBeenCalled();
+        expect(onCommandUse).not.toHaveBeenCalled();
+        expect(ensureQuests).not.toHaveBeenCalled();
+    });
+
+    test('a finished command quest is not a reason to hydrate', async () => {
+        stubFindOne({
+            userId: 'player-1', guildId: 'guild-1',
+            quests: [...settledQuests(), entry('daily_commands_5', EXPIRIES.daily, { completedAt: new Date() })],
+        });
+
+        await trackQuestCommandUse(interaction);
+
+        expect(saveWithBalanceDelta).not.toHaveBeenCalled();
+    });
+});
+
+describe('a command that can move something', () => {
+    test('a live command quest hydrates and saves as before', async () => {
+        stubFindOne({
+            userId: 'player-1', guildId: 'guild-1', balance: 100,
+            quests: [...settledQuests(), entry('daily_commands_5', EXPIRIES.daily)],
+        });
+
+        await trackQuestCommandUse(interaction);
+
+        expect(mockUser.findOne).toHaveBeenCalledTimes(2);
+        expect(onCommandUse).toHaveBeenCalled();
+        expect(saveWithBalanceDelta).toHaveBeenCalled();
+    });
+
+    test('a live AI quest hydrates too, since its mechanic is not knowable from here', async () => {
+        stubFindOne({
+            userId: 'player-1', guildId: 'guild-1', balance: 100,
+            quests: [...settledQuests(), entry('ai_legendary_7', EXPIRIES.weekly)],
+        });
+
+        await trackQuestCommandUse(interaction);
+
+        expect(onCommandUse).toHaveBeenCalled();
+    });
+
+    test('a set due for a rollover hydrates, so the quests still get assigned', async () => {
+        // Nothing live to advance, but nothing live at all — skipping here is
+        // how a member stops being given quests altogether.
+        stubFindOne({ userId: 'player-1', guildId: 'guild-1', balance: 0, quests: [] });
+
+        await trackQuestCommandUse(interaction);
+
+        expect(ensureQuests).toHaveBeenCalled();
+    });
+});

--- a/tests/commandQuestPrecheck.test.js
+++ b/tests/commandQuestPrecheck.test.js
@@ -47,32 +47,47 @@ const { saveWithBalanceDelta } = require('../src/utils/balanceDelta');
 const { ensureQuests, onCommandUse } = require('../src/services/questService');
 const { trackQuestCommandUse } = require('../src/events/interactionCreate');
 
+const { useFixedClock } = require('./helpers/fixedClock');
+
 const QUESTS_PER_DAY = 3;
 const QUESTS_PER_WEEK = 2;
+
+// Pinned, and pinned before the boundaries below are derived. `ensureQuests`
+// mints them from the wall clock at module load, while `questAssignmentNeeded`
+// recomputes `getDailyExpiry()` on every call — so a run that crosses UTC
+// midnight between the two buckets the fixture into yesterday and every
+// "nothing to do" case flips. The helper's default instant is 23:30 UTC, half
+// an hour from that boundary, so these now exercise the case rather than
+// merely dodging it.
+//
+// It installs the clock in `beforeEach`, which a module-load constant would
+// run ahead of — hence a function, called from the fixtures under the pinned
+// clock. The derivation itself is unchanged.
+useFixedClock();
 
 // Real expiry boundaries, minted by `ensureQuests` rather than written down
 // here: the pre-check buckets a quest by exact expiry match, so an invented
 // date lands in neither bucket and the set reads as empty — which would make
 // the "nothing to do" cases pass for the wrong reason. `ensureQuests` mutates
 // synchronously despite being declared async.
-const EXPIRIES = (() => {
+function expiries() {
     const seed = { level: 1, quests: [] };
     jest.requireActual('../src/services/questService')
         .ensureQuests(seed, { quests: { enabled: true, questsPerDay: QUESTS_PER_DAY, questsPerWeek: QUESTS_PER_WEEK } });
     const distinct = [...new Set(seed.quests.map(q => q.expiresAt.getTime()))].sort((a, b) => a - b);
     return { daily: new Date(distinct[0]), weekly: new Date(distinct[distinct.length - 1]) };
-})();
+}
 
 const entry = (questId, expiresAt, extra = {}) =>
     ({ questId, progress: 0, completedAt: null, expiresAt, ...extra });
 
 // A full, live set with nothing a command can advance.
 const settledQuests = () => [
-    entry('daily_messages_5',  EXPIRIES.daily),
-    entry('daily_messages_10', EXPIRIES.daily),
-    entry('daily_messages_25', EXPIRIES.daily),
-    entry('weekly_messages_50',  EXPIRIES.weekly),
-    entry('weekly_messages_150', EXPIRIES.weekly),
+    entry('daily_messages_5',  expiries().daily),
+    entry('daily_messages_10', expiries().daily),
+    entry('daily_messages_25', expiries().daily),
+    entry('weekly_messages_50',  expiries().weekly),
+    entry('weekly_messages_150', expiries().weekly),
 ];
 
 function stubFindOne(doc) {
@@ -120,7 +135,7 @@ describe('a command with no command quest to move', () => {
     test('a finished command quest is not a reason to hydrate', async () => {
         stubFindOne({
             userId: 'player-1', guildId: 'guild-1',
-            quests: [...settledQuests(), entry('daily_commands_5', EXPIRIES.daily, { completedAt: new Date() })],
+            quests: [...settledQuests(), entry('daily_commands_5', expiries().daily, { completedAt: new Date() })],
         });
 
         await trackQuestCommandUse(interaction);
@@ -133,7 +148,7 @@ describe('a command that can move something', () => {
     test('a live command quest hydrates and saves as before', async () => {
         stubFindOne({
             userId: 'player-1', guildId: 'guild-1', balance: 100,
-            quests: [...settledQuests(), entry('daily_commands_5', EXPIRIES.daily)],
+            quests: [...settledQuests(), entry('daily_commands_5', expiries().daily)],
         });
 
         await trackQuestCommandUse(interaction);
@@ -146,7 +161,7 @@ describe('a command that can move something', () => {
     test('a live AI quest hydrates too, since its mechanic is not knowable from here', async () => {
         stubFindOne({
             userId: 'player-1', guildId: 'guild-1', balance: 100,
-            quests: [...settledQuests(), entry('ai_legendary_7', EXPIRIES.weekly)],
+            quests: [...settledQuests(), entry('ai_legendary_7', expiries().weekly)],
         });
 
         await trackQuestCommandUse(interaction);

--- a/tests/economyFreezeQuestReward.test.js
+++ b/tests/economyFreezeQuestReward.test.js
@@ -32,12 +32,20 @@ jest.mock('../src/models/User', () => mockUser);
 jest.mock('../src/utils/guildSettingsCache', () => ({
     getGuildSettings: jest.fn(async () => ({ quests: { enabled: true } })),
 }));
-jest.mock('../src/services/questService', () => ({
-    ensureQuests: jest.fn(async () => {}),
-    onCommandUse: jest.fn(async () => ({ completed: [], nearComplete: [] })),
-    notifyQuestComplete: jest.fn(async () => {}),
-    notifyQuestNearComplete: jest.fn(async () => {}),
-}));
+// The predicates are the real ones: what they answer decides whether the
+// document is hydrated at all, and a stub that always says "yes" would hide the
+// skip these tests now have to work around.
+jest.mock('../src/services/questService', () => {
+    const actual = jest.requireActual('../src/services/questService');
+    return {
+        ensureQuests: jest.fn(async () => {}),
+        onCommandUse: jest.fn(async () => ({ completed: [], nearComplete: [] })),
+        questEventCanProgress: actual.questEventCanProgress,
+        questAssignmentNeeded: actual.questAssignmentNeeded,
+        notifyQuestComplete: jest.fn(async () => {}),
+        notifyQuestNearComplete: jest.fn(async () => {}),
+    };
+});
 jest.mock('../src/utils/balanceDelta', () => ({
     saveWithBalanceDelta: jest.fn(async () => ({ credited: true, balance: 0 })),
     detachBalanceDelta: jest.fn(),
@@ -56,10 +64,22 @@ const interaction = {
     channel: {},
 };
 
+// `findOne` is called twice with different shapes now: once projected, whose
+// result is read through `.lean()`, and once unprojected and awaited directly.
+// One stand-in serves both — a promise for the document that also answers
+// `lean()` with it.
+function stubFindOne(doc) {
+    mockUser.findOne.mockImplementation(() => {
+        const query = Promise.resolve(doc);
+        query.lean = async () => doc;
+        return query;
+    });
+}
+
 beforeEach(() => jest.clearAllMocks());
 
 test('a frozen member accrues no quest progress and is paid nothing', async () => {
-    mockUser.findOne.mockResolvedValue({ userId: 'player-1', guildId: 'guild-1', balance: 100, economyFrozen: true });
+    stubFindOne({ userId: 'player-1', guildId: 'guild-1', balance: 100, economyFrozen: true });
 
     await trackQuestCommandUse(interaction);
 
@@ -69,10 +89,14 @@ test('a frozen member accrues no quest progress and is paid nothing', async () =
     expect(onCommandUse).not.toHaveBeenCalled();
     // And nothing is written, so there is no credit to be recorded as owed.
     expect(saveWithBalanceDelta).not.toHaveBeenCalled();
+    // The freeze is read off the projection, so the refusal costs one small
+    // read rather than a full document hydrate (#898).
+    expect(mockUser.findOne).toHaveBeenCalledTimes(1);
+    expect(mockUser.findOne.mock.calls[0][1]).toEqual({ quests: 1, economyFrozen: 1 });
 });
 
 test('an unfrozen member is tracked and paid as before', async () => {
-    mockUser.findOne.mockResolvedValue({ userId: 'player-1', guildId: 'guild-1', balance: 100 });
+    stubFindOne({ userId: 'player-1', guildId: 'guild-1', balance: 100 });
 
     await trackQuestCommandUse(interaction);
 
@@ -84,7 +108,7 @@ test('an unfrozen member is tracked and paid as before', async () => {
 // freeze committed in between has to be refused by the write itself, which is
 // the same rule every debit follows.
 test('the reward write carries the freeze guard, not just the check', async () => {
-    mockUser.findOne.mockResolvedValue({ userId: 'player-1', guildId: 'guild-1', balance: 100 });
+    stubFindOne({ userId: 'player-1', guildId: 'guild-1', balance: 100 });
 
     await trackQuestCommandUse(interaction);
 
@@ -95,7 +119,7 @@ test('the reward write carries the freeze guard, not just the check', async () =
 test('a member with no document yet is tracked, not refused', async () => {
     // The row is created empty, so `economyFrozen` is absent rather than false
     // — the same case the `$ne: true` guard exists for everywhere else.
-    mockUser.findOne.mockResolvedValue(null);
+    stubFindOne(null);
     mockUser.create.mockResolvedValue({ userId: 'player-1', guildId: 'guild-1', balance: 0 });
 
     await trackQuestCommandUse(interaction);

--- a/tests/messageCreateDailyCounter.test.js
+++ b/tests/messageCreateDailyCounter.test.js
@@ -1,0 +1,241 @@
+'use strict';
+
+/**
+ * #893 — the write the per-message pipeline used to make unconditionally.
+ *
+ * With leveling and quests on, every guild message cost a full `User` read and
+ * a full `User` write. The write was forced by one field: `dailyMessages`, the
+ * raider-track counter, which ticks on every message including the ones where
+ * XP is on cooldown and nothing else about the user changed. So a chatty server
+ * paid a document save per message per active member for a `+1`.
+ *
+ * The counter now goes out as the `$inc` it always was, and the save is skipped
+ * — but only when the counter really is all that is pending. Everything else in
+ * this chain (a streak rollover, quest progress, a milestone's coins, XP) still
+ * takes the full save, and these tests are mostly about that boundary: skipping
+ * a write on a wrong guess is how XP goes missing.
+ */
+
+jest.mock('../src/models/User',     () => ({ findOne: jest.fn(), create: jest.fn(), updateOne: jest.fn(async () => ({ modifiedCount: 1 })) }));
+jest.mock('../src/models/Guild',    () => ({ create: jest.fn() }));
+jest.mock('../src/models/Case',     () => ({ findOne: jest.fn().mockResolvedValue(null), countDocuments: jest.fn().mockResolvedValue(0) }));
+jest.mock('../src/models/Reminder', () => ({ create: jest.fn() }));
+
+jest.mock('../src/services/aiService',            () => ({ handleAIChat: jest.fn() }));
+jest.mock('../src/services/moderationLogService', () => ({ logModeration: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../src/services/rivalryService',       () => ({ checkRivalry: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../src/services/chatEventService',     () => ({ maybeTriggerChatEvent: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../src/utils/wealthMilestone',         () => ({ checkAndBroadcastWealthMilestone: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../src/services/achievementService', () => ({
+    checkAndAward: jest.fn().mockResolvedValue([]),
+    announceAchievements: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../src/utils/streakMultiplier', () => ({
+    getStreakMultiplier: jest.fn(() => 1),
+    checkNewMilestones: jest.fn(() => []),
+}));
+jest.mock('../src/services/effectsService', () => ({
+    hasEffect: jest.fn(() => false),
+    consumeEffect: jest.fn(),
+    getXpMultiplier: jest.fn(() => 1),
+    getServerXpMultiplier: jest.fn(() => 1),
+}));
+jest.mock('../src/services/questService', () => ({
+    ensureQuests: jest.fn().mockResolvedValue({ assignedNewDaily: false }),
+    onMessage: jest.fn().mockResolvedValue({ completed: [], nearComplete: [] }),
+    onStreakUpdate: jest.fn().mockResolvedValue({ completed: [], nearComplete: [] }),
+    notifyQuestComplete: jest.fn().mockResolvedValue(undefined),
+    notifyQuestNearComplete: jest.fn().mockResolvedValue(undefined),
+    notifyDailyQuestReset: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../src/services/levelingService', () => ({
+    applyXpGain: jest.fn((user, amount) => {
+        user.xp = (user.xp || 0) + amount;
+        return { leveled: false, newLevel: user.level, gained: amount };
+    }),
+    announceLevelUp: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../src/utils/guildSettingsCache', () => ({ getGuildSettings: jest.fn() }));
+jest.mock('../src/utils/balanceDelta', () => ({
+    saveWithBalanceDelta: jest.fn(async (Model, user) => {
+        await user.save();
+        return { credited: true, balance: user.balance ?? 0 };
+    }),
+}));
+
+const User = require('../src/models/User');
+const { getGuildSettings } = require('../src/utils/guildSettingsCache');
+const { saveWithBalanceDelta } = require('../src/utils/balanceDelta');
+const { checkNewMilestones } = require('../src/utils/streakMultiplier');
+const { checkAndAward } = require('../src/services/achievementService');
+const messageCreate = require('../src/events/messageCreate');
+const { makeMessage, makeSettings } = require('./helpers/messageCreateMessage');
+
+// ---------------------------------------------------------------------------
+// A document that reports its modified paths, because that is what the write
+// decision now reads. The set is cleared by `save()`, and by `unmarkModified`
+// for the one path the `$inc` settles on its own.
+// ---------------------------------------------------------------------------
+function makeUserDoc(overrides = {}) {
+    const now = new Date();
+    const modified = new Set();
+    const target = {
+        _id: 'doc1',
+        userId: 'author1',
+        guildId: 'guild1',
+        xp: 0,
+        level: 0,
+        messages: 0,
+        balance: 0,
+        dailyMessages: 4,
+        // Same UTC day on both, so neither the streak nor the daily reset has
+        // anything to do — the steady state this is all about.
+        lastDailyReset: now,
+        lastXpGain: null,
+        streak: { current: 3, longest: 3, lastActive: now, claimedMilestones: [] },
+        quests: [],
+        pets: [],
+        modifiedPaths() { return [...modified]; },
+        isModified(path) { return path ? modified.has(path) : modified.size > 0; },
+        unmarkModified(path) { modified.delete(path); },
+        ...overrides,
+    };
+    target.save = jest.fn(async () => { modified.clear(); target.savedXp = target.xp; });
+
+    const internal = new Set(['savedXp']);
+    return new Proxy(target, {
+        set(t, prop, value) {
+            // Mongoose only marks a path modified when the value actually
+            // differs; assigning the same number back is not a write.
+            if (!internal.has(prop) && t[prop] !== value) modified.add(prop);
+            t[prop] = value;
+            return true;
+        },
+    });
+}
+
+const onCooldown = () => ({ lastXpGain: new Date() });
+
+const run = message => messageCreate.execute(message, { user: { id: 'bot1' } });
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    User.updateOne.mockResolvedValue({ modifiedCount: 1 });
+    getGuildSettings.mockResolvedValue(makeSettings());
+});
+
+// ---------------------------------------------------------------------------
+
+describe('a message where only the daily counter moved', () => {
+    test('the document is not saved', async () => {
+        const doc = makeUserDoc(onCooldown());
+        User.findOne.mockResolvedValue(doc);
+
+        await run(makeMessage());
+
+        expect(doc.save).not.toHaveBeenCalled();
+        expect(saveWithBalanceDelta).not.toHaveBeenCalled();
+    });
+
+    test('the counter goes out as an $inc instead', async () => {
+        const doc = makeUserDoc(onCooldown());
+        User.findOne.mockResolvedValue(doc);
+
+        await run(makeMessage());
+
+        expect(User.updateOne).toHaveBeenCalledTimes(1);
+        const [filter, update] = User.updateOne.mock.calls[0];
+        expect(filter).toEqual({ userId: 'author1', guildId: 'guild1' });
+        expect(update).toEqual({ $inc: { dailyMessages: 1 } });
+    });
+
+    test('the in-memory counter still counts this message', async () => {
+        // The raider bonus reads it on the next message through the same
+        // process; an `$inc` that left the loaded copy behind would under-pay.
+        const doc = makeUserDoc(onCooldown());
+        User.findOne.mockResolvedValue(doc);
+
+        await run(makeMessage());
+
+        expect(doc.dailyMessages).toBe(5);
+    });
+
+    test('the path is settled, so the backstop flush writes nothing', async () => {
+        // The caller flushes anything left modified. Leaving `dailyMessages`
+        // flagged after the `$inc` would put the full save straight back, and
+        // double-count the message into the bargain.
+        const doc = makeUserDoc(onCooldown());
+        User.findOne.mockResolvedValue(doc);
+
+        await run(makeMessage());
+
+        expect(doc.isModified()).toBe(false);
+        expect(doc.save).not.toHaveBeenCalled();
+    });
+});
+
+describe('a message where anything else moved', () => {
+    test('XP earned takes the full save, not the $inc', async () => {
+        const doc = makeUserDoc();   // not on cooldown, so XP lands
+        User.findOne.mockResolvedValue(doc);
+
+        await run(makeMessage());
+
+        expect(saveWithBalanceDelta).toHaveBeenCalledTimes(1);
+        expect(doc.savedXp).toBeGreaterThan(0);
+        expect(User.updateOne).not.toHaveBeenCalled();
+    });
+
+    test('a streak milestone takes the full save', async () => {
+        const doc = makeUserDoc(onCooldown());
+        User.findOne.mockResolvedValue(doc);
+        checkNewMilestones.mockReturnValueOnce([{ days: 7, coins: 12_500, badge: 'Week Warrior' }]);
+
+        await run(makeMessage());
+
+        // The coins are on the document; an `$inc` of the counter alone would
+        // drop them.
+        expect(saveWithBalanceDelta).toHaveBeenCalledTimes(1);
+        expect(User.updateOne).not.toHaveBeenCalled();
+    });
+
+    test('a fresh achievement takes the full save', async () => {
+        const doc = makeUserDoc(onCooldown());
+        User.findOne.mockResolvedValue(doc);
+        checkAndAward.mockImplementationOnce(async user => {
+            user.achievementsCount = (user.achievementsCount || 0) + 1;
+            return [{ id: 'chatty' }];
+        });
+
+        await run(makeMessage());
+
+        expect(saveWithBalanceDelta).toHaveBeenCalledTimes(1);
+        expect(User.updateOne).not.toHaveBeenCalled();
+    });
+
+    test("the day's first message takes the full save, because the reset is a $set", async () => {
+        const doc = makeUserDoc({
+            ...onCooldown(),
+            dailyMessages: 40,
+            lastDailyReset: new Date('2020-01-01'),
+        });
+        User.findOne.mockResolvedValue(doc);
+
+        await run(makeMessage());
+
+        expect(saveWithBalanceDelta).toHaveBeenCalledTimes(1);
+        expect(User.updateOne).not.toHaveBeenCalled();
+        expect(doc.dailyMessages).toBe(1);
+    });
+
+    test('a document that cannot report its modified paths is saved, not guessed at', async () => {
+        const doc = makeUserDoc(onCooldown());
+        doc.modifiedPaths = undefined;
+        User.findOne.mockResolvedValue(doc);
+
+        await run(makeMessage());
+
+        expect(saveWithBalanceDelta).toHaveBeenCalledTimes(1);
+        expect(User.updateOne).not.toHaveBeenCalled();
+    });
+});

--- a/tests/questProgressPrechecks.test.js
+++ b/tests/questProgressPrechecks.test.js
@@ -22,6 +22,15 @@ const {
     onMessage, onReaction, onCommandUse,
 } = require('../src/services/questService');
 
+const { useFixedClock } = require('./helpers/fixedClock');
+
+// Same reason as the two pre-check suites: `fullSet()` mints its expiry
+// boundaries from the wall clock and `questAssignmentNeeded` recomputes them a
+// moment later, so a UTC midnight landing between the two would flip the
+// answer. The window here is one test wide rather than a whole module load,
+// but it is the same race, and the helper exists for it (#632).
+useFixedClock();
+
 const SETTINGS = { quests: { enabled: true, questsPerDay: 3, questsPerWeek: 2 } };
 
 const HOUR = 3600_000;

--- a/tests/questProgressPrechecks.test.js
+++ b/tests/questProgressPrechecks.test.js
@@ -1,0 +1,190 @@
+'use strict';
+
+/**
+ * The two questions the hot paths ask before they pay for a user document.
+ *
+ * `trackQuestCommandUse` (#898) and the reaction quest handler (#929) both ran
+ * after every event, hydrating and saving the whole user for a counter that
+ * usually had nothing to move; the per-message pipeline (#893) saved for the
+ * same reason. All three now ask `questEventCanProgress` and
+ * `questAssignmentNeeded` of a projected quest list first, and only hydrate
+ * when one of them says yes.
+ *
+ * What makes that safe is that the predicates answer from the same id lists the
+ * hooks tick. These tests pin both halves of that: the answers themselves, and
+ * that the hooks and the predicates have not drifted apart — a predicate that
+ * says "nothing to do" about a quest `onMessage` would have advanced is a quest
+ * that silently stops progressing.
+ */
+
+const {
+    ensureQuests, questEventCanProgress, questAssignmentNeeded,
+    onMessage, onReaction, onCommandUse,
+} = require('../src/services/questService');
+
+const SETTINGS = { quests: { enabled: true, questsPerDay: 3, questsPerWeek: 2 } };
+
+const HOUR = 3600_000;
+const future = () => new Date(Date.now() + HOUR);
+const past   = () => new Date(Date.now() - HOUR);
+
+const live = (questId, extra = {}) => ({ questId, progress: 0, completedAt: null, expiresAt: future(), ...extra });
+
+// ---------------------------------------------------------------------------
+// questEventCanProgress
+// ---------------------------------------------------------------------------
+
+describe('questEventCanProgress', () => {
+    test('a live quest of the event type is something to do', () => {
+        expect(questEventCanProgress([live('daily_messages_10')], 'message')).toBe(true);
+        expect(questEventCanProgress([live('daily_reactions_5')], 'reaction')).toBe(true);
+        expect(questEventCanProgress([live('daily_commands_5')], 'command')).toBe(true);
+    });
+
+    test('a quest of another event type is not', () => {
+        const quests = [live('daily_reactions_5'), live('daily_commands_5')];
+        expect(questEventCanProgress(quests, 'message')).toBe(false);
+    });
+
+    test('a finished quest is not', () => {
+        expect(questEventCanProgress([live('daily_messages_10', { completedAt: new Date() })], 'message')).toBe(false);
+    });
+
+    test('an expired quest is not', () => {
+        expect(questEventCanProgress([live('daily_messages_10', { expiresAt: past() })], 'message')).toBe(false);
+    });
+
+    test('an empty or absent list is nothing to do', () => {
+        expect(questEventCanProgress([], 'message')).toBe(false);
+        expect(questEventCanProgress(undefined, 'message')).toBe(false);
+    });
+
+    test('a live AI quest counts for the events that carry a mechanic', () => {
+        // The mechanic lives in another collection, so the prefix is as much as
+        // this can know without the round trip it exists to avoid. Answering
+        // yes is the direction that cannot lose progress.
+        expect(questEventCanProgress([live('ai_legendary_1')], 'message')).toBe(true);
+        expect(questEventCanProgress([live('ai_legendary_1')], 'command')).toBe(true);
+        // Reactions advance no AI quest, so one is not a reason to hydrate.
+        expect(questEventCanProgress([live('ai_legendary_1')], 'reaction')).toBe(false);
+    });
+
+    test('dates that arrived as strings from a lean read are still compared as dates', () => {
+        const asRead = [{ questId: 'daily_messages_10', completedAt: null, expiresAt: future().toISOString() }];
+        expect(questEventCanProgress(asRead, 'message')).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// questAssignmentNeeded
+// ---------------------------------------------------------------------------
+
+describe('questAssignmentNeeded', () => {
+    // Built by ensureQuests itself, so the expiries are the exact ones it
+    // classifies on — the boundary the daily/weekly counting turns on.
+    function fullSet() {
+        const user = { level: 5, quests: [] };
+        ensureQuests(user, SETTINGS);
+        return user.quests;
+    }
+
+    test('a user holding a full set needs nothing', () => {
+        expect(questAssignmentNeeded(fullSet(), SETTINGS)).toBe(false);
+    });
+
+    test('a user with no quests needs a set', () => {
+        expect(questAssignmentNeeded([], SETTINGS)).toBe(true);
+    });
+
+    test('an expired entry is work, because pruning it drops the count', () => {
+        expect(questAssignmentNeeded([...fullSet(), live('daily_messages_5', { expiresAt: past() })], SETTINGS))
+            .toBe(true);
+    });
+
+    test('a short daily set is topped up', () => {
+        const quests = fullSet();
+        expect(questAssignmentNeeded(quests, { quests: { enabled: true, questsPerDay: 9, questsPerWeek: 2 } }))
+            .toBe(true);
+    });
+
+    test('a completed-but-unexpired quest still counts toward the set', () => {
+        // Finishing a daily does not earn a replacement — it holds its slot
+        // until it expires, which is what stops a chatty user farming the pool.
+        const quests = fullSet().map(q => ({ ...q, completedAt: new Date() }));
+        expect(questAssignmentNeeded(quests, SETTINGS)).toBe(false);
+    });
+
+    test('quests turned off is never work', () => {
+        expect(questAssignmentNeeded([], { quests: { enabled: false } })).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// The predicates and the hooks agree
+// ---------------------------------------------------------------------------
+
+describe('the pre-check and the hook it guards agree', () => {
+    // A quest id the predicate does not recognise but the hook does would be
+    // skipped forever. Driving both off one user is the cheapest way to catch
+    // that: whatever the hook moved, the predicate must have said yes about.
+    const cases = [
+        ['message',  onMessage],
+        ['reaction', onReaction],
+        ['command',  onCommandUse],
+    ];
+
+    test.each(cases)('%s: every quest the hook advances is one the pre-check admits', async (event, hook) => {
+        const user = { level: 1, xp: 0, balance: 0, quests: [] };
+        ensureQuests(user, { quests: { enabled: true, questsPerDay: 99, questsPerWeek: 99 } });
+
+        const before = user.quests.map(q => [q.questId, q.progress || 0]);
+        await hook(user, SETTINGS);
+        const moved = user.quests.filter((q, i) => (q.progress || 0) !== before[i][1]);
+
+        // The pool is large enough that at least one quest of each type is
+        // always assigned, so an empty `moved` means the hook stopped working
+        // rather than that the case is vacuous.
+        expect(moved.length).toBeGreaterThan(0);
+        for (const quest of moved) {
+            expect(questEventCanProgress([quest], event)).toBe(true);
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// ensureQuests and the array it used to rebuild
+// ---------------------------------------------------------------------------
+
+describe('ensureQuests and the quest array', () => {
+    test('leaves the array alone when nothing expired', () => {
+        const user = { level: 5, quests: [] };
+        ensureQuests(user, SETTINGS);
+        const assigned = user.quests;
+
+        ensureQuests(user, SETTINGS);
+
+        // Reassigning re-casts every entry into a subdocument, on a handler
+        // that runs per message (#893). Mongoose sees the two arrays are equal
+        // and marks nothing modified, so this is not about the write — it is
+        // the rebuild, and the array identity the callers below hold on to.
+        expect(user.quests).toBe(assigned);
+    });
+
+    test('replaces the array when something did expire', () => {
+        const user = { level: 5, quests: [live('daily_messages_5', { expiresAt: past() })] };
+        const stale = user.quests;
+
+        ensureQuests(user, SETTINGS);
+
+        expect(user.quests).not.toBe(stale);
+        expect(user.quests.some(q => q.expiresAt <= new Date())).toBe(false);
+    });
+
+    test('a user who has never held quests still gets an array', () => {
+        const user = { level: 1 };
+
+        expect(() => ensureQuests(user, SETTINGS)).not.toThrow();
+        expect(Array.isArray(user.quests)).toBe(true);
+        expect(user.quests.length).toBeGreaterThan(0);
+    });
+});

--- a/tests/reactionQuestPrecheck.test.js
+++ b/tests/reactionQuestPrecheck.test.js
@@ -1,0 +1,217 @@
+'use strict';
+
+/**
+ * #929 — what a single reaction used to cost.
+ *
+ * `handleReactionQuests` ran an upsert, a full `User` hydrate, a save and a
+ * `guild.members.fetch` for every reaction the bot saw, for a set of four quest
+ * ids that a given member has usually either finished for the day or never been
+ * assigned. Reaction bursts are what made that expensive: a message that
+ * catches on, or a starboard-active channel, lands dozens of these in seconds
+ * and each one paid in full.
+ *
+ * A projected quest list is read first now, and the rest of the work happens
+ * only when it says something could move. The member fetch waits until there is
+ * actually a notification to address.
+ */
+
+const mockUser = {
+    findOne: jest.fn(),
+    findOneAndUpdate: jest.fn(),
+    create: jest.fn(),
+    updateOne: jest.fn(),
+};
+
+jest.mock('../src/models/User', () => mockUser);
+jest.mock('../src/models/Guild', () => ({ updateOne: jest.fn(async () => ({ modifiedCount: 0 })) }));
+jest.mock('../src/utils/guildSettingsCache', () => ({ getGuildSettings: jest.fn() }));
+jest.mock('../src/utils/balanceDelta', () => ({
+    saveWithBalanceDelta: jest.fn(async () => ({ credited: true, balance: 0 })),
+}));
+jest.mock('../src/services/questService', () => {
+    const actual = jest.requireActual('../src/services/questService');
+    return {
+        // The predicates are the real ones — they are what decides whether the
+        // document is touched at all, so stubbing them would test nothing.
+        questEventCanProgress: actual.questEventCanProgress,
+        questAssignmentNeeded: actual.questAssignmentNeeded,
+        ensureQuests: jest.fn(async () => ({ assignedNewDaily: false })),
+        onReaction: jest.fn(async () => ({ completed: [], nearComplete: [] })),
+        notifyQuestComplete: jest.fn(async () => {}),
+        notifyQuestNearComplete: jest.fn(async () => {}),
+    };
+});
+
+const { getGuildSettings } = require('../src/utils/guildSettingsCache');
+const { saveWithBalanceDelta } = require('../src/utils/balanceDelta');
+const {
+    ensureQuests, onReaction, notifyQuestComplete, notifyQuestNearComplete,
+} = require('../src/services/questService');
+const messageReactionAdd = require('../src/events/messageReactionAdd');
+
+const QUESTS_PER_DAY = 3;
+const QUESTS_PER_WEEK = 2;
+
+// The real expiry boundaries, minted by `ensureQuests` rather than written down
+// here. The pre-check classifies a quest into the daily or the weekly bucket by
+// *exact* expiry match, so an invented date lands in neither and every set reads
+// as empty — which would make the "nothing to do" cases pass for the wrong
+// reason. `ensureQuests` mutates synchronously despite being declared async.
+const EXPIRIES = (() => {
+    const seed = { level: 1, quests: [] };
+    jest.requireActual('../src/services/questService')
+        .ensureQuests(seed, { quests: { enabled: true, questsPerDay: QUESTS_PER_DAY, questsPerWeek: QUESTS_PER_WEEK } });
+    // One value on the day the two windows coincide (a Saturday), two otherwise.
+    const distinct = [...new Set(seed.quests.map(q => q.expiresAt.getTime()))].sort((a, b) => a - b);
+    return { daily: new Date(distinct[0]), weekly: new Date(distinct[distinct.length - 1]) };
+})();
+
+const entry = (questId, expiresAt, progress = 0) => ({ questId, progress, completedAt: null, expiresAt });
+
+// A full, live quest set of the *wrong* kind: nothing a reaction can advance,
+// and nothing `ensureQuests` would need to top up. The steady state.
+function settledQuests() {
+    return [
+        entry('daily_messages_5',  EXPIRIES.daily),
+        entry('daily_messages_10', EXPIRIES.daily),
+        entry('daily_messages_25', EXPIRIES.daily),
+        entry('weekly_messages_50',  EXPIRIES.weekly),
+        entry('weekly_messages_150', EXPIRIES.weekly),
+    ];
+}
+
+function makeSettings() {
+    return {
+        quests: { enabled: true, questsPerDay: QUESTS_PER_DAY, questsPerWeek: QUESTS_PER_WEEK },
+        reactionRoles: [],
+        starboard: { enabled: false },
+    };
+}
+
+function makeGuild(members) {
+    return {
+        id: 'guild-1',
+        members,
+        channels: { cache: { get: () => null } },
+    };
+}
+
+function makeReaction(guild) {
+    return {
+        partial: false,
+        emoji: { name: '⭐' },
+        message: {
+            id: 'm1', partial: false, guild, channel: { id: 'c1' },
+            author: { id: 'someone-else' },
+            reactions: { cache: { find: () => null } },
+        },
+    };
+}
+
+function stubFindOne(doc) {
+    mockUser.findOne.mockImplementation(() => {
+        const query = Promise.resolve(doc);
+        query.lean = async () => doc;
+        return query;
+    });
+}
+
+let membersFetch;
+let guild;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    membersFetch = jest.fn(async () => ({ id: 'u1' }));
+    guild = makeGuild({ fetch: membersFetch });
+    mockUser.findOneAndUpdate.mockResolvedValue({
+        userId: 'u1', guildId: 'guild-1', balance: 0, quests: [],
+        save: jest.fn(async () => {}),
+    });
+});
+
+const react = () => messageReactionAdd.execute(makeReaction(guild), { bot: false, id: 'u1' }, { user: { id: 'bot' } });
+
+// ---------------------------------------------------------------------------
+
+describe('a reaction that cannot move a quest', () => {
+    beforeEach(() => {
+        stubFindOne({ userId: 'u1', guildId: 'guild-1', quests: settledQuests() });
+        getGuildSettings.mockResolvedValue(makeSettings());
+    });
+
+    test('costs one projected read and nothing else', async () => {
+        await react();
+
+        expect(mockUser.findOne).toHaveBeenCalledTimes(1);
+        expect(mockUser.findOne.mock.calls[0][1]).toEqual({ quests: 1 });
+        expect(mockUser.findOneAndUpdate).not.toHaveBeenCalled();
+        expect(saveWithBalanceDelta).not.toHaveBeenCalled();
+    });
+
+    test('does not fetch the member', async () => {
+        await react();
+
+        expect(membersFetch).not.toHaveBeenCalled();
+    });
+
+    test('does not run the quest hooks either', async () => {
+        await react();
+
+        expect(ensureQuests).not.toHaveBeenCalled();
+        expect(onReaction).not.toHaveBeenCalled();
+    });
+});
+
+describe('a reaction that can move a quest', () => {
+    beforeEach(() => {
+        stubFindOne({
+            userId: 'u1', guildId: 'guild-1',
+            quests: [...settledQuests(), entry('daily_reactions_5', EXPIRIES.daily, 1)],
+        });
+        getGuildSettings.mockResolvedValue(makeSettings());
+    });
+
+    test('still hydrates and saves', async () => {
+        await react();
+
+        expect(mockUser.findOneAndUpdate).toHaveBeenCalledTimes(1);
+        expect(saveWithBalanceDelta).toHaveBeenCalledTimes(1);
+    });
+
+    test('but fetches no member while there is nothing to say', async () => {
+        await react();
+
+        expect(membersFetch).not.toHaveBeenCalled();
+        expect(notifyQuestComplete).not.toHaveBeenCalled();
+    });
+
+    test('fetches the member once a quest actually completes', async () => {
+        onReaction.mockResolvedValueOnce({ completed: [{ questId: 'daily_reactions_5' }], nearComplete: [] });
+
+        await react();
+
+        expect(membersFetch).toHaveBeenCalledWith('u1');
+        expect(notifyQuestComplete).toHaveBeenCalledTimes(1);
+        expect(notifyQuestNearComplete).toHaveBeenCalledTimes(1);
+    });
+
+    test('and once one is nearly there', async () => {
+        onReaction.mockResolvedValueOnce({ completed: [], nearComplete: [{ questId: 'daily_reactions_5' }] });
+
+        await react();
+
+        expect(membersFetch).toHaveBeenCalledWith('u1');
+    });
+});
+
+describe('a member with no document yet', () => {
+    test('is upserted, not skipped — quests still have to be assigned', async () => {
+        stubFindOne(null);
+        getGuildSettings.mockResolvedValue(makeSettings());
+
+        await react();
+
+        expect(mockUser.findOneAndUpdate).toHaveBeenCalledTimes(1);
+        expect(ensureQuests).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/reactionQuestPrecheck.test.js
+++ b/tests/reactionQuestPrecheck.test.js
@@ -49,22 +49,37 @@ const {
 } = require('../src/services/questService');
 const messageReactionAdd = require('../src/events/messageReactionAdd');
 
+const { useFixedClock } = require('./helpers/fixedClock');
+
 const QUESTS_PER_DAY = 3;
 const QUESTS_PER_WEEK = 2;
+
+// Pinned, and pinned before the boundaries below are derived. `ensureQuests`
+// mints them from the wall clock at module load, while `questAssignmentNeeded`
+// recomputes `getDailyExpiry()` on every call — so a run that crosses UTC
+// midnight between the two buckets the fixture into yesterday and every
+// "nothing to do" case flips. The helper's default instant is 23:30 UTC, half
+// an hour from that boundary, so these now exercise the case rather than
+// merely dodging it.
+//
+// It installs the clock in `beforeEach`, which a module-load constant would
+// run ahead of — hence a function, called from the fixtures under the pinned
+// clock. The derivation itself is unchanged.
+useFixedClock();
 
 // The real expiry boundaries, minted by `ensureQuests` rather than written down
 // here. The pre-check classifies a quest into the daily or the weekly bucket by
 // *exact* expiry match, so an invented date lands in neither and every set reads
 // as empty — which would make the "nothing to do" cases pass for the wrong
 // reason. `ensureQuests` mutates synchronously despite being declared async.
-const EXPIRIES = (() => {
+function expiries() {
     const seed = { level: 1, quests: [] };
     jest.requireActual('../src/services/questService')
         .ensureQuests(seed, { quests: { enabled: true, questsPerDay: QUESTS_PER_DAY, questsPerWeek: QUESTS_PER_WEEK } });
     // One value on the day the two windows coincide (a Saturday), two otherwise.
     const distinct = [...new Set(seed.quests.map(q => q.expiresAt.getTime()))].sort((a, b) => a - b);
     return { daily: new Date(distinct[0]), weekly: new Date(distinct[distinct.length - 1]) };
-})();
+}
 
 const entry = (questId, expiresAt, progress = 0) => ({ questId, progress, completedAt: null, expiresAt });
 
@@ -72,11 +87,11 @@ const entry = (questId, expiresAt, progress = 0) => ({ questId, progress, comple
 // and nothing `ensureQuests` would need to top up. The steady state.
 function settledQuests() {
     return [
-        entry('daily_messages_5',  EXPIRIES.daily),
-        entry('daily_messages_10', EXPIRIES.daily),
-        entry('daily_messages_25', EXPIRIES.daily),
-        entry('weekly_messages_50',  EXPIRIES.weekly),
-        entry('weekly_messages_150', EXPIRIES.weekly),
+        entry('daily_messages_5',  expiries().daily),
+        entry('daily_messages_10', expiries().daily),
+        entry('daily_messages_25', expiries().daily),
+        entry('weekly_messages_50',  expiries().weekly),
+        entry('weekly_messages_150', expiries().weekly),
     ];
 }
 
@@ -166,7 +181,7 @@ describe('a reaction that can move a quest', () => {
     beforeEach(() => {
         stubFindOne({
             userId: 'u1', guildId: 'guild-1',
-            quests: [...settledQuests(), entry('daily_reactions_5', EXPIRIES.daily, 1)],
+            quests: [...settledQuests(), entry('daily_reactions_5', expiries().daily, 1)],
         });
         getGuildSettings.mockResolvedValue(makeSettings());
     });


### PR DESCRIPTION
The message, command and reaction paths each read and wrote the whole
`User` document on every event, for counters that usually had nothing to
move. That is the bot's throughput ceiling: it scales with chat volume
rather than with command volume.

Per message (#893): the write was forced by one field. `dailyMessages`
ticks on every message, including the ones where XP is on cooldown and
nothing else about the user changed, so a full-document `save()` went out
for a `+1`. It is now the `$inc` it always was, and `save()` is skipped —
but only when the counter really is all that is pending. The decision
reads `modifiedPaths()` rather than a hand-written "could anything have
changed?", so a handler added to this chain later cannot fall through the
gap and stop being persisted; anything else pending (a streak rollover,
quest progress, a milestone's coins, a fresh achievement) still takes the
full save. The unprojected read in `handleLeveling` stays: the fields this
chain touches are spread across most of the document, and a projected doc
that later gets saved is a way to write wrong values, not a way to save a
round trip.

Per command (#898) and per reaction (#929): both hydrated and saved the
whole user for a handful of quest ids that most members have either
finished for the day or are not holding. Both now ask a projected
`{ quests: 1 }` read whether anything could move, and hydrate only when the
answer is yes — one extra small read on the rare path, in exchange for
dropping a hydrate and a save from the common one. The reaction path also
stops upserting a document for a passer-by who reacts once, and defers
`members.fetch` until there is actually a notification to address.

The two questions those pre-checks ask live in questService beside the
hooks they guard, over one copy of the quest ids: a predicate that says
"nothing to do" about a quest `onMessage` would have advanced is a quest
that silently stops progressing, and two copies of the ids would drift.
A test drives the hooks and the predicates off one user to pin that.

Also on the reaction path, reaction roles and the starboard share no
document with each other or with anything else, so they settle together
rather than one behind the other; the two that both load and save the
member's `User` document stay in sequence, because concurrently they would
erase each other's write.

And #930: the bot's mention token is compiled once per bot id instead of
on every mention-triggered message.

Not a saved write, and the comment says so: `ensureQuests` reassigning the
quest array is skipped when nothing expired, but mongoose compares the two
arrays and already declined to mark the path modified. What that avoids is
re-casting every entry into a subdocument on each message.

Closes #893
Closes #898
Closes #929
Closes #930

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TMVFSPsPYJNAJxodvSJyfA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary database reads, document loading, and saves during quest, message, and reaction processing.
  * Improved daily message counter updates for faster, lower-overhead persistence.
  * Reused bot mention-matching patterns to improve message handling efficiency.
  * Reaction-based role and starboard processing now runs concurrently with independent error handling.
  * Quest checks more quickly skip inactive, completed, or unavailable quests while preserving assignment and progress behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->