### PR TITLE
Lint the ops files, publish arm64, and four smaller issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,8 +276,8 @@ jobs:
   # `test` rather than after it: the two answer different questions, and a red
   # suite should not hide a broken image any more than the reverse.
   #
-  # What `publish: needs: [test, image]` buys is worth stating precisely, because
-  # `needs:` orders the two jobs and nothing more — it does not hand this image
+  # What `publish: needs: […, image, …]` buys is worth stating precisely, because
+  # `needs:` orders the jobs and nothing more — it does not hand this image
   # over, and that job builds again before it pushes. So the guarantee is that
   # the same commit, Dockerfile, lockfile and digest-pinned base produced an
   # image that booted and scanned clean; it is not byte identity, because
@@ -286,15 +286,18 @@ jobs:
   # publish build is a cache hit rather than a second compile, and a cache hit is
   # the same layers. The residue is a cache miss inside a single run.
   #
-  # All of that is about amd64, and since #941 the publish job builds arm64 as
-  # well, which nothing here boots or scans. Deliberately: buildx cannot
-  # `--load` a multi-platform result — there is no single image for `docker run`
-  # to name — so holding arm64 to this standard means a second, emulated build
-  # of a tree that compiles `canvas` from source, on every pull request. What
-  # arm64 does get is that compile: the toolchain, the headers and the native
-  # binding are exactly what an architecture change breaks, and a failure there
-  # fails the publish. docs/SETUP_GUIDE.md says what the difference means for
-  # somebody running the published image on a Pi.
+  # All of that is about amd64. Since #941 the publish job also builds arm64,
+  # and the `arm64` job below is what holds that half to the same vulnerability
+  # gate before the manifest list goes out. It is a job of its own rather than
+  # more steps here for two reasons: buildx cannot `--load` a multi-platform
+  # result, so the scan needs a single-platform build to name, and that build is
+  # emulated — minutes of it, on a tree that compiles `canvas` from source —
+  # which is not a cost worth paying on a pull request that publishes nothing.
+  #
+  # So the two differ, and docs/SETUP_GUIDE.md says how: amd64 is booted and
+  # scanned on every event, arm64 is compiled and scanned on the events that
+  # publish. Booting arm64 as well would mean running an emulated Node through
+  # its whole require graph, and is not done.
   #
   # Closing it properly means pushing a staging tag from here and promoting it by
   # digest, which needs `packages: write` in a job that also runs on pull
@@ -304,8 +307,8 @@ jobs:
     name: Build, boot and scan Docker image
     runs-on: ubuntu-latest
     # On a cold cache this compiles canvas from source, which is minutes rather
-    # than seconds; a warm one is a small fraction of that. Matches the publish
-    # job's budget, since it is the same build.
+    # than seconds; a warm one is a small fraction of that. Native throughout —
+    # the emulated build that needs a bigger budget is the `arm64` job below.
     timeout-minutes: 30
     outputs:
       # Read by `publish` so both builds carry the same value — see the step
@@ -348,8 +351,13 @@ jobs:
           # otherwise leaves its result in the builder cache and nowhere else.
           load: true
           tags: ${{ env.SMOKE_IMAGE }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Scoped per platform. Both this job and `arm64` below export a cache
+          # on every push, and a buildx export replaces the whole manifest for
+          # the scope it writes — unscoped, the second to finish would evict the
+          # first and `publish` would rebuild whichever it lost. The names are
+          # what `publish` reads back.
+          cache-from: type=gha,scope=amd64
+          cache-to: type=gha,mode=max,scope=amd64
 
       # Everything that is true of the image rather than of the source tree: the
       # native canvas binding actually links, the fonts the card generators
@@ -415,7 +423,84 @@ jobs:
           exit-code: '1'
           format: table
 
-  # Publishing lives here, behind `needs: [test, image]`, rather than in its own
+  # The arm64 half of what `publish` pushes, built and scanned before it goes
+  # out. Added because the multi-platform publish of #941 put an image into the
+  # manifest list that the Trivy gate had never looked at — the gate's whole
+  # premise, stated on the scan step above, is that a finding stops the image
+  # existing rather than being raised against one already deployed, and that
+  # premise did not survive the second platform.
+  #
+  # Only where it can matter. Nothing publishes on a pull request, and this is
+  # an emulated build of the stage that compiles `canvas` from source, so the
+  # condition below is what keeps that cost off every PR. `needs: image` is for
+  # the apk refresh key: the same value has to reach all three builds, or they
+  # are three different images and this scans one nobody ships.
+  #
+  # What this buys is what the amd64 pair buys, with the same residue: the same
+  # commit, Dockerfile, lockfile and digest-pinned base produced an arm64 image
+  # that scanned clean, and the cache is what makes the build `publish` pushes
+  # the same layers rather than merely the same inputs.
+  arm64:
+    name: Build and scan the arm64 image
+    needs: image
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    # Emulated, and cold on the first build after a Dockerfile or lockfile
+    # change: tens of minutes rather than the handful the native build takes.
+    timeout-minutes: 90
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Same pin, and for a weaker version of the same reason as in `publish`:
+      # this job holds no registry credential, but a mutable image run
+      # `--privileged` against the checkout is not something to leave floating
+      # anywhere. Both steps move together.
+      - name: Set up QEMU for the arm64 build
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
+        with:
+          image: docker.io/tonistiigi/binfmt:qemu-v9.2.2@sha256:1b804311fe87047a4c96d38b4b3ef6f62fca8cd125265917a9e3dc3c996c39e6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Build the arm64 image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: linux/arm64
+          build-args: |
+            APK_REFRESH=${{ needs.image.outputs.apk-refresh }}
+          # Never pushed from here: this job has no credentials and the manifest
+          # list is `publish`'s to assemble. `load` is what gives the scan below
+          # something to name.
+          push: false
+          load: true
+          tags: ${{ env.SMOKE_IMAGE }}-arm64
+          cache-from: type=gha,scope=arm64
+          cache-to: type=gha,mode=max,scope=arm64
+
+      # Same narrowings as the amd64 scan above, and deliberately the same: the
+      # two platforms are gated at one bar or the bar means nothing.
+      #
+      # Trivy reads the image's layers rather than running it, so an arm64
+      # filesystem is as scannable on this runner as a native one. The findings
+      # are usually the same as amd64's — both stages install the same Alpine
+      # packages from the same repository — and "usually" is the reason this
+      # exists.
+      - name: Scan the arm64 image for known vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.SMOKE_IMAGE }}-arm64
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '1'
+          format: table
+
+  # Publishing lives here, behind `needs: [test, image, arm64]`, rather than in its own
   # workflow. It used to be a separate file triggered on `push: main`, which
   # ran alongside the tests instead of after them: a commit that broke the
   # suite still got built and pushed as `:latest`, and `:latest` is the tag
@@ -426,18 +511,17 @@ jobs:
   # simply depends on the one before it in the same run.
   publish:
     name: Build and publish Docker image
-    needs: [test, image]
+    needs: [test, image, arm64]
     # Pull requests build the image in the `image` job above but publish
     # nothing: they have no push credentials worth using and no tag that
     # anything deploys. Pushes to main and to v* tags do.
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     # Three times the `image` job's budget, for the arm64 half added in #941.
-    # That half is emulated and this tree compiles `canvas` from source, so a
-    # cold cache here is tens of minutes rather than the handful an amd64 build
-    # takes. A warm one is a small fraction of that — emulated layers cache like
-    # any others — so this is the ceiling for the first build after a Dockerfile
-    # or lockfile change, not the cost of an ordinary merge.
+    # In the ordinary case this job builds nothing: `image` and `arm64` have
+    # each just built and checked their platform, and this assembles the
+    # manifest list out of their caches. The budget is for the case where one of
+    # those restores misses and buildx compiles `canvas` under emulation again.
     timeout-minutes: 90
     permissions:
       contents: read
@@ -531,12 +615,28 @@ jobs:
           # for @napi-rs/canvas, which ships prebuilt musl binaries for both
           # architectures and would turn this compile into a download twice
           # over.
+          #
+          # Neither platform reaches the registry unscanned: `image` boots and
+          # scans amd64, `arm64` scans arm64, and both gate this job through
+          # `needs:`.
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Both platform scopes, and no export of its own. `image` and `arm64`
+          # are the producers — each has just built and checked the platform it
+          # writes — so this build is meant to be two cache hits and an assembly
+          # of the manifest list. Exporting from here would write a third
+          # manifest over one of theirs for no gain.
+          #
+          # A miss is slow rather than wrong: buildx rebuilds the platform it
+          # could not restore, which for arm64 is the emulated compile the
+          # timeout above is sized for. It is also what makes "the image that
+          # scanned clean" and "the image that was pushed" the same layers
+          # rather than merely the same inputs.
+          cache-from: |
+            type=gha,scope=amd64
+            type=gha,scope=arm64
           # Attestations, attached to the image in the registry (#652).
           # `sbom` is an SPDX inventory of what the image contains, which is
           # what turns "does any published build ship the vulnerable version?"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,8 +488,18 @@ jobs:
       # Registers the binfmt handlers that let the arm64 half of the build below
       # run its RUN steps on this amd64 runner (#941). Only the publish job
       # needs it: the `image` job builds one native platform and loads it.
+      #
+      # `image` is pinned for the same reason every `uses:` in this job is. The
+      # action's default is `tonistiigi/binfmt:latest`, a mutable tag it then
+      # runs `--privileged` — in the one job holding `packages: write`, after
+      # the GHCR login above. A repointed tag there is arbitrary privileged code
+      # beside a registry credential, which is precisely the exposure the SHA
+      # pinning below was written against. Tag kept beside the digest, as in the
+      # Dockerfile: the digest is what resolves, the tag is the readable half.
       - name: Set up QEMU for the arm64 build
         uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
+        with:
+          image: docker.io/tonistiigi/binfmt:qemu-v9.2.2@sha256:1b804311fe87047a4c96d38b4b3ef6f62fca8cd125265917a9e3dc3c996c39e6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,57 @@ jobs:
         if: always()
         run: npm run lint
 
+      # #940: CI lints and tests the JavaScript thoroughly and checked nothing
+      # about the files that deploy it. The four steps below are the ops half,
+      # and they are steps in this job rather than a job of their own for the
+      # reason the lint step above already is: one of them needs `npm ci` for
+      # js-yaml, and a second job would pay for that install again to save a few
+      # seconds. `always()` throughout, so a red suite never hides them and they
+      # never hide each other.
+      #
+      # This was not a hypothetical gap. The first run of the third step found
+      # that both stack files' backup entrypoints had been truncated two thirds
+      # of the way through by an apostrophe in a comment — compose splits a
+      # string entrypoint into arguments, and a single quote inside the script
+      # ends it — so the backup container had been starting, failing to parse
+      # its own script, and exiting. See scripts/lint-stack-shell.js.
+      - name: Lint the Dockerfile
+        if: always()
+        uses: hadolint/hadolint-action@06be81baf89a55ffd0e24b8f04a4185738dd3387 # v3.5.0
+        with:
+          dockerfile: Dockerfile
+          # The rule this turns off, and why, are recorded in the file itself.
+          config: .hadolint.yaml
+
+      # ubuntu-latest ships shellcheck, so this needs no install and no action.
+      # `-x` follows `. lib/archive.sh`, which restore.sh and verify-backup.sh
+      # both source — without it the shared functions are unchecked and every
+      # variable they set reads as unassigned in the scripts that use them.
+      - name: Lint the shell scripts
+        if: always()
+        run: |
+          shellcheck --version
+          shellcheck -x --severity=warning scripts/*.sh scripts/lib/*.sh
+
+      - name: Lint the shell inside the stack files
+        if: always()
+        run: npm run lint:stacks
+
+      # Neither stack file is parsed by anything else in CI, so a typo in one
+      # was found by the deploy that failed on it. `--quiet` because the point
+      # is the exit code: interpolation resolves, the schema is honoured, every
+      # anchor and merge key lands. .env.example stands in for the .env an
+      # operator writes — services declare `env_file: .env`, and a compose
+      # version that treats a missing one as fatal would otherwise fail here for
+      # a reason that has nothing to do with the file being checked.
+      - name: Validate both stack files
+        if: always()
+        run: |
+          cp .env.example .env
+          docker compose -f docker-compose.yml config --quiet
+          docker compose -f portainer-stack.yml config --quiet
+          rm -f .env
+
       # #645: CI gated on the tests and nothing else, so a dependency with a
       # published advisory reached the image with nothing in the way. Dependabot
       # raises the bump, but a bump nobody merges is not a control; this is what
@@ -227,6 +278,7 @@ jobs:
   # The `type=gha` cache this job writes is what closes that in practice: the
   # publish build is a cache hit rather than a second compile, and a cache hit is
   # the same layers. The residue is a cache miss inside a single run.
+  #
   #
   # Closing it properly means pushing a staging tag from here and promoting it by
   # digest, which needs `packages: write` in a job that also runs on pull

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,13 @@ jobs:
           dockerfile: Dockerfile
           # The rule this turns off, and why, are recorded in the file itself.
           config: .hadolint.yaml
+          # Repeated from that file because it has to be. The action passes this
+          # input through the environment and the environment beats the config,
+          # so leaving it at the action's `info` default would silently discard
+          # the threshold .hadolint.yaml states — which is how the first run of
+          # this step failed, on an info-level finding the file had already
+          # decided not to gate on.
+          failure-threshold: warning
 
       # ubuntu-latest ships shellcheck, so this needs no install and no action.
       # `-x` follows `. lib/archive.sh`, which restore.sh and verify-backup.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,15 @@ jobs:
   # publish build is a cache hit rather than a second compile, and a cache hit is
   # the same layers. The residue is a cache miss inside a single run.
   #
+  # All of that is about amd64, and since #941 the publish job builds arm64 as
+  # well, which nothing here boots or scans. Deliberately: buildx cannot
+  # `--load` a multi-platform result — there is no single image for `docker run`
+  # to name — so holding arm64 to this standard means a second, emulated build
+  # of a tree that compiles `canvas` from source, on every pull request. What
+  # arm64 does get is that compile: the toolchain, the headers and the native
+  # binding are exactly what an architecture change breaks, and a failure there
+  # fails the publish. docs/SETUP_GUIDE.md says what the difference means for
+  # somebody running the published image on a Pi.
   #
   # Closing it properly means pushing a staging tag from here and promoting it by
   # digest, which needs `packages: write` in a job that also runs on pull
@@ -416,7 +425,13 @@ jobs:
     # anything deploys. Pushes to main and to v* tags do.
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Three times the `image` job's budget, for the arm64 half added in #941.
+    # That half is emulated and this tree compiles `canvas` from source, so a
+    # cold cache here is tens of minutes rather than the handful an amd64 build
+    # takes. A warm one is a small fraction of that — emulated layers cache like
+    # any others — so this is the ceiling for the first build after a Dockerfile
+    # or lockfile change, not the cost of an ordinary merge.
+    timeout-minutes: 90
     permissions:
       contents: read
       packages: write
@@ -463,6 +478,12 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
 
+      # Registers the binfmt handlers that let the arm64 half of the build below
+      # run its RUN steps on this amd64 runner (#941). Only the publish job
+      # needs it: the `image` job builds one native platform and loads it.
+      - name: Set up QEMU for the arm64 build
+        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
@@ -479,6 +500,21 @@ jobs:
           # midnight UTC is exactly the case worth not leaving to chance.
           build-args: |
             APK_REFRESH=${{ needs.image.outputs.apk-refresh }}
+          # #941: the image was amd64 only, which rules out a Raspberry Pi, an
+          # Oracle Ampere instance and an Apple Silicon machine — three of the
+          # commonest places somebody self-hosts a Discord bot, and an odd set
+          # to exclude from a project whose whole pitch is that you host it
+          # yourself. Both platforms go out under one tag as a manifest list, so
+          # `docker pull` on either resolves without anybody choosing.
+          #
+          # It is not free: arm64 is emulated on an amd64 runner and this tree
+          # compiles `canvas` from source, which is what the raised timeout
+          # above is for. The dependency is worth naming here, because it is the
+          # whole of the cost — docs/CANVAS_BACKEND.md records the measured case
+          # for @napi-rs/canvas, which ships prebuilt musl binaries for both
+          # architectures and would turn this compile into a download twice
+          # over.
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -21,5 +21,10 @@ ignored:
 # Warnings and errors fail the build; info and style are reported and do not.
 # Same bar as `npm audit --audit-level=high` and the image scan's
 # HIGH,CRITICAL: a gate that is normally red is a gate everyone learns to
-# merge past.
+# merge past. DL3066 on `USER node` is the one that lands under it today.
+#
+# This governs a local `hadolint` run and nothing else. hadolint-action passes
+# its own `failure-threshold` input through the environment, which wins over
+# this file, so ci.yml sets that input to the same word — the two have to be
+# changed together, and this comment is the only thing saying so.
 failure-threshold: warning

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,25 @@
+# hadolint, for the Dockerfile (#940).
+#
+# One rule is turned off, and it is turned off rather than worked around
+# because the Dockerfile disagrees with it on purpose.
+ignored:
+  # DL3018: "Pin versions in apk add".
+  #
+  # The runtime stage opens with `apk upgrade` and a build argument whose whole
+  # job is to make that upgrade re-resolve daily (#961) — the point being to
+  # take an Alpine fix the day it lands rather than waiting for a node:24-alpine
+  # rebuild to carry it. Pinning the six shared libraries beside it would freeze
+  # exactly what that is there to keep moving, and the reproducibility DL3018
+  # protects is already held from above: every FROM carries an @sha256 digest
+  # (#644), and tests/imagePinning.test.js fails if one loses it.
+  #
+  # The trade is written out in the Dockerfile's own comments, and it is the
+  # image scan in CI — Trivy, HIGH and CRITICAL, before anything is pushed —
+  # that says when an unpinned package has become a problem.
+  - DL3018
+
+# Warnings and errors fail the build; info and style are reported and do not.
+# Same bar as `npm audit --audit-level=high` and the image scan's
+# HIGH,CRITICAL: a gate that is normally red is a gate everyone learns to
+# merge past.
+failure-threshold: warning

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,11 +79,19 @@ repository nothing checked, which is a poor place for it given that most of it
 is the backup path. Four gates, all of them seconds:
 
 ```bash
-hadolint --config .hadolint.yaml Dockerfile
+hadolint Dockerfile                       # v2.15.1, the version CI's action pins
 shellcheck -x --severity=warning scripts/*.sh scripts/lib/*.sh
 npm run lint:stacks                       # the shell inside the stack files
 docker compose -f docker-compose.yml config --quiet
 ```
+
+hadolint picks up `.hadolint.yaml` from the working directory on its own, so
+run it from the repo root and it will agree with CI — but only on the same
+version. It gained rules between 2.14 and 2.15, and CI is what decides: the
+action pins its own hadolint, and a bump can arrive as a red build on a
+Dockerfile nobody edited. That is the linter working; read the rule, and either
+fix the line or record the disagreement the way `.hadolint.yaml` and the
+`DL3025` note above the `HEALTHCHECK` already do.
 
 `npm run lint:stacks` is the odd one and the one worth knowing about. Both stack
 files run their backup on an eleven-kilobyte shell script written inline as

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,29 @@ applies Jest's global thresholds, and `npm run coverage:check` applies the
 per-directory floors. CI runs both — see [Coverage](#coverage) below.
 `npm run lint:fix` applies what ESLint can fix on its own.
 
+The ops files are linted too, and they used not to be (#940) — the shell in
+`scripts/` and in the two stack files was the only substantial code in the
+repository nothing checked, which is a poor place for it given that most of it
+is the backup path. Four gates, all of them seconds:
+
+```bash
+hadolint --config .hadolint.yaml Dockerfile
+shellcheck -x --severity=warning scripts/*.sh scripts/lib/*.sh
+npm run lint:stacks                       # the shell inside the stack files
+docker compose -f docker-compose.yml config --quiet
+```
+
+`npm run lint:stacks` is the odd one and the one worth knowing about. Both stack
+files run their backup on an eleven-kilobyte shell script written inline as
+`entrypoint: > sh -c '…'`, and **compose splits that string into arguments
+before the container starts**: one single quote inside the script — an
+apostrophe in a comment is enough — ends it, and the rest becomes positional
+arguments that never run. That had already happened to both files, and the
+symptom was a backup container that started, failed to parse its own script and
+exited, saying nothing anywhere anyone looks. So: no apostrophes in those
+entrypoints, reword instead, and `tests/stackEntrypointShell.test.js` holds it
+on every `npm test` whether or not shellcheck is installed.
+
 ### Formatting
 
 Formatting is `npm run format -- <paths>`, and it takes explicit paths on

--- a/Dockerfile
+++ b/Dockerfile
@@ -201,6 +201,15 @@ EXPOSE 3000
 # and nothing else, and /health on that port is the only HTTP it answers. The
 # dashboard container runs the same image with neither variable set, so it falls
 # through to DASHBOARD_PORT exactly as before.
+#
+# DL3025 wants JSON notation for this CMD and it stays shell form (#940). The
+# command is one `node -e` whose argument is a JavaScript program full of
+# quotes; in a JSON array every one of them is escaped by hand, and the line
+# below is already the least readable in this file. Exec form would also drop
+# the `/bin/sh -c` the check currently goes through, which changes how a
+# deployed container reports its health — worth doing deliberately, if ever,
+# and not as a side effect of turning a linter on.
+# hadolint ignore=DL3025
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=90s \
     CMD node -e "require('http').get('http://127.0.0.1:' + (process.env.BOT_GATEWAY_PORT || process.env.DASHBOARD_PORT || 3000) + '/health', r => { let b=''; r.on('data', d => b += d); r.on('end', () => { try { process.exit(JSON.parse(b).status === 'unhealthy' ? 1 : 0); } catch { process.exit(1); } }); }).on('error', () => process.exit(1))"
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ moderation attached, that is what she is built for.
 | [docs/EXTENDING.md](docs/EXTENDING.md) | Adding a command, a route, a model or a dashboard panel |
 | [docs/RELEASING.md](docs/RELEASING.md) | Cutting a release |
 | [docs/CANVAS_BACKEND.md](docs/CANVAS_BACKEND.md) | What the image's native build toolchain is for, and the measured case for replacing it |
+| [docs/AUDIT_LOG.md](docs/AUDIT_LOG.md) | Which subsystems have been through a line-by-line audit, what each one found, and the much longer list of what has not been audited |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Getting set up, the coverage ratchets, and what surprises people |
 
 Each topic is written in exactly one of them. AI provider setup, Daily News and

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,6 +124,14 @@ services:
     environment:
       MONGODB_ROOT_USERNAME: ${MONGODB_ROOT_USERNAME:-}
       MONGODB_ROOT_PASSWORD: ${MONGODB_ROOT_PASSWORD:-}
+    # No apostrophes below — not in a comment either (#940). Compose splits a
+    # string entrypoint into arguments before the container starts, so the first
+    # single quote inside this script closes the one that opened it and
+    # everything after becomes positional arguments that never run. That is not
+    # a warning in the abstract: "the day's backup", in a comment two thirds of
+    # the way down the backup entrypoint, had been truncating it mid-`if` in
+    # both stack files. Reword; there is no escape for one in this form.
+    # tests/stackEntrypointShell.test.js fails on the next one.
     entrypoint: >
       sh -c '
         # The host:port the members list will carry, which is how every client
@@ -481,6 +489,14 @@ services:
     depends_on:
       mongodb:
         condition: service_healthy
+    # No apostrophes below — not in a comment either (#940). Compose splits a
+    # string entrypoint into arguments before the container starts, so the first
+    # single quote inside this script closes the one that opened it and
+    # everything after becomes positional arguments that never run. That is not
+    # a warning in the abstract: "the day's backup", in a comment two thirds of
+    # the way down the backup entrypoint, had been truncating it mid-`if` in
+    # both stack files. Reword; there is no escape for one in this form.
+    # tests/stackEntrypointShell.test.js fails on the next one.
     entrypoint: >
       sh -c '
         if [ -n "$$MONGODB_URI_FILE" ]; then
@@ -601,10 +617,11 @@ services:
           if ! mongodump --uri="$$MONGODB_URI" --gzip --archive="$$WORK"; then
             # mongodump has no rollback: a dump killed part-way through leaves
             # whatever it had written under the real name. Left there, that
-            # partial file is what the boot catch-up counts as the day's backup
-            # and what `verify-backup.sh --latest` picks up — a failure that
-            # reads as a success. Quarantined under the same suffix a failed
-            # verification uses, so it is still pruned and still there to look at.
+            # partial file is what the boot catch-up counts as the backup for
+            # that day and what `verify-backup.sh --latest` picks up — a failure
+            # that reads as a success. Quarantined under the same suffix a
+            # failed verification uses, so it is still pruned and still there to
+            # look at.
             # Encrypting, the partial dump is plaintext in /tmp and is removed:
             # there is nothing there worth keeping that would be safe to keep.
             if [ "$$WORK" = "$$ARCHIVE" ]; then
@@ -650,10 +667,11 @@ services:
           if ! mongorestore --uri="$$MONGODB_URI" --gzip --archive="$$WORK" --dryRun --quiet; then
             # Renamed rather than kept or deleted. Kept under its own name, an
             # unreadable archive is what --latest picks up and what the boot
-            # catch-up counts as this day's backup; deleted, an operator has
-            # nothing to look at, and the check can fail for reasons that are
-            # not the archive (mongorestore has to reach the server for --dryRun
-            # too). The suffix keeps it off both globs and inside the prune.
+            # catch-up counts as the backup for that day; deleted, an operator
+            # has nothing to look at, and the check can fail for reasons that
+            # are not the archive (mongorestore has to reach the server for
+            # --dryRun too). The suffix keeps it off both globs and inside the
+            # prune.
             mv "$$ARCHIVE" "$$ARCHIVE.unverified";
             rm -f "$$WORK";
             echo "verify-failed $$TIMESTAMP $$ARCHIVE.unverified" > "$$STATUS";

--- a/docs/AUDIT_LOG.md
+++ b/docs/AUDIT_LOG.md
@@ -17,9 +17,9 @@ The file records what was audited on the day it was audited, so the paths below
 are the paths as they stood then and are deliberately left that way. One has
 moved since and is cited often enough to be worth naming: the settings
 validators and the `/stats` fixes were audited in `src/dashboard/routes/api.js`,
-which is now a mounter and nothing else — that code lives in
-`src/dashboard/routes/api/`, the validators in `settings.js` and the guild
-statistics in `stats.js`.
+which mounts the sub-routers and re-exports two of their functions and holds no
+handler of its own — that code lives in `src/dashboard/routes/api/`, the
+validators in `settings.js` and the guild statistics in `stats.js`.
 
 ---
 

--- a/docs/AUDIT_LOG.md
+++ b/docs/AUDIT_LOG.md
@@ -13,6 +13,14 @@ nothing — neither that it is broken nor that it is sound. Do not read the
 absence of a section as a clean bill of health, and do not treat this file as a
 release gate.
 
+The file records what was audited on the day it was audited, so the paths below
+are the paths as they stood then and are deliberately left that way. One has
+moved since and is cited often enough to be worth naming: the settings
+validators and the `/stats` fixes were audited in `src/dashboard/routes/api.js`,
+which is now a mounter and nothing else — that code lives in
+`src/dashboard/routes/api/`, the validators in `settings.js` and the guild
+statistics in `stats.js`.
+
 ---
 
 ## Welcome Function

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -750,6 +750,48 @@ Two related conventions worth knowing while writing a panel:
   animation mid-flight leaves the element somewhere wrong — the background
   blobs are the example, since finishing early would strand them off-position.
 
+### What the browser scripts may assume
+
+**ES2020, and nothing newer.** Optional chaining, `??`, `Promise.allSettled`,
+`String.matchAll` and `BigInt` are all in; top-level `await`, `??=`, `.at()`,
+`Object.hasOwn` and class fields are not.
+
+The floor is written down in one place — `target: 'es2020'` in
+`scripts/build-assets.js` — and it is a statement of intent, not a gate. Nothing
+checks it for you, and two things about how these files are served are why that
+matters:
+
+- esbuild *lowers* most newer syntax to hit the target rather than refusing it,
+  so a `??=` or a class field minifies clean and only top-level `await` is
+  actually rejected. It never polyfills library additions at all: `.at()` and
+  `Object.hasOwn` pass straight through and fail in the browser, not the build.
+- The `.min` twins are only what the Docker image serves. A checkout run with
+  `npm start` has none, so `lib/assets.js` serves these files exactly as
+  authored — undownlevelled, whatever esbuild would have done to them.
+
+So the floor holds by being written to, and the review question for a browser
+script is "is this ES2020?", asked here rather than by a tool.
+
+That is also what settles the question #948 was filed about — whether a legacy
+guard in one of these files is worth its lines. Two different answers:
+
+- **Older than the floor: the guard cannot run.** The file is parsed whole
+  before a line of it executes, so a browser missing `window.matchMedia` — one
+  from a decade before `?.` — throws a SyntaxError and never reaches the check
+  written for it. `media()` in `public/guild-settings.js` keeps that check
+  regardless, because its live subject is jsdom rather than any browser, and
+  the comment there says so. Write that down when you keep one.
+- **Inside the floor: the guard runs, and dropping it is a support decision.**
+  The same file carried an `addListener` branch for the Safari versions whose
+  MediaQueryList was an `EventTarget` in name only; those parse ES2020 without
+  complaint, so the branch was live code. It went because that band is years
+  below what a dashboard administered from the same browser as Discord has to
+  reach — a floor, argued here, rather than a dead line.
+
+Feature-detecting something *newer* than the floor is a different thing again
+and is fine. Raising the floor means moving that one `target`; lowering it means
+adding a build step, not scattering fallbacks.
+
 ### Adding API Endpoints
 
 API routes live one feature per file in `src/dashboard/routes/api/`, and

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -677,13 +677,17 @@ OS, an Oracle Ampere instance, and Docker on an Apple Silicon Mac.
 
 Two things are worth knowing before you deploy to one:
 
-- **arm64 is built, not booted.** CI builds the image on every push and then
-  boots and vulnerability-scans it, but only the amd64 one: a multi-platform
-  build produces a manifest list, and there is no single image for `docker run`
-  to name. So the arm64 image is proven to *compile* — including the native
-  `canvas` binding, which is the part an architecture change actually breaks —
-  and is not proven to *start*. If it does not, that is a bug worth filing
-  rather than something known.
+- **arm64 is built and scanned, not booted.** Both images are compiled and
+  vulnerability-scanned before anything is published, and a HIGH or CRITICAL
+  finding with a fix available stops the release on either. What only the amd64
+  image gets is the boot check — it is started with an empty config and has to
+  reject it — because booting the arm64 one means running an emulated Node
+  through its whole require graph on an x86 runner.
+
+  So the arm64 image is proven to *compile*, including the native `canvas`
+  binding that an architecture change actually breaks, and proven to carry no
+  known fixable vulnerability. It is not proven to *start*. If it does not,
+  that is a bug worth filing rather than something known.
 - **32-bit ARM is not built.** A Pi running the 32-bit Raspberry Pi OS needs the
   64-bit one; `uname -m` says `aarch64` when you are on it and `armv7l` when you
   are not. `docker pull` on armv7l fails with "no matching manifest", which is

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -668,6 +668,30 @@ contains — see below.
 
 ## Portainer Deployment
 
+### Which architectures the image is built for
+
+`ghcr.io/theshield2594/clawdia` is published for **linux/amd64 and
+linux/arm64**, under one tag as a manifest list — `docker pull` on either
+resolves without you choosing. arm64 covers a Raspberry Pi 4 or 5 on a 64-bit
+OS, an Oracle Ampere instance, and Docker on an Apple Silicon Mac.
+
+Two things are worth knowing before you deploy to one:
+
+- **arm64 is built, not booted.** CI builds the image on every push and then
+  boots and vulnerability-scans it, but only the amd64 one: a multi-platform
+  build produces a manifest list, and there is no single image for `docker run`
+  to name. So the arm64 image is proven to *compile* — including the native
+  `canvas` binding, which is the part an architecture change actually breaks —
+  and is not proven to *start*. If it does not, that is a bug worth filing
+  rather than something known.
+- **32-bit ARM is not built.** A Pi running the 32-bit Raspberry Pi OS needs the
+  64-bit one; `uname -m` says `aarch64` when you are on it and `armv7l` when you
+  are not. `docker pull` on armv7l fails with "no matching manifest", which is
+  the intended failure — it is clearer than an image that starts and then
+  crashes.
+
+Everything else in this guide is the same on either architecture.
+
 ### Migrating an existing UltraBot stack
 
 Skip this section on a fresh install. If you already run the stack under the old

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "og-image": "node scripts/make-og-image.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "lint:stacks": "node scripts/lint-stack-shell.js",
     "format": "prettier --write",
     "test": "jest",
     "test:coverage": "jest --coverage",

--- a/portainer-stack.yml
+++ b/portainer-stack.yml
@@ -173,6 +173,14 @@ services:
     environment:
       MONGODB_ROOT_USERNAME: ${MONGODB_ROOT_USERNAME:-}
       MONGODB_ROOT_PASSWORD: ${MONGODB_ROOT_PASSWORD:-}
+    # No apostrophes below — not in a comment either (#940). Compose splits a
+    # string entrypoint into arguments before the container starts, so the first
+    # single quote inside this script closes the one that opened it and
+    # everything after becomes positional arguments that never run. That is not
+    # a warning in the abstract: "the day's backup", in a comment two thirds of
+    # the way down the backup entrypoint, had been truncating it mid-`if` in
+    # both stack files. Reword; there is no escape for one in this form.
+    # tests/stackEntrypointShell.test.js fails on the next one.
     entrypoint: >
       sh -c '
         # The host:port the members list will carry, which is how every client
@@ -454,6 +462,14 @@ services:
     depends_on:
       mongodb:
         condition: service_healthy
+    # No apostrophes below — not in a comment either (#940). Compose splits a
+    # string entrypoint into arguments before the container starts, so the first
+    # single quote inside this script closes the one that opened it and
+    # everything after becomes positional arguments that never run. That is not
+    # a warning in the abstract: "the day's backup", in a comment two thirds of
+    # the way down the backup entrypoint, had been truncating it mid-`if` in
+    # both stack files. Reword; there is no escape for one in this form.
+    # tests/stackEntrypointShell.test.js fails on the next one.
     entrypoint: >
       sh -c '
         if [ -n "$$MONGODB_URI_FILE" ]; then
@@ -574,10 +590,11 @@ services:
           if ! mongodump --uri="$$MONGODB_URI" --gzip --archive="$$WORK"; then
             # mongodump has no rollback: a dump killed part-way through leaves
             # whatever it had written under the real name. Left there, that
-            # partial file is what the boot catch-up counts as the day's backup
-            # and what `verify-backup.sh --latest` picks up — a failure that
-            # reads as a success. Quarantined under the same suffix a failed
-            # verification uses, so it is still pruned and still there to look at.
+            # partial file is what the boot catch-up counts as the backup for
+            # that day and what `verify-backup.sh --latest` picks up — a failure
+            # that reads as a success. Quarantined under the same suffix a
+            # failed verification uses, so it is still pruned and still there to
+            # look at.
             # Encrypting, the partial dump is plaintext in /tmp and is removed:
             # there is nothing there worth keeping that would be safe to keep.
             if [ "$$WORK" = "$$ARCHIVE" ]; then
@@ -623,10 +640,11 @@ services:
           if ! mongorestore --uri="$$MONGODB_URI" --gzip --archive="$$WORK" --dryRun --quiet; then
             # Renamed rather than kept or deleted. Kept under its own name, an
             # unreadable archive is what --latest picks up and what the boot
-            # catch-up counts as this day's backup; deleted, an operator has
-            # nothing to look at, and the check can fail for reasons that are
-            # not the archive (mongorestore has to reach the server for --dryRun
-            # too). The suffix keeps it off both globs and inside the prune.
+            # catch-up counts as the backup for that day; deleted, an operator
+            # has nothing to look at, and the check can fail for reasons that
+            # are not the archive (mongorestore has to reach the server for
+            # --dryRun too). The suffix keeps it off both globs and inside the
+            # prune.
             mv "$$ARCHIVE" "$$ARCHIVE.unverified";
             rm -f "$$WORK";
             echo "verify-failed $$TIMESTAMP $$ARCHIVE.unverified" > "$$STATUS";

--- a/scripts/build-assets.js
+++ b/scripts/build-assets.js
@@ -77,6 +77,14 @@ function minify(source, file) {
         // The dashboard's browser support is whatever runs Discord; nothing
         // here needs downlevelling, and a transform that rewrites syntax is a
         // transform that can change behaviour. Minify only.
+        //
+        // This line is also where that floor is written down, and
+        // docs/EXTENDING.md ("What the browser scripts may assume") is what
+        // points at it (#948). Note what it is not: esbuild lowers newer syntax
+        // to reach a target rather than rejecting it, and never polyfills a
+        // library addition at all, so this catches nothing on its own — and the
+        // twins are only what the image serves, while `npm start` serves the
+        // sources as authored. The floor holds by being written to.
         target: 'es2020',
         sourcefile: file,
     });

--- a/scripts/build-assets.js
+++ b/scripts/build-assets.js
@@ -81,10 +81,12 @@ function minify(source, file) {
         // This line is also where that floor is written down, and
         // docs/EXTENDING.md ("What the browser scripts may assume") is what
         // points at it (#948). Note what it is not: esbuild lowers newer syntax
-        // to reach a target rather than rejecting it, and never polyfills a
-        // library addition at all, so this catches nothing on its own — and the
-        // twins are only what the image serves, while `npm start` serves the
-        // sources as authored. The floor holds by being written to.
+        // to reach a target rather than rejecting it — it refuses only what it
+        // cannot express at all, which here is top-level `await` — and never
+        // polyfills a library addition, so `.at()` and `Object.hasOwn` pass
+        // straight through to fail in the browser instead. Nor do the twins
+        // decide it: they are what the image serves, while `npm start` serves
+        // these sources as authored. The floor holds by being written to.
         target: 'es2020',
         sourcefile: file,
     });

--- a/scripts/lint-stack-shell.js
+++ b/scripts/lint-stack-shell.js
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+'use strict';
+
+// Checks the shell scripts that live *inside* the two stack files (#940).
+//
+// `shellcheck scripts/*.sh` covers the scripts on disk and misses the largest
+// shell script in the repository: the backup entrypoint, eleven kilobytes of it
+// in docker-compose.yml and again in portainer-stack.yml, plus the replica-set
+// initialiser beside it. That is the code that takes the dumps #872 is about
+// and writes the status files #899 is about — shell nobody runs by hand and
+// nobody reads until the night it is needed.
+//
+// Two checks, and the first is the one that earned this file. A string
+// entrypoint is split into arguments by compose before `sh` ever sees it, so a
+// single quote anywhere inside the script — an apostrophe in a comment is
+// enough — closes the quote that opened it and the rest of the script becomes
+// positional arguments. That is what had happened to both backup entrypoints:
+// "the day's backup" in a comment two thirds of the way down truncated the
+// script mid-`if`, so the container did nothing but report a syntax error, and
+// nothing anywhere said so. So:
+//
+//   1. every embedded entrypoint must split into exactly `sh -c <script>`, and
+//   2. shellcheck must be clean on the script that splitting produces.
+//
+// Check 1 needs no tools and is what tests/stackEntrypointShell.test.js runs on
+// every `npm test`. Check 2 needs shellcheck and runs in CI.
+//
+//   node scripts/lint-stack-shell.js          both checks
+//   node scripts/lint-stack-shell.js --list   name what was found, and stop
+//
+// Requires an installed node_modules for js-yaml, and shellcheck on PATH for
+// check 2 (ubuntu-latest ships it; `apt-get install shellcheck` locally).
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const yaml = require('js-yaml');
+
+const ROOT = path.join(__dirname, '..');
+const STACKS = ['docker-compose.yml', 'portainer-stack.yml'];
+
+/**
+ * Split a command string into arguments the way compose does before handing
+ * them to the container — POSIX quoting, no expansion, no operators.
+ *
+ * Deliberately its own eighty lines rather than a `docker compose config` call:
+ * this has to run inside `npm test`, on a machine with no Docker, and the whole
+ * point is to answer "how many arguments is this?" before anyone deploys it.
+ *
+ * @param {string} input - the raw `entrypoint:` or `command:` string
+ * @returns {string[]|null} the arguments, or null if a quote is left open
+ */
+function splitArguments(input) {
+    const args = [];
+    let current = null;
+    let quote = null;
+
+    for (let i = 0; i < input.length; i += 1) {
+        const char = input[i];
+
+        if (quote === "'") {
+            if (char === "'") quote = null;
+            else current += char;
+            continue;
+        }
+
+        if (quote === '"') {
+            // Inside double quotes a backslash only escapes these four.
+            if (char === '\\' && '"\\$`'.includes(input[i + 1])) {
+                current += input[i + 1];
+                i += 1;
+            } else if (char === '"') {
+                quote = null;
+            } else {
+                current += char;
+            }
+            continue;
+        }
+
+        if (char === '\\' && i + 1 < input.length) {
+            current = (current ?? '') + input[i + 1];
+            i += 1;
+            continue;
+        }
+
+        if (char === "'" || char === '"') {
+            quote = char;
+            current = current ?? '';
+            continue;
+        }
+
+        if (/\s/.test(char)) {
+            if (current !== null) args.push(current);
+            current = null;
+            continue;
+        }
+
+        current = (current ?? '') + char;
+    }
+
+    if (quote) return null;
+    if (current !== null) args.push(current);
+    return args;
+}
+
+/**
+ * Every embedded shell script in one stack file, as it will actually be run.
+ *
+ * @param {string} file - repo-relative path of the stack file
+ * @returns {{file: string, service: string, key: string, raw: string,
+ *            args: string[]|null, shell: string|null, script: string|null}[]}
+ */
+function embeddedShell(file) {
+    const doc = yaml.load(fs.readFileSync(path.join(ROOT, file), 'utf8'));
+    const found = [];
+
+    for (const [service, definition] of Object.entries(doc?.services ?? {})) {
+        for (const key of ['entrypoint', 'command']) {
+            const raw = definition?.[key];
+            // The list form is already split and needs none of this; a string
+            // is the form compose has to lex, which is the form that bites.
+            if (typeof raw !== 'string' || !/^\s*(sh|bash)\s+-c\s/.test(raw)) continue;
+
+            const args = splitArguments(raw);
+            const wrapped = args !== null && args.length === 3 && args[1] === '-c';
+
+            found.push({
+                file,
+                service,
+                key,
+                raw,
+                args,
+                shell: wrapped ? args[0] : null,
+                // `$$` is compose's escape for a literal `$`: the container
+                // sees one dollar where the YAML holds two. Undone here, or
+                // shellcheck reads every variable as the PID of the shell.
+                script: wrapped ? args[2].replace(/\$\$/g, '$') : null,
+            });
+        }
+    }
+
+    return found;
+}
+
+/**
+ * Check 1: the string splits into exactly `sh -c <script>`.
+ *
+ * @param {ReturnType<typeof embeddedShell>[number]} entry
+ * @returns {string|null} what is wrong with it, or null
+ */
+function splittingProblem(entry) {
+    const where = `${entry.file} → ${entry.service}.${entry.key}`;
+
+    if (entry.args === null) {
+        return `${where}: unterminated quote — compose cannot split this at all.`;
+    }
+
+    if (entry.args.length !== 3 || entry.args[1] !== '-c') {
+        // Point at the offender rather than the symptom: the script ends where
+        // the quote closed, and the next argument is the first word after it.
+        const script = entry.args[2] ?? '';
+        const truncated = `${entry.raw.split('\n')[0]}…`;
+        return [
+            `${where}: splits into ${entry.args.length} arguments, not 3.`,
+            `  The script \`sh -c\` receives stops after ${script.length} of ${entry.raw.length} characters;`,
+            `  everything past it (starting "${entry.args[3] ?? ''}") is passed as positional arguments and never runs.`,
+            '  Almost always an apostrophe in a comment closing the quote that opened at:',
+            `    ${truncated}`,
+            '  Reword it — compose has no way to escape a single quote inside this form.',
+        ].join('\n');
+    }
+
+    return null;
+}
+
+/**
+ * Check 2: shellcheck on the script that splitting produced.
+ *
+ * `--severity=warning` for the same reason `npm audit` is gated at `high` and
+ * the image scan at HIGH,CRITICAL: dense shell inside a YAML string collects
+ * style findings the way any dense shell does, and a gate that is normally red
+ * is a gate everyone learns to merge past. Warnings and errors are the levels
+ * that describe something that can go wrong at three in the morning.
+ *
+ * @param {ReturnType<typeof embeddedShell>[number]} entry
+ * @param {string} dir - a temporary directory to write the script into
+ * @returns {{status: number, output: string}}
+ */
+function shellcheck(entry, dir) {
+    const file = path.join(dir, `${entry.service}-${entry.key}.sh`);
+    fs.writeFileSync(file, `#!/bin/${entry.shell}\n${entry.script}\n`);
+
+    const run = spawnSync('shellcheck', ['--shell', entry.shell, '--severity=warning', file], {
+        encoding: 'utf8',
+    });
+
+    if (run.error) {
+        if (run.error.code === 'ENOENT') {
+            console.error('shellcheck is not on PATH. Install it (apt-get install shellcheck) and re-run.');
+            process.exit(2);
+        }
+        throw run.error;
+    }
+
+    // The temp path means nothing to a reader; name the stack and the service
+    // the shell actually lives in.
+    const where = `${entry.file} → ${entry.service}.${entry.key}`;
+    return { status: run.status, output: `${run.stdout}${run.stderr}`.split(file).join(where) };
+}
+
+function main() {
+    const entries = STACKS.flatMap(embeddedShell);
+
+    // A stack file rewritten so that nothing matches would otherwise pass by
+    // checking nothing at all, silently — which is one instance of exactly the
+    // failure mode this script exists for.
+    if (entries.length === 0) {
+        console.error(`No embedded shell found in ${STACKS.join(' or ')}.`);
+        console.error('Either the entrypoints moved or this stopped recognising them; both need a look.');
+        process.exit(1);
+    }
+
+    if (process.argv.includes('--list')) {
+        for (const entry of entries) {
+            const size = entry.script === null ? 'does not split' : `${entry.script.length} chars`;
+            console.log(`${entry.file} → ${entry.service}.${entry.key} (${size})`);
+        }
+        return;
+    }
+
+    const problems = entries.map(splittingProblem).filter(Boolean);
+    for (const problem of problems) console.error(problem);
+
+    // No point shellchecking a script that is not the script that will run.
+    if (problems.length > 0) process.exit(1);
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawdia-stack-shell-'));
+    let failed = 0;
+
+    try {
+        for (const entry of entries) {
+            const { status, output } = shellcheck(entry, dir);
+            if (output.trim()) console.log(output.trimEnd());
+            if (status !== 0) failed += 1;
+        }
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+
+    console.log(
+        failed === 0
+            ? `shellcheck: ${entries.length} embedded entrypoints clean`
+            : `shellcheck: ${failed} of ${entries.length} embedded entrypoints have findings`
+    );
+
+    if (failed > 0) process.exit(1);
+}
+
+if (require.main === module) main();
+
+module.exports = { STACKS, embeddedShell, splitArguments, splittingProblem };

--- a/scripts/offsite-sync.sh
+++ b/scripts/offsite-sync.sh
@@ -72,6 +72,8 @@ notify_failure() {
         || echo "[offsite] posting to ERROR_WEBHOOK_URL failed" >&2
 }
 
+# shellcheck disable=SC2154  # `status` is assigned by the trap's own first
+# command; shellcheck reads a trap string without knowing when it runs.
 trap 'status=$?; [ "${status}" -eq 0 ] || notify_failure "sync to ${BACKUP_REMOTE:-<no remote>} exited ${status}"; exit "${status}"' EXIT
 
 if [ -z "${BACKUP_REMOTE:-}" ]; then

--- a/src/dashboard/public/guild-settings.js
+++ b/src/dashboard/public/guild-settings.js
@@ -16,10 +16,18 @@ function boot(key) {
 }
 
 // ── Media queries ────────────────────────────────────────────────────
-// jsdom has no matchMedia, and neither did a handful of browsers this page
-// still loads in. A query nobody can answer reads as "no preference expressed"
-// — the desktop layout, and motion left as authored — which is what the page
-// did before any of this existed.
+// jsdom has no matchMedia, and a page that called it there would throw before
+// it rendered anything. A query nobody can answer reads as "no preference
+// expressed" — the desktop layout, and motion left as authored — which is what
+// the page did before any of this existed.
+//
+// jsdom is the whole of the reason, and the comment here used to credit old
+// browsers as well. It cannot have been helping any: this file is parsed as a
+// whole before a line of it runs and it is ES2020 throughout, so a browser with
+// no matchMedia — one from a decade before `?.` — fails on the syntax and never
+// reaches the check written for it (#948). The floor is ES2020 and the DOM of
+// the browsers that also run Discord; docs/EXTENDING.md, "What the browser
+// scripts may assume", is where that is written down.
 function media(query) {
     return typeof window.matchMedia === 'function' ? window.matchMedia(query) : null;
 }
@@ -279,13 +287,14 @@ if (navToggle && dashSide && narrowViewport) {
     navToggle.addEventListener('click', () => {
         setNavOpen(dashSide.classList.contains('nav-collapsed'));
     });
-    // addEventListener where it exists, addListener for the Safari versions
-    // where MediaQueryList is still an EventTarget in name only.
-    if (typeof narrowViewport.addEventListener === 'function') {
-        narrowViewport.addEventListener('change', syncNavToggle);
-    } else if (typeof narrowViewport.addListener === 'function') {
-        narrowViewport.addListener(syncNavToggle);
-    }
+    // A plain addEventListener, with no `addListener` fallback beside it any
+    // more. That fallback was for the Safari versions whose MediaQueryList was
+    // an EventTarget in name only, and unlike the matchMedia guard above it was
+    // genuinely reachable — those browsers parse this file's ES2020 without
+    // complaint. It is dropped on the support floor rather than on the syntax:
+    // that band is years below anything that also runs Discord, and a fallback
+    // nobody here can test is one that rots in place (#948).
+    narrowViewport.addEventListener('change', syncNavToggle);
     syncNavToggle();
 }
 

--- a/src/dashboard/public/robots.txt
+++ b/src/dashboard/public/robots.txt
@@ -1,0 +1,11 @@
+# Everything on this host except the landing page needs a session cookie.
+# /dashboard and /auth answer a crawler with a redirect into Discord's OAuth,
+# and /api answers 401 — so the rules below save the crawl rather than protect
+# anything. They are not an access control: the middleware in
+# src/dashboard/lib/middleware.js is (#947).
+User-agent: *
+Disallow: /dashboard
+Disallow: /api
+Disallow: /auth
+
+# Deliberately no Sitemap: line. There is one public page.

--- a/src/dashboard/views/index.ejs
+++ b/src/dashboard/views/index.ejs
@@ -10,6 +10,14 @@
     // resolves. Written once so a fork renaming the repository moves them
     // together rather than leaving a dozen 404s behind.
     const repo = 'https://github.com/TheShield2594/clawdia';
+
+    // The share card and the alt text that travels with it, written once for
+    // the Open Graph and Twitter pairs below. Absolute and therefore
+    // conditional: an unfurler fetches the URL and resolves nothing against the
+    // page it came from, and `baseUrl` is null in the misconfiguration that
+    // already refuses to start.
+    const cardImage = locals.baseUrl ? `${locals.baseUrl}${asset('/og-image.png')}` : null;
+    const cardImageAlt = 'Clawdia — a chill Discord bot with serious teeth. Moderation, leveling, economy, AI chat and analytics.';
 %>
 <head>
     <%- include('partials/head', { title: pageTitle, description: pageDescription }) %>
@@ -35,20 +43,37 @@
     <meta property="og:site_name" content="Clawdia">
     <meta property="og:title" content="<%= pageTitle %>">
     <meta property="og:description" content="<%= pageDescription %>">
-    <%_ if (locals.baseUrl) { _%>
+    <%_ if (cardImage) { _%>
     <meta property="og:url" content="<%= baseUrl %>/">
-    <meta property="og:image" content="<%= baseUrl %><%= asset('/og-image.png') %>">
+    <meta property="og:image" content="<%= cardImage %>">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <%# The card carries text, so it needs alt text like any other image. -%>
-    <meta property="og:image:alt" content="Clawdia — a chill Discord bot with serious teeth. Moderation, leveling, economy, AI chat and analytics.">
+    <meta property="og:image:alt" content="<%= cardImageAlt %>">
     <link rel="canonical" href="<%= baseUrl %>/">
     <%_ } _%>
     <%# summary_large_image rather than summary: the card is 1.91:1 artwork
-        with type in it, and the square summary crop cuts the wordmark off. -%>
+        with type in it, and the square summary crop cuts the wordmark off.
+
+        twitter:image names the same file the og:image pair above does, and is
+        written out rather than left to the fallback (#947). Twitter does read
+        og:image when there is no twitter:image, but that is documented
+        behaviour rather than a guarantee, and every other unfurler that claims
+        to speak Twitter cards — Slack, Teams, a dozen link previewers — reads
+        the tags each in its own way. One extra line buys a card that does not
+        depend on any of them agreeing. -%>
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="<%= pageTitle %>">
     <meta name="twitter:description" content="<%= pageDescription %>">
+    <%_ if (cardImage) { _%>
+    <meta name="twitter:image" content="<%= cardImage %>">
+    <meta name="twitter:image:alt" content="<%= cardImageAlt %>">
+    <%_ } _%>
+    <%# The address-bar tint on a mobile browser, matching the cream this page
+        actually paints. Here rather than in partials/head.ejs on purpose: the
+        other two views are the dark dashboard chrome, and one shared value
+        would be wrong for whichever half did not choose it. -%>
+    <meta name="theme-color" content="#faf6ef">
 </head>
 <body style="background:var(--cream-50);">
 

--- a/tests/dashboardOpenGraph.test.js
+++ b/tests/dashboardOpenGraph.test.js
@@ -67,8 +67,22 @@ describe('the landing page unfurls', () => {
         expect(attr(html, /<meta name="twitter:card" content="([^"]*)">/)).toBe('summary_large_image');
     });
 
-    it('gives the card alt text', () => {
-        expect(attr(html, /<meta property="og:image:alt" content="([^"]*)">/)).toContain('Clawdia');
+    it('gives the card alt text, on both tags', () => {
+        const alt = attr(html, /<meta property="og:image:alt" content="([^"]*)">/);
+        expect(alt).toContain('Clawdia');
+        expect(attr(html, /<meta name="twitter:image:alt" content="([^"]*)">/)).toBe(alt);
+    });
+
+    // #947. Twitter falls back to og:image when there is no twitter:image, and
+    // the other half-dozen unfurlers that read "Twitter cards" each do their
+    // own thing about it. Naming the image on both tags costs a line.
+    it('names the same image on twitter:image as on og:image', () => {
+        expect(attr(html, /<meta name="twitter:image" content="([^"]*)">/))
+            .toBe(attr(html, /<meta property="og:image" content="([^"]*)">/));
+    });
+
+    it('tints the address bar to the cream the page actually paints', () => {
+        expect(attr(html, /<meta name="theme-color" content="([^"]*)">/)).toBe('#faf6ef');
     });
 
     it('points og:image at an absolute, content-hashed URL', () => {
@@ -88,10 +102,12 @@ describe('the landing page unfurls', () => {
         const withoutBase = landing({ baseUrl: null });
         expect(withoutBase).not.toContain('og:url');
         expect(withoutBase).not.toContain('og:image');
+        expect(withoutBase).not.toContain('twitter:image');
         expect(withoutBase).not.toContain('rel="canonical"');
         // The tags that need no host still go out.
         expect(withoutBase).toContain('<meta property="og:title"');
         expect(withoutBase).toContain('<meta name="twitter:card"');
+        expect(withoutBase).toContain('<meta name="theme-color"');
     });
 });
 

--- a/tests/dashboardRobots.test.js
+++ b/tests/dashboardRobots.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/**
+ * #947. The dashboard answered /robots.txt with the same 404 every unmatched
+ * path gets, so every crawler that found the landing page — and they find it,
+ * it is the one page on the host that is not behind checkAuth — spent its first
+ * request learning nothing and then walked into /dashboard and /auth, which
+ * answer a redirect into Discord's OAuth, and /api, which answers 401.
+ *
+ * The file is static and lives in public/, so the static handler serves it
+ * exactly as it serves the favicon. These drive the real app rather than
+ * reading the file off disk: a robots.txt that is not reachable at /robots.txt
+ * is not a robots.txt.
+ */
+
+const request = require('supertest');
+const session = require('express-session');
+
+const SAVED_ENV = { ...process.env };
+
+beforeEach(() => {
+    process.env.SESSION_SECRET = 'x'.repeat(48);
+    process.env.MONGODB_URI = 'mongodb://127.0.0.1:27017/clawdia-test';
+    process.env.NODE_ENV = 'test';
+});
+
+afterEach(() => {
+    for (const key of ['SESSION_SECRET', 'MONGODB_URI', 'NODE_ENV']) {
+        if (SAVED_ENV[key] === undefined) delete process.env[key];
+        else process.env[key] = SAVED_ENV[key];
+    }
+});
+
+const { createApp } = require('../src/dashboard/server');
+
+const app = () => createApp({
+    bot: { hasGuild: () => false },
+    sessionStore: new session.MemoryStore(),
+    configurePassport: () => {},
+});
+
+/** The `Disallow:` paths, in order, ignoring comments and blank lines. */
+function disallowed(body) {
+    return body
+        .split('\n')
+        .map(line => line.replace(/#.*$/, '').trim())
+        .filter(line => /^Disallow:/i.test(line))
+        .map(line => line.slice('Disallow:'.length).trim());
+}
+
+describe('/robots.txt', () => {
+    test('is served, as text, instead of falling through to a 404', async () => {
+        const res = await request(app()).get('/robots.txt');
+        expect(res.status).toBe(200);
+        expect(res.headers['content-type']).toMatch(/^text\/plain/);
+    });
+
+    test('addresses every crawler', async () => {
+        const { text } = await request(app()).get('/robots.txt');
+        expect(text).toMatch(/^User-agent: \*$/m);
+    });
+
+    test('keeps crawlers out of the three prefixes that need a session', async () => {
+        const { text } = await request(app()).get('/robots.txt');
+        expect(disallowed(text).sort()).toEqual(['/api', '/auth', '/dashboard']);
+    });
+
+    test('leaves the landing page and its assets crawlable', async () => {
+        // A blanket `Disallow: /` would take the one page this file exists to
+        // advertise with it — and the og:image the card points at, which an
+        // unfurler is entitled to fetch.
+        const { text } = await request(app()).get('/robots.txt');
+        expect(disallowed(text)).not.toContain('/');
+        expect(disallowed(text).some(path => '/og-image.png'.startsWith(path))).toBe(false);
+    });
+});

--- a/tests/docsStructure.test.js
+++ b/tests/docsStructure.test.js
@@ -29,14 +29,20 @@ const allDocs = [...rootDocs, ...docsDir.map(f => `docs/${f}`)];
 
 describe('the reference material lives in docs/', () => {
     it('keeps the root to the files a repo root is for', () => {
-        // README, the changelog, the two contributor-facing files, and the
-        // production checklist. Everything else is reference and belongs in
-        // docs/, where the four moved files now are.
+        // README, the changelog, and the two contributor-facing files.
+        // Everything else is reference and belongs in docs/, where the four
+        // moved files — and now the audit log — live.
+        //
+        // PRODUCTIONREADY.md was the fifth entry here until #915. It is a
+        // scrupulous audit log that says in its own header not to read it as a
+        // release gate, under a filename that asserted exactly that from the
+        // repo root, where it was one of the first things a visitor saw. It is
+        // docs/AUDIT_LOG.md now, which is what the file has always called
+        // itself.
         expect(rootDocs).toEqual([
             'CHANGELOG.md',
             'CLAUDE.md',
             'CONTRIBUTING.md',
-            'PRODUCTIONREADY.md',
             'README.md',
         ]);
     });

--- a/tests/lintGate.test.js
+++ b/tests/lintGate.test.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const yaml = require('js-yaml');
 
 // #714: 63k lines across 278 files with no linter and no formatter config, and
 // a CI that ran only the tests. The config is only half of the fix — a linter
@@ -24,7 +25,12 @@ describe('lint gate', () => {
         // the one after it — the image build and scan sit between them (#646).
         const testJob = ci.slice(ci.indexOf('\n  test:'), ci.indexOf('\n  image:'));
         expect(testJob).toMatch(/run: npm run lint/);
-        expect(ci).toMatch(/needs: \[test, image\]/);
+        // Read off the parsed workflow rather than matched as text. This was
+        // `/needs: \[test, image\]/` until the arm64 scan job joined that list
+        // (#941) and broke a test with no opinion about arm64. The claim is
+        // that publishing waits for this job, and nothing about what else it
+        // waits for.
+        expect(yaml.load(ci).jobs.publish.needs).toContain('test');
     });
 
     // Without `if: always()` a failing test hides the lint result and vice

--- a/tests/stackEntrypointShell.test.js
+++ b/tests/stackEntrypointShell.test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+/**
+ * #940. Both stack files run their backup on an eleven-kilobyte shell script
+ * written inline as `entrypoint: > sh -c '…'`, and compose splits that string
+ * into arguments before the container ever starts. A single quote inside the
+ * script closes the one that opened it — an apostrophe in a comment is enough —
+ * and everything after it becomes positional arguments instead of code.
+ *
+ * That is not hypothetical. "the day's backup", in a comment two thirds of the
+ * way down, cut both backup entrypoints off mid-`if`: the container started,
+ * `sh` reported a syntax error, and it exited. Nothing said so anywhere, which
+ * is the failure mode #872 and #899 are both about — the backup that is only
+ * discovered to be missing on the day it is needed.
+ *
+ * So the shape is asserted here rather than left to a deploy: every embedded
+ * entrypoint must split into exactly `sh -c <script>`, and the script must be
+ * the whole of what the file holds. shellcheck runs over the same scripts in
+ * CI; this half needs no tools and so runs everywhere.
+ */
+
+const { STACKS, embeddedShell, splitArguments, splittingProblem } = require('../scripts/lint-stack-shell');
+
+const entries = STACKS.flatMap(embeddedShell);
+
+describe('the shell embedded in the stack files', () => {
+    test('is found in both files', () => {
+        // A rename that leaves this finding nothing would otherwise pass by
+        // checking nothing, which is the same class of silence.
+        for (const stack of STACKS) {
+            expect([stack, entries.some(entry => entry.file === stack)]).toEqual([stack, true]);
+        }
+    });
+
+    test('covers the backup entrypoint in particular', () => {
+        const backups = entries.filter(entry => entry.service === 'backup');
+        expect(backups).toHaveLength(STACKS.length);
+        // The one that was truncated. Well over the ~6 KB the broken split
+        // produced, so a regression cannot pass this by being merely long.
+        for (const backup of backups) expect(backup.script.length).toBeGreaterThan(9000);
+    });
+
+    test.each(entries.map(entry => [`${entry.file} → ${entry.service}.${entry.key}`, entry]))(
+        '%s reaches the container whole',
+        (_name, entry) => {
+            expect(splittingProblem(entry)).toBeNull();
+            expect(entry.args[0]).toMatch(/^(sh|bash)$/);
+            expect(entry.args[1]).toBe('-c');
+        }
+    );
+
+    test.each(entries.map(entry => [`${entry.file} → ${entry.service}.${entry.key}`, entry]))(
+        '%s carries no single quote for compose to split on',
+        (_name, entry) => {
+            // The rule stated directly, so a failure names the cause rather
+            // than the argument count it produces. Compose offers no escape
+            // for one inside this form: the fix is always to reword.
+            expect(entry.script).not.toContain("'");
+        }
+    );
+});
+
+describe('the splitter the checks are built on', () => {
+    // It stands in for compose's own lexing, so it is worth pinning to the
+    // cases that decide whether an entrypoint runs.
+    test.each([
+        ['sh -c \'echo hi\'', ['sh', '-c', 'echo hi']],
+        ['sh -c \'a b\' c', ['sh', '-c', 'a b', 'c']],
+        ['sh -c "one two"', ['sh', '-c', 'one two']],
+        // The shape the bug had: a second quote closes the script, and what
+        // follows becomes arguments of its own.
+        ['sh -c \'echo one\' \'echo two\'', ['sh', '-c', 'echo one', 'echo two']],
+        // Quoted runs butt together into one argument rather than splitting.
+        ['sh -c \'a\'b\'c\'', ['sh', '-c', 'abc']],
+        ['  spaced   out  ', ['spaced', 'out']],
+    ])('%s', (input, expected) => {
+        expect(splitArguments(input)).toEqual(expected);
+    });
+
+    test('reports an unterminated quote rather than guessing', () => {
+        expect(splitArguments("sh -c 'never closed")).toBeNull();
+    });
+
+    test('keeps an empty quoted argument, which is not the same as no argument', () => {
+        expect(splitArguments('a "" b')).toEqual(['a', '', 'b']);
+    });
+});


### PR DESCRIPTION
Closes #915, closes #948, closes #947, closes #940, closes #941.

Five issues from the ten-agent review. One of them turned up a live bug, which is the part worth a reviewer's time.

## The backup entrypoint was truncated in both stack files

Adding the ops linting #940 asked for is what found it, so it ships in that commit.

Compose splits a string `entrypoint` into arguments before the container starts. `"the day's backup"`, in a comment two thirds of the way down the backup entrypoint, closed the quote that opened at `sh -c '` — so `sh -c` received 6,436 bytes of an 11,145-byte script, ending mid-`if`, and the rest arrived as 68 positional arguments. The container started, failed to parse its own script, and exited. No dump, no verify, no status file, no schedule, and nothing anywhere saying so.

Measured with `docker compose config` before and after, on both files:

| | before | after |
|---|---|---|
| `entrypoint` argv | 71 | 3 |
| script `sh -c` receives | 6,436 B | 11,145 B |

Fixed by rewording the two comments that carry an apostrophe, with the rule stated at each entrypoint — compose offers no escape for one in this form. Two guards so it cannot come back: `scripts/lint-stack-shell.js` splits each entrypoint the way compose does and refuses anything that is not exactly `sh -c <script>` before shellchecking the result, and `tests/stackEntrypointShell.test.js` runs that first half on every `npm test`, since it needs no tools installed.

## The five issues

**#940 — lint the ops files.** hadolint on the Dockerfile, shellcheck over `scripts/` and `scripts/lib/`, `docker compose config` on both stack files, and the embedded-shell linter above. Steps in the `test` job rather than a job of their own, for the reason the existing lint step already is — one of them needs the same `npm ci`. `.hadolint.yaml` turns off DL3018 and records why: pinning apk versions is exactly what the runtime stage's daily `apk upgrade` exists not to do. The only shellcheck finding in `scripts/` was a false positive on a trap's own assignment, annotated in place.

**#941 — arm64.** The image is published as a `linux/amd64,linux/arm64` manifest list, so `docker pull` resolves on either without anyone choosing. The CI shape:

```
test   (suite, coverage, lint, ops gates)     ┐
image  (amd64: build → smoke → boot → scan)   ┼→ publish (manifest list, both platforms)
arm64  (arm64: build → scan)                  ┘
```

`arm64` is gated to events that publish — an emulated build of a tree that compiles `canvas` from source is not a cost worth paying on a pull request that publishes nothing — and `publish` gates on both through `needs:`, so neither platform reaches the registry unscanned. The build caches are scoped per platform because two jobs now export on every push and a buildx export replaces the whole manifest for its scope; `publish` reads both and exports nothing. `docs/SETUP_GUIDE.md` records which architectures are published (32-bit ARM is not) and that arm64 is built and scanned but not booted, since booting it means running an emulated Node through its whole require graph.

**#915 — audit log rename.** `PRODUCTIONREADY.md` → `docs/AUDIT_LOG.md`, which is what the file has always called itself. Content unchanged but for a note that the `routes/api.js` it cites nine times now mounts the sub-routers and re-exports two of their functions rather than holding handlers, and that code lives in `routes/api/`.

**#948 — browser guards.** One correction to the issue's premise, which changed how this is written up: the `matchMedia` guard is unreachable as described, but the `addListener` branch was **not**. Safari got optional chaining in 13.1 and gave MediaQueryList the `EventTarget` interface in 14, so that band parsed the file fine and ran the fallback. It goes on the support floor rather than on the syntax — years below anything that also runs Discord — and the comment says so. `docs/EXTENDING.md` gains a section stating the ES2020 floor and being honest that `build-assets.js`'s esbuild target is not a gate: esbuild lowers newer syntax rather than refusing it (top-level `await` is the one thing it refuses), never polyfills a library addition, and `npm start` serves these files as authored anyway.

**#947 — robots.txt and the share card.** A static `robots.txt` disallowing `/dashboard`, `/api` and `/auth`, served by the same handler as the favicon. Explicit `twitter:image` and `twitter:image:alt` mirroring the og pair, with the URL and alt string hoisted to one place, plus a `theme-color` on the landing view only. Deliberately left out: an apple-touch-icon, which needs a 180×180 raster and a decision about the background iOS composites onto.

## Follow-ups on this branch

- **`de96fb3`** — the first CI run of the new hadolint step failed, and correctly. `hadolint-action` pins its own hadolint (2.15.1, newer than the 2.14.0 this was written against) which raises DL3025 on the `HEALTHCHECK`, and the action passes its own `failure-threshold` input through the environment where it beats the config file. The rule is ignored inline with the reasoning beside it — exec form would drop the `/bin/sh -c` the health check goes through, which is a decision to take deliberately rather than as a side effect of turning a linter on — and `ci.yml` now sets the threshold input to match `.hadolint.yaml`.
- **`eaadf33`** — the QEMU step ran `tonistiigi/binfmt:latest`, a mutable tag executed `--privileged` in the one job holding `packages: write`, so it is pinned by digest now. Two documentation claims corrected: `routes/api.js` is not "a mounter and nothing else", and `build-assets.js`'s esbuild comment omitted the rejection case.
- **`6fb3eea`** — the `arm64` scan job described above.

One review finding was rejected rather than fixed, and the reviewer withdrew it: a null guard for `narrowViewport` that the enclosing `if (navToggle && dashSide && narrowViewport)` already provides, with the no-`matchMedia` path covered by `describe('without matchMedia')` in `tests/dashboardMobileNav.test.js`.

## Verification

- `npm run lint` clean; all four ops gates run clean locally (hadolint 2.15.1 under the action's environment, shellcheck, both `docker compose config`, `npm run lint:stacks`).
- CI ran the whole suite green on this branch: 381 suites, 7,585 tests, coverage floors passing. Locally three integration suites (`models`, `migrations`, `guildIndexMigration`) cannot run — the sandbox's egress proxy returns 403 for `fastdl.mongodb.org`, so `mongodb-memory-server` cannot fetch its binary — which is why CI is the check that matters for those and for `coverage:check`.
- New tests: `tests/stackEntrypointShell.test.js`, `tests/dashboardRobots.test.js`, plus additions to `tests/dashboardOpenGraph.test.js`.
- **Not exercised by this PR:** the `arm64` job is gated to non-PR events, so its first run is the merge to `main` — or a `workflow_dispatch` on this branch beforehand, which will run it in full. That first run is also cold at both cache scopes, since renaming a scope means the previous entries are not read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmAwkhskMw8D1G2S2UWJ3k


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Docker images are now published for both amd64 and arm64 platforms.
  - Dashboard pages now include richer social sharing metadata, including preview images, alt text, and theme color.
  - Added `robots.txt` guidance to prevent crawling of protected dashboard, API, and authentication paths.

- **Bug Fixes**
  - Improved protection against malformed shell entrypoints in deployment stack files.

- **Documentation**
  - Added guidance covering image architectures, browser support, auditing, and contributor linting requirements.

- **Quality**
  - Expanded automated validation for Dockerfiles, shell scripts, Compose files, and deployment metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->