### PR TITLE
Let db-network be encrypted, without making it a dated bomb

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,35 @@ MONGODB_APP_PASSWORD=
 # that already has data.
 MONGODB_REPLICA_SET_ARGS=
 
+# MongoDB TLS. Both empty means today's behaviour exactly — cleartext on
+# db-network, which is `internal: true` and unreachable from outside the host
+# (#975). What TLS closes is a process that has already joined that network:
+# authentication stopped it logging in, but not reading. SCRAM keeps the
+# passwords themselves off the wire; everything after the handshake is on it in
+# the clear, including the root session that initiates the replica set.
+#
+# It is all clients or none — one client left on cleartext leaves the traffic
+# readable, and a mongod that requires TLS with one client that was not told is
+# a deploy that cannot reach its own database. There are three settings and
+# they go in together, in this order:
+#
+#   1. MONGODB_CLIENT_TLS_ARGS, for the two mongosh probes (the healthcheck and
+#      mongo-replset-init), which connect by host and port and so have no URI to
+#      carry the options.
+#   2. the tls options on MONGODB_URI above, which is what the bot, mongodump
+#      and mongorestore all read — one edit covers all three:
+#
+#        MONGODB_URI=mongodb://user:pass@mongodb:27017/ultrabot?authSource=ultrabot&tls=true&tlsCAFile=/etc/mongo-tls/ca.crt
+#
+#   3. MONGODB_TLS_ARGS last, which is what actually turns mongod over.
+#
+# Generate the certificate with `./scripts/mongo-tls-cert.sh` first, uncomment
+# the four mongo-tls mounts in the compose file, and read "Encrypting MongoDB
+# traffic with TLS" in docs/SETUP_GUIDE.md — including the part about the
+# expiry date, which is the half of this that causes outages.
+MONGODB_CLIENT_TLS_ARGS=
+MONGODB_TLS_ARGS=
+
 # Dashboard
 # The port the app listens on *inside* the container. The image EXPOSEs and
 # health-checks this one, so leave it at 3000 unless you have a reason.

--- a/.env.example
+++ b/.env.example
@@ -87,7 +87,8 @@ MONGODB_REPLICA_SET_ARGS=
 #   3. MONGODB_TLS_ARGS last, which is what actually turns mongod over.
 #
 # Generate the certificate with `./scripts/mongo-tls-cert.sh` first, uncomment
-# the four mongo-tls mounts in the compose file, and read "Encrypting MongoDB
+# the mongo-tls mounts in the compose file — ca.crt on all four services and
+# server.pem on mongodb — and read "Encrypting MongoDB
 # traffic with TLS" in docs/SETUP_GUIDE.md — including the part about the
 # expiry date, which is the half of this that causes outages.
 MONGODB_CLIENT_TLS_ARGS=

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,15 @@ updates:
           - patch
     labels:
       - dependencies
+    # No `ignore` list, and adding one wants care: Dependabot applies it to
+    # security updates too, so an entry added to quiet a noisy weekly bump takes
+    # that package out of the advisory path with it. One package is watched
+    # deliberately rather than incidentally — `rss-parser` is slow-moving and
+    # carries a transitive XML-parsing surface that processes any feed URL a
+    # guild admin subscribes to (#954). tests/rssParserWatch.test.js holds both
+    # halves of that watch: this schedule still reaching it, and the two call
+    # sites staying small enough that vendoring the parse is a morning's work if
+    # the package is ever abandoned.
 
   # Pin drift in the workflow actions themselves. ci.yml pins actions by commit
   # SHA, which is the right call for supply-chain safety but means nothing ever

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,20 @@ both stack files in step so neither can gain a client the other has not, and
 `docs/SETUP_GUIDE.md` has the procedure, the ordering and the case for leaving it
 off.
 
+The watch on `rss-parser` is written down where it can lapse loudly (#954).
+Nothing is wrong with the package today and nothing here changes how a feed is
+parsed. It is slow-moving, though, and it brings a transitive XML-parsing
+surface — a category with a long history of entity-expansion and parser CVEs —
+that sees any URL a guild admin subscribes to. The fetch side was already
+answered by `safeFeedFetch.js`; what was only in an issue was the parse side and
+the plan if the package is abandoned. `tests/rssParserWatch.test.js` now holds
+the two things that plan depends on: that Dependabot still reaches it, since an
+`ignore` entry added to quiet a weekly bump would take the advisory PRs with it,
+and that the surface stays one method on a string something else already
+fetched and bounded — a `parseURL`, which does its own unpinned, uncapped HTTP,
+or a third call site would each be one line and would each turn a morning of
+vendoring into a migration.
+
 ## [4.5.2] - 2026-09-01
 
 Migrations through `021_market_listing_ttl_grace`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,30 @@ own credential in its path and a GitHub-hosted runner reaches nothing that is
 not across the public internet. The URL is never echoed on any path, and a
 failure warns rather than failing a build whose image is already published. `docs/RELEASING.md` has the setup.
 
+MongoDB traffic on `db-network` can be encrypted (#975). Nothing that talked to
+`mongod` used TLS, so with authentication on a process that had joined that
+network could no longer log in but could still read every balance, every audit
+entry and every administrative command off the wire — including the root session
+`mongo-replset-init` uses to initiate the replica set. SCRAM keeps the passwords
+themselves off it; everything after the handshake was in the clear. The exposure
+is bounded by `db-network` being `internal: true`, which is why this is opt-in
+and unset changes nothing: `MONGODB_TLS_ARGS` for `mongod`,
+`MONGODB_CLIENT_TLS_ARGS` for the two `mongosh` probes that connect by host and
+port, and `tls=true&tlsCAFile=…` on the `MONGODB_URI` the bot, `mongodump` and
+`mongorestore` all share — deliberately not command-line flags for those three,
+which the database tools reject as a configuration given twice. It is all five
+clients or none, and the healthcheck is what makes that safe rather than
+sharp-edged: it is one of the probes, so a `mongod` that requires TLS and a
+client that was not told never reports healthy and the bot never starts against
+a database it could not have reached. `scripts/mongo-tls-cert.sh` issues the CA
+and the server certificate, and `--check` prints the days remaining and reports
+to `ERROR_WEBHOOK_URL` under sixty — because a `mongod` that stops accepting
+connections at midnight on a forgotten expiry is a worse outage than the
+cleartext it was turned on to prevent. `tests/deployStackParity.test.js` holds
+both stack files in step so neither can gain a client the other has not, and
+`docs/SETUP_GUIDE.md` has the procedure, the ordering and the case for leaving it
+off.
+
 ## [4.5.2] - 2026-09-01
 
 Migrations through `021_market_listing_ttl_grace`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,20 @@ fetched and bounded — a `parseURL`, which does its own unpinned, uncapped HTTP
 or a third call site would each be one line and would each turn a morning of
 vendoring into a migration.
 
+Sequencing becomes a decision with a record (#914). There was no roadmap, no
+milestones and no pinned planning issue, so direction was reconstructable only
+by reading this file backwards and following issue references — and the one
+tradeoff that actually governs the project, audit the economy (#873) or ship the
+next game system, was being made implicitly, one pull request at a time.
+`docs/ROADMAP.md` makes it explicitly: the economy audit comes before net-new
+game features, with the two landed passes and the thirteen critical defects they
+found as the argument, and with bug fixes, security and operational work
+explicitly not blocked behind it. It names the next four items, the order of the
+audit queue within the economy — money-moving first — and, in a section for the
+purpose, the things that were closed with a decision rather than a task, so the
+next reader who notices one finds the reasoning instead of reopening it. No dates
+and no estimates: it would be wrong about both, and what it is for is order.
+
 ## [4.5.2] - 2026-09-01
 
 Migrations through `021_market_listing_ttl_grace`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,10 +191,15 @@ a database it could not have reached. `scripts/mongo-tls-cert.sh` issues the CA
 and the server certificate, and `--check` prints the days remaining and reports
 to `ERROR_WEBHOOK_URL` under sixty — because a `mongod` that stops accepting
 connections at midnight on a forgotten expiry is a worse outage than the
-cleartext it was turned on to prevent. `tests/deployStackParity.test.js` holds
-both stack files in step so neither can gain a client the other has not, and
-`docs/SETUP_GUIDE.md` has the procedure, the ordering and the case for leaving it
-off.
+cleartext it was turned on to prevent, and it refuses to issue against a CA that
+cannot outlast the certificate, since a leaf outlives its issuer only on paper.
+The mounts name files rather than the directory holding them: `ca.crt` goes to
+all four containers, `server.pem` to `mongod` alone, and `ca.key` — the one thing
+that can mint a certificate this deployment would trust — into none of them.
+`tests/deployStackParity.test.js` holds both stack files in step so neither can
+gain a client the other has not, and fails on a directory mount or a mounted
+`ca.key`; `docs/SETUP_GUIDE.md` has the procedure, the ordering, the CA rollover
+and the case for leaving it off.
 
 The watch on `rss-parser` is written down where it can lapse loudly (#954).
 Nothing is wrong with the package today and nothing here changes how a feed is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,12 @@ that will surprise you if nobody says them first.
 - [Adding a command, a route or a model](#adding-a-command-a-route-or-a-model)
 - [Commits and pull requests](#commits-and-pull-requests)
 
+Looking for something to work on, rather than arriving with a change already in
+mind: [docs/ROADMAP.md](docs/ROADMAP.md) is what is planned next and why, and it
+carries the one piece of sequencing worth knowing before you start — new game
+features are waiting on the economy audit, and bug fixes, security work and
+documentation are not.
+
 ## Getting set up
 
 Node **24.19.0** or newer — the version in `.nvmrc`, which CI reads and

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ moderation attached, that is what she is built for.
 | [docs/EXTENDING.md](docs/EXTENDING.md) | Adding a command, a route, a model or a dashboard panel |
 | [docs/RELEASING.md](docs/RELEASING.md) | Cutting a release |
 | [docs/CANVAS_BACKEND.md](docs/CANVAS_BACKEND.md) | What the image's native build toolchain is for, and the measured case for replacing it |
+| [docs/ROADMAP.md](docs/ROADMAP.md) | What is planned next, in what order, and the tradeoff that decides the order |
 | [docs/AUDIT_LOG.md](docs/AUDIT_LOG.md) | Which subsystems have been through a line-by-line audit, what each one found, and the much longer list of what has not been audited |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Getting set up, the coverage ratchets, and what surprises people |
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,11 +45,47 @@ services:
     # `mongo-replset-init` does the one-time `rs.initiate()`. See "Running
     # MongoDB as a single-node replica set" in docs/SETUP_GUIDE.md for the full
     # procedure, including the one for a deployment that already has data.
-    command: mongod ${MONGODB_REPLICA_SET_ARGS:-}
+    # TLS on the wire, empty by default so nothing changes for a deployment that
+    # does not set it (#975). db-network is `internal: true` — no gateway, no
+    # published ports — so this is defence in depth and not a live hole: what it
+    # closes is a process that has *already* joined that network. Authentication
+    # stopped such a process logging in; it did not stop it reading. MongoDB
+    # authenticates with SCRAM, so no password is ever on the wire and a captured
+    # session cannot be replayed to log in, but everything after the handshake is
+    # cleartext — every balance, every audit entry, every admin command, and the
+    # root session `mongo-replset-init` uses to initiate the set:
+    #
+    #   MONGODB_TLS_ARGS=--tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo-tls/server.pem --tlsCAFile /etc/mongo-tls/ca.crt --tlsAllowConnectionsWithoutCertificates
+    #
+    # The last flag is not optional and not a weakening. Naming a CA file is
+    # what lets mongod validate the certificate it presents to *itself* over
+    # the replication connection, and it is also what makes mongod start
+    # demanding a certificate from every client — which none of the four here
+    # has, because this is server authentication and not mutual TLS. Without
+    # it the CA file turns every client connection away.
+    #
+    # It is all clients or none. A single client left on cleartext leaves the
+    # traffic readable, and a `requireTLS` mongod with one client that has not
+    # been told is simply a deploy that cannot reach its own database. The other
+    # two halves are MONGODB_CLIENT_TLS_ARGS, for the two mongosh probes that
+    # connect by host and port, and the tls options on MONGODB_URI, which is what
+    # the bot, mongodump and mongorestore all read. Generate the material with
+    # `scripts/mongo-tls-cert.sh` and follow "Encrypting MongoDB traffic with
+    # TLS" in docs/SETUP_GUIDE.md — the ordering matters, and so does the expiry
+    # date: a mongod that stops accepting connections at midnight is a worse
+    # outage than the exposure this prevents.
+    command: mongod ${MONGODB_REPLICA_SET_ARGS:-} ${MONGODB_TLS_ARGS:-}
     volumes:
       - mongodb_data:/data/db
       - ./scripts/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
       # - ./secrets/mongo-keyfile:/etc/mongo-keyfile:ro
+      # The TLS material MONGODB_TLS_ARGS names (#975), produced by
+      # `scripts/mongo-tls-cert.sh`. server.pem is the certificate and its
+      # private key concatenated, which is the single file mongod wants; ca.crt
+      # is what every client on db-network validates it against. The same
+      # directory is mounted read-only into mongo-replset-init, bot and backup,
+      # because TLS here is all four or none.
+      # - ./secrets/mongo-tls:/etc/mongo-tls:ro
     networks:
       - db-network   # internal-only: no external routing, no published ports
     healthcheck:
@@ -60,7 +96,15 @@ services:
       # which the bot must not be started: its migrations run at boot and would
       # fail against a node that is not primary. A standalone mongod reports
       # itself writable as soon as it is up, so nothing changes there.
-      test: ["CMD", "mongosh", "--quiet", "--eval", "quit(db.hello().isWritablePrimary ? 0 : 1)"]
+      #
+      # CMD-SHELL rather than CMD because of MONGODB_CLIENT_TLS_ARGS (#975):
+      # unset, it has to expand to no arguments at all, and an exec-form list
+      # would hand mongosh one empty string instead. It is also what makes a
+      # half-configured TLS deployment fail safely — a mongod that requires TLS
+      # and a probe that does not offer it never reports healthy, and the bot and
+      # the backup both wait on that condition, so neither starts against a
+      # database it could not have reached.
+      test: ["CMD-SHELL", "mongosh --quiet ${MONGODB_CLIENT_TLS_ARGS:-} --eval \"quit(db.hello().isWritablePrimary ? 0 : 1)\""]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -124,6 +168,15 @@ services:
     environment:
       MONGODB_ROOT_USERNAME: ${MONGODB_ROOT_USERNAME:-}
       MONGODB_ROOT_PASSWORD: ${MONGODB_ROOT_PASSWORD:-}
+      # The same flags mongod's own healthcheck passes, for the same reason
+      # (#975): this reaches mongod by host and port rather than through a URI,
+      # so a mongod started with --tlsMode requireTLS has no other way to be
+      # spoken to. The cert mount below has to be uncommented with it.
+      MONGODB_CLIENT_TLS_ARGS: ${MONGODB_CLIENT_TLS_ARGS:-}
+    # Uncomment alongside it — this reaches mongod as a client and so
+    # needs the CA to validate it against.
+    # volumes:
+    #   - ./secrets/mongo-tls:/etc/mongo-tls:ro
     # No apostrophes below — not in a comment either (#940). Compose splits a
     # string entrypoint into arguments before the container starts, so the first
     # single quote inside this script closes the one that opened it and
@@ -144,22 +197,27 @@ services:
         # arguments and mongosh would get a truncated one; quoted, it would be a
         # single empty argument when auth is off. Passing the credentials as
         # their own quoted arguments is the only form that is right both ways.
+        # Unquoted, and that is the opposite of the rule above rather than an
+        # oversight: this one is a list of arguments, not a value. Unset it has
+        # to disappear entirely, which is what an unquoted empty expansion does
+        # and a quoted one does not. The password is one value that must survive
+        # a space; this is zero or more flags that must survive being absent.
         authed_mongosh() {
           if [ -n "$$MONGODB_ROOT_USERNAME" ]; then
-            mongosh --host "$$HOST" --quiet --username "$$MONGODB_ROOT_USERNAME" --password "$$MONGODB_ROOT_PASSWORD" --authenticationDatabase admin "$$@";
+            mongosh --host "$$HOST" --quiet $$MONGODB_CLIENT_TLS_ARGS --username "$$MONGODB_ROOT_USERNAME" --password "$$MONGODB_ROOT_PASSWORD" --authenticationDatabase admin "$$@";
           else
-            mongosh --host "$$HOST" --quiet "$$@";
+            mongosh --host "$$HOST" --quiet $$MONGODB_CLIENT_TLS_ARGS "$$@";
           fi;
         };
         # Unauthenticated on purpose: `hello` is answered before login, which is
         # what lets this work on a deployment whose credentials it was not given.
         writable() {
-          mongosh --host "$$HOST" --quiet --eval "quit(db.hello().isWritablePrimary ? 0 : 1)" >/dev/null 2>&1;
+          mongosh --host "$$HOST" --quiet $$MONGODB_CLIENT_TLS_ARGS --eval "quit(db.hello().isWritablePrimary ? 0 : 1)" >/dev/null 2>&1;
         };
         # mongod accepts a TCP connection well before it answers anything, so
         # this waits on an answer and not on the port being open.
         i=0;
-        until mongosh --host "$$HOST" --quiet --eval "db.hello()" >/dev/null 2>&1; do
+        until mongosh --host "$$HOST" --quiet $$MONGODB_CLIENT_TLS_ARGS --eval "db.hello()" >/dev/null 2>&1; do
           i=$$((i + 1));
           if [ $$i -ge 60 ]; then echo "[replset-init] mongod at $$HOST never answered"; exit 1; fi;
           sleep 2;
@@ -274,6 +332,11 @@ services:
       # MCP server list, read at startup. Mounted rather than baked into the
       # image so the file (which can hold OAuth tokens) stays on the host.
       - ./config:/app/config:ro
+      # The CA that validates mongod, when MONGODB_TLS_ARGS is on (#975). Only
+      # ca.crt is read here; nothing in this container needs the private key.
+      # The bot reads it through MONGODB_URI: add
+      # `?tls=true&tlsCAFile=/etc/mongo-tls/ca.crt` to it in the same edit.
+      # - ./secrets/mongo-tls:/etc/mongo-tls:ro
     networks:
       - db-network      # reaches MongoDB
       - clawdia-network # reaches the internet (Discord API, AI APIs, etc.)
@@ -484,6 +547,11 @@ services:
     #   - backup_encryption_passphrase
     volumes:
       - ./backups:/backups
+      # The CA that validates mongod, when MONGODB_TLS_ARGS is on (#975). Only
+      # ca.crt is read here; nothing in this container needs the private key.
+      # mongodump and mongorestore read it out of the same MONGODB_URI the
+      # bot uses, so there is no separate flag to set here — only this mount.
+      # - ./secrets/mongo-tls:/etc/mongo-tls:ro
     networks:
       - db-network   # only needs to reach MongoDB
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,10 +82,14 @@ services:
       # The TLS material MONGODB_TLS_ARGS names (#975), produced by
       # `scripts/mongo-tls-cert.sh`. server.pem is the certificate and its
       # private key concatenated, which is the single file mongod wants; ca.crt
-      # is what every client on db-network validates it against. The same
-      # directory is mounted read-only into mongo-replset-init, bot and backup,
-      # because TLS here is all four or none.
-      # - ./secrets/mongo-tls:/etc/mongo-tls:ro
+      # is what it validates its own replication connection against.
+      #
+      # File by file, not the directory that holds them. ca.key is in there too,
+      # and it is the one thing that can mint a certificate this whole
+      # deployment would trust — it belongs on the host and in no container at
+      # all, this one included. mongod never reads it.
+      # - ./secrets/mongo-tls/server.pem:/etc/mongo-tls/server.pem:ro
+      # - ./secrets/mongo-tls/ca.crt:/etc/mongo-tls/ca.crt:ro
     networks:
       - db-network   # internal-only: no external routing, no published ports
     healthcheck:
@@ -174,9 +178,10 @@ services:
       # spoken to. The cert mount below has to be uncommented with it.
       MONGODB_CLIENT_TLS_ARGS: ${MONGODB_CLIENT_TLS_ARGS:-}
     # Uncomment alongside it — this reaches mongod as a client and so
-    # needs the CA to validate it against.
+    # needs the CA to validate it against, and nothing else in the directory
+    # that CA lives in.
     # volumes:
-    #   - ./secrets/mongo-tls:/etc/mongo-tls:ro
+    #   - ./secrets/mongo-tls/ca.crt:/etc/mongo-tls/ca.crt:ro
     # No apostrophes below — not in a comment either (#940). Compose splits a
     # string entrypoint into arguments before the container starts, so the first
     # single quote inside this script closes the one that opened it and
@@ -332,11 +337,12 @@ services:
       # MCP server list, read at startup. Mounted rather than baked into the
       # image so the file (which can hold OAuth tokens) stays on the host.
       - ./config:/app/config:ro
-      # The CA that validates mongod, when MONGODB_TLS_ARGS is on (#975). Only
-      # ca.crt is read here; nothing in this container needs the private key.
+      # The CA that validates mongod, when MONGODB_TLS_ARGS is on (#975). The one
+      # file, not the directory it lives in: ca.key and mongod's own private key
+      # sit beside it and nothing here has any use for either.
       # The bot reads it through MONGODB_URI: add
       # `?tls=true&tlsCAFile=/etc/mongo-tls/ca.crt` to it in the same edit.
-      # - ./secrets/mongo-tls:/etc/mongo-tls:ro
+      # - ./secrets/mongo-tls/ca.crt:/etc/mongo-tls/ca.crt:ro
     networks:
       - db-network      # reaches MongoDB
       - clawdia-network # reaches the internet (Discord API, AI APIs, etc.)
@@ -547,11 +553,12 @@ services:
     #   - backup_encryption_passphrase
     volumes:
       - ./backups:/backups
-      # The CA that validates mongod, when MONGODB_TLS_ARGS is on (#975). Only
-      # ca.crt is read here; nothing in this container needs the private key.
+      # The CA that validates mongod, when MONGODB_TLS_ARGS is on (#975). The one
+      # file, not the directory it lives in: ca.key and mongod's own private key
+      # sit beside it and nothing here has any use for either.
       # mongodump and mongorestore read it out of the same MONGODB_URI the
       # bot uses, so there is no separate flag to set here — only this mount.
-      # - ./secrets/mongo-tls:/etc/mongo-tls:ro
+      # - ./secrets/mongo-tls/ca.crt:/etc/mongo-tls/ca.crt:ro
     networks:
       - db-network   # only needs to reach MongoDB
     depends_on:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,117 @@
+# Roadmap
+
+What is planned next, in what order, and the one tradeoff that decides the order.
+
+Sequencing used to be reconstructable only by reading [CHANGELOG.md](../CHANGELOG.md)
+backwards and following issue references (#914), which meant the debt-versus-feature
+call — audit the economy or ship the next game system — was being made implicitly,
+one pull request at a time. It is made here instead.
+
+This file carries no dates and no estimates, because it would be wrong about
+both. It carries order, and the reason for it. It is a record of a decision, not
+a promise: changing the order is an edit to this file in the pull request that
+changes it, which is the whole of the mechanism.
+
+## The standing decision: the economy audit comes before new game features
+
+The economy and RPG layer is the largest area of the codebase, the
+highest-churn, the lowest-covered, and the one that has already shipped
+coin-integrity bugs — dual jackpot pools, minted boosters, negative balances
+that needed a migration to clamp. It is also the area with the least audit
+coverage, which is [#873](https://github.com/TheShield2594/clawdia/issues/873):
+audit coverage is widest exactly where the risk is not.
+
+So net-new game features wait, and every currency-mutation path gets the
+treatment the nine long-stable subsystems got. Two passes have landed under that
+decision already — `/duel` escrow and the `/heist` and `/syndicate` crew splits
+in v4.5.2, the casino's progressive jackpot in v4.6.0 — and between them they
+found thirteen critical defects in code that was live. That is the argument for
+the order, and it is worth re-reading before anybody proposes suspending it.
+
+What this does *not* mean: bug fixes, security work, operational work and
+documentation are not features and are not blocked. Nothing below is sequenced
+behind the audit except new game systems.
+
+## Next
+
+Each item links to the issue that holds the detail. Nothing is restated here,
+so that there is only ever one copy to correct.
+
+1. **Economy audit, pass 3 — the rest of the casino.**
+   ([#873](https://github.com/TheShield2594/clawdia/issues/873)) The progressive
+   jackpot is audited. The eight games' own wager and payout writes,
+   `confirmBet`, and the crash lobby's `pendingCrashRefund` escrow are not — and
+   they are where every ordinary casino payout is made.
+2. **Economy audit, pass 4 — `gift` and `market`.**
+   ([#873](https://github.com/TheShield2594/clawdia/issues/873)) The last two
+   unticked entries on that issue's checklist, and the two remaining paths where
+   coins move between users outside a game.
+3. **The unapplied CodeRabbit findings.**
+   ([#985](https://github.com/TheShield2594/clawdia/issues/985)) Four items:
+   undrained response bodies leaking sockets, MCP requests that carry
+   credentials over plain HTTP, and two tests that pass whether or not the thing
+   they name is true. Independent of the audit and small enough to take whenever
+   a pass is waiting on review.
+4. **Ratchet the coverage floors each pass earns.** `src/commands/economy/fish`
+   and `src/commands/economy/mine` sit at 14% and 16% statements with branch
+   floors of 0 — recorded in `coverage-floors.json`'s `unguarded` list, so they
+   may shrink and must not grow. Neither pass has reached them yet. The floors
+   move when a pass lands on that code, not before and not by hand.
+
+## The audit queue
+
+[docs/AUDIT_LOG.md](AUDIT_LOG.md) is the record of what has been audited and what
+each pass found; its
+[Not yet reviewed](AUDIT_LOG.md#not-yet-reviewed) section is the queue. That list
+is long and mostly unordered, deliberately — it is a survey, not a plan. The
+order this roadmap commits to, within the economy, is money-moving first:
+
+1. the rest of the casino — per-game wagers and payouts, `confirmBet`, the crash
+   lobby's refunds
+2. `gift` and `market`
+3. the core currency commands — `balance`, `bank`, `daily`, `work`, `jobs`,
+   `crime`, `invest`
+4. the gathering loops — `hunt`, `fish`, `mine`, `explore` — and items, effects
+   and `use`
+5. progression, the group and PvP systems, seasonal events
+
+Everything outside the economy stays in the audit log's list and is not sequenced
+ahead of any of the above.
+
+## Decided, not planned
+
+Recorded so they are not silently re-opened by the next reader who notices them.
+Each of these is a decision with a reason, and either can be revisited — by
+editing this file.
+
+- **TLS on `db-network`
+  ([#975](https://github.com/TheShield2594/clawdia/issues/975)).** Built, opt-in,
+  and off by default. `db-network` is `internal: true`, and deciding that an
+  unroutable network is a sufficient trust boundary for a single-host deployment
+  is a legitimate answer rather than a deferred one — the certificate that
+  encryption needs is an operational cost with an expiry date attached. The
+  procedure, and the case for leaving it off, are in
+  [SETUP_GUIDE.md](SETUP_GUIDE.md#encrypting-mongodb-traffic-with-tls).
+- **`rss-parser` ([#954](https://github.com/TheShield2594/clawdia/issues/954)).**
+  A watch, not a task. No work is planned unless the package goes unmaintained;
+  `tests/rssParserWatch.test.js` is what keeps the watch from lapsing quietly,
+  and the exit — vendoring the one method the bot actually calls — stays cheap
+  for as long as that test holds.
+- **A durable outbox for jackpot payouts.** Deferred during pass 2 with the
+  reasoning written down in the audit log rather than dropped:
+  `casinoJackpot.pendingPayoutKey` holds one unsettled claim per guild, so losing
+  a claim needs a failed credit *and* the process dying before the owed payout is
+  filed *and* a second jackpot in the same guild before the next boot. The
+  alternative considered was a growing array on the guild document, which is the
+  shape [#888](https://github.com/TheShield2594/clawdia/issues/888) had just
+  finished removing. Worth its own issue if that trade should be reopened.
+
+## Keeping this honest
+
+A roadmap goes stale the way every roadmap goes stale: by describing a plan
+nobody is following any more. The guard against that here is that it is short
+and that it says one thing — what is next. Update it when a pass lands.
+[CHANGELOG.md](../CHANGELOG.md) says what happened,
+[docs/AUDIT_LOG.md](AUDIT_LOG.md) says what was audited and what it found, and
+this file says what comes after. If it ever disagrees with the issue tracker, the
+tracker is right and this file is out of date.

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -1198,18 +1198,31 @@ the database tools reject a configuration specified both ways.
 ./scripts/mongo-tls-cert.sh /opt/clawdia/mongo-tls    # Portainer host path
 ```
 
-That writes `ca.crt` (what clients validate against), `ca.key` (the only thing
-that can mint a replacement — the one file worth moving off the host) and
-`server.pem` (certificate and key concatenated, which is the single file
-`mongod` wants). The certificate is issued for `mongodb`, the service name every
-client dials, plus `localhost` and `127.0.0.1` for a `docker exec` `mongosh`;
-pass any additional hostnames as further arguments. It chowns `server.pem` to
-uid 999, which is what `mongod` runs as inside the image — if you did not run it
-as root it says so, and `mongod` will not start until you do that step.
+That writes three files:
 
-**2. Mount it.** Uncomment the four `mongo-tls` mounts — on `mongodb`,
-`mongo-replset-init`, `bot` and `backup`. All four, or step 4 locks out whichever
-one you skipped.
+| File | What reads it |
+| --- | --- |
+| `ca.crt` | every client, to validate `mongod` — and `mongod` itself, for its own replication connection |
+| `server.pem` | `mongod` only. Certificate and private key concatenated, which is the single file `--tlsCertificateKeyFile` wants |
+| `ca.key` | nothing, until you renew. It is the only thing that can mint a certificate this deployment would trust, and it goes into no container at all — this is the one file worth moving off the host once the pair is issued |
+
+The certificate is issued for `mongodb`, the service name every client dials,
+plus `localhost` and `127.0.0.1` for a `docker exec` `mongosh`; pass any
+additional hostnames as further arguments. It chowns `server.pem` to uid 999,
+which is what `mongod` runs as inside the image — if you did not run it as root
+it says so, and `mongod` will not start until you do that step.
+
+**2. Mount it, file by file.** Uncomment the five `mongo-tls` mounts: `ca.crt`
+on all four services, and `server.pem` on `mongodb` as well. Four containers
+mount the CA, or step 4 locks out whichever one you skipped.
+
+They name files rather than the directory that holds them, and that is
+deliberate. A `mongo-tls:/etc/mongo-tls:ro` mount is one line shorter and hands
+`ca.key` — and `mongod`'s private key — to the `bot` container, which is the one
+with a route to the internet. Neither has any reader there. If you add a
+container that talks to `mongod`, give it `ca.crt` and nothing else;
+`tests/deployStackParity.test.js` fails on a directory mount or a mounted
+`ca.key` in either stack file.
 
 **3. Point the clients at it, before `mongod`.** In `.env` or the stack
 environment:
@@ -1282,16 +1295,49 @@ that one:
 0 6 * * *  cd /opt/clawdia && ./scripts/mongo-tls-cert.sh --check >> /var/log/clawdia-tls.log 2>&1
 ```
 
-Renewing is the same script against the same directory. It reuses the existing
-CA rather than minting a new one — a new CA would mean re-distributing `ca.crt`
-to all four containers, which is exactly the step someone renewing in a hurry
-skips — so only `server.pem` changes, and `mongod` keeps serving the old
-certificate until it is restarted:
+**Renewing the server certificate** is the same script against the same
+directory. It reuses the existing CA rather than minting a new one — a new CA
+would mean re-distributing `ca.crt` to all four containers, which is exactly the
+step someone renewing in a hurry skips — so only `server.pem` changes, nothing
+else has to be touched, and `mongod` keeps serving the old certificate until it
+is restarted:
 
 ```bash
 ./scripts/mongo-tls-cert.sh
 docker compose up -d --force-recreate mongodb
 ```
+
+If the CA has less time left than the five years a server certificate normally
+gets, the new certificate is capped at whatever the CA has and the script says
+so. That is not a limitation being worked around: a certificate is only good for
+as long as the CA above it, and every client rejects the chain on the CA's date
+whatever the leaf's own dates claim. A certificate issued for longer would be
+lying about when it stops working.
+
+**Rolling the CA over** is the other half, and it is a different job: it replaces
+the trust material every client holds, so it cannot be done one container at a
+time. The script refuses to issue against a CA with less than
+`MONGO_TLS_WARN_DAYS` left and points here. With a ten-year CA this should
+happen roughly never, which is exactly why it is worth having written down:
+
+```bash
+# 1. Mint a new CA and a server certificate under it. This overwrites ca.crt,
+#    ca.key and server.pem in place; keep a copy of the old ca.crt if you want
+#    a way back before step 3.
+./scripts/mongo-tls-cert.sh --new-ca
+
+# 2. On a Portainer host, copy the new ca.crt and server.pem to wherever the
+#    mounts point (the mounted paths do not change, so the stack file does not).
+
+# 3. Recreate every container with a mongo-tls mount, together. A client still
+#    holding the old ca.crt refuses the new certificate, so a rolling restart
+#    is an outage taken one container at a time instead of once.
+docker compose up -d --force-recreate mongodb mongo-replset-init bot backup
+```
+
+There is no revocation here, so the old CA stops mattering the moment nothing
+holds it any more. Delete the copy you kept once the stack is up and
+`./scripts/mongo-tls-cert.sh --check` is green.
 
 ### Automated Backups
 

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -1146,6 +1146,153 @@ the variable back on resumes the same set rather than needing a second
 `rs.initiate()` — and transactions are unavailable again for as long as it is
 off, which is the thing to weigh, not the data.
 
+### Encrypting MongoDB traffic with TLS
+
+Off by default, and genuinely optional — read the tradeoff before turning it on.
+
+`db-network` is declared `internal: true`: it has no gateway, no published ports,
+and nothing outside the Docker host can route to it. So this is defence in depth
+rather than a live hole. What it closes is a process that has *already* joined
+that network. Authentication (the section above) closed half of that position —
+such a process can no longer log in. This is the other half: with auth on and TLS
+off, it still reads every balance, every audit entry and every administrative
+command off the wire, including the root session `mongo-replset-init` uses to
+initiate the replica set.
+
+To be precise about how urgent that is, because it changes the answer: MongoDB
+authenticates with SCRAM, a challenge-response exchange. No password is ever
+transmitted, and a captured session cannot be replayed to log in. Everything
+*after* the handshake is cleartext.
+
+If an `internal: true` network is an acceptable trust boundary for your
+deployment — one host, one operator, nothing else scheduled on it — leaving this
+off is a defensible decision and not a deferred one. What is not defensible is
+turning it on and forgetting the expiry date; see the last part of this section.
+
+**It is all clients or none.** Five things talk to `mongod` on `db-network`, and
+one of them left on cleartext leaves the traffic readable. Worse, a `mongod` in
+`requireTLS` mode with one client that was not told is not a weaker deployment —
+it is a deployment that cannot reach its own database. They are configured by
+three settings, and `tests/deployStackParity.test.js` holds both stack files in
+step so neither can gain a client the other does not have:
+
+| Client | Configured by |
+| --- | --- |
+| the bot | `tls=true&tlsCAFile=…` on `MONGODB_URI` |
+| the nightly `mongodump` and its `mongorestore --dryRun` | the same `MONGODB_URI` |
+| `mongod`'s healthcheck (`mongosh`) | `MONGODB_CLIENT_TLS_ARGS` |
+| `mongo-replset-init` (`mongosh`) | `MONGODB_CLIENT_TLS_ARGS` |
+| `mongod` itself | `MONGODB_TLS_ARGS` |
+
+The two `mongosh` probes need their own setting because they connect by host and
+port and have no connection string to carry the options. The three that do take
+one all read the same `MONGODB_URI`, so they are one edit and cannot disagree
+with each other — and they are deliberately given *no* command-line TLS flags:
+the database tools reject a configuration specified both ways.
+
+**1. Issue the certificate.** On the Docker host, beside `docker-compose.yml`
+(or wherever the stack keeps its secrets):
+
+```bash
+./scripts/mongo-tls-cert.sh                    # writes ./secrets/mongo-tls
+./scripts/mongo-tls-cert.sh /opt/clawdia/mongo-tls    # Portainer host path
+```
+
+That writes `ca.crt` (what clients validate against), `ca.key` (the only thing
+that can mint a replacement — the one file worth moving off the host) and
+`server.pem` (certificate and key concatenated, which is the single file
+`mongod` wants). The certificate is issued for `mongodb`, the service name every
+client dials, plus `localhost` and `127.0.0.1` for a `docker exec` `mongosh`;
+pass any additional hostnames as further arguments. It chowns `server.pem` to
+uid 999, which is what `mongod` runs as inside the image — if you did not run it
+as root it says so, and `mongod` will not start until you do that step.
+
+**2. Mount it.** Uncomment the four `mongo-tls` mounts — on `mongodb`,
+`mongo-replset-init`, `bot` and `backup`. All four, or step 4 locks out whichever
+one you skipped.
+
+**3. Point the clients at it, before `mongod`.** In `.env` or the stack
+environment:
+
+```bash
+MONGODB_CLIENT_TLS_ARGS=--tls --tlsCAFile /etc/mongo-tls/ca.crt
+MONGODB_URI=mongodb://clawdia:<app-password>@mongodb:27017/ultrabot?authSource=ultrabot&tls=true&tlsCAFile=/etc/mongo-tls/ca.crt
+```
+
+**4. Then turn `mongod` over**, in the same edit:
+
+```bash
+MONGODB_TLS_ARGS=--tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo-tls/server.pem --tlsCAFile /etc/mongo-tls/ca.crt --tlsAllowConnectionsWithoutCertificates
+```
+
+```bash
+docker compose up -d --force-recreate
+```
+
+The last flag is not a weakening and not optional. Naming a CA file is what lets
+`mongod` validate the certificate it presents to *itself* over the replication
+connection — a single-node replica set still opens one — and it is also what
+makes `mongod` start demanding a certificate from every client. None of the four
+clients has one, because this is server authentication, not mutual TLS. Without
+that flag the CA file turns every client connection away.
+
+The ordering above is the safe one, but it is not load-bearing, because the
+healthcheck is: `mongod`'s probe is a `mongosh` carrying
+`MONGODB_CLIENT_TLS_ARGS`, so a `mongod` that requires TLS and a probe that was
+not told never reports healthy — and the bot and the `backup` service both wait
+on `service_healthy`. A half-configured deployment stalls with a red container
+instead of starting the bot against a database it cannot reach. The one gap that
+guard does not cover is `MONGODB_URI`: forget the options there and `mongod` goes
+green while the bot fails to connect, which is why it belongs in step 3 rather
+than being left for later.
+
+Check it took:
+
+```bash
+docker exec -it clawdia-mongodb mongosh --tls --tlsCAFile /etc/mongo-tls/ca.crt \
+  --quiet --eval 'db.adminCommand({ getParameter: 1, sslMode: 1 })'
+```
+
+**Turning it back off** is the reverse order — clear `MONGODB_TLS_ARGS` first,
+recreate, then clear the two client settings — and no data is touched either way.
+
+#### The expiry date
+
+This is the part that decides whether the whole thing was worth having on. A
+`mongod` that stops accepting connections at midnight on a date nobody recorded
+is a worse outage than the cleartext it was turned on to prevent, and a
+self-signed CA is very easy to leave un-rotated.
+
+Two things are done about it. The lifetimes are deliberately long — ten years for
+the CA, five for the server certificate — because a private CA on an
+internal-only network gains nothing from short rotation; there is no revocation
+path here that would make it meaningful, and every month shaved off is a month
+closer to that outage. And the script will tell you where you stand:
+
+```bash
+./scripts/mongo-tls-cert.sh --check              # prints the days remaining
+```
+
+It exits non-zero under 60 days (`MONGO_TLS_WARN_DAYS`) and reports to
+`ERROR_WEBHOOK_URL` — the same sink the bot posts crashes to and
+`verify-backup.sh` posts failures to — so it belongs in the host crontab beside
+that one:
+
+```bash
+0 6 * * *  cd /opt/clawdia && ./scripts/mongo-tls-cert.sh --check >> /var/log/clawdia-tls.log 2>&1
+```
+
+Renewing is the same script against the same directory. It reuses the existing
+CA rather than minting a new one — a new CA would mean re-distributing `ca.crt`
+to all four containers, which is exactly the step someone renewing in a hurry
+skips — so only `server.pem` changes, and `mongod` keeps serving the old
+certificate until it is restarted:
+
+```bash
+./scripts/mongo-tls-cert.sh
+docker compose up -d --force-recreate mongodb
+```
+
 ### Automated Backups
 
 Both `docker-compose.yml` and `portainer-stack.yml` run a `backup` service that

--- a/portainer-stack.yml
+++ b/portainer-stack.yml
@@ -94,11 +94,47 @@ services:
     # `mongo-replset-init` does the one-time `rs.initiate()`. See "Running
     # MongoDB as a single-node replica set" in docs/SETUP_GUIDE.md for the full
     # procedure, including the one for a deployment that already has data.
-    command: mongod ${MONGODB_REPLICA_SET_ARGS:-}
+    # TLS on the wire, empty by default so nothing changes for a deployment that
+    # does not set it (#975). db-network is `internal: true` — no gateway, no
+    # published ports — so this is defence in depth and not a live hole: what it
+    # closes is a process that has *already* joined that network. Authentication
+    # stopped such a process logging in; it did not stop it reading. MongoDB
+    # authenticates with SCRAM, so no password is ever on the wire and a captured
+    # session cannot be replayed to log in, but everything after the handshake is
+    # cleartext — every balance, every audit entry, every admin command, and the
+    # root session `mongo-replset-init` uses to initiate the set:
+    #
+    #   MONGODB_TLS_ARGS=--tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo-tls/server.pem --tlsCAFile /etc/mongo-tls/ca.crt --tlsAllowConnectionsWithoutCertificates
+    #
+    # The last flag is not optional and not a weakening. Naming a CA file is
+    # what lets mongod validate the certificate it presents to *itself* over
+    # the replication connection, and it is also what makes mongod start
+    # demanding a certificate from every client — which none of the four here
+    # has, because this is server authentication and not mutual TLS. Without
+    # it the CA file turns every client connection away.
+    #
+    # It is all clients or none. A single client left on cleartext leaves the
+    # traffic readable, and a `requireTLS` mongod with one client that has not
+    # been told is simply a deploy that cannot reach its own database. The other
+    # two halves are MONGODB_CLIENT_TLS_ARGS, for the two mongosh probes that
+    # connect by host and port, and the tls options on MONGODB_URI, which is what
+    # the bot, mongodump and mongorestore all read. Generate the material with
+    # `scripts/mongo-tls-cert.sh` and follow "Encrypting MongoDB traffic with
+    # TLS" in docs/SETUP_GUIDE.md — the ordering matters, and so does the expiry
+    # date: a mongod that stops accepting connections at midnight is a worse
+    # outage than the exposure this prevents.
+    command: mongod ${MONGODB_REPLICA_SET_ARGS:-} ${MONGODB_TLS_ARGS:-}
     volumes:
       - mongodb_data:/data/db
       # - /opt/clawdia/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
       # - /opt/clawdia/mongo-keyfile:/etc/mongo-keyfile:ro
+      # The TLS material MONGODB_TLS_ARGS names (#975), produced by
+      # `scripts/mongo-tls-cert.sh`. server.pem is the certificate and its
+      # private key concatenated, which is the single file mongod wants; ca.crt
+      # is what every client on db-network validates it against. The same
+      # directory is mounted read-only into mongo-replset-init, bot and backup,
+      # because TLS here is all four or none.
+      # - /opt/clawdia/mongo-tls:/etc/mongo-tls:ro
     networks:
       - db-network   # internal-only: no external routing, no published ports
     healthcheck:
@@ -109,7 +145,15 @@ services:
       # which the bot must not be started: its migrations run at boot and would
       # fail against a node that is not primary. A standalone mongod reports
       # itself writable as soon as it is up, so nothing changes there.
-      test: ["CMD", "mongosh", "--quiet", "--eval", "quit(db.hello().isWritablePrimary ? 0 : 1)"]
+      #
+      # CMD-SHELL rather than CMD because of MONGODB_CLIENT_TLS_ARGS (#975):
+      # unset, it has to expand to no arguments at all, and an exec-form list
+      # would hand mongosh one empty string instead. It is also what makes a
+      # half-configured TLS deployment fail safely — a mongod that requires TLS
+      # and a probe that does not offer it never reports healthy, and the bot and
+      # the backup both wait on that condition, so neither starts against a
+      # database it could not have reached.
+      test: ["CMD-SHELL", "mongosh --quiet ${MONGODB_CLIENT_TLS_ARGS:-} --eval \"quit(db.hello().isWritablePrimary ? 0 : 1)\""]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -173,6 +217,15 @@ services:
     environment:
       MONGODB_ROOT_USERNAME: ${MONGODB_ROOT_USERNAME:-}
       MONGODB_ROOT_PASSWORD: ${MONGODB_ROOT_PASSWORD:-}
+      # The same flags mongod's own healthcheck passes, for the same reason
+      # (#975): this reaches mongod by host and port rather than through a URI,
+      # so a mongod started with --tlsMode requireTLS has no other way to be
+      # spoken to. The cert mount below has to be uncommented with it.
+      MONGODB_CLIENT_TLS_ARGS: ${MONGODB_CLIENT_TLS_ARGS:-}
+    # Uncomment alongside it — this reaches mongod as a client and so
+    # needs the CA to validate it against.
+    # volumes:
+    #   - /opt/clawdia/mongo-tls:/etc/mongo-tls:ro
     # No apostrophes below — not in a comment either (#940). Compose splits a
     # string entrypoint into arguments before the container starts, so the first
     # single quote inside this script closes the one that opened it and
@@ -193,22 +246,27 @@ services:
         # arguments and mongosh would get a truncated one; quoted, it would be a
         # single empty argument when auth is off. Passing the credentials as
         # their own quoted arguments is the only form that is right both ways.
+        # Unquoted, and that is the opposite of the rule above rather than an
+        # oversight: this one is a list of arguments, not a value. Unset it has
+        # to disappear entirely, which is what an unquoted empty expansion does
+        # and a quoted one does not. The password is one value that must survive
+        # a space; this is zero or more flags that must survive being absent.
         authed_mongosh() {
           if [ -n "$$MONGODB_ROOT_USERNAME" ]; then
-            mongosh --host "$$HOST" --quiet --username "$$MONGODB_ROOT_USERNAME" --password "$$MONGODB_ROOT_PASSWORD" --authenticationDatabase admin "$$@";
+            mongosh --host "$$HOST" --quiet $$MONGODB_CLIENT_TLS_ARGS --username "$$MONGODB_ROOT_USERNAME" --password "$$MONGODB_ROOT_PASSWORD" --authenticationDatabase admin "$$@";
           else
-            mongosh --host "$$HOST" --quiet "$$@";
+            mongosh --host "$$HOST" --quiet $$MONGODB_CLIENT_TLS_ARGS "$$@";
           fi;
         };
         # Unauthenticated on purpose: `hello` is answered before login, which is
         # what lets this work on a deployment whose credentials it was not given.
         writable() {
-          mongosh --host "$$HOST" --quiet --eval "quit(db.hello().isWritablePrimary ? 0 : 1)" >/dev/null 2>&1;
+          mongosh --host "$$HOST" --quiet $$MONGODB_CLIENT_TLS_ARGS --eval "quit(db.hello().isWritablePrimary ? 0 : 1)" >/dev/null 2>&1;
         };
         # mongod accepts a TCP connection well before it answers anything, so
         # this waits on an answer and not on the port being open.
         i=0;
-        until mongosh --host "$$HOST" --quiet --eval "db.hello()" >/dev/null 2>&1; do
+        until mongosh --host "$$HOST" --quiet $$MONGODB_CLIENT_TLS_ARGS --eval "db.hello()" >/dev/null 2>&1; do
           i=$$((i + 1));
           if [ $$i -ge 60 ]; then echo "[replset-init] mongod at $$HOST never answered"; exit 1; fi;
           sleep 2;
@@ -351,6 +409,11 @@ services:
       # somewhere on the Docker host and point MCP_SERVERS_CONFIG at it inside
       # the container. Mounted read-only: the file can hold OAuth tokens.
       # - /opt/clawdia/config:/app/config:ro
+      # The CA that validates mongod, when MONGODB_TLS_ARGS is on (#975). Only
+      # ca.crt is read here; nothing in this container needs the private key.
+      # The bot reads it through MONGODB_URI: add
+      # `?tls=true&tlsCAFile=/etc/mongo-tls/ca.crt` to it in the same edit.
+      # - /opt/clawdia/mongo-tls:/etc/mongo-tls:ro
     # Loopback only — put your reverse proxy in front of this. Publish on
     # 0.0.0.0 only if TLS is terminated elsewhere on the host network.
     #
@@ -457,6 +520,11 @@ services:
     #   - backup_encryption_passphrase
     volumes:
       - backups:/backups
+      # The CA that validates mongod, when MONGODB_TLS_ARGS is on (#975). Only
+      # ca.crt is read here; nothing in this container needs the private key.
+      # mongodump and mongorestore read it out of the same MONGODB_URI the
+      # bot uses, so there is no separate flag to set here — only this mount.
+      # - /opt/clawdia/mongo-tls:/etc/mongo-tls:ro
     networks:
       - db-network   # only needs to reach MongoDB
     depends_on:

--- a/portainer-stack.yml
+++ b/portainer-stack.yml
@@ -131,10 +131,14 @@ services:
       # The TLS material MONGODB_TLS_ARGS names (#975), produced by
       # `scripts/mongo-tls-cert.sh`. server.pem is the certificate and its
       # private key concatenated, which is the single file mongod wants; ca.crt
-      # is what every client on db-network validates it against. The same
-      # directory is mounted read-only into mongo-replset-init, bot and backup,
-      # because TLS here is all four or none.
-      # - /opt/clawdia/mongo-tls:/etc/mongo-tls:ro
+      # is what it validates its own replication connection against.
+      #
+      # File by file, not the directory that holds them. ca.key is in there too,
+      # and it is the one thing that can mint a certificate this whole
+      # deployment would trust — it belongs on the host and in no container at
+      # all, this one included. mongod never reads it.
+      # - /opt/clawdia/mongo-tls/server.pem:/etc/mongo-tls/server.pem:ro
+      # - /opt/clawdia/mongo-tls/ca.crt:/etc/mongo-tls/ca.crt:ro
     networks:
       - db-network   # internal-only: no external routing, no published ports
     healthcheck:
@@ -223,9 +227,10 @@ services:
       # spoken to. The cert mount below has to be uncommented with it.
       MONGODB_CLIENT_TLS_ARGS: ${MONGODB_CLIENT_TLS_ARGS:-}
     # Uncomment alongside it — this reaches mongod as a client and so
-    # needs the CA to validate it against.
+    # needs the CA to validate it against, and nothing else in the directory
+    # that CA lives in.
     # volumes:
-    #   - /opt/clawdia/mongo-tls:/etc/mongo-tls:ro
+    #   - /opt/clawdia/mongo-tls/ca.crt:/etc/mongo-tls/ca.crt:ro
     # No apostrophes below — not in a comment either (#940). Compose splits a
     # string entrypoint into arguments before the container starts, so the first
     # single quote inside this script closes the one that opened it and
@@ -409,11 +414,12 @@ services:
       # somewhere on the Docker host and point MCP_SERVERS_CONFIG at it inside
       # the container. Mounted read-only: the file can hold OAuth tokens.
       # - /opt/clawdia/config:/app/config:ro
-      # The CA that validates mongod, when MONGODB_TLS_ARGS is on (#975). Only
-      # ca.crt is read here; nothing in this container needs the private key.
+      # The CA that validates mongod, when MONGODB_TLS_ARGS is on (#975). The one
+      # file, not the directory it lives in: ca.key and mongod's own private key
+      # sit beside it and nothing here has any use for either.
       # The bot reads it through MONGODB_URI: add
       # `?tls=true&tlsCAFile=/etc/mongo-tls/ca.crt` to it in the same edit.
-      # - /opt/clawdia/mongo-tls:/etc/mongo-tls:ro
+      # - /opt/clawdia/mongo-tls/ca.crt:/etc/mongo-tls/ca.crt:ro
     # Loopback only — put your reverse proxy in front of this. Publish on
     # 0.0.0.0 only if TLS is terminated elsewhere on the host network.
     #
@@ -520,11 +526,12 @@ services:
     #   - backup_encryption_passphrase
     volumes:
       - backups:/backups
-      # The CA that validates mongod, when MONGODB_TLS_ARGS is on (#975). Only
-      # ca.crt is read here; nothing in this container needs the private key.
+      # The CA that validates mongod, when MONGODB_TLS_ARGS is on (#975). The one
+      # file, not the directory it lives in: ca.key and mongod's own private key
+      # sit beside it and nothing here has any use for either.
       # mongodump and mongorestore read it out of the same MONGODB_URI the
       # bot uses, so there is no separate flag to set here — only this mount.
-      # - /opt/clawdia/mongo-tls:/etc/mongo-tls:ro
+      # - /opt/clawdia/mongo-tls/ca.crt:/etc/mongo-tls/ca.crt:ro
     networks:
       - db-network   # only needs to reach MongoDB
     depends_on:

--- a/scripts/mongo-tls-cert.sh
+++ b/scripts/mongo-tls-cert.sh
@@ -11,6 +11,7 @@
 # Usage:
 #   ./scripts/mongo-tls-cert.sh [dir] [extra-hostname ...]   issue CA + server cert
 #   ./scripts/mongo-tls-cert.sh --check [dir]                how long is left
+#   ./scripts/mongo-tls-cert.sh --new-ca [dir] [host ...]    roll the CA over
 #
 # `dir` defaults to ./secrets/mongo-tls, which is what the commented mounts in
 # docker-compose.yml expect. On a Portainer host it is wherever you pointed
@@ -18,8 +19,9 @@
 #
 # What it writes:
 #   ca.crt      the CA every client validates mongod against (world-readable)
-#   ca.key      the CA private key — the only thing here that can mint a new
-#               server certificate, and the only thing worth moving off the host
+#   ca.key      the CA private key — the only thing here that can mint a
+#               certificate this deployment would trust. It is mounted into no
+#               container, and it is the one file worth moving off the host
 #   server.pem  certificate + private key concatenated, which is the one file
 #               mongod's --tlsCertificateKeyFile wants
 #
@@ -29,7 +31,8 @@
 # mongosh, plus any extra names given on the command line.
 #
 # Lifetimes are deliberately long: ten years for the CA, five for the server
-# certificate. A private CA on an internal-only network gains nothing from short
+# certificate — or whatever is left of the CA, if that is less, since a leaf
+# outlives its issuer only on paper. A private CA on an internal-only network gains nothing from short
 # rotation — there is no revocation path here to make it meaningful — and every
 # month shaved off is a month closer to the outage above. Renewing is this
 # script again with the same directory and a restart; see "Encrypting MongoDB
@@ -177,11 +180,35 @@ issue() {
     # Reuse an existing CA when there is one: reissuing the server certificate
     # under a new CA would mean re-distributing ca.crt to all four containers,
     # which is the step an operator renewing in a hurry would skip.
-    if [ -r "${dir}/ca.key" ] && [ -r "${dir}/ca.crt" ]; then
-        echo "[mongo-tls] Reusing the existing CA in ${dir}"
+    local issue_days ca_left
+    issue_days="${SERVER_DAYS}"
+    if [ "${NEW_CA}" != yes ] && [ -r "${dir}/ca.key" ] && [ -r "${dir}/ca.crt" ]; then
+        ca_left=$(days_left "${dir}/ca.crt") || return 1
+        # A leaf certificate is only good for as long as the chain above it. Its
+        # own notAfter says nothing once the issuer has expired — every client
+        # rejects it on the CA date, whatever the server certificate claims. So
+        # a CA that cannot cover the requested lifetime does not silently issue
+        # a certificate that lies about when it stops working.
+        if [ "${ca_left}" -lt "${WARN_DAYS}" ]; then
+            echo "[mongo-tls] The CA in ${dir} has ${ca_left} days left, which is not enough to issue against." >&2
+            echo "[mongo-tls] Roll it over deliberately — this replaces the trust material every client holds:" >&2
+            echo "[mongo-tls]   ${0} --new-ca ${dir}" >&2
+            echo "[mongo-tls] then recreate every container with a mongo-tls mount. See docs/SETUP_GUIDE.md." >&2
+            return 1
+        fi
+        echo "[mongo-tls] Reusing the existing CA in ${dir} (${ca_left} days left)"
+        if [ "${ca_left}" -lt "${issue_days}" ]; then
+            echo "[mongo-tls] Capping the server certificate at ${ca_left} days to match it, rather than the usual ${SERVER_DAYS}."
+            issue_days="${ca_left}"
+        fi
         cp "${dir}/ca.key" "${WORK}/ca.key"
         cp "${dir}/ca.crt" "${WORK}/ca.crt"
     else
+        if [ -r "${dir}/ca.crt" ]; then
+            echo "[mongo-tls] Replacing the CA in ${dir}. Every client holding the old ca.crt stops"
+            echo "[mongo-tls] trusting mongod the moment it restarts, so redistribute the new one and"
+            echo "[mongo-tls] recreate all four containers together."
+        fi
         echo "[mongo-tls] Creating a CA valid for ${CA_DAYS} days"
         openssl req -x509 -newkey rsa:4096 -sha256 -nodes \
             -days "${CA_DAYS}" \
@@ -191,7 +218,7 @@ issue() {
             -addext "keyUsage=critical,keyCertSign,cRLSign" 2>/dev/null
     fi
 
-    echo "[mongo-tls] Issuing a server certificate valid for ${SERVER_DAYS} days (${alt_names})"
+    echo "[mongo-tls] Issuing a server certificate valid for ${issue_days} days (${alt_names})"
     openssl req -newkey rsa:4096 -sha256 -nodes \
         -keyout "${WORK}/server.key" -out "${WORK}/server.csr" \
         -subj "/CN=mongodb/O=Clawdia" 2>/dev/null
@@ -208,7 +235,7 @@ EXT
 
     openssl x509 -req -in "${WORK}/server.csr" -sha256 \
         -CA "${WORK}/ca.crt" -CAkey "${WORK}/ca.key" -CAcreateserial \
-        -days "${SERVER_DAYS}" -extfile "${WORK}/ext" \
+        -days "${issue_days}" -extfile "${WORK}/ext" \
         -out "${WORK}/server.crt" 2>/dev/null
 
     # mongod wants one file, key first is conventional and either order parses.
@@ -232,10 +259,18 @@ EXT
 
     echo
     echo "[mongo-tls] Written to ${dir}:"
-    check "${dir}" || true
+    # Not `|| true`. This is the only thing that reads back what was just
+    # written, and a pair that cannot be parsed or is already inside the warning
+    # window is not a successful issue — reporting it as one would leave the
+    # operator moving on to mount it.
+    if ! check "${dir}"; then
+        echo "[mongo-tls] The certificate that was just written did not pass its own check." >&2
+        return 1
+    fi
     echo
-    echo "[mongo-tls] Next: uncomment the mongo-tls mounts on mongodb, mongo-replset-init,"
-    echo "[mongo-tls] bot and backup, then set — in this order, all in one edit —"
+    echo "[mongo-tls] Next: uncomment the mongo-tls mounts — ca.crt on mongodb,"
+    echo "[mongo-tls] mongo-replset-init, bot and backup, and server.pem on mongodb."
+    echo "[mongo-tls] ca.key is mounted nowhere. Then set — in this order, all in one edit —"
     echo "[mongo-tls]   MONGODB_CLIENT_TLS_ARGS=--tls --tlsCAFile /etc/mongo-tls/ca.crt"
     echo "[mongo-tls]   MONGODB_URI=...?tls=true&tlsCAFile=/etc/mongo-tls/ca.crt"
     echo "[mongo-tls]   MONGODB_TLS_ARGS=--tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo-tls/server.pem --tlsCAFile /etc/mongo-tls/ca.crt --tlsAllowConnectionsWithoutCertificates"
@@ -243,11 +278,18 @@ EXT
 }
 
 MODE=issue
+NEW_CA=no
 if [ "${1:-}" = "--check" ]; then
     MODE=check
     shift
+elif [ "${1:-}" = "--new-ca" ]; then
+    # Deliberate, and never implicit: a new CA invalidates the ca.crt every
+    # client holds, so it is a flag rather than something a renewal decides on
+    # the operator behalf.
+    NEW_CA=yes
+    shift
 elif [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
-    sed -n '2,45p' "$0" | sed 's/^# \{0,1\}//'
+    sed -n "2,$(( $(grep -n '^set -euo pipefail' "$0" | cut -d: -f1) - 1 ))p" "$0" | sed 's/^# \{0,1\}//'
     exit 0
 fi
 

--- a/scripts/mongo-tls-cert.sh
+++ b/scripts/mongo-tls-cert.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# The certificate material MONGODB_TLS_ARGS names (#975).
+#
+# Encrypting db-network is opt-in, and the thing that decides whether it is
+# worth having on is not the crypto — it is this file. A self-signed CA and a
+# server certificate are ten minutes of openssl and then a dated bomb: a mongod
+# that stops accepting connections at midnight on an expiry nobody recorded is a
+# worse outage than the cleartext it was turned on to prevent. So the two jobs
+# live together here, and the second one is schedulable.
+#
+# Usage:
+#   ./scripts/mongo-tls-cert.sh [dir] [extra-hostname ...]   issue CA + server cert
+#   ./scripts/mongo-tls-cert.sh --check [dir]                how long is left
+#
+# `dir` defaults to ./secrets/mongo-tls, which is what the commented mounts in
+# docker-compose.yml expect. On a Portainer host it is wherever you pointed
+# /opt/clawdia/mongo-tls at.
+#
+# What it writes:
+#   ca.crt      the CA every client validates mongod against (world-readable)
+#   ca.key      the CA private key — the only thing here that can mint a new
+#               server certificate, and the only thing worth moving off the host
+#   server.pem  certificate + private key concatenated, which is the one file
+#               mongod's --tlsCertificateKeyFile wants
+#
+# The server certificate is issued for `mongodb` — the service name on
+# db-network, which is the name every client dials and therefore the name the
+# certificate has to carry — plus localhost and 127.0.0.1 for a `docker exec`
+# mongosh, plus any extra names given on the command line.
+#
+# Lifetimes are deliberately long: ten years for the CA, five for the server
+# certificate. A private CA on an internal-only network gains nothing from short
+# rotation — there is no revocation path here to make it meaningful — and every
+# month shaved off is a month closer to the outage above. Renewing is this
+# script again with the same directory and a restart; see "Encrypting MongoDB
+# traffic with TLS" in docs/SETUP_GUIDE.md.
+#
+# `--check` prints the days remaining and exits non-zero under
+# MONGO_TLS_WARN_DAYS (60), reporting to ERROR_WEBHOOK_URL the same way
+# verify-backup.sh does. It reads nothing secret, so it is safe in a host
+# crontab:
+#
+#   0 6 * * *  cd /opt/clawdia && ./scripts/mongo-tls-cert.sh --check >> /var/log/clawdia-tls.log 2>&1
+#
+# Requires: openssl.
+set -euo pipefail
+
+CA_DAYS=3650
+SERVER_DAYS=1825
+WARN_DAYS="${MONGO_TLS_WARN_DAYS:-60}"
+# The mongo image runs mongod as this uid, and it is the only process that has
+# to be able to read server.pem.
+MONGO_UID=999
+MONGO_GID=999
+
+command -v openssl >/dev/null 2>&1 || { echo "[mongo-tls] openssl is not on PATH" >&2; exit 1; }
+
+# The same rule src/utils/errorReporter.js applies to the same variable: https
+# anywhere, http only to loopback, anything else refused rather than downgraded.
+sink_allowed() {
+    case "$1" in
+        https://*) return 0 ;;
+        http://localhost|http://localhost/*|http://localhost:*) return 0 ;;
+        http://127.0.0.1|http://127.0.0.1/*|http://127.0.0.1:*) return 0 ;;
+        "http://[::1]"|"http://[::1]/"*|"http://[::1]:"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# A path or a hostname may hold a quote or a backslash, and interpolating one
+# straight into a JSON string produces a body the sink rejects — so the report
+# about the problem fails too.
+json_escape() {
+    printf '%s' "$1" | tr -d '\000-\037' | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+notify_failure() {
+    echo "[mongo-tls] $1" >&2
+    [ -n "${ERROR_WEBHOOK_URL:-}" ] || return 0
+    if ! sink_allowed "${ERROR_WEBHOOK_URL}"; then
+        echo "[mongo-tls] Ignoring ERROR_WEBHOOK_URL: expected an https:// URL (or http:// to loopback)" >&2
+        return 0
+    fi
+    command -v curl >/dev/null 2>&1 || { echo "[mongo-tls] curl not found; ERROR_WEBHOOK_URL not posted" >&2; return 0; }
+    local body message
+    message=$(json_escape "$1")
+    case "${ERROR_WEBHOOK_URL}" in
+        https://discord.com/api/webhooks/*|https://discordapp.com/api/webhooks/*)
+            body=$(printf '{"content":"**MongoDB TLS certificate** on %s: %s"}' "$(json_escape "$(hostname)")" "${message}") ;;
+        *)
+            body=$(printf '{"kind":"mongo_tls_expiring","service":"clawdia-mongodb","message":"%s"}' "${message}") ;;
+    esac
+    curl -fsS --max-time 10 -X POST -H 'content-type: application/json' \
+        -d "${body}" "${ERROR_WEBHOOK_URL}" >/dev/null 2>&1 \
+        || echo "[mongo-tls] posting to ERROR_WEBHOOK_URL failed" >&2
+}
+
+# Days until a certificate expires, negative once it has. `openssl x509
+# -checkend` answers a yes/no and this needs the number, so the notBefore date
+# is parsed instead — GNU date and BSD date disagree about how, hence both.
+days_left() {
+    local cert not_after end now
+    cert="$1"
+    not_after=$(openssl x509 -in "${cert}" -noout -enddate | cut -d= -f2-)
+    end=$(date -u -d "${not_after}" +%s 2>/dev/null \
+        || date -u -j -f '%b %d %T %Y %Z' "${not_after}" +%s 2>/dev/null) || {
+        echo "[mongo-tls] could not parse the expiry date of ${cert}: ${not_after}" >&2
+        return 1
+    }
+    now=$(date -u +%s)
+    echo $(( (end - now) / 86400 ))
+}
+
+check() {
+    local dir server ca status left
+    dir="$1"
+    server="${dir}/server.pem"
+    ca="${dir}/ca.crt"
+    status=0
+    for cert in "${ca}" "${server}"; do
+        if [ ! -r "${cert}" ]; then
+            echo "[mongo-tls] ${cert} is missing or unreadable" >&2
+            return 1
+        fi
+    done
+    for cert in "${ca}" "${server}"; do
+        left=$(days_left "${cert}") || return 1
+        if [ "${left}" -lt 0 ]; then
+            notify_failure "${cert} EXPIRED $(( -left )) days ago; mongod is refusing connections or about to"
+            status=1
+        elif [ "${left}" -lt "${WARN_DAYS}" ]; then
+            notify_failure "${cert} expires in ${left} days; reissue it with scripts/mongo-tls-cert.sh"
+            status=1
+        else
+            echo "[mongo-tls] ${cert}: ${left} days left"
+        fi
+    done
+    return "${status}"
+}
+
+issue() {
+    local dir
+    dir="$1"
+    shift
+
+    if [ -e "${dir}/server.pem" ]; then
+        # Reissuing in place is the renewal path and is meant to work, but it
+        # invalidates nothing until mongod is restarted — and a half-written
+        # pair while mongod is running is the one state that breaks a live
+        # deployment. Everything is written to temporary names and moved into
+        # place at the end, so the window is a rename rather than an openssl run.
+        echo "[mongo-tls] ${dir} already holds a certificate; reissuing (mongod keeps the old one until it is restarted)"
+    fi
+
+    mkdir -p "${dir}"
+    chmod 750 "${dir}"
+
+    # Every name a client might dial. `mongodb` is the service name on
+    # db-network and the one that actually matters; without it in the SAN list
+    # the driver rejects the certificate on hostname verification and no amount
+    # of trusting the CA helps.
+    local alt_names
+    alt_names="DNS:mongodb,DNS:localhost,IP:127.0.0.1"
+    for extra in "$@"; do
+        case "${extra}" in
+            *[!0-9.]*) alt_names="${alt_names},DNS:${extra}" ;;
+            *) alt_names="${alt_names},IP:${extra}" ;;
+        esac
+    done
+
+    # WORK is deliberately not `local`: the EXIT trap runs after this function
+    # has returned, and a local would be unbound by then — which under `set -u`
+    # turns a clean run into an error on the way out.
+    WORK=$(mktemp -d "${dir}/.issue.XXXXXX")
+    trap 'rm -rf "${WORK:-}"' EXIT
+
+    # Reuse an existing CA when there is one: reissuing the server certificate
+    # under a new CA would mean re-distributing ca.crt to all four containers,
+    # which is the step an operator renewing in a hurry would skip.
+    if [ -r "${dir}/ca.key" ] && [ -r "${dir}/ca.crt" ]; then
+        echo "[mongo-tls] Reusing the existing CA in ${dir}"
+        cp "${dir}/ca.key" "${WORK}/ca.key"
+        cp "${dir}/ca.crt" "${WORK}/ca.crt"
+    else
+        echo "[mongo-tls] Creating a CA valid for ${CA_DAYS} days"
+        openssl req -x509 -newkey rsa:4096 -sha256 -nodes \
+            -days "${CA_DAYS}" \
+            -keyout "${WORK}/ca.key" -out "${WORK}/ca.crt" \
+            -subj "/CN=Clawdia MongoDB CA/O=Clawdia" \
+            -addext "basicConstraints=critical,CA:TRUE,pathlen:0" \
+            -addext "keyUsage=critical,keyCertSign,cRLSign" 2>/dev/null
+    fi
+
+    echo "[mongo-tls] Issuing a server certificate valid for ${SERVER_DAYS} days (${alt_names})"
+    openssl req -newkey rsa:4096 -sha256 -nodes \
+        -keyout "${WORK}/server.key" -out "${WORK}/server.csr" \
+        -subj "/CN=mongodb/O=Clawdia" 2>/dev/null
+
+    # clientAuth as well as serverAuth: a single-node replica set opens a
+    # replication connection to itself, and on that one mongod is the client.
+    # Without it the set never reaches primary and the healthcheck stays red.
+    cat > "${WORK}/ext" <<EXT
+basicConstraints=CA:FALSE
+keyUsage=critical,digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth,clientAuth
+subjectAltName=${alt_names}
+EXT
+
+    openssl x509 -req -in "${WORK}/server.csr" -sha256 \
+        -CA "${WORK}/ca.crt" -CAkey "${WORK}/ca.key" -CAcreateserial \
+        -days "${SERVER_DAYS}" -extfile "${WORK}/ext" \
+        -out "${WORK}/server.crt" 2>/dev/null
+
+    # mongod wants one file, key first is conventional and either order parses.
+    cat "${WORK}/server.key" "${WORK}/server.crt" > "${WORK}/server.pem"
+
+    mv "${WORK}/ca.crt" "${dir}/ca.crt"
+    mv "${WORK}/ca.key" "${dir}/ca.key"
+    mv "${WORK}/server.pem" "${dir}/server.pem"
+
+    chmod 444 "${dir}/ca.crt"
+    chmod 400 "${dir}/ca.key" "${dir}/server.pem"
+    # server.pem is bind-mounted into a container whose mongod runs as uid 999,
+    # and 0400 owned by anyone else is a file that container cannot read. Not
+    # fatal when this is not run as root — say so rather than leaving a mongod
+    # that will not start with no explanation.
+    if ! chown "${MONGO_UID}:${MONGO_GID}" "${dir}/server.pem" 2>/dev/null; then
+        echo "[mongo-tls] Could not chown ${dir}/server.pem to ${MONGO_UID}:${MONGO_GID} — run:"
+        echo "[mongo-tls]   sudo chown ${MONGO_UID}:${MONGO_GID} ${dir}/server.pem"
+        echo "[mongo-tls] mongod runs as that uid and cannot read the file otherwise."
+    fi
+
+    echo
+    echo "[mongo-tls] Written to ${dir}:"
+    check "${dir}" || true
+    echo
+    echo "[mongo-tls] Next: uncomment the mongo-tls mounts on mongodb, mongo-replset-init,"
+    echo "[mongo-tls] bot and backup, then set — in this order, all in one edit —"
+    echo "[mongo-tls]   MONGODB_CLIENT_TLS_ARGS=--tls --tlsCAFile /etc/mongo-tls/ca.crt"
+    echo "[mongo-tls]   MONGODB_URI=...?tls=true&tlsCAFile=/etc/mongo-tls/ca.crt"
+    echo "[mongo-tls]   MONGODB_TLS_ARGS=--tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo-tls/server.pem --tlsCAFile /etc/mongo-tls/ca.crt --tlsAllowConnectionsWithoutCertificates"
+    echo "[mongo-tls] and recreate the stack. See docs/SETUP_GUIDE.md."
+}
+
+MODE=issue
+if [ "${1:-}" = "--check" ]; then
+    MODE=check
+    shift
+elif [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    sed -n '2,45p' "$0" | sed 's/^# \{0,1\}//'
+    exit 0
+fi
+
+DIR="${1:-./secrets/mongo-tls}"
+[ $# -gt 0 ] && shift
+
+if [ "${MODE}" = check ]; then
+    check "${DIR}"
+else
+    issue "${DIR}" "$@"
+fi

--- a/tests/deployStackParity.test.js
+++ b/tests/deployStackParity.test.js
@@ -383,7 +383,7 @@ describe('the two files agree where they must', () => {
             // in it, because MongoDB requires internal authentication for an
             // authenticated replica set and refuses to start without the file.
             expect([name, doc.services.mongodb.command])
-                .toEqual([name, 'mongod ${MONGODB_REPLICA_SET_ARGS:-}']);
+                .toEqual([name, 'mongod ${MONGODB_REPLICA_SET_ARGS:-} ${MONGODB_TLS_ARGS:-}']);
         }
     });
 
@@ -415,6 +415,101 @@ describe('the two files agree where they must', () => {
             expect([name, probe]).toEqual([name, expect.stringContaining('isWritablePrimary')]);
             expect([name, probe]).not.toEqual([name, expect.stringContaining("adminCommand('ping')")]);
         }
+    });
+
+    // #975. Nothing on db-network used TLS, so with authentication on a process
+    // that had joined that network could still read every balance, every audit
+    // entry and every administrative command off the wire — including the root
+    // session mongo-replset-init uses to initiate the set. Turning it on is
+    // opt-in, and the property that has to hold is that it is opt-in for *all
+    // five* clients at once: mongod plus one client still speaking cleartext is
+    // not a weaker deployment, it is a deployment that cannot reach its own
+    // database. That is what this asserts, because it is the only place it can
+    // be asserted — the alternative is finding out on the redeploy.
+    describe('TLS on db-network is all of it or none of it (#975)', () => {
+        const CERT_MOUNT = /mongo-tls:\/etc\/mongo-tls:ro/g;
+
+        it('lets mongod be given TLS flags, the same way, in both', () => {
+            for (const [name, doc] of stacks) {
+                // Beside the replica-set flags rather than merged into them:
+                // one deployment may want a replica set and no TLS, another the
+                // reverse, and a single variable holding both makes turning one
+                // off mean retyping the other.
+                expect([name, String(doc.services.mongodb.command)])
+                    .toEqual([name, expect.stringContaining('${MONGODB_TLS_ARGS:-}')]);
+            }
+        });
+
+        it('tells both mongosh probes to speak it', () => {
+            for (const [name, doc] of stacks) {
+                // These two reach mongod by host and port, so unlike every other
+                // client here they have no connection string to carry the
+                // options and must be told separately.
+                const probe = doc.services.mongodb.healthcheck.test;
+                // CMD-SHELL, because unset the variable has to expand to no
+                // arguments at all and an exec-form list would pass mongosh a
+                // single empty string instead.
+                expect([name, probe[0]]).toEqual([name, 'CMD-SHELL']);
+                expect([name, probe.join(' ')])
+                    .toEqual([name, expect.stringContaining('${MONGODB_CLIENT_TLS_ARGS:-}')]);
+
+                const init = doc.services['mongo-replset-init'];
+                expect([name, Object.keys(init.environment)])
+                    .toEqual([name, expect.arrayContaining(['MONGODB_CLIENT_TLS_ARGS'])]);
+                // Every mongosh in that script, not merely one of them: the
+                // wait loop, the writable probe and the authenticated call are
+                // three separate connections and a mongod in requireTLS mode
+                // refuses whichever one was missed.
+                // `mongosh --host` and not `mongosh`: the script also calls its
+                // own authed_mongosh wrapper, whose name ends in the same word.
+                const invocations = String(init.entrypoint).match(/mongosh --host[^;]*/g) || [];
+                expect([name, invocations.length]).toEqual([name, 4]);
+                for (const call of invocations) {
+                    expect([name, call]).toEqual([name, expect.stringContaining('$$MONGODB_CLIENT_TLS_ARGS')]);
+                }
+            }
+        });
+
+        it('leaves the URI clients to the URI, and passes them no flags', () => {
+            for (const [name, doc] of stacks) {
+                // The bot, mongodump and mongorestore all take a connection
+                // string, so `tls=true&tlsCAFile=...` on MONGODB_URI configures
+                // all three in one edit and there is no second setting to
+                // disagree with it. Passing the tools CLI flags *as well* is the
+                // way to get "cannot specify different ssl configuration in the
+                // connection URI and as a command line option" at 03:00.
+                expect([name, String(doc.services.backup.entrypoint)])
+                    .not.toEqual([name, expect.stringContaining('MONGODB_CLIENT_TLS_ARGS')]);
+            }
+        });
+
+        it('offers the certificate to every container that needs it', () => {
+            for (const [name] of stacks) {
+                // Commented out, like the key-file mount beside it, so this
+                // reads the file rather than the parsed YAML. Four: mongod
+                // serves the certificate, and mongo-replset-init, bot and backup
+                // each validate against the CA in it.
+                const text = fs.readFileSync(path.join(ROOT, name), 'utf8');
+                expect([name, (text.match(CERT_MOUNT) || []).length]).toEqual([name, 4]);
+            }
+        });
+
+        it('is issued by a script that names the same three settings', () => {
+            // The script prints the settings to apply once it has written the
+            // certificate. Three copies of these names exist — here, the stack
+            // comments, and SETUP_GUIDE — and the one an operator pastes from is
+            // the script.
+            const script = fs.readFileSync(path.join(ROOT, 'scripts/mongo-tls-cert.sh'), 'utf8');
+            for (const setting of ['MONGODB_CLIENT_TLS_ARGS', 'MONGODB_URI', 'MONGODB_TLS_ARGS']) {
+                expect([setting, script.includes(setting)]).toEqual([setting, true]);
+            }
+            // Naming a CA file makes mongod demand a client certificate from
+            // everything that connects, and nothing here has one — this is
+            // server authentication, not mutual TLS. Without this flag the CA
+            // file turns every client away, which is a deployment that starts
+            // and then refuses the bot.
+            expect(script).toContain('--tlsAllowConnectionsWithoutCertificates');
+        });
     });
 
     it('gives the two services the same MONGODB_URI default', () => {

--- a/tests/deployStackParity.test.js
+++ b/tests/deployStackParity.test.js
@@ -427,7 +427,8 @@ describe('the two files agree where they must', () => {
     // database. That is what this asserts, because it is the only place it can
     // be asserted — the alternative is finding out on the redeploy.
     describe('TLS on db-network is all of it or none of it (#975)', () => {
-        const CERT_MOUNT = /mongo-tls:\/etc\/mongo-tls:ro/g;
+        const CA_MOUNT = /mongo-tls\/ca\.crt:\/etc\/mongo-tls\/ca\.crt:ro/g;
+        const SERVER_MOUNT = /mongo-tls\/server\.pem:\/etc\/mongo-tls\/server\.pem:ro/g;
 
         it('lets mongod be given TLS flags, the same way, in both', () => {
             for (const [name, doc] of stacks) {
@@ -483,14 +484,33 @@ describe('the two files agree where they must', () => {
             }
         });
 
-        it('offers the certificate to every container that needs it', () => {
+        it('offers each container the one file it needs, and no more', () => {
             for (const [name] of stacks) {
                 // Commented out, like the key-file mount beside it, so this
-                // reads the file rather than the parsed YAML. Four: mongod
-                // serves the certificate, and mongo-replset-init, bot and backup
-                // each validate against the CA in it.
+                // reads the file rather than the parsed YAML.
                 const text = fs.readFileSync(path.join(ROOT, name), 'utf8');
-                expect([name, (text.match(CERT_MOUNT) || []).length]).toEqual([name, 4]);
+                const mounts = text.split('\n').filter(line => /:\/etc\/mongo-tls/.test(line));
+
+                // Four: mongod validates its own replication connection against
+                // the CA, and mongo-replset-init, bot and backup each validate
+                // mongod against it.
+                expect([name, (text.match(CA_MOUNT) || []).length]).toEqual([name, 4]);
+                // One: only mongod serves the certificate.
+                expect([name, (text.match(SERVER_MOUNT) || []).length]).toEqual([name, 1]);
+
+                // The point of naming files rather than the directory that holds
+                // them. `scripts/mongo-tls-cert.sh` writes ca.key into that
+                // directory, and it is the one thing that can mint a certificate
+                // this deployment would trust — a directory mount hands it, and
+                // mongod's private key, to the bot, which is the container with
+                // a route to the internet. Neither belongs in any container.
+                for (const mount of mounts) {
+                    expect([name, mount]).not.toEqual([name, expect.stringContaining('ca.key')]);
+                    // A bare `…/mongo-tls:/etc/mongo-tls` mount is the whole
+                    // directory again under another spelling.
+                    expect([name, /:\/etc\/mongo-tls:/.test(mount)]).toEqual([name, false]);
+                }
+                expect([name, mounts.length]).toEqual([name, 5]);
             }
         });
 

--- a/tests/envExampleDrift.test.js
+++ b/tests/envExampleDrift.test.js
@@ -37,6 +37,8 @@ const CONSUMED_OUTSIDE_SRC = new Set([
     'MONGODB_APP_USERNAME',
     'MONGODB_APP_PASSWORD',
     'MONGODB_REPLICA_SET_ARGS',
+    'MONGODB_TLS_ARGS',
+    'MONGODB_CLIENT_TLS_ARGS',
     'DISCORD_TOKEN_FILE',
     // Read by the backup service's entrypoint and by the host scripts that
     // write and open archives (#886, #900); the bot process never sees them.

--- a/tests/rssParserWatch.test.js
+++ b/tests/rssParserWatch.test.js
@@ -1,0 +1,120 @@
+'use strict';
+
+/**
+ * The watch on `rss-parser` (#954).
+ *
+ * Not a defect, and there is nothing to fix today. `rss-parser` is historically
+ * slow-moving and brings a transitive XML-parsing surface, which is a category
+ * with a long history of entity-expansion and parser CVEs — and it processes
+ * attacker-influenced input, since any URL a guild admin can subscribe to ends
+ * up in it. The fetch side is already handled: `safeFeedFetch.js` pins DNS,
+ * refuses private and reserved addresses on every redirect hop, and caps the
+ * body at 5 MB. This is about the parse side and the package's maintenance
+ * trajectory.
+ *
+ * A watch item that lives only in an issue is a watch item nobody keeps. What
+ * this file does is hold the two things that make the watch actionable, so
+ * neither can lapse quietly:
+ *
+ *   1. Dependabot still covers it, so a published advisory raises a PR the day
+ *      it lands rather than whenever somebody next runs `npm audit`.
+ *   2. The surface stays small. The exit plan, if the package does go
+ *      unmaintained, is to vendor or replace the parsing this project actually
+ *      uses — and that plan is only cheap while "what it actually uses" is one
+ *      method on a string that something else already fetched and bounded. A
+ *      third call site, or a `parseURL` that does its own fetching, is what
+ *      would turn a morning's work into a migration; each is one line to write
+ *      and neither would be noticed in review.
+ *
+ * If it does go stale, the replacement is `parseString` against a maintained
+ * parser, and nothing else in `src/` has to change.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const ROOT = path.join(__dirname, '..');
+const pkg = require('../package.json');
+
+function walk(dir) {
+    const out = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) out.push(...walk(full));
+        else if (entry.name.endsWith('.js')) out.push(full);
+    }
+    return out;
+}
+
+// Comments stripped throughout: both rssService.js and safeFeedFetch.js explain
+// in prose why they do not use the call this file asserts nobody makes, and the
+// assertion would otherwise be failed by its own documentation.
+const stripComments = src => src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n').filter(line => !line.trim().startsWith('//')).join('\n');
+
+const sources = walk(path.join(ROOT, 'src'))
+    .map(file => [path.relative(ROOT, file), stripComments(fs.readFileSync(file, 'utf8'))]);
+
+const importers = sources
+    .filter(([, src]) => /require\(['"]rss-parser['"]\)/.test(src))
+    .map(([file]) => file);
+
+describe('rss-parser stays watched (#954)', () => {
+    it('is a direct dependency, so Dependabot can see it at all', () => {
+        // A transitive-only dependency is updated when its parent chooses to,
+        // which for a slow-moving package is the failure mode this watch is
+        // about. It is direct today; this fails if it is ever demoted.
+        expect(Object.keys(pkg.dependencies)).toContain('rss-parser');
+    });
+
+    it('is not excluded from the npm update schedule', () => {
+        const config = yaml.load(fs.readFileSync(path.join(ROOT, '.github', 'dependabot.yml'), 'utf8'));
+        const npm = config.updates.find(u => u['package-ecosystem'] === 'npm');
+        expect(npm).toBeDefined();
+        expect(npm.directory).toBe('/');
+        // `ignore` is the cheapest way to make this watch silently stop: one
+        // entry added to quiet a noisy bump takes the security PRs with it,
+        // because Dependabot applies it to those too.
+        const ignored = (npm.ignore || []).map(rule => rule['dependency-name']);
+        expect(ignored).not.toContain('rss-parser');
+        expect(ignored).not.toContain('*');
+    });
+
+    it('is required in exactly the two places that parse a feed', () => {
+        // Named rather than counted: a third importer is not automatically
+        // wrong, but it is the thing to look at, and adding it here is the
+        // moment to ask whether the vendoring plan still holds.
+        expect(importers.sort()).toEqual([
+            'src/dashboard/routes/api/rss.js',
+            'src/services/rssService.js',
+        ]);
+    });
+
+    it('never fetches for itself', () => {
+        for (const [file, src] of sources) {
+            // `parseURL` does its own HTTP, which walks straight past the DNS
+            // pinning, the private-address refusal on every redirect hop and the
+            // body cap in safeFeedFetch.js — a feed URL is operator-supplied, so
+            // that is an SSRF proxy and an unbounded read in one call.
+            expect([file, src.includes('parseURL')]).toEqual([file, false]);
+        }
+    });
+
+    it('is only ever handed a string something else already bounded', () => {
+        for (const file of importers) {
+            const src = stripComments(fs.readFileSync(path.join(ROOT, file), 'utf8'));
+            expect([file, /safeFeedFetch/.test(src)]).toEqual([file, true]);
+            // `parseString` is the whole of the surface, and so the whole of
+            // what a replacement would have to provide. Anything else here
+            // means the exit plan wants re-costing before it is needed rather
+            // than after.
+            const calls = src.match(/\b(?:parser|feedParser)\.\w+\(/g) || [];
+            expect([file, calls.length]).not.toEqual([file, 0]);
+            for (const call of calls) {
+                expect([file, call]).toEqual([file, expect.stringContaining('.parseString(')]);
+            }
+        }
+    });
+});

--- a/tests/rssParserWatch.test.js
+++ b/tests/rssParserWatch.test.js
@@ -54,6 +54,28 @@ const stripComments = src => src
     .replace(/\/\*[\s\S]*?\*\//g, '')
     .split('\n').filter(line => !line.trim().startsWith('//')).join('\n');
 
+/**
+ * The argument text of every `.parseString(...)` call in one source file.
+ *
+ * Paren-matched rather than regexed to the next `)`, because the argument that
+ * matters most — `parseString(await safeFetchFeed(url))` — contains one.
+ */
+function parseStringArguments(src) {
+    const args = [];
+    const CALL = /\.parseString\(/g;
+    for (let match = CALL.exec(src); match; match = CALL.exec(src)) {
+        let depth = 1;
+        let i = match.index + match[0].length;
+        const start = i;
+        for (; i < src.length && depth > 0; i += 1) {
+            if (src[i] === '(') depth += 1;
+            else if (src[i] === ')') depth -= 1;
+        }
+        args.push(src.slice(start, i - 1).trim());
+    }
+    return args;
+}
+
 const sources = walk(path.join(ROOT, 'src'))
     .map(file => [path.relative(ROOT, file), stripComments(fs.readFileSync(file, 'utf8'))]);
 
@@ -80,6 +102,15 @@ describe('rss-parser stays watched (#954)', () => {
         const ignored = (npm.ignore || []).map(rule => rule['dependency-name']);
         expect(ignored).not.toContain('rss-parser');
         expect(ignored).not.toContain('*');
+        // `allow` is the same hole from the other side, and the quieter one: it
+        // is a whitelist, so adding an entry for any *other* package silently
+        // drops everything not named — this one included — rather than
+        // mentioning it. Absent is the state today and the state that keeps the
+        // schedule reaching everything.
+        const allowed = (npm.allow || []).map(rule => rule['dependency-name']);
+        if (npm.allow) {
+            expect(allowed).toContain('rss-parser');
+        }
     });
 
     it('is required in exactly the two places that parse a feed', () => {
@@ -105,15 +136,34 @@ describe('rss-parser stays watched (#954)', () => {
     it('is only ever handed a string something else already bounded', () => {
         for (const file of importers) {
             const src = stripComments(fs.readFileSync(path.join(ROOT, file), 'utf8'));
-            expect([file, /safeFeedFetch/.test(src)]).toEqual([file, true]);
+            // The module and the function it exports are spelled differently —
+            // `safeFeedFetch.js` exports `safeFetchFeed` — and only the second
+            // proves the guard is actually called rather than merely imported.
+            expect([file, /require\(['"][^'"]*safeFeedFetch['"]\)/.test(src)]).toEqual([file, true]);
+            expect([file, /\bsafeFetchFeed\s*\(/.test(src)]).toEqual([file, true]);
+
             // `parseString` is the whole of the surface, and so the whole of
             // what a replacement would have to provide. Anything else here
             // means the exit plan wants re-costing before it is needed rather
             // than after.
-            const calls = src.match(/\b(?:parser|feedParser)\.\w+\(/g) || [];
+            const calls = [...src.matchAll(/\b(?:parser|feedParser)\.(\w+)\(/g)];
             expect([file, calls.length]).not.toEqual([file, 0]);
-            for (const call of calls) {
-                expect([file, call]).toEqual([file, expect.stringContaining('.parseString(')]);
+            for (const [, method] of calls) {
+                expect([file, method]).toEqual([file, 'parseString']);
+            }
+
+            // And what it is handed has to come from the guard, not merely be
+            // parsed in a file that happens to import it. Both shapes are in
+            // use: the service inlines the call, the route awaits it into a
+            // local first — so an argument is either the call itself or an
+            // identifier this file assigns from it. `parseString(rawBody)`
+            // after a bare fetch is the regression, and it is one line.
+            for (const argument of parseStringArguments(src)) {
+                if (/\bsafeFetchFeed\s*\(/.test(argument)) continue;
+                expect([file, argument]).toEqual([file, expect.stringMatching(/^[A-Za-z_$][\w$]*$/)]);
+                const assignment = new RegExp(
+                    `\\b(?:const|let|var)\\s+${argument}\\s*=\\s*await\\s+safeFetchFeed\\s*\\(`);
+                expect([file, argument, assignment.test(src)]).toEqual([file, argument, true]);
             }
         }
     });


### PR DESCRIPTION
Nothing that talked to mongod used TLS. Authentication closed half of the
position the compose comments already name — a process that has joined
db-network can no longer log in — and left the other half open: it could still
read every balance, every audit entry and every admin command off the wire,
including the root session mongo-replset-init uses to initiate the set. SCRAM
means no password is ever on it and a captured session cannot be replayed;
everything after the handshake was cleartext.

The exposure is bounded by db-network being internal: true, so this is opt-in
and unset is byte-for-byte today's behaviour. Three settings, because there are
two kinds of client: MONGODB_TLS_ARGS for mongod, MONGODB_CLIENT_TLS_ARGS for
the healthcheck and mongo-replset-init, which reach mongod by host and port and
so have no connection string to carry the options, and the tls options on the
MONGODB_URI that the bot, mongodump and mongorestore already share. Those three
deliberately get no command-line flags: the database tools refuse a TLS
configuration specified both in the URI and as an option, which would have made
03:00 the time we found out.

It has to be all five or none, and the healthcheck is what makes that a stall
rather than a lockout — it is one of the two probes, so a requireTLS mongod with
a client that was not told never goes healthy, and the bot and backup both wait
on that condition.

scripts/mongo-tls-cert.sh is the other half of the answer, and the half that
decides whether this is worth turning on: a self-signed CA is ten minutes of
openssl and then a dated bomb. It issues the pair with long, deliberate
lifetimes, reuses an existing CA when renewing so ca.crt does not have to be
redistributed to four containers by someone in a hurry, and --check prints the
days remaining, exits non-zero under sixty and reports to ERROR_WEBHOOK_URL,
so it can sit in the host crontab beside verify-backup.sh.

deployStackParity gains a block asserting the property rather than the lines:
every mongosh in both files carries the client flags, the URI clients are given
none, and the certificate is offered to all four containers in both stacks.
SETUP_GUIDE carries the procedure, the ordering, the expiry, and the case for
deciding an internal: true network is a sufficient boundary and leaving this off.

Closes #975

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011CTcXekSmC142VdY4zvh3y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional end-to-end MongoDB TLS encryption for database, bot, backup, and health-check connections.
  - Added a certificate utility to generate, validate, renew, and monitor MongoDB TLS certificates, with optional webhook warnings.

- **Documentation**
  - Added setup guidance for TLS configuration, certificate management, verification, and renewal.
  - Added a project roadmap and linked it from contributor and README documentation.
  - Updated the changelog with TLS and dependency-monitoring information.

- **Tests**
  - Added coverage to verify TLS configuration consistency and continued monitoring of RSS parser usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->