### PR TITLE
Close the gaps review found in the backup and shop-image work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,12 @@ namespaced because shop item ids are whatever an admin typed, and one called
 upload is a targeted upsert on one small document, the settings endpoint no
 longer has to carry Buffers across a shop rewrite item by item, the cache's
 `HEAVY_FIELDS_PROJECTION` special case is gone, and the settings page reads its
-document unprojected in one read rather than two. `022` moves what is stored and
-clears the inline fields only once every image is written; it is reversible.
+document unprojected in one read rather than two. Deleting a shop item still
+deletes its artwork — the image was part of the item when it was inline, and a
+row nothing can reach is a row nothing would ever reclaim — but an id that
+survives a shop rewrite, or is re-added in the same request, keeps it. `022`
+moves what is stored and clears the inline fields only once every image is
+written, and only on the entries it moved; it is reversible.
 
 Stored credentials and the archives that hold them (#886). Without
 `SECRET_ENCRYPTION_KEY` the per-guild AI provider keys and the MCP OAuth refresh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -510,6 +510,9 @@ services:
             echo "[backup] BACKUP_ENCRYPTION_PASSPHRASE_FILE=$$BACKUP_ENCRYPTION_PASSPHRASE_FILE is not readable"; exit 1;
           fi;
           BACKUP_ENCRYPTION_PASSPHRASE=$$(tr -d "\r\n" < "$$BACKUP_ENCRYPTION_PASSPHRASE_FILE");
+          if [ -z "$$BACKUP_ENCRYPTION_PASSPHRASE" ]; then
+            echo "[backup] BACKUP_ENCRYPTION_PASSPHRASE_FILE=$$BACKUP_ENCRYPTION_PASSPHRASE_FILE is empty"; exit 1;
+          fi;
           export BACKUP_ENCRYPTION_PASSPHRASE;
           echo "[backup] Read BACKUP_ENCRYPTION_PASSPHRASE from $$BACKUP_ENCRYPTION_PASSPHRASE_FILE";
         fi;

--- a/portainer-stack.yml
+++ b/portainer-stack.yml
@@ -483,6 +483,9 @@ services:
             echo "[backup] BACKUP_ENCRYPTION_PASSPHRASE_FILE=$$BACKUP_ENCRYPTION_PASSPHRASE_FILE is not readable"; exit 1;
           fi;
           BACKUP_ENCRYPTION_PASSPHRASE=$$(tr -d "\r\n" < "$$BACKUP_ENCRYPTION_PASSPHRASE_FILE");
+          if [ -z "$$BACKUP_ENCRYPTION_PASSPHRASE" ]; then
+            echo "[backup] BACKUP_ENCRYPTION_PASSPHRASE_FILE=$$BACKUP_ENCRYPTION_PASSPHRASE_FILE is empty"; exit 1;
+          fi;
           export BACKUP_ENCRYPTION_PASSPHRASE;
           echo "[backup] Read BACKUP_ENCRYPTION_PASSPHRASE from $$BACKUP_ENCRYPTION_PASSPHRASE_FILE";
         fi;

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -29,12 +29,28 @@ fi
 
 mkdir -p "${BACKUP_DIR}"
 
+# Where mongodump writes. Unencrypted that is the archive itself, as it always
+# was. Encrypted, it is a private directory (mktemp -d is 0700) outside
+# BACKUP_DIR and only the sealed file is moved in — the plaintext of the whole
+# database must not appear in the directory whose readability is the reason the
+# archive is sealed at all, and a dump or an openssl invocation that fails part
+# way must not leave it there either. The nightly service stages the same way.
+WORK="${ARCHIVE}"
+if [ -n "${BACKUP_ENCRYPTION_PASSPHRASE:-}" ]; then
+    STAGING=$(mktemp -d)
+    WORK="${STAGING}/clawdia-${TIMESTAMP}.gz"
+    ARCHIVE="${ARCHIVE}.enc"
+    # However this ends — a failed dump, a failed seal, a Ctrl-C between them.
+    # The Docker branch below replaces this trap and carries the same cleanup.
+    trap 'rm -rf "${STAGING}"' EXIT
+fi
+
 MONGO_URI_MASKED=$(echo "${MONGO_URI}" | sed 's|://[^@]*@|://***@|')
 echo "[backup] Starting backup → ${ARCHIVE}"
 echo "[backup] URI: ${MONGO_URI_MASKED}"
 
 if command -v mongodump &>/dev/null; then
-    mongodump --uri="${MONGO_URI}" --gzip --archive="${ARCHIVE}"
+    mongodump --uri="${MONGO_URI}" --gzip --archive="${WORK}"
 else
     # Fall back to running mongodump inside the Docker container.
     # Replace 'localhost' with '127.0.0.1' so the URI points to the container's
@@ -53,20 +69,26 @@ else
         echo "[backup] ERROR: could not create a temp directory in clawdia-mongodb" >&2
         exit 1
     fi
-    trap 'docker exec clawdia-mongodb rm -rf "${REMOTE_DIR}" >/dev/null 2>&1 || true' EXIT
+    trap 'docker exec clawdia-mongodb rm -rf "${REMOTE_DIR}" >/dev/null 2>&1 || true; rm -rf "${STAGING:-}"' EXIT
     docker exec clawdia-mongodb \
         mongodump --uri="${CONTAINER_URI}" --gzip --archive="${REMOTE_DIR}/backup.gz"
-    docker cp "clawdia-mongodb:${REMOTE_DIR}/backup.gz" "${ARCHIVE}"
+    docker cp "clawdia-mongodb:${REMOTE_DIR}/backup.gz" "${WORK}"
 fi
 
-# Sealed in place: the plaintext is replaced, not kept beside the ciphertext.
+# Sealed out of the staging directory and into BACKUP_DIR, so the only thing
+# that ever lands there is the finished ciphertext.
 if [ -n "${BACKUP_ENCRYPTION_PASSPHRASE:-}" ]; then
     # `-pass env:` and not the passphrase on the command line, which every other
     # user of the host can read out of `ps`.
-    openssl enc -aes-256-cbc -pbkdf2 -iter 200000 -salt \
-        -pass env:BACKUP_ENCRYPTION_PASSPHRASE -in "${ARCHIVE}" -out "${ARCHIVE}.enc"
-    rm -f "${ARCHIVE}"
-    ARCHIVE="${ARCHIVE}.enc"
+    if ! openssl enc -aes-256-cbc -pbkdf2 -iter 200000 -salt \
+        -pass env:BACKUP_ENCRYPTION_PASSPHRASE -in "${WORK}" -out "${ARCHIVE}"; then
+        # A half-written .enc is not an archive, and leaving it under a name the
+        # prune and `verify-backup.sh --latest` both reach for is a failure that
+        # reads as a success.
+        rm -f "${ARCHIVE}"
+        echo "[backup] ERROR: encrypting the archive failed; nothing was kept." >&2
+        exit 1
+    fi
 fi
 
 SIZE=$(du -sh "${ARCHIVE}" | cut -f1)

--- a/src/config/validateEnv.js
+++ b/src/config/validateEnv.js
@@ -215,10 +215,20 @@ function checkSecretEncryption(env) {
 
     const key = (env.SECRET_ENCRYPTION_KEY || '').trim();
     if (!key) {
+        // The archive half is conditional because it can be closed separately:
+        // with BACKUP_ENCRYPTION_PASSPHRASE set the nightly dumps are ciphertext
+        // whatever this variable is doing, and telling that operator their
+        // credentials are readable in every backup would send them looking for
+        // an exposure they have already covered. The database half is not
+        // conditional — that is what this variable, and only this variable, is
+        // for.
+        const alsoInBackups = (env.BACKUP_ENCRYPTION_PASSPHRASE || '').trim()
+            ? 'in the database.'
+            : 'in the database and in every nightly backup archive.';
         return [
             'SECRET_ENCRYPTION_KEY is not set, so per-guild AI provider keys and MCP OAuth ' +
-            'refresh tokens are stored in the clear — in the database and in every nightly ' +
-            'backup archive. Generate one with `openssl rand -base64 32`, then run ' +
+            `refresh tokens are stored in the clear — ${alsoInBackups} ` +
+            'Generate one with `openssl rand -base64 32`, then run ' +
             '`npm run secrets:encrypt` to seal what is already stored. See "Encrypting stored ' +
             'provider keys" in docs/SETUP_GUIDE.md.',
         ];

--- a/src/config/validateEnv.js
+++ b/src/config/validateEnv.js
@@ -215,19 +215,21 @@ function checkSecretEncryption(env) {
 
     const key = (env.SECRET_ENCRYPTION_KEY || '').trim();
     if (!key) {
-        // The archive half is conditional because it can be closed separately:
-        // with BACKUP_ENCRYPTION_PASSPHRASE set the nightly dumps are ciphertext
-        // whatever this variable is doing, and telling that operator their
-        // credentials are readable in every backup would send them looking for
-        // an exposure they have already covered. The database half is not
-        // conditional — that is what this variable, and only this variable, is
-        // for.
-        const alsoInBackups = (env.BACKUP_ENCRYPTION_PASSPHRASE || '').trim()
-            ? 'in the database.'
-            : 'in the database and in every nightly backup archive.';
+        // The archive half is qualified rather than branched on. It can be
+        // closed separately — BACKUP_ENCRYPTION_PASSPHRASE seals the nightly
+        // dumps whatever this variable is doing — so saying it flatly would
+        // send an operator who has done that looking for an exposure they have
+        // already covered. Reading the passphrase to find out would be worse:
+        // it is the backup container's secret, this process has no other use
+        // for one, and #901 is the argument against handing a container a
+        // credential it does not need. A second BACKUP_ENCRYPTION_ENABLED flag
+        // would answer it without the secret and is not worth having either —
+        // two variables that have to agree is a way for them to disagree, and
+        // the disagreement here would be a security warning that is wrong.
         return [
             'SECRET_ENCRYPTION_KEY is not set, so per-guild AI provider keys and MCP OAuth ' +
-            `refresh tokens are stored in the clear — ${alsoInBackups} ` +
+            'refresh tokens are stored in the clear in the database — and in every nightly ' +
+            'backup archive BACKUP_ENCRYPTION_PASSPHRASE has not sealed. ' +
             'Generate one with `openssl rand -base64 32`, then run ' +
             '`npm run secrets:encrypt` to seal what is already stored. See "Encrypting stored ' +
             'provider keys" in docs/SETUP_GUIDE.md.',

--- a/src/dashboard/routes/api/settings.js
+++ b/src/dashboard/routes/api/settings.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const Guild = require('../../../models/Guild');
+const ItemImage = require('../../../models/ItemImage');
+const { shopImageId } = require('../../../models/itemImageKeys');
 const { checkAuth, checkGuildAccess, checkWriteRateLimit } = require('../../lib/middleware');
 const { sanitizeMongoValue, logAuditEvent } = require('../../lib/apiHelpers');
 const { validateBaseUrl: validateOllamaBaseUrl } = require('../../../services/ai/providers/ollama');
@@ -444,10 +446,14 @@ router.post('/guild/:guildId/settings', checkAuth, checkGuildAccess, checkWriteR
         // settings save. They live in the ItemImage collection now, keyed by
         // guild and item, so a rewritten shop array cannot touch them.
         //
-        // What it can still do is orphan one: an item deleted from the shop
-        // leaves its image behind. That is deliberate — an admin who removes an
-        // item and re-adds it under the same id keeps the artwork, and the row
-        // is small, keyed and invisible to every read that does not ask for it.
+        // What it can do is strand one, and that is what the ids below are for:
+        // an item removed from the shop used to take its image with it, because
+        // the image was part of the item. Now the row outlives the item unless
+        // something deletes it, and nothing else would — leaving a 512 KB
+        // document per removed item that no read can reach and no prune covers.
+        const shopIdsBefore = Array.isArray(updates.shop)
+            ? (guildSettings.shop || []).map(item => item?.itemId).filter(Boolean)
+            : [];
 
         // H1: Strip any MongoDB operator keys ($ne, $regex, etc.) before writing.
         Object.keys(updates).forEach(key => {
@@ -455,6 +461,23 @@ router.post('/guild/:guildId/settings', checkAuth, checkGuildAccess, checkWriteR
         });
 
         await guildSettings.save();
+
+        // After the save, so a rejected write cannot delete the images of a
+        // shop that still has the items. Scoped to this guild's own rows and to
+        // the ids that actually went: an item re-added under the same id in the
+        // same request keeps its artwork, which is what an admin reordering or
+        // renaming their shop expects.
+        const removedShopIds = shopIdsBefore.filter(
+            id => !(guildSettings.shop || []).some(item => item?.itemId === id));
+        if (removedShopIds.length) {
+            await ItemImage.deleteMany({
+                guildId,
+                itemId: { $in: removedShopIds.map(shopImageId) },
+            // Never fatal: the settings the caller asked for are saved, and a
+            // failed cleanup is a row to collect later rather than a reason to
+            // report the save as failed.
+            }).catch(err => console.error('[SETTINGS] shop image cleanup failed:', err.message));
+        }
 
         // L1: Record what changed and who changed it.
         await logAuditEvent(req, guildId, 'settings_update', { keys: Object.keys(updates) });

--- a/src/migrations/022_move_shop_images_to_itemimages.js
+++ b/src/migrations/022_move_shop_images_to_itemimages.js
@@ -101,18 +101,31 @@ module.exports = {
             // `shop.find(...)`, so a second element carrying the same id was
             // already unreachable. Moving the last would change which artwork a
             // guild sees, on a migration whose job is to move it unchanged.
+            //
+            // Resolved in two steps for the same reason, and in this order: the
+            // first entry carrying an id is the one `find()` returns whether or
+            // not it has an image, so an empty first duplicate means the guild
+            // saw no shop image for that id — and taking a later duplicate's
+            // image would put artwork on screen that was not there before.
             const byId = new Map();
-            for (const item of guild.shop ?? []) {
+            (guild.shop ?? []).forEach((item, index) => {
                 // An item with no id was never servable either: the image route
                 // keys on `itemId`, so no URL could have reached it.
-                if (!item?.itemId || !byteLength(item.imageData)) continue;
-                if (!byId.has(item.itemId)) byId.set(item.itemId, item);
-            }
-            if (!byId.size) continue;
+                if (!item?.itemId || byId.has(item.itemId)) return;
+                byId.set(item.itemId, { item, index });
+            });
+            const movable = [...byId].filter(([, { item }]) => byteLength(item.imageData));
+            if (!movable.length) continue;
             guildsTouched++;
-            movedByGuild.push({ _id: guild._id, itemIds: [...byId.keys()] });
+            // By array index, not by id: two entries sharing an id share the
+            // arrayFilter that an id-based clear would use, so the duplicate
+            // whose image was *not* moved would be cleared along with the one
+            // that was. Indexes are stable here because migrations run at boot,
+            // before the bot logs in and before the dashboard opens its port —
+            // the same thing that makes the whole sweep safe to do unlocked.
+            movedByGuild.push({ _id: guild._id, indexes: movable.map(([, { index }]) => index) });
 
-            for (const [itemId, item] of byId) {
+            for (const [itemId, { item }] of movable) {
                 batch.push({
                     updateOne: {
                         filter: { guildId: guild.guildId, itemId: shopImageId(itemId) },
@@ -139,16 +152,18 @@ module.exports = {
         // them have been. `$[]` over every element of every shop was simpler and
         // wrong twice over: it rewrote every guild document that has a shop at
         // all, including the ones with no image in it, and it destroyed the
-        // image on any entry `up` had skipped — an item with no `itemId` has no
+        // image on any entry `up` had skipped — an entry this cannot move has no
         // row to move its artwork to, so clearing it is a delete with nothing
-        // written down and nothing for `down` to put back.
+        // written down and nothing for `down` to put back. That covers an item
+        // with no `itemId` and the second of two entries sharing one.
         let cleared = 0;
-        for (const { _id, itemIds } of movedByGuild) {
-            const result = await guilds().updateOne(
-                { _id },
-                { $unset: { 'shop.$[moved].imageData': '', 'shop.$[moved].imageType': '' } },
-                { arrayFilters: [{ 'moved.itemId': { $in: itemIds } }] },
-            );
+        for (const { _id, indexes } of movedByGuild) {
+            const unset = {};
+            for (const index of indexes) {
+                unset[`shop.${index}.imageData`] = '';
+                unset[`shop.${index}.imageType`] = '';
+            }
+            const result = await guilds().updateOne({ _id }, { $unset: unset });
             cleared += result.modifiedCount ?? 0;
         }
 

--- a/src/migrations/022_move_shop_images_to_itemimages.js
+++ b/src/migrations/022_move_shop_images_to_itemimages.js
@@ -20,7 +20,10 @@ const { shopImageId, isShopImageId, SHOP_IMAGE_PREFIX } = require('../models/ite
  *
  * Reversible: `down()` copies the Buffers back onto the shop subdocuments and
  * removes the rows it wrote. It is still the migration to have a backup before,
- * because the data being moved is the only copy of it.
+ * because the data being moved is the only copy of it — which is also why the
+ * cleanup below touches only the entries that were moved. An entry this cannot
+ * move (no `itemId`, so no key to store it under) keeps its inline image rather
+ * than losing it to a tidy-up.
  *
  * The driver is used directly rather than the model, as in migration 018 and
  * for the same reason twice over: the Guild schema no longer declares
@@ -71,6 +74,11 @@ module.exports = {
 
         let moved = 0;
         let guildsTouched = 0;
+        // What to clear afterwards, per guild. Collected rather than cleared as
+        // it goes, so nothing is unset until every image is written: the other
+        // order loses whatever had not been copied when it failed, and there is
+        // no second copy of it.
+        const movedByGuild = [];
 
         const cursor = guilds().find(WITH_INLINE_IMAGES, {
             projection: { guildId: 1, 'shop.itemId': 1, 'shop.imageData': 1, 'shop.imageType': 1 },
@@ -86,18 +94,23 @@ module.exports = {
             // One write per item id, not per array element. Nothing stops a
             // shop array holding two items with the same `itemId`, and two
             // upserts to one key inside a single unordered bulkWrite race each
-            // other into a duplicate-key error. The later element wins, which is
-            // also which one the image route served: it took the first match on
-            // the id, and a second element with the same id was unreachable.
+            // other into a duplicate-key error.
+            //
+            // The *first* wins, because that is the one the routes served: both
+            // the image route and utils/itemImageHelper.js resolved an id with
+            // `shop.find(...)`, so a second element carrying the same id was
+            // already unreachable. Moving the last would change which artwork a
+            // guild sees, on a migration whose job is to move it unchanged.
             const byId = new Map();
             for (const item of guild.shop ?? []) {
-                // An item with no id was never servable: the image route keys on
-                // `itemId`, so no URL could have reached it.
+                // An item with no id was never servable either: the image route
+                // keys on `itemId`, so no URL could have reached it.
                 if (!item?.itemId || !byteLength(item.imageData)) continue;
-                byId.set(item.itemId, item);
+                if (!byId.has(item.itemId)) byId.set(item.itemId, item);
             }
             if (!byId.size) continue;
             guildsTouched++;
+            movedByGuild.push({ _id: guild._id, itemIds: [...byId.keys()] });
 
             for (const [itemId, item] of byId) {
                 batch.push({
@@ -122,17 +135,26 @@ module.exports = {
         }
         await flush();
 
-        // Only after every image is written. Unsetting first and failing part
-        // way through would lose the ones not yet copied, and there is no other
-        // copy of them.
-        const cleared = await guilds().updateMany(
-            { 'shop.0': { $exists: true } },
-            { $unset: { 'shop.$[].imageData': '', 'shop.$[].imageType': '' } },
-        );
+        // Only the entries that were actually moved, and only now that all of
+        // them have been. `$[]` over every element of every shop was simpler and
+        // wrong twice over: it rewrote every guild document that has a shop at
+        // all, including the ones with no image in it, and it destroyed the
+        // image on any entry `up` had skipped — an item with no `itemId` has no
+        // row to move its artwork to, so clearing it is a delete with nothing
+        // written down and nothing for `down` to put back.
+        let cleared = 0;
+        for (const { _id, itemIds } of movedByGuild) {
+            const result = await guilds().updateOne(
+                { _id },
+                { $unset: { 'shop.$[moved].imageData': '', 'shop.$[moved].imageType': '' } },
+                { arrayFilters: [{ 'moved.itemId': { $in: itemIds } }] },
+            );
+            cleared += result.modifiedCount ?? 0;
+        }
 
         console.log(
             `[MIGRATIONS] 022: moved ${moved} shop image(s) from ${guildsTouched} guild(s) into ` +
-            `itemimages; cleared the inline fields on ${cleared.modifiedCount} guild document(s).`,
+            `itemimages; cleared the inline fields on ${cleared} guild document(s).`,
         );
     },
 

--- a/tests/backupArchiveEncryption.test.js
+++ b/tests/backupArchiveEncryption.test.js
@@ -389,6 +389,11 @@ describe("the backup service's entrypoint", () => {
         };
     }
 
+    // Not gated on openssl, unlike its neighbours: the emptiness check sits in
+    // the file-reading block above the `command -v openssl` one, so this refusal
+    // is reached on a machine that has no openssl at all — and it is the case
+    // where a missing gate would let plaintext through, so it is worth having
+    // run everywhere.
     it('refuses an empty passphrase file rather than writing plaintext', () => {
         // The failure this closes: a docker secret that exists and is readable
         // but holds nothing — a mount pointed at the wrong path, a file the
@@ -408,7 +413,7 @@ describe("the backup service's entrypoint", () => {
         expect(run.archives).toEqual([]);
     });
 
-    it('reads a passphrase file that has one, and seals with it', () => {
+    withOpenssl('reads a passphrase file that has one, and seals with it', () => {
         const secret = path.join(dir, 'good.secret');
         fs.writeFileSync(secret, 'a passphrase with spaces\n');
 

--- a/tests/backupArchiveEncryption.test.js
+++ b/tests/backupArchiveEncryption.test.js
@@ -26,6 +26,7 @@ const { execFileSync, spawnSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const yaml = require('js-yaml');
 
 const ROOT = path.join(__dirname, '..');
 const ARCHIVE_LIB = path.join(ROOT, 'scripts', 'lib', 'archive.sh');
@@ -160,6 +161,76 @@ describe('the archive readers both go through it', () => {
     });
 });
 
+// scripts/backup.sh is the same dump taken by hand, and it has to hold the same
+// invariant the nightly service does: the plaintext of the database never
+// appears in the archive directory, not even between the dump and the seal, and
+// not after a failure.
+describe('a backup taken by hand', () => {
+    function backup(env = {}) {
+        const out = path.join(dir, 'out');
+        const bin = path.join(dir, 'bin');
+        fs.mkdirSync(out, { recursive: true });
+        fs.mkdirSync(bin, { recursive: true });
+        fs.writeFileSync(path.join(bin, 'mongodump'), [
+            '#!/bin/sh',
+            'for a in "$@"; do case "$a" in --archive=*) OUT="${a#--archive=}";; esac; done',
+            'printf THE-DATABASE > "$OUT"',
+        ].join('\n'));
+        fs.chmodSync(path.join(bin, 'mongodump'), 0o755);
+
+        const run = spawnSync('bash', [path.join(ROOT, 'scripts', 'backup.sh'), out], {
+            encoding: 'utf8',
+            env: {
+                ...process.env,
+                PATH: `${bin}:${process.env.PATH}`,
+                MONGODB_URI: 'mongodb://db/clawdia',
+                BACKUP_ENCRYPTION_PASSPHRASE: '',
+                ...env,
+            },
+        });
+        return { ...run, written: fs.readdirSync(out).sort() };
+    }
+
+    it('writes a plain archive when no passphrase is configured', () => {
+        const run = backup();
+
+        expect(run.status).toBe(0);
+        expect(run.written).toEqual([expect.stringMatching(/^clawdia-.*\.gz$/)]);
+    });
+
+    withOpenssl('seals the archive, and puts only the sealed file in the directory', () => {
+        const run = backup({ BACKUP_ENCRYPTION_PASSPHRASE: 'a passphrase with spaces' });
+
+        expect(run.status).toBe(0);
+        expect(run.written).toEqual([expect.stringMatching(/^clawdia-.*\.gz\.enc$/)]);
+
+        // And it is the database, sealed — not a file that merely has the name.
+        const sealed = path.join(dir, 'out', run.written[0]);
+        const opened = spawnSync('bash', ['-c',
+            `. "${ARCHIVE_LIB}"; open_archive "${sealed}" "${dir}/work"`], {
+            encoding: 'utf8',
+            env: { ...process.env, BACKUP_ENCRYPTION_PASSPHRASE: 'a passphrase with spaces' },
+        });
+        expect(fs.readFileSync(opened.stdout, 'utf8')).toBe('THE-DATABASE');
+    });
+
+    it('keeps nothing when the seal fails', () => {
+        // The plaintext dump is staged outside the archive directory, so a
+        // failure between the dump and the seal cannot strand a readable copy
+        // of the database in the directory being backed up to.
+        const bin = path.join(dir, 'bin');
+        fs.mkdirSync(bin, { recursive: true });
+        fs.writeFileSync(path.join(bin, 'openssl'), '#!/bin/sh\nexit 7\n');
+        fs.chmodSync(path.join(bin, 'openssl'), 0o755);
+
+        const run = backup({ BACKUP_ENCRYPTION_PASSPHRASE: 'passphrase' });
+
+        expect(run.status).not.toBe(0);
+        expect(run.stderr).toMatch(/encrypting the archive failed/);
+        expect(run.written).toEqual([]);
+    });
+});
+
 describe('off-site replication (#900)', () => {
     /** Runs offsite-sync.sh against `dir`, with a stub rclone on PATH. */
     function sync(env = {}) {
@@ -252,5 +323,137 @@ describe('off-site replication (#900)', () => {
         // A quarantined archive failed its own parse check; off-site storage
         // holding a known-bad archive beside good ones is a trap at 3am.
         expect(command).not.toContain('unverified');
+    });
+});
+
+// The backup service's own loop, run. tests/deployStackParity.test.js holds its
+// shape and holds the two stack files to the same one; this drives it, because
+// the properties that matter are about what ends up on disk after a failure —
+// which no amount of reading the YAML can answer.
+describe("the backup service's entrypoint", () => {
+    /** The inline `sh -c` script, with its paths pointed at a scratch tree. */
+    function loopScript(archives, work) {
+        const service = yaml.load(fs.readFileSync(path.join(ROOT, 'docker-compose.yml'), 'utf8'))
+            .services.backup.entrypoint;
+        return String(service)
+            .replace(/^\s*sh -c '/, '')
+            .replace(/'\s*$/, '')
+            // Compose escapes `$` for its own interpolation; the shell sees one.
+            .replace(/\$\$/g, '$')
+            // The staging path first: it is a /tmp path and would otherwise be
+            // caught by the /backups rewrite below.
+            .replace(/\/tmp\/clawdia-/g, `${work}/clawdia-`)
+            .replace(/\/backups/g, archives)
+            // Everything up to the scheduling loop: the boot catch-up runs one
+            // backup, which is the whole of what is under test here.
+            .replace(/while true[\s\S]*$/, '');
+    }
+
+    /** Stand-ins that record what they were handed rather than reaching a database. */
+    function stubMongoTools(bin) {
+        fs.mkdirSync(bin, { recursive: true });
+        fs.writeFileSync(path.join(bin, 'mongodump'), [
+            '#!/bin/sh',
+            'for a in "$@"; do case "$a" in --archive=*) OUT="${a#--archive=}";; esac; done',
+            // A dump killed part way leaves what it had written behind.
+            '[ -n "$FAIL_DUMP" ] && { printf partial > "$OUT"; exit 3; }',
+            'printf THE-DATABASE > "$OUT"',
+        ].join('\n'));
+        fs.writeFileSync(path.join(bin, 'mongorestore'), [
+            '#!/bin/sh',
+            'for a in "$@"; do case "$a" in --archive=*) IN="${a#--archive=}";; esac; done',
+            '[ -n "$FAIL_VERIFY" ] && exit 4',
+            'grep -q THE-DATABASE "$IN" 2>/dev/null || exit 5',
+        ].join('\n'));
+        for (const tool of ['mongodump', 'mongorestore']) fs.chmodSync(path.join(bin, tool), 0o755);
+    }
+
+    function runLoop(env = {}) {
+        const archives = path.join(dir, 'backups');
+        const work = path.join(dir, 'staging');
+        const bin = path.join(dir, 'bin');
+        fs.mkdirSync(archives, { recursive: true });
+        fs.mkdirSync(work, { recursive: true });
+        stubMongoTools(bin);
+
+        const run = spawnSync('sh', ['-c', loopScript(archives, work)], {
+            encoding: 'utf8',
+            env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, MONGODB_URI: 'mongodb://db/clawdia', ...env },
+        });
+        // The two dotfiles the loop keeps for the healthcheck and for a human
+        // are state, not archives, and are asserted by name where they matter.
+        return {
+            ...run,
+            archives: fs.readdirSync(archives).filter(f => !f.startsWith('.')).sort(),
+            staging: fs.readdirSync(work),
+        };
+    }
+
+    it('refuses an empty passphrase file rather than writing plaintext', () => {
+        // The failure this closes: a docker secret that exists and is readable
+        // but holds nothing — a mount pointed at the wrong path, a file the
+        // operator has not filled in yet. The `-n` test on the variable is
+        // satisfied by a file and unsatisfied by its contents, so without this
+        // the run falls through to the unencrypted branch and reports itself
+        // done, which is the "asked for encryption, silently got plaintext"
+        // outcome the openssl check a few lines below already refuses.
+        const secret = path.join(dir, 'empty.secret');
+        fs.writeFileSync(secret, '');
+
+        const run = runLoop({ BACKUP_ENCRYPTION_PASSPHRASE_FILE: secret });
+
+        expect(run.status).toBe(1);
+        expect(run.stdout).toMatch(/is empty/);
+        // Refused before anything was dumped, not after.
+        expect(run.archives).toEqual([]);
+    });
+
+    it('reads a passphrase file that has one, and seals with it', () => {
+        const secret = path.join(dir, 'good.secret');
+        fs.writeFileSync(secret, 'a passphrase with spaces\n');
+
+        const run = runLoop({ BACKUP_ENCRYPTION_PASSPHRASE_FILE: secret });
+
+        expect(run.status).toBe(0);
+        expect(run.archives.filter(f => f.endsWith('.gz.enc'))).toHaveLength(1);
+        // And the staging copy does not outlive the run.
+        expect(run.staging).toEqual([]);
+    });
+
+    withOpenssl('never leaves the plaintext dump in the archive directory', () => {
+        // Not even for the seconds between the dump and the seal: that
+        // directory being readable is the premise of the whole feature.
+        const run = runLoop({ BACKUP_ENCRYPTION_PASSPHRASE: 'passphrase' });
+
+        expect(run.status).toBe(0);
+        expect(run.archives).toEqual([expect.stringMatching(/^clawdia-.*\.gz\.enc$/)]);
+        expect(run.archives.some(f => f.endsWith('.gz'))).toBe(false);
+    });
+
+    withOpenssl('removes the partial plaintext when the dump fails', () => {
+        const run = runLoop({ BACKUP_ENCRYPTION_PASSPHRASE: 'passphrase', FAIL_DUMP: '1' });
+
+        expect(run.archives).toEqual([]);
+        expect(run.staging).toEqual([]);
+        expect(fs.readFileSync(path.join(dir, 'backups', '.backup-status'), 'utf8')).toMatch(/^dump-failed/);
+    });
+
+    withOpenssl('quarantines a sealed archive that will not read back, and keeps no plaintext', () => {
+        const run = runLoop({ BACKUP_ENCRYPTION_PASSPHRASE: 'passphrase', FAIL_VERIFY: '1' });
+
+        expect(run.archives).toEqual([expect.stringMatching(/\.gz\.enc\.unverified$/)]);
+        expect(run.staging).toEqual([]);
+        // A quarantined archive is not the day's backup.
+        expect(fs.existsSync(path.join(dir, 'backups', '.backup-ok'))).toBe(false);
+    });
+
+    it('leaves the unencrypted path exactly as it was', () => {
+        // Every deployment that has not set a passphrase runs this branch, and
+        // it has to be what it was before the feature existed.
+        const run = runLoop();
+
+        expect(run.status).toBe(0);
+        expect(run.archives).toEqual([expect.stringMatching(/^clawdia-.*\.gz$/)]);
+        expect(fs.existsSync(path.join(dir, 'backups', '.backup-ok'))).toBe(true);
     });
 });

--- a/tests/envValidation.test.js
+++ b/tests/envValidation.test.js
@@ -124,7 +124,7 @@ describe('SECRET_ENCRYPTION_KEY', () => {
     test('an unset key warns in production, naming what is exposed', () => {
         const [warning] = checkSecretEncryption({ NODE_ENV: 'production' });
         expect(warning).toMatch(/SECRET_ENCRYPTION_KEY is not set/);
-        expect(warning).toMatch(/backup/);
+        expect(warning).toMatch(/in the database and in every nightly backup archive/);
         // And says how to fix it, both halves: the variable and the sweep that
         // seals what is already stored.
         expect(warning).toMatch(/openssl rand -base64 32/);
@@ -145,6 +145,21 @@ describe('SECRET_ENCRYPTION_KEY', () => {
         // reading it as configured here would silence the one warning about it.
         expect(checkSecretEncryption({ NODE_ENV: 'production', SECRET_ENCRYPTION_KEY: '   ' }))
             .toHaveLength(1);
+    });
+
+    test('it stops claiming the backups when those are sealed too', () => {
+        // BACKUP_ENCRYPTION_PASSPHRASE closes the archive half on its own, and
+        // telling an operator who set it that their credentials are readable in
+        // every backup sends them looking for an exposure they have covered.
+        // The database half is what this variable is for, so it stays.
+        const [warning] = checkSecretEncryption({
+            NODE_ENV: 'production',
+            BACKUP_ENCRYPTION_PASSPHRASE: 'a passphrase',
+        });
+
+        expect(warning).toMatch(/SECRET_ENCRYPTION_KEY is not set/);
+        expect(warning).toMatch(/in the database\./);
+        expect(warning).not.toMatch(/backup archive/);
     });
 
     test('a short passphrase is called out on its own terms', () => {

--- a/tests/envValidation.test.js
+++ b/tests/envValidation.test.js
@@ -124,7 +124,11 @@ describe('SECRET_ENCRYPTION_KEY', () => {
     test('an unset key warns in production, naming what is exposed', () => {
         const [warning] = checkSecretEncryption({ NODE_ENV: 'production' });
         expect(warning).toMatch(/SECRET_ENCRYPTION_KEY is not set/);
-        expect(warning).toMatch(/in the database and in every nightly backup archive/);
+        expect(warning).toMatch(/in the clear in the database/);
+        // The archive half is qualified rather than stated flatly, so it is
+        // right for an operator who has sealed the archives and for one who
+        // has not.
+        expect(warning).toMatch(/BACKUP_ENCRYPTION_PASSPHRASE has not sealed/);
         // And says how to fix it, both halves: the variable and the sweep that
         // seals what is already stored.
         expect(warning).toMatch(/openssl rand -base64 32/);
@@ -147,19 +151,18 @@ describe('SECRET_ENCRYPTION_KEY', () => {
             .toHaveLength(1);
     });
 
-    test('it stops claiming the backups when those are sealed too', () => {
-        // BACKUP_ENCRYPTION_PASSPHRASE closes the archive half on its own, and
-        // telling an operator who set it that their credentials are readable in
-        // every backup sends them looking for an exposure they have covered.
-        // The database half is what this variable is for, so it stays.
-        const [warning] = checkSecretEncryption({
+    test('the answer does not depend on the backup container\'s secret', () => {
+        // It could be read to say whether the archives are sealed, and must not
+        // be: it is the backup container's passphrase, this process has no
+        // other use for one, and the bot's `env_file: .env` would then be
+        // holding a credential it does not need (#901). The message is worded
+        // to be right either way instead.
+        const sealed = checkSecretEncryption({
             NODE_ENV: 'production',
             BACKUP_ENCRYPTION_PASSPHRASE: 'a passphrase',
         });
 
-        expect(warning).toMatch(/SECRET_ENCRYPTION_KEY is not set/);
-        expect(warning).toMatch(/in the database\./);
-        expect(warning).not.toMatch(/backup archive/);
+        expect(sealed).toEqual(checkSecretEncryption({ NODE_ENV: 'production' }));
     });
 
     test('a short passphrase is called out on its own terms', () => {

--- a/tests/migrationShopImages.test.js
+++ b/tests/migrationShopImages.test.js
@@ -42,6 +42,9 @@ const bytes = text => Buffer.from(text);
 function fakeDb({ guilds = [], images = [], unique = true } = {}) {
     const order = [];
 
+    // The clear is addressed by _id, which a real cursor always carries.
+    guilds.forEach((guild, i) => { guild._id = guild._id ?? `guild-${i}`; });
+
     const hasInlineImage = g => (g.shop ?? []).some(i => i?.imageData != null);
 
     const cursor = docs => ({
@@ -55,22 +58,22 @@ function fakeDb({ guilds = [], images = [], unique = true } = {}) {
             expect(filter).toEqual({ 'shop.imageData': { $exists: true, $ne: null } });
             return cursor(guilds.filter(hasInlineImage));
         },
-        updateMany: async (filter, update) => {
-            order.push('clear');
-            expect(filter).toEqual({ 'shop.0': { $exists: true } });
-            expect(Object.keys(update)).toEqual(['$unset']);
-            let modified = 0;
-            for (const guild of guilds) {
-                if (!guild.shop?.length) continue;
-                modified++;
-                for (const item of guild.shop) {
+        updateOne: async (filter, update, options = {}) => {
+            // `up` clears the entries it moved, addressed by _id and an array
+            // filter; `down` restores one entry, addressed by the positional $.
+            if (update.$unset) {
+                order.push('clear');
+                const guild = guilds.find(g => g._id === filter._id);
+                const wanted = options.arrayFilters?.[0]?.['moved.itemId']?.$in ?? [];
+                let modified = 0;
+                for (const item of guild?.shop ?? []) {
+                    if (!wanted.includes(item.itemId)) continue;
                     delete item.imageData;
                     delete item.imageType;
+                    modified = 1;
                 }
+                return { modifiedCount: modified };
             }
-            return { modifiedCount: modified };
-        },
-        updateOne: async (filter, update) => {
             const guild = guilds.find(g => g.guildId === filter.guildId);
             const item = guild?.shop?.find(i => i.itemId === filter['shop.itemId']);
             if (!item) return { matchedCount: 0 };
@@ -183,8 +186,11 @@ describe('up', () => {
     it('writes one row per item id when a shop holds the same id twice', async () => {
         // Nothing stops a shop array holding two items with one `itemId`, and
         // two upserts to one key in an unordered bulkWrite race into a
-        // duplicate-key error. The later element wins, which is the one the
-        // image route could never reach anyway.
+        // duplicate-key error. The first wins, because that is the one the
+        // routes served — both resolved an id with `shop.find(...)`, so the
+        // second was already unreachable. Moving the second would change which
+        // artwork the guild sees, on a migration whose job is to move it
+        // unchanged.
         const db = fakeDb({
             guilds: [{
                 guildId: 'g1',
@@ -198,7 +204,7 @@ describe('up', () => {
         await migration.up();
 
         expect(db.images).toHaveLength(1);
-        expect(db.images[0].imageData).toEqual(bytes('second'));
+        expect(db.images[0].imageData).toEqual(bytes('first'));
     });
 
     it('skips an item with no id, which was never servable', async () => {
@@ -211,6 +217,44 @@ describe('up', () => {
         await migration.up();
 
         expect(db.images).toEqual([]);
+    });
+
+    it('leaves the inline image of an entry it could not move', async () => {
+        // Clearing it would be a delete with nothing written down: there is no
+        // key to store an image for an item with no id under, so there would be
+        // nothing for `down` to put back and no copy of it anywhere.
+        const db = fakeDb({
+            guilds: [{
+                guildId: 'g1',
+                shop: [
+                    { itemId: 'padlock', imageData: bytes('moved'), imageType: 'image/png' },
+                    { itemId: null, imageData: bytes('unmovable'), imageType: 'image/gif' },
+                ],
+            }],
+        });
+
+        await migration.up();
+
+        expect(db.guilds[0].shop[0]).toEqual({ itemId: 'padlock' });
+        expect(db.guilds[0].shop[1]).toEqual({
+            itemId: null, imageData: bytes('unmovable'), imageType: 'image/gif',
+        });
+    });
+
+    it('rewrites only the guilds it moved something out of', async () => {
+        // `$[]` over every shop in the collection rewrote every guild document
+        // that has one, including the ones with no image to move.
+        const db = fakeDb({
+            guilds: [
+                { guildId: 'g1', shop: [{ itemId: 'padlock', imageData: bytes('art') }] },
+                { guildId: 'g2', shop: [{ itemId: 'shield', price: 10 }] },
+            ],
+        });
+
+        await migration.up();
+
+        expect(db.guilds[1].shop[0]).toEqual({ itemId: 'shield', price: 10 });
+        expect(db.order.filter(op => op === 'clear')).toHaveLength(1);
     });
 
     it('refuses to run without the unique index the keys depend on', async () => {

--- a/tests/migrationShopImages.test.js
+++ b/tests/migrationShopImages.test.js
@@ -58,18 +58,20 @@ function fakeDb({ guilds = [], images = [], unique = true } = {}) {
             expect(filter).toEqual({ 'shop.imageData': { $exists: true, $ne: null } });
             return cursor(guilds.filter(hasInlineImage));
         },
-        updateOne: async (filter, update, options = {}) => {
+        updateOne: async (filter, update) => {
             // `up` clears the entries it moved, addressed by _id and an array
             // filter; `down` restores one entry, addressed by the positional $.
             if (update.$unset) {
                 order.push('clear');
                 const guild = guilds.find(g => g._id === filter._id);
-                const wanted = options.arrayFilters?.[0]?.['moved.itemId']?.$in ?? [];
                 let modified = 0;
-                for (const item of guild?.shop ?? []) {
-                    if (!wanted.includes(item.itemId)) continue;
-                    delete item.imageData;
-                    delete item.imageType;
+                for (const path of Object.keys(update.$unset)) {
+                    // `shop.<index>.<field>` — addressed by position, so a
+                    // duplicate id cannot drag its sibling's image out with it.
+                    const [, index, field] = path.split('.');
+                    const item = guild?.shop?.[Number(index)];
+                    if (!item || !(field in item)) continue;
+                    delete item[field];
                     modified = 1;
                 }
                 return { modifiedCount: modified };
@@ -205,6 +207,32 @@ describe('up', () => {
 
         expect(db.images).toHaveLength(1);
         expect(db.images[0].imageData).toEqual(bytes('first'));
+        // And the one that was not moved keeps its inline image: there is no key
+        // to store a second image for one id under, so clearing it would be a
+        // delete with nothing written down.
+        expect(db.guilds[0].shop[0]).toEqual({ itemId: 'padlock' });
+        expect(db.guilds[0].shop[1]).toEqual({ itemId: 'padlock', imageData: bytes('second') });
+    });
+
+    it('takes the entry the routes resolved, even when it is the empty one', () => {
+        // `shop.find(...)` returns the first entry with the id whatever its
+        // image, so an empty first duplicate is a guild that saw no shop image
+        // for it. Moving the second one's artwork would put a picture on screen
+        // that was not there before, which is not a migration's job.
+        const db = fakeDb({
+            guilds: [{
+                guildId: 'g1',
+                shop: [
+                    { itemId: 'padlock', imageData: null },
+                    { itemId: 'padlock', imageData: bytes('hidden') },
+                ],
+            }],
+        });
+
+        return migration.up().then(() => {
+            expect(db.images).toEqual([]);
+            expect(db.guilds[0].shop[1].imageData).toEqual(bytes('hidden'));
+        });
     });
 
     it('skips an item with no id, which was never servable', async () => {

--- a/tests/shopImageOrphans.test.js
+++ b/tests/shopImageOrphans.test.js
@@ -1,0 +1,151 @@
+'use strict';
+
+/**
+ * #888, the other side of moving shop images out of the guild document.
+ *
+ * Inline, an item's image was part of the item: deleting the item from the shop
+ * deleted its artwork with it, because the settings save rewrote the array the
+ * Buffer lived in. As a row in `itemimages` the image outlives the item unless
+ * something removes it — and nothing else would. The retention prune only
+ * covers archive files, the image route only reads, and no read reaches a row
+ * whose item is gone. That is a 512 KB document per removed item, accumulating
+ * for as long as an admin keeps editing their shop.
+ *
+ * So the settings endpoint removes the rows for the ids that actually went, and
+ * only those: an id that survives the rewrite, or is re-added in the same
+ * request under the same name, keeps its artwork.
+ */
+
+const express = require('express');
+
+jest.mock('../src/dashboard/lib/middleware', () => ({
+    checkAuth: (_req, _res, next) => next(),
+    checkGuildAccess: (_req, _res, next) => next(),
+    checkWriteRateLimit: (_req, _res, next) => next(),
+}));
+jest.mock('../src/dashboard/lib/apiHelpers', () => ({
+    ...jest.requireActual('../src/dashboard/lib/apiHelpers'),
+    logAuditEvent: jest.fn(async () => {}),
+}));
+jest.mock('../src/models/Guild');
+jest.mock('../src/models/ItemImage');
+
+const Guild = require('../src/models/Guild');
+const ItemImage = require('../src/models/ItemImage');
+
+let server;
+let baseUrl;
+let doc;
+
+/** A settings document whose `set('shop', …)` behaves the way Mongoose's does. */
+function guildDoc(shop) {
+    return {
+        guildId: 'g1',
+        shop,
+        set: jest.fn(function set(key, value) { this[key] = value; }),
+        save: jest.fn(async () => {}),
+    };
+}
+
+const item = itemId => ({ itemId, name: itemId, price: 10 });
+
+beforeAll(done => {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => { req.user = { id: 'admin-1' }; next(); });
+    app.use('/api', require('../src/dashboard/routes/api/settings'));
+    server = app.listen(0, () => {
+        baseUrl = `http://127.0.0.1:${server.address().port}`;
+        done();
+    });
+});
+
+afterAll(done => { server.close(done); });
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    doc = guildDoc([item('padlock'), item('shield')]);
+    Guild.findOne.mockResolvedValue(doc);
+    ItemImage.deleteMany.mockResolvedValue({ deletedCount: 1 });
+});
+
+const saveShop = shop =>
+    fetch(`${baseUrl}/api/guild/g1/settings`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ shop }),
+    });
+
+describe('removing an item from the shop', () => {
+    it('takes its image with it, the way the inline Buffer used to', async () => {
+        const res = await saveShop([item('padlock')]);
+
+        expect(res.status).toBe(200);
+        expect(ItemImage.deleteMany).toHaveBeenCalledWith({
+            guildId: 'g1',
+            itemId: { $in: ['shop:shield'] },
+        });
+    });
+
+    it('leaves the images of the items that stayed', async () => {
+        await saveShop([item('padlock')]);
+
+        const [{ itemId }] = ItemImage.deleteMany.mock.calls[0];
+        expect(itemId.$in).not.toContain('shop:padlock');
+    });
+
+    it('deletes nothing when the shop is only reordered or edited', async () => {
+        await saveShop([item('shield'), { ...item('padlock'), price: 99 }]);
+
+        expect(ItemImage.deleteMany).not.toHaveBeenCalled();
+    });
+
+    it('keeps the artwork of an item re-added under the same id in one request', async () => {
+        // An admin who deletes a row and adds it back before pressing save has
+        // not asked for the artwork to go.
+        await saveShop([item('padlock'), item('shield')]);
+
+        expect(ItemImage.deleteMany).not.toHaveBeenCalled();
+    });
+
+    it('touches nothing when the request is not about the shop at all', async () => {
+        const res = await fetch(`${baseUrl}/api/guild/g1/settings`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ 'economy.currencySymbol': '🪙' }),
+        });
+
+        expect(res.status).toBe(200);
+        expect(ItemImage.deleteMany).not.toHaveBeenCalled();
+    });
+
+    it('deletes only after the save, so a rejected write keeps every image', async () => {
+        doc.save.mockRejectedValue(new Error('write concern failed'));
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        const res = await saveShop([item('padlock')]);
+
+        expect(res.status).toBe(500);
+        expect(ItemImage.deleteMany).not.toHaveBeenCalled();
+    });
+
+    it('reports the save as saved even when the cleanup fails', async () => {
+        // The settings the admin asked for are written. A row left behind is
+        // something to collect later, not a reason to tell them it did not save.
+        const errors = jest.spyOn(console, 'error').mockImplementation(() => {});
+        ItemImage.deleteMany.mockRejectedValue(new Error('connection reset'));
+
+        const res = await saveShop([item('padlock')]);
+
+        expect(res.status).toBe(200);
+        expect(errors).toHaveBeenCalledWith('[SETTINGS] shop image cleanup failed:', 'connection reset');
+    });
+
+    it('never reaches outside the guild being edited', async () => {
+        await saveShop([]);
+
+        expect(ItemImage.deleteMany).toHaveBeenCalledWith(
+            expect.objectContaining({ guildId: 'g1' }),
+        );
+    });
+});


### PR DESCRIPTION
Follow-up to #981, which shipped #884/#886/#888/#900/#907. Review found eight things; six held up against the code.

## Fixed

**An empty `BACKUP_ENCRYPTION_PASSPHRASE_FILE` produced plaintext archives, silently.** `[ -n "$BACKUP_ENCRYPTION_PASSPHRASE" ]` is satisfied by a file existing, not by its contents, so a secret mounted at the wrong path — or one not filled in yet — fell through to the unencrypted branch and reported the run as done. That is the "asked for encryption, silently got plaintext" outcome the `openssl` check a few lines below already refuses. It is refused the same way `MONGODB_URI_FILE`'s emptiness is, in both stack files.

The service's entrypoint is now driven rather than only grepped: `tests/backupArchiveEncryption.test.js` extracts the inline `sh -c` script, points its paths at a scratch tree, and runs it against stub mongo tools. That covers the empty file, the plaintext never reaching the archive directory, what each failure path leaves behind, and that the unencrypted branch is unchanged.

**`scripts/backup.sh` held the staging invariant only on the happy path.** It dumped into `BACKUP_DIR` and encrypted in place, so a readable copy of the whole database sat in the archive directory between the two steps — and stayed there if `openssl` failed. It stages into a private temp directory now and moves only the finished ciphertext in; a failed seal keeps nothing.

**An item removed from the shop left its `ItemImage` row behind.** Inline, the image was part of the item and went with it. As a row nothing can reach it is 512 KB that nothing would ever reclaim — the prune covers archive files, the image route only reads, and no read reaches a row whose item is gone. #981 called that orphan deliberate; it was not. The settings save now deletes the rows for the ids that actually went, after the save and never fatally. An id that survives a shop rewrite, or is re-added in the same request, keeps its artwork.

**Migration 022 moved the wrong one of two shop entries sharing an `itemId`.** Its own comment said the routes served the first — they do, both resolve an id with `shop.find(...)` — while the code kept the last. Moving the second would change which artwork a guild sees, on a migration whose job is to move it unchanged.

**Migration 022's cleanup was too broad.** `$[]` unset every shop entry in every guild with a shop, which rewrote documents it had taken nothing out of and destroyed the image on any entry it had skipped. An item with no `itemId` has no key to be moved under, so clearing it is a delete with nothing written down and nothing for `down()` to restore. It clears only the entries it moved now, still only after every one is written.

**The startup warning overstated the exposure.** It claimed the provider keys were readable "in every nightly backup archive" even where `BACKUP_ENCRYPTION_PASSPHRASE` had sealed them, which sends an operator looking for something they have already covered. The database half is unconditional; the archive half is not.

## Not taken

**Replacing AES-256-CBC with an authenticated format binding archive name and version.** What CBC costs here is tamper detection, and that is written up in `scripts/lib/archive.sh` as the accepted trade-off: `openssl enc` has no AEAD mode reachable from the CLI, and the stock mongo image the backup service runs in carries no other tool. A bespoke archive format is a larger change than the exposure it addresses, and encryption is strictly an improvement on the unauthenticated plaintext it replaced.

**`no-store` on the item-image responses.** `private` already keeps them out of shared caches, and the cache in question belongs to the admin who was authorised. It is the pre-existing choice for both image routes with its reasoning in the source, and re-fetching every thumbnail on every panel load is a real cost for a 35-item shop.

## Validation

`npx eslint .` clean. 375 suites / 7,435 tests pass; `coverage:check` and the global thresholds pass (52.53/42.75/54.58/53.86 against 51/41/53/52). The three `tests/integration/` suites need a real mongod and cannot run in this environment.

Beyond the test suite, the changed shell was exercised directly: the compose entrypoint against stub mongo tools across the encrypted, unencrypted, dump-failure and verify-failure paths, and `backup.sh` through a real `openssl` round trip plus an induced seal failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191fqu1jAo9MJ3hHKK4MWh1

---
_Generated by [Claude Code](https://claude.ai/code/session_0191fqu1jAo9MJ3hHKK4MWh1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup encryption safety by rejecting empty passphrases and preventing plaintext or incomplete archives from being left behind.
  * Preserved shop-item artwork when items are reordered, edited, or re-added.
  * Removed artwork only for shop items that are actually deleted.
  * Improved warnings about unencrypted credentials based on backup encryption settings.
* **Tests**
  * Added coverage for encrypted backups, failure cleanup, passphrase validation, migration behavior, and shop-image lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->