### PR TITLE
Take the entrypoints' logic out of hiding, and say what was published

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -777,6 +777,7 @@ jobs:
       # registry blip cannot be misread as a security finding. This is the same
       # rule the npm audit step above follows for the same reason.
       - name: Check the published layers are the ones that were scanned
+        id: scanned
         env:
           SCANNED_AMD64: ${{ needs.image.outputs.scanned-layers }}
           SCANNED_ARM64: ${{ needs.arm64.outputs.scanned-layers }}
@@ -798,8 +799,14 @@ jobs:
           if [ -z "$config" ] || ! printf '%s' "$config" | jq -e . >/dev/null 2>&1; then
             echo "::warning::could not read the published image config, so this run does not say whether the published layers are the scanned ones"
             echo 'Not checked — the published image config could not be read.' >> "$GITHUB_STEP_SUMMARY"
+            # Unverified is not verified. The webhook below reads this, and an
+            # unreadable manifest must not be allowed to auto-deploy on the
+            # strength of a check that never ran.
+            echo 'verified=false' >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          verified=true
 
           {
             echo '| platform | published layers |'
@@ -830,6 +837,7 @@ jobs:
               # job that was skipped, or a manifest shape this cannot read.
               echo "::warning::$platform: nothing to compare, so it is unknown whether the published image is the scanned one"
               echo "| $platform | not checked |" >> "$GITHUB_STEP_SUMMARY"
+              verified=false
             elif [ "$pushed" = "$scanned" ]; then
               echo "$platform: published layers are the ones that were scanned"
               echo "| $platform | match the scanned image |" >> "$GITHUB_STEP_SUMMARY"
@@ -841,8 +849,14 @@ jobs:
               echo "  scanned: $scanned"
               echo "  pushed:  $pushed"
               echo "| $platform | **DO NOT DEPLOY** — rebuilt on a cache miss, never scanned |" >> "$GITHUB_STEP_SUMMARY"
+              verified=false
             fi
           done
+
+          # True only when every platform matched. Read by the webhook step
+          # below, which must not auto-deploy an image this step just told a
+          # human not to deploy.
+          echo "verified=$verified" >> "$GITHUB_OUTPUT"
 
       # The active half of the deploy signal (#953).
       #
@@ -876,10 +890,43 @@ jobs:
       # unreachable for thirty seconds is an operator's problem to retry, not a
       # reason to mark the build red and have somebody re-publish an image that
       # is already in the registry.
+      #
+      # And it only fires behind the check above. Auto-deploying an image that
+      # step has just labelled **DO NOT DEPLOY** would be this workflow telling
+      # an operator not to deploy something while deploying it for them — the
+      # gate is worth less than nothing if the automation walks straight past
+      # it. `verified` is true only when every platform matched, so the
+      # unreadable-manifest and missing-output cases hold the deploy too: a
+      # check that did not run is not a check that passed. The step below says
+      # so on the summary, since the operator then has a redeploy to do by hand
+      # once they are satisfied.
       - name: Tell the Portainer stack there is a new image
-        if: env.PORTAINER_WEBHOOK_URL != '' && github.ref_name == github.event.repository.default_branch
+        if: >-
+          env.PORTAINER_WEBHOOK_URL != ''
+          && github.ref_name == github.event.repository.default_branch
+          && steps.scanned.outputs.verified == 'true'
         run: |
           set -u
+
+          # HTTPS or nothing. The webhook URL carries its own credential in the
+          # path — anyone who sees it can redeploy the stack — so posting to an
+          # http:// endpoint hands that credential to every hop in between. The
+          # usual argument for allowing cleartext, that Portainer is on a LAN,
+          # does not apply here: this runs on a GitHub-hosted runner, so any URL
+          # it can reach at all is one crossing the public internet.
+          #
+          # Refuses rather than downgrading silently, and says nothing about the
+          # value beyond its scheme being wrong — the point is to keep the URL
+          # out of the log, and echoing it in an error message would defeat the
+          # step that is careful not to.
+          case "$PORTAINER_WEBHOOK_URL" in
+            https://*) ;;
+            *)
+              echo "::warning::PORTAINER_WEBHOOK_URL is not an https:// URL, so no redeploy was requested — the webhook URL is a deploy credential and is not sent in cleartext. The image is published; redeploy the stack by hand."
+              echo 'Portainer webhook skipped — the configured URL is not HTTPS.' >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+              ;;
+          esac
 
           status=$(curl -sS -o /dev/null -w '%{http_code}' \
             --request POST \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,6 +314,9 @@ jobs:
       # Read by `publish` so both builds carry the same value — see the step
       # that computes it, and the note on the publish build.
       apk-refresh: ${{ steps.apk.outputs.key }}
+      # The amd64 layers this job actually booted and scanned, for `publish` to
+      # check what it pushed against (#952).
+      scanned-layers: ${{ steps.layers.outputs.diff-ids }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -423,6 +426,37 @@ jobs:
           exit-code: '1'
           format: table
 
+      # What "the tested image" actually is, written down so the publish job can
+      # be held to it (#952).
+      #
+      # `publish` rebuilds rather than promoting this artifact, and the note at
+      # the top of this job explains why that is not fixed by pushing a staging
+      # tag from here: it would need `packages: write` in a job that also runs
+      # on pull requests, which is a wider exposure than the gap it closes. What
+      # was missing is not the guarantee — it is that a *breach* of the
+      # guarantee was silent. A cache eviction between the two jobs would have
+      # published an image nothing in this job ever looked at, and nothing
+      # anywhere would have said so.
+      #
+      # Diff IDs rather than the image digest, because the digest cannot answer
+      # the question. `publish` adds OCI labels from docker/metadata-action, and
+      # a label lands in the image config — so the config digest, and with it
+      # the manifest digest, differ between the two builds every single time
+      # even on a perfect cache hit. Diff IDs are the uncompressed content
+      # hashes of the filesystem layers, which is precisely "the same bytes" and
+      # is untouched by labels.
+      #
+      # This step runs after the scan, so what it records is only ever an image
+      # that passed. A failing scan stops the job here and there is nothing to
+      # compare against.
+      - name: Record the layers that were booted and scanned
+        id: layers
+        run: |
+          diff_ids=$(docker image inspect --format '{{json .RootFS.Layers}}' "$SMOKE_IMAGE")
+          echo "amd64 layers that passed the smoke test and the scan:"
+          printf '%s\n' "$diff_ids"
+          echo "diff-ids=$diff_ids" >> "$GITHUB_OUTPUT"
+
   # The arm64 half of what `publish` pushes, built and scanned before it goes
   # out. Added because the multi-platform publish of #941 put an image into the
   # manifest list that the Trivy gate had never looked at — the gate's whole
@@ -445,6 +479,9 @@ jobs:
     needs: image
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    outputs:
+      # The arm64 half of the same check the amd64 job records (#952).
+      scanned-layers: ${{ steps.layers.outputs.diff-ids }}
     # Emulated, and cold on the first build after a Dockerfile or lockfile
     # change: tens of minutes rather than the handful the native build takes.
     timeout-minutes: 90
@@ -500,6 +537,20 @@ jobs:
           exit-code: '1'
           format: table
 
+      # The arm64 half of the record the amd64 job keeps — same reasoning, same
+      # reason it is diff IDs and not a digest. See that step (#952).
+      #
+      # Both platforms or neither: `publish` assembles one manifest list out of
+      # two caches, and either restore can miss independently. Checking only
+      # amd64 would report half of the thing that can go wrong.
+      - name: Record the arm64 layers that were scanned
+        id: layers
+        run: |
+          diff_ids=$(docker image inspect --format '{{json .RootFS.Layers}}' "${SMOKE_IMAGE}-arm64")
+          echo "arm64 layers that passed the scan:"
+          printf '%s\n' "$diff_ids"
+          echo "diff-ids=$diff_ids" >> "$GITHUB_OUTPUT"
+
   # Publishing lives here, behind `needs: [test, image, arm64]`, rather than in its own
   # workflow. It used to be a separate file triggered on `push: main`, which
   # ran alongside the tests instead of after them: a commit that broke the
@@ -526,6 +577,14 @@ jobs:
     permissions:
       contents: read
       packages: write
+
+    # Lifted to the job so the step below can be conditional on it (#953). A
+    # step `if:` cannot read the `secrets` context, but it can read `env`, and
+    # this is the documented way to spell "only if the operator configured one".
+    # Unset — which is the default, and every fork — it is the empty string and
+    # the step is skipped.
+    env:
+      PORTAINER_WEBHOOK_URL: ${{ secrets.PORTAINER_WEBHOOK_URL }}
 
     # Every action below is pinned to a commit SHA, not a floating tag. This is
     # the job holding `packages: write` and pushing the `:latest` that
@@ -655,13 +714,24 @@ jobs:
           provenance: mode=max
           sbom: true
 
-      # The digest, on the run's summary page. Every tag above can be repointed
-      # by a later build — including sha-<commit>, by a re-run of this very
-      # workflow — so the digest is the only reference that always names *this*
-      # build. Recording it here is what makes it available at rollback time,
-      # when the run that produced it is weeks old and nobody wants to go
-      # spelunking in the registry API for it.
-      - name: Record image digest
+      # What was published, on the run's summary page.
+      #
+      # The digest is here because every tag above can be repointed by a later
+      # build — including sha-<commit>, by a re-run of this very workflow — so
+      # it is the only reference that always names *this* build. Recording it is
+      # what makes it available at rollback time, when the run that produced it
+      # is weeks old and nobody wants to go spelunking in the registry API.
+      #
+      # The sha- tag is here for the other direction (#953). Nothing tells a
+      # deployment that a newer image exists: the Portainer stack needs a manual
+      # redeploy to pick up a repointed `:latest`, and a deployment pinned to a
+      # specific CLAWDIA_IMAGE_TAG gets no signal at all — so a security fix can
+      # sit published and undeployed indefinitely because nothing announced it.
+      # The webhook below is the active half of that answer and is opt-in; this
+      # is the half that always runs, and it is written as the line to paste
+      # rather than as a bare tag so that an operator reading CI has the deploy
+      # in front of them rather than a fact to act on.
+      - name: Record what was published
         run: |
           {
             echo '### Image'
@@ -669,5 +739,167 @@ jobs:
             echo '| | |'
             echo '|---|---|'
             echo "| digest | \`${{ steps.build.outputs.digest }}\` |"
-            echo "| rollback to this build | \`CLAWDIA_IMAGE_TAG=latest@${{ steps.build.outputs.digest }}\` |"
+            echo "| deploy this build | \`CLAWDIA_IMAGE_TAG=sha-${{ github.sha }}\` |"
+            echo "| pin it immutably | \`CLAWDIA_IMAGE_TAG=latest@${{ steps.build.outputs.digest }}\` |"
+            echo
+            echo 'Set that in the stack environment and redeploy. See docs/RELEASING.md.'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Whether the bytes that were just pushed are the bytes the gates looked
+      # at (#952).
+      #
+      # This job rebuilds rather than promoting the artifact `image` and `arm64`
+      # checked, and the note at the top of the `image` job says why promoting
+      # by digest is not done: it needs `packages: write` in a job that also
+      # runs on pull requests, which is a wider exposure than the gap it closes.
+      # The guarantee therefore rests on the two `cache-from` scopes above being
+      # hits rather than misses — which they almost always are, and which
+      # nothing checked. A cache eviction between the jobs would publish an
+      # image that was never booted and never scanned, and the run would be
+      # green and silent about it. That silence is what this step removes.
+      #
+      # Diff IDs, not digests: this job adds OCI labels from metadata-action,
+      # and a label changes the image config — so the config and manifest
+      # digests differ from the scanned build's on every run, cache hit or not.
+      # Diff IDs are the uncompressed hashes of the filesystem layers, which is
+      # exactly "the same bytes" and is unaffected by labels or by the
+      # provenance and SBOM manifests attached alongside.
+      #
+      # It warns rather than fails, deliberately. The push has already happened,
+      # so failing here cannot unpublish anything — and a re-run would restore
+      # from the same evicted cache and fail again, which is a red main branch
+      # that no action clears. What the operator needs is to know the image is
+      # unscanned so they can decide; that is a warning annotation and a row in
+      # the summary, both of which this writes.
+      #
+      # Nothing here can fail the job on its own account either: an unreadable
+      # manifest is reported as "not checked" rather than as a mismatch, so a
+      # registry blip cannot be misread as a security finding. This is the same
+      # rule the npm audit step above follows for the same reason.
+      - name: Check the published layers are the ones that were scanned
+        env:
+          SCANNED_AMD64: ${{ needs.image.outputs.scanned-layers }}
+          SCANNED_ARM64: ${{ needs.arm64.outputs.scanned-layers }}
+          PUSHED: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+        run: |
+          set -u
+
+          # stdout only. Folding stderr in would let a buildx warning land in
+          # front of the JSON and turn a perfectly good manifest into a "not
+          # checked", which is the quiet failure this step is meant to remove
+          # rather than add.
+          config=$(docker buildx imagetools inspect "$PUSHED" --format '{{json .Image}}' 2>/dev/null) || config=''
+
+          {
+            echo '### Scanned-image check'
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -z "$config" ] || ! printf '%s' "$config" | jq -e . >/dev/null 2>&1; then
+            echo "::warning::could not read the published image config, so this run does not say whether the published layers are the scanned ones"
+            echo 'Not checked — the published image config could not be read.' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            echo '| platform | published layers |'
+            echo '|---|---|'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          for platform in linux/amd64 linux/arm64; do
+            case "$platform" in
+              linux/amd64) scanned=$SCANNED_AMD64 ;;
+              linux/arm64) scanned=$SCANNED_ARM64 ;;
+            esac
+
+            pushed=$(printf '%s' "$config" \
+              | jq -c --arg p "$platform" 'if type=="object" and has($p) then .[$p].rootfs.diff_ids else null end' 2>/dev/null) \
+              || pushed=null
+            scanned=$(printf '%s' "$scanned" | jq -c . 2>/dev/null) || scanned=null
+
+            # Empty as well as the literal `null`: jq exits 0 and prints nothing
+            # when handed an empty stdin, which is what an upstream job that did
+            # not run leaves in these variables. Read as a value it would
+            # compare unequal to everything and report a mismatch — a false
+            # alarm of exactly the kind this step must not raise.
+            [ -z "$pushed" ] && pushed=null
+            [ -z "$scanned" ] && scanned=null
+
+            if [ "$pushed" = 'null' ] || [ "$scanned" = 'null' ]; then
+              # One side is missing, which says nothing either way — an upstream
+              # job that was skipped, or a manifest shape this cannot read.
+              echo "::warning::$platform: nothing to compare, so it is unknown whether the published image is the scanned one"
+              echo "| $platform | not checked |" >> "$GITHUB_STEP_SUMMARY"
+            elif [ "$pushed" = "$scanned" ]; then
+              echo "$platform: published layers are the ones that were scanned"
+              echo "| $platform | match the scanned image |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              # The case the whole step exists for. Say what it means, not just
+              # that two strings differ — this line is read by whoever has to
+              # decide whether to deploy the image.
+              echo "::warning::$platform: the published image is NOT the one that was scanned. The build cache missed between the scan job and this one, so these layers were never booted or scanned. Re-run the workflow to rebuild and re-scan before deploying this tag."
+              echo "  scanned: $scanned"
+              echo "  pushed:  $pushed"
+              echo "| $platform | **DO NOT DEPLOY** — rebuilt on a cache miss, never scanned |" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
+      # The active half of the deploy signal (#953).
+      #
+      # `publish` repoints `:latest`, and that is where the story used to end: a
+      # Portainer stack does not poll, so the new image sat in the registry
+      # until somebody opened the UI and redeployed. Nothing announced that
+      # there was anything to redeploy, which is how a published security fix
+      # can stay undeployed for weeks.
+      #
+      # Opt-in, and off unless an operator sets the secret. Self-hosted
+      # deployments are operator-driven by design — this repo has no idea where
+      # anybody's Portainer is, and a workflow that assumed one would be wrong
+      # for every fork. Portainer's stack webhook is a single URL that redeploys
+      # the stack when POSTed to, which an operator creates in Portainer >
+      # Stacks > Webhooks and pastes into the repository secret named here.
+      # docs/RELEASING.md has the setup.
+      #
+      # Only on the default branch, because that is the only branch that moves
+      # `:latest` (see `enable={{is_default_branch}}` in the tags above) and
+      # `:latest` is what the stack pulls by default. A v* tag push publishes a
+      # version tag nothing is pointed at until an operator chooses to be, so
+      # firing a redeploy on one would deploy something they had not asked for.
+      #
+      # The URL is a deploy credential — anyone holding it can redeploy the
+      # stack — so it is never echoed. `-o /dev/null` keeps the response body
+      # out of the log for the same reason, since Portainer answers with the
+      # stack definition.
+      #
+      # A failure here warns rather than fails the job. The image is published
+      # and the scan passed, which is what this job is for; a Portainer that was
+      # unreachable for thirty seconds is an operator's problem to retry, not a
+      # reason to mark the build red and have somebody re-publish an image that
+      # is already in the registry.
+      - name: Tell the Portainer stack there is a new image
+        if: env.PORTAINER_WEBHOOK_URL != '' && github.ref_name == github.event.repository.default_branch
+        run: |
+          set -u
+
+          status=$(curl -sS -o /dev/null -w '%{http_code}' \
+            --request POST \
+            --max-time 30 --retry 3 --retry-delay 5 --retry-connrefused \
+            "$PORTAINER_WEBHOOK_URL" 2>/dev/null) || status=000
+
+          case "$status" in
+            2*)
+              echo "Portainer accepted the redeploy request (HTTP $status)."
+              echo 'Portainer stack webhook fired — the stack is pulling this image.' >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            000)
+              echo "::warning::could not reach the Portainer webhook. The image is published; redeploy the stack by hand."
+              echo 'Portainer webhook unreachable — redeploy by hand.' >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            *)
+              # 404 is the one worth calling out: Portainer invalidates a stack
+              # webhook when the stack is recreated, so the commonest cause is a
+              # secret still holding the URL of a stack that no longer exists.
+              echo "::warning::the Portainer webhook answered HTTP $status. The image is published but the stack was not redeployed — check that PORTAINER_WEBHOOK_URL still names an existing stack."
+              echo "Portainer webhook answered HTTP $status — redeploy by hand." >> "$GITHUB_STEP_SUMMARY"
+              ;;
+          esac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,52 @@ zeroes apart. The floors themselves are re-recorded against the current suite �
 from 4 to 10, `src/data` from 61/26/34/61 to 77/57/64/78 — and the global
 thresholds from 50/40/53/51 to 51/41/53/52.
 
+The three process entrypoints stop hiding logic from the test suite (#951).
+`src/index.js`, `src/shard.js` and `src/deploy-commands.js` are all on
+`coverage-floors.json`'s `neverExecuted` list, legitimately — requiring one
+starts a bot — but decisions had accumulated inside them that boot perfectly and
+then do the wrong thing, which is the one class of bug the CI image job's boot
+test cannot see. Shard-count selection is now `resolveTotalShards` in
+`utils/sharding.js`, where the branch that turns a mistyped `SHARD_COUNT` into
+`'auto'` rather than into a manager spawning `NaN` shards is actually run.
+Shutdown sequencing is `utils/shutdown.js`, so the order the four steps close in
+— scheduler, then gateway, then the buffered command metrics, then the database
+— is asserted rather than remembered; extracting it also closed a hole, in that
+`stopScheduler()` sat outside the try, so a throw from it propagated out of the
+signal handler and the gateway, the buffered metrics and the connection were
+never closed at all. The `npm run deploy` guard is `runDeployCli`, returning an
+exit code instead of calling `process.exit`, so the branch deciding whether an
+operator gets a deploy or an error message has tests. The three files stay on
+the list as the thin wrappers they now are.
+
+A publish that is not the image the gates looked at now says so (#952). The
+`publish` job rebuilds rather than promoting the artifact the `image` and
+`arm64` jobs booted and scanned — deliberately, because promoting by digest
+would need `packages: write` in a job that also runs on pull requests — so the
+guarantee rests on a `type=gha` cache hit. What was missing was not the
+guarantee but the alarm: a cache eviction between the jobs would publish an
+image nothing had ever scanned, and the run would be green and silent. Both scan
+jobs now record the layer diff IDs of what they passed, and `publish` compares
+them against what it actually pushed, per platform. Diff IDs rather than
+digests, because `publish` adds OCI labels and a label changes the image config,
+so the digests differ on every run even on a perfect cache hit. It warns rather
+than failing — the push has already happened, and a re-run would restore from
+the same evicted cache — and an unreadable manifest is reported as "not checked"
+rather than as a mismatch, so a registry blip cannot be misread as a finding.
+
+And a published image announces itself (#953). Nothing pulls on its own: a
+Portainer stack holds the image it last deployed until somebody redeploys it, so
+a security fix could sit published and undeployed because nothing said it was
+there. The run summary now carries the `CLAWDIA_IMAGE_TAG=sha-<commit>` line to
+deploy this build alongside the digest to pin it immutably, so an operator
+watching CI has the deploy in front of them rather than a fact to act on.
+Optionally, setting a `PORTAINER_WEBHOOK_URL` secret has the publish job POST to
+a Portainer stack webhook after a push to the default branch, which redeploys
+the stack on its own. Off unless configured, default branch only — a `v*` tag
+publishes something nothing is pointed at yet — never echoed, since the URL is a
+deploy credential, and a failure warns rather than failing a build whose image
+is already published. `docs/RELEASING.md` has the setup.
+
 ## [4.5.2] - 2026-09-01
 
 Migrations through `021_market_listing_ttl_grace`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,10 @@ Shutdown sequencing is `utils/shutdown.js`, so the order the four steps close in
 — is asserted rather than remembered; extracting it also closed a hole, in that
 `stopScheduler()` sat outside the try, so a throw from it propagated out of the
 signal handler and the gateway, the buffered metrics and the connection were
-never closed at all. The `npm run deploy` guard is `runDeployCli`, returning an
+never closed at all. Each of the four is now attempted independently, in the
+same order: none of them is a precondition for the next — the sequencing is
+about not racing, not about dependency — so a gateway that rejects `destroy()`
+no longer takes the metrics drain and the connection close down with it. The `npm run deploy` guard is `runDeployCli`, returning an
 exit code instead of calling `process.exit`, so the branch deciding whether an
 operator gets a deploy or an error message has tests. The three files stay on
 the list as the thin wrappers they now are.
@@ -150,6 +153,9 @@ so the digests differ on every run even on a perfect cache hit. It warns rather
 than failing — the push has already happened, and a re-run would restore from
 the same evicted cache — and an unreadable manifest is reported as "not checked"
 rather than as a mismatch, so a registry blip cannot be misread as a finding.
+The check exports its verdict, and the webhook below fires only on a clean one:
+a workflow that labels an image **DO NOT DEPLOY** and then deploys it anyway is
+a workflow whose gate is worth less than nothing.
 
 And a published image announces itself (#953). Nothing pulls on its own: a
 Portainer stack holds the image it last deployed until somebody redeploys it, so
@@ -160,9 +166,11 @@ watching CI has the deploy in front of them rather than a fact to act on.
 Optionally, setting a `PORTAINER_WEBHOOK_URL` secret has the publish job POST to
 a Portainer stack webhook after a push to the default branch, which redeploys
 the stack on its own. Off unless configured, default branch only — a `v*` tag
-publishes something nothing is pointed at yet — never echoed, since the URL is a
-deploy credential, and a failure warns rather than failing a build whose image
-is already published. `docs/RELEASING.md` has the setup.
+publishes something nothing is pointed at yet — gated on the scanned-image check
+above, and refused outright unless the URL is `https://`, since it carries its
+own credential in its path and a GitHub-hosted runner reaches nothing that is
+not across the public internet. The URL is never echoed on any path, and a
+failure warns rather than failing a build whose image is already published. `docs/RELEASING.md` has the setup.
 
 ## [4.5.2] - 2026-09-01
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -69,8 +69,10 @@ The summary page of a green publish carries three lines: the digest, the
 `CLAWDIA_IMAGE_TAG=sha-<commit>` to deploy this build, and the
 `CLAWDIA_IMAGE_TAG=latest@sha256:…` to pin it immutably. It also carries a
 **Scanned-image check** table saying, per platform, whether the layers that were
-published are the ones the boot and vulnerability gates actually looked at. That
-row normally reads "match the scanned image". If it says **DO NOT DEPLOY**, the
+published are the ones the vulnerability scan actually looked at. (amd64 is also
+booted before it is scanned; arm64 is scanned but never booted, because booting
+it would mean running an emulated Node through its whole require graph.) Those
+rows normally read "match the scanned image". If one says **DO NOT DEPLOY**, the
 build cache was evicted between the scan job and the publish job, so the image
 in the registry was rebuilt and never scanned — re-run the workflow before
 deploying that tag.
@@ -133,6 +135,16 @@ Some notes on the edges:
 - **It fires on `main` only.** A `v*` tag push publishes a version tag that
   nothing is pointed at until you choose to be, so firing a redeploy on one
   would deploy something you did not ask for.
+- **It fires only behind the scanned-image check.** If that table reports
+  anything other than a match on every platform — including "not checked" — no
+  redeploy is requested, and the summary says so. A workflow that told you not
+  to deploy an image and then deployed it for you would make the check
+  worthless.
+- **The URL must be `https://`.** It carries its own credential in the path, so
+  a cleartext POST would hand that credential to every hop in between. An
+  `http://` value is refused with a warning rather than being sent. The usual
+  LAN argument does not apply: this runs on a GitHub-hosted runner, so any URL
+  it can reach is one crossing the public internet.
 - **It redeploys whatever the stack is pinned to.** The webhook tells Portainer
   to pull and recreate; it does not change `CLAWDIA_IMAGE_TAG`. A stack pinned to
   `4.2.1` will pull `4.2.1` again and come back on the same image. The webhook is

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -65,6 +65,16 @@ does not pin the base image or the apt packages under it. For a rollback target
 that cannot move at all, use the **digest** — the publish job writes it to the
 run's summary page, along with the exact `CLAWDIA_IMAGE_TAG` value to paste.
 
+The summary page of a green publish carries three lines: the digest, the
+`CLAWDIA_IMAGE_TAG=sha-<commit>` to deploy this build, and the
+`CLAWDIA_IMAGE_TAG=latest@sha256:…` to pin it immutably. It also carries a
+**Scanned-image check** table saying, per platform, whether the layers that were
+published are the ones the boot and vulnerability gates actually looked at. That
+row normally reads "match the scanned image". If it says **DO NOT DEPLOY**, the
+build cache was evicted between the scan job and the publish job, so the image
+in the registry was rebuilt and never scanned — re-run the workflow before
+deploying that tag.
+
 ## Pinning the deploy
 
 `portainer-stack.yml` reads its tag from `CLAWDIA_IMAGE_TAG`:
@@ -90,6 +100,51 @@ needs no change to the stack file:
 ```dotenv
 CLAWDIA_IMAGE_TAG=latest@sha256:3f8a…
 ```
+
+## Getting told there is something to deploy
+
+Nothing pulls on its own. A Portainer stack holds whatever image it last
+deployed until somebody redeploys it, so a repointed `:latest` — or a newer
+`sha-` tag, for a deployment pinned to one — changes nothing until an operator
+acts. Left at that, a published security fix can sit undeployed indefinitely
+because nothing announced it.
+
+There are two signals, and the first always runs:
+
+1. **The run summary.** Every green publish writes the `CLAWDIA_IMAGE_TAG` line
+   for that build, as above. An operator watching CI sees what to move to
+   without having to work it out from a commit sha.
+
+2. **A Portainer stack webhook**, which is opt-in and off by default. Portainer
+   can expose a URL that redeploys a stack when it is POSTed to; give the
+   workflow that URL and a push to `main` redeploys the stack on its own.
+
+To turn the second one on:
+
+1. In Portainer, open the stack, and under **Webhooks** create (or copy) the
+   stack webhook URL. It looks like
+   `https://portainer.example.com/api/stacks/webhooks/<uuid>`.
+2. In GitHub, add it as a repository secret named `PORTAINER_WEBHOOK_URL`
+   (Settings > Secrets and variables > Actions).
+
+The publish job then POSTs to it after a successful push to the default branch.
+Some notes on the edges:
+
+- **It fires on `main` only.** A `v*` tag push publishes a version tag that
+  nothing is pointed at until you choose to be, so firing a redeploy on one
+  would deploy something you did not ask for.
+- **It redeploys whatever the stack is pinned to.** The webhook tells Portainer
+  to pull and recreate; it does not change `CLAWDIA_IMAGE_TAG`. A stack pinned to
+  `4.2.1` will pull `4.2.1` again and come back on the same image. The webhook is
+  useful precisely when the stack tracks `latest`.
+- **The URL is a deploy credential.** Anyone holding it can redeploy the stack,
+  so it belongs in a secret and nowhere else. The workflow never echoes it.
+- **A failure does not fail the build.** The image is published and scanned
+  either way; an unreachable Portainer is logged as a warning on the run, with a
+  line in the summary saying to redeploy by hand.
+- Portainer invalidates a stack's webhook when the stack is recreated. If the
+  run starts warning about an HTTP 404, the secret is naming a stack that no
+  longer exists — create a new webhook and update it.
 
 ## Rolling back
 

--- a/src/deploy-commands.js
+++ b/src/deploy-commands.js
@@ -4,19 +4,15 @@ require('dotenv').config();
 // straight after dotenv so .env can set the *_FILE paths too, and before
 // anything reads process.env.
 require('./config/fileSecrets').loadFileSecrets();
-const { deployCommands } = require('./utils/commandDeployer');
+const { runDeployCli } = require('./utils/commandDeployer');
 
-(async () => {
-    if (!process.env.CLIENT_ID || !process.env.DISCORD_TOKEN) {
-        console.error('Missing CLIENT_ID or DISCORD_TOKEN environment variable.');
-        process.exit(1);
-    }
-    try {
-        console.log('Started refreshing application (/) commands.');
-        const count = await deployCommands(process.env.CLIENT_ID, process.env.DISCORD_TOKEN);
-        console.log(`Successfully reloaded ${count} application (/) commands.`);
-    } catch (error) {
-        console.error('Failed to deploy commands:', error);
-        process.exit(1);
-    }
-})();
+// Everything this used to do is in `runDeployCli`, where it is tested — this
+// file is on the `neverExecuted` list, and the guard it holds is the difference
+// between a deploy and an error message (#951). What is left is the exit.
+//
+// Only a failure exits explicitly. On success the process falls off the end of
+// the event loop, which is what lets the last `console.log` finish draining to
+// a pipe; `process.exit(0)` here would sometimes cut it off.
+runDeployCli().then(code => {
+    if (code !== 0) process.exit(code);
+});

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ const { makeCache, sweepers } = require('./utils/cacheOptions');
 const { isPrimaryShard, shardTag } = require('./utils/sharding');
 const { loadCommandModules } = require('./utils/commandLoader');
 const { startCooldownSweeper } = require('./utils/commandCooldowns');
+const { runShutdown } = require('./utils/shutdown');
 
 const client = new Client({
     intents: [
@@ -202,26 +203,22 @@ async function startDashboard() {
     }
 }
 
-// Graceful shutdown: close DB and destroy Discord client before exiting
-async function shutdown(signal) {
-    console.log(`[SHUTDOWN] Received ${signal}. Shutting down gracefully...`);
-    const { stopScheduler } = require('./services/scheduler');
-    stopScheduler();
-    try {
-        await client.destroy();
-        // After the client, before the connection closes. Command metrics are
-        // buffered in memory between 30s flushes (#895), so a deploy would
-        // otherwise drop up to an interval of counts on every restart — and
-        // draining them after the gateway is closed means no new command can
-        // arrive behind the write and be reported as lost.
-        const { stopCommandMetrics } = require('./utils/commandMetricsBuffer');
-        await stopCommandMetrics();
-        await connection.close();
-        console.log('[SHUTDOWN] Clean exit.');
-    } catch (err) {
-        console.error('[SHUTDOWN] Error during shutdown:', err);
-    }
-    process.exit(0);
+// Graceful shutdown: close DB and destroy Discord client before exiting.
+//
+// The sequence itself is in utils/shutdown.js, where it can be tested — the
+// order the four steps happen in is the whole of the logic, and this file is on
+// the `neverExecuted` list (#951). What is left here is binding it to this
+// process's client and connection.
+function shutdown(signal) {
+    return runShutdown(signal, {
+        client,
+        connection,
+        // Required rather than defaulted inside utils/shutdown.js: `services`
+        // is a layer above `utils` and may not be required from there. Lazy, as
+        // it always was, so the scheduler's graph is pulled in at shutdown
+        // rather than at boot.
+        stopScheduler: () => require('./services/scheduler').stopScheduler(),
+    });
 }
 
 async function startBot() {

--- a/src/shard.js
+++ b/src/shard.js
@@ -30,6 +30,10 @@ require('./config/fileSecrets').loadFileSecrets();
 
 const path = require('path');
 const { ShardingManager } = require('discord.js');
+// How SHARD_COUNT is read. It lives in utils/sharding.js with the rest of the
+// shard arithmetic rather than here, because this file is on the
+// `neverExecuted` list and that made the one branch in it untested (#951).
+const { resolveTotalShards } = require('./utils/sharding');
 
 // The same rules the children apply, applied once here first (#639). A shard
 // manager that spawns N processes to watch each of them exit on the same missing
@@ -42,17 +46,9 @@ require('./config/validateEnv').assertEnv({ label: 'SHARD' });
 // structured too rather than being the one unparsed thing in the stream.
 require('./utils/logger').installConsoleBridge();
 
-function resolveShardCount() {
-    const pinned = Number(process.env.SHARD_COUNT);
-    if (Number.isInteger(pinned) && pinned > 0) return pinned;
-    // 'auto' asks the gateway what it wants. Anything else and the manager would
-    // read the string as a number and spawn NaN shards.
-    return 'auto';
-}
-
 const manager = new ShardingManager(path.join(__dirname, 'index.js'), {
     token: process.env.DISCORD_TOKEN,
-    totalShards: resolveShardCount(),
+    totalShards: resolveTotalShards(),
     // The child reads its own identity from `client.shard`, but the singleton
     // gate runs before login — so the count is passed down as an env var too,
     // and `shardCount()` falls back to it.

--- a/src/utils/commandDeployer.js
+++ b/src/utils/commandDeployer.js
@@ -315,8 +315,62 @@ async function recordDeployment(clientId, hash, count, token = null) {
     );
 }
 
+/**
+ * The `npm run deploy` front door: the guard, the logging and the exit code
+ * (#951).
+ *
+ * It was the body of src/deploy-commands.js, which is on the `neverExecuted`
+ * list in coverage-floors.json — so the branch that decides whether an operator
+ * gets a deploy or an error message was never run by anything. It is here
+ * rather than there because that is the difference between logic with a test
+ * and logic without one.
+ *
+ * Returns the exit code instead of calling `process.exit`, for two reasons: a
+ * function that kills the process cannot be tested, and the caller can then do
+ * what the entrypoint has always done — exit explicitly on failure, and fall
+ * off the end on success rather than truncating a pipe that has not drained.
+ *
+ * The two variables are checked here as well as in config/validateEnv.js
+ * because this path deliberately does not run the validator: `npm run deploy`
+ * needs a token and an application id and nothing else, and holding it to the
+ * bot's whole configuration would make an operator set DASHBOARD_URL to
+ * register slash commands.
+ *
+ * @param {object} [deps]
+ * @param {object} [deps.env] the environment to read; injectable for the tests.
+ * @param {function(string, string): Promise<number>} [deps.deploy]
+ * @param {function(...*): void} [deps.log]
+ * @param {function(...*): void} [deps.logError]
+ * @returns {Promise<number>} 0 when the set was published, 1 otherwise.
+ */
+async function runDeployCli({
+    env = process.env,
+    deploy = deployCommands,
+    log = console.log,
+    logError = console.error,
+} = {}) {
+    if (!env.CLIENT_ID || !env.DISCORD_TOKEN) {
+        logError('Missing CLIENT_ID or DISCORD_TOKEN environment variable.');
+        return 1;
+    }
+
+    try {
+        log('Started refreshing application (/) commands.');
+        const count = await deploy(env.CLIENT_ID, env.DISCORD_TOKEN);
+        log(`Successfully reloaded ${count} application (/) commands.`);
+        return 0;
+    } catch (error) {
+        // The whole error, not `error.message`: a Discord rejection carries the
+        // per-command detail in `rawError`, and that detail is the only thing
+        // that says *which* command body it refused.
+        logError('Failed to deploy commands:', error);
+        return 1;
+    }
+}
+
 module.exports = {
     deployCommands,
+    runDeployCli,
     buildCommandPayload,
     deployCommandsIfChanged,
     commandSetHash,

--- a/src/utils/sharding.js
+++ b/src/utils/sharding.js
@@ -118,6 +118,33 @@ function shardIdForGuild(guildId, shardCount) {
 }
 
 /**
+ * What to hand `ShardingManager` as its `totalShards` (#951).
+ *
+ * SHARD_COUNT pins a number. Anything else — unset, empty, a typo, a zero, a
+ * negative, a float — falls through to `'auto'`, which asks the gateway how
+ * many it wants. That fallback is deliberately not a throw: this is read by
+ * the process an operator starts, and refusing to boot over a mistyped
+ * *optional* variable trades a running deployment for a strict one.
+ *
+ * `'auto'` as the literal string because that is the value discord.js reads.
+ * Returning the unparsed variable instead is the failure this exists to
+ * prevent: the manager takes the string as a number and spawns NaN shards.
+ *
+ * Distinct from `shardCount()` below, which answers a different question — that
+ * one is "how many shards are there", asked by an already-running child that
+ * has a client; this one is "how many should be spawned", asked once by the
+ * manager before any of them exist.
+ *
+ * @param {object} [env] the environment to read; injectable for the tests.
+ * @returns {number|'auto'} a pinned positive integer, or the gateway's call.
+ */
+function resolveTotalShards(env = process.env) {
+    const pinned = Number(env.SHARD_COUNT);
+    if (Number.isInteger(pinned) && pinned > 0) return pinned;
+    return 'auto';
+}
+
+/**
  * How many shards this deployment runs. One when unsharded, which is the
  * default and makes every rule here a no-op rather than a special case.
  */
@@ -225,6 +252,7 @@ function shardTag(client = null) {
 module.exports = {
     GUILD_SHARD_SHIFT,
     shardIdForGuild,
+    resolveTotalShards,
     shardCount,
     shardId,
     isPrimaryShard,

--- a/src/utils/shutdown.js
+++ b/src/utils/shutdown.js
@@ -88,14 +88,35 @@ async function runShutdown(signal, {
         logError('[SHUTDOWN] Error stopping the scheduler:', err);
     }
 
-    try {
-        await client.destroy();
-        await stopCommandMetrics();
-        await connection.close();
-        log('[SHUTDOWN] Clean exit.');
-    } catch (err) {
-        logError('[SHUTDOWN] Error during shutdown:', err);
+    // Each step is attempted on its own, in order. Sequencing is the point of
+    // this function and is unchanged; what a step does *not* do any more is
+    // cancel the ones after it.
+    //
+    // They shared a try until a review pointed out it was the same hole the
+    // scheduler guard above exists to close, one level in: a gateway that
+    // rejects `destroy()` skipped the metrics drain and the connection close,
+    // so the buffered counts (#895) were lost to a failure that had nothing to
+    // do with them. Nothing here is a precondition for what follows it — the
+    // order is about not racing, not about dependency — so a failed step leaves
+    // the next one both safe and worth doing.
+    let failed = false;
+    for (const [what, step] of [
+        ['closing the gateway', () => client.destroy()],
+        ['draining the command metrics', () => stopCommandMetrics()],
+        ['closing the database connection', () => connection.close()],
+    ]) {
+        try {
+            await step();
+        } catch (err) {
+            failed = true;
+            logError(`[SHUTDOWN] Error ${what}:`, err);
+        }
     }
+
+    // Only when every step actually succeeded. "Clean exit" over a shutdown
+    // that dropped a step is the log line that makes the next incident harder
+    // to read.
+    if (!failed) log('[SHUTDOWN] Clean exit.');
 
     exit(0);
 }

--- a/src/utils/shutdown.js
+++ b/src/utils/shutdown.js
@@ -1,0 +1,103 @@
+'use strict';
+
+// The graceful shutdown sequence, lifted out of src/index.js so it can be
+// tested (#951).
+//
+// It lived inside the entrypoint, which is on the `neverExecuted` list in
+// coverage-floors.json — so the one path that runs on every single deploy was
+// the one path nothing exercised. The CI image job boots the container, which
+// would catch a shutdown that failed to load; it does not catch a shutdown that
+// closes things in the wrong order, because nothing there ever sends the
+// signal.
+//
+// ── The order, and why it is that order ──────────────────────────────────────
+//
+// Each step is here because the step before it has to have finished:
+//
+//   1. stopScheduler()        no new cron job may start while the rest of this
+//                             runs — a job that begins here would be reaching
+//                             for a database connection step 4 is about to
+//                             close.
+//   2. client.destroy()       close the gateway. After this no new interaction
+//                             can arrive, which is what makes step 3 a drain
+//                             rather than a race.
+//   3. stopCommandMetrics()   command counts are buffered in memory between 30s
+//                             flushes (#895), so a deploy would otherwise drop
+//                             up to an interval of them on every restart. It is
+//                             after the gateway closes so that no command can
+//                             arrive behind the write and be reported as lost,
+//                             and before step 4 because it writes to Mongo.
+//   4. connection.close()     last, because 3 needs it open.
+//
+// ── Why the exit is unconditional ────────────────────────────────────────────
+//
+// Every failure path still reaches `exit(0)`. The container is going away
+// either way: the signal has already been sent, and a process that answers
+// SIGTERM by throwing does not stay alive — it waits out Docker's grace period
+// and is killed, which is the slow version of the same outcome with a worse
+// log. So a step that throws is logged and the sequence continues.
+//
+// `stopScheduler` is guarded separately for that reason. In the entrypoint it
+// sat outside the try, so a throw from it propagated out of the signal handler
+// as an unhandled rejection and the gateway and the database were never closed
+// at all — the buffered metrics went with them. It is the first step, so it is
+// also the step with the most left to lose.
+
+/**
+ * Close everything this process holds open, in order, and exit.
+ *
+ * Collaborators are injected. `stopCommandMetrics` defaults to a lazy require,
+ * matching how the entrypoint pulled it in — at shutdown rather than at module
+ * load, so that requiring this file (which the tests do) does not drag that
+ * graph in behind it.
+ *
+ * `stopScheduler` has no default and must be passed. It is not an oversight:
+ * `services` sits above `utils` in the layer order this tree is linted against
+ * (see LAYERS in eslint.config.js), so this module may not reach for the
+ * scheduler even lazily. The entrypoint is above both and owns that wiring —
+ * which is the right place for it anyway. A caller that forgets is caught by
+ * the guard below and logged rather than taking the shutdown down.
+ *
+ * @param {string} signal the signal that started this, for the log line.
+ * @param {object} deps
+ * @param {{destroy: function(): Promise<void>}} deps.client the Discord client.
+ * @param {{close: function(): Promise<void>}} deps.connection the mongoose connection.
+ * @param {function(): void} deps.stopScheduler required; see above.
+ * @param {function(): Promise<void>} [deps.stopCommandMetrics]
+ * @param {function(number): void} [deps.exit]
+ * @param {function(...*): void} [deps.log]
+ * @param {function(...*): void} [deps.logError]
+ * @returns {Promise<void>} resolves once `exit` has been called.
+ */
+async function runShutdown(signal, {
+    client,
+    connection,
+    stopScheduler,
+    stopCommandMetrics = () => require('./commandMetricsBuffer').stopCommandMetrics(),
+    exit = code => process.exit(code),
+    log = console.log,
+    logError = console.error,
+} = {}) {
+    log(`[SHUTDOWN] Received ${signal}. Shutting down gracefully...`);
+
+    // Its own try: see the note above on why a throw here must not take the
+    // gateway and the database down with it.
+    try {
+        stopScheduler();
+    } catch (err) {
+        logError('[SHUTDOWN] Error stopping the scheduler:', err);
+    }
+
+    try {
+        await client.destroy();
+        await stopCommandMetrics();
+        await connection.close();
+        log('[SHUTDOWN] Clean exit.');
+    } catch (err) {
+        logError('[SHUTDOWN] Error during shutdown:', err);
+    }
+
+    exit(0);
+}
+
+module.exports = { runShutdown };

--- a/tests/ciDeploySignal.test.js
+++ b/tests/ciDeploySignal.test.js
@@ -131,6 +131,14 @@ describe('#952 — a publish that is not the scanned image is reported', () => {
     test('the result reaches the run summary, not only the log', () => {
         expect(checkStep.run).toMatch(/GITHUB_STEP_SUMMARY/);
     });
+
+    test('it exports a verified result for the webhook to gate on', () => {
+        // Every path has to set it, the early return included: a check that did
+        // not run must not read as a check that passed.
+        expect(checkStep.id).toBeTruthy();
+        expect(checkStep.run).toMatch(/verified=false[\s\S]*exit 0/);
+        expect(checkStep.run).toMatch(/verified=\$verified" >> "\$GITHUB_OUTPUT"/);
+    });
 });
 
 describe('#953 — a published image announces itself', () => {
@@ -195,6 +203,40 @@ describe('#953 — a published image announces itself', () => {
         // reason to re-publish an image already in the registry.
         expect(hookStep.run).toMatch(/::warning::/);
         expect(hookStep['continue-on-error']).toBeUndefined();
+    });
+
+    test('it does not fire when the published image was not the scanned one', () => {
+        // The check step labels a mismatched platform "DO NOT DEPLOY". A
+        // workflow that then auto-deploys it is one that walks past its own
+        // gate, which is worth less than not having the gate.
+        const check = stepsOf(publishJob).find(s => /imagetools inspect/.test(s.run || ''));
+        expect(hookStep.if).toMatch(
+            new RegExp(`steps\\.${check.id}\\.outputs\\.verified\\s*==\\s*'true'`));
+    });
+
+    test('it refuses a non-HTTPS webhook URL', () => {
+        // The URL carries its own credential in the path, and this runs on a
+        // GitHub-hosted runner — so any URL it can reach crosses the public
+        // internet, and the LAN argument for cleartext does not apply.
+        expect(hookStep.run).toMatch(/https:\/\/\*\)/);
+        // Refused before the request, not after it.
+        const guard = hookStep.run.indexOf('https://*)');
+        expect(guard).toBeGreaterThanOrEqual(0);
+        expect(guard).toBeLessThan(hookStep.run.indexOf('curl'));
+    });
+
+    test('no line in the step prints the URL', () => {
+        // Reading the variable is fine — the `case` guard has to. Printing it
+        // is not, on any path, refusal included.
+        const printing = hookStep.run.split('\n')
+            .filter(line => /\b(echo|printf)\b/.test(line))
+            .filter(line => /PORTAINER_WEBHOOK_URL/.test(line));
+
+        // The one allowed mention is the advice naming the *variable* for the
+        // operator to go and check, which is not its value.
+        for (const line of printing) {
+            expect(line).not.toMatch(/\$\{?PORTAINER_WEBHOOK_URL\}?/);
+        }
     });
 
     test('the webhook runs after the image is pushed', () => {

--- a/tests/ciDeploySignal.test.js
+++ b/tests/ciDeploySignal.test.js
@@ -1,0 +1,205 @@
+'use strict';
+
+/**
+ * The two halves of "what happened to the image after it was built" — #952 and
+ * #953.
+ *
+ * Both are a few lines of YAML that nothing else in the tree refers to, which
+ * is the kind of thing a workflow rewrite drops and nobody notices for a
+ * release. tests/ciSupplyChainGates.test.js exists for exactly that reason and
+ * this is its neighbour, holding the two gaps that sat on the other side of the
+ * push:
+ *
+ *   #952  `publish` rebuilds rather than promoting the artifact that was booted
+ *         and scanned. That is documented and deliberate — promoting by digest
+ *         needs `packages: write` in a job that also runs on pull requests. But
+ *         a cache eviction between the jobs publishes an image nothing ever
+ *         looked at, and nothing reported that it had happened.
+ *   #953  a new image was published and nothing told the deployment. The
+ *         Portainer stack does not poll, so a security fix could sit published
+ *         and undeployed because nothing announced it.
+ *
+ * These assert the reporting, not the guarantee. The guarantee is still the
+ * cache hit; what is now testable is that a breach of it is loud.
+ */
+
+const fs   = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const ROOT = path.join(__dirname, '..');
+const ci = yaml.load(fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'ci.yml'), 'utf8'));
+
+const jobs = ci.jobs;
+const stepsOf = job => jobs[job].steps || [];
+const runScript = job => stepsOf(job).map(s => s.run || '').join('\n');
+
+// Found by what the job does rather than by its name, the same way the
+// supply-chain gates find theirs — renaming a job must not turn these into
+// assertions about a job that no longer exists.
+const jobWhoseBuild = pushes => Object.keys(jobs).find(name => stepsOf(name).some(
+    step => /build-push-action/.test(step.uses || '') && step.with && step.with.push === pushes));
+
+const publishJob = jobWhoseBuild(true);
+
+/** Every job that records the layers it scanned, by its output. */
+const recordingJobs = Object.keys(jobs).filter(name => jobs[name].outputs
+    && Object.prototype.hasOwnProperty.call(jobs[name].outputs, 'scanned-layers'));
+
+describe('#952 — a publish that is not the scanned image is reported', () => {
+    test('the jobs that scan an image record the layers they scanned', () => {
+        // Both platforms or neither: publish assembles one manifest list out of
+        // two cache scopes, and either can be evicted independently, so
+        // checking one platform would report half the problem.
+        expect(recordingJobs.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('every job that scans with Trivy also records its layers', () => {
+        const scanning = Object.keys(jobs).filter(name => stepsOf(name).some(
+            step => /trivy-action/.test(step.uses || '')));
+
+        expect(scanning).not.toEqual([]);
+        for (const job of scanning) {
+            expect(recordingJobs).toContain(job);
+        }
+    });
+
+    test('the record is taken after the scan, so only a passing image is recorded', () => {
+        for (const job of recordingJobs) {
+            const steps = stepsOf(job);
+            const scan = steps.findIndex(s => /trivy-action/.test(s.uses || ''));
+            const record = steps.findIndex(s => /docker image inspect/.test(s.run || ''));
+
+            expect(scan).toBeGreaterThanOrEqual(0);
+            expect(record).toBeGreaterThan(scan);
+        }
+    });
+
+    test('it records diff IDs, not a digest', () => {
+        // The digest cannot answer the question: publish adds OCI labels from
+        // metadata-action, a label changes the image config, and so the config
+        // and manifest digests differ from the scanned build's on every run —
+        // cache hit or not. Diff IDs are the uncompressed layer hashes, which
+        // is what "the same bytes" means and what labels do not touch.
+        for (const job of recordingJobs) {
+            expect(runScript(job)).toMatch(/RootFS\.Layers/);
+        }
+    });
+
+    const checkStep = stepsOf(publishJob).find(s => /imagetools inspect/.test(s.run || ''));
+
+    test('publish compares what it pushed against what was scanned', () => {
+        expect(checkStep).toBeDefined();
+        expect(checkStep.run).toMatch(/rootfs\.diff_ids/);
+    });
+
+    test('it compares the image it actually pushed, by digest', () => {
+        // Not `:latest` and not the sha- tag: both are mutable, and by the time
+        // this reads them a concurrent run could have repointed either.
+        const env = checkStep.env || {};
+        expect(JSON.stringify(env)).toMatch(/steps\.build\.outputs\.digest/);
+    });
+
+    test('it reads both platforms', () => {
+        expect(checkStep.run).toMatch(/linux\/amd64/);
+        expect(checkStep.run).toMatch(/linux\/arm64/);
+    });
+
+    test('it consumes the recording jobs rather than recomputing', () => {
+        const env = JSON.stringify(checkStep.env || {});
+        for (const job of recordingJobs) {
+            expect(env).toContain(`needs.${job}.outputs.scanned-layers`);
+        }
+    });
+
+    test('a mismatch warns rather than failing the job', () => {
+        // The push has already happened, so failing here unpublishes nothing —
+        // and a re-run would restore from the same evicted cache and fail
+        // again, which is a red main branch that no action clears. What the
+        // operator needs is to know, which is what the annotation is.
+        expect(checkStep.run).toMatch(/::warning::/);
+        expect(checkStep['continue-on-error']).toBeUndefined();
+    });
+
+    test('an unreadable manifest is reported as unchecked, not as a mismatch', () => {
+        // Same rule the npm audit step follows: a registry blip read as a
+        // security finding is the false alarm that teaches everyone to ignore
+        // the real one.
+        expect(checkStep.run).toMatch(/not checked/i);
+    });
+
+    test('the result reaches the run summary, not only the log', () => {
+        expect(checkStep.run).toMatch(/GITHUB_STEP_SUMMARY/);
+    });
+});
+
+describe('#953 — a published image announces itself', () => {
+    const summaryStep = stepsOf(publishJob).find(s => /### Image/.test(s.run || ''));
+
+    test('the summary carries the tag to deploy, not only the digest', () => {
+        expect(summaryStep).toBeDefined();
+        // The gap this closes: the digest was already there, so a rollback
+        // target was recoverable, but nothing said what to move *forward* to.
+        expect(summaryStep.run).toMatch(/CLAWDIA_IMAGE_TAG=sha-/);
+    });
+
+    test('the summary still carries the immutable digest pin', () => {
+        expect(summaryStep.run).toMatch(/CLAWDIA_IMAGE_TAG=latest@/);
+        expect(summaryStep.run).toMatch(/steps\.build\.outputs\.digest/);
+    });
+
+    test('the sha- tag in the summary is the one metadata-action publishes', () => {
+        // `type=sha,format=long` produces `sha-<full commit sha>`. A summary
+        // naming a tag that was not published is worse than no summary.
+        const meta = stepsOf(publishJob).find(s => /metadata-action/.test(s.uses || ''));
+        expect(meta.with.tags).toMatch(/type=sha,format=long/);
+        expect(summaryStep.run).toMatch(/sha-\$\{\{\s*github\.sha\s*\}\}/);
+    });
+
+    const hookStep = stepsOf(publishJob).find(s => /PORTAINER_WEBHOOK_URL/.test(
+        (s.run || '') + JSON.stringify(s.if || '')));
+
+    test('there is an opt-in Portainer webhook', () => {
+        expect(hookStep).toBeDefined();
+    });
+
+    test('it is off unless an operator configured one', () => {
+        // Every fork, and this repo by default, has no such secret. A workflow
+        // that assumed a Portainer would be wrong for all of them.
+        expect(hookStep.if).toMatch(/env\.PORTAINER_WEBHOOK_URL\s*!=\s*''/);
+    });
+
+    test('the secret is lifted to job env, because a step `if` cannot read secrets', () => {
+        expect(jobs[publishJob].env.PORTAINER_WEBHOOK_URL).toMatch(/secrets\.PORTAINER_WEBHOOK_URL/);
+    });
+
+    test('it fires on the default branch only', () => {
+        // A v* tag push publishes a version tag nothing is pointed at until an
+        // operator chooses to be; redeploying on one would deploy something
+        // they did not ask for. `:latest` — what the stack pulls by default —
+        // only moves on the default branch anyway.
+        expect(hookStep.if).toMatch(/default_branch/);
+    });
+
+    test('it never echoes the URL, which is a deploy credential', () => {
+        expect(hookStep.run).not.toMatch(/echo[^\n]*\$PORTAINER_WEBHOOK_URL/);
+        expect(hookStep.run).not.toMatch(/echo[^\n]*\$\{PORTAINER_WEBHOOK_URL\}/);
+        // And the response body stays out of the log too: Portainer answers a
+        // webhook with the stack definition.
+        expect(hookStep.run).toMatch(/-o \/dev\/null/);
+    });
+
+    test('a webhook failure warns rather than failing the publish', () => {
+        // The image is published and scanned either way, which is what this job
+        // is for. A Portainer that was unreachable for thirty seconds is not a
+        // reason to re-publish an image already in the registry.
+        expect(hookStep.run).toMatch(/::warning::/);
+        expect(hookStep['continue-on-error']).toBeUndefined();
+    });
+
+    test('the webhook runs after the image is pushed', () => {
+        const steps = stepsOf(publishJob);
+        const build = steps.findIndex(s => /build-push-action/.test(s.uses || ''));
+        expect(steps.indexOf(hookStep)).toBeGreaterThan(build);
+    });
+});

--- a/tests/entrypointLogic.test.js
+++ b/tests/entrypointLogic.test.js
@@ -160,26 +160,46 @@ describe('#951 — graceful shutdown ordering', () => {
         expect(exit).toHaveBeenCalledWith(0);
     });
 
-    test('a rejecting client.destroy still exits', async () => {
-        const exit = jest.fn();
-        const deps = harness({ exit });
-        deps.client = { destroy: () => Promise.reject(new Error('gateway hung')) };
-
-        await runShutdown('SIGTERM', deps);
-
-        expect(exit).toHaveBeenCalledWith(0);
-    });
-
-    test('a rejecting metrics drain is logged and still exits', async () => {
+    // A failing step must not cancel the ones after it. The three shared a try
+    // until review caught that a gateway rejecting `destroy()` took the metrics
+    // drain and the connection close down with it — losing the buffered counts
+    // to a failure that had nothing to do with them.
+    test('a rejecting client.destroy still drains metrics and closes the database', async () => {
         const exit = jest.fn();
         const logError = jest.fn();
         const deps = harness({ exit, logError });
-        deps.stopCommandMetrics = () => Promise.reject(new Error('mongo gone'));
+        deps.client = {
+            destroy: () => {
+                deps.calls.push('client.destroy');
+                return Promise.reject(new Error('gateway hung'));
+            },
+        };
 
         await runShutdown('SIGTERM', deps);
 
-        expect(exit).toHaveBeenCalledWith(0);
+        expect(deps.calls).toEqual([
+            'stopScheduler', 'client.destroy', 'stopCommandMetrics', 'connection.close',
+        ]);
         expect(logError).toHaveBeenCalled();
+        expect(exit).toHaveBeenCalledWith(0);
+    });
+
+    test('a rejecting metrics drain still closes the database', async () => {
+        const exit = jest.fn();
+        const logError = jest.fn();
+        const deps = harness({ exit, logError });
+        deps.stopCommandMetrics = () => {
+            deps.calls.push('stopCommandMetrics');
+            return Promise.reject(new Error('mongo gone'));
+        };
+
+        await runShutdown('SIGTERM', deps);
+
+        expect(deps.calls).toContain('connection.close');
+        expect(deps.calls.indexOf('connection.close'))
+            .toBeGreaterThan(deps.calls.indexOf('stopCommandMetrics'));
+        expect(logError).toHaveBeenCalled();
+        expect(exit).toHaveBeenCalledWith(0);
     });
 
     test('a rejecting connection.close still exits', async () => {
@@ -190,6 +210,39 @@ describe('#951 — graceful shutdown ordering', () => {
         await runShutdown('SIGTERM', deps);
 
         expect(exit).toHaveBeenCalledWith(0);
+    });
+
+    test('every step is attempted even when all of them reject', async () => {
+        const exit = jest.fn();
+        const logError = jest.fn();
+        const deps = harness({ exit, logError });
+        const boom = name => () => {
+            deps.calls.push(name);
+            return Promise.reject(new Error(name));
+        };
+        deps.client = { destroy: boom('client.destroy') };
+        deps.stopCommandMetrics = boom('stopCommandMetrics');
+        deps.connection = { close: boom('connection.close') };
+
+        await runShutdown('SIGTERM', deps);
+
+        expect(deps.calls).toEqual([
+            'stopScheduler', 'client.destroy', 'stopCommandMetrics', 'connection.close',
+        ]);
+        // One line per failure, so the log says which steps went wrong rather
+        // than only that something did.
+        expect(logError).toHaveBeenCalledTimes(3);
+        expect(exit).toHaveBeenCalledWith(0);
+    });
+
+    test('does not claim a clean exit when a step failed', async () => {
+        const log = jest.fn();
+        const deps = harness({ log, logError: () => {} });
+        deps.connection = { close: () => Promise.reject(new Error('already closed')) };
+
+        await runShutdown('SIGTERM', deps);
+
+        expect(log.mock.calls.flat().join(' ')).not.toMatch(/Clean exit/);
     });
 
     // The defaults themselves, which are part of the wiring: a default that

--- a/tests/entrypointLogic.test.js
+++ b/tests/entrypointLogic.test.js
@@ -1,0 +1,292 @@
+'use strict';
+
+/**
+ * The logic the entrypoints used to hide (#951).
+ *
+ * src/index.js, src/shard.js and src/deploy-commands.js are all on the
+ * `neverExecuted` list in coverage-floors.json, and they are there legitimately:
+ * requiring one starts a bot. What was not legitimate is how much *decision*
+ * had accumulated inside them — the shard count a deployment spawns, the order
+ * a shutdown closes things in, and whether `npm run deploy` runs at all.
+ *
+ * CI's image job boots the container, so a totally broken entrypoint was always
+ * caught. None of these three are that: each is a branch or an ordering that
+ * boots perfectly and does the wrong thing, which is exactly the class of bug a
+ * smoke test cannot see. They now live in importable functions, and this is
+ * what runs them.
+ */
+
+const { resolveTotalShards } = require('../src/utils/sharding');
+const { runShutdown } = require('../src/utils/shutdown');
+const { runDeployCli } = require('../src/utils/commandDeployer');
+
+describe('#951 — shard-count selection', () => {
+    test('a pinned positive integer is used as given', () => {
+        expect(resolveTotalShards({ SHARD_COUNT: '4' })).toBe(4);
+        expect(resolveTotalShards({ SHARD_COUNT: '1' })).toBe(1);
+        // Read as a number, not passed through as the string it arrived as.
+        expect(resolveTotalShards({ SHARD_COUNT: '12' })).toBe(12);
+    });
+
+    test('an unset SHARD_COUNT asks the gateway', () => {
+        expect(resolveTotalShards({})).toBe('auto');
+        expect(resolveTotalShards({ SHARD_COUNT: '' })).toBe('auto');
+    });
+
+    // The whole point of the branch. discord.js reads `totalShards` as a
+    // number, so anything that survives to it unparsed spawns NaN shards —
+    // which is not an error, it is a manager that spawns nothing and reports
+    // success.
+    test.each([
+        ['a typo',        'auto-detect'],
+        ['a word',        'auto'],
+        ['zero',          '0'],
+        ['a negative',    '-2'],
+        ['a float',       '2.5'],
+        ['whitespace',    '   '],
+        ['a stray unit',  '4 shards'],
+    ])('%s falls back to auto rather than reaching the manager', (_label, value) => {
+        expect(resolveTotalShards({ SHARD_COUNT: value })).toBe('auto');
+    });
+
+    test('the fallback is the string discord.js understands, not null', () => {
+        // `null` and `undefined` are both falsy and both wrong here: the
+        // ShardingManager option is documented as a number or 'auto'.
+        expect(resolveTotalShards({ SHARD_COUNT: 'nonsense' })).toBe('auto');
+    });
+});
+
+describe('#951 — graceful shutdown ordering', () => {
+    /** A shutdown whose every collaborator records the order it was called in. */
+    function harness(overrides = {}) {
+        const calls = [];
+        const record = (name, result) => (...args) => {
+            calls.push(name);
+            if (typeof result === 'function') return result(...args);
+            return result;
+        };
+        const deps = {
+            calls,
+            client: { destroy: record('client.destroy', Promise.resolve()) },
+            connection: { close: record('connection.close', Promise.resolve()) },
+            stopScheduler: record('stopScheduler'),
+            stopCommandMetrics: record('stopCommandMetrics', Promise.resolve()),
+            exit: record('exit'),
+            log: () => {},
+            logError: () => {},
+            ...overrides,
+        };
+        return deps;
+    }
+
+    test('closes everything in the order the steps depend on', async () => {
+        const deps = harness();
+        await runShutdown('SIGTERM', deps);
+
+        expect(deps.calls).toEqual([
+            // No new cron job may start while the rest runs.
+            'stopScheduler',
+            // Gateway first, so the metrics drain is not racing new commands.
+            'client.destroy',
+            // Buffered counts written while Mongo is still open (#895).
+            'stopCommandMetrics',
+            'connection.close',
+            'exit',
+        ]);
+    });
+
+    test('drains the command metrics after the gateway and before the database', async () => {
+        const deps = harness();
+        await runShutdown('SIGINT', deps);
+
+        const at = name => deps.calls.indexOf(name);
+        // Stated as the two orderings that matter rather than as the whole
+        // list, so the reason survives a step being added between them.
+        expect(at('stopCommandMetrics')).toBeGreaterThan(at('client.destroy'));
+        expect(at('stopCommandMetrics')).toBeLessThan(at('connection.close'));
+    });
+
+    test('exits 0', async () => {
+        const exit = jest.fn();
+        await runShutdown('SIGTERM', harness({ exit }));
+        expect(exit).toHaveBeenCalledWith(0);
+    });
+
+    test('names the signal in the log', async () => {
+        const log = jest.fn();
+        await runShutdown('SIGTERM', harness({ log }));
+        expect(log.mock.calls.flat().join(' ')).toMatch(/SIGTERM/);
+    });
+
+    // The four failure paths. The container is going away either way: the
+    // signal has been sent, and a process that answers it by throwing is not
+    // saved, it waits out Docker's grace period and is killed. So every one of
+    // these still has to reach the exit.
+    test('a throwing scheduler still closes the gateway and the database', async () => {
+        const logError = jest.fn();
+        const deps = harness({ logError });
+        deps.stopScheduler = () => {
+            deps.calls.push('stopScheduler');
+            throw new Error('scheduler stuck');
+        };
+
+        await runShutdown('SIGTERM', deps);
+
+        // This is the regression the extraction fixed: in the entrypoint
+        // `stopScheduler` sat outside the try, so a throw from it propagated out
+        // of the signal handler and the gateway, the buffered metrics and the
+        // database connection were all left open.
+        expect(deps.calls).toContain('client.destroy');
+        expect(deps.calls).toContain('stopCommandMetrics');
+        expect(deps.calls).toContain('connection.close');
+        expect(deps.calls).toContain('exit');
+        expect(logError).toHaveBeenCalled();
+    });
+
+    test('a caller that forgets stopScheduler is logged, not left running', async () => {
+        // It has no default because `services` sits above `utils` in the layer
+        // order, so utils/shutdown.js may not require the scheduler even
+        // lazily — the entrypoint injects it. This is what happens if a future
+        // caller does not.
+        const exit = jest.fn();
+        const logError = jest.fn();
+        const deps = harness({ exit, logError });
+        delete deps.stopScheduler;
+
+        await runShutdown('SIGTERM', deps);
+
+        expect(logError).toHaveBeenCalled();
+        expect(deps.calls).toContain('client.destroy');
+        expect(exit).toHaveBeenCalledWith(0);
+    });
+
+    test('a rejecting client.destroy still exits', async () => {
+        const exit = jest.fn();
+        const deps = harness({ exit });
+        deps.client = { destroy: () => Promise.reject(new Error('gateway hung')) };
+
+        await runShutdown('SIGTERM', deps);
+
+        expect(exit).toHaveBeenCalledWith(0);
+    });
+
+    test('a rejecting metrics drain is logged and still exits', async () => {
+        const exit = jest.fn();
+        const logError = jest.fn();
+        const deps = harness({ exit, logError });
+        deps.stopCommandMetrics = () => Promise.reject(new Error('mongo gone'));
+
+        await runShutdown('SIGTERM', deps);
+
+        expect(exit).toHaveBeenCalledWith(0);
+        expect(logError).toHaveBeenCalled();
+    });
+
+    test('a rejecting connection.close still exits', async () => {
+        const exit = jest.fn();
+        const deps = harness({ exit });
+        deps.connection = { close: () => Promise.reject(new Error('already closed')) };
+
+        await runShutdown('SIGTERM', deps);
+
+        expect(exit).toHaveBeenCalledWith(0);
+    });
+
+    // The defaults themselves, which are part of the wiring: a default that
+    // reaches for the wrong module is a shutdown that throws on the one path
+    // nothing else runs.
+    test('drains the real metrics buffer when none is injected', async () => {
+        const buffer = require('../src/utils/commandMetricsBuffer');
+        const spy = jest.spyOn(buffer, 'stopCommandMetrics').mockResolvedValue(0);
+        const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+        const logError = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const exit = jest.fn();
+
+        try {
+            await runShutdown('SIGTERM', {
+                client: { destroy: () => Promise.resolve() },
+                connection: { close: () => Promise.resolve() },
+                stopScheduler: () => {},
+                exit,
+            });
+
+            expect(spy).toHaveBeenCalled();
+            // Defaulted through to the console rather than swallowed.
+            expect(log).toHaveBeenCalled();
+            expect(exit).toHaveBeenCalledWith(0);
+        } finally {
+            spy.mockRestore();
+            log.mockRestore();
+            logError.mockRestore();
+        }
+    });
+});
+
+describe('#951 — the deploy guard', () => {
+    const silent = { log: () => {}, logError: () => {} };
+
+    test('refuses without CLIENT_ID', async () => {
+        const deploy = jest.fn();
+        const code = await runDeployCli({ ...silent, env: { DISCORD_TOKEN: 't' }, deploy });
+
+        expect(code).toBe(1);
+        // The point of the guard: nothing reaches Discord.
+        expect(deploy).not.toHaveBeenCalled();
+    });
+
+    test('refuses without DISCORD_TOKEN', async () => {
+        const deploy = jest.fn();
+        const code = await runDeployCli({ ...silent, env: { CLIENT_ID: '1' }, deploy });
+
+        expect(code).toBe(1);
+        expect(deploy).not.toHaveBeenCalled();
+    });
+
+    test('refuses on an empty string, not just a missing key', async () => {
+        const deploy = jest.fn();
+        const code = await runDeployCli({ ...silent, env: { CLIENT_ID: '', DISCORD_TOKEN: 't' }, deploy });
+
+        expect(code).toBe(1);
+        expect(deploy).not.toHaveBeenCalled();
+    });
+
+    test('says which variables are missing', async () => {
+        const logError = jest.fn();
+        await runDeployCli({ ...silent, logError, env: {}, deploy: jest.fn() });
+
+        expect(logError.mock.calls.flat().join(' ')).toMatch(/CLIENT_ID.*DISCORD_TOKEN/);
+    });
+
+    test('deploys with both present, and reports the count', async () => {
+        const deploy = jest.fn().mockResolvedValue(92);
+        const log = jest.fn();
+        const code = await runDeployCli({ ...silent, log, env: { CLIENT_ID: '1', DISCORD_TOKEN: 't' }, deploy });
+
+        expect(code).toBe(0);
+        expect(deploy).toHaveBeenCalledWith('1', 't');
+        expect(log.mock.calls.flat().join(' ')).toMatch(/92/);
+    });
+
+    test('a rejected deploy is exit 1, not a thrown promise', async () => {
+        // The entrypoint turns this into `process.exit(1)`. Left to throw it
+        // would be an unhandled rejection, which Node reports on stderr and
+        // then exits *non-deterministically* depending on the version's
+        // --unhandled-rejections default.
+        const deploy = jest.fn().mockRejectedValue(new Error('Discord said no'));
+        const code = await runDeployCli({ ...silent, env: { CLIENT_ID: '1', DISCORD_TOKEN: 't' }, deploy });
+
+        expect(code).toBe(1);
+    });
+
+    test('logs the whole error, so a rejection keeps its per-command detail', async () => {
+        const error = new Error('Invalid Form Body');
+        error.rawError = { errors: { 3: { name: { _errors: [{ code: 'X' }] } } } };
+        const logError = jest.fn();
+        await runDeployCli({ ...silent, logError, env: { CLIENT_ID: '1', DISCORD_TOKEN: 't' },
+            deploy: jest.fn().mockRejectedValue(error) });
+
+        // The error object itself, not `error.message` — `rawError` is the only
+        // thing that says which command body was refused.
+        expect(logError).toHaveBeenCalledWith(expect.any(String), error);
+    });
+});


### PR DESCRIPTION
Three things nothing was watching, on either side of the build.

The process entrypoints hid decisions from the suite (#951). src/index.js,
src/shard.js and src/deploy-commands.js are all on coverage-floors.json's
neverExecuted list, and legitimately so — requiring one starts a bot. What is
not legitimate is how much had accumulated inside them: shard-count selection,
shutdown ordering and the deploy guard all boot perfectly and then do the wrong
thing, which is the one class of bug the CI image job's boot test cannot see.
Each moves to an importable function with tests, leaving the three files as the
thin wrappers that belong on the list. Extracting the shutdown also closed a
hole: stopScheduler() sat outside the try, so a throw from it propagated out of
the signal handler and the gateway, the buffered command metrics and the
database connection were never closed at all.

A publish that is not the scanned image now says so (#952). publish rebuilds
rather than promoting the artifact image and arm64 booted and scanned, which
stays deliberate — promoting by digest needs packages: write in a job that also
runs on pull requests, a wider exposure than the gap it closes. The gap was
never the guarantee, it was that a breach of it was silent: a cache eviction
between the jobs publishes an image nothing ever scanned, and the run is green.
Both scan jobs record the layer diff IDs they passed and publish compares them
against what it pushed, per platform. Diff IDs rather than digests because
publish adds OCI labels, and a label changes the config, so digests differ on
every run even on a perfect cache hit. It warns rather than failing — the push
has already happened, and a re-run restores from the same evicted cache — and an
unreadable manifest reports "not checked" rather than a mismatch, so a registry
blip cannot be misread as a finding.

And a published image announces itself (#953). Nothing pulls on its own, so a
security fix could sit published and undeployed because nothing said it was
there. The run summary now carries the CLAWDIA_IMAGE_TAG line to deploy this
build alongside the digest to pin it immutably. Setting a PORTAINER_WEBHOOK_URL
secret additionally has publish POST to a Portainer stack webhook after a push
to the default branch: off unless configured, default branch only, never echoed
since the URL is a deploy credential, and a warning rather than a failure on a
build whose image is already in the registry.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HmgaHbqNDacAedcJKsjVb2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deployment**
  * Added image-layer verification before deployment, with clear warnings for mismatches or unavailable scan data.
  * Publish summaries now include immutable image tags and digest references.
  * Added optional automatic redeployment through Portainer on the default branch.

* **Reliability**
  * Improved graceful shutdown behavior so services complete cleanup even when individual steps encounter errors.
  * Added safer deployment command validation and error reporting.
  * Improved shard-count configuration handling, with automatic fallback for invalid values.

* **Documentation**
  * Updated release and deployment guidance for image verification, immutable tags, and optional redeployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->